### PR TITLE
Add VMSnapshot failure phase and deadline

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13515,6 +13515,9 @@
       },
       "x-kubernetes-list-type": "set"
      },
+     "phase": {
+      "type": "string"
+     },
      "readyToUse": {
       "type": "boolean"
      },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13486,6 +13486,10 @@
      "deletionPolicy": {
       "type": "string"
      },
+     "failureDeadline": {
+      "description": "This time represents the number of seconds we permit the vm snapshot to take. In case we pass this deadline we mark this snapshot as failed. Defaults to DefaultFailureDeadline - 5min",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Duration"
+     },
      "source": {
       "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
      }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -230,6 +230,15 @@ func (admitter *VMRestoreAdmitter) validateSnapshot(field *k8sfield.Path, namesp
 
 	var causes []metav1.StatusCause
 
+	if snapshot.Status != nil && snapshot.Status.Phase == snapshotv1.Failed {
+		cause := metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("VirtualMachineSnapshot %q has failed and is invalid to use", name),
+			Field:   field.String(),
+		}
+		causes = append(causes, cause)
+	}
+
 	if snapshot.Status == nil || snapshot.Status.ReadyToUse == nil || !*snapshot.Status.ReadyToUse {
 		cause := metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -160,7 +160,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshot(vmSnapshot *snapshotv1.Virtua
 		}
 	}
 
-	if vmSnapshot.DeletionTimestamp != nil && content != nil {
+	if (vmSnapshot.DeletionTimestamp != nil || vmSnapshotDeadlineExceeded(vmSnapshot)) && content != nil {
 		if controller.HasFinalizer(content, vmSnapshotContentFinalizer) {
 			cpy := content.DeepCopy()
 			controller.RemoveFinalizer(cpy, vmSnapshotContentFinalizer)

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -574,6 +574,7 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 	}
 
 	if vmSnapshotProgressing(vmSnapshotCpy) {
+		vmSnapshotCpy.Status.Phase = snapshotv1.InProgress
 		if source != nil {
 			if source.Locked() {
 				updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"))
@@ -611,9 +612,11 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "In error state"))
 		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionFalse, "Error"))
 	} else if vmSnapshotReady(vmSnapshotCpy) {
+		vmSnapshotCpy.Status.Phase = snapshotv1.Succeeded
 		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "Operation complete"))
 		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionTrue, "Operation complete"))
 	} else {
+		vmSnapshotCpy.Status.Phase = snapshotv1.Unknown
 		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionUnknown, "Unknown state"))
 		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionUnknown, "Unknown state"))
 	}

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -52,6 +52,8 @@ const (
 
 	volumeSnapshotMissingEvent = "VolumeSnapshotMissing"
 
+	vmSnapshotDeadlineExceededError = "snapshot deadline exceeded"
+
 	snapshotRetryInterval = 5 * time.Second
 )
 
@@ -70,8 +72,24 @@ func vmSnapshotError(vmSnapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.
 	return nil
 }
 
+func vmSnapshotFailed(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
+	return vmSnapshot.Status != nil && vmSnapshot.Status.Phase == snapshotv1.Failed
+}
+
+func vmSnapshotSucceeded(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
+	return vmSnapshot.Status != nil && vmSnapshot.Status.Phase == snapshotv1.Succeeded
+}
+
 func vmSnapshotProgressing(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
-	return vmSnapshotError(vmSnapshot) == nil && !vmSnapshotReady(vmSnapshot)
+	return vmSnapshotError(vmSnapshot) == nil && !vmSnapshotReady(vmSnapshot) &&
+		!vmSnapshotFailed(vmSnapshot) && !vmSnapshotSucceeded(vmSnapshot)
+}
+
+func vmSnapshotDeadlineExceeded(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
+	if vmSnapshotSucceeded(vmSnapshot) {
+		return false
+	}
+	return timeUntilDeadline(vmSnapshot) < 0
 }
 
 func getVMSnapshotContentName(vmSnapshot *snapshotv1.VirtualMachineSnapshot) string {
@@ -110,7 +128,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshot(vmSnapshot *snapshotv1.Virtua
 	// Make sure status is initialized before doing anything
 	if vmSnapshot.Status != nil {
 		if source != nil {
-			if vmSnapshotProgressing(vmSnapshot) && vmSnapshot.DeletionTimestamp == nil {
+			if vmSnapshotProgressing(vmSnapshot) && vmSnapshot.DeletionTimestamp == nil && !vmSnapshotDeadlineExceeded(vmSnapshot) {
 				// attempt to lock source
 				// if fails will attempt again when source is updated
 				if !source.Locked() {
@@ -170,6 +188,10 @@ func (ctrl *VMSnapshotController) updateVMSnapshot(vmSnapshot *snapshotv1.Virtua
 		return 0, err
 	}
 
+	if retry == 0 {
+		return timeUntilDeadline(vmSnapshot), nil
+	}
+
 	return retry, nil
 }
 
@@ -184,6 +206,10 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 	if err != nil || vmSnapshot == nil {
 		return 0, err
 	}
+	if vmSnapshotDeadlineExceeded(vmSnapshot) {
+		return 0, nil
+	}
+
 	currentlyReady := vmSnapshotContentReady(content)
 	currentlyError := (content.Status != nil && content.Status.Error != nil) || vmSnapshotError(vmSnapshot) != nil
 
@@ -573,7 +599,11 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 		}
 	}
 
-	if vmSnapshotProgressing(vmSnapshotCpy) {
+	if vmSnapshotDeadlineExceeded(vmSnapshotCpy) {
+		vmSnapshotCpy.Status.Phase = snapshotv1.Failed
+		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, vmSnapshotDeadlineExceededError))
+		updateSnapshotCondition(vmSnapshotCpy, newFailureCondition(corev1.ConditionTrue, vmSnapshotDeadlineExceededError))
+	} else if vmSnapshotProgressing(vmSnapshotCpy) {
 		vmSnapshotCpy.Status.Phase = snapshotv1.InProgress
 		if source != nil {
 			if source.Locked() {

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -41,11 +41,12 @@ const (
 )
 
 var (
-	vmUID            types.UID = "vm-uid"
-	vmAPIGroup                 = "kubevirt.io"
-	storageClassName           = "rook-ceph-block"
-	t                          = true
-	f                          = false
+	vmUID             types.UID        = "vm-uid"
+	vmAPIGroup                         = "kubevirt.io"
+	storageClassName                   = "rook-ceph-block"
+	t                                  = true
+	f                                  = false
+	noFailureDeadline *metav1.Duration = &metav1.Duration{Duration: 0}
 )
 
 var _ = Describe("Snapshot controlleer", func() {
@@ -794,6 +795,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSource.Add(vm)
 
 				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.Status.Phase = snapshotv1.InProgress
 				updatedSnapshot.ResourceVersion = "1"
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
@@ -1047,6 +1049,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			})
 
 			It("should update VirtualMachineSnapshotContent", func() {
+				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
@@ -1055,6 +1058,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					CreationTime: timeFunc(),
 				}
 
+				vmSnapshotSource.Add(vmSnapshot)
 				vmSnapshotContentSource.Add(vmSnapshotContent)
 				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
 
@@ -1077,6 +1081,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			})
 
 			It("should update VirtualMachineSnapshotContent no snapshots", func() {
+				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
 				for i := range vmSnapshotContent.Spec.VolumeBackups {
 					vmSnapshotContent.Spec.VolumeBackups[i].VolumeSnapshotName = nil
@@ -1090,11 +1095,13 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 
 				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
+				vmSnapshotSource.Add(vmSnapshot)
 				addVirtualMachineSnapshotContent(vmSnapshotContent)
 				controller.processVMSnapshotContentWorkItem()
 			})
 
 			DescribeTable("should update VirtualMachineSnapshotContent on error", func(rtu bool, ct *metav1.Time) {
+				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
@@ -1103,6 +1110,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					CreationTime: ct,
 				}
 
+				vmSnapshotSource.Add(vmSnapshot)
 				vmSnapshotContentSource.Add(vmSnapshotContent)
 				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
 
@@ -1903,6 +1911,7 @@ func createVirtualMachineSnapshot(namespace, name, vmName string) *snapshotv1.Vi
 				Kind:     "VirtualMachine",
 				Name:     vmName,
 			},
+			FailureDeadline: noFailureDeadline,
 		},
 	}
 }

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
 				newReadyCondition(corev1.ConditionTrue, "Operation complete"),
 			},
+			Phase: snapshotv1.Succeeded,
 		}
 
 		return vms
@@ -87,6 +88,7 @@ var _ = Describe("Snapshot controlleer", func() {
 		vms.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 			ReadyToUse: &f,
 			SourceUID:  &vmUID,
+			Phase:      snapshotv1.InProgress,
 		}
 
 		return vms
@@ -402,6 +404,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
 					ReadyToUse: &f,
+					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "Source not locked"),
 						newReadyCondition(corev1.ConditionFalse, "Not ready"),
@@ -420,6 +423,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Finalizers = []string{"snapshot.kubevirt.io/vmsnapshot-protection"}
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					ReadyToUse: &f,
+					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionFalse, "Source does not exist"),
 						newReadyCondition(corev1.ConditionFalse, "Not ready"),
@@ -439,6 +443,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
 					ReadyToUse: &f,
+					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
 						newReadyCondition(corev1.ConditionFalse, "Not ready"),
@@ -822,6 +827,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
 					SourceUID:  &vmUID,
 					ReadyToUse: &f,
+					Phase:      snapshotv1.InProgress,
 					Conditions: []snapshotv1.Condition{
 						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
 						newReadyCondition(corev1.ConditionFalse, "Not ready"),
@@ -847,6 +853,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
 				updatedSnapshot.Status.CreationTime = timeFunc()
 				updatedSnapshot.Status.ReadyToUse = &t
+				updatedSnapshot.Status.Phase = snapshotv1.Succeeded
 				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
@@ -1176,6 +1183,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
 				updatedSnapshot.Status.CreationTime = timeFunc()
 				updatedSnapshot.Status.ReadyToUse = &t
+				updatedSnapshot.Status.Phase = snapshotv1.Succeeded
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
 					newReadyCondition(corev1.ConditionTrue, "Operation complete"),

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -391,6 +391,7 @@ func NewVirtualMachineSnapshotCrd() (*extv1.CustomResourceDefinition, error) {
 	err := addFieldsToAllVersions(crd, []extv1.CustomResourceColumnDefinition{
 		{Name: "SourceKind", Type: "string", JSONPath: ".spec.source.kind"},
 		{Name: "SourceName", Type: "string", JSONPath: ".spec.source.name"},
+		{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
 		{Name: "ReadyToUse", Type: "boolean", JSONPath: ".status.readyToUse"},
 		{Name: "CreationTime", Type: "date", JSONPath: ".status.creationTime"},
 		{Name: "Error", Type: "string", JSONPath: errorMessageJSONPath},

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11840,6 +11840,9 @@ var CRDsValidation map[string]string = map[string]string{
             type: string
           type: array
           x-kubernetes-list-type: set
+        phase:
+          description: VirtualMachineSnapshotPhase is the current phase of the VirtualMachineSnapshot
+          type: string
         readyToUse:
           type: boolean
         sourceUID:

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11768,6 +11768,11 @@ var CRDsValidation map[string]string = map[string]string{
           description: DeletionPolicy defines that to do with VirtualMachineSnapshot
             when VirtualMachineSnapshot is deleted
           type: string
+        failureDeadline:
+          description: This time represents the number of seconds we permit the vm
+            snapshot to take. In case we pass this deadline we mark this snapshot
+            as failed. Defaults to DefaultFailureDeadline - 5min
+          type: string
         source:
           description: TypedLocalObjectReference contains enough information to let
             you locate the typed referenced object inside the same namespace.

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/deepcopy_generated.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
 
@@ -438,6 +439,11 @@ func (in *VirtualMachineSnapshotSpec) DeepCopyInto(out *VirtualMachineSnapshotSp
 	if in.DeletionPolicy != nil {
 		in, out := &in.DeletionPolicy, &out.DeletionPolicy
 		*out = new(DeletionPolicy)
+		**out = **in
+	}
+	if in.FailureDeadline != nil {
+		in, out := &in.FailureDeadline, &out.FailureDeadline
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	return

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -21267,12 +21267,18 @@ func schema_client_go_apis_snapshot_v1alpha1_VirtualMachineSnapshotSpec(ref comm
 							Format: "",
 						},
 					},
+					"failureDeadline": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This time represents the number of seconds we permit the vm snapshot to take. In case we pass this deadline we mark this snapshot as failed. Defaults to DefaultFailureDeadline - 5min",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 				Required: []string{"source"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.TypedLocalObjectReference"},
+			"k8s.io/api/core/v1.TypedLocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -21300,6 +21300,12 @@ func schema_client_go_apis_snapshot_v1alpha1_VirtualMachineSnapshotStatus(ref co
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"phase": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"readyToUse": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
@@ -20,12 +20,16 @@
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/client-go/api/v1"
 )
+
+const DefaultFailureDeadline = 5 * time.Minute
 
 // VirtualMachineSnapshot defines the operation of snapshotting a VM
 // +genclient
@@ -60,6 +64,13 @@ type VirtualMachineSnapshotSpec struct {
 
 	// +optional
 	DeletionPolicy *DeletionPolicy `json:"deletionPolicy,omitempty"`
+
+	// This time represents the number of seconds we permit the vm snapshot
+	// to take. In case we pass this deadline we mark this snapshot
+	// as failed.
+	// Defaults to DefaultFailureDeadline - 5min
+	// +optional
+	FailureDeadline *metav1.Duration `json:"failureDeadline,omitempty"`
 }
 
 // Indication is a way to indicate the state of the vm when taking the snapshot

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
@@ -71,6 +71,17 @@ const (
 	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
 )
 
+// VirtualMachineSnapshotPhase is the current phase of the VirtualMachineSnapshot
+type VirtualMachineSnapshotPhase string
+
+const (
+	PhaseUnset VirtualMachineSnapshotPhase = ""
+	InProgress VirtualMachineSnapshotPhase = "InProgress"
+	Succeeded  VirtualMachineSnapshotPhase = "Succeeded"
+	Failed     VirtualMachineSnapshotPhase = "Failed"
+	Unknown    VirtualMachineSnapshotPhase = "Unknown"
+)
+
 // VirtualMachineSnapshotStatus is the status for a VirtualMachineSnapshot resource
 type VirtualMachineSnapshotStatus struct {
 	// +optional
@@ -82,6 +93,9 @@ type VirtualMachineSnapshotStatus struct {
 	// +optional
 	// +nullable
 	CreationTime *metav1.Time `json:"creationTime,omitempty"`
+
+	// +optional
+	Phase VirtualMachineSnapshotPhase `json:"phase,omitempty"`
 
 	// +optional
 	ReadyToUse *bool `json:"readyToUse,omitempty"`

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
@@ -140,6 +140,9 @@ const (
 
 	// ConditionProgressing is the "progressing" condition type
 	ConditionProgressing ConditionType = "Progressing"
+
+	// ConditionFailure is the "failure" condition type
+	ConditionFailure ConditionType = "Failure"
 )
 
 // Condition defines conditions

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types_swagger_generated.go
@@ -11,8 +11,9 @@ func (VirtualMachineSnapshot) SwaggerDoc() map[string]string {
 
 func (VirtualMachineSnapshotSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":               "VirtualMachineSnapshotSpec is the spec for a VirtualMachineSnapshot resource",
-		"deletionPolicy": "+optional",
+		"":                "VirtualMachineSnapshotSpec is the spec for a VirtualMachineSnapshot resource",
+		"deletionPolicy":  "+optional",
+		"failureDeadline": "This time represents the number of seconds we permit the vm snapshot\nto take. In case we pass this deadline we mark this snapshot\nas failed.\nDefaults to DefaultFailureDeadline - 5min\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types_swagger_generated.go
@@ -22,6 +22,7 @@ func (VirtualMachineSnapshotStatus) SwaggerDoc() map[string]string {
 		"sourceUID":                         "+optional",
 		"virtualMachineSnapshotContentName": "+optional",
 		"creationTime":                      "+optional\n+nullable",
+		"phase":                             "+optional",
 		"readyToUse":                        "+optional",
 		"error":                             "+optional",
 		"conditions":                        "+optional",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -564,11 +564,13 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 						updatedVMI.Status.FSFreezeStatus == "frozen"
 				}, 30*time.Second, 2*time.Second).Should(BeTrue())
 
+				contentName := fmt.Sprintf("%s-%s", "vmsnapshot-content", snapshot.UID)
 				Eventually(func() bool {
 					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
+					_, contentErr := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
 					return snapshot.Status != nil &&
 						len(snapshot.Status.Conditions) == 3 &&
 						snapshot.Status.Conditions[0].Status == corev1.ConditionFalse &&
@@ -579,7 +581,8 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 						snapshot.Status.Conditions[2].Type == snapshotv1.ConditionFailure &&
 						strings.Contains(snapshot.Status.Conditions[2].Reason, "snapshot deadline exceeded") &&
 						snapshot.Status.Phase == snapshotv1.Failed &&
-						updatedVMI.Status.FSFreezeStatus == ""
+						updatedVMI.Status.FSFreezeStatus == "" &&
+						errors.IsNotFound(contentErr)
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 			})
 		})
@@ -844,9 +847,11 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
+				contentName := fmt.Sprintf("%s-%s", "vmsnapshot-content", snapshot.UID)
 				Eventually(func() bool {
 					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
+					_, contentErr := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
 					return snapshot.Status != nil &&
 						len(snapshot.Status.Conditions) == 3 &&
 						snapshot.Status.Conditions[0].Status == corev1.ConditionFalse &&
@@ -856,7 +861,8 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 						snapshot.Status.Conditions[2].Status == corev1.ConditionTrue &&
 						snapshot.Status.Conditions[2].Type == snapshotv1.ConditionFailure &&
 						strings.Contains(snapshot.Status.Conditions[2].Reason, "snapshot deadline exceeded") &&
-						snapshot.Status.Phase == snapshotv1.Failed
+						snapshot.Status.Phase == snapshotv1.Failed &&
+						errors.IsNotFound(contentErr)
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 
 				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
@@ -865,11 +871,6 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				Expect(updatedVM.Finalizers).To(BeEmpty())
 
 				Expect(snapshot.Status.CreationTime).To(BeNil())
-
-				contentName := fmt.Sprintf("%s-%s", "vmsnapshot-content", snapshot.UID)
-				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(content.Status).To(BeNil())
 			})
 		})
 	})

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -513,6 +514,74 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					return updatedVMI.Status.FSFreezeStatus == ""
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 			})
+
+			It("should unfreeze vm if snapshot fails when deadline exceeded", func() {
+				dataVolume := tests.NewRandomDataVolumeWithHttpImportInStorageClass(
+					tests.GetUrl(tests.FedoraHttpUrl),
+					util.NamespaceTestDefault,
+					snapshotStorageClass,
+					corev1.ReadWriteOnce)
+				dataVolume.Spec.PVC.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("6Gi")
+				var vmi *v1.VirtualMachineInstance
+				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserData(
+					dataVolume,
+					"#cloud-config\npassword: fedora\nchpasswd: { expire: False }\npackages:\n qemu-guest-agent",
+				))
+				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Eventually(func() error {
+					var batch []expect.Batcher
+					batch = append(batch, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "sudo systemctl start qemu-guest-agent\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+						&expect.BSnd{S: "sudo systemctl enable qemu-guest-agent\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+					}...)
+
+					return console.SafeExpectBatch(vmi, batch, 120)
+				}, 720*time.Second, 1*time.Second).Should(Succeed())
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				createDenyVolumeSnapshotCreateWebhook()
+				snapshot = newSnapshot()
+				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: 40 * time.Second}
+
+				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() bool {
+					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status != nil &&
+						snapshot.Status.Phase == snapshotv1.InProgress &&
+						updatedVMI.Status.FSFreezeStatus == "frozen"
+				}, 30*time.Second, 2*time.Second).Should(BeTrue())
+
+				Eventually(func() bool {
+					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					updatedVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status != nil &&
+						len(snapshot.Status.Conditions) == 3 &&
+						snapshot.Status.Conditions[0].Status == corev1.ConditionFalse &&
+						strings.Contains(snapshot.Status.Conditions[0].Reason, "snapshot deadline exceeded") &&
+						snapshot.Status.Conditions[1].Status == corev1.ConditionFalse &&
+						strings.Contains(snapshot.Status.Conditions[1].Reason, "Not ready") &&
+						snapshot.Status.Conditions[2].Status == corev1.ConditionTrue &&
+						snapshot.Status.Conditions[2].Type == snapshotv1.ConditionFailure &&
+						strings.Contains(snapshot.Status.Conditions[2].Reason, "snapshot deadline exceeded") &&
+						snapshot.Status.Phase == snapshotv1.Failed &&
+						updatedVMI.Status.FSFreezeStatus == ""
+				}, time.Minute, 2*time.Second).Should(BeTrue())
+			})
 		})
 
 		Context("With more complicated VM", func() {
@@ -706,6 +775,101 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(snapshot.Status.Error).To(BeNil())
 				Expect(*snapshot.Status.ReadyToUse).To(BeTrue())
+			})
+
+			It("snapshot change phase to in progress and succeeded and then should not fail", func() {
+				createDenyVolumeSnapshotCreateWebhook()
+				snapshot = newSnapshot()
+				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: time.Minute}
+
+				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() bool {
+					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status != nil &&
+						len(snapshot.Status.Conditions) == 2 &&
+						snapshot.Status.Conditions[0].Status == corev1.ConditionTrue &&
+						strings.Contains(snapshot.Status.Conditions[0].Reason, "Source locked and operation in progress") &&
+						snapshot.Status.Conditions[1].Status == corev1.ConditionFalse &&
+						strings.Contains(snapshot.Status.Conditions[1].Reason, "Not ready") &&
+						snapshot.Status.Phase == snapshotv1.InProgress
+				}, 30*time.Second, 2*time.Second).Should(BeTrue())
+
+				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*updatedVM.Status.SnapshotInProgress).To(Equal(snapshot.Name))
+
+				Expect(snapshot.Status.CreationTime).To(BeNil())
+
+				contentName := fmt.Sprintf("%s-%s", "vmsnapshot-content", snapshot.UID)
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content.Status).To(BeNil())
+
+				deleteWebhook()
+
+				Eventually(func() bool {
+					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status != nil &&
+						len(snapshot.Status.Conditions) == 2 &&
+						snapshot.Status.Conditions[0].Status == corev1.ConditionFalse &&
+						strings.Contains(snapshot.Status.Conditions[0].Reason, "Operation complete") &&
+						snapshot.Status.Conditions[1].Status == corev1.ConditionTrue &&
+						strings.Contains(snapshot.Status.Conditions[1].Reason, "Operation complete") &&
+						snapshot.Status.Phase == snapshotv1.Succeeded
+				}, 30*time.Second, 2*time.Second).Should(BeTrue())
+
+				Expect(snapshot.Status.CreationTime).ToNot(BeNil())
+				content, err = virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(*content.Spec.VirtualMachineSnapshotName).To(Equal(snapshot.Name))
+				Expect(content.Spec.Source.VirtualMachine.Spec).To(Equal(vm.Spec))
+				Expect(content.Spec.VolumeBackups).Should(HaveLen(len(vm.Spec.DataVolumeTemplates)))
+
+				// Sleep to pass the time of the deadline
+				time.Sleep(time.Second)
+				// If snapshot succeeded it should not change to failure when deadline exceeded
+				Expect(snapshot.Status.Phase).To(Equal(snapshotv1.Succeeded))
+			})
+
+			It("snapshot should fail when deadline exceeded due to volume snapshots failure", func() {
+				createDenyVolumeSnapshotCreateWebhook()
+				snapshot = newSnapshot()
+				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: 40 * time.Second}
+
+				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() bool {
+					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return snapshot.Status != nil &&
+						len(snapshot.Status.Conditions) == 3 &&
+						snapshot.Status.Conditions[0].Status == corev1.ConditionFalse &&
+						strings.Contains(snapshot.Status.Conditions[0].Reason, "snapshot deadline exceeded") &&
+						snapshot.Status.Conditions[1].Status == corev1.ConditionFalse &&
+						strings.Contains(snapshot.Status.Conditions[1].Reason, "Not ready") &&
+						snapshot.Status.Conditions[2].Status == corev1.ConditionTrue &&
+						snapshot.Status.Conditions[2].Type == snapshotv1.ConditionFailure &&
+						strings.Contains(snapshot.Status.Conditions[2].Reason, "snapshot deadline exceeded") &&
+						snapshot.Status.Phase == snapshotv1.Failed
+				}, time.Minute, 2*time.Second).Should(BeTrue())
+
+				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedVM.Status.SnapshotInProgress).To(BeNil())
+				Expect(updatedVM.Finalizers).To(BeEmpty())
+
+				Expect(snapshot.Status.CreationTime).To(BeNil())
+
+				contentName := fmt.Sprintf("%s-%s", "vmsnapshot-content", snapshot.UID)
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content.Status).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
It adds a failure phase to the vm snapshot in case it takes more the defined deadline time
In such case we mark the vm snapshot as failed and clean as needed. This phase is irreversible. 

```release-note
Add phases to the vm snapshot api, specifically a failure phase
```
