### PR TITLE
network, masquerade: remove dead code

### DIFF
--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -198,21 +198,6 @@ func (b *MasqueradePodNetworkConfigurator) createBridge() error {
 	return nil
 }
 
-func (b *MasqueradePodNetworkConfigurator) skipForwardingForReservedPortsUsingNftables(proto iptables.Protocol) error {
-	chainWhereDnatIsPerformed := "output"
-	chainWhereSnatIsPerformed := "KUBEVIRT_POSTINBOUND"
-	for _, chain := range []string{chainWhereDnatIsPerformed, chainWhereSnatIsPerformed} {
-		err := b.handler.NftablesAppendRule(proto, "nat", chain,
-			"tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(PortsUsedByLiveMigration(), ", ")),
-			b.handler.GetNFTIPString(proto), "saddr", GetLoopbackAdrress(proto),
-			"counter", "return")
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func hasIstioSidecarInjectionEnabled(vmi *v1.VirtualMachineInstance) bool {
 	if val, ok := vmi.GetAnnotations()[consts.ISTIO_INJECT_ANNOTATION]; ok {
 		return strings.ToLower(val) == "true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This code removes an unused function from the masquerade infrastructure configurator; the same functionality is provided by 
https://github.com/kubevirt/kubevirt/blob/5083ee7b91bd25ce9186f0dc2d68322ee810d7c6/pkg/network/infraconfigurators/masquerade.go#L476

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
