### PR TITLE
[tests] make sure Kubevirt resource remains consistent during e2e run

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -689,7 +689,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			AfterEach(func() {
-				tests.RestoreKubeVirtResource()
+				tests.UpdateKubevirtCRAndWait(tests.E2eCR)
 
 				// Wait until virt-handler ds will have expected number of pods
 				Eventually(func() bool {


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
In order to prevent leftovers or any other unintended changes
in Kubevirt resource this patch suggests to check the resource
in BeforeTestCleanup.

The original Kubevirt resource that comes with the kubevirt cluster
will be stored in OriginalCR var. When the whole e2e test suite ends
the original kv resource will be restored. During the test suites run
the BeforeTestCleanup will check if the kv resource was changed. If it
was changed it will be restored either to the original or the the so called
e2e default configuration (that is always used by the automation)

**Special notes for your reviewer**:
I know we can refactor that area. It will come in the following PRs. The aim of this PR is to
give initial functional solution.

```release-note
NONE
```
