### PR TITLE
live-migration: initiate migration using a unix socket

### DIFF
--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -21,7 +21,6 @@ import (
 )
 
 const (
-	LibvirtLocalConnectionPort         = 22222
 	LibvirtDirectMigrationPort         = 49152
 	LibvirtBlockMigrationPort          = 49153
 	EnvoyAdminPort                     = 15000
@@ -224,7 +223,6 @@ func GetLoopbackAdrress(proto iptables.Protocol) string {
 
 func PortsUsedByLiveMigration() []string {
 	return []string{
-		fmt.Sprint(LibvirtLocalConnectionPort),
 		fmt.Sprint(LibvirtDirectMigrationPort),
 		fmt.Sprint(LibvirtBlockMigrationPort),
 	}
@@ -543,7 +541,6 @@ func getLoopbackAdrress(proto iptables.Protocol) string {
 
 func portsUsedByLiveMigration() []string {
 	return []string{
-		fmt.Sprint(LibvirtLocalConnectionPort),
 		fmt.Sprint(LibvirtDirectMigrationPort),
 		fmt.Sprint(LibvirtBlockMigrationPort),
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -74,11 +74,10 @@ import (
 )
 
 const (
-	LibvirtLocalConnectionPort = 22222
-	gpuEnvPrefix               = "GPU_PASSTHROUGH_DEVICES"
-	vgpuEnvPrefix              = "VGPU_PASSTHROUGH_DEVICES"
-	PCI_RESOURCE_PREFIX        = "PCI_RESOURCE"
-	MDEV_RESOURCE_PREFIX       = "MDEV_PCI_RESOURCE"
+	gpuEnvPrefix         = "GPU_PASSTHROUGH_DEVICES"
+	vgpuEnvPrefix        = "VGPU_PASSTHROUGH_DEVICES"
+	PCI_RESOURCE_PREFIX  = "PCI_RESOURCE"
+	MDEV_RESOURCE_PREFIX = "MDEV_PCI_RESOURCE"
 )
 
 type contextStore struct {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -68,7 +68,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 
 	const (
 		testPort                   = 1500
-		LibvirtLocalConnectionPort = 22222
 		LibvirtDirectMigrationPort = 49152
 		LibvirtBlockMigrationPort  = 49153
 	)
@@ -679,7 +678,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 
 		portsUsedByLiveMigration := func() []v1.Port {
 			return []v1.Port{
-				{Port: LibvirtLocalConnectionPort},
 				{Port: LibvirtDirectMigrationPort},
 				{Port: LibvirtBlockMigrationPort},
 			}
@@ -741,7 +739,7 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv4Protocol)).To(Succeed())
 			},
 				table.Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
-				table.Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtLocalConnectionPort, ""),
+				table.Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
 				table.Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, ""),
 				table.Entry("with custom CIDR [IPv4]", []v1.Port{}, 8080, "10.10.10.0/24"),
 			)
@@ -798,7 +796,7 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
 			},
 				table.Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
-				table.Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtLocalConnectionPort, ""),
+				table.Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
 				table.Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, ""),
 				table.Entry("with custom CIDR [IPv6]", []v1.Port{}, 8080, "fd10:10:10::/120"),
 			)


### PR DESCRIPTION
Initiate live migration directly using the unix socket proxy
exposed by the 'source' virt-handler, there's no need to have an
additional tcp proxy that tunnels the data to the local virt-handler.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It simplifies live migration by removing an 'excess' tcp proxy started on the source virt-launcher and transferring data directly to the unix socket migration proxy on the source virt-handler.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Initiate Live-Migration using a unix socket (exposed by virt-handler) instead of an additional TCP<->Unix migration proxy started by virt-launcher
```
