### PR TITLE
Add a CR option to set the libvirtd log level

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11065,6 +11065,10 @@
     "description": "LogVerbosity sets log verbosity level of  various components",
     "type": "object",
     "properties": {
+     "libvirtLogLevel": {
+      "type": "integer",
+      "format": "int32"
+     },
      "nodeVerbosity": {
       "description": "NodeVerbosity represents a map of nodes with a specific verbosity level",
       "type": "object",

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -126,6 +126,8 @@ spec:
                         description: LogVerbosity sets log verbosity level of  various
                           components
                         properties:
+                          libvirtLogLevel:
+                            type: integer
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
@@ -2023,6 +2025,8 @@ spec:
                         description: LogVerbosity sets log verbosity level of  various
                           components
                         properties:
+                          libvirtLogLevel:
+                            type: integer
                           nodeVerbosity:
                             additionalProperties:
                               type: integer

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -228,6 +228,11 @@ func (c *ClusterConfig) GetVirtLauncherVerbosity() uint {
 	return logConf.VirtLauncher
 }
 
+func (c *ClusterConfig) GetLibvirtLogLevel() int {
+	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
+	return logConf.LibvirtLogLevel
+}
+
 //GetMinCPUModel return minimal cpu which is used in node-labeller
 func (c *ClusterConfig) GetMinCPUModel() string {
 	return c.GetConfig().MinCPUModel

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -91,6 +91,7 @@ const MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION = "v1.multus-cni.io/default-network"
 const ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
 
 const ENV_VAR_LIBVIRT_DEBUG_LOGS = "LIBVIRT_DEBUG_LOGS"
+const ENV_VAR_LIBVIRT_LOG_LEVEL = "LIBVIRT_LOG_LEVEL"
 const ENV_VAR_VIRTIOFSD_DEBUG_LOGS = "VIRTIOFSD_DEBUG_LOGS"
 const ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY = "VIRT_LAUNCHER_LOG_VERBOSITY"
 
@@ -1084,6 +1085,9 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 
 	if labelValue, ok := vmi.Labels[debugLogs]; (ok && strings.EqualFold(labelValue, "true")) || virtLauncherLogVerbosity > EXT_LOG_VERBOSITY_THRESHOLD {
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_DEBUG_LOGS, Value: "1"})
+	}
+	if libvirtLogLevel := t.clusterConfig.GetLibvirtLogLevel(); libvirtLogLevel > 0 {
+		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_LOG_LEVEL, Value: strconv.Itoa(libvirtLogLevel)})
 	}
 	if labelValue, ok := vmi.Labels[virtiofsDebugLogs]; (ok && strings.EqualFold(labelValue, "true")) || virtLauncherLogVerbosity > EXT_LOG_VERBOSITY_THRESHOLD {
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_VIRTIOFSD_DEBUG_LOGS, Value: "1"})

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -479,6 +479,12 @@ func SetupLibvirt() (err error) {
 			return err
 		}
 	}
+	if envVarValue, ok := os.LookupEnv("LIBVIRT_LOG_LEVEL"); ok && (envVarValue != "0") {
+		_, err = libvirtConf.WriteString("log_level = " + envVarValue + "\n")
+		if err != nil {
+			return err
+		}
+	}
 	if envVarValue, ok := os.LookupEnv("VIRTIOFSD_DEBUG_LOGS"); ok && (envVarValue == "1") {
 		_, err = qemuConf.WriteString("virtiofsd_debug = 1\n")
 		if err != nil {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -534,6 +534,8 @@ var CRDsValidation map[string]string = map[string]string{
                 logVerbosity:
                   description: LogVerbosity sets log verbosity level of  various components
                   properties:
+                    libvirtLogLevel:
+                      type: integer
                     nodeVerbosity:
                       additionalProperties:
                         type: integer

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -21979,6 +21979,12 @@ func schema_kubevirtio_client_go_api_v1_LogVerbosity(ref common.ReferenceCallbac
 							Format: "int32",
 						},
 					},
+					"libvirtLogLevel": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"nodeVerbosity": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeVerbosity represents a map of nodes with a specific verbosity level",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1926,11 +1926,12 @@ type DeveloperConfiguration struct {
 // LogVerbosity sets log verbosity level of  various components
 // +k8s:openapi-gen=true
 type LogVerbosity struct {
-	VirtAPI        uint `json:"virtAPI,omitempty"`
-	VirtController uint `json:"virtController,omitempty"`
-	VirtHandler    uint `json:"virtHandler,omitempty"`
-	VirtLauncher   uint `json:"virtLauncher,omitempty"`
-	VirtOperator   uint `json:"virtOperator,omitempty"`
+	VirtAPI         uint `json:"virtAPI,omitempty"`
+	VirtController  uint `json:"virtController,omitempty"`
+	VirtHandler     uint `json:"virtHandler,omitempty"`
+	VirtLauncher    uint `json:"virtLauncher,omitempty"`
+	VirtOperator    uint `json:"virtOperator,omitempty"`
+	LibvirtLogLevel int  `json:"libvirtLogLevel,omitempty"`
 	// NodeVerbosity represents a map of nodes with a specific verbosity level
 	NodeVerbosity map[string]uint `json:"nodeVerbosity,omitempty"`
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -17050,6 +17050,12 @@ func schema_kubevirtio_client_go_api_v1_LogVerbosity(ref common.ReferenceCallbac
 							Format: "int32",
 						},
 					},
+					"libvirtLogLevel": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"nodeVerbosity": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeVerbosity represents a map of nodes with a specific verbosity level",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `libvirtLogLevel` option under `logVerbosity` to configure how verbose libvirtd is (lower is more verbose).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1945532

**Special notes for your reviewer**:
Used the term "LogLevel" instead of "Verbosity" because lower is more verbose

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The libvirtd log level for VMs is now configurable at the CR level
```
