### PR TITLE
patchValidation should consider kind if singular name is empty

### DIFF
--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -91,6 +91,9 @@ func addFieldsToAllVersions(crd *extv1.CustomResourceDefinition, fields ...inter
 
 func patchValidation(crd *extv1.CustomResourceDefinition, version *extv1.CustomResourceDefinitionVersion) error {
 	name := crd.Spec.Names.Singular
+	if name == "" {
+		name = strings.ToLower(crd.Spec.Names.Kind)
+	}
 
 	crd.Spec.PreserveUnknownFields = PreserveUnknownFieldsFalse
 	validation, ok := CRDsValidation[name]

--- a/pkg/virt-operator/resource/generate/components/crds_test.go
+++ b/pkg/virt-operator/resource/generate/components/crds_test.go
@@ -9,6 +9,14 @@ import (
 
 var _ = Describe("CRDs", func() {
 
+	newVirtualMachineCrdWOSingular := func() (*extv1.CustomResourceDefinition, error) {
+		crd, err := NewVirtualMachineCrd()
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		crd.Spec.Names.Singular = ""
+		return crd, err
+	}
+
 	table.DescribeTable("Should patch validation", func(crdFunc func() (*extv1.CustomResourceDefinition, error)) {
 		crd, err := crdFunc()
 		Expect(err).NotTo(HaveOccurred())
@@ -18,6 +26,7 @@ var _ = Describe("CRDs", func() {
 		}
 	},
 		table.Entry("for VM", NewVirtualMachineCrd),
+		table.Entry("for VM without singular name set", newVirtualMachineCrdWOSingular),
 		table.Entry("for VMI", NewVirtualMachineInstanceCrd),
 		table.Entry("for VMIPRESET", NewPresetCrd),
 		table.Entry("for VMIRS", NewReplicaSetCrd),


### PR DESCRIPTION
**What this PR does / why we need it**:

This fix a case when one don't want to provide singular name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
