### PR TITLE
[SIG-scale] Add density performance tests to evaluate the Kubevirt control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ functest-image-push: functest-image-build
 conformance:
 	hack/dockerized "export SKIP_OUTSIDE_CONN_TESTS=${SKIP_OUTSIDE_CONN_TESTS} && hack/conformance.sh"
 
+perftest: build-functests
+	hack/perftests.sh
+
 clean:
 	hack/dockerized "./hack/build-go.sh clean ${WHAT} && rm _out/* -rf"
 	hack/dockerized "bazel clean --expunge"

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -202,6 +202,7 @@ go_test(
         "//tests/libvmi:go_default_library",
         "//tests/network:go_default_library",
         "//tests/numa:go_default_library",
+        "//tests/performance:go_default_library",
         "//tests/reporter:go_default_library",
         "//tests/storage:go_default_library",
         "//tests/util:go_default_library",

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "density.go",
+        "framework.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tests/performance",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/containerdisk:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -1,0 +1,121 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package performance
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kvv1 "kubevirt.io/client-go/api/v1"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
+	var (
+		err        error
+		virtClient kubecli.KubevirtClient
+	)
+
+	BeforeEach(func() {
+		if !RunPerfTests {
+			Skip("Performance tests are not enabled.")
+		}
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+		tests.BeforeTestCleanup()
+	})
+
+	AfterEach(func() {
+		// ensure the metrics get scraped by Prometheus till the end, since the default Prometheus scrape interval is 30s
+		time.Sleep(30 * time.Second)
+	})
+
+	Describe("Density test", func() {
+		vmCount := 100
+		vmBatchStartupLimit := 5 * time.Minute
+
+		Context(fmt.Sprintf("[small] create a batch of %d VMIs", vmCount), func() {
+			It("should sucessfully create all VMIS", func() {
+				By("Creating a batch of VMIs")
+				createBatchVMIWithRateControl(virtClient, vmCount)
+
+				By("Waiting a batch of VMIs")
+				waitRunningVMI(virtClient, vmCount, vmBatchStartupLimit)
+			})
+		})
+	})
+})
+
+// createBatchVMIWithRateControl creates a batch of vms concurrently, uses one goroutine for each creation.
+// between creations there is an interval for throughput control
+func createBatchVMIWithRateControl(virtClient kubecli.KubevirtClient, vmCount int) {
+	for i := 1; i <= vmCount; i++ {
+		vmi := createVMISpecWithResources(virtClient)
+		By(fmt.Sprintf("Creating VMI %s", vmi.ObjectMeta.Name))
+		_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		// interval for throughput control
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func createVMISpecWithResources(virtClient kubecli.KubevirtClient) *kvv1.VirtualMachineInstance {
+	vmImage := cd.ContainerDiskFor("cirros")
+	cpuLimit := "100m"
+	memLimit := "90Mi"
+	cloudInitUserData := "#!/bin/bash\necho 'hello'\n"
+	vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmImage, cloudInitUserData)
+	vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: resource.MustParse(memLimit),
+		k8sv1.ResourceCPU:    resource.MustParse(cpuLimit),
+	}
+	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: resource.MustParse(memLimit),
+		k8sv1.ResourceCPU:    resource.MustParse(cpuLimit),
+	}
+	return vmi
+}
+
+func waitRunningVMI(virtClient kubecli.KubevirtClient, vmiCount int, timeout time.Duration) {
+	Eventually(func() int {
+		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		running := 0
+		for _, vmi := range vmis.Items {
+			if vmi.Status.Phase == kvv1.Running {
+				running++
+			}
+		}
+		return running
+	}, timeout, 10*time.Second).Should(Equal(vmiCount))
+}

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package performance
+
+import (
+	"flag"
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var RunPerfTests = false
+
+func init() {
+	flag.BoolVar(&RunPerfTests, "performance-test", false, "run performance tests. If false, all performance tests will be skiped.")
+	if ptest, _ := strconv.ParseBool(os.Getenv("KUBEVIRT_E2E_PERF_TEST")); ptest {
+		RunPerfTests = true
+	}
+}
+
+func SIGDescribe(text string, body func()) bool {
+	return Describe("[sig-performance][Serial] "+text, body)
+}
+
+func FSIGDescribe(text string, body func()) bool {
+	return FDescribe("[sig-performance][Serial] "+text, body)
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -39,6 +39,7 @@ import (
 
 	_ "kubevirt.io/kubevirt/tests/network"
 	_ "kubevirt.io/kubevirt/tests/numa"
+	_ "kubevirt.io/kubevirt/tests/performance"
 	_ "kubevirt.io/kubevirt/tests/storage"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds support for performance tests to be the basis of performance evaluation. More specifically, It enables the creation of density tests to run 100 VMs in parallel.

This test was previously merged in PR #5835 but with a Bug skipping all the functional tests. This PR is the same density as the previous PR but with the fix moving the skip logic down to the test `Description` to prevent it skip any other test. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6059 

**Special notes for your reviewer**:
We would like to integrate those tests into our CI/CD system to facilitate the evaluation of the Kubevirt control plane. The motivation of such evaluation is because code changes may affect system scalability and performance. Then, with a set of performance and scalability tests, we may identify possible performance regression in the KubeVirt control plane between PRs and new Releases.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
