### PR TITLE
Detect and report an ErrImagePull/ImagePullBackOff VM status

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1523,6 +1523,8 @@ func (c *VMController) setPrintableStatus(vm *virtv1.VirtualMachine, vmi *virtv1
 		{virtv1.VirtualMachineStatusRunning, c.isVirtualMachineStatusRunning},
 		{virtv1.VirtualMachineStatusUnschedulable, c.isVirtualMachineStatusUnschedulable},
 		{virtv1.VirtualMachineStatusProvisioning, c.isVirtualMachineStatusProvisioning},
+		{virtv1.VirtualMachineStatusErrImagePull, c.isVirtualMachineStatusErrImagePull},
+		{virtv1.VirtualMachineStatusImagePullBackOff, c.isVirtualMachineStatusImagePullBackOff},
 		{virtv1.VirtualMachineStatusStarting, c.isVirtualMachineStatusStarting},
 		{virtv1.VirtualMachineStatusCrashLoopBackOff, c.isVirtualMachineStatusCrashLoopBackOff},
 		{virtv1.VirtualMachineStatusStopped, c.isVirtualMachineStatusStopped},
@@ -1630,6 +1632,18 @@ func (c *VMController) isVirtualMachineStatusUnschedulable(vm *virtv1.VirtualMac
 		virtv1.VirtualMachineInstanceConditionType(k8score.PodScheduled),
 		k8score.ConditionFalse,
 		k8score.PodReasonUnschedulable)
+}
+
+// isVirtualMachineStatusErrImagePull determines whether the VM status field should be set to "ErrImagePull"
+func (c *VMController) isVirtualMachineStatusErrImagePull(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	syncCond := controller.NewVirtualMachineInstanceConditionManager().GetCondition(vmi, virtv1.VirtualMachineInstanceSynchronized)
+	return syncCond != nil && syncCond.Status == k8score.ConditionFalse && syncCond.Reason == ErrImagePullReason
+}
+
+// isVirtualMachineStatusImagePullBackOff determines whether the VM status field should be set to "ImagePullBackOff"
+func (c *VMController) isVirtualMachineStatusImagePullBackOff(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	syncCond := controller.NewVirtualMachineInstanceConditionManager().GetCondition(vmi, virtv1.VirtualMachineInstanceSynchronized)
+	return syncCond != nil && syncCond.Status == k8score.ConditionFalse && syncCond.Reason == ImagePullBackOffReason
 }
 
 func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1222,9 +1222,15 @@ const (
 	// VirtualMachineStatusUnknown indicates that the state of the virtual machine could not be obtained,
 	// typically due to an error in communicating with the host on which it's running.
 	VirtualMachineStatusUnknown VirtualMachinePrintableStatus = "Unknown"
-	// VirtualMachineStatusUnschedulable indicates that an error has occurred while scheduling the virtual machime,
+	// VirtualMachineStatusUnschedulable indicates that an error has occurred while scheduling the virtual machine,
 	// e.g. due to unsatisfiable resource requests or unsatisfiable scheduling constraints.
 	VirtualMachineStatusUnschedulable VirtualMachinePrintableStatus = "FailedUnschedulable"
+	// VirtualMachineStatusErrImagePull indicates that an error has occured while pulling an image for
+	// a containerDisk VM volume.
+	VirtualMachineStatusErrImagePull VirtualMachinePrintableStatus = "ErrImagePull"
+	// VirtualMachineStatusImagePullBackOff indicates that an error has occured while pulling an image for
+	// a containerDisk VM volume, and that kubelet is backing off before retrying.
+	VirtualMachineStatusImagePullBackOff VirtualMachinePrintableStatus = "ImagePullBackOff"
 )
 
 // VirtualMachineStartFailure tracks VMIs which failed to transition successfully

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -723,6 +723,28 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}),
 		)
 
+		It("[test_id:6869]should report an error status when image pull error occurs", func() {
+			vmi := tests.NewRandomVMIWithEphemeralDisk("no-such-image")
+
+			vm := createVirtualMachine(true, vmi)
+
+			vmPrintableStatus := func() v1.VirtualMachinePrintableStatus {
+				updatedVm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return updatedVm.Status.PrintableStatus
+			}
+
+			By("Verifying that the status toggles between ErrImagePull and ImagePullBackOff")
+			const times = 2
+			for i := 0; i < times; i++ {
+				Eventually(vmPrintableStatus, 300*time.Second, 1*time.Second).
+					Should(Equal(v1.VirtualMachineStatusErrImagePull))
+
+				Eventually(vmPrintableStatus, 300*time.Second, 1*time.Second).
+					Should(Equal(v1.VirtualMachineStatusImagePullBackOff))
+			}
+		})
+
 		Context("Using virtctl interface", func() {
 			It("[test_id:1529]should start a VirtualMachineInstance once", func() {
 				By("getting a VM")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the VM status field (`.status.printableStatus`) with new `ErrImagePull`/`ImagePullBackOff` statuses, reported when an error occurs when pulling a container image for the VM.

This will typically indicate that one of the container disks of the VM has failed to be pulled, but may also indicate that there was an error pulling the virt-launcher image or one of its init container images.

**Special notes for your reviewer**:

This was implemented by first propagating the `ErrImagePull`/`ImagePullBackOff` container status from the virt-launcher pod, to the VMI conditions (Synchronized=False, Reason: `ErrImagePull`/`ImagePullBackOff`), and then from the VMI to the VM's status.

This approach involves additional updates to the VMI object. Alternatively, we could have avoided that by adding a pod informer to the VM controller, and propagate the status directly from the pod to the VM (without updating the VMI). But there's a caveat too:
- If we configure the pod informer callbacks to trigger the controller with each pod update, then we add quite a lot of additional processing to the VM controller. This is not necessarily better than additional VMI updates.
- If we avoid pod informer callbacks in the VM controller, we won't be able to track the ErrImagePull-->ImagePullBackOff transitions in the pod, so we'll have to just report a single value in the VM status.

Eventually, I chose the pod-->VMI-->VM approach since it's (1) able to report both ErrImagePull, ImagePullBackOff statuses from the pod, and (2) provides visibility to this kind of error via the VMI object too.


**Release note**:
```release-note
Report ErrImagePull/ImagePullBackOff VM status when image pull errors occur
```
