### PR TITLE
network: remove MTU link validation from the pod links

### DIFF
--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -73,10 +73,6 @@ func (b *BridgePodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceName 
 		b.vmMac = &b.podNicLink.Attrs().HardwareAddr
 	}
 
-	if err := validateMTU(b.podNicLink.Attrs().MTU); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -22,8 +22,6 @@
 package infraconfigurators
 
 import (
-	"fmt"
-
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
@@ -46,13 +44,6 @@ func createAndBindTapToBridge(handler netdriver.NetworkHandler, deviceName strin
 		return err
 	}
 	return handler.BindTapDeviceToBridge(deviceName, bridgeIfaceName)
-}
-
-func validateMTU(mtu int) error {
-	if mtu < 0 || mtu > 65535 {
-		return fmt.Errorf("MTU value out of range ")
-	}
-	return nil
 }
 
 func calculateNetworkQueues(vmi *v1.VirtualMachineInstance) uint32 {

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -65,10 +65,6 @@ func (b *MasqueradePodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceN
 	}
 	b.podNicLink = link
 
-	if err := validateMTU(b.podNicLink.Attrs().MTU); err != nil {
-		return err
-	}
-
 	if err := b.computeIPv4GatewayAndVmIp(); err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -337,26 +337,7 @@ var _ = Describe("Pod Network", func() {
 			api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 			TestPodInterfaceIPBinding(vm, domain)
 		})
-		It("should return an error if the MTU is out or range", func() {
-			primaryPodInterface = &netlink.GenericLink{LinkAttrs: netlink.LinkAttrs{Index: 1, MTU: 65536}}
-			domain := NewDomainWithBridgeInterface()
-			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 
-			api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
-
-			mockNetwork.EXPECT().ReadIPAddressesFromLink(primaryPodInterfaceName).Return("", "", nil)
-			mockNetwork.EXPECT().LinkByName(primaryPodInterfaceName).Return(primaryPodInterface, nil).Times(2)
-			mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_ALL).Return(addrList, nil)
-			mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_V4).Return(addrList, nil)
-			mockNetwork.EXPECT().GetMacDetails(primaryPodInterfaceName).Return(fakeMac, nil)
-			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
-			mockNetwork.EXPECT().RouteList(primaryPodInterface, netlink.FAMILY_V4).Return(routeList, nil)
-
-			podnic, err := newPhase1PodNIC(vm, &vm.Spec.Networks[0], mockNetwork, cacheFactory, &pid)
-			Expect(err).ToNot(HaveOccurred())
-			err = podnic.PlugPhase1()
-			Expect(err).To(HaveOccurred())
-		})
 		Context("func filterPodNetworkRoutes()", func() {
 			defRoute := netlink.Route{
 				Gw: net.IPv4(10, 35, 0, 1),


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR removes MTU link validation from the pod links.

It is redundant to check that the links read from the kernel have valid MTUs since you cannot create a link with an invalid MTU.

As such, I'm removing both the MTU and the test that assures it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
