### PR TITLE
[tests] fix cert rotation test in operator test suite

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -455,7 +455,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
-			Eventually(func() error {
+			Consistently(func() error {
 				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
 
 				return err


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Negative tests were using the Eventually wrapper while
it needs to use a Consistently wrapper since the error
that should be produced should happen in a consistent
manner rather than eventual.

```release-note
NONE
```
