### PR TITLE
Increase VM creation timeout in VmWatch test

### DIFF
--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -28,7 +28,8 @@ const (
 
 	// Define a timeout for read operations in order to prevent test hanging
 	statusChangeTimeout = 10 * time.Minute
-	vmCreationTimeout   = 1 * time.Minute
+	vmCreationTimeout   = 2 * time.Minute
+	vmRecreationTimeout = 5 * time.Minute
 	vmMigrationTimeout  = 5 * time.Minute
 
 	vmAgeRegex   = "^[0-9]+[sm]$"
@@ -420,7 +421,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			}
 
 			return false
-		}, vmCreationTimeout, 1*time.Second).Should(BeTrue())
+		}, vmRecreationTimeout, 1*time.Second).Should(BeTrue())
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up PR to #6030 with another attempt to stabilize the [flaky](https://search.ci.kubevirt.io/?search=VmWatch) [VmWatch test](https://github.com/zcahana/kubevirt/blob/ecaaf34277a5a4361426125ba5f371b6678ac52f/tests/vm_watch_test.go#L144).

Based on [this failure](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-cgroupsv2/1416805188089417728#1:build-log.txt%3A5563), it appears that there isn't sufficient time for the VMI to get recreated - the allotted time (previously 1m, now 5m) should allow both for the deletion of the old VMI (which sometimes takes a while, or even completely hang as in #6037), and the creation of another one.

**Release note**:
```release-note
NONE
```
