### PR TITLE
configure virt-handler max-device with kubelet maxPods

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -98,7 +98,7 @@ const (
 	podIpAddress = ""
 
 	// This value is derived from default MaxPods in Kubelet Config
-	maxDevices = 110
+	maxDevices = 1000
 
 	maxRequestsInFlight = 3
 	// Default port that virt-handler listens to console requests

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -97,7 +97,7 @@ const (
 
 	podIpAddress = ""
 
-	// This value is derived from default MaxPods in Kubelet Config
+	// This value reflects in the max number of VMIs per node
 	maxDevices = 1000
 
 	maxRequestsInFlight = 3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the recent [SIG-scale meeting](https://docs.google.com/document/d/1d_b2o05FfBG37VwlC2Z1ZArnT9-_AEJoQTe7iKaQZ6I/edit#heading=h.50eclt5fctl9), we are discussing to run a scale test with more than 110 VMIs per node. It is trivial to increase the max number of pods per node, but the max number of VMIs is not straightforward. 

Currently, `virt-handler` already have `max-devices` flag to increase the number of VMs per node
https://github.com/kubevirt/kubevirt/blob/0514a664151863d901d90694feb08c86df0076bb/cmd/virt-handler/virt-handler.go#L527 However, the `virt-handler` configuration is determined by the `virt-operator` that reverts all changes in the `virt-handler` Daemonset during the  strict-reconciliation.

This PR change `virt-handler` to detect the per node pod limit and use that as our VMI limit (`max-devices`), instead of using the hardcoded 110. 

This PR is related to #6082

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>
