### PR TITLE
Remove the last operator test from quarantine

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1621,7 +1621,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[QUARANTINE][sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
+		It("[sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
During the last stability check period we didn't
got any failure from operator tests so it's now
the time to remove also the last one from
the quarantine.

**Special notes for your reviewer**:
only removing an operator test from quarantine.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
