### PR TITLE
network: delete duplicated function getEnvoyLoopbackAddress

### DIFF
--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -512,7 +512,7 @@ func (b *MasqueradePodNetworkConfigurator) geVmIfaceIpByProtocol(proto iptables.
 func (b *MasqueradePodNetworkConfigurator) getSrcAddressesToSnat(proto iptables.Protocol) string {
 	addresses := []string{getLoopbackAdrress(proto)}
 	if hasIstioSidecarInjectionEnabled(b.vmi) && proto == iptables.ProtocolIPv4 {
-		addresses = append(addresses, getEnvoyLoopbackAddress())
+		addresses = append(addresses, GetEnvoyLoopbackAddress())
 	}
 	return fmt.Sprintf("{ %s }", strings.Join(addresses, ", "))
 }
@@ -527,10 +527,6 @@ func (b *MasqueradePodNetworkConfigurator) getDstAddressesToDnat(proto iptables.
 		addresses = append(addresses, ipv4)
 	}
 	return fmt.Sprintf("{ %s }", strings.Join(addresses, ", ")), nil
-}
-
-func getEnvoyLoopbackAddress() string {
-	return "127.0.0.6"
 }
 
 func getLoopbackAdrress(proto iptables.Protocol) string {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
Deletes duplicated function that sneaked in probably during rebase

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
