### PR TITLE
[virt-operator] add validation for the infra and workloads placement config in Kubevirt CR

### DIFF
--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -15,7 +15,10 @@ go_library(
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -20,11 +20,17 @@
 package webhooks
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -60,6 +66,14 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *
 
 	results = append(results, validateCustomizeComponents(newKV.Spec.CustomizeComponents)...)
 	results = append(results, validateCertificates(newKV.Spec.CertificateRotationStrategy.SelfSigned)...)
+
+	if newKV.Spec.Infra != nil && newKV.Spec.Infra.NodePlacement != nil {
+		results = append(results, validateInfraPlacement(newKV.Spec.Infra.NodePlacement, admitter.Client)...)
+	}
+
+	if newKV.Spec.Workloads != nil && newKV.Spec.Workloads.NodePlacement != nil {
+		results = append(results, validateWorkloadPlacement(newKV.Spec.Workloads.NodePlacement, admitter.Client)...)
+	}
 
 	return validating_webhooks.NewAdmissionResponse(results)
 }
@@ -157,6 +171,119 @@ func validateCertificates(certConfig *v1.KubeVirtSelfSignConfiguration) []metav1
 		statuses = append(statuses, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("Certificate duration cannot exceed CA (spec.certificateRotationStrategy.selfSigned.server.duration > spec.certificateRotationStrategy.selfSigned.ca.duration)"),
+		})
+	}
+
+	return statuses
+}
+
+//validateWorkloadPlacement
+func validateWorkloadPlacement(placementConfig *v1.NodePlacement, client kubecli.KubevirtClient) []metav1.StatusCause {
+	statuses := []metav1.StatusCause{}
+
+	const (
+		dsName    = "placement-validation-webhook"
+		namespace = "default"
+		mockLabel = "kubevirt.io/choose-me"
+		podName   = "placement-verification-pod"
+		mockUrl   = "test.only:latest"
+	)
+
+	mockDaemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dsName,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					mockLabel: "",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: podName,
+					Labels: map[string]string{
+						mockLabel: "",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  podName,
+							Image: mockUrl,
+						},
+					},
+					// Inject placement fields here
+					NodeSelector: placementConfig.NodeSelector,
+					Affinity:     placementConfig.Affinity,
+					Tolerations:  placementConfig.Tolerations,
+				},
+			},
+		},
+	}
+
+	_, err := client.AppsV1().DaemonSets(namespace).Create(context.Background(), mockDaemonSet, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+
+	if err != nil {
+		statuses = append(statuses, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: err.Error(),
+		})
+	}
+	return statuses
+}
+
+func validateInfraPlacement(placementConfig *v1.NodePlacement, client kubecli.KubevirtClient) []metav1.StatusCause {
+	statuses := []metav1.StatusCause{}
+
+	const (
+		deploymentName = "placement-validation-webhook"
+		namespace      = "default"
+		mockLabel      = "kubevirt.io/choose-me"
+		podName        = "placement-verification-pod"
+		mockUrl        = "test.only:latest"
+	)
+
+	mockDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: deploymentName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					mockLabel: "",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: podName,
+					Labels: map[string]string{
+						mockLabel: "",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  podName,
+							Image: mockUrl,
+						},
+					},
+					// Inject placement fields here
+					NodeSelector: placementConfig.NodeSelector,
+					Affinity:     placementConfig.Affinity,
+					Tolerations:  placementConfig.Tolerations,
+				},
+			},
+		},
+	}
+
+	_, err := client.AppsV1().Deployments(namespace).Create(context.Background(), mockDeployment, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+
+	if err != nil {
+		statuses = append(statuses, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: err.Error(),
 		})
 	}
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2172,7 +2172,7 @@ spec:
 			patchKvWorkloads(nil, false, "")
 		})
 
-		It("should reject infra placement configuration with incorrect toleraion operator", func() {
+		It("should reject infra placement configuration with incorrect toleration operator", func() {
 			incorrectOperator := "foo"
 			incorrectWorkload := v1.ComponentConfig{
 				NodePlacement: &v1.NodePlacement{


### PR DESCRIPTION
Added validation for the `Spec.infra` and `Spec.workloads` sections in Kubevirt CR. 
Validation code placed in the virt-operator webhook code, and it will happen upon CR update.
Added functional test coverage as well.

**What this PR does / why we need it**:
Since we weren't fail fast on incorrect configuration, the apply of this configuration on the control place deployments/DS 
would fail and we will have inconsistent state of the control plane deployment. 

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1938262

**Special notes for your reviewer**:
More refactoring in the virt-operator functest area will come in following PRs..

**Release note**:
```release-note
NONE
```
