### PR TITLE
Detect and report a FailedUnschedulable VM status

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1331,6 +1331,7 @@ func (c *VMController) setPrintableStatus(vm *virtv1.VirtualMachine, vmi *virtv1
 		{virtv1.VirtualMachineStatusMigrating, c.isVirtualMachineStatusMigrating},
 		{virtv1.VirtualMachineStatusPaused, c.isVirtualMachineStatusPaused},
 		{virtv1.VirtualMachineStatusRunning, c.isVirtualMachineStatusRunning},
+		{virtv1.VirtualMachineStatusUnschedulable, c.isVirtualMachineStatusUnschedulable},
 		{virtv1.VirtualMachineStatusProvisioning, c.isVirtualMachineStatusProvisioning},
 		{virtv1.VirtualMachineStatusStarting, c.isVirtualMachineStatusStarting},
 		{virtv1.VirtualMachineStatusStopped, c.isVirtualMachineStatusStopped},
@@ -1407,6 +1408,14 @@ func (c *VMController) isVirtualMachineStatusTerminating(vm *virtv1.VirtualMachi
 // isVirtualMachineStatusPaused determines whether the VM status field should be set to "Migrating".
 func (c *VMController) isVirtualMachineStatusMigrating(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
 	return vmi != nil && migrations.IsMigrating(vmi)
+}
+
+// isVirtualMachineStatusUnschedulable determines whether the VM status field should be set to "FailedUnschedulable".
+func (c *VMController) isVirtualMachineStatusUnschedulable(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	return controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatusAndReason(vmi,
+		virtv1.VirtualMachineInstanceConditionType(k8score.PodScheduled),
+		k8score.ConditionFalse,
+		k8score.PodReasonUnschedulable)
 }
 
 func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1215,6 +1215,9 @@ const (
 	// VirtualMachineStatusUnknown indicates that the state of the virtual machine could not be obtained,
 	// typically due to an error in communicating with the host on which it's running.
 	VirtualMachineStatusUnknown VirtualMachinePrintableStatus = "Unknown"
+	// VirtualMachineStatusUnschedulable indicates that an error has occurred while scheduling the virtual machime,
+	// e.g. due to unsatisfiable resource requests or unsatisfiable scheduling constraints.
+	VirtualMachineStatusUnschedulable VirtualMachinePrintableStatus = "FailedUnschedulable"
 )
 
 // VirtualMachineStatus represents the status returned by the

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -693,6 +693,36 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Should(Equal(k8sv1.ConditionFalse))
 		})
 
+		table.DescribeTable("[test_id:todo]should report an error status when VM scheduling error occurs", func(unschedulableFunc func(vmi *v1.VirtualMachineInstance)) {
+			vmi := tests.NewRandomVMIWithEphemeralDisk("no-such-image")
+			unschedulableFunc(vmi)
+
+			vm := createVirtualMachine(true, vmi)
+
+			vmPrintableStatus := func() v1.VirtualMachinePrintableStatus {
+				updatedVm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return updatedVm.Status.PrintableStatus
+			}
+
+			By("Verifying that the VM status eventually gets set to FailedUnschedulable")
+			Eventually(vmPrintableStatus, 300*time.Second, 1*time.Second).
+				Should(Equal(v1.VirtualMachineStatusUnschedulable))
+		},
+			table.Entry("unsatisfiable resource requirements", func(vmi *v1.VirtualMachineInstance) {
+				vmi.Spec.Domain.Resources.Requests = corev1.ResourceList{
+					// This may stop working sometime around 2040
+					corev1.ResourceMemory: resource.MustParse("1Ei"),
+					corev1.ResourceCPU:    resource.MustParse("1M"),
+				}
+			}),
+			table.Entry("unsatisfiable scheduling constraints", func(vmi *v1.VirtualMachineInstance) {
+				vmi.Spec.NodeSelector = map[string]string{
+					"node-label": "that-doesnt-exist",
+				}
+			}),
+		)
+
 		Context("Using virtctl interface", func() {
 			It("[test_id:1529]should start a VirtualMachineInstance once", func() {
 				By("getting a VM")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the VM status field (`.status.printableStatus`) with a new `FailedUnschedulable` status, reported when an error occurs while scheduling the virt-launcher pod for the VM.

This will typically indicate that the VM was configured with unsatisfiable resource requests (e.g., too much memory requested), or unsatisfiable scheduling constraints (e.g., invalid node selector, missing tolerations, ...).

**Special notes for your reviewer**:

Related PR inflight: #6078

**Release note**:
```release-note
Report FailedUnschedulable VM status when scheduling errors occur
```
