### PR TITLE
allow users to set MaxDevices on KubeVirt CR

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10871,6 +10871,10 @@
       "items": {
        "type": "string"
       }
+     },
+     "virtualMachineInstancesPerNode": {
+      "type": "integer",
+      "format": "int32"
      }
     }
    },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -295,6 +295,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  virtualMachineInstancesPerNode:
+                    type: integer
                 type: object
               customizeComponents:
                 properties:
@@ -2192,6 +2194,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  virtualMachineInstancesPerNode:
+                    type: integer
                 type: object
               customizeComponents:
                 properties:

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/resource/generate/install:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -30,6 +30,7 @@ import (
 	"github.com/blang/semver"
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	secv1 "github.com/openshift/api/security/v1"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -715,6 +715,8 @@ var CRDsValidation map[string]string = map[string]string{
               items:
                 type: string
               type: array
+            virtualMachineInstancesPerNode:
+              type: integer
           type: object
         customizeComponents:
           properties:

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -2015,6 +2015,11 @@ func (in *KubeVirtConfiguration) DeepCopyInto(out *KubeVirtConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	if in.VirtualMachineInstancesPerNode != nil {
+		in, out := &in.VirtualMachineInstancesPerNode, &out.VirtualMachineInstancesPerNode
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -21595,6 +21595,12 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							},
 						},
 					},
+					"virtualMachineInstancesPerNode": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1874,11 +1874,12 @@ type KubeVirtConfiguration struct {
 	DefaultRuntimeClass    string                  `json:"defaultRuntimeClass,omitempty"`
 	SMBIOSConfig           *SMBiosConfiguration    `json:"smbios,omitempty"`
 	// deprecated
-	SupportedGuestAgentVersions []string              `json:"supportedGuestAgentVersions,omitempty"`
-	MemBalloonStatsPeriod       *uint32               `json:"memBalloonStatsPeriod,omitempty"`
-	PermittedHostDevices        *PermittedHostDevices `json:"permittedHostDevices,omitempty"`
-	MinCPUModel                 string                `json:"minCPUModel,omitempty"`
-	ObsoleteCPUModels           map[string]bool       `json:"obsoleteCPUModels,omitempty"`
+	SupportedGuestAgentVersions    []string              `json:"supportedGuestAgentVersions,omitempty"`
+	MemBalloonStatsPeriod          *uint32               `json:"memBalloonStatsPeriod,omitempty"`
+	PermittedHostDevices           *PermittedHostDevices `json:"permittedHostDevices,omitempty"`
+	MinCPUModel                    string                `json:"minCPUModel,omitempty"`
+	ObsoleteCPUModels              map[string]bool       `json:"obsoleteCPUModels,omitempty"`
+	VirtualMachineInstancesPerNode *int                  `json:"virtualMachineInstancesPerNode,omitempty"`
 }
 
 //

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -16653,6 +16653,12 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							},
 						},
 					},
+					"virtualMachineInstancesPerNode": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allows the user to easily modify the number of VMIs they would like to run per node

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6082

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VirtualMachineInstancesPerNode to KubeVirt CR under Spec.Configuration
```
