### PR TITLE
Allow NET_BIND_SERVICE in the virt-controller SCC

### DIFF
--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -74,7 +74,12 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyRunAsAny,
 	}
-	scc.AllowedCapabilities = []corev1.Capability{"SYS_NICE"}
+	scc.AllowedCapabilities = []corev1.Capability{
+		// add a CAP_SYS_NICE capability to allow setting cpu affinity
+		"SYS_NICE",
+		// add CAP_NET_BIND_SERVICE capability to allow dhcp and slirp operations
+		"NET_BIND_SERVICE",
+	}
 	scc.AllowHostDirVolumePlugin = true
 	scc.AllowHostNetwork = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}


### PR DESCRIPTION
**What this PR does / why we need it**:

NET_BIND_SERVICE is right now explicitly requested to make the
requirement explicit. It needs to be added to the SCC too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix virt-controller SCC: Reflect the need for NET_BIND_SERVICE in the virt-controller SCC.
```
