### PR TITLE
Configure VFIO for non-root & tun device

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -97,6 +97,12 @@ func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bo
 	return WantVirtioNetDevice(vmi) && !allowEmulation
 }
 
+func NeedTunDevice(vmi *v1.VirtualMachineInstance) bool {
+	return (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
+		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
+		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true)
+}
+
 // UseSoftwareEmulationForDevice determines whether to fallback to software emulation for the given device.
 // This happens when the given device doesn't exist, and software emulation is enabled.
 func UseSoftwareEmulationForDevice(devicePath string, allowEmulation bool) (bool, error) {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -363,10 +363,6 @@ func canBeNonRoot(vmi *v1.VirtualMachineInstance) error {
 	if util.IsVMIVirtiofsEnabled(vmi) {
 		return fmt.Errorf("VirtioFS doesn't work with session mode(used by nonroot)")
 	}
-
-	if util.IsSRIOVVmi(vmi) {
-		return fmt.Errorf("SRIOV doesn't work with nonroot")
-	}
 	return nil
 }
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -935,20 +935,6 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			Expect(meta.Annotations).To(HaveKeyWithValue("kubevirt.io/nonroot", ""))
 		})
 
-		It("Should reject SRIOV vmi", func() {
-			vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces,
-				v1.Interface{
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						SRIOV: &v1.InterfaceSRIOV{},
-					},
-				},
-			)
-
-			resp := admitVMI()
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Message).To(And(ContainSubstring("SRIOV"), ContainSubstring("nonroot")))
-		})
-
 		It("Should reject VirtioFS vmi", func() {
 			vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
 				Virtiofs: &v1.FilesystemVirtiofs{},

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1812,9 +1812,7 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance, config *virtconfig.
 
 func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k8sv1.ResourceList {
 	res := k8sv1.ResourceList{}
-	if (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
-		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
-		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true) {
+	if util.NeedTunDevice(vmi) {
 		res[TunDevice] = resource.MustParse("1")
 	}
 	if util.NeedVirtioNetDevice(vmi, allowEmulation) {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -745,8 +745,6 @@ var _ = Describe("[Serial]SRIOV", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.SkipIfNonRoot(virtClient, "SRIOV")
-
 		// Check if the hardware supports SRIOV
 		if err := validateSRIOVSetup(virtClient, sriovResourceName, 1); err != nil {
 			Skip("Sriov is not enabled in this environment. Skip these tests using - export FUNC_TEST_ARGS='--ginkgo.skip=SRIOV'")

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -13,7 +13,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -33,16 +32,6 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 		tests.BeforeTestCleanup()
 	})
 
-	sriovVM := func() *v1.VirtualMachineInstance {
-		name := "test"
-		withVmiOptions := []libvmi.Option{
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(name)),
-			libvmi.WithNetwork(libvmi.MultusNetwork(name, name)),
-		}
-
-		return libvmi.NewSriovFedora(withVmiOptions...)
-	}
-
 	virtioFsVM := func() *v1.VirtualMachineInstance {
 		name := "test"
 		return tests.NewRandomVMIWithPVCFS(name)
@@ -59,7 +48,6 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 		Expect(err.Error()).To(And(ContainSubstring(feature), ContainSubstring("nonroot")))
 
 	},
-		table.Entry("[test_id:7126]SRIOV", sriovVM, "", "SRIOV"),
 		table.Entry("[test_id:7127]VirtioFS", virtioFsVM, virtconfig.VirtIOFSGate, "VirtioFS"),
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This will enable SRIOV VMs with non-root implementation.

`/dev/vfio/vfio` is changed to `0666`
`/dev/vfio/{group}` ownership is changed to `qemu`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
[Nonroot] SRIOV is now available.
```
