### PR TITLE
network, tests: address vmi_multus sonarcloud

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1391,6 +1391,7 @@ func getInterfaceNetworkNameByMAC(vmi *v1.VirtualMachineInstance, macAddress str
 // Set creates a linux bridge and configures the firewall. We use iptables-compat in order to work with
 // both iptables and newer nftables.
 func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
+	const networkConfigName = "network-config"
 
 	// Fetching the kubevirt-operator image from the pod makes this independent from the installation method / image used
 	pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-handler"})
@@ -1406,21 +1407,21 @@ func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
 			Kind:       "DaemonSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "network-config",
+			Name:      networkConfigName,
 			Namespace: metav1.NamespaceSystem,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": "network-config"},
+				MatchLabels: map[string]string{"name": networkConfigName},
 			},
 			Template: k8sv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": "network-config"},
+					Labels: map[string]string{"name": networkConfigName},
 				},
 				Spec: k8sv1.PodSpec{
 					Containers: []k8sv1.Container{
 						{
-							Name: "network-config",
+							Name: networkConfigName,
 							// Reuse image which is already installed in the cluster. All we need is chroot.
 							// Local OKD cluster doesn't allow us to pull from the outside.
 							Image: virtHandlerImage,

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -803,8 +803,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, sriovnet1, sriovResourceName)).To(Succeed())
+			Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, sriovnet1, sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
 
@@ -825,8 +824,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, sriovnet1, sriovResourceName)).To(Succeed())
+			Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, sriovnet1, sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
 
@@ -857,8 +855,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, sriovnet1, sriovResourceName)).To(Succeed())
+			Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, sriovnet1, sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
 
@@ -896,9 +893,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variables are defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			for _, name := range sriovNetworks {
-				Expect(validatePodKubevirtResourceName(virtClient, vmiPod, name, sriovResourceName)).To(Succeed())
+				Expect(validatePodKubevirtResourceNameByVMI(virtClient, vmi, name, sriovResourceName)).To(Succeed())
 			}
 
 			checkDefaultInterfaceInPod(vmi)
@@ -1512,10 +1508,10 @@ func validateSRIOVSetup(virtClient kubecli.KubevirtClient, sriovResourceName str
 	return nil
 }
 
-func validatePodKubevirtResourceName(virtClient kubecli.KubevirtClient, vmiPod *k8sv1.Pod, networkName, sriovResourceName string) error {
+func validatePodKubevirtResourceNameByVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, networkName, sriovResourceName string) error {
 	out, err := tests.ExecuteCommandOnPod(
 		virtClient,
-		vmiPod,
+		tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace),
 		"compute",
 		[]string{"sh", "-c", fmt.Sprintf("echo $KUBEVIRT_RESOURCE_NAME_%s", networkName)},
 	)


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>


**What this PR does / why we need it**:
Addresses sonarcloud issues in vmi_multus tests

Commit 1:
- [linux-bridge duplication](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXg5J8ZUey6zG9Z1SjlP&resolved=false&types=CODE_SMELL)
- [ptp-conf-1 duplication](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXpaVJkQ6dE-hQjgpuho&resolved=false&types=CODE_SMELL)
- [ptp-conf-2 dup](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXg5J8ZUey6zG9Z1SjlJ&resolved=false&types=CODE_SMELL)
- [cloud init data duplication](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXg5J8ZUey6zG9Z1SjlG&resolved=false&types=CODE_SMELL) and [here](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXrjd9DfmKbceZzJJw7E&resolved=false&types=CODE_SMELL)
- ip address dup [1](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXg5J8ZUey6zG9Z1SjlH&resolved=false&types=CODE_SMELL) [2](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXrjd9DfmKbceZzJJw7F&resolved=false&types=CODE_SMELL)

Commit 2:
-   [network config name duplication](https://sonarcloud.io/project/issues?fileUuids=AXg5J8E-ey6zG9Z1Sjkn&id=kubevirt_kubevirt&open=AXg5J8ZUey6zG9Z1SjlE&resolved=false&types=CODE_SMELL) 

Commit 3:
- Several tests fetch pod of a VMI and check in-pod
env variable KUBEVIRT_RESOURCE_NAME_<networkName>
is set with correct value. Adding a function to
simplify that and remove some code duplication.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
