### PR TITLE
tests: Fix the istio test to actually perform the required check

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -337,7 +337,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					It("Should not be able to reach http service outside of mesh", func() {
 						Eventually(func() error {
 							return checkHTTPServiceReturnCode(serverVMIAddress, testPort, generateExpectedHTTPReturnCodeRegex("5.."))
-						}, externalServiceCheckTimeout, externalServiceCheckInterval)
+						}, externalServiceCheckTimeout, externalServiceCheckInterval).Should(Succeed())
 					})
 				})
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The `Istio Virtual Machine with masquerade interface Outbound traffic With Sidecar allowing only registered external services VMI with no explicit ports Should not be able to reach http service outside of mesh` what missing the part that actually verified the test
succeeded. This PR fixes it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
