### PR TITLE
[virt-controller]: Refactor renderLaunchManifest function

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1278,6 +1278,13 @@ func renderLaunchManifestVolumes(t *templateService, vmi *v1.VirtualMachineInsta
 	var imagePullSecrets []k8sv1.LocalObjectReference
 	serviceAccountName := ""
 
+	// This detects hotplug volumes for a started but not ready VMI
+	for _, volume := range vmi.Spec.Volumes {
+		if (volume.DataVolume != nil && volume.DataVolume.Hotpluggable) || (volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable) {
+			hotplugVolumes[volume.Name] = true
+		}
+	}
+
 	for _, volume := range vmi.Spec.Volumes {
 		if hotplugVolumes[volume.Name] {
 			continue
@@ -1579,13 +1586,6 @@ func renderLaunchManifestVolumes(t *templateService, vmi *v1.VirtualMachineInsta
 		imagePullSecrets = appendUniqueImagePullSecret(imagePullSecrets, k8sv1.LocalObjectReference{
 			Name: t.imagePullSecret,
 		})
-	}
-
-	// This detects hotplug volumes for a started but not ready VMI
-	for _, volume := range vmi.Spec.Volumes {
-		if (volume.DataVolume != nil && volume.DataVolume.Hotpluggable) || (volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable) {
-			hotplugVolumes[volume.Name] = true
-		}
 	}
 
 	return volumes, volumeDevices, volumeMounts, imagePullSecrets, serviceAccountName, nil

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -514,8 +514,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 
 	var command []string
 	if tempPod {
-		logger := log.DefaultLogger()
-		logger.Infof("RUNNING doppleganger pod for %s", vmi.Name)
+		log.Log.Infof("RUNNING pod to pre bind pvc for %s", vmi.Name)
 		command = []string{"/bin/bash",
 			"-c",
 			"echo", "bound PVCs"}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -451,10 +451,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
 	domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
 
-	var imagePullSecrets []k8sv1.LocalObjectReference
-
-	volumes, volumeDevices, volumeMounts, hotplugVolumes := renderLaunchManifestInitDefaultVolumes(t, vmi)
-
 	var userId int64 = util.RootUser
 	privileged := false
 
@@ -468,8 +464,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		privileged = true
 	}
 
-	serviceAccountName := ""
-	volumes, volumeDevices, volumeMounts, imagePullSecrets, serviceAccountName, err = renderLaunchManifestVolumes(t, vmi, volumes, volumeDevices, volumeMounts, hotplugVolumes, namespace)
+	volumes, volumeDevices, volumeMounts, imagePullSecrets, serviceAccountName, err := renderLaunchManifestVolumes(t, vmi)
 	if err != nil {
 		return nil, err
 	}
@@ -1274,9 +1269,12 @@ func renderLaunchManifestInitDefaultVolumes(t *templateService, vmi *v1.VirtualM
 	return
 }
 
-func renderLaunchManifestVolumes(t *templateService, vmi *v1.VirtualMachineInstance, volumes []k8sv1.Volume, volumeDevices []k8sv1.VolumeDevice, volumeMounts []k8sv1.VolumeMount, hotplugVolumes map[string]bool, namespace string) ([]k8sv1.Volume, []k8sv1.VolumeDevice, []k8sv1.VolumeMount, []k8sv1.LocalObjectReference, string, error) {
+func renderLaunchManifestVolumes(t *templateService, vmi *v1.VirtualMachineInstance) ([]k8sv1.Volume, []k8sv1.VolumeDevice, []k8sv1.VolumeMount, []k8sv1.LocalObjectReference, string, error) {
 	var imagePullSecrets []k8sv1.LocalObjectReference
 	serviceAccountName := ""
+	namespace := vmi.GetNamespace()
+
+	volumes, volumeDevices, volumeMounts, hotplugVolumes := renderLaunchManifestInitDefaultVolumes(t, vmi)
 
 	// This detects hotplug volumes for a started but not ready VMI
 	for _, volume := range vmi.Spec.Volumes {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -532,10 +532,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	allowEmulation := t.clusterConfig.AllowEmulation()
 	imagePullPolicy := t.clusterConfig.GetImagePullPolicy()
 
-	if resources.Limits == nil {
-		resources.Limits = make(k8sv1.ResourceList)
-	}
-
 	extraResources := getRequiredResources(vmi, allowEmulation)
 	for key, val := range extraResources {
 		resources.Limits[key] = val

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -469,7 +469,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		return nil, err
 	}
 
-	// Pad the virt-launcher grace period.
 	// Ideally we want virt-handler to handle tearing down
 	// the vmi without virt-launcher's termination forcing
 	// the vmi down.
@@ -477,6 +476,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	if vmi.Spec.TerminationGracePeriodSeconds != nil {
 		gracePeriodSeconds = *vmi.Spec.TerminationGracePeriodSeconds
 	}
+	// Pad the virt-launcher grace period.
 	gracePeriodSeconds = gracePeriodSeconds + int64(15)
 	gracePeriodKillAfter := gracePeriodSeconds + int64(15)
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -489,7 +489,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	// Get memory overhead
 	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch())
 
-	resources := renderLaunchManifestRequirements(t, vmi)
+	resources := renderLaunchManifestResourceRequirements(t, vmi)
 
 	// Consider hugepages resource for pod scheduling
 	if util.HasHugePages(vmi) {
@@ -1693,7 +1693,7 @@ func renderLaunchManifestVolumes(t *templateService, vmi *v1.VirtualMachineInsta
 	return volumes, volumeDevices, volumeMounts, imagePullSecrets, serviceAccountName, nil
 }
 
-func renderLaunchManifestRequirements(t *templateService, vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements {
+func renderLaunchManifestResourceRequirements(t *templateService, vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements {
 	// Consider CPU and memory requests and limits for pod scheduling
 	resources := k8sv1.ResourceRequirements{}
 	vmiResources := vmi.Spec.Domain.Resources

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -510,8 +510,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	var nodeSelector map[string]string
 	nodeSelector, resources = renderLaunchManifestCPUDedicated(vmi, resources)
 
-	ovmfPath := t.clusterConfig.GetOVMFPath()
-
 	var command []string
 	if tempPod {
 		log.Log.Infof("RUNNING pod to pre bind pvc for %s", vmi.Name)
@@ -529,7 +527,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			"--container-disk-dir", t.containerDiskDir,
 			"--grace-period-seconds", strconv.Itoa(int(gracePeriodSeconds)),
 			"--hook-sidecars", strconv.Itoa(len(requestedHookSidecarList)),
-			"--ovmf-path", ovmfPath,
+			"--ovmf-path", t.clusterConfig.GetOVMFPath(),
 		}
 		if nonRoot {
 			command = append(command, "--run-as-nonroot")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR breaks apart some of the logic in `renderLaunchManifest` into smaller private helper functions. [This function](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/services/template.go#L383) is almost 1300 line long and very non-cohesive. This PR reduces it into about 500 lines of code and introduces 5 helper functions to achieve it. Every helper function is cohesive - deals with one task (or renders a different manifest aspect).

This is an initial work that breaks apart some of the logic but not all. Follow-up PR(s) can continue this until we have a clear and clean function.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
