### PR TITLE
[virt-operator] remove duplicated and redundant unit tests from webhook test suite

### DIFF
--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/virt-api/webhooks:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
@@ -38,7 +37,5 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -151,41 +151,4 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			},
 		}, 0),
 	)
-
-	It("should reject with JSON patch validation invalid", func() {
-		kvAdmitter := getAdmitter(true)
-		kv := getKV()
-		kvBytes, _ := json.Marshal(&kv)
-
-		cc := getComponentConfig()
-		kv.Spec.Workloads = &cc
-		kv.Spec.CustomizeComponents = v1.CustomizeComponents{
-			Patches: []v1.CustomizeComponentsPatch{
-				{
-					ResourceName: "virt-api",
-					ResourceType: "Deployment",
-					Type:         v1.StrategicMergePatchType,
-					Patch:        ``,
-				},
-			},
-		}
-		kvUpdateBytes, _ := json.Marshal(&kv)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.KubeVirtGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: kvUpdateBytes,
-				},
-				OldObject: runtime.RawExtension{
-					Raw: kvBytes,
-				},
-				Operation: admissionv1.Update,
-			},
-		}
-
-		resp := kvAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeFalse())
-		Expect(len(resp.Result.Details.Causes)).To(Equal(1))
-	})
 })


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Going over the unit tests I've noticed the following redundancy:
1. Due to [PR#5221](https://github.com/kubevirt/kubevirt/pull/5221) we don't restrict the modification
of Kubevirt CR pod placement configuration while VMs are running, therefore these scenarios:

- `should accept workload update when no VMIS are running`

- `should accept KV update with VMIS running if workloads object is not changed`

seems not relevant anymore.

2. We test twice the same scenario of rejecting invalid JSON patching format, [here](https://github.com/kubevirt/kubevirt/blob/1375bcdacde6781d3fb40f3e2ce111677421164d/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go#L133) and [here](https://github.com/kubevirt/kubevirt/blob/1375bcdacde6781d3fb40f3e2ce111677421164d/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go#L155) 


**Release note**:
```release-note
NONE
```