### PR TITLE
Test test_id:5004 stability

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1232,6 +1232,10 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				By("create a new NFS PV and PVC")
 				os := string(cd.ContainerDiskFedora)
 				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
+
+				cfg := getCurrentKv()
+				cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewMilliQuantity(1, resource.BinarySI)
+				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
Signed-off-by: Itamar Holder <iholder@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Once again trying to see if we can get test_id:5004 out of quarantine after these two PRs have been merged:
- https://github.com/kubevirt/kubevirt/pull/6007 which fixes bandwidth restrictions that is now used in the test
- https://github.com/kubevirt/kubevirt/pull/6062 which replaces `stress` with `stress-ng` that is now used in all functional migration tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
