### PR TITLE
Added virt-freezer

### DIFF
--- a/cmd/virt-freezer/BUILD.bazel
+++ b/cmd/virt-freezer/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/virt-freezer",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/virt-handler/cmd-client:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "virt-freezer",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/virt-freezer/main.go
+++ b/cmd/virt-freezer/main.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/log"
+	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+)
+
+func getGrpcClient() (cmdclient.LauncherClient, error) {
+	sockFile := "/run/kubevirt/sockets/launcher-sock"
+	client, err := cmdclient.NewClient(sockFile)
+	if err != nil {
+		log.Log.Reason(err).Error("Failed to connect launcher")
+		os.Exit(1)
+	}
+
+	return client, err
+}
+
+func main() {
+	log.InitializeLogging("freezer")
+	log.Log.Info("Starting...")
+
+	freeze := pflag.Bool("freeze", false, "Freeze VM")
+	unfreeze := pflag.Bool("unfreeze", false, "Freeze VM")
+	name := pflag.String("name", "", "Name of the VirtualMachineInstance")
+	namespace := pflag.String("namespace", "", "Namespace of the VirtualMachineInstance")
+
+	pflag.Parse()
+
+	if !*freeze && !*unfreeze {
+		log.Log.Errorf("Use either --freeze or --unfreeze")
+		os.Exit(1)
+	}
+	if name == nil || namespace == nil {
+		log.Log.Errorf("Both name and namespace flags must be provided")
+		os.Exit(1)
+	}
+
+	vmi := &v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      *name,
+			Namespace: *namespace,
+		},
+	}
+
+	client, err := getGrpcClient()
+	if err != nil {
+		log.Log.Reason(err).Error("Failed to connect launcher")
+		os.Exit(1)
+	}
+
+	if *freeze {
+		err = client.FreezeVirtualMachine(vmi)
+		if err != nil {
+			log.Log.Reason(err).Error("Freezeing VMI failed")
+			os.Exit(1)
+		}
+	} else {
+		err = client.UnfreezeVirtualMachine(vmi)
+		if err != nil {
+			log.Log.Reason(err).Error("Unfreezeing VMI failed")
+			os.Exit(1)
+		}
+	}
+
+	log.Log.Info("Exiting...")
+}

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -159,6 +159,7 @@ container_image(
     files = [
         "node-labeller/node-labeller.sh",
         "//cmd/container-disk-v2alpha:container-disk",
+        "//cmd/virt-freezer",
         "//cmd/virt-probe",
     ],
     tars = [":setcaps"],

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -94,6 +94,11 @@ const MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION = "v1.multus-cni.io/default-network"
 // Istio list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound traffic in envoy
 const ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
 
+const VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION = "pre.hook.backup.velero.io/container"
+const VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION = "pre.hook.backup.velero.io/command"
+const VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION = "post.hook.backup.velero.io/container"
+const VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION = "post.hook.backup.velero.io/command"
+
 const ENV_VAR_LIBVIRT_DEBUG_LOGS = "LIBVIRT_DEBUG_LOGS"
 const ENV_VAR_VIRTIOFSD_DEBUG_LOGS = "VIRTIOFSD_DEBUG_LOGS"
 const ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY = "VIRT_LAUNCHER_LOG_VERBOSITY"
@@ -2086,6 +2091,17 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance) (map[string]string, 
 	if HaveMasqueradeInterface(vmi.Spec.Domain.Devices.Interfaces) {
 		annotationsSet[ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
 	}
+	annotationsSet[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
+	annotationsSet[VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
+		"[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
+		vmi.GetObjectMeta().GetName(),
+		vmi.GetObjectMeta().GetNamespace())
+	annotationsSet[VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
+	annotationsSet[VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(
+		"[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"%s\", \"--namespace\", \"%s\"]",
+		vmi.GetObjectMeta().GetName(),
+		vmi.GetObjectMeta().GetNamespace())
+
 	return annotationsSet, nil
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -245,21 +245,37 @@ var _ = Describe("Template", func() {
 					map[string]string{
 						"kubectl.kubernetes.io/last-applied-configuration": "open",
 					},
-					map[string]string{"kubevirt.io/domain": "testvmi"},
+					map[string]string{
+						"kubevirt.io/domain":                   "testvmi",
+						"pre.hook.backup.velero.io/container":  "compute",
+						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"post.hook.backup.velero.io/container": "compute",
+						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+					},
 				),
 				table.Entry("and don't contain kubevirt annotation added by apiserver",
 					map[string]string{
 						"kubevirt.io/latest-observed-api-version":  "source",
 						"kubevirt.io/storage-observed-api-version": ".com",
 					},
-					map[string]string{"kubevirt.io/domain": "testvmi"},
+					map[string]string{
+						"kubevirt.io/domain":                   "testvmi",
+						"pre.hook.backup.velero.io/container":  "compute",
+						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"post.hook.backup.velero.io/container": "compute",
+						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+					},
 				),
 				table.Entry("and contain kubevirt domain annotation",
 					map[string]string{
 						"kubevirt.io/domain": "fedora",
 					},
 					map[string]string{
-						"kubevirt.io/domain": "fedora",
+						"kubevirt.io/domain":                   "fedora",
+						"pre.hook.backup.velero.io/container":  "compute",
+						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"post.hook.backup.velero.io/container": "compute",
+						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 					},
 				),
 				table.Entry("and contain kubernetes annotation",
@@ -269,6 +285,10 @@ var _ = Describe("Template", func() {
 					map[string]string{
 						"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
 						"kubevirt.io/domain":                             "testvmi",
+						"pre.hook.backup.velero.io/container":            "compute",
+						"pre.hook.backup.velero.io/command":              "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"post.hook.backup.velero.io/container":           "compute",
+						"post.hook.backup.velero.io/command":             "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 					},
 				),
 				table.Entry("and contain kubevirt ignitiondata annotation",
@@ -286,6 +306,10 @@ var _ = Describe("Template", func() {
 								"version": "3"
 							 },
 						}`,
+						"pre.hook.backup.velero.io/container":  "compute",
+						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"post.hook.backup.velero.io/container": "compute",
+						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 					},
 				),
 			)
@@ -322,9 +346,13 @@ var _ = Describe("Template", func() {
 					v1.CreatedByLabel: "1234",
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
-					v1.DomainAnnotation:                 "testvmi",
-					"test":                              "shouldBeInPod",
-					hooks.HookSidecarListAnnotationName: `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
+					v1.DomainAnnotation:                    "testvmi",
+					"test":                                 "shouldBeInPod",
+					hooks.HookSidecarListAnnotationName:    `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
+					"pre.hook.backup.velero.io/container":  "compute",
+					"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+					"post.hook.backup.velero.io/container": "compute",
+					"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 				}))
 				Expect(pod.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{{
 					APIVersion:         v1.VirtualMachineInstanceGroupVersionKind.GroupVersion().String(),


### PR DESCRIPTION


Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Added virt-freezer binary to the launcher pod. Its job is to
freeze/unfreeze the VM from within the launcher pod (without going
through the KubeVirt API) for the sake of Velero backup hooks.

Appropriate annotations for Velero are also added to the launcher pod.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
