### PR TITLE
Take test_id:4100 out of quarantine

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -214,7 +214,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 		})
 
-		It("[QUARANTINE][sig-compute][test_id:4100] should be valid during the whole rotation process", func() {
+		It("[sig-compute][test_id:4100] should be valid during the whole rotation process", func() {
 			oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
 			oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Test proved it's stability during the last 14 days. Therefore removing it from quarantine

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**Release note**:
```release-note
NONE
```
