### PR TITLE
network, Istio: Fix outbound test

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -337,7 +337,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					It("Should not be able to reach http service outside of mesh", func() {
 						Eventually(func() error {
 							return checkHTTPServiceReturnCode(serverVMIAddress, testPort, generateExpectedHTTPReturnCodeRegex("5.."))
-						}, externalServiceCheckTimeout, externalServiceCheckInterval)
+						}, externalServiceCheckTimeout, externalServiceCheckInterval).Should(Succeed())
 					})
 				})
 			})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1757,8 +1757,10 @@ func cleanNamespaces() {
 			util2.PanicOnError(virtCli.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Delete(context.Background(), netDef.GetName(), metav1.DeleteOptions{}))
 		}
 
-		// Remove all Istio Sidecars
-		util2.PanicOnError(removeAllGroupVersionResourceFromNamespace(schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: "sidecars"}, namespace))
+		// Remove all Istio Sidecars, VirtualServices, DestinationRules and Gateways
+		for _, res := range []string{"sidecars", "virtualservices", "destinationrules", "gateways"} {
+			util2.PanicOnError(removeAllGroupVersionResourceFromNamespace(schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: res}, namespace))
+		}
 
 		// Remove all Istio PeerAuthentications
 		util2.PanicOnError(removeAllGroupVersionResourceFromNamespace(schema.GroupVersionResource{Group: "security.istio.io", Version: "v1beta1", Resource: "peerauthentications"}, namespace))


### PR DESCRIPTION
**What this PR does / why we need it**:

The negative test checking that Envoy refuses to
connect to external service was missing .Should(Succeed())
so when we changed from using "kubevirt.io" as an external
service to another cluster vmi, the test was broken without
us knowing about it.

This commit properly registers the server vmi (there are two VMIs, server VMI without proxy 
sidecar and the tested client VMI which does have the proxy sidecar) as a service by defining
VirtualService, destinationRule and Gateway.

The vmi HTTP server is now accessed via Istio ingressgateway, and when 
Sidecar disallowing all external services is created, the Envoy proxy properly
refuses to forward the request.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
