### PR TITLE
[Sig-scale] add scripts to build and run performance density tests

### DIFF
--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# This script should be executed through the makefile via `make perftest`.
+
+set -e
+
+DOCKER_TAG=${DOCKER_TAG:-devel}
+DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
+
+source hack/common.sh
+source hack/config.sh
+
+_default_previous_release_registry="quay.io/kubevirt"
+
+previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_release_registry}
+
+perftest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
+
+if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then
+    oc=${kubectl}
+fi
+
+if [ -z "$kubeconfig" ]; then
+    kubeconfig="$KUBECONFIG"
+fi
+
+echo 'Performance testing'
+export KUBEVIRT_E2E_PERF_TEST=true
+
+echo 'Preparing directory for artifacts'
+export ARTIFACTS=${ARTIFACTS}/performance
+rm -rf $ARTIFACTS
+mkdir -p $ARTIFACTS
+
+export TESTS_OUT_DIR=${TESTS_OUT_DIR}
+mkdir -p ${TESTS_OUT_DIR}/performance
+
+echo 'ARTIFACTS ' ${ARTIFACTS}
+echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
+
+function perftest() {
+    _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
+}
+
+if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+    export KUBEVIRT_E2E_FOCUS="${KUBEVIRT_E2E_FOCUS}|\\[sig-performance\\]"
+else
+    export KUBEVIRT_E2E_FOCUS="\\[sig-performance\\]"
+fi
+
+additional_test_args=""
+if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+    additional_test_args="${additional_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
+fi
+
+if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+    additional_test_args="${additional_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
+fi
+
+additional_test_args="${additional_test_args} --skipPackage test/performance"
+
+perftest ${additional_test_args} ${FUNC_TEST_ARGS}


### PR DESCRIPTION
Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The previous PR #6076 was missing the file to build and run the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
