### PR TITLE
k8s reporter, Use dmesg directly in logDMESG

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -240,13 +240,15 @@ func (r *KubernetesReporter) logDMESG(virtCli kubecli.KubevirtClient, logsdir st
 				fmt.Fprintf(os.Stderr, "failed to get virt-handler pod on node %s: %v\n", node, err)
 				return
 			}
+
+			command := []string{"dmesg", "--kernel", "--ctime", "--userspace", "--decode"}
 			// TODO may need to be improved, in case that the auditlog is really huge, since stdout is in memory
-			stdout, _, err := tests.ExecuteCommandOnPodV2(virtCli, pod, "virt-handler", []string{"/proc/1/root/bin/dmesg", "--kernel", "--ctime", "--userspace", "--decode"})
+			stdout, _, err := tests.ExecuteCommandOnPodV2(virtCli, pod, "virt-handler", command)
 			if err != nil {
 				fmt.Fprintf(
 					os.Stderr,
 					"failed to execute command %s on node %s, stdout: %s, error: %v\n",
-					[]string{"/proc/1/root/bin/dmesg", "--kernel", "--ctime", "--userspace", "--decode"},
+					command,
 					node, stdout, err,
 				)
 				return


### PR DESCRIPTION
This way logDMESG will also work on kind based provider,
which otherwise fails (unless it also virt-chroot to the mnt namespace):
```
/proc/1/root/bin/dmesg: /lib64/libtinfo.so.6: no version information available (required by /proc/1/root/bin/dmesg)
/proc/1/root/bin/dmesg: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by /proc/1/root/bin/dmesg)
```

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
