### PR TITLE
virt-launcher: libvirt and qemu conf cleanup

### DIFF
--- a/cmd/virt-launcher/libvirtd.conf
+++ b/cmd/virt-launcher/libvirtd.conf
@@ -1,4 +1,3 @@
 listen_tls = 0
-listen_tcp = 1
-auth_tcp = "none"
+listen_tcp = 0
 log_outputs = "1:stderr"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove duplicated settings we forcibly write in libvirtd.conf and qemu.conf since they're already present in the shipped config files.

Disable libvirt unencrypted TCP socket since we only use the unix socket to communicate with the daemon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher: disable unencrypted TCP socket for libvirtd.
virt-launcher: 'cgroup_controllers = [ ]' is not injected anymore at runtime and thus is a required setting in the image /etct/libvirt/qemu.conf file.
```
