### PR TITLE
Don't copy qemu.conf when running as root

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -32,9 +32,10 @@ import (
 
 const QEMUSeaBiosDebugPipe = converter.QEMUSeaBiosDebugPipe
 const (
-	qemuConfPath       = "/etc/libvirt/qemu.conf"
-	libvirdConfPath    = "/etc/libvirt/libvirtd.conf"
-	libvirtRuntimePath = "/var/run/libvirt"
+	qemuConfPath        = "/etc/libvirt/qemu.conf"
+	libvirdConfPath     = "/etc/libvirt/libvirtd.conf"
+	libvirtRuntimePath  = "/var/run/libvirt"
+	qemuNonRootConfPath = libvirtRuntimePath + "/qemu.conf"
 )
 
 var LifeCycleTranslationMap = map[libvirt.DomainState]api.LifeCycle{
@@ -485,9 +486,13 @@ func copyFile(from, to string) error {
 }
 
 func (l LibvirtWrapper) SetupLibvirt() (err error) {
-	runtimeQemuConfPath := path.Join(libvirtRuntimePath, "qemu.conf")
-	if err := copyFile(qemuConfPath, runtimeQemuConfPath); err != nil {
-		return err
+	runtimeQemuConfPath := qemuConfPath
+	if !l.root() {
+		runtimeQemuConfPath = qemuNonRootConfPath
+
+		if err := copyFile(qemuConfPath, runtimeQemuConfPath); err != nil {
+			return err
+		}
 	}
 
 	if err := configureQemuConf(runtimeQemuConfPath); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Root is using /etc/libvirt/qemu.conf
$XDG_CONFIG_HOME/libvirt/qemu.conf is used only in non-root

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
