### PR TITLE
move host device validation to happen on pod creation

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1969,31 +1969,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(len(causes)).To(Equal(0))
 		})
-
-		It("should reject GPU devices that are not permitted in the hostdev config", func() {
-			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.GPUGate}
-			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
-				PciHostDevices: []v1.PciHostDevice{
-					{
-						PCIVendorSelector: "DEAD:BEEF",
-						ResourceName:      "example.org/deadbeef",
-					},
-				},
-			}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
-
-			vmi := v1.NewMinimalVMI("testvm")
-			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
-				{
-					Name:       "gpu1",
-					DeviceName: "example.org/deadbeef1",
-				},
-			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.GPUs"))
-		})
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.GPUGate}
@@ -2045,7 +2020,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.HostDevices"))
 		})
-		It("should reject host devices that are not permitted in the hostdev config", func() {
+		It("should accept host devices that are not permitted in the hostdev config", func() {
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{virtconfig.HostDevicesGate}
 			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
@@ -2065,8 +2040,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.HostDevices"))
+			Expect(len(causes)).To(Equal(0))
 		})
 		It("should accept permitted host devices", func() {
 			kvConfig := kv.DeepCopy()

--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virtctl/configuration:go_default_library",
         "//pkg/virtctl/console:go_default_library",
         "//pkg/virtctl/expose:go_default_library",
         "//pkg/virtctl/guestfs:go_default_library",

--- a/pkg/virtctl/configuration/BUILD.bazel
+++ b/pkg/virtctl/configuration/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["configuration.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/configuration",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)

--- a/pkg/virtctl/configuration/configuration.go
+++ b/pkg/virtctl/configuration/configuration.go
@@ -1,0 +1,86 @@
+package configuration
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+var clientOnly bool
+
+func NewListPermittedDevices(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "permitted-devices",
+		Short:   "List the permitted devices for vmis.",
+		Example: usage(),
+		Args:    templates.ExactArgs("permitted-devices", 0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := command{clientConfig: clientConfig}
+			return c.run()
+		},
+	}
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func usage() string {
+	usage := "  # Print the permitted devices for VMIs:\n"
+	usage += "  {{ProgramName}} permitted-devices"
+	return usage
+}
+
+type command struct {
+	clientConfig clientcmd.ClientConfig
+}
+
+func (c *command) run() error {
+
+	namespace, _, err := c.clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(c.clientConfig)
+	if err != nil {
+		return fmt.Errorf("cannot obtain KubeVirt client: %v", err)
+	}
+
+	kvList, err := virtClient.KubeVirt(namespace).List(&metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(kvList.Items) == 0 {
+		return fmt.Errorf("No KubeVirt resource in %q namespace", namespace)
+	}
+
+	kv := kvList.Items[0]
+
+	hostDeviceList := []string{}
+	gpuDeviceList := []string{}
+
+	if kv.Spec.Configuration.PermittedHostDevices != nil {
+		for _, hd := range kv.Spec.Configuration.PermittedHostDevices.PciHostDevices {
+			hostDeviceList = append(hostDeviceList, hd.ResourceName)
+		}
+
+		for _, hd := range kv.Spec.Configuration.PermittedHostDevices.MediatedDevices {
+			gpuDeviceList = append(gpuDeviceList, hd.ResourceName)
+		}
+	}
+
+	fmt.Printf("Permitted Devices: \nHost Devices: \n%s \nGPU Devices: \n%s\n",
+		fmt.Sprint(strings.Join(hostDeviceList, ", ")),
+		fmt.Sprint(strings.Join(gpuDeviceList, ", ")),
+	)
+
+	return nil
+}

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -10,6 +10,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/virtctl/configuration"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
@@ -69,6 +70,7 @@ func NewVirtctlCommand() *cobra.Command {
 	AddGlogFlags(rootCmd.PersistentFlags())
 	rootCmd.SetUsageTemplate(templates.MainUsageTemplate())
 	rootCmd.AddCommand(
+		configuration.NewListPermittedDevices(clientConfig),
 		console.NewCommand(clientConfig),
 		usbredir.NewCommand(clientConfig),
 		vnc.NewCommand(clientConfig),


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since permitted host devices can be updated and changed we should not reject the creation of a VMI if its host device is not currently permitted. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=1983079

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove HostDevice validation on VMI creation
```
