### PR TITLE
Always add hint-dedicated kvm feature with dedicated cpus to allow guest optimizations 

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -1295,6 +1295,11 @@ func (in *FeatureKVM) DeepCopyInto(out *FeatureKVM) {
 		*out = new(FeatureState)
 		**out = **in
 	}
+	if in.HintDedicated != nil {
+		in, out := &in.HintDedicated, &out.HintDedicated
+		*out = new(FeatureState)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -336,7 +336,8 @@ type FeatureState struct {
 }
 
 type FeatureKVM struct {
-	Hidden *FeatureState `xml:"hidden,omitempty"`
+	Hidden        *FeatureState `xml:"hidden,omitempty"`
+	HintDedicated *FeatureState `xml:"hint-dedicated,omitempty"`
 }
 
 type Metadata struct {

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -94,6 +94,7 @@ var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/doma
     <smm></smm>
     <kvm>
       <hidden state="on"></hidden>
+      <hint-dedicated state="on"></hint-dedicated>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
@@ -173,6 +174,7 @@ var exampleXMLppc64le = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schem
     <smm></smm>
     <kvm>
       <hidden state="on"></hidden>
+      <hint-dedicated state="on"></hint-dedicated>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
@@ -253,6 +255,7 @@ var exampleXMLarm64 = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas
     <smm></smm>
     <kvm>
       <hidden state="on"></hidden>
+      <hint-dedicated state="on"></hint-dedicated>
     </kvm>
     <pvspinlock state="off"></pvspinlock>
     <pmu state="off"></pmu>
@@ -364,7 +367,8 @@ var _ = Describe("Schema", func() {
 			ACPI: &FeatureEnabled{},
 			SMM:  &FeatureEnabled{},
 			KVM: &FeatureKVM{
-				Hidden: &FeatureState{State: "on"},
+				Hidden:        &FeatureState{State: "on"},
+				HintDedicated: &FeatureState{State: "on"},
 			},
 			PVSpinlock: &FeaturePVSpinlock{State: "off"},
 			PMU:        &FeatureState{State: "off"},

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1639,6 +1639,14 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			}
 			domain.Spec.CPUTune = cpuTune
 
+			// always add the hint-dedicated feature when dedicatedCPUs are requested.
+			if domain.Spec.Features.KVM == nil {
+				domain.Spec.Features.KVM = &api.FeatureKVM{}
+			}
+			domain.Spec.Features.KVM.HintDedicated = &api.FeatureState{
+				State: "on",
+			}
+
 			var emulatorThread uint32
 			if vmi.Spec.Domain.CPU.IsolateEmulatorThread {
 				emulatorThread, err = cpuPool.FitThread()

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2360,6 +2360,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: "2"},
 				}, 15)).To(Succeed())
+
+				By("Check values in domain XML")
+				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, cpuVmi)
+				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
+				Expect(domXML).To(ContainSubstring("<hint-dedicated state='on'/>"), "should container the hint-dedicated feature")
 			})
 			It("[test_id:4632]should be able to start a vm with guest memory different from requested and keep guaranteed qos", func() {
 				Skip("Skip test till issue https://github.com/kubevirt/kubevirt/issues/3910 is fixed")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will always add <hints-dedicated state='on'/> which set the KVM_HINTS_REALTIME 
According to QEMU documentation guest checks this feature bit to determine that vCPUs are never
preempted for an unlimited time, allowing optimizations.


```release-note
KVM_HINTS_REALTIME will always be set when dedicatedCpusPlacement is requested
```
