### PR TITLE
Handle Zombie QEMU Processes

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -548,6 +548,7 @@ func ForkAndMonitor(containerDiskDir string) (int, error) {
 					log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
 				}
 
+				log.Log.Infof("Reaped pid %d with status %d", wpid, int(wstatus))
 				// there's a race between cmd.Wait() and syscall.Wait4 when
 				// cleaning up the cmd's pid after it exits. This allows us
 				// to detect the correct exit code regardless of which wait

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"kubevirt.io/client-go/log"
@@ -138,7 +139,7 @@ func (mon *monitor) refresh() {
 		log.Log.Infof("Found PID for %s: %d", mon.cmdlineMatchStr, mon.pid)
 	}
 
-	exists, err := pidExists(mon.pid)
+	exists, isZombie, err := pidExists(mon.pid)
 	if err != nil {
 		log.Log.Reason(err).Errorf("Error detecting pid (%d) status.", mon.pid)
 		return
@@ -148,6 +149,13 @@ func (mon *monitor) refresh() {
 		mon.pid = 0
 		mon.isDone = true
 		return
+	}
+
+	if isZombie {
+		log.Log.Infof("Process %s and pid %d is a zombie, sending SIGCHLD to pid 1 to reap process", mon.cmdlineMatchStr, mon.pid)
+		syscall.Kill(1, syscall.SIGCHLD)
+		mon.pid = 0
+		mon.isDone = true
 	}
 
 	if expired {
@@ -195,18 +203,29 @@ func (mon *monitor) RunForever(startTimeout time.Duration, signalStopChan chan s
 	mon.monitorLoop(startTimeout, signalStopChan)
 }
 
-func pidExists(pid int) (bool, error) {
-	path := fmt.Sprintf("/proc/%d/cmdline", pid)
+func pidExists(pid int) (exists bool, isZombie bool, err error) {
 
-	exists, err := diskutils.FileExists(path)
+	pathCmdline := fmt.Sprintf("/proc/%d/cmdline", pid)
+	pathStatus := fmt.Sprintf("/proc/%d/status", pid)
+
+	exists, err = diskutils.FileExists(pathCmdline)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if exists == false {
-		return false, nil
+		return false, false, nil
 	}
 
-	return true, nil
+	dataBytes, err := ioutil.ReadFile(pathStatus)
+	if err != nil {
+		return false, false, err
+	}
+
+	if strings.Contains(string(dataBytes), "Z (zombie)") {
+		isZombie = true
+	}
+
+	return exists, isZombie, nil
 }
 
 func FindPid(commandNamePrefix string) (int, error) {

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -142,6 +142,16 @@ var _ = Describe("VirtLauncher", func() {
 				VerifyProcessStopped()
 			})
 
+			It("verify zombie pid detection works", func() {
+				StartProcess()
+				VerifyProcessStarted()
+				StopProcess()
+				VerifyProcessStopped()
+
+				// cleanup after stopping ensures zombie process is detected
+				CleanupProcess()
+			})
+
 			It("verify start timeout works", func() {
 				stopChan := make(chan struct{})
 				done := make(chan string)


### PR DESCRIPTION
**What this PR does / why we need it**:

Under high load, we've observed that libvirt does not always successfully reap the qemu processes, which leaves them around in a defunc (zombie) state, never cleaning them up. Arguably this is a bug in libvirt, but we can handle it a bit more gracefully on our end as well.

The result is, when this occurs the virt-launcher pod never shuts down because the qemu pid virt-launcher is monitoring never disappears.

Previously, our pid monitoring only checked for the presence of the qemu pid. Now we detect the pid's presence and whether or not the pid is a zombie. When a zombie pid is detected, we exit the monitor loop and raise SIGCHLD to pid 1 (virt-launcher). Virt-launcher already watches for SIGCHLD and will call wait() to reap the process.

related to: https://bugzilla.redhat.com/show_bug.cgi?id=1985083


```release-note
Handle qemu processes in defunc (zombie) state
```
