### PR TITLE
Fix setting vmi Pending phase transition timestamp

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	k8sv1 "k8s.io/api/core/v1"
@@ -119,6 +120,12 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 
 		// Set the phase to pending to avoid blank status
 		newVMI.Status.Phase = v1.Pending
+
+		now := metav1.NewTime(time.Now())
+		newVMI.Status.PhaseTransitionTimestamps = append(newVMI.Status.PhaseTransitionTimestamps, v1.VirtualMachineInstancePhaseTransitionTimestamp{
+			Phase:                    newVMI.Status.Phase,
+			PhaseTransitionTimestamp: now,
+		})
 
 		if mutator.ClusterConfig.NonRootEnabled() {
 			if err := canBeNonRoot(newVMI); err != nil {


### PR DESCRIPTION
Previously, the phase transition timestamp slice never got an entry due to the Pending phase being set during the VMI creation webhook. To account for this, we need to initialize the pending transition timestamp in the mutation webhook along side setting the phase to pending.

Without this fix, our Prometheus metrics related to calculating transition timestamps can't capture the time spent between pending and scheduling. 

```release-note
NONE
```
