### PR TITLE
Fix goroutine leaks due to use of non-buffered channels

### DIFF
--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -438,8 +438,8 @@ func (m *migrationProxy) Stop() {
 func (m *migrationProxy) handleConnection(fd net.Conn) {
 	defer fd.Close()
 
-	outBoundErr := make(chan error)
-	inBoundErr := make(chan error)
+	outBoundErr := make(chan error, 1)
+	inBoundErr := make(chan error, 1)
 
 	var conn net.Conn
 	var err error

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -228,7 +228,7 @@ func (t *ConsoleHandler) stream(vmi *v1.VirtualMachineInstance, request *restful
 
 	log.Log.Object(vmi).Infof("Connected to %s", unixSocketPath)
 
-	errCh := make(chan error)
+	errCh := make(chan error, 2)
 	go func() {
 		_, err := kubecli.CopyTo(clientSocket, fd)
 		log.Log.Object(vmi).Reason(err).Error("error encountered reading from unix socket")


### PR DESCRIPTION
Due to a channel not being buffered, and not having a guaranteed read occur, it's likely that one of the proxy copy goroutines blocks indefinitely writing to a non buffered channel. This is fixed by making the channel buffered. We see something similar in the console code as well. 

Here's an example showing what i'm referring to. With the code below, we'll never see the `sent error` print statement

```
package main

import (
	"fmt"
	"time"
)

func main() {

	errChan := make(chan error)
	go func() {

		fmt.Println("sending error")
		errChan <- fmt.Errorf("err")
		fmt.Println("sent error")
	}()

	fmt.Println("sleeping")
	time.Sleep(100 * time.Second)
}


```


But with this code we will see the print statement.

```
package main

import (
	"fmt"
	"time"
)

func main() {

	errChan := make(chan error, 1)
	go func() {

		fmt.Println("sending error")
		errChan <- fmt.Errorf("err")
		fmt.Println("sent error")
	}()

	fmt.Println("sleeping")
	time.Sleep(100 * time.Second)
}
```

the difference is the use of a buffered channel. 


```release-note
NONE
```
