### PR TITLE
use latest release-tool image from quay.io

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -19,7 +19,7 @@ GIT_EMAIL=${GIT_EMAIL:-$(git config user.email)}
 echo "git user:  $GIT_USER"
 echo "git email: $GIT_EMAIL"
 
-docker pull kubevirtci/release-tool:latest
+docker pull quay.io/kubevirtci/release-tool:latest
 
 echo "docker run -it --rm \
 -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
@@ -36,7 +36,7 @@ docker run -it --rm \
     -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
     -v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase \
     -v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token \
-    kubevirtci/release-tool:latest \
+    quay.io/kubevirtci/release-tool:latest \
     --org=kubevirt \
     --repo=kubevirt \
     --git-email "${GIT_EMAIL}" \


### PR DESCRIPTION

The release-tool was still being pulled from docker hub. new release tool builds are now in quay. 

```release-note
NONE
```
