### PR TITLE
[SIG-scale] Add the possibility to configure virt-launcher qemu-timeout via virt-controller

### DIFF
--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -99,6 +99,7 @@ var _ = Describe("Template", func() {
 			config, _, _, kvInformer := testutils.NewFakeClusterConfigUsingKVWithCPUArch(kv, cpuArch)
 
 			svc = NewTemplateService("kubevirt/virt-launcher",
+				240,
 				"/var/run/kubevirt",
 				"/var/lib/kubevirt",
 				"/var/run/kubevirt-ephemeral-disks",
@@ -3243,6 +3244,8 @@ func validateAndExtractQemuTimeoutArg(args []string) string {
 
 	timeoutInt, err := strconv.Atoi(strings.TrimSuffix(timeoutString, "s"))
 	Expect(err).To(BeNil())
+
+	qemuTimeoutBaseSeconds := 240
 
 	failMsg := ""
 	if timeoutInt < qemuTimeoutBaseSeconds {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -73,7 +73,8 @@ const (
 
 	defaultHost = "0.0.0.0"
 
-	launcherImage = "virt-launcher"
+	launcherImage       = "virt-launcher"
+	launcherQemuTimeout = 240
 
 	imagePullSecret = ""
 
@@ -164,6 +165,7 @@ type VirtControllerApp struct {
 	LeaderElection leaderelectionconfig.Configuration
 
 	launcherImage              string
+	launcherQemuTimeout        int
 	imagePullSecret            string
 	virtShareDir               string
 	virtLibDir                 string
@@ -453,6 +455,7 @@ func (vca *VirtControllerApp) initCommon() {
 
 	containerdisk.SetLocalDirectory(vca.ephemeralDiskDir + "/container-disk-data")
 	vca.templateService = services.NewTemplateService(vca.launcherImage,
+		vca.launcherQemuTimeout,
 		vca.virtShareDir,
 		vca.virtLibDir,
 		vca.ephemeralDiskDir,
@@ -615,6 +618,9 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.StringVar(&vca.launcherImage, "launcher-image", launcherImage,
 		"Shim container for containerized VMIs")
+
+	flag.IntVar(&vca.launcherQemuTimeout, "launcher-qemu-timeout", launcherQemuTimeout,
+		"Amount of time to wait for qemu")
 
 	flag.StringVar(&vca.imagePullSecret, "image-pull-secret", imagePullSecret,
 		"Secret to use for pulling virt-launcher and/or registry disks")

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Application", func() {
 		app.evacuationController = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)
 		app.disruptionBudgetController = disruptionbudget.NewDisruptionBudgetController(vmiInformer, pdbInformer, podInformer, migrationInformer, recorder, virtClient)
 		app.nodeController = NewNodeController(virtClient, nodeInformer, vmiInformer, recorder)
-		app.vmiController = NewVMIController(services.NewTemplateService("a", "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
+		app.vmiController = NewVMIController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
 			vmiInformer,
 			vmInformer,
 			podInformer,
@@ -115,7 +115,7 @@ var _ = Describe("Application", func() {
 		)
 		app.rsController = NewVMIReplicaSet(vmiInformer, rsInformer, recorder, virtClient, uint(10))
 		app.vmController = NewVMController(vmiInformer, vmInformer, dataVolumeInformer, pvcInformer, recorder, virtClient)
-		app.migrationController = NewMigrationController(services.NewTemplateService("a", "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
+		app.migrationController = NewMigrationController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
 			vmiInformer,
 			podInformer,
 			migrationInformer,

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Migration watcher", func() {
 		config, _, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 		controller = NewMigrationController(
-			services.NewTemplateService("a", "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
 			vmiInformer,
 			podInformer,
 			migrationInformer,

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -212,7 +212,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		config, _, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		controller = NewVMIController(
-			services.NewTemplateService("a", "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
+			services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid),
 			vmiInformer,
 			vmInformer,
 			podInformer,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the recent SIG-scale meeting, we are discussing to run a scale test with more than 110 VMIs per node. 

It is trivial to increase the max number of pods per node, and PR#6098 increased the `virt-handler` max-device to 1000.

However, it is still not possible to create more than 200 VMIs in my environment, because of creating such amount of VMIs the creation process is slow and the `virt-launcher` `qemu` response timeout.

Currently, `virt-launcher` already have `qemu-timeout` flag:
https://github.com/kubevirt/kubevirt/blob/962aabb5f4816066c99b18993513abdca96fcf49/cmd/virt-launcher/virt-launcher.go#L341
However, `virt-launcher` is created and configured by `virt-controller` which does have a flag to configure the `qemu-timeout`.

This PR introduces the possibility to configure `virt-launcher` `qemu-timeout` via `virt-controller`.

Then, it will be possible to patch `KubeVirt` CR, withe the slightly hidden feature in #3612.

For example, creating the file `kubevirt.yaml` to increase the `qemu` timeout to 15mim:
```
spec:
   customizeComponents:
     patches:
     - patch: '[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--launcher-qemu-timeout=900"}]'
       resourceName: virt-controller
       resourceType: Deployment
       type: json
```
And running the following command to patch`KubeVirt` CR:
`kubectl patch --type=merge kubevirt kubevirt -n kubevirt --patch "$(cat kubevirt.yaml)"`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
