### PR TITLE
tests, Fix Relogin of fedora

### DIFF
--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -116,11 +116,9 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 	// Do not login, if we already logged in
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")},
+		&expect.BExp{R: fmt.Sprintf(`(\[fedora@(localhost|%s) ~\]\$ |\[root@(localhost|%s) fedora\]\# )`, vmi.Name, vmi.Name)},
 	})
-	_, err = expecter.ExpectBatch(b, 30*time.Second)
+	_, err = expecter.ExpectBatch(b, 5*time.Second)
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
LoginToFedora had a bug that in case of re-login,
where the previous command failed, but its return code
was not consumed yet, it will fail the loggedin check
and execute almost all the login flow again,
(for example reconfigure the console).

Scenario for example:
1. Login to the VM.
2. Run a command that returns error (don't use check its return code).
3. Try to relogin to the VM.

Since the relogin tried to check that `echo $?` returns 0,
it would fail in the above case, since that last command returned non zero value.
The send of `\n` just before it, doesn't consume the non zero return code.
```
~ $ false
~ $ 
~ $ echo $?
1
~ $ 
```
The result will be that the either the relogin will perform unneeded steps,
or even fail if the user was already logged in as sudo, since sudo has a different
prompt, which is not expected by the login batch.

Fix it by check if the full prompt is met.
Prompt might be the one of the fedora user or the one
of root, if sudo su was executed.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
