### PR TITLE
Decrease factor for high bandwidth duration in bandwith limited migration test

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -431,7 +431,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				durationLowBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "10Mi", 3)
 				durationHighBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "128Mi", 3)
-				Expect(durationHighBandwidth.Seconds() * 3).To(BeNumerically("<=", durationLowBandwidth.Seconds()))
+				Expect(durationHighBandwidth.Seconds() * 2.5).To(BeNumerically("<=", durationLowBandwidth.Seconds()))
 			})
 		})
 		Context("with a Cirros disk", func() {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -431,7 +431,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				durationLowBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "10Mi", 3)
 				durationHighBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "128Mi", 3)
-				Expect(durationHighBandwidth.Seconds() * 3).To(BeNumerically("<", durationLowBandwidth.Seconds()))
+				Expect(durationHighBandwidth.Seconds() * 3).To(BeNumerically("<=", durationLowBandwidth.Seconds()))
 			})
 		})
 		Context("with a Cirros disk", func() {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -431,7 +431,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				durationLowBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "10Mi", 3)
 				durationHighBandwidth := repeatedlyMigrateWithBandwidthLimitation(vmi, "128Mi", 3)
-				Expect(durationHighBandwidth.Seconds() * 2.5).To(BeNumerically("<=", durationLowBandwidth.Seconds()))
+				Expect(durationHighBandwidth.Seconds() * 2).To(BeNumerically("<", durationLowBandwidth.Seconds()))
 			})
 		})
 		Context("with a Cirros disk", func() {


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: The test `VM Live Migration Starting a VirtualMachineInstance with bandwidth limitations should apply them and result in different migration durations ` is failing in some cases with this error:
```
tests/migration_test.go:426
Expected
    <float64>: 30
to be <
    <float64>: 30
tests/migration_test.go:434
```
Examples: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6145/pull-kubevirt-e2e-k8s-1.20-sig-compute-nonroot/1420355203323924480 and https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6150/pull-kubevirt-e2e-k8s-1.20-sig-compute/1422195208744865792

This PR changes the numerical comparator so that low bandwidth migrations with 30s duration don't cause an error compared to high bandwidth migrations with 10s duration. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
