### PR TITLE
[release-0.41] Replace dead "stress" binary with new, maintained, "stress-ng" binary

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -448,9 +448,9 @@ container_pull(
 # TODO build fedora_with_test_tooling for multi-arch
 container_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:9ec3e137bff093597d192f5a4e346f25b614c3a94216b857de0e3d75b68bfb17",
+    digest = "sha256:ce36d2b4f81b038fba0b61b1bb1ac7f671d47687fb1f9d7ddedd22742cc79dd9",
     registry = "quay.io",
-    repository = "kubevirt/fedora-with-test-tooling",
+    repository = "kubevirtci/fedora-with-test-tooling",
 )
 
 container_pull(

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -310,7 +310,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 	runStressTest := func(vmi *v1.VirtualMachineInstance, vmsize string, stressTimeoutSeconds int) {
 		By("Run a stress test to dirty some pages and slow down the migration")
-		stressCmd := fmt.Sprintf("stress --vm 1 --vm-bytes %sM --vm-keep --timeout %ds&\n", vmsize, stressTimeoutSeconds)
+		stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %sM --vm-keep --timeout %ds&\n", vmsize, stressTimeoutSeconds)
 		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},


### PR DESCRIPTION
Manual cherrypick of #6062 

**What this PR does / why we need it**:
This patch should addresss the flakiness issue with `test_id:5004`.

**Release note**:

```release-note
NONE
```
