### PR TITLE
[Sig-scale] Metric for monitoring Request Counts by Resource and Operation

### DIFF
--- a/pkg/monitoring/client/prometheus/BUILD.bazel
+++ b/pkg/monitoring/client/prometheus/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/metrics:go_default_library",
     ],
 )

--- a/pkg/monitoring/client/prometheus/BUILD.bazel
+++ b/pkg/monitoring/client/prometheus/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/monitoring/client/prometheus",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/metrics:go_default_library",

--- a/pkg/monitoring/client/prometheus/BUILD.bazel
+++ b/pkg/monitoring/client/prometheus/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/monitoring/client/prometheus/BUILD.bazel
+++ b/pkg/monitoring/client/prometheus/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,5 +9,19 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/metrics:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "prometheus_suite_test.go",
+        "prometheus_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/monitoring/client/prometheus/prometheus.go
+++ b/pkg/monitoring/client/prometheus/prometheus.go
@@ -176,9 +176,13 @@ func (r *rtWrapper) RoundTrip(request *http.Request) (response *http.Response, e
 	}
 
 	resource, verb = parseURLResourceOperation(request)
-	if verb != "" && resource != "" {
-		requestResult.WithLabelValues(status, request.Method, host, resource, verb).Add(1)
+	if verb == "" {
+		verb = "none"
 	}
+	if resource == "" {
+		resource = "none"
+	}
+	requestResult.WithLabelValues(status, request.Method, host, resource, verb).Add(1)
 
 	return response, err
 }

--- a/pkg/monitoring/client/prometheus/prometheus.go
+++ b/pkg/monitoring/client/prometheus/prometheus.go
@@ -30,6 +30,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/metrics"
+
+	"kubevirt.io/client-go/kubecli"
 )
 
 var (
@@ -83,6 +85,8 @@ func init() {
 	// globally scoped core k8s apis and globally scoped custom apis
 	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/api/%s/(?P<resource>%s)`, resPat, resPat)))
 	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/apis/%s/%s/(?P<resource>%s)`, resPat, resPat, resPat)))
+
+	kubecli.RegisterRestConfigHook(addHTTPRoundTripClientMonitoring)
 
 	prometheus.MustRegister(requestLatency)
 	prometheus.MustRegister(requestResult)
@@ -179,7 +183,7 @@ func (r *rtWrapper) RoundTrip(request *http.Request) (response *http.Response, e
 	return response, err
 }
 
-func AddHTTPRoundTripClientMonitoring(config *rest.Config) {
+func addHTTPRoundTripClientMonitoring(config *rest.Config) {
 	fn := func(rt http.RoundTripper) http.RoundTripper {
 		return &rtWrapper{
 			origRoundTripper: rt,

--- a/pkg/monitoring/client/prometheus/prometheus.go
+++ b/pkg/monitoring/client/prometheus/prometheus.go
@@ -19,10 +19,16 @@ limitations under the License.
 package prometheus
 
 import (
+	"fmt"
+	"net/http"
 	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/metrics"
 )
 
@@ -52,18 +58,38 @@ var (
 			Name: "rest_client_requests_total",
 			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
 		},
-		[]string{"code", "method", "host"},
+		[]string{"code", "method", "host", "resource", "verb"},
 	)
+
+	resourceParsingRegexs = []*regexp.Regexp{}
 )
 
 func init() {
+
+	resPat := `[A-Za-z0-9.\-]*`
+
+	// watch core k8s apis
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/api/%s/watch/namespaces/%s/(?P<resource>%s)`, resPat, resPat, resPat)))
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/api/%s/watch/(?P<resource>%s)`, resPat, resPat)))
+
+	// watch custom resource apis
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/apis/%s/%s/watch/namespaces/%s/(?P<resource>%s)`, resPat, resPat, resPat, resPat)))
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/apis/%s/%s/watch/(?P<resource>%s)`, resPat, resPat, resPat)))
+
+	// namespaced core k8 apis and namespaced custom apis
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/api/%s/namespaces/%s/(?P<resource>%s)`, resPat, resPat, resPat)))
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/apis/%s/%s/namespaces/%s/(?P<resource>%s)`, resPat, resPat, resPat, resPat)))
+
+	// globally scoped core k8s apis and globally scoped custom apis
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/api/%s/(?P<resource>%s)`, resPat, resPat)))
+	resourceParsingRegexs = append(resourceParsingRegexs, regexp.MustCompile(fmt.Sprintf(`/apis/%s/%s/(?P<resource>%s)`, resPat, resPat, resPat)))
+
 	prometheus.MustRegister(requestLatency)
 	prometheus.MustRegister(requestResult)
 	prometheus.MustRegister(rateLimiterLatency)
 	metrics.Register(metrics.RegisterOpts{
 		RequestLatency:     &latencyAdapter{requestLatency},
 		RateLimiterLatency: &latencyAdapter{rateLimiterLatency},
-		RequestResult:      &resultAdapter{requestResult},
 	})
 }
 
@@ -75,10 +101,89 @@ func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) 
 	l.m.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
 }
 
-type resultAdapter struct {
-	m *prometheus.CounterVec
+type rtWrapper struct {
+	origRoundTripper http.RoundTripper
 }
 
-func (r *resultAdapter) Increment(code, method, host string) {
-	r.m.WithLabelValues(code, method, host).Inc()
+func parseURLResourceOperation(request *http.Request) (resource string, verb string) {
+	method := request.Method
+
+	resource = ""
+	verb = ""
+
+	if request.URL.Path == "" || method == "" {
+		return
+	}
+
+	for _, r := range resourceParsingRegexs {
+		if resource != "" {
+			break
+		}
+		match := r.FindStringSubmatch(request.URL.Path)
+		if len(match) > 1 {
+			resource = match[1]
+		}
+	}
+
+	if resource == "" {
+		return
+	}
+
+	switch method {
+	case "GET":
+		verb = "GET"
+		if strings.Contains(request.URL.Path, "/watch/") {
+			verb = "WATCH"
+		} else if strings.HasSuffix(request.URL.Path, resource) {
+			// If the resource is the last element in the url, then
+			// we're asking to list all resources of that type instead
+			// of getting an individual resource
+			verb = "LIST"
+		}
+	case "PUT":
+		verb = "UPDATE"
+	case "PATCH":
+		verb = "PATCH"
+	case "POST":
+		verb = "CREATE"
+	case "DELETE":
+		verb = "DELETE"
+	}
+
+	return resource, verb
+}
+
+func (r *rtWrapper) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	var status string
+	var resource string
+	var verb string
+	var host string
+
+	response, err = r.origRoundTripper.RoundTrip(request)
+	if err != nil {
+		status = "<error>"
+	} else {
+		status = strconv.Itoa(response.StatusCode)
+	}
+
+	host = "none"
+	if request.URL != nil {
+		host = request.URL.Host
+	}
+
+	resource, verb = parseURLResourceOperation(request)
+	if verb != "" && resource != "" {
+		requestResult.WithLabelValues(status, request.Method, host, resource, verb).Add(1)
+	}
+
+	return response, err
+}
+
+func AddHTTPRoundTripClientMonitoring(config *rest.Config) {
+	fn := func(rt http.RoundTripper) http.RoundTripper {
+		return &rtWrapper{
+			origRoundTripper: rt,
+		}
+	}
+	config.Wrap(fn)
 }

--- a/pkg/monitoring/client/prometheus/prometheus_suite_test.go
+++ b/pkg/monitoring/client/prometheus/prometheus_suite_test.go
@@ -1,0 +1,13 @@
+package prometheus_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPrometheus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Prometheus Suite")
+}

--- a/pkg/monitoring/client/prometheus/prometheus_suite_test.go
+++ b/pkg/monitoring/client/prometheus/prometheus_suite_test.go
@@ -1,13 +1,11 @@
-package prometheus_test
+package prometheus
 
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestPrometheus(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Prometheus Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/monitoring/client/prometheus/prometheus_test.go
+++ b/pkg/monitoring/client/prometheus/prometheus_test.go
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package prometheus
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/onsi/ginkgo/extensions/table"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = BeforeSuite(func() {
+})
+
+var _ = Describe("URL Parsing", func() {
+	Context("with resource and operation", func() {
+		table.DescribeTable("accurately parse resource and operation", func(urlStr, method, expectedResource, expectedOperation string) {
+
+			request := &http.Request{
+				Method: method,
+				URL: &url.URL{
+					Path: urlStr,
+				},
+			}
+
+			resource, operation := parseURLResourceOperation(request)
+			Expect(resource).To(Equal(expectedResource))
+			Expect(operation).To(Equal(expectedOperation))
+
+		},
+			table.Entry("should handle an empty URL and method", "", "", "", ""),
+			table.Entry("should handle an empty URL", "", "GET", "", ""),
+			table.Entry("should handle an empty Method", "/api/v1/watch/namespaces/kubevirt/pods", "", "", ""),
+			table.Entry("should handle watching namespaced resource", "/api/v1/watch/namespaces/kubevirt/pods", "GET", "pods", "WATCH"),
+			table.Entry("should handle watching globally scoped resource", "/api/v1/watch/pods", "GET", "pods", "WATCH"),
+			table.Entry("should handle list of namespaced resources", "/api/v1/namespaces/kubevirt/pods", "GET", "pods", "LIST"),
+			table.Entry("should handle get of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "GET", "pods", "GET"),
+			table.Entry("should handle list of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances", "GET", "virtualmachineinstances", "LIST"),
+			table.Entry("should handle get of custom namespaced resources", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi", "GET", "virtualmachineinstances", "GET"),
+			table.Entry("should handle list of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts", "GET", "kubevirts", "LIST"),
+			table.Entry("should handle get of custom globally scoped resources", "/apis/kubevirt.io/v1/kubevirts/my-kv", "GET", "kubevirts", "GET"),
+			table.Entry("should handle UPDATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "PUT", "pods", "UPDATE"),
+			table.Entry("should handle PATCH of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "PATCH", "pods", "PATCH"),
+			table.Entry("should handle CREATE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "POST", "pods", "CREATE"),
+			table.Entry("should handle DELETE of namespaced resources", "/api/v1/namespaces/kubevirt/pods/my-pod", "DELETE", "pods", "DELETE"),
+			table.Entry("should handle UPDATE to status subresource", "/api/v1/namespaces/kubevirt/pods/my-pod/status", "PUT", "pods", "UPDATE"),
+			table.Entry("should handle UPDATE to custom subresource", "/apis/kubevirt.io/v1/namespaces/kubevirt/virtualmachineinstances/my-vmi/some-subresource", "PUT", "virtualmachineinstances", "UPDATE"),
+		)
+	})
+
+})

--- a/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "kubevirt.io/client-go/kubecli",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/monitoring/client/prometheus:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned:go_default_library",

--- a/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     importpath = "kubevirt.io/client-go/kubecli",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/monitoring/client/prometheus:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned:go_default_library",

--- a/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
@@ -44,6 +44,7 @@ import (
 	generatedclient "kubevirt.io/client-go/generated/kubevirt/clientset/versioned"
 	networkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned"
 	promclient "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned"
+	client_metrics "kubevirt.io/kubevirt/pkg/monitoring/client/prometheus"
 )
 
 var (
@@ -235,6 +236,8 @@ func GetKubevirtClientFromRESTConfig(config *rest.Config) (KubevirtClient, error
 	if config.UserAgent == "" {
 		config.UserAgent = restclient.DefaultKubernetesUserAgent()
 	}
+
+	client_metrics.AddHTTPRoundTripClientMonitoring(&shallowCopy)
 
 	restClient, err := rest.RESTClientFor(&shallowCopy)
 	if err != nil {

--- a/tools/perfscale-audit/api/api.go
+++ b/tools/perfscale-audit/api/api.go
@@ -89,6 +89,10 @@ const (
 	ResultTypeVMICreationToRunningP50 ResultType = "vmiCreationToRunningSecondsP50"
 )
 
+const (
+	ResultTypeResourceOperationCountFormat = "%s-%s-count"
+)
+
 type ThresholdResult struct {
 	ThresholdValue    float64 `json:"thresholdValue"`
 	ThresholdExceeded bool    `json:"thresholdExceeded"`


### PR DESCRIPTION
This PR introduces expands the rest_client_requests_total counter metric to provide labels for the resource and k8s verb associated with the request. This means we have a metric that can tell us how many times we call an operation (like "UPDATE" ) on a specific resource (like "VirtualMachineInstances")

I've also integrated this metric into our perf-audit tool which allows us to audit if specific operation/resource counts hit above an expected threshold over a set period of time.

For example, If i'm running a repeatable and predictable density test that starts 100 VMIs, then I'd expect a fairly consistent number of client API calls across our control plane involved with updating those VMI objects. We can run the density test, give the perf-audit tool a threshold for the number of VMI UPDATES we expect to occur over that period (along with other thresholds) and determine if we met our performance target during the density test.


## Perf Audit tool example 

Input config establishes the expected thresholds (VMI p95 start time in under 50 seconds, and < 100 VMI UPDATE http requests)
```
cat perfaudit-cfg.json 
{
	"prometheusURL": "http://127.0.0.1:9090",
	"duration": "5m",
	"thresholdExpectations": {
		"vmiCreationToRunningSecondsP95": {
			"value": 50
		},
		"UPDATE-virtualmachineinstances-count": {
			"value": 100
		}
		"PATCH-virtualmachineinstances-count": {
			"value": 20
		}
	}
}
```

Execute the perf-audit tool and gather results. Threshold results will be set for items in input config that had predefined thresholds.
```
perfscale-audit --config-file perfaudit-cfg.json
{
  "Values": {
    "CREATE-events-count": {
      "value": 2.2222222222222223
    },
    "CREATE-pods-count": {
      "value": 1.2625533333333334
    },
    "GET-endpoints-count": {
      "value": 485.5555555555556
    },
    "GET-nodes-count": {
      "value": 2.2222222222222223
    },
     "LIST-virtualmachineinstances-count": {
      "value": 1.1111111111111112
    },
    "PATCH-virtualmachineinstances-count": {
      "value": 15.3281916666666667
      "thresholdResult": {
        "thresholdValue": 20,
        "thresholdExceeded": false
      }
    },
    "UPDATE-virtualmachineinstances-count": {
      "value": 70.087466666666668,
      "thresholdResult": {
        "thresholdValue": 100,
        "thresholdExceeded": false
      }
    },
    "vmiCreationToRunningSecondsP50": {
      "value": 15,
    },
    "vmiCreationToRunningSecondsP95": {
      "value": 19.5,
      "thresholdResult": {
        "thresholdValue": 50,
        "thresholdExceeded": false
      }
    },
    "vmiCreationToRunningSecondsP99": {
      "value": 19.9,
    }
  }
}
```


```release-note
Add resource and verb labels to rest_client_requests_total metric
```
