### PR TITLE
janitorial: avoid one boolean argument

### DIFF
--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -20,5 +20,5 @@ func main() {
 	// Hardcoding maxFails to 1 since the purpouse here is just to dump the state once
 	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), 1)
 	reporter.Cleanup()
-	reporter.Dump(duration, true)
+	reporter.DumpAllNamespaces(duration)
 }

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -90,8 +90,6 @@ func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	r.Dump(specSummary.RunTime, false)
 }
 
-// Dump dumps the current state of the cluster. The relevant logs are collected starting
-// from the since parameter.
 func (r *KubernetesReporter) Dump(duration time.Duration, isExternal bool) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {


### PR DESCRIPTION
This PR replaces a function with a boolean argument with two properly-named functions.

Function calls with a boolean argument, such as `Dump(duration, true)` are hard to read and understand. I believe that `DumpAllNamespaces(duration)` is clearer

```release-note
NONE
```
