### PR TITLE
Avoid setting ownership for /dev/kvm in emulation mode

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -79,6 +80,23 @@ func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, useEmulation bool) bool
 		}
 	}
 	return false
+}
+
+// UseSoftwareEmulationForDevice determines whether to fallback to software emulation for the given device.
+// This happens when the given device doesn't exist, and software emulation is enabled.
+func UseSoftwareEmulationForDevice(devicePath string, useEmulation bool) (bool, error) {
+	if !useEmulation {
+		return false, nil
+	}
+
+	_, err := os.Stat(devicePath)
+	if err == nil {
+		return false, nil
+	}
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, err
 }
 
 func ResourceNameToEnvVar(prefix string, resourceName string) string {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2772,16 +2772,10 @@ func (d *VirtualMachineController) claimKVMDeviceOwnership(vmi *v1.VirtualMachin
 	}
 
 	kvmPath := path.Join(isolation.MountRoot(), "dev", "kvm")
-	hasKVM, err := diskutils.FileExists(kvmPath)
-	if err != nil {
-		return err
-	}
 
-	// This is the logic applied by virt-launcher (see virtwrap/converter/converter.go)
-	// to determine whether to start the VM via KVM or QEMU.
-	needsKVM := hasKVM || !d.clusterConfig.IsUseEmulation()
-	if !needsKVM {
-		return nil
+	softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, d.clusterConfig.IsUseEmulation())
+	if err != nil || softwareEmulation {
+		return err
 	}
 
 	return diskutils.DefaultOwnershipManager.SetFileOwnership(kvmPath)

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1137,7 +1137,9 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	kvmPath := "/dev/kvm"
-	if softwareEmulation, _ := util.UseSoftwareEmulationForDevice(kvmPath, c.UseEmulation); softwareEmulation {
+	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, c.UseEmulation); err != nil {
+		return err
+	} else if softwareEmulation {
 		logger := log.DefaultLogger()
 		logger.Infof("Hardware emulation device '%s' not present. Using software emulation.", kvmPath)
 		domain.Spec.Type = "qemu"
@@ -1149,7 +1151,9 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 	virtioNetProhibited := false
 	vhostNetPath := "/dev/vhost-net"
-	if softwareEmulation, _ := util.UseSoftwareEmulationForDevice(vhostNetPath, c.UseEmulation); softwareEmulation {
+	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(vhostNetPath, c.UseEmulation); err != nil {
+		return err
+	} else if softwareEmulation {
 		logger := log.DefaultLogger()
 		logger.Infof("In-kernel virtio-net device emulation '%s' not present. Falling back to QEMU userland emulation.", vhostNetPath)
 	} else if _, err := os.Stat(vhostNetPath); os.IsNotExist(err) {


### PR DESCRIPTION
Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**What this PR does / why we need it**:

This PR fixes a bug in virt-handler that attempts to set the file ownership of `/dev/kvm` also when running in emulation mode with no KVM device. This results with a VMI stuck in `Scheduled` phase, and the following errors in virt-handler's logs:
```
{"component":"virt-handler","level":"info","msg":"Processing event default/cirros","pos":"vm.go:1549","timestamp":"2021-08-05T08:39:25.238640Z"}
{"component":"virt-handler","kind":"","level":"info","msg":"VMI is in phase: Scheduled\n","name":"cirros","namespace":"default","pos":"vm.go:1551","timestamp":"2021-08-05T08:39:25.238747Z","uid":"433d2b7c-02bf-4219-acb4-0ba63219f207"}
{"component":"virt-handler","level":"info","msg":"Domain does not exist","pos":"vm.go:1558","timestamp":"2021-08-05T08:39:25.238768Z"}
{"component":"virt-handler","kind":"","level":"info","msg":"mounting kernel artifacts","name":"cirros","namespace":"default","pos":"mount.go:378","timestamp":"2021-08-05T08:39:25.248976Z","uid":"433d2b7c-02bf-4219-acb4-0ba63219f207"}
{"component":"virt-handler","kind":"","level":"info","msg":"kernel boot not defined - nothing to mount","name":"cirros","namespace":"default","pos":"mount.go:381","timestamp":"2021-08-05T08:39:25.249041Z","uid":"433d2b7c-02bf-4219-acb4-0ba63219f207"}
{"component":"virt-handler","kind":"","level":"error","msg":"Synchronizing the VirtualMachineInstance failed.","name":"cirros","namespace":"default","pos":"vm.go:1689","reason":"stat /proc/1453211/root/dev/kvm: no such file or directory","timestamp":"2021-08-05T08:39:25.249613Z","uid":"433d2b7c-02bf-4219-acb4-0ba63219f207"}
{"component":"virt-handler","level":"info","msg":"re-enqueuing VirtualMachineInstance default/cirros","pos":"vm.go:1345","reason":"stat /proc/1453211/root/dev/kvm: no such file or directory","timestamp":"2021-08-05T08:39:25.249748Z"}
```

Related discussion:
https://kubernetes.slack.com/archives/C0163DT0R8X/p1628152821032400

**Special notes for your reviewer**:

No release note since this was only introduced in #6041 which isn't part of any released version.
Note that it *is* included though in `v0.44.0-rc.0` and `v0.43.1-rc.1` so should probably be backported to these branches before cutting the actual `v0.44.0` and `v0.43.1`.

**Release note**:
```release-note
NONE
```
