### PR TITLE
[virt-api]: Add Prometheus records & alerts for bad REST calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ prom-rules-verify: build-prom-spec-dumper
 	./hack/prom-rule-ci/verify-rules.sh \
 		"${current-dir}/${rule-spec-dumper-executable}" \
 		"${current-dir}/hack/prom-rule-ci/prom-rules-tests.yaml"
-	$(MAKE) clean-prom-spec-dumper
 
 olm-push:
 	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} CSV_VERSION=${CSV_VERSION} QUAY_USERNAME=${QUAY_USERNAME} \

--- a/Makefile
+++ b/Makefile
@@ -159,14 +159,19 @@ olm-verify:
 	hack/dockerized "./hack/olm.sh verify"
 
 current-dir := $(realpath .)
+rule-spec-dumper-executable := "rule-spec-dumper"
 
 build-prom-spec-dumper:
-	hack/dockerized "go build -o rule-spec-dumper ./hack/prom-rule-ci/rule-spec-dumper.go"
+	hack/dockerized "go build -o ${rule-spec-dumper-executable} ./hack/prom-rule-ci/rule-spec-dumper.go"
+
+clean-prom-spec-dumper:
+	rm -f ${rule-spec-dumper-executable}
 
 prom-rules-verify: build-prom-spec-dumper
 	./hack/prom-rule-ci/verify-rules.sh \
-		"${current-dir}/rule-spec-dumper" \
+		"${current-dir}/${rule-spec-dumper-executable}" \
 		"${current-dir}/hack/prom-rule-ci/prom-rules-tests.yaml"
+	$(MAKE) clean-prom-spec-dumper
 
 olm-push:
 	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} CSV_VERSION=${CSV_VERSION} QUAY_USERNAME=${QUAY_USERNAME} \

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -184,6 +184,10 @@ tests:
         values: "2 2 2 2 2 2 2 2 2 2"
       - series: 'rest_client_requests_total{namespace="ci", pod="virt-handler-1", code="500"}'
         values: "10 10 10 10 10 10 10 10 10 20"
+      - series: 'rest_client_requests_total{namespace="ci", pod="virt-api-1", code="200"}'
+        values: "2 2 2 2 2 2 2 2 2 2"
+      - series: 'rest_client_requests_total{namespace="ci", pod="virt-api-1", code="500"}'
+        values: "10 10 10 10 10 10 10 10 10 20"
 
     alert_rule_test:
       - eval_time: 5m
@@ -239,6 +243,22 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsBurst"
             exp_labels:
               pod: "virt-handler-1"
+              severity: "critical"
+      - eval_time: 5m
+        alertname: VirtApiRESTErrorsHigh
+        exp_alerts:
+          - exp_annotations:
+              summary: "More than 5% of the rest calls failed in virt-api for the last hour"
+            exp_labels:
+              pod: "virt-api-1"
+              severity: "warning"
+      - eval_time: 5m
+        alertname: VirtApiRESTErrorsBurst
+        exp_alerts:
+          - exp_annotations:
+              summary: "More than 80% of the rest calls failed in virt-api for the last 5 minutes"
+            exp_labels:
+              pod: "virt-api-1"
               severity: "critical"
 
   # Some nodes without KVM resources

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -77,6 +77,11 @@ func NewPrometheusRuleCR(namespace string, workloadUpdatesEnabled bool) *v1.Prom
 
 // NewPrometheusRuleSpec makes a prometheus rule spec for kubevirt
 func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.PrometheusRuleSpec {
+	getRestCallsFailedWarning := func(failingCallsPercentage int, component, duration string) string {
+		const restCallsFailWarningTemplate = "More than %d%% of the rest calls failed in %s for the last %s"
+		return fmt.Sprintf(restCallsFailWarningTemplate, failingCallsPercentage, component, duration)
+	}
+
 	ruleSpec := &v1.PrometheusRuleSpec{
 		Groups: []v1.RuleGroup{
 			{
@@ -222,7 +227,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_controllers_failed_client_rest_requests_in_last_hour / vec_by_virt_controllers_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary":     "More than 5% of the rest calls failed in virt-controller for the last hour",
+							"summary":     getRestCallsFailedWarning(5, "virt-controller", "hour"),
 							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
@@ -234,7 +239,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_controllers_failed_client_rest_requests_in_last_5m / vec_by_virt_controllers_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary":     "More than 80% of the rest calls failed in virt-controller for the last 5 minutes",
+							"summary":     getRestCallsFailedWarning(80, "virt-controller", "5 minutes"),
 							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
@@ -300,7 +305,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_operators_failed_client_rest_requests_in_last_hour / vec_by_virt_operators_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary":     "More than 5% of the rest calls failed in virt-operator for the last hour",
+							"summary":     getRestCallsFailedWarning(5, "virt-operator", "hour"),
 							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsHigh",
 						},
 						Labels: map[string]string{
@@ -312,7 +317,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_operators_failed_client_rest_requests_in_last_5m / vec_by_virt_operators_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary":     "More than 80% of the rest calls failed in virt-operator for the last 5 minutes",
+							"summary":     getRestCallsFailedWarning(80, "virt-operator", "5 minutes"),
 							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsBurst",
 						},
 						Labels: map[string]string{
@@ -415,7 +420,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_handlers_failed_client_rest_requests_in_last_hour / vec_by_virt_handlers_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary":     "More than 5% of the rest calls failed in virt-handler for the last hour",
+							"summary":     getRestCallsFailedWarning(5, "virt-handler", "hour"),
 							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
@@ -427,7 +432,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_handlers_failed_client_rest_requests_in_last_5m / vec_by_virt_handlers_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary":     "More than 80% of the rest calls failed in virt-handler for the last 5 minutes",
+							"summary":     getRestCallsFailedWarning(80, "virt-handler", "5 minutes"),
 							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
@@ -463,7 +468,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_apis_failed_client_rest_requests_in_last_hour / vec_by_virt_apis_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 5% of the rest calls failed in virt-api for the last hour",
+							"summary": getRestCallsFailedWarning(5, "virt-api", "hour"),
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -474,7 +479,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("(vec_by_virt_apis_failed_client_rest_requests_in_last_5m / vec_by_virt_apis_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 80% of the rest calls failed in virt-api for the last 5 minutes",
+							"summary": getRestCallsFailedWarning(80, "virt-api", "5 minutes"),
 						},
 						Labels: map[string]string{
 							"severity": "critical",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Prometheus records to track total amount of REST calls in last hour & 5 minutes, and bad REST calls over the same time-frame:
- `vec_by_virt_apis_all_client_rest_requests_in_last_5m`
- `vec_by_virt_apis_all_client_rest_requests_in_last_hour`
- `vec_by_virt_apis_failed_client_rest_requests_in_last_5m`
- `vec_by_virt_apis_failed_client_rest_requests_in_last_hour`

These records then set these alert rules:
- `VirtApiRESTErrorsHigh`: `More than 5% of the rest calls failed in virt-api for the last hour`
- `VirtApiRESTErrorsBurst`: `More than 80% of the rest calls failed in virt-api for the last 5 minutes`

**Special notes for your reviewer**:
I'm not entirely sure where `prom-rules-tests.yaml` is used besides testing. Does it have any non-testing usage? How exactly does it help for testing? How was it generated?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fire a Prometheus alert when a lot of REST failures are detected in virt-api
```
