### PR TITLE
[WIP] [Bugfix] Update dedicated CPUs on migration

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12518,6 +12518,15 @@
       "description": "The address of the target node to use for the migration",
       "type": "string"
      },
+     "targetNodeCPUSet": {
+      "description": "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node",
+      "type": "array",
+      "items": {
+       "type": "integer",
+       "format": "int32"
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "targetNodeDomainDetected": {
       "description": "The Target Node has seen the Domain Start Event",
       "type": "boolean"

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/network/errors:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -24,6 +24,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -139,6 +140,35 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance) (string
 	inMeta := false
 	inMetaKV := false
 	inMetaKVMigration := false
+
+	// If the VMI has dedicated CPUs, we need to replace the old CPUs that were
+	// assigned in the source node with the new CPUs assigned in the target node
+	var (
+		targetNodeCPUSet []int
+		cpuPinFields     []string
+		cpuSetMapping    map[int]int
+	)
+
+	if vmi.IsCPUDedicated() {
+		targetNodeCPUSet = vmi.Status.MigrationState.TargetNodeCPUSet
+		cpuPinFields = []string{"vcpupin", "emulatorpin", "iothreadpin"}
+		cpuSetMapping = map[int]int{}
+
+		if targetNodeCPUSet == nil || len(targetNodeCPUSet) == 0 {
+			return "", fmt.Errorf("target node CPU set is missing for migrating VMI %s/%s", vmi.GetNamespace(), vmi.GetName())
+		}
+
+		sourceNodeCPUSet, err := util.GetPodCPUSet()
+		if err != nil {
+			return "", err
+		}
+
+		// sourceCPUSet and tagetCPUSet are of the same length
+		for i := range sourceNodeCPUSet {
+			cpuSetMapping[sourceNodeCPUSet[i]] = targetNodeCPUSet[i]
+		}
+	}
+
 	for {
 		token, err := decoder.RawToken()
 		if err == io.EOF {
@@ -159,6 +189,19 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance) (string
 				inMetaKVMigration = true
 			}
 			depth++
+
+			// If the VMI requires dedicated CPUs, we need to patch the domain with
+			// the new CPU set in the target node prior to migration
+			if vmi.IsCPUDedicated() {
+				for _, field := range cpuPinFields {
+					if v.Name.Local == field {
+						err = updateCPUSetAttributeForXMLElement(&v, cpuSetMapping)
+						if err != nil {
+							return "", err
+						}
+					}
+				}
+			}
 		case xml.EndElement:
 			depth--
 			if inMetaKVMigration && depth == 3 && v.Name.Local == "migration" {
@@ -188,6 +231,41 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance) (string
 	}
 
 	return string(buf.Bytes()), nil
+}
+
+func updateCPUSetAttributeForXMLElement(v *xml.StartElement, cpuSetMapping map[int]int) error {
+	for i := 0; i < len(v.Attr); i++ {
+		if v.Attr[i].Name.Local == "cpuset" {
+			currentCPUsStr := v.Attr[i].Value
+
+			// if a collection of CPUs is defined, replace all CPUs
+			if strings.Contains(currentCPUsStr, ",") {
+				strCPUs := strings.Split(currentCPUsStr, ",")
+				var newCPUs []int
+
+				for _, strCPU := range strCPUs {
+					cpu, err := strconv.Atoi(strCPU)
+					if err != nil {
+						return err
+					}
+
+					newCPUs = append(newCPUs, cpuSetMapping[cpu])
+				}
+
+				v.Attr[i].Value = strings.Trim(strings.Join(strings.Fields(fmt.Sprint(newCPUs)), ","), "[]")
+			} else {
+				// a single CPU is defined
+				currentCPU, err := strconv.Atoi(v.Attr[i].Value)
+				if err != nil {
+					return err
+				}
+
+				v.Attr[i].Value = strconv.Itoa(cpuSetMapping[currentCPU])
+			}
+		}
+	}
+
+	return nil
 }
 
 func (d *migrationDisks) isSharedVolume(name string) bool {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8129,6 +8129,13 @@ var CRDsValidation map[string]string = map[string]string{
             targetNodeAddress:
               description: The address of the target node to use for the migration
               type: string
+            targetNodeCPUSet:
+              description: If the VMI requires dedicated CPUs, this field will hold
+                the dedicated CPU set on the target node
+              items:
+                type: integer
+              type: array
+              x-kubernetes-list-type: atomic
             targetNodeDomainDetected:
               description: The Target Node has seen the Domain Start Event
               type: boolean

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -3703,6 +3703,11 @@ func (in *VirtualMachineInstanceMigrationState) DeepCopyInto(out *VirtualMachine
 			(*out)[key] = val
 		}
 	}
+	if in.TargetNodeCPUSet != nil {
+		in, out := &in.TargetNodeCPUSet, &out.TargetNodeCPUSet
+		*out = make([]int, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -24395,6 +24395,25 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceMigrationState(ref
 							Format:      "",
 						},
 					},
+					"targetNodeCPUSet": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"integer"},
+										Format: "int32",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -576,6 +576,10 @@ type VirtualMachineInstanceMigrationState struct {
 	MigrationUID types.UID `json:"migrationUid,omitempty"`
 	// Lets us know if the vmi is currently running pre or post copy migration
 	Mode MigrationMode `json:"mode,omitempty"`
+	// If the VMI requires dedicated CPUs, this field will
+	// hold the dedicated CPU set on the target node
+	// +listType=atomic
+	TargetNodeCPUSet []int `json:"targetNodeCPUSet,omitempty"`
 }
 
 //

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -167,6 +167,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"abortStatus":                    "Indicates the final status of the live migration abortion",
 		"migrationUid":                   "The VirtualMachineInstanceMigration object associated with this migration",
 		"mode":                           "Lets us know if the vmi is currently running pre or post copy migration",
+		"targetNodeCPUSet":               "If the VMI requires dedicated CPUs, this field will\nhold the dedicated CPU set on the target node\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -19453,6 +19453,25 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceMigrationState(ref
 							Format:      "",
 						},
 					},
+					"targetNodeCPUSet": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "If the VMI requires dedicated CPUs, this field will hold the dedicated CPU set on the target node",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"integer"},
+										Format: "int32",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR patches a domain of a VMI that requires dedicated CPUs with the new CPU set dedicated for it on the target node

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1945586

**Special notes for your reviewer**:
- I have not found a better place to patch the domain other than the `migratableDomXML()`, if there is a better option, please let me know
- Tests are still WIP
- With those changes applied, a migration passes, but the domain xml within virt-launcher does not seem to match the actual configuration, for example:
When running `virsh edit` from within virt-launcher I can see:
```
...
<cputune>
    <vcpupin vcpu='0' cpuset='1'/>
</cputune>
...
```
But when looking at the vcpupin info of the VM with `virsh vcpupin $domain` I can see:
```
 VCPU   CPU Affinity
----------------------
 0      2
```
I am still investigating this issue, so if you have any ideas, they would be appreciated

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
