### PR TITLE
Rename "UseEmulation" --> "AllowEmulation"

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10058,6 +10058,7 @@
       "format": "int32"
      },
      "useEmulation": {
+      "description": "UseEmulation can be set to true to allow fallback to software emulation in case hardware-assisted emulation is not available.",
       "type": "boolean"
      }
     }

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -347,7 +347,7 @@ func main() {
 	uid := pflag.String("uid", "", "UID of the VirtualMachineInstance")
 	namespace := pflag.String("namespace", "", "Namespace of the VirtualMachineInstance")
 	gracePeriodSeconds := pflag.Int("grace-period-seconds", 30, "Grace period to observe before sending SIGTERM to vmi process")
-	useEmulation := pflag.Bool("use-emulation", false, "Use software emulation")
+	allowEmulation := pflag.Bool("allow-emulation", false, "Allow use of software emulation as fallback")
 	runWithNonRoot := pflag.Bool("run-as-nonroot", false, "Run libvirtd with the 'virt' user")
 	hookSidecars := pflag.Uint("hook-sidecars", 0, "Number of requested hook sidecars, virt-launcher will wait for all of them to become available")
 	noFork := pflag.Bool("no-fork", false, "Fork and let virt-launcher watch itself to react to crashes if set to false")
@@ -444,7 +444,7 @@ func main() {
 	// Start the virt-launcher command service.
 	// Clients can use this service to tell virt-launcher
 	// to start/stop virtual machines
-	options := cmdserver.NewServerOptions(*useEmulation)
+	options := cmdserver.NewServerOptions(*allowEmulation)
 	cmdclient.SetLegacyBaseDir(*virtShareDir)
 	cmdServerDone := startCmdServer(cmdclient.UninitializedSocketOnGuest(), domainManager, stopChan, options)
 

--- a/docs/software-emulation.md
+++ b/docs/software-emulation.md
@@ -9,16 +9,24 @@ in case that at least one network interface model is virtio (note: if the NIC
 model is not explicitly specified, by default virtio is chosen).
 
 If `useEmulation` is enabled,
-- hardware emulation via `/dev/kvm` will not be attempted. `qemu` will be used
-  for software emulation instead.
-- in-kernel virtio-net backend emulation via `/dev/vhost-net` will not be
-  attempted. QEMU userland virtio NIC emulation will be used for virtio-net
-  interface instead.
+- `qemu` will be used for software emulation, in case that hardware emulation
+  via `/dev/kvm` is unavailable.
+- QEMU userland virtio NIC emulation will be used for virtio-net interfaces,
+  in case that in-kernel virtio-net backend emulation via `/dev/vhost-net` 
+  is unavailable.
+
+If `useEmulation` is disabled, and a required hardware emulation device is unavailable
+(`/dev/kvm`, or `/dev/vhost-net` for a VirtualMachine which uses virtio for at least one interface),
+the VirtualMachine will fail to start and an error will be reported.
+
+Note that software emulation, when enabled, is only used as a fallback when
+hardware emulation is not available. Hardware emulation is always attempted first,
+regardless of the value of the `useEmulation`.
 
 # Configuration
 
 Enabling software emulation is a cluster-wide setting, and is activated by
-editing the kubevirt-config as follows:
+editing the `KubeVirt` CR as follows:
 
 ```bash
 cluster-up/kubectl.sh --namespace kubevirt edit kubevirt kubevirt

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -223,6 +223,9 @@ spec:
                       pvcTolerateLessSpaceUpToPercent:
                         type: integer
                       useEmulation:
+                        description: UseEmulation can be set to true to allow fallback
+                          to software emulation in case hardware-assisted emulation
+                          is not available.
                         type: boolean
                     type: object
                   emulatedMachines:
@@ -2256,6 +2259,9 @@ spec:
                       pvcTolerateLessSpaceUpToPercent:
                         type: integer
                       useEmulation:
+                        description: UseEmulation can be set to true to allow fallback
+                          to software emulation in case hardware-assisted emulation
+                          is not available.
                         type: boolean
                     type: object
                   emulatedMachines:

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -73,9 +73,9 @@ func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, useEmulation bool) bool {
+func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if !useEmulation && (iface.Model == "" || iface.Model == "virtio") {
+		if !allowEmulation && (iface.Model == "" || iface.Model == "virtio") {
 			return true
 		}
 	}
@@ -84,8 +84,8 @@ func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, useEmulation bool) bool
 
 // UseSoftwareEmulationForDevice determines whether to fallback to software emulation for the given device.
 // This happens when the given device doesn't exist, and software emulation is enabled.
-func UseSoftwareEmulationForDevice(devicePath string, useEmulation bool) (bool, error) {
-	if !useEmulation {
+func UseSoftwareEmulationForDevice(devicePath string, allowEmulation bool) (bool, error) {
+	if !allowEmulation {
 		return false, nil
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -73,13 +73,21 @@ func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
+// WantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
+// Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
+func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if !allowEmulation && (iface.Model == "" || iface.Model == "virtio") {
+		if iface.Model == "" || iface.Model == "virtio" {
 			return true
 		}
 	}
 	return false
+}
+
+// NeedVirtioNetDevice checks whether a VMI requires the presence of the "virtio" net device.
+// This happens when the VMI wants to use a "virtio" network interface, and software emulation is disallowed.
+func NeedVirtioNetDevice(vmi *v1.VirtualMachineInstance, allowEmulation bool) bool {
+	return WantVirtioNetDevice(vmi) && !allowEmulation
 }
 
 // UseSoftwareEmulationForDevice determines whether to fallback to software emulation for the given device.

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -43,7 +43,7 @@ const (
 	FeatureGatesKey                   = "feature-gates"
 	EmulatedMachinesKey               = "emulated-machines"
 	MachineTypeKey                    = "machine-type"
-	UseEmulationKey                   = "debug.useEmulation"
+	AllowEmulationKey                 = "debug.useEmulation"
 	ImagePullPolicyKey                = "dev.imagePullPolicy"
 	MigrationsConfigKey               = "migrations"
 	CPUModelKey                       = "default-cpu-model"
@@ -202,7 +202,7 @@ func defaultClusterConfig(cpuArch string) *v1.KubeVirtConfiguration {
 	return &v1.KubeVirtConfiguration{
 		ImagePullPolicy: DefaultImagePullPolicy,
 		DeveloperConfiguration: &v1.DeveloperConfiguration{
-			UseEmulation:           DefaultUseEmulation,
+			UseEmulation:           DefaultAllowEmulation,
 			MemoryOvercommit:       DefaultMemoryOvercommit,
 			LessPVCSpaceToleration: DefaultLessPVCSpaceToleration,
 			MinimumReservePVCBytes: DefaultMinimumReservePVCBytes,
@@ -359,8 +359,8 @@ func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.C
 	}
 
 	// set if emulation is used
-	useEmulation := strings.TrimSpace(configMap.Data[UseEmulationKey])
-	switch useEmulation {
+	allowEmulation := strings.TrimSpace(configMap.Data[AllowEmulationKey])
+	switch allowEmulation {
 	case "":
 		// keep the default
 	case "true":
@@ -368,7 +368,7 @@ func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.C
 	case "false":
 		config.DeveloperConfiguration.UseEmulation = false
 	default:
-		return fmt.Errorf("invalid debug.useEmulation in config: %v", useEmulation)
+		return fmt.Errorf("invalid %s in config: %v", AllowEmulationKey, allowEmulation)
 	}
 
 	// set machine type

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -37,12 +37,12 @@ var _ = Describe("ConfigMap", func() {
 		clusterConfig, _, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{"debug.useEmulation": value},
 		})
-		Expect(clusterConfig.IsUseEmulation()).To(Equal(result))
+		Expect(clusterConfig.AllowEmulation()).To(Equal(result))
 	},
-		table.Entry("is true, IsUseEmulation should return true", "true", true),
-		table.Entry("is false, IsUseEmulation should return false", "false", false),
-		table.Entry("when unset, IsUseEmulation should return false", "", false),
-		table.Entry("when invalid, IsUseEmulation should return the default", "invalid", false),
+		table.Entry("is true, AllowEmulation should return true", "true", true),
+		table.Entry("is false, AllowEmulation should return false", "false", false),
+		table.Entry("when unset, AllowEmulation should return false", "", false),
+		table.Entry("when invalid, AllowEmulation should return the default", "invalid", false),
 	)
 
 	table.DescribeTable(" when permitSlirpInterface", func(value string, result bool) {
@@ -485,7 +485,7 @@ var _ = Describe("ConfigMap", func() {
 			},
 		})
 
-		emulation := clusterConfig.IsUseEmulation()
+		emulation := clusterConfig.AllowEmulation()
 		Expect(emulation).To(BeTrue())
 
 		cminformer.GetStore().Add(&kubev1.ConfigMap{
@@ -494,10 +494,10 @@ var _ = Describe("ConfigMap", func() {
 				Name:            virtconfig.ConfigMapName,
 				ResourceVersion: rand.String(10),
 			},
-			Data: map[string]string{virtconfig.UseEmulationKey: "false"},
+			Data: map[string]string{virtconfig.AllowEmulationKey: "false"},
 		})
 
-		emulation = clusterConfig.IsUseEmulation()
+		emulation = clusterConfig.AllowEmulation()
 		Expect(emulation).To(BeFalse())
 	})
 

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -51,7 +51,7 @@ const (
 	DefaultNodeSelectors                            = ""
 	DefaultNetworkInterface                         = "bridge"
 	DefaultImagePullPolicy                          = k8sv1.PullIfNotPresent
-	DefaultUseEmulation                             = false
+	DefaultAllowEmulation                           = false
 	DefaultUnsafeMigrationOverride                  = false
 	DefaultPermitSlirpInterface                     = false
 	SmbiosConfigDefaultFamily                       = "KubeVirt"
@@ -107,7 +107,7 @@ func (c *ClusterConfig) GetMemBalloonStatsPeriod() uint32 {
 	return *c.GetConfig().MemBalloonStatsPeriod
 }
 
-func (c *ClusterConfig) IsUseEmulation() bool {
+func (c *ClusterConfig) AllowEmulation() bool {
 	return c.GetConfig().DeveloperConfiguration.UseEmulation
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1027,20 +1027,20 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		}
 	}
 
-	useEmulation := t.clusterConfig.IsUseEmulation()
+	allowEmulation := t.clusterConfig.AllowEmulation()
 	imagePullPolicy := t.clusterConfig.GetImagePullPolicy()
 
 	if resources.Limits == nil {
 		resources.Limits = make(k8sv1.ResourceList)
 	}
 
-	extraResources := getRequiredResources(vmi, useEmulation)
+	extraResources := getRequiredResources(vmi, allowEmulation)
 	for key, val := range extraResources {
 		resources.Limits[key] = val
 	}
 
-	if useEmulation {
-		command = append(command, "--use-emulation")
+	if allowEmulation {
+		command = append(command, "--allow-emulation")
 	} else {
 		resources.Limits[KvmDevice] = resource.MustParse("1")
 	}
@@ -1764,15 +1764,15 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance, config *virtconfig.
 	return capabilities
 }
 
-func getRequiredResources(vmi *v1.VirtualMachineInstance, useEmulation bool) k8sv1.ResourceList {
+func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k8sv1.ResourceList {
 	res := k8sv1.ResourceList{}
 	if (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
 		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true) {
 		res[TunDevice] = resource.MustParse("1")
 	}
-	if util.NeedVirtioNetDevice(vmi, useEmulation) {
-		// Note that about network interface, useEmulation does not make
+	if util.NeedVirtioNetDevice(vmi, allowEmulation) {
+		// Note that about network interface, allowEmulation does not make
 		// any difference on eventual Domain xml, but uniformly making
 		// /dev/vhost-net unavailable and libvirt implicitly fallback
 		// to use QEMU userland NIC emulation.

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -509,7 +509,7 @@ func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineIns
 		return false, nil
 	}
 
-	if virtutil.IsNonRootVMI(vmi) && virtutil.NeedVirtioNetDevice(vmi, d.clusterConfig.IsUseEmulation()) {
+	if virtutil.IsNonRootVMI(vmi) && virtutil.NeedVirtioNetDevice(vmi, d.clusterConfig.AllowEmulation()) {
 		vhostNet := path.Join(res.MountRoot(), "dev", "vhost-net")
 		err := diskutils.DefaultOwnershipManager.SetFileOwnership(vhostNet)
 		if err != nil {
@@ -2772,7 +2772,7 @@ func (d *VirtualMachineController) claimKVMDeviceOwnership(vmi *v1.VirtualMachin
 
 	kvmPath := path.Join(isolation.MountRoot(), "dev", "kvm")
 
-	softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, d.clusterConfig.IsUseEmulation())
+	softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, d.clusterConfig.AllowEmulation())
 	if err != nil || softwareEmulation {
 		return err
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -509,11 +509,10 @@ func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineIns
 		return false, nil
 	}
 
-	if virtutil.IsNonRootVMI(vmi) && virtutil.NeedVirtioNetDevice(vmi, d.clusterConfig.AllowEmulation()) {
-		vhostNet := path.Join(res.MountRoot(), "dev", "vhost-net")
-		err := diskutils.DefaultOwnershipManager.SetFileOwnership(vhostNet)
+	if virtutil.IsNonRootVMI(vmi) && virtutil.WantVirtioNetDevice(vmi) {
+		err := d.claimDeviceOwnership(vmi, "vhost-net")
 		if err != nil {
-			return true, fmt.Errorf("Failed to set up vhost-net device, %s", err)
+			return true, fmt.Errorf("failed to set up vhost-net device, %s", err)
 		}
 	}
 
@@ -2426,7 +2425,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 
 	}
 
-	err = d.claimKVMDeviceOwnership(vmi)
+	err = d.claimDeviceOwnership(vmi, "kvm")
 	if err != nil {
 		return fmt.Errorf("failed to set up file ownership for /dev/kvm: %v", err)
 	}
@@ -2499,7 +2498,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 
 		}
 
-		err = d.claimKVMDeviceOwnership(vmi)
+		err = d.claimDeviceOwnership(vmi, "kvm")
 		if err != nil {
 			return fmt.Errorf("failed to set up file ownership for /dev/kvm: %v", err)
 		}
@@ -2764,13 +2763,13 @@ func (d *VirtualMachineController) isHostModelMigratable(vmi *v1.VirtualMachineI
 	return nil
 }
 
-func (d *VirtualMachineController) claimKVMDeviceOwnership(vmi *v1.VirtualMachineInstance) error {
+func (d *VirtualMachineController) claimDeviceOwnership(vmi *v1.VirtualMachineInstance, deviceName string) error {
 	isolation, err := d.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return err
 	}
 
-	kvmPath := path.Join(isolation.MountRoot(), "dev", "kvm")
+	kvmPath := path.Join(isolation.MountRoot(), "dev", deviceName)
 
 	softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, d.clusterConfig.AllowEmulation())
 	if err != nil || softwareEmulation {

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -75,7 +75,7 @@ var _ = Describe("AccessCredentials", func() {
 		c := &converter.ConverterContext{
 			Architecture:   runtime.GOARCH,
 			VirtualMachine: vmi,
-			UseEmulation:   true,
+			AllowEmulation: true,
 			SMBios:         &cmdv1.SMBios{},
 		}
 		Expect(converter.Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, domain, c)).To(Succeed())

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -45,16 +45,16 @@ const (
 )
 
 type ServerOptions struct {
-	useEmulation bool
+	allowEmulation bool
 }
 
-func NewServerOptions(useEmulation bool) *ServerOptions {
-	return &ServerOptions{useEmulation: useEmulation}
+func NewServerOptions(allowEmulation bool) *ServerOptions {
+	return &ServerOptions{allowEmulation: allowEmulation}
 }
 
 type Launcher struct {
-	domainManager virtwrap.DomainManager
-	useEmulation  bool
+	domainManager  virtwrap.DomainManager
+	allowEmulation bool
 }
 
 func getVMIFromRequest(request *cmdv1.VMI) (*v1.VirtualMachineInstance, *cmdv1.Response) {
@@ -161,7 +161,7 @@ func (l *Launcher) SyncMigrationTarget(_ context.Context, request *cmdv1.VMIRequ
 		return response, nil
 	}
 
-	if err := l.domainManager.PrepareMigrationTarget(vmi, l.useEmulation); err != nil {
+	if err := l.domainManager.PrepareMigrationTarget(vmi, l.allowEmulation); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to prepare migration target pod")
 		response.Success = false
 		response.Message = getErrorMessage(err)
@@ -180,7 +180,7 @@ func (l *Launcher) SyncVirtualMachine(_ context.Context, request *cmdv1.VMIReque
 		return response, nil
 	}
 
-	if _, err := l.domainManager.SyncVMI(vmi, l.useEmulation, request.Options); err != nil {
+	if _, err := l.domainManager.SyncVMI(vmi, l.allowEmulation, request.Options); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to sync vmi")
 		response.Success = false
 		response.Message = getErrorMessage(err)
@@ -518,15 +518,15 @@ func RunServer(socketPath string,
 	stopChan chan struct{},
 	options *ServerOptions) (chan struct{}, error) {
 
-	useEmulation := false
+	allowEmulation := false
 	if options != nil {
-		useEmulation = options.useEmulation
+		allowEmulation = options.allowEmulation
 	}
 
 	grpcServer := grpc.NewServer([]grpc.ServerOption{}...)
 	server := &Launcher{
-		domainManager: domainManager,
-		useEmulation:  useEmulation,
+		domainManager:  domainManager,
+		allowEmulation: allowEmulation,
 	}
 	registerInfoServer(grpcServer)
 

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Virt remote commands", func() {
 	var shareDir string
 	var stop chan struct{}
 	var stopped bool
-	var useEmulation bool
+	var allowEmulation bool
 	var options *ServerOptions
 
 	BeforeEach(func() {
@@ -65,8 +65,8 @@ var _ = Describe("Virt remote commands", func() {
 
 		socketPath := filepath.Join(shareDir, "server.sock")
 
-		useEmulation = true
-		options = NewServerOptions(useEmulation)
+		allowEmulation = true
+		options = NewServerOptions(allowEmulation)
 		RunServer(socketPath, domainManager, stop, options)
 		client, err = cmdclient.NewClient(socketPath)
 		Expect(err).ToNot(HaveOccurred())
@@ -85,7 +85,7 @@ var _ = Describe("Virt remote commands", func() {
 		It("should start a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domain := api.NewMinimalDomain("testvmi")
-			domainManager.EXPECT().SyncVMI(vmi, useEmulation, &cmdv1.VirtualMachineOptions{}).Return(&domain.Spec, nil)
+			domainManager.EXPECT().SyncVMI(vmi, allowEmulation, &cmdv1.VirtualMachineOptions{}).Return(&domain.Spec, nil)
 
 			err := client.SyncVirtualMachine(vmi, &cmdv1.VirtualMachineOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -95,7 +95,7 @@ type EFIConfiguration struct {
 
 type ConverterContext struct {
 	Architecture          string
-	UseEmulation          bool
+	AllowEmulation        bool
 	Secrets               map[string]*k8sv1.Secret
 	VirtualMachine        *v1.VirtualMachineInstance
 	CPUSet                []int
@@ -1092,7 +1092,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	kvmPath := "/dev/kvm"
-	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, c.UseEmulation); err != nil {
+	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, c.AllowEmulation); err != nil {
 		return err
 	} else if softwareEmulation {
 		logger := log.DefaultLogger()
@@ -1106,7 +1106,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 	virtioNetProhibited := false
 	vhostNetPath := "/dev/vhost-net"
-	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(vhostNetPath, c.UseEmulation); err != nil {
+	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(vhostNetPath, c.AllowEmulation); err != nil {
 		return err
 	} else if softwareEmulation {
 		logger := log.DefaultLogger()

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1410,7 +1410,7 @@ var _ = Describe("Converter", func() {
 						},
 					},
 				},
-				UseEmulation:          true,
+				AllowEmulation:        true,
 				IsBlockPVC:            isBlockPVCMap,
 				IsBlockDV:             isBlockDVMap,
 				SMBios:                TestSmbios,
@@ -1958,8 +1958,8 @@ var _ = Describe("Converter", func() {
 						},
 					},
 				},
-				UseEmulation: true,
-				SMBios:       TestSmbios,
+				AllowEmulation: true,
+				SMBios:         TestSmbios,
 			}
 		})
 
@@ -2318,7 +2318,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices = v1.Devices{
 				AutoattachGraphicsDevice: autoAttach,
 			}
-			domain := vmiToDomain(&vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(&vmi, &ConverterContext{AllowEmulation: true})
 			Expect(domain.Spec.Devices.Video).To(HaveLen(devices))
 			Expect(domain.Spec.Devices.Graphics).To(HaveLen(devices))
 
@@ -2346,7 +2346,7 @@ var _ = Describe("Converter", func() {
 				},
 			}
 
-			domain := vmiToDomain(&vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(&vmi, &ConverterContext{AllowEmulation: true})
 			Expect(domain.Spec.Features.Hyperv).To(Equal(result))
 
 		},
@@ -2408,7 +2408,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices = v1.Devices{
 				AutoattachSerialConsole: autoAttach,
 			}
-			domain := vmiToDomain(&vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(&vmi, &ConverterContext{AllowEmulation: true})
 			Expect(domain.Spec.Devices.Serials).To(HaveLen(devices))
 			Expect(domain.Spec.Devices.Consoles).To(HaveLen(devices))
 
@@ -2574,7 +2574,7 @@ var _ = Describe("Converter", func() {
 				},
 			}
 
-			domain := vmiToDomain(&vmi, &ConverterContext{UseEmulation: true, EphemeraldiskCreator: EphemeralDiskImageCreator})
+			domain := vmiToDomain(&vmi, &ConverterContext{AllowEmulation: true, EphemeraldiskCreator: EphemeralDiskImageCreator})
 			Expect(domain.Spec.IOThreads).ToNot(BeNil())
 			Expect(int(domain.Spec.IOThreads.IOThreads)).To(Equal(threadCount))
 			for idx, disk := range domain.Spec.Devices.Disks {
@@ -2673,7 +2673,7 @@ var _ = Describe("Converter", func() {
 				Cores: 2,
 			}
 
-			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true, SMBios: &cmdv1.SMBios{}})
+			domain := vmiToDomain(vmi, &ConverterContext{AllowEmulation: true, SMBios: &cmdv1.SMBios{}})
 			Expect(*(domain.Spec.Devices.Disks[0].Driver.Queues)).To(Equal(expectedQueues),
 				"expected number of queues to equal number of requested vCPUs")
 		})
@@ -2705,8 +2705,8 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("16")
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			c := &ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
-				UseEmulation: true,
-				SMBios:       &cmdv1.SMBios{},
+				AllowEmulation: true,
+				SMBios:         &cmdv1.SMBios{},
 			}
 			domain := vmiToDomain(vmi, c)
 			domain.Spec.IOThreads = &api.IOThreads{}
@@ -2729,7 +2729,7 @@ var _ = Describe("Converter", func() {
 		It("should pack iothreads equally on available vcpus, if there are more iothreads than vcpus", func() {
 			vmi.Spec.Domain.CPU.Cores = 2
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			c := &ConverterContext{CPUSet: []int{5, 6}, UseEmulation: true}
+			c := &ConverterContext{CPUSet: []int{5, 6}, AllowEmulation: true}
 			domain := vmiToDomain(vmi, c)
 			domain.Spec.IOThreads = &api.IOThreads{}
 			domain.Spec.IOThreads.IOThreads = uint(6)
@@ -2775,7 +2775,7 @@ var _ = Describe("Converter", func() {
 				Cores: 2,
 			}
 
-			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(vmi, &ConverterContext{AllowEmulation: true})
 			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(expectedQueues),
 				"expected number of queues to equal number of requested vCPUs")
 		})
@@ -2787,14 +2787,14 @@ var _ = Describe("Converter", func() {
 				Sockets: 1,
 				Threads: 2,
 			}
-			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(vmi, &ConverterContext{AllowEmulation: true})
 			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(expectedQueues),
 				"expected number of queues to equal number of requested vCPUs")
 		})
 
 		It("should not assign queues to a non-virtio devices", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
-			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(vmi, &ConverterContext{AllowEmulation: true})
 			Expect(domain.Spec.Devices.Interfaces[0].Driver).To(BeNil(),
 				"queues should not be set for models other than virtio")
 		})
@@ -2805,7 +2805,7 @@ var _ = Describe("Converter", func() {
 				Sockets: 1,
 				Threads: 2,
 			}
-			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			domain := vmiToDomain(vmi, &ConverterContext{AllowEmulation: true})
 			expectedNumberQueues := uint(multiQueueMaxQueues)
 			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(expectedNumberQueues),
 				"should be capped to the maximum number of queues on tap devices")
@@ -2828,7 +2828,7 @@ var _ = Describe("Converter", func() {
 
 			c = &ConverterContext{
 				VirtualMachine: vmi,
-				UseEmulation:   true,
+				AllowEmulation: true,
 			}
 		})
 
@@ -2908,7 +2908,7 @@ var _ = Describe("Converter", func() {
 
 			c = &ConverterContext{
 				VirtualMachine: vmi,
-				UseEmulation:   true,
+				AllowEmulation: true,
 			}
 		})
 
@@ -2968,7 +2968,7 @@ var _ = Describe("Converter", func() {
 
 			c = &ConverterContext{
 				VirtualMachine: vmi,
-				UseEmulation:   true,
+				AllowEmulation: true,
 				IsBlockPVC: map[string]bool{
 					"test-block-pvc": true,
 				},

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -61,7 +61,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 			Alias: api.NewUserDefinedAlias(iface.Name),
 		}
 
-		// if UseEmulation unset and at least one NIC model is virtio,
+		// if AllowEmulation unset and at least one NIC model is virtio,
 		// /dev/vhost-net must be present as we should have asked for it.
 		var virtioNetMQRequested bool
 		if mq := vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue; mq != nil {

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -54,14 +54,14 @@ func shouldBlockMigrationTargetPreparation(vmi *v1.VirtualMachineInstance) bool 
 	return shouldBlock
 }
 
-func (l *LibvirtDomainManager) prepareMigrationTarget(vmi *v1.VirtualMachineInstance, useEmulation bool) error {
+func (l *LibvirtDomainManager) prepareMigrationTarget(vmi *v1.VirtualMachineInstance, allowEmulation bool) error {
 	logger := log.Log.Object(vmi)
 
 	if shouldBlockMigrationTargetPreparation(vmi) {
 		return fmt.Errorf("Blocking preparation of migration target in order to satisfy a functional test condition")
 	}
 
-	c, err := l.generateConverterContext(vmi, useEmulation, nil, true)
+	c, err := l.generateConverterContext(vmi, allowEmulation, nil, true)
 	if err != nil {
 		return fmt.Errorf("Failed to generate libvirt domain from VMI spec: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -296,8 +296,8 @@ func (l *LibvirtDomainManager) getGuestTimeContext() context.Context {
 }
 
 // PrepareMigrationTarget the target pod environment before the migration is initiated
-func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInstance, useEmulation bool) error {
-	return l.prepareMigrationTarget(vmi, useEmulation)
+func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInstance, allowEmulation bool) error {
+	return l.prepareMigrationTarget(vmi, allowEmulation)
 }
 
 // FinalizeVirtualMachineMigration finalized the migration after the migration has completed and vmi is running on target pod.
@@ -625,7 +625,7 @@ func parseDeviceAddress(addrString string) []string {
 	return addrs
 }
 
-func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineInstance, useEmulation bool, options *cmdv1.VirtualMachineOptions, isMigrationTarget bool) (*converter.ConverterContext, error) {
+func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineInstance, allowEmulation bool, options *cmdv1.VirtualMachineOptions, isMigrationTarget bool) (*converter.ConverterContext, error) {
 
 	logger := log.Log.Object(vmi)
 
@@ -707,7 +707,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	c := &converter.ConverterContext{
 		Architecture:          runtime.GOARCH,
 		VirtualMachine:        vmi,
-		UseEmulation:          useEmulation,
+		AllowEmulation:        allowEmulation,
 		CPUSet:                podCPUSet,
 		IsBlockPVC:            isBlockPVCMap,
 		IsBlockDV:             isBlockDVMap,
@@ -767,7 +767,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	return c, nil
 }
 
-func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulation bool, options *cmdv1.VirtualMachineOptions) (*api.DomainSpec, error) {
+func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmulation bool, options *cmdv1.VirtualMachineOptions) (*api.DomainSpec, error) {
 	l.domainModifyLock.Lock()
 	defer l.domainModifyLock.Unlock()
 
@@ -775,7 +775,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 
 	domain := &api.Domain{}
 
-	c, err := l.generateConverterContext(vmi, useEmulation, options, false)
+	c, err := l.generateConverterContext(vmi, allowEmulation, options, false)
 	if err != nil {
 		logger.Reason(err).Error("failed to generate libvirt domain from VMI spec")
 		return nil, err

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Manager", func() {
 		c := &converter.ConverterContext{
 			Architecture:     runtime.GOARCH,
 			VirtualMachine:   vmi,
-			UseEmulation:     true,
+			AllowEmulation:   true,
 			SMBios:           &cmdv1.SMBios{},
 			HotplugVolumes:   hotplugVolumes,
 			PermanentVolumes: permanentVolumes,

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -644,6 +644,9 @@ var CRDsValidation map[string]string = map[string]string{
                 pvcTolerateLessSpaceUpToPercent:
                   type: integer
                 useEmulation:
+                  description: UseEmulation can be set to true to allow fallback to
+                    software emulation in case hardware-assisted emulation is not
+                    available.
                   type: boolean
               type: object
             emulatedMachines:

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -19702,8 +19702,9 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 					},
 					"useEmulation": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "UseEmulation can be set to true to allow fallback to software emulation in case hardware-assisted emulation is not available.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"cpuAllocationRatio": {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -2016,8 +2016,10 @@ type DeveloperConfiguration struct {
 	MinimumReservePVCBytes uint64            `json:"minimumReservePVCBytes,omitempty"`
 	MemoryOvercommit       int               `json:"memoryOvercommit,omitempty"`
 	NodeSelectors          map[string]string `json:"nodeSelectors,omitempty"`
-	UseEmulation           bool              `json:"useEmulation,omitempty"`
-	CPUAllocationRatio     int               `json:"cpuAllocationRatio,omitempty"`
+	// UseEmulation can be set to true to allow fallback to software emulation
+	// in case hardware-assisted emulation is not available.
+	UseEmulation       bool `json:"useEmulation,omitempty"`
+	CPUAllocationRatio int  `json:"cpuAllocationRatio,omitempty"`
 	// Allow overriding the automatically determined minimum TSC frequency of the cluster
 	// and fixate the minimum to this frequency.
 	MinimumClusterTSCFrequency *int64            `json:"minimumClusterTSCFrequency,omitempty"`

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -640,6 +640,7 @@ func (DiskVerification) SwaggerDoc() map[string]string {
 func (DeveloperConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                           "DeveloperConfiguration holds developer options\n+k8s:openapi-gen=true",
+		"useEmulation":               "UseEmulation can be set to true to allow fallback to software emulation\nin case hardware-assisted emulation is not available.",
 		"minimumClusterTSCFrequency": "Allow overriding the automatically determined minimum TSC frequency of the cluster\nand fixate the minimum to this frequency.",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14760,8 +14760,9 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 					},
 					"useEmulation": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Description: "UseEmulation can be set to true to allow fallback to software emulation in case hardware-assisted emulation is not available.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"cpuAllocationRatio": {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -814,24 +814,24 @@ func deleteStorageClass(name string) {
 	util2.PanicOnError(err)
 }
 
-func ShouldUseEmulation(virtClient kubecli.KubevirtClient) bool {
-	useEmulation := false
+func ShouldAllowEmulation(virtClient kubecli.KubevirtClient) bool {
+	allowEmulation := false
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
 	kv := util2.GetCurrentKv(virtClient)
 	if kv.Spec.Configuration.DeveloperConfiguration != nil {
-		useEmulation = kv.Spec.Configuration.DeveloperConfiguration.UseEmulation
+		allowEmulation = kv.Spec.Configuration.DeveloperConfiguration.UseEmulation
 	}
 
-	return useEmulation
+	return allowEmulation
 }
 
 func EnsureKVMPresent() {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
-	if !ShouldUseEmulation(virtClient) {
+	if !ShouldAllowEmulation(virtClient) {
 		listOptions := metav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
 		virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -420,7 +420,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 
 			It("[test_id:1665]should map cores to virtio net queues", func() {
-				if tests.ShouldUseEmulation(virtClient) {
+				if tests.ShouldAllowEmulation(virtClient) {
 					Skip("Software emulation should not be enabled for this test to run")
 				}
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -86,7 +86,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	var vmi *v1.VirtualMachineInstance
 
-	var useEmulation *bool
+	var allowEmulation *bool
 
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
@@ -1209,12 +1209,12 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("VirtualMachineInstance Emulation Mode", func() {
 			BeforeEach(func() {
-				// useEmulation won't change in a test suite run, so cache it
-				if useEmulation == nil {
-					emulation := tests.ShouldUseEmulation(virtClient)
-					useEmulation = &emulation
+				// allowEmulation won't change in a test suite run, so cache it
+				if allowEmulation == nil {
+					emulation := tests.ShouldAllowEmulation(virtClient)
+					allowEmulation = &emulation
 				}
-				if !(*useEmulation) {
+				if !(*allowEmulation) {
 					Skip("Software emulation is not enabled on this cluster")
 				}
 			})
@@ -1235,7 +1235,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						computeContainerFound = true
 						for _, cmd := range container.Command {
 							By(cmd)
-							if cmd == "--use-emulation" {
+							if cmd == "--allow-emulation" {
 								emulationFlagFound = true
 							}
 						}
@@ -1243,7 +1243,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
-				Expect(emulationFlagFound).To(BeTrue(), "Expected VirtualMachineInstance pod to have '--use-emulation' flag")
+				Expect(emulationFlagFound).To(BeTrue(), "Expected VirtualMachineInstance pod to have '--allow-emulation' flag")
 			})
 
 			It("[test_id:1644]should be reflected in domain XML", func() {
@@ -1278,7 +1278,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				domain := &api.Domain{}
 				context := &converter.ConverterContext{
 					VirtualMachine: newVMI,
-					UseEmulation:   true,
+					AllowEmulation: true,
 				}
 				converter.Convert_v1_VirtualMachineInstance_To_api_Domain(newVMI, domain, context)
 
@@ -1318,12 +1318,12 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("VM Accelerated Mode", func() {
 			BeforeEach(func() {
-				// useEmulation won't change in a test suite run, so cache it
-				if useEmulation == nil {
-					emulation := tests.ShouldUseEmulation(virtClient)
-					useEmulation = &emulation
+				// allowEmulation won't change in a test suite run, so cache it
+				if allowEmulation == nil {
+					emulation := tests.ShouldAllowEmulation(virtClient)
+					allowEmulation = &emulation
 				}
-				if *useEmulation {
+				if *allowEmulation {
 					Skip("Software emulation is enabled on this cluster")
 				}
 			})
@@ -1369,7 +1369,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						computeContainerFound = true
 						for _, cmd := range container.Command {
 							By(cmd)
-							if cmd == "--use-emulation" {
+							if cmd == "--allow-emulation" {
 								emulationFlagFound = true
 							}
 						}
@@ -1377,7 +1377,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
-				Expect(emulationFlagFound).To(BeFalse(), "Expected VM pod not to have '--use-emulation' flag")
+				Expect(emulationFlagFound).To(BeFalse(), "Expected VM pod not to have '--allow-emulation' flag")
 			})
 
 			It("[test_id:1648]Should provide KVM via plugin framework", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR renames all(*) code uses of "UseEmulation" config to "AllowEmulation", to better reflect the semantics of this field (i.e., allow to use software emulation as fallback in case hardware emulation is not available). The previous terminology was inaccurate since hardware virtualization was still attempted first, even when UseEmulation was explicitly set.

* (*) One notable exception is the `KubeVirt.spec.configuration.developerConfiguration.useEmulation` field that wasn't changed to retain backward compatibility. Corollary: should we deprecate that field and introduce a `.allowEmulation` heir?

* This PR also updates the [Software Emulation](./docs/software-emulation.md) doc to clarify the semantics of `.useEmulation`, as well as adds a doc comment to the API field, displayable with `kubectl explain`.

* ~This PR was based on the branch from #6190, so includes several of its commits. Once #6190 is merged, I'll rebase to get them out of this PR~ (done).

**Release note**:
```release-note
NONE
```
