### PR TITLE
Add runbook_url to alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -21,6 +21,7 @@ tests:
           - exp_annotations:
               description: "Container virt-controller in pod virt-controller-8546c99968-x9jgg cpu usage exceeds the CPU requested"
               summary: "The container is using more CPU than what is defined in the containers resource requests"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU"
             exp_labels:
               severity: "warning"
               pod: "virt-controller-8546c99968-x9jgg"
@@ -44,6 +45,7 @@ tests:
           - exp_annotations:
               description: "Container virt-controller in pod virt-controller-8546c99968-x9jgg memory usage exceeds the memory requested"
               summary: "The container is using more memory than what is defined in the containers resource requests"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedMemory"
             exp_labels:
               severity: "warning"
               namespace: ci
@@ -68,6 +70,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "All virt-api servers are down."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
       - eval_time: 5m
@@ -75,6 +78,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 5 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
       - eval_time: 5m
@@ -82,6 +86,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "All virt-operator servers are down."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
 
@@ -105,6 +110,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No virt-handler pod detected on node node01 with running vmis for more than an hour"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineImages"
             exp_labels:
               node: "node01"
               pod: "virt-handler-asdf"
@@ -128,6 +134,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt controllers are running but not ready."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtControllersCount"
             exp_labels:
               severity: "warning"
 
@@ -143,6 +150,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No ready virt-controller was detected for the last 5 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
 
@@ -157,6 +165,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No ready virt-controller was detected for the last 5 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
 
@@ -182,6 +191,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "More than 5% of the rest calls failed in virt-controller for the last hour"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerRESTErrorsHigh"
             exp_labels:
               pod: "virt-controller-1"
               severity: "warning"
@@ -190,6 +200,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "More than 80% of the rest calls failed in virt-controller for the last 5 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerRESTErrorsBurst"
             exp_labels:
               pod: "virt-controller-1"
               severity: "critical"
@@ -198,6 +209,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "More than 5% of the rest calls failed in virt-operator for the last hour"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorRESTErrorsHigh"
             exp_labels:
               pod: "virt-operator-1"
               severity: "warning"
@@ -206,6 +218,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "More than 80% of the rest calls failed in virt-operator for the last 5 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorRESTErrorsBurst"
             exp_labels:
               pod: "virt-operator-1"
               severity: "critical"
@@ -214,6 +227,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "More than 5% of the rest calls failed in virt-handler for the last hour"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsHigh"
             exp_labels:
               pod: "virt-handler-1"
               severity: "warning"
@@ -222,6 +236,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "More than 80% of the rest calls failed in virt-handler for the last 5 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsBurst"
             exp_labels:
               pod: "virt-handler-1"
               severity: "critical"
@@ -241,6 +256,7 @@ tests:
           - exp_annotations:
               description: "Low number of nodes with KVM resource available."
               summary: "At least two nodes with kvm resource required for VM life migration."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
 
@@ -259,6 +275,7 @@ tests:
           - exp_annotations:
               description: "Low number of nodes with KVM resource available."
               summary: "At least two nodes with kvm resource required for VM life migration."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
 
@@ -290,6 +307,7 @@ tests:
           - exp_annotations:
               description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to memory limit"
               summary: "VM is at risk of being terminated by the runtime."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
               pod: "virt-launcher-testvm-123"
@@ -321,6 +339,7 @@ tests:
           - exp_annotations:
               description: "Eviction policy for vm-evict-nonmigratable (on node node1) is set to Live Migration but the VM is not migratable"
               summary: "The VM's eviction strategy is set to Live Migration but the VM is not migratable"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VMCannotBeEvicted"
             exp_labels:
               severity: "warning"
               name: "vm-evict-nonmigratable"

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -41,6 +41,7 @@ const (
 	creationTimestampJSONPath = ".metadata.creationTimestamp"
 	errorMessageJSONPath      = ".status.error.message"
 	prometheusLabelKey        = "prometheus.kubevirt.io"
+	runbookUrlBasePath        = "https://kubevirt.io/monitoring/runbooks/"
 )
 
 var (
@@ -566,7 +567,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_api_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "All virt-api servers are down.",
+							"summary":     "All virt-api servers are down.",
+							"runbook_url": runbookUrlBasePath + "VirtAPIDown",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -581,7 +583,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_api_up_total < 2)"),
 						For:   "60m",
 						Annotations: map[string]string{
-							"summary": "More than one virt-api should be running if more than one worker nodes exist.",
+							"summary":     "More than one virt-api should be running if more than one worker nodes exist.",
+							"runbook_url": runbookUrlBasePath + "LowVirtAPICount",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -598,6 +601,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"description": "Low number of nodes with KVM resource available.",
 							"summary":     "At least two nodes with kvm resource required for VM life migration.",
+							"runbook_url": runbookUrlBasePath + "LowKVMNodesCount",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -620,7 +624,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_controller_ready_total <  kubevirt_virt_controller_up_total"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "Some virt controllers are running but not ready.",
+							"summary":     "Some virt controllers are running but not ready.",
+							"runbook_url": runbookUrlBasePath + "LowReadyVirtControllersCount",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -631,7 +636,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_controller_ready_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "No ready virt-controller was detected for the last 5 min.",
+							"summary":     "No ready virt-controller was detected for the last 5 min.",
+							"runbook_url": runbookUrlBasePath + "NoReadyVirtController",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -642,7 +648,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_controller_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "No running virt-controller was detected for the last 5 min.",
+							"summary":     "No running virt-controller was detected for the last 5 min.",
+							"runbook_url": runbookUrlBasePath + "VirtControllerDown",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -653,7 +660,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_controller_ready_total < 2)"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than one virt-controller should be ready if more than one worker node.",
+							"summary":     "More than one virt-controller should be ready if more than one worker node.",
+							"runbook_url": runbookUrlBasePath + "LowVirtControllersCount",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -688,7 +696,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(vec_by_virt_controllers_failed_client_rest_requests_in_last_hour / vec_by_virt_controllers_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 5% of the rest calls failed in virt-controller for the last hour",
+							"summary":     "More than 5% of the rest calls failed in virt-controller for the last hour",
+							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -699,7 +708,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(vec_by_virt_controllers_failed_client_rest_requests_in_last_5m / vec_by_virt_controllers_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 80% of the rest calls failed in virt-controller for the last 5 minutes",
+							"summary":     "More than 80% of the rest calls failed in virt-controller for the last 5 minutes",
+							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -716,7 +726,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_operator_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "All virt-operator servers are down.",
+							"summary":     "All virt-operator servers are down.",
+							"runbook_url": runbookUrlBasePath + "VirtOperatorDown",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -727,7 +738,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_operator_up_total < 2)"),
 						For:   "60m",
 						Annotations: map[string]string{
-							"summary": "More than one virt-operator should be running if more than one worker nodes exist.",
+							"summary":     "More than one virt-operator should be running if more than one worker nodes exist.",
+							"runbook_url": runbookUrlBasePath + "LowVirtOperatorCount",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -762,7 +774,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(vec_by_virt_operators_failed_client_rest_requests_in_last_hour / vec_by_virt_operators_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 5% of the rest calls failed in virt-operator for the last hour",
+							"summary":     "More than 5% of the rest calls failed in virt-operator for the last hour",
+							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsHigh",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -773,7 +786,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(vec_by_virt_operators_failed_client_rest_requests_in_last_5m / vec_by_virt_operators_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 80% of the rest calls failed in virt-operator for the last 5 minutes",
+							"summary":     "More than 80% of the rest calls failed in virt-operator for the last 5 minutes",
+							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsBurst",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -796,7 +810,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_operator_ready_total <  kubevirt_virt_operator_up_total"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "Some virt-operators are running but not ready.",
+							"summary":     "Some virt-operators are running but not ready.",
+							"runbook_url": runbookUrlBasePath + "LowReadyVirtOperatorsCount",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -807,7 +822,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_operator_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "No ready virt-operator was detected for the last 5 min.",
+							"summary":     "No ready virt-operator was detected for the last 5 min.",
+							"runbook_url": runbookUrlBasePath + "NoReadyVirtOperator",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -818,7 +834,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_virt_operator_leading_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "No leading virt-operator was detected for the last 5 min.",
+							"summary":     "No leading virt-operator was detected for the last 5 min.",
+							"runbook_url": runbookUrlBasePath + "NoLeadingVirtOperator",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -836,7 +853,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 								fmt.Sprintf("kube_daemonset_status_desired_number_scheduled{namespace='%s', daemonset='virt-handler'}", ns))),
 						For: "15m",
 						Annotations: map[string]string{
-							"summary": "Some virt-handlers failed to roll out",
+							"summary":     "Some virt-handlers failed to roll out",
+							"runbook_url": runbookUrlBasePath + "VirtHandlerDaemonSetRolloutFailing",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -871,7 +889,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(vec_by_virt_handlers_failed_client_rest_requests_in_last_hour / vec_by_virt_handlers_all_client_rest_requests_in_last_hour) >= 0.05"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 5% of the rest calls failed in virt-handler for the last hour",
+							"summary":     "More than 5% of the rest calls failed in virt-handler for the last hour",
+							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -882,7 +901,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(vec_by_virt_handlers_failed_client_rest_requests_in_last_5m / vec_by_virt_handlers_all_client_rest_requests_in_last_5m) >= 0.8"),
 						For:   "5m",
 						Annotations: map[string]string{
-							"summary": "More than 80% of the rest calls failed in virt-handler for the last 5 minutes",
+							"summary":     "More than 80% of the rest calls failed in virt-handler for the last 5 minutes",
+							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
 							"severity": "critical",
@@ -899,6 +919,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} free memory is less than 20 MB and it is close to memory limit",
 							"summary":     "VM is at risk of being terminated by the runtime.",
+							"runbook_url": runbookUrlBasePath + "KubevirtVmHighMemoryUsage",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -913,7 +934,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("(kubevirt_num_virt_handlers_by_node_running_virt_launcher) == 0"),
 						For:   "60m",
 						Annotations: map[string]string{
-							"summary": "No virt-handler pod detected on node {{ $labels.node }} with running vmis for more than an hour",
+							"summary":     "No virt-handler pod detected on node {{ $labels.node }} with running vmis for more than an hour",
+							"runbook_url": runbookUrlBasePath + "OrphanedVirtualMachineImages",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -926,6 +948,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"description": "Eviction policy for {{ $labels.name }} (on node {{ $labels.node }}) is set to Live Migration but the VM is not migratable",
 							"summary":     "The VM's eviction strategy is set to Live Migration but the VM is not migratable",
+							"runbook_url": runbookUrlBasePath + "VMCannotBeEvicted",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -938,6 +961,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage exceeds the memory requested",
 							"summary":     "The container is using more memory than what is defined in the containers resource requests",
+							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedMemory",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -952,6 +976,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} cpu usage exceeds the CPU requested",
 							"summary":     "The container is using more CPU than what is defined in the containers resource requests",
+							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedCPU",
 						},
 						Labels: map[string]string{
 							"severity": "warning",
@@ -969,7 +994,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 			Expr:  intstr.FromString("kubevirt_vmi_outdated_count != 0"),
 			For:   "1440m",
 			Annotations: map[string]string{
-				"summary": "Some running VMIs are still active in outdated pods after KubeVirt control plane update has completed.",
+				"summary":     "Some running VMIs are still active in outdated pods after KubeVirt control plane update has completed.",
+				"runbook_url": runbookUrlBasePath + "OutdatedVirtualMachineInstanceWorkloads",
 			},
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add runbook_url to alerts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR adds to each alert the runbook url that points to a runbook that provides additional details on each alert and how to mitigate it.
```
