### PR TITLE
Test compute quarantine tests inter-dependencies

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1226,7 +1226,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			},
 				table.Entry("[test_id:2653] with default migration configuration", nil, v1.MigrationPreCopy),
-				table.Entry("[QUARANTINE][test_id:5004] with postcopy", &v1.MigrationConfiguration{
+				table.Entry("[test_id:5004] with postcopy", &v1.MigrationConfiguration{
 					AllowPostCopy:           pointer.BoolPtr(true),
 					CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
 				}, v1.MigrationPostCopy),

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1619,7 +1619,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[test_id:3150]should be able to update kubevirt install with custom image tag", func() {
+		It("[sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
I merged a bunch of stability improvements for test_id:5004.

In every PR the presubmit lanes (which I always ran for at least 5 times in a row) passed in a near to 100% pass rate. In periodic lanes though the test passed for about 30-40% of the times.

After talking to @fgimenez about this issue, he suggested that the different results may occur from the fact that periodics run all quarantines tests, therefore it could be that one of the tests causes the whole lane for instability. If this is the case, finding this problematic test will have much value, as now it is pretty much impossible to further debug the test and know where the problem is coming from (the test? other test? some inter-dependency between them?).

P.S. We can also discuss if there's a better way to isolate tests from one another so this won't happen in the future, as it causes a waste of time and prevents from performing a meaningful debug.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
