### PR TITLE
Fix false positive gosec complaints on hardedcoded credentials

### DIFF
--- a/pkg/virt-operator/resource/generate/components/secrets.go
+++ b/pkg/virt-operator/resource/generate/components/secrets.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 )
 
+// #nosec 101, false positives were caused by variables not holding any secret value.
 const (
 	KubeVirtCASecretName            = "kubevirt-ca"
 	VirtHandlerCertSecretName       = "kubevirt-virt-handler-certs"

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -76,6 +76,7 @@ const (
 	// the regex used to parse the operator image
 	operatorImageRegex = "^(.*)/(.*)virt-operator([@:].*)?$"
 
+	// #nosec 101, the variable is not holding any credential
 	// Prefix for env vars that will be passed along
 	PassthroughEnvPrefix = "KV_IO_EXTRA_ENV_"
 )


### PR DESCRIPTION
Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The purpose of this PR is to eliminate the false positive complaints about "hardcoded credentials" from "make gosec". The said complaints contain the initialization of string variables whose variable-names contain key-words "Secret" and "Pass". The current over-conservatively defined rule 101 for "potential hardcoded credentials" is defined at https://securego.io/docs/rules/g101.html. 

Overall, there are 2 complaints with regard to the rule G101. The proposed solution is to add 2 comment lines with "#nosec G101" at 
- https://github.com/kubevirt/kubevirt/blob/2250bcba717fd52611724abb1815dd4abf214d25/pkg/virt-operator/resource/generate/components/secrets.go#L23
- https://github.com/kubevirt/kubevirt/blob/2250bcba717fd52611724abb1815dd4abf214d25/pkg/virt-operator/util/config.go#L80

As discussed in the review, an alternative solution is to have the "make gosec" exclude the rule G101 (potential hardcoded credentials) by adding a command-line option "-exclude=G101", given the rule is widely considered poorly defined. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
