### PR TITLE
login, Decrease Cirros relogin timeout to 5 seconds

### DIFF
--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -36,7 +36,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 	if err != nil {
 		return err
 	}
-	_, _, err = expecter.Expect(regexp.MustCompile(`\$`), 10*time.Second)
+	_, _, err = expecter.Expect(regexp.MustCompile(`\$`), 5*time.Second)
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
There is no need to let Cirros relogin logic wait 10
seconds for the prompt.
Most of the tests do not relogin, so its a waste of time.
Even in cases where there is need for relogin, 10 seconds is too much.

Reduce it to 5 seconds.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
