### PR TITLE
Bug - Remove noop file ownership change

### DIFF
--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -99,11 +99,6 @@ func ReplacePVCByHostDisk(vmi *v1.VirtualMachineInstance, clientset kubecli.Kube
 			}
 			// PersistenVolumeClaim is replaced by HostDisk
 			volumeSource.PersistentVolumeClaim = nil
-			// Set ownership of the disk.img to qemu
-			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(file); err != nil && !os.IsNotExist(err) {
-				log.Log.Reason(err).Errorf("Couldn't set Ownership on %s: %v", file, err)
-				return err
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This change is noop because func ReplacePVCByHostDisk is
executed from handler context but the file path is
relevant to launcher context. Therefore the change is
failing 100% time and we are ignoring it.

Also, this is a side-effect of the function.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I will handle the ownership change in follow-up PR.


**Release note**:

```release-note
NONE
```
