### PR TITLE
[release-0.41] fix goroutine leak in virt-handler

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -286,24 +286,30 @@ func handleDomainNotifyPipe(domainPipeStopChan chan struct{}, ln net.Listener, v
 
 	fdChan := make(chan net.Conn, 100)
 
-	// Listen for new connections,
 	// Close listener and exit when stop encountered
+	go func() {
+		<-domainPipeStopChan
+		log.Log.Object(vmi).Infof("closing notify pipe listener for vmi")
+		if err := ln.Close(); err != nil {
+			log.Log.Object(vmi).Infof("failed closing notify pipe listener for vmi: %v", err)
+		}
+	}()
+
+	// Listen for new connections,
 	go func(vmi *v1.VirtualMachineInstance, ln net.Listener, domainPipeStopChan chan struct{}) {
 		for {
-			select {
-			case <-domainPipeStopChan:
-				log.Log.Object(vmi).Infof("closing notify pipe listener for vmi")
-				ln.Close()
-				return
-			default:
-				fd, err := ln.Accept()
-				if err != nil {
-					log.Log.Reason(err).Error("Domain pipe accept error encountered.")
-					// keep listening until stop invoked
-					time.Sleep(1)
-				} else {
-					fdChan <- fd
+			fd, err := ln.Accept()
+			if err != nil {
+				var netErr *net.OpError
+				if goerror.As(err, &netErr) && !netErr.Temporary() {
+					// As Accept blocks, closing it is our mechanism to exit this loop
+					return
 				}
+				log.Log.Reason(err).Error("Domain pipe accept error encountered.")
+				// keep listening until stop invoked
+				time.Sleep(1 * time.Second)
+			} else {
+				fdChan <- fd
 			}
 		}
 	}(vmi, ln, domainPipeStopChan)


### PR DESCRIPTION
This is an modified version of #6176 for compatibility with Go 1.13.

/assign @kwiesmueller

```release-note
Fix goroutine leak in virt-handler, potentially causing issues with a high turnover of VMIs.
```
