### PR TITLE
cluster-sync, Run clean parallel to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,7 @@ cluster-deploy: cluster-clean
 	./hack/cluster-deploy.sh
 
 cluster-sync:
-	$(MAKE) cluster-build
-	$(MAKE) cluster-deploy
+	./hack/cluster-sync.sh
 
 builder-build:
 	./hack/builder/build.sh

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2021 Red Hat, Inc.
+#
+
+set -e
+
+. ./hack/cluster-clean.sh --source-only
+
+TEMP_FILE=$(mktemp -p /tmp -t kubevirt.deploy.XXXX)
+
+trap 'rm -f $TEMP_FILE' EXIT SIGINT
+
+function main() {
+    cluster_clean >$TEMP_FILE 2>&1 &
+    CLEAN_PID=$!
+
+    make cluster-build
+
+    echo "waiting for cluster-clean to finish"
+    if ! wait $CLEAN_PID; then
+        echo "cluster-clean failed, output was:"
+        cat $TEMP_FILE
+        exit 1
+    fi
+
+    wait_for_namespaces_deletion
+    ./hack/cluster-deploy.sh
+}
+
+main "$@"


### PR DESCRIPTION
In order to make cluster-sync faster,
run the cluster-clean parallel to the cluster-build.
Before running cluster-deploy, wait for the resources
to be cleaned.

Logs of the clean process will not be printed in case
the clean finished successfully.
It is simply not needed, and then the cluster-sync log 
is cleaner.
In case of an error in cluster-clean, logs will be printed 
and exit with an error.
    
This saves around 2 - 3.5 minutes on non first `cluster-sync`.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
