### PR TITLE
Yd/fix ephemeral volume manifest

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -527,7 +527,25 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 			})
 		}
 		if volume.Ephemeral != nil {
-			volumeMounts = append(volumeMounts, volumeMount)
+			logger := log.DefaultLogger()
+			claimName := volume.Ephemeral.PersistentVolumeClaim.ClaimName
+			_, exists, isBlock, err := types.IsPVCBlockFromStore(t.persistentVolumeClaimStore, namespace, claimName)
+			if err != nil {
+				logger.Errorf("error getting PVC: %v", claimName)
+				return nil, err
+			} else if !exists {
+				logger.Errorf("didn't find PVC %v", claimName)
+				return nil, PvcNotFoundError(fmt.Errorf("didn't find PVC %v", claimName))
+			} else if isBlock {
+				devicePath := filepath.Join(string(filepath.Separator), "dev", volume.Name)
+				device := k8sv1.VolumeDevice{
+					Name:       volume.Name,
+					DevicePath: devicePath,
+				}
+				volumeDevices = append(volumeDevices, device)
+			} else {
+				volumeMounts = append(volumeMounts, volumeMount)
+			}
 			volumes = append(volumes, k8sv1.Volume{
 				Name: volume.Name,
 				VolumeSource: k8sv1.VolumeSource{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -742,6 +742,7 @@ func Convert_v1_BlockVolumeSource_To_api_Disk(volumeName string, disk *api.Disk,
 	if !contains(volumesDiscardIgnore, volumeName) {
 		disk.Driver.Discard = "unmap"
 	}
+	disk.Source.Name = volumeName
 	disk.Source.Dev = GetBlockDeviceVolumePath(volumeName)
 	return nil
 }
@@ -865,11 +866,15 @@ func Convert_v1_EphemeralVolumeSource_To_api_Disk(volumeName string, disk *api.D
 	}
 
 	backingDisk := &api.Disk{Driver: &api.DiskDriver{}}
-	err := Convert_v1_FilesystemVolumeSource_To_api_Disk(volumeName, backingDisk, c.VolumesDiscardIgnore)
-	if err != nil {
-		return err
+	if c.IsBlockPVC[volumeName] {
+		if err := Convert_v1_BlockVolumeSource_To_api_Disk(volumeName, backingDisk, c.VolumesDiscardIgnore); err != nil {
+			return err
+		}
+	} else {
+		if err := Convert_v1_FilesystemVolumeSource_To_api_Disk(volumeName, backingDisk, c.VolumesDiscardIgnore); err != nil {
+			return err
+		}
 	}
-
 	disk.BackingStore.Format.Type = backingDisk.Driver.Type
 	disk.BackingStore.Source = &backingDisk.Source
 	disk.BackingStore.Type = backingDisk.Type

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -487,7 +487,15 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		return domain, fmt.Errorf("preparing ephemeral container disk images failed: %v", err)
 	}
 	// Create images for volumes that are marked ephemeral.
-	err = l.ephemeralDiskCreator.CreateEphemeralImages(vmi)
+	isDevEphemeralBackingSource := make(map[string]bool)
+	for _, disk := range domain.Spec.Devices.Disks {
+		if disk.BackingStore != nil && disk.BackingStore.Source != nil {
+			if disk.BackingStore.Source.Dev != "" && disk.BackingStore.Source.Name != "" {
+				isDevEphemeralBackingSource[disk.BackingStore.Source.Name] = true
+			}
+		}
+	}
+	err = l.ephemeralDiskCreator.CreateEphemeralImages(vmi, isDevEphemeralBackingSource)
 	if err != nil {
 		return domain, fmt.Errorf("preparing ephemeral images failed: %v", err)
 	}
@@ -674,7 +682,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	isBlockDVMap := make(map[string]bool)
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
-		if volume.VolumeSource.PersistentVolumeClaim != nil {
+		if volume.VolumeSource.PersistentVolumeClaim != nil || volume.VolumeSource.Ephemeral != nil {
 			isBlockPVC := false
 			if _, ok := hotplugVolumes[volume.Name]; ok {
 				isBlockPVC = isHotplugBlockDeviceVolume(volume.Name)


### PR DESCRIPTION
Signed-off-by: YitzyD <yitzy.i.dier@gmail.com>

**What this PR does / why we need it**: 
- Fixes issue with ephemeral volumes where the PVC volume mode is unchecked, rendering an invalid pod manifest for `volumeMode: Block` PVCs. Additionally, I have added a check in virt launcher to select the correct location for the backing disk when it performs qemu-img in the preStart hook.

**Special notes for your reviewer**:
NONE
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
