### PR TITLE
Remove test-id:3468 from quarantine - no failures in a while

### DIFF
--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -211,7 +211,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		util.PanicOnError(err)
 	})
 
-	It("[QUARANTINE][test_id:3468]Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
+	It("[test_id:3468]Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
 		By("Waiting for a VM to be created")
 		Eventually(func() bool {
 			_, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &v1.GetOptions{})


### PR DESCRIPTION
**Special notes for your reviewer**:
[test_id:3468 in search.ci.kubevirt.io link](https://search.ci.kubevirt.io/?search=test_id%3A3468&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job).
This test_id appears in two tests and it's the other test_id occurrence that is failing. And even that hasn't happened in 13 days.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
