### PR TITLE
Add spec generator pkg

### DIFF
--- a/pkg/network/domainspec/BUILD.bazel
+++ b/pkg/network/domainspec/BUILD.bazel
@@ -2,47 +2,35 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "network.go",
-        "podnic.go",
-    ],
-    importpath = "kubevirt.io/kubevirt/pkg/network/setup",
+    srcs = ["generators.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network/domainspec",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/network/cache:go_default_library",
-        "//pkg/network/dhcp:go_default_library",
-        "//pkg/network/domainspec:go_default_library",
         "//pkg/network/driver:go_default_library",
-        "//pkg/network/errors:go_default_library",
-        "//pkg/network/infraconfigurators:go_default_library",
+        "//pkg/network/link:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//staging/src/kubevirt.io/client-go/precond:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
-        "network_suite_test.go",
-        "network_test.go",
-        "podnic_test.go",
+        "domainspec_suite_test.go",
+        "generators_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
-        "//pkg/network/cache:go_default_library",
-        "//pkg/network/dhcp:go_default_library",
         "//pkg/network/driver:go_default_library",
-        "//pkg/network/errors:go_default_library",
-        "//pkg/network/infraconfigurators:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )

--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -1,0 +1,68 @@
+package domainspec
+
+import (
+	"testing"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+func TestDomainSpec(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}
+
+func newVMI(namespace, name string) *v1.VirtualMachineInstance {
+	vmi := v1.NewMinimalVMIWithNS(namespace, name)
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	return vmi
+}
+
+func newVMISlirpInterface(namespace string, name string) *v1.VirtualMachineInstance {
+	vmi := newVMI(namespace, name)
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultSlirpNetworkInterface()}
+	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+	return vmi
+}
+
+func newVMIMacvtapInterface(namespace string, vmiName string, ifaceName string) *v1.VirtualMachineInstance {
+	vmi := newVMI(namespace, vmiName)
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMacvtapNetworkInterface(ifaceName)}
+	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+	return vmi
+}
+
+func NewDomainWithSlirpInterface() *api.Domain {
+	domain := &api.Domain{}
+	domain.Spec.Devices.Interfaces = []api.Interface{{
+		Model: &api.Model{
+			Type: "e1000",
+		},
+		Type:  "user",
+		Alias: api.NewUserDefinedAlias("default"),
+	},
+	}
+
+	// Create network interface
+	if domain.Spec.QEMUCmd == nil {
+		domain.Spec.QEMUCmd = &api.Commandline{}
+	}
+
+	if domain.Spec.QEMUCmd.QEMUArg == nil {
+		domain.Spec.QEMUCmd.QEMUArg = make([]api.Arg, 0)
+	}
+
+	return domain
+}
+
+func NewDomainWithMacvtapInterface(macvtapName string) *api.Domain {
+	domain := &api.Domain{}
+	domain.Spec.Devices.Interfaces = []api.Interface{{
+		Alias: api.NewUserDefinedAlias(macvtapName),
+		Model: &api.Model{
+			Type: "virtio",
+		},
+		Type: "ethernet",
+	}}
+	return domain
+}

--- a/pkg/network/domainspec/generators.go
+++ b/pkg/network/domainspec/generators.go
@@ -17,7 +17,7 @@
  *
  */
 
-package network
+package domainspec
 
 import (
 	"fmt"
@@ -33,10 +33,10 @@ import (
 )
 
 type LibvirtSpecGenerator interface {
-	generate() error
+	Generate() error
 }
 
-func newMacvtapLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain, podInterfaceName string, handler netdriver.NetworkHandler) *MacvtapLibvirtSpecGenerator {
+func NewMacvtapLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain, podInterfaceName string, handler netdriver.NetworkHandler) *MacvtapLibvirtSpecGenerator {
 	return &MacvtapLibvirtSpecGenerator{
 		vmiSpecIface:     iface,
 		domain:           domain,
@@ -45,7 +45,7 @@ func newMacvtapLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain, pod
 	}
 }
 
-func newMasqueradeLibvirtSpecGenerator(iface *v1.Interface, vmiSpecNetwork *v1.Network, domain *api.Domain, podInterfaceName string, handler netdriver.NetworkHandler) *MasqueradeLibvirtSpecGenerator {
+func NewMasqueradeLibvirtSpecGenerator(iface *v1.Interface, vmiSpecNetwork *v1.Network, domain *api.Domain, podInterfaceName string, handler netdriver.NetworkHandler) *MasqueradeLibvirtSpecGenerator {
 	return &MasqueradeLibvirtSpecGenerator{
 		vmiSpecIface:     iface,
 		vmiSpecNetwork:   vmiSpecNetwork,
@@ -55,14 +55,14 @@ func newMasqueradeLibvirtSpecGenerator(iface *v1.Interface, vmiSpecNetwork *v1.N
 	}
 }
 
-func newSlirpLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *SlirpLibvirtSpecGenerator {
+func NewSlirpLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *SlirpLibvirtSpecGenerator {
 	return &SlirpLibvirtSpecGenerator{
 		vmiSpecIface: iface,
 		domain:       domain,
 	}
 }
 
-func newBridgeLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain, cachedDomainInterface api.Interface, podInterfaceName string, handler netdriver.NetworkHandler) *BridgeLibvirtSpecGenerator {
+func NewBridgeLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain, cachedDomainInterface api.Interface, podInterfaceName string, handler netdriver.NetworkHandler) *BridgeLibvirtSpecGenerator {
 	return &BridgeLibvirtSpecGenerator{
 		vmiSpecIface:          iface,
 		domain:                domain,
@@ -80,7 +80,7 @@ type BridgeLibvirtSpecGenerator struct {
 	handler               netdriver.NetworkHandler
 }
 
-func (b *BridgeLibvirtSpecGenerator) generate() error {
+func (b *BridgeLibvirtSpecGenerator) Generate() error {
 	domainIface, err := b.discoverDomainIfaceSpec()
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ type MasqueradeLibvirtSpecGenerator struct {
 	podInterfaceName string
 }
 
-func (b *MasqueradeLibvirtSpecGenerator) generate() error {
+func (b *MasqueradeLibvirtSpecGenerator) Generate() error {
 	domainIface, err := b.discoverDomainIfaceSpec()
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ type SlirpLibvirtSpecGenerator struct {
 	domain       *api.Domain
 }
 
-func (b *SlirpLibvirtSpecGenerator) generate() error {
+func (b *SlirpLibvirtSpecGenerator) Generate() error {
 	// remove slirp interface from domain spec devices interfaces
 	var foundIfaceModelType string
 	ifaces := b.domain.Spec.Devices.Interfaces
@@ -211,7 +211,7 @@ type MacvtapLibvirtSpecGenerator struct {
 	handler          netdriver.NetworkHandler
 }
 
-func (b *MacvtapLibvirtSpecGenerator) generate() error {
+func (b *MacvtapLibvirtSpecGenerator) Generate() error {
 	domainIface, err := b.discoverDomainIfaceSpec()
 	if err != nil {
 		return err

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -443,22 +443,3 @@ func (h *NetworkUtilsHandler) DisableTXOffloadChecksum(ifaceName string) error {
 // Allow mocking for tests
 var DHCPServer = dhcpserver.SingleClientDHCPServer
 var DHCPv6Server = dhcpserverv6.SingleClientDHCPv6Server
-
-// filter out irrelevant routes
-func FilterPodNetworkRoutes(routes []netlink.Route, nic *cache.DHCPConfig) (filteredRoutes []netlink.Route) {
-	for _, route := range routes {
-		log.Log.V(5).Infof("route: %s", route.String())
-		// don't create empty static routes
-		if route.Dst == nil && route.Src.Equal(nil) && route.Gw.Equal(nil) {
-			continue
-		}
-
-		// don't create static route for src == nic
-		if route.Src != nil && route.Src.Equal(nic.IP.IP) {
-			continue
-		}
-
-		filteredRoutes = append(filteredRoutes, route)
-	}
-	return
-}

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -16,8 +16,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
-const bridgeFakeIP = "169.254.75.1%d/32"
-
 type BridgePodNetworkConfigurator struct {
 	bridgeInterfaceName string
 	vmiSpecIface        *v1.Interface

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -181,7 +181,7 @@ func (b *BridgePodNetworkConfigurator) decorateDhcpConfigRoutes(dhcpConfig *cach
 	log.Log.V(4).Infof("the default route is: %s", b.podIfaceRoutes[0].String())
 	dhcpConfig.Gateway = b.podIfaceRoutes[0].Gw
 	if len(b.podIfaceRoutes) > 1 {
-		dhcpRoutes := netdriver.FilterPodNetworkRoutes(b.podIfaceRoutes, dhcpConfig)
+		dhcpRoutes := virtnetlink.FilterPodNetworkRoutes(b.podIfaceRoutes, dhcpConfig)
 		dhcpConfig.Routes = &dhcpRoutes
 	}
 }

--- a/pkg/network/link/BUILD.bazel
+++ b/pkg/network/link/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/network/link",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/cache:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -28,10 +29,12 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/network/cache:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )

--- a/pkg/network/link/address.go
+++ b/pkg/network/link/address.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -117,4 +118,23 @@ func GetFakeBridgeIP(vmiSpecIfaces []v1.Interface, vmiSpecIface *v1.Interface) s
 		}
 	}
 	return ""
+}
+
+// FilterPodNetworkRoutes filters out irrelevant routes
+func FilterPodNetworkRoutes(routes []netlink.Route, nic *cache.DHCPConfig) (filteredRoutes []netlink.Route) {
+	for _, route := range routes {
+		log.Log.V(5).Infof("route: %s", route.String())
+		// don't create empty static routes
+		if route.Dst == nil && route.Src.Equal(nil) && route.Gw.Equal(nil) {
+			continue
+		}
+
+		// don't create static route for src == nic
+		if route.Src != nil && route.Src.Equal(nic.IP.IP) {
+			continue
+		}
+
+		filteredRoutes = append(filteredRoutes, route)
+	}
+	return
 }

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -35,20 +35,6 @@ func newVMIMasqueradeInterface(namespace, name, masqueradeCidr, masqueradeIpv6Ci
 	return vmi
 }
 
-func newVMISlirpInterface(namespace string, name string) *v1.VirtualMachineInstance {
-	vmi := newVMI(namespace, name)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultSlirpNetworkInterface()}
-	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-	return vmi
-}
-
-func newVMIMacvtapInterface(namespace string, vmiName string, ifaceName string) *v1.VirtualMachineInstance {
-	vmi := newVMI(namespace, vmiName)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMacvtapNetworkInterface(ifaceName)}
-	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-	return vmi
-}
-
 func NewDomainWithBridgeInterface() *api.Domain {
 	domain := &api.Domain{}
 	domain.Spec.Devices.Interfaces = []api.Interface{{
@@ -62,40 +48,5 @@ func NewDomainWithBridgeInterface() *api.Domain {
 		Alias: api.NewUserDefinedAlias("default"),
 	},
 	}
-	return domain
-}
-
-func NewDomainWithSlirpInterface() *api.Domain {
-	domain := &api.Domain{}
-	domain.Spec.Devices.Interfaces = []api.Interface{{
-		Model: &api.Model{
-			Type: "e1000",
-		},
-		Type:  "user",
-		Alias: api.NewUserDefinedAlias("default"),
-	},
-	}
-
-	// Create network interface
-	if domain.Spec.QEMUCmd == nil {
-		domain.Spec.QEMUCmd = &api.Commandline{}
-	}
-
-	if domain.Spec.QEMUCmd.QEMUArg == nil {
-		domain.Spec.QEMUCmd.QEMUArg = make([]api.Arg, 0)
-	}
-
-	return domain
-}
-
-func NewDomainWithMacvtapInterface(macvtapName string) *api.Domain {
-	domain := &api.Domain{}
-	domain.Spec.Devices.Interfaces = []api.Interface{{
-		Alias: api.NewUserDefinedAlias(macvtapName),
-		Model: &api.Model{
-			Type: "virtio",
-		},
-		Type: "ethernet",
-	}}
 	return domain
 }

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -315,7 +315,7 @@ type fakeLibvirtSpecGenerator struct {
 	shouldGenerateFail bool
 }
 
-func (b *fakeLibvirtSpecGenerator) generate() error {
+func (b *fakeLibvirtSpecGenerator) Generate() error {
 	if b.shouldGenerateFail {
 		return fmt.Errorf("Fake LibvirtSpecGenerator.Generate failure")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR splits the invocation of the network setup operations (infrastructure configuration / libvirt spec generation)
which are located within the `setup` package from the actual domain spec generation.

The actual domain spec generation was moved to a new package under the network folder, having the following structure:
- pkg
  - network
    - **domainspec**
      - **generators.go**
    - infraconfigurators
      - ...
    - setup
      - ...

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
