### PR TITLE
Update the emails for security and conduct violations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,9 @@ Enforcement
 -----------
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting Fabian Deutsch at fabiand-at-fedoraproject-dot-org. All
+reported by contacting [the KubeVirt Maintainers](mailto:cncf-kubevirt-conduct@lists.cncf.io). 
+If you wish to report an incident that involves
+a KubeVirt Maintainer, contact the [CNCF Staff](mailto: conduct@cncf.io). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ manner to allow adequate time to respond.  If a security issue or
 vulnerability has been found, please disclose the details to our
 dedicated email address:
 
-kubevirt-security@redhat.com [PGP](#PGP Encryption)
+cncf-kubevirt-security@lists.cncf.io [PGP](#PGP Encryption)
 
 Please include as much information as possible with the report. The
 following details assist with analysis efforts:
@@ -40,10 +40,4 @@ mailing list and published to the
 page.
 
 ## Security Team
-The security team consists of key developers, vendor security contacts
-and project leadership.
-
-Membership of the security team is assessed on a case-by-case basis. If
-you have cause to join the team, please sent an email to the email address
-above. Members will need to demonstrate secure information handling
-practices and procedures before joining.
+The security team currently consists of the Maintainers of Kubevirt.


### PR DESCRIPTION
to match supplied CNCF addresses.

Signed-off-by: Josh Berkus <josh@agliodbs.com>

**What this PR does / why we need it**:

Email addresses for project contacts have changed.

