### PR TITLE
dockerized: ensure artifacts directory exists before using it as a volume

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -118,6 +118,7 @@ fi
 
 # if defined, append the ARTIFACTS directory
 if [ -n "$ARTIFACTS" ]; then
+    mkdir -p "$ARTIFACTS"
     if [[ "$ARTIFACTS" = /* ]]; then
         volumes="$volumes -v ${ARTIFACTS}:${ARTIFACTS}:rw,z"
     else


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems like podman expects all volume source directories to exist, while docker maybe creates them?
Anyway, when using podman as a container runtime, I often run into the artifacts-is-missing error.
This PR fixes it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6259 

**Special notes for your reviewer**:
Use podman

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
