### PR TITLE
[release-0.36] Backport #5806

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -333,7 +333,7 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:9ae61a4649c643caff7c667456a139eb47bd396517e18f4e37312fe95cccba19",
+    digest = "sha256:5906a710f1fae67fa9b51ea788318993f4c8009d7e5197fc7f82d704cfc9ddbf",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
     #tag = "20201210-917a01f",

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -371,13 +371,18 @@ func defaultIsoFunc(isoOutFile, volumeID string, inDir string) error {
 	args = append(args, volumeID)
 	args = append(args, "-joliet")
 	args = append(args, "-rock")
+	args = append(args, "-partition_cyl_align")
+	args = append(args, "on")
 	args = append(args, inDir)
 
-	cmd := exec.Command("genisoimage", args...)
+	isoBinary := "xorrisofs"
+
+	// #nosec No risk for attacket injection. Parameters are predefined strings
+	cmd := exec.Command(isoBinary, args...)
 
 	err := cmd.Start()
 	if err != nil {
-		log.Log.V(2).Reason(err).Errorf("genisoimage cmd failed to start while generating iso file %s", isoOutFile)
+		log.Log.V(2).Reason(err).Errorf("%s cmd failed to start while generating iso file %s", isoBinary, isoOutFile)
 		return err
 	}
 
@@ -393,7 +398,7 @@ func defaultIsoFunc(isoOutFile, volumeID string, inDir string) error {
 			cmd.Process.Kill()
 		case err := <-done:
 			if err != nil {
-				log.Log.V(2).Reason(err).Errorf("genisoimage returned non-zero exit code while generating iso file %s", isoOutFile)
+				log.Log.V(2).Reason(err).Errorf("%s returned non-zero exit code while generating iso file %s with args '%s'", isoBinary, isoOutFile, strings.Join(cmd.Args, " "))
 				return err
 			}
 			return nil

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -411,6 +411,10 @@ func SetIsoCreationFunction(isoFunc IsoCreationFunc) {
 	cloudInitIsoFunc = isoFunc
 }
 
+func SetLocalDirectoryNoCreate(dir string) {
+	cloudInitLocalDir = dir
+}
+
 func SetLocalDirectory(dir string) error {
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,9 +106,14 @@ func defaultCreateIsoImage(output string, volID string, files []string) error {
 	args = append(args, "-joliet")
 	args = append(args, "-rock")
 	args = append(args, "-graft-points")
+	args = append(args, "-partition_cyl_align")
+	args = append(args, "on")
 	args = append(args, files...)
 
-	cmd := exec.Command("genisoimage", args...)
+	isoBinary := "xorrisofs"
+
+	// #nosec No risk for attacket injection. Parameters are predefined strings
+	cmd := exec.Command(isoBinary, args...)
 	err := cmd.Run()
 	if err != nil {
 		return err

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -19,6 +19,9 @@
 package tests_test
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -39,6 +42,33 @@ import (
 var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component]Config", func() {
 
 	var virtClient kubecli.KubevirtClient
+	var CheckIsoVolumeSizes func(vmi *v1.VirtualMachineInstance)
+
+	tests.BeforeAll(func() {
+		CheckIsoVolumeSizes = func(vmi *v1.VirtualMachineInstance) {
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+
+			for _, volume := range vmi.Spec.Volumes {
+				var path = ""
+				if volume.ConfigMap != nil {
+					path = config.GetConfigMapDiskPath(volume.Name)
+					By(fmt.Sprintf("Checking ConfigMap at '%s' is 4k-block fs compatible", path))
+				}
+				if volume.Secret != nil {
+					path = config.GetSecretDiskPath(volume.Name)
+					By(fmt.Sprintf("Checking Secret at '%s' is 4k-block fs compatible", path))
+				}
+				if len(path) > 0 {
+					cmdCheck := []string{"stat", "--printf='%s'", path}
+					out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+					Expect(err).NotTo(HaveOccurred())
+					size, err := strconv.Atoi(strings.Trim(out, "'"))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(size % 4096).To(Equal(0))
+				}
+			}
+		}
+	})
 
 	BeforeEach(func() {
 		var err error
@@ -81,6 +111,8 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				By("Running VMI")
 				vmi := tests.NewRandomVMIWithConfigMap(configMapName)
 				tests.RunVMIAndExpectLaunch(vmi, 90)
+
+				CheckIsoVolumeSizes(vmi)
 
 				By("Checking if ConfigMap has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -139,6 +171,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				tests.AddConfigMapDisk(vmi, configMaps[2], configMaps[2])
 
 				tests.RunVMIAndExpectLaunch(vmi, 90)
+				CheckIsoVolumeSizes(vmi)
 			})
 		})
 	})
@@ -174,6 +207,8 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				By("Running VMI")
 				vmi := tests.NewRandomVMIWithSecret(secretName)
 				tests.RunVMIAndExpectLaunch(vmi, 90)
+
+				CheckIsoVolumeSizes(vmi)
 
 				By("Checking if Secret has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -231,6 +266,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				tests.AddSecretDisk(vmi, secrets[2], secrets[2])
 
 				tests.RunVMIAndExpectLaunch(vmi, 90)
+				CheckIsoVolumeSizes(vmi)
 			})
 		})
 
@@ -246,6 +282,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			By("Running VMI")
 			vmi := tests.NewRandomVMIWithServiceAccount("default")
 			tests.RunVMIAndExpectLaunch(vmi, 90)
+			CheckIsoVolumeSizes(vmi)
 
 			By("Checking if ServiceAccount has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -345,6 +382,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				}
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+				CheckIsoVolumeSizes(vmi)
 
 				By("Checking if ConfigMap has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -455,6 +493,8 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				tests.AddSecretDisk(vmi, secretName, secretName)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
+				CheckIsoVolumeSizes(vmi)
+
 				By("Checking if Secret has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
 				podOutput1, err := tests.ExecuteCommandOnPod(
@@ -522,6 +562,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			tests.AddLabelDownwardAPIVolume(vmi, downwardAPIName)
 
 			tests.RunVMIAndExpectLaunch(vmi, 90)
+			CheckIsoVolumeSizes(vmi)
 
 			By("Checking if DownwardAPI has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -63,11 +65,15 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		MountCloudInitConfigDrive func(*v1.VirtualMachineInstance)
 		CheckCloudInitFile        func(*v1.VirtualMachineInstance, string, string)
 		CheckCloudInitMetaData    func(*v1.VirtualMachineInstance, string, string)
+		CheckCloudInitIsoSize     func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType)
 	)
 
 	tests.BeforeAll(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		tests.PanicOnError(err)
+
+		// from default virt-launcher flag: do we need to make this configurable in some cases?
+		cloudinit.SetLocalDirectory("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
 
 		LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 			By("Starting a VirtualMachineInstance")
@@ -126,6 +132,19 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(res[1].Output).To(ContainSubstring(testData))
 			}
 		}
+		CheckCloudInitIsoSize = func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType) {
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			path := cloudinit.GetIsoFilePath(source, vmi.Name, vmi.Namespace)
+
+			By(fmt.Sprintf("Checking cloud init ISO at '%s' is 4k-block fs compatible", path))
+			cmdCheck := []string{"stat", "--printf='%s'", path}
+
+			out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+			Expect(err).NotTo(HaveOccurred())
+			size, err := strconv.Atoi(strings.Trim(out, "'"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(size % 4096).To(Equal(0))
+		}
 	})
 
 	BeforeEach(func() {
@@ -139,6 +158,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 				LaunchVMI(vmi)
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 				VerifyUserDataVMI(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: expectedUserData},
@@ -155,7 +175,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedora), userData)
 
 					LaunchVMI(vmi)
-
+					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 					VerifyUserDataVMI(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
 						&expect.BExp{R: "login:"},
@@ -176,6 +196,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 				LaunchVMI(vmi)
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				VerifyUserDataVMI(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: expectedUserData},
@@ -192,7 +213,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedora), userData)
 
 					LaunchVMI(vmi)
-
+					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 					VerifyUserDataVMI(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
 						&expect.BExp{R: "login:"},
@@ -213,7 +234,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 
 				vmi = LaunchVMI(vmi)
-
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 				By("executing a user-data script")
 				VerifyUserDataVMI(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
@@ -236,7 +257,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 
 				vmi = LaunchVMI(vmi)
-
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				By("executing a user-data script")
 				VerifyUserDataVMI(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
@@ -288,6 +309,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				break
 			}
 			LaunchVMI(vmi)
+			CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 			VerifyUserDataVMI(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: expectedUserData},
@@ -307,6 +329,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+
 				By("mouting cloudinit iso")
 				MountCloudInitNoCloud(vmi)
 
@@ -321,6 +345,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), testUserData, testNetworkData, true)
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
 				By("mouting cloudinit iso")
 				MountCloudInitNoCloud(vmi)
@@ -373,6 +399,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+
 				By("mouting cloudinit iso")
 				MountCloudInitNoCloud(vmi)
 
@@ -401,6 +429,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+
 				By("mouting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)
 
@@ -417,6 +447,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -464,6 +495,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				By("mouting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)
 
@@ -514,6 +546,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				By("mouting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)
@@ -593,6 +627,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+
+				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				By("mounting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -73,7 +73,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		tests.PanicOnError(err)
 
 		// from default virt-launcher flag: do we need to make this configurable in some cases?
-		cloudinit.SetLocalDirectory("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
+		err = cloudinit.SetLocalDirectory("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
+		Expect(err).ToNot(HaveOccurred())
 
 		LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 			By("Starting a VirtualMachineInstance")

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -73,8 +73,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		tests.PanicOnError(err)
 
 		// from default virt-launcher flag: do we need to make this configurable in some cases?
-		err = cloudinit.SetLocalDirectory("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
-		Expect(err).ToNot(HaveOccurred())
+		cloudinit.SetLocalDirectoryNoCreate("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
 
 		LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 			By("Starting a VirtualMachineInstance")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a backport of #5806 with some minor tweaks to make it work in the release v0.36 branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Take a look at the SetLocalDirectoryNoCreate function. I had to add this because calling SetLocalDirectory tries to create the passed in directory, and when running locally, the user had no permissions to actually create the directory. However the call to SetLocalDirectory was there just so we could build the path of where the cloudInit/noCloud images are stored in the virt-launcher container. Because of the failure to create the directory, the value was never set and tests failed. But we are not interested in creating the directory in the test, so simply setting the variable is enough to make it work.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Generate ISO images 4k aligned for node storage with 4k blocksize
```
