### PR TITLE
dockerized: handle podman auth files

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -107,9 +107,13 @@ _rsync \
 
 volumes="-v ${BUILDER}:/root:rw,z"
 
-# append .docker directory as volume
-mkdir -p "${HOME}/.docker"
-volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
+# Use a bind-mount to expose docker/podman auth file to the container
+ID=$(id -u)
+if [[ $KUBEVIRT_CRI = "podman" ]] && [[ -f "/tmp/podman-run-${ID}/containers/auth.json" ]]; then
+    volumes="$volumes --mount type=bind,source=/tmp/podman-run-${ID}/containers/auth.json,target=/root/.docker/config.json,readonly"
+elif [[ -f "${HOME}/.docker/config.json" ]]; then
+    volumes="$volumes --mount type=bind,source=${HOME}/.docker/config.json,target=/root/.docker/config.json,readonly"
+fi
 
 # add custom docker certs, if needed
 if [ -n "$DOCKER_CA_CERT_FILE" ] && [ -f "$DOCKER_CA_CERT_FILE" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This should allow running `make push` when using podman as a CRI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6260

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
