### PR TITLE
tests, net, macvtap: Wait for a non-empty IP value

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1232,8 +1232,11 @@ var _ = SIGDescribe("[Serial]Macvtap", func() {
 
 					for _, iface := range vmi.Status.Interfaces {
 						if iface.MAC == macAddress {
-							vmiIP = iface.IP
-							return true, nil
+							if ip := iface.IP; ip != "" {
+								vmiIP = ip
+								return true, nil
+							}
+							return false, nil
 						}
 					}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Matching the interface based on the mac address and retrieving the IP
value blindly is not safe. Although the interface may be in place, the
IP address may appear a bit later.

Fix by continuing querying the VMI state for the IP until it appears.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
