### PR TITLE
[SIG-scale] Record the VMI deletion time

### DIFF
--- a/pkg/monitoring/perfscale/perfscale_test.go
+++ b/pkg/monitoring/perfscale/perfscale_test.go
@@ -41,12 +41,10 @@ var _ = Describe("VMI phase transition time histogram", func() {
 
 			vmi := createVMISForPhaseTransitionTime(curPhase, oldPhase, expectedVal*1000, true)
 
-			if oldPhase != "" {
-				oldVMI = vmi.DeepCopy()
-				oldVMI.Status.Phase = oldPhase
-			}
+			oldVMI = vmi.DeepCopy()
+			oldVMI.Status.Phase = oldPhase
 
-			diffSeconds, err := getTransitionTimeSeconds(false, oldVMI, vmi)
+			diffSeconds, err := getTransitionTimeSeconds(false, false, oldVMI, vmi)
 			Expect(err).To(BeNil())
 
 			Expect(diffSeconds).To(Equal(expectedVal))
@@ -56,23 +54,44 @@ var _ = Describe("VMI phase transition time histogram", func() {
 			table.Entry("Time between running and scheduled using fraction of a second", .5, v1.Running, v1.Scheduled),
 			table.Entry("Time between scheduled and scheduling", 2.0, v1.Scheduled, v1.Scheduling),
 			table.Entry("Time between scheduling and pending", 1.0, v1.Scheduling, v1.Pending),
-			table.Entry("Time between scheduling and creation", 3.0, v1.Scheduling, v1.VmPhaseUnset),
-			table.Entry("Time between scheduling and creation when timestamps are within one second of another", 0.0, v1.Scheduling, v1.VmPhaseUnset),
 		)
 	})
 
+	Context("Time since Create/Delete calculations", func() {
+		table.DescribeTable("time diff calculations", func(expectedVal float64, curPhase v1.VirtualMachineInstancePhase, oldPhase v1.VirtualMachineInstancePhase, creation bool) {
+			var oldVMI *v1.VirtualMachineInstance
+
+			vmi := createVMISForPhaseTransitionTime(curPhase, oldPhase, expectedVal*1000, true)
+			if !creation {
+				vmi.DeletionTimestamp = &vmi.CreationTimestamp
+			}
+
+			if oldPhase != "" {
+				oldVMI = vmi.DeepCopy()
+				oldVMI.Status.Phase = oldPhase
+			}
+
+			diffSeconds, err := getTransitionTimeSeconds(creation, !creation, oldVMI, vmi)
+			Expect(err).To(BeNil())
+
+			// Time since created or deleted timestamp
+			// Value should be 2x expectedVal while time between Phases should be
+			// 1x expectedVal because the measurement is creationtime -> oldphase -> newphase
+			Expect(diffSeconds).To(Equal(2 * expectedVal))
+		},
+			table.Entry("Time between creation and pending", 3.0, v1.Pending, v1.VmPhaseUnset, true),
+			table.Entry("Time between creation and running", 5.0, v1.Running, v1.Scheduled, true),
+			table.Entry("Time between creation and scheduling using fraction of a second", .5, v1.Scheduling, v1.Scheduled, true),
+			table.Entry("Time spent deleting a VMI that exited in a failed state", 5.0, v1.Failed, v1.Running, false),
+			table.Entry("Time spent deleting a VMI that exited in a succeeded state", 5.0, v1.Succeeded, v1.Running, false),
+		)
+	})
 })
 
 func createVMISForPhaseTransitionTime(phase v1.VirtualMachineInstancePhase, oldPhase v1.VirtualMachineInstancePhase, offset float64, hasTransitionTime bool) *v1.VirtualMachineInstance {
-
 	now := metav1.NewTime(time.Now())
-
 	old := metav1.NewTime(now.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
-
-	creation := old
-	if oldPhase != "" {
-		creation = metav1.NewTime(old.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
-	}
+	creation := metav1.NewTime(old.Time.Add(-time.Duration(int64(offset)) * time.Millisecond))
 
 	vmi := &v1.VirtualMachineInstance{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/monitoring/perfscale/perfscale_test.go
+++ b/pkg/monitoring/perfscale/perfscale_test.go
@@ -54,6 +54,7 @@ var _ = Describe("VMI phase transition time histogram", func() {
 			table.Entry("Time between running and scheduled using fraction of a second", .5, v1.Running, v1.Scheduled),
 			table.Entry("Time between scheduled and scheduling", 2.0, v1.Scheduled, v1.Scheduling),
 			table.Entry("Time between scheduling and pending", 1.0, v1.Scheduling, v1.Pending),
+			table.Entry("Time between running and failed", 1.0, v1.Running, v1.Failed),
 		)
 	})
 

--- a/pkg/monitoring/perfscale/register.go
+++ b/pkg/monitoring/perfscale/register.go
@@ -30,4 +30,5 @@ func RegisterPerfScaleMetrics(vmiInformer cache.SharedIndexInformer) {
 	log.Log.Infof("Starting performance and scale metrics")
 	prometheus.MustRegister(newVMIPhaseTransitionTimeHistogramVec(vmiInformer))
 	prometheus.MustRegister(newVMIPhaseTransitionTimeFromCreationHistogramVec(vmiInformer))
+	prometheus.MustRegister(newVMIPhaseTransitionTimeFromDeletionHistogramVec(vmiInformer))
 }


### PR DESCRIPTION
Signed-off-by: Ryan Hallisey <rhallisey@nvidia.com>

Time from deletion is the amount of time between the DeletionTimestamp and when kubevirt notices the VMI's Finalizer has been removed.

<img width="1705" alt="Time from deletion" src="https://user-images.githubusercontent.com/6795213/130460060-e9bf3489-e51a-4a40-b575-6ea92b613f0a.png">

```release-note
Record the time it takes to delete a VMI and expose it as a metric
```

Closes: https://github.com/kubevirt/kubevirt/issues/6235