### PR TITLE
Remove linux-bridge creation before Multus tests suite starts

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As for today on Multus tests suite [[1]](https://github.com/kubevirt/kubevirt/blob/259de8032ac84f8c8a3e6f37cbb94f598f936c3d/tests/network/vmi_multus.go#L101) we create a linux-bridge on each cluster node [[2]](https://github.com/kubevirt/kubevirt/blob/259de8032ac84f8c8a3e6f37cbb94f598f936c3d/tests/network/vmi_multus.go#L173)    [[3]](https://github.com/kubevirt/kubevirt/blob/259de8032ac84f8c8a3e6f37cbb94f598f936c3d/tests/network/vmi_multus.go#L1409)
before all tests starts in order for the tests that uses bridge CNI plugin to work.

The bridge CNI plugin is capable of creating a linux-bridge on the cluster nodes 
according to the NAD definition as being done on the tests.
Thus there is no need to create the linux-bridge beforehand.

This PR removes the code that deploy DaemonSet which creates the linux-bridge before all test starts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
