### PR TITLE
tests: fix skipping of HostDisk tests

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -727,15 +727,18 @@ var _ = SIGDescribe("Storage", func() {
 
 		Context("[rfe_id:2298][crit:medium][vendor:cnv-qe@redhat.com][level:component] With HostDisk and PVC initialization", func() {
 
+			BeforeEach(func() {
+				if !checks.HasFeature(virtconfig.HostDiskGate) {
+					Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
+				}
+			})
+
 			Context("With a HostDisk defined", func() {
 
 				var hostDiskDir string
 				var nodeName string
 
 				BeforeEach(func() {
-					if !checks.HasFeature(virtconfig.HostDiskGate) {
-						Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
-					}
 					hostDiskDir = tests.RandTmpDir()
 					nodeName = ""
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:

Some tests related to the HostDisk feature gate are failing when it is not enabled instead of being skipped.

This PR extends the scope of the check for the HostDisk feature gate to more tests.

**Release note**:

```release-note
NONE
```
