### PR TITLE
kubevirtci, Add whatchanged script

### DIFF
--- a/hack/whatchanged.sh
+++ b/hack/whatchanged.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2021 Red Hat, Inc.
+#
+
+set -e
+
+REPO="https://github.com/kubevirt/kubevirtci.git"
+
+TEMP_DIR=$(mktemp -d /tmp/git-tmp.XXXXXX)
+trap 'rm -rf $TEMP_DIR' EXIT SIGINT
+
+function main() {
+    CURRENT=$(git diff cluster-up/version.txt | grep -v "\-\-" | grep -v "++" | grep "^+" | cut -d - -f 2)
+    PREVIOUS=$(git diff cluster-up/version.txt | grep -v "\-\-" | grep -v "++" | grep "^-" | cut -d - -f 3)
+
+    if [[ -z $CURRENT ]] || [[ -z $PREVIOUS ]]; then
+        exit 0
+    fi
+
+    cd "$TEMP_DIR"
+    git clone --depth=100 -n "$REPO" >/dev/null 2>&1
+    cd kubevirtci
+    info=$(git log $PREVIOUS..$CURRENT --format="%h %s" | sed 's!#!https://github.com/kubevirt/kubevirtci/pull/!g')
+    decorated_info=$(echo -e "Bump kubevirtci\n\n\`\`\`\n${info}\n\`\`\`")
+    echo "$decorated_info"
+}
+
+main "$@"


### PR DESCRIPTION
Run `./hack/whatchanged.sh` after bumping (before committing),
in order to create a summary of what changed by
the kubevirtci bump.

Example of output:

```
2c2862b cnao, Bump CNAO to 0.58.0 on all providers (https://github.com/kubevirt/kubevirtci/pull/664)
ba05421 cluster-provision, Prefetch cdi images (https://github.com/kubevirt/kubevirtci/pull/660)
71d8ce5 Bump k8s providers (https://github.com/kubevirt/kubevirtci/pull/661)
0007793 cdi, Bump cdi to 1.36.0 on k8s-1.21 (https://github.com/kubevirt/kubevirtci/pull/659)
9c1261b Kind infra providers: Deploy default CNI (https://github.com/kubevirt/kubevirtci/pull/644)
```

Signed-off-by: Or Shoval oshoval@redhat.com

```release-note
None
```