### PR TITLE
Fix hostpath hotplug not working when volume on separate device

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -35,7 +35,6 @@ num=$(losetup -l | wc -l)
 
 # Put LOOP_DEVICE in /etc/bashrc in order to detach this loop device when the pod stopped.
 LOOP_DEVICE=$(chroot /host losetup --find --show /mnt/local-storage/cirros.img.raw)
-echo $LOOP_DEVICE
 echo LOOP_DEVICE=${LOOP_DEVICE} >>/etc/bashrc
 rm -f /local-storage/cirros-block-device
 ln -s $LOOP_DEVICE /local-storage/cirros-block-device
@@ -65,7 +64,6 @@ dd if=/dev/zero of=/local-storage/hp_file.img bs=4k count=1024k
 ls -al /local-storage/hp_file.img
 # Put LOOP_DEVICE_HP in /etc/bashrc in order to detach this loop device when the pod stopped.
 LOOP_DEVICE_HP=$(chroot /host losetup --verbose --find --show /mnt/local-storage/hp_file.img)
-echo $LOOP_DEVICE_HP
 echo LOOP_DEVICE_HP=${LOOP_DEVICE_HP} >>/etc/bashrc
 chroot /host mkfs.ext4 $LOOP_DEVICE_HP
 mkdir -p /hostImages/mount_hp

--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -35,6 +35,7 @@ num=$(losetup -l | wc -l)
 
 # Put LOOP_DEVICE in /etc/bashrc in order to detach this loop device when the pod stopped.
 LOOP_DEVICE=$(losetup --find --show /local-storage/cirros.img.raw)
+echo $LOOP_DEVICE
 echo LOOP_DEVICE=${LOOP_DEVICE} >>/etc/bashrc
 rm -f /local-storage/cirros-block-device
 ln -s $LOOP_DEVICE /local-storage/cirros-block-device
@@ -58,6 +59,27 @@ chmod -R 777 /hostImages
 if [ ${SELINUX_TAG:0:1} != "?" ]; then
     chcon -Rt svirt_sandbox_file_t /hostImages
 fi
+
+# Create a 4Gi blank disk image
+dd if=/dev/zero of=/local-storage/hp_file.img bs=4k count=1024k
+ls -al /local-storage/hp_file.img
+# Put LOOP_DEVICE_HP in /etc/bashrc in order to detach this loop device when the pod stopped.
+LOOP_DEVICE_HP=$(losetup --verbose --find --show /local-storage/hp_file.img)
+echo $LOOP_DEVICE_HP
+echo LOOP_DEVICE_HP=${LOOP_DEVICE_HP} >>/etc/bashrc
+mkfs.ext4 $LOOP_DEVICE_HP
+mkdir -p /hostImages/mount_hp
+mount ${LOOP_DEVICE_HP} /hostImages/mount_hp
+mkdir -p /hostImages/mount_hp/test
+# When the host is ubuntu, by default, selinux is not used, so chcon is not necessary.
+# If selinux tag is set, use chcon to change /hostImages privileges.
+if [ ${SELINUX_TAG:0:1} != "?" ]; then
+    chcon -Rt svirt_sandbox_file_t /hostImages/mount_hp
+fi
+chmod 777 /hostImages/mount_hp
+chmod 777 /hostImages/mount_hp/test
+
+cat /etc/bashrc
 
 # for some reason without sleep, container sometime fails to create the file
 sleep 10

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -72,13 +72,15 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","source /etc/bashrc && losetup -d ${LOOP_DEVICE} && umount ${LOOP_DEVICE_HP} && losetup -d ${LOOP_DEVICE_HP}"]
+                command: ["/bin/sh","-c","source /etc/bashrc && chroot /host losetup -d ${LOOP_DEVICE} && chroot /host umount ${LOOP_DEVICE_HP} && chroot /host losetup -d ${LOOP_DEVICE_HP}"]
           volumeMounts:
           - name: images
             mountPath: /hostImages
-            mountPropagation: Bidirectional
           - name: local-storage
             mountPath: /local-storage
+          - name: host-dir
+            mountPath: /host
+            mountPropagation: Bidirectional
           securityContext:
             privileged: true
           readinessProbe:
@@ -97,3 +99,6 @@ spec:
           hostPath:
             path: /mnt/local-storage
             type: DirectoryOrCreate
+        - name: host-dir
+          hostPath:
+            path: /

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -72,10 +72,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","source /etc/bashrc && losetup -d ${LOOP_DEVICE}"]
+                command: ["/bin/sh","-c","source /etc/bashrc && losetup -d ${LOOP_DEVICE} && umount ${LOOP_DEVICE_HP} && losetup -d ${LOOP_DEVICE_HP}"]
           volumeMounts:
           - name: images
             mountPath: /hostImages
+            mountPropagation: Bidirectional
           - name: local-storage
             mountPath: /local-storage
           securityContext:

--- a/pkg/virt-handler/hotplug-disk/findmnt.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	sourceRgx = regexp.MustCompile(`\[(.+)\]`)
+	deviceRgx = regexp.MustCompile(`([^\[]+)\[.+\]`)
 
 	findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
 		return exec.Command("/usr/bin/findmnt", "-T", fmt.Sprintf("/%s", volumeName), "-N", strconv.Itoa(pid), "-J").CombinedOutput()
@@ -80,12 +81,20 @@ func parseMntInfoJson(mntInfoJson []byte) ([]FindmntInfo, error) {
 	return mntinfo.Filesystems, nil
 }
 
-func (f *FindmntInfo) GetSource() string {
+func (f *FindmntInfo) GetSourcePath() string {
 	match := sourceRgx.FindStringSubmatch(f.Source)
 	if len(match) != 2 {
 		return strings.TrimPrefix(f.Source, rhcosPrefix)
 	}
 	return strings.TrimPrefix(match[1], rhcosPrefix)
+}
+
+func (f *FindmntInfo) GetSourceDevice() string {
+	match := deviceRgx.FindStringSubmatch(f.Source)
+	if len(match) == 0 {
+		return ""
+	}
+	return match[1]
 }
 
 func (f *FindmntInfo) GetOptions() []string {

--- a/pkg/virt-handler/hotplug-disk/findmnt.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt.go
@@ -91,10 +91,10 @@ func (f *FindmntInfo) GetSourcePath() string {
 
 func (f *FindmntInfo) GetSourceDevice() string {
 	match := deviceRgx.FindStringSubmatch(f.Source)
-	if len(match) == 0 {
-		return ""
+	if len(match) == 2 {
+		return match[1]
 	}
-	return match[1]
+	return ""
 }
 
 func (f *FindmntInfo) GetOptions() []string {

--- a/pkg/virt-handler/hotplug-disk/findmnt_test.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt_test.go
@@ -83,7 +83,7 @@ var _ = Describe("findmnt", func() {
 		res, err := findMntFunc()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(res)).To(Equal(1))
-		Expect(res[0].GetSource()).To(Equal("/test/path"))
+		Expect(res[0].GetSourcePath()).To(Equal("/test/path"))
 		Expect(res[0].Target).To(Equal("/testvolume"))
 		Expect(res[0].Fstype).To(Equal("xfs"))
 		Expect(len(res[0].GetOptions())).To(Equal(8))
@@ -119,19 +119,38 @@ var _ = Describe("findmnt", func() {
 		table.Entry("for findmntbydevice", callFindMntByDeviceInvalidJson),
 	)
 
-	It("GetSource should properly match source field", func() {
+	It("GetSourcePath should properly match source field", func() {
 		test := FindmntInfo{
 			Source: "/dev/test",
 		}
-		Expect(test.GetSource()).To(Equal("/dev/test"))
+		Expect(test.GetSourcePath()).To(Equal("/dev/test"))
 		test2 := FindmntInfo{
 			Source: "/dev/test[/mnt/something/else/]",
 		}
-		Expect(test2.GetSource()).To(Equal("/mnt/something/else/"))
+		Expect(test2.GetSourcePath()).To(Equal("/mnt/something/else/"))
 		test3 := FindmntInfo{
 			Source: "/dev/test[/mnt/something/else/[/more]]",
 		}
-		Expect(test3.GetSource()).To(Equal("/mnt/something/else/[/more]"))
+		Expect(test3.GetSourcePath()).To(Equal("/mnt/something/else/[/more]"))
+	})
+
+	It("GetSourceDevice should return the device", func() {
+		test := FindmntInfo{
+			Source: "/dev/test",
+		}
+		Expect(test.GetSourceDevice()).To(Equal(""))
+		test2 := FindmntInfo{
+			Source: "/dev/test[/mnt/something/else/]",
+		}
+		Expect(test2.GetSourceDevice()).To(Equal("/dev/test"))
+		test3 := FindmntInfo{
+			Source: "/dev/test[/mnt/something/else/[/more]]",
+		}
+		Expect(test3.GetSourceDevice()).To(Equal("/dev/test"))
+		test4 := FindmntInfo{
+			Source: "/path/to/somewhere",
+		}
+		Expect(test4.GetSourceDevice()).To(Equal(""))
 	})
 
 	It("GetOptions should properly return a list", func() {

--- a/tests/config.go
+++ b/tests/config.go
@@ -35,6 +35,8 @@ type KubeVirtTestsConfiguration struct {
 	StorageClassHostPath string `json:"storageClassHostPath"`
 	// StorageClass to use to create block-volume PVCs
 	StorageClassBlockVolume string `json:"storageClassBlockVolume"`
+	// StorageClassHostPathSeparateDevice to use to create host-path PVCs that are on a separate device from the boot device
+	StorageClassHostPathSeparateDevice string `json:"storageClassHostPathSeparateDevice"`
 	// StorageClass to use to create rhel PVCs
 	StorageClassRhel string `json:"storageClassRhel"`
 	// StorageClass to use to create windows PVCs

--- a/tests/default-config.json
+++ b/tests/default-config.json
@@ -1,6 +1,7 @@
 {
     "storageClassLocal":       "local",
     "storageClassHostPath":    "host-path",
+    "storageClassHostPathSeparateDevice":    "host-path-sd",
     "storageClassBlockVolume": "block-volume",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
findmnt returns device[path relative in device] when looking up the
source of a mount by container pid. So on separate device that often
returned /<path> which is not where it is mounted in the boot device.

This PR modifies the check to look up the device, and then the path
where the device is mounted, and combines the two paths to get the
path relative to the boot device so we can properly bind mount the
hostpath volume into another container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6303 

**Special notes for your reviewer**:
I have made some modifications to disks-images-provider.yaml.in and the entrypoint.sh. In particular I am mounting the host root directory under /host, and then chrooting the losetup commands. This is needed because it will not allow one to create more than 1 loop back device in the container otherwise.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: hotplug was broken when using it with a hostpath volume that was on a separate device.
```
