### PR TITLE
Switch kubectl port-forward -> NodePort as an attempt to stabilize 4621 from quarantine

### DIFF
--- a/manifests/testing/uploadproxy-nodeport.yaml.in
+++ b/manifests/testing/uploadproxy-nodeport.yaml.in
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cdi-uploadproxy-nodeport
+  namespace: {{.CDINamespace}}
+  labels:
+    kubevirt.io: "cdi-uploadproxy-nodeport"
+spec:
+  type: NodePort
+  selector:
+    cdi.kubevirt.io: cdi-uploadproxy
+  ports:
+    - port: 443
+      targetPort: 8443
+      nodePort: 31001


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Our functional tests are using `kubectl port-forward` to upload the images, which is not very reliable.
Since https://github.com/kubevirt/kubevirtci/pull/653, we have a port that is exposed from host -> VM;
We can look it up and set up a NodePort against it instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
