### PR TITLE
Fix flaky Macvtap tests suite: Wait for QEMU guest-agent on VMI create

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1283,6 +1283,8 @@ var _ = SIGDescribe("[Serial]Macvtap", func() {
 
 				serverVMI, err = createFedoraVMIRandomNode(macvtapNetworkName, macAddress)
 				Expect(err).NotTo(HaveOccurred(), "must have succeeded creating a fedora VMI on a random node")
+				// Ensure QEMU GuestAgent is up as it should report network interfaces stats
+				tests.WaitAgentConnected(virtClient, serverVMI)
 				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
 				serverVMIPodName = tests.GetVmPodName(virtClient, serverVMI)
 


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As we rely on QEMU guest agent to learn and report the network interfaces stats of the guest 
we need to make sure its up and running before asserting on VMI network status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
