### PR TITLE
Test fix: Use a pod with virt-launcher image to run dmsetup commands.

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/cleanup:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/util:go_default_library",
@@ -73,6 +74,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
         "//vendor/k8s.io/client-go/transport/spdy:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -22,17 +22,20 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests/flags"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 func NodeNameWithHandler() string {
@@ -117,11 +120,44 @@ func FixErrorDevice(nodeName string) {
 
 }
 
+func executeDeviceMapperOnNode(nodeName string, cmd []string) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Image that happens to have dmsetup
+	image := fmt.Sprintf("%s/vm-killer:%s", flags.KubeVirtRepoPrefix, flags.KubeVirtVersionTag)
+	pod := &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "device-mapper-pod-",
+		},
+		Spec: k8sv1.PodSpec{
+			RestartPolicy: k8sv1.RestartPolicyNever,
+			Containers: []k8sv1.Container{
+				{
+					Name:    "launcher",
+					Image:   image,
+					Command: cmd,
+					SecurityContext: &k8sv1.SecurityContext{
+						Privileged: pointer.BoolPtr(true),
+						RunAsUser:  pointer.Int64Ptr(0),
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			},
+		},
+	}
+	pod, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(ThisPod(pod), 30).Should(HaveSucceeded())
+}
+
 func CreateFaultyDisk(nodeName, deviceName string) {
 	By(fmt.Sprintf("Creating faulty disk %s on %s node", deviceName, nodeName))
 	args := []string{"dmsetup", "create", deviceName, "--table", "0 204791 error"}
-	_, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create faulty disk")
+	executeDeviceMapperOnNode(nodeName, args)
 }
 
 func CreatePVandPVCwithFaultyDisk(nodeName, devicePath, namespace string) (*corev1.PersistentVolume, *corev1.PersistentVolumeClaim, error) {
@@ -196,8 +232,5 @@ func CreatePVandPVCwithFaultyDisk(nodeName, devicePath, namespace string) (*core
 func RemoveFaultyDisk(nodeName, deviceName string) {
 	By(fmt.Sprintf("Removing faulty disk %s on %s node", deviceName, nodeName))
 	args := []string{"dmsetup", "remove", deviceName}
-	EventuallyWithOffset(1, func() error {
-		_, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
-		return err
-	}, 30*time.Second, 5*time.Second).ShouldNot(HaveOccurred(), "Failed to remove faulty disk")
+	executeDeviceMapperOnNode(nodeName, args)
 }


### PR DESCRIPTION
Virt-handler no longer installs device-mapper, so tests using
these functions always fail. This was missed as they are flaky
and quarantined.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
