### PR TITLE
Switch live migration to use unix sockets between instead of TCP

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12936,6 +12936,10 @@
       "description": "Represents the status of a live migration",
       "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationState"
      },
+     "migrationTransport": {
+      "description": "This represents the migration transport",
+      "type": "string"
+     },
      "nodeName": {
       "description": "NodeName is the name where the VirtualMachineInstance is currently running.",
       "type": "string"

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -513,7 +513,7 @@ func getLoopbackAdrress(proto iptables.Protocol) string {
 
 func (b *MasqueradePodNetworkConfigurator) portsUsedByLiveMigration() []string {
 	if b.vmi.Status.MigrationTransport == v1.MigrationTransportUnix {
-		return []string{}
+		return nil
 	}
 	return []string{
 		fmt.Sprint(LibvirtDirectMigrationPort),

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -198,13 +198,6 @@ func GetLoopbackAdrress(proto iptables.Protocol) string {
 	}
 }
 
-func PortsUsedByLiveMigration() []string {
-	return []string{
-		fmt.Sprint(LibvirtDirectMigrationPort),
-		fmt.Sprint(LibvirtBlockMigrationPort),
-	}
-}
-
 func (b *MasqueradePodNetworkConfigurator) createNatRules(protocol iptables.Protocol) error {
 	err := b.handler.ConfigureIpForwarding(protocol)
 	if err != nil {
@@ -246,7 +239,7 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingIptables(protocol 
 		return err
 	}
 
-	err = b.skipForwardingForPortsUsingIptables(protocol, portsUsedByLiveMigration())
+	err = b.skipForwardingForPortsUsingIptables(protocol, b.portsUsedByLiveMigration())
 	if err != nil {
 		return err
 	}
@@ -329,6 +322,9 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingIptables(protocol 
 }
 
 func (b *MasqueradePodNetworkConfigurator) skipForwardingForPortsUsingIptables(protocol iptables.Protocol, ports []string) error {
+	if len(ports) == 0 {
+		return nil
+	}
 	chainWhereDnatIsPerformed := "OUTPUT"
 	chainWhereSnatIsPerformed := "KUBEVIRT_POSTINBOUND"
 	for _, chain := range []string{chainWhereDnatIsPerformed, chainWhereSnatIsPerformed} {
@@ -370,7 +366,7 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingNftables(proto ipt
 		return err
 	}
 
-	err = b.skipForwardingForPortsUsingNftables(proto, portsUsedByLiveMigration())
+	err = b.skipForwardingForPortsUsingNftables(proto, b.portsUsedByLiveMigration())
 	if err != nil {
 		return err
 	}
@@ -454,6 +450,9 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingNftables(proto ipt
 }
 
 func (b *MasqueradePodNetworkConfigurator) skipForwardingForPortsUsingNftables(proto iptables.Protocol, ports []string) error {
+	if len(ports) == 0 {
+		return nil
+	}
 	chainWhereDnatIsPerformed := "output"
 	chainWhereSnatIsPerformed := "KUBEVIRT_POSTINBOUND"
 	for _, chain := range []string{chainWhereDnatIsPerformed, chainWhereSnatIsPerformed} {
@@ -512,7 +511,10 @@ func getLoopbackAdrress(proto iptables.Protocol) string {
 	}
 }
 
-func portsUsedByLiveMigration() []string {
+func (b *MasqueradePodNetworkConfigurator) portsUsedByLiveMigration() []string {
+	if b.vmi.Status.MigrationTransport == v1.MigrationTransportUnix {
+		return []string{}
+	}
 	return []string{
 		fmt.Sprint(LibvirtDirectMigrationPort),
 		fmt.Sprint(LibvirtBlockMigrationPort),

--- a/pkg/network/infraconfigurators/masquerade_test.go
+++ b/pkg/network/infraconfigurators/masquerade_test.go
@@ -287,12 +287,11 @@ var _ = Describe("Masquerade infrastructure configurator", func() {
 
 func portsUsedByLiveMigration(isMigrationOverSockets bool) []string {
 	if isMigrationOverSockets {
-		return []string{}
-	} else {
-		return []string{
-			fmt.Sprint(LibvirtDirectMigrationPort),
-			fmt.Sprint(LibvirtBlockMigrationPort),
-		}
+		return nil
+	}
+	return []string{
+		fmt.Sprint(LibvirtDirectMigrationPort),
+		fmt.Sprint(LibvirtBlockMigrationPort),
 	}
 }
 
@@ -413,9 +412,7 @@ func mockNFTablesFrontend(handler *netdriver.MockNetworkHandler, proto iptables.
 	handler.EXPECT().NftablesAppendRule(proto, "nat", "prerouting", "iifname", "eth0", "counter", "jump", "KUBEVIRT_PREINBOUND").Return(nil)
 	handler.EXPECT().NftablesAppendRule(proto, "nat", "postrouting", "oifname", "k6t-eth0", "counter", "jump", "KUBEVIRT_POSTINBOUND").Return(nil)
 
-	skipPorts := portsUsedByLiveMigration(isMigrationOverSockets)
-
-	if len(skipPorts) > 0 {
+	if skipPorts := portsUsedByLiveMigration(isMigrationOverSockets); len(skipPorts) > 0 {
 		for _, chain := range []string{"output", "KUBEVIRT_POSTINBOUND"} {
 			handler.EXPECT().NftablesAppendRule(proto, "nat", chain, "tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(skipPorts, ", ")), nftIPString, "saddr", GetLoopbackAdrress(proto), "counter", "return").Return(nil)
 		}
@@ -487,9 +484,7 @@ func mockIPTablesBackend(handler *netdriver.MockNetworkHandler, proto iptables.P
 		"-j",
 		"KUBEVIRT_POSTINBOUND").Return(nil)
 
-	skipPorts := portsUsedByLiveMigration(isMigrationOverSockets)
-
-	if len(skipPorts) > 0 {
+	if skipPorts := portsUsedByLiveMigration(isMigrationOverSockets); len(skipPorts) > 0 {
 		for _, chain := range []string{"OUTPUT", "KUBEVIRT_POSTINBOUND"} {
 			handler.EXPECT().IptablesAppendRule(proto, "nat", chain,
 				"-p", "tcp", "--match", "multiport",

--- a/pkg/network/infraconfigurators/masquerade_test.go
+++ b/pkg/network/infraconfigurators/masquerade_test.go
@@ -39,7 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/istio"
 )
 
-type mockNetfilterFrontend func(*netdriver.MockNetworkHandler, iptables.Protocol, string, string, string, []int, map[string]string)
+type mockNetfilterFrontend func(*netdriver.MockNetworkHandler, iptables.Protocol, string, string, string, []int, map[string]string, bool)
 
 var _ = Describe("Masquerade infrastructure configurator", func() {
 	var (
@@ -89,6 +89,11 @@ var _ = Describe("Masquerade infrastructure configurator", func() {
 		vmi.Annotations = map[string]string{
 			istio.ISTIO_INJECT_ANNOTATION: "true",
 		}
+		return vmi
+	}
+	newVMIMasqueradeMigrateOverSockets := func(namespace string, name string, ports ...int) *v1.VirtualMachineInstance {
+		vmi := newVMIMasqueradeInterface(namespace, name, ports...)
+		vmi.Status.MigrationTransport = v1.MigrationTransportUnix
 		return vmi
 	}
 
@@ -179,15 +184,16 @@ var _ = Describe("Masquerade infrastructure configurator", func() {
 
 	Context("preparing network infrastructure", func() {
 		const (
-			ifaceName     = "eth0"
-			ipv6GwStr     = "fd10:0:2::1/120"
-			launcherPID   = 1000
-			mtu           = 1000
-			namespace     = "default"
-			queueCount    = uint32(0)
-			tapDeviceName = "tap0"
-			vmIPv6Str     = "fd10:0:2::2/120"
-			vmName        = "vm1"
+			ifaceName        = "eth0"
+			ipv6GwStr        = "fd10:0:2::1/120"
+			launcherPID      = 1000
+			mtu              = 1000
+			namespace        = "default"
+			queueCount       = uint32(0)
+			tapDeviceName    = "tap0"
+			vmIPv6Str        = "fd10:0:2::2/120"
+			vmName           = "vm1"
+			migrationOverTCP = false
 		)
 
 		var (
@@ -242,7 +248,7 @@ var _ = Describe("Masquerade infrastructure configurator", func() {
 					newVMIMasqueradeInterface(namespace, vmName, 15000, 18000),
 					mockNetfilterIPTables),
 				table.Entry("NFTables backend on an IPv4 cluster when *reserved* ports are specified",
-					newVMIMasqueradeInterface(namespace, vmName, getReservedPortList()...),
+					newVMIMasqueradeInterface(namespace, vmName, getReservedPortList(migrationOverTCP)...),
 					mockNetfilterNFTables),
 				table.Entry("NFTables backend on an IPv4 cluster when using an ISTIO aware VMI",
 					newIstioAwareVMIWithSingleInterface(namespace, vmName),
@@ -264,17 +270,31 @@ var _ = Describe("Masquerade infrastructure configurator", func() {
 					mockNetfilterIPTables,
 					iptables.ProtocolIPv6),
 				table.Entry("NFTables backend on a dual stack cluster when *reserved* ports are specified",
-					newVMIMasqueradeInterface(namespace, vmName, getReservedPortList()...),
+					newVMIMasqueradeInterface(namespace, vmName, getReservedPortList(migrationOverTCP)...),
 					mockNetfilterNFTables,
 					iptables.ProtocolIPv6),
 				table.Entry("NFTables backend on a dual stack cluster when using an ISTIO aware VMI",
 					newIstioAwareVMIWithSingleInterface(namespace, vmName),
 					mockNetfilterNFTables,
 					iptables.ProtocolIPv6),
+				table.Entry("NFTables backend on an IPv4 cluster with migration over sockets",
+					newVMIMasqueradeMigrateOverSockets(namespace, vmName, getReservedPortList(!migrationOverTCP)...),
+					mockNetfilterNFTables),
 			)
 		})
 	})
 })
+
+func portsUsedByLiveMigration(isMigrationOverSockets bool) []string {
+	if isMigrationOverSockets {
+		return []string{}
+	} else {
+		return []string{
+			fmt.Sprint(LibvirtDirectMigrationPort),
+			fmt.Sprint(LibvirtBlockMigrationPort),
+		}
+	}
+}
 
 func podBridge(ifaceName string, mtu int) *netlink.Bridge {
 	inPodBridgeMAC, _ := net.ParseMAC("02:00:00:00:00:00")
@@ -350,6 +370,7 @@ func mockNATNetfilterRules(configurator MasqueradePodNetworkConfigurator, dhcpCo
 
 	handler := configurator.handler.(*netdriver.MockNetworkHandler)
 	portList := getVMPrimaryInterfacePortList(*configurator.vmi)
+	isMigrationOverSockets := configurator.vmi.Status.MigrationTransport == v1.MigrationTransportUnix
 	for _, proto := range protocols(optionalIPProtocol...) {
 		vmIP := dhcpConfig.IP.IP.String()
 		gwIP := dhcpConfig.AdvertisingIPAddr.String()
@@ -358,7 +379,7 @@ func mockNATNetfilterRules(configurator MasqueradePodNetworkConfigurator, dhcpCo
 			gwIP = dhcpConfig.AdvertisingIPv6Addr.String()
 		}
 		handler.EXPECT().ConfigureIpForwarding(proto).Return(nil)
-		mockFrontendFunc(handler, proto, getNFTIPString(proto), vmIP, gwIP, portList, configurator.vmi.Annotations)
+		mockFrontendFunc(handler, proto, getNFTIPString(proto), vmIP, gwIP, portList, configurator.vmi.Annotations, isMigrationOverSockets)
 	}
 }
 
@@ -370,20 +391,20 @@ func getVMPrimaryInterfacePortList(vmi v1.VirtualMachineInstance) []int {
 	return portList
 }
 
-func mockNetfilterIPTables(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, vmiAnnotations map[string]string) {
+func mockNetfilterIPTables(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, vmiAnnotations map[string]string, isMigrationOverSockets bool) {
 	handler.EXPECT().NftablesLoad(proto).Return(fmt.Errorf("nft not found"))
 	handler.EXPECT().HasNatIptables(proto).Return(true)
-	mockIPTablesBackend(handler, proto, nftIPString, vmIP, gwIP, portList)
+	mockIPTablesBackend(handler, proto, nftIPString, vmIP, gwIP, portList, isMigrationOverSockets)
 }
 
-func mockNetfilterNFTables(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, vmiAnnotations map[string]string) {
+func mockNetfilterNFTables(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, vmiAnnotations map[string]string, isMigrationOverSockets bool) {
 	handler.EXPECT().NftablesLoad(proto).Return(nil)
 	handler.EXPECT().HasNatIptables(proto).Return(true).Times(0)
 	handler.EXPECT().HasNatIptables(proto).Return(false).Times(0)
-	mockNFTablesFrontend(handler, proto, nftIPString, vmIP, gwIP, portList, vmiAnnotations)
+	mockNFTablesFrontend(handler, proto, nftIPString, vmIP, gwIP, portList, vmiAnnotations, isMigrationOverSockets)
 }
 
-func mockNFTablesFrontend(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, vmiAnnotations map[string]string) {
+func mockNFTablesFrontend(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, vmiAnnotations map[string]string, isMigrationOverSockets bool) {
 	handler.EXPECT().GetNFTIPString(proto).Return(nftIPString).AnyTimes()
 	handler.EXPECT().NftablesNewChain(proto, "nat", "KUBEVIRT_PREINBOUND").Return(nil)
 	handler.EXPECT().NftablesNewChain(proto, "nat", "KUBEVIRT_POSTINBOUND").Return(nil)
@@ -392,8 +413,12 @@ func mockNFTablesFrontend(handler *netdriver.MockNetworkHandler, proto iptables.
 	handler.EXPECT().NftablesAppendRule(proto, "nat", "prerouting", "iifname", "eth0", "counter", "jump", "KUBEVIRT_PREINBOUND").Return(nil)
 	handler.EXPECT().NftablesAppendRule(proto, "nat", "postrouting", "oifname", "k6t-eth0", "counter", "jump", "KUBEVIRT_POSTINBOUND").Return(nil)
 
-	for _, chain := range []string{"output", "KUBEVIRT_POSTINBOUND"} {
-		handler.EXPECT().NftablesAppendRule(proto, "nat", chain, "tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(PortsUsedByLiveMigration(), ", ")), nftIPString, "saddr", GetLoopbackAdrress(proto), "counter", "return").Return(nil)
+	skipPorts := portsUsedByLiveMigration(isMigrationOverSockets)
+
+	if len(skipPorts) > 0 {
+		for _, chain := range []string{"output", "KUBEVIRT_POSTINBOUND"} {
+			handler.EXPECT().NftablesAppendRule(proto, "nat", chain, "tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(skipPorts, ", ")), nftIPString, "saddr", GetLoopbackAdrress(proto), "counter", "return").Return(nil)
+		}
 	}
 
 	if len(portList) > 0 {
@@ -438,7 +463,7 @@ func mockNFTablesBackendAllPorts(handler *netdriver.MockNetworkHandler, proto ip
 	handler.EXPECT().NftablesAppendRule(proto, "nat", "output", nftIPString, "daddr", fmt.Sprintf("{ %s }", GetLoopbackAdrress(proto)), "counter", "dnat", "to", vmIP).Return(nil)
 }
 
-func mockIPTablesBackend(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int) {
+func mockIPTablesBackend(handler *netdriver.MockNetworkHandler, proto iptables.Protocol, nftIPString string, vmIP string, gwIP string, portList []int, isMigrationOverSockets bool) {
 	handler.EXPECT().GetNFTIPString(proto).Return(nftIPString).AnyTimes()
 	handler.EXPECT().IptablesNewChain(proto, "nat", "KUBEVIRT_PREINBOUND").Return(nil)
 	handler.EXPECT().IptablesNewChain(proto, "nat", "KUBEVIRT_POSTINBOUND").Return(nil)
@@ -462,11 +487,15 @@ func mockIPTablesBackend(handler *netdriver.MockNetworkHandler, proto iptables.P
 		"-j",
 		"KUBEVIRT_POSTINBOUND").Return(nil)
 
-	for _, chain := range []string{"OUTPUT", "KUBEVIRT_POSTINBOUND"} {
-		handler.EXPECT().IptablesAppendRule(proto, "nat", chain,
-			"-p", "tcp", "--match", "multiport",
-			"--dports", fmt.Sprintf("%s", strings.Join(PortsUsedByLiveMigration(), ",")),
-			"--source", GetLoopbackAdrress(proto), "-j", "RETURN").Return(nil)
+	skipPorts := portsUsedByLiveMigration(isMigrationOverSockets)
+
+	if len(skipPorts) > 0 {
+		for _, chain := range []string{"OUTPUT", "KUBEVIRT_POSTINBOUND"} {
+			handler.EXPECT().IptablesAppendRule(proto, "nat", chain,
+				"-p", "tcp", "--match", "multiport",
+				"--dports", fmt.Sprintf("%s", strings.Join(skipPorts, ",")),
+				"--source", GetLoopbackAdrress(proto), "-j", "RETURN").Return(nil)
+		}
 	}
 
 	if len(portList) > 0 {
@@ -557,9 +586,9 @@ func protocols(optionalIPProtocol ...iptables.Protocol) []iptables.Protocol {
 		optionalIPProtocol...)
 }
 
-func getReservedPortList() []int {
+func getReservedPortList(isMigrationOverSockets bool) []int {
 	var portList []int
-	for _, port := range PortsUsedByLiveMigration() {
+	for _, port := range portsUsedByLiveMigration(isMigrationOverSockets) {
 		intPort, err := strconv.ParseInt(port, 10, 64)
 		if err != nil {
 			Panic()

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -2145,6 +2145,9 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance) (map[string]string, 
 		vmi.GetObjectMeta().GetName(),
 		vmi.GetObjectMeta().GetNamespace())
 
+	// Set this annotation now to indicate that the newly created virt-launchers will use
+	// unix sockets as a transport for migration
+	annotationsSet[v1.MigrationTransportUnixAnnotation] = "true"
 	return annotationsSet, nil
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -252,6 +252,7 @@ var _ = Describe("Template", func() {
 						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 						"post.hook.backup.velero.io/container": "compute",
 						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"kubevirt.io/migrationTransportUnix":   "true",
 					},
 				),
 				table.Entry("and don't contain kubevirt annotation added by apiserver",
@@ -265,6 +266,7 @@ var _ = Describe("Template", func() {
 						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 						"post.hook.backup.velero.io/container": "compute",
 						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"kubevirt.io/migrationTransportUnix":   "true",
 					},
 				),
 				table.Entry("and contain kubevirt domain annotation",
@@ -277,6 +279,7 @@ var _ = Describe("Template", func() {
 						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 						"post.hook.backup.velero.io/container": "compute",
 						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"kubevirt.io/migrationTransportUnix":   "true",
 					},
 				),
 				table.Entry("and contain kubernetes annotation",
@@ -290,6 +293,7 @@ var _ = Describe("Template", func() {
 						"pre.hook.backup.velero.io/command":              "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 						"post.hook.backup.velero.io/container":           "compute",
 						"post.hook.backup.velero.io/command":             "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"kubevirt.io/migrationTransportUnix":             "true",
 					},
 				),
 				table.Entry("and contain kubevirt ignitiondata annotation",
@@ -311,6 +315,7 @@ var _ = Describe("Template", func() {
 						"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 						"post.hook.backup.velero.io/container": "compute",
 						"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+						"kubevirt.io/migrationTransportUnix":   "true",
 					},
 				),
 			)
@@ -354,6 +359,7 @@ var _ = Describe("Template", func() {
 					"pre.hook.backup.velero.io/command":    "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
 					"post.hook.backup.velero.io/container": "compute",
 					"post.hook.backup.velero.io/command":   "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+					"kubevirt.io/migrationTransportUnix":   "true",
 				}))
 				Expect(pod.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{{
 					APIVersion:         v1.VirtualMachineInstanceGroupVersionKind.GroupVersion().String(),
@@ -860,6 +866,17 @@ var _ = Describe("Template", func() {
 
 			})
 
+		})
+		Context("migration over unix sockets", func() {
+			It("virt-launcher should have a MigrationTransportUnixAnnotation", func() {
+				config, kvInformer, svc = configFactory(defaultArch)
+				vmi := v1.NewMinimalVMI("fake-vmi")
+
+				pod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				_, ok := pod.Annotations[v1.MigrationTransportUnixAnnotation]
+				Expect(ok).To(BeTrue())
+			})
 		})
 		Context("with multus annotation", func() {
 			It("should add multus networks in the pod annotation", func() {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -515,6 +515,12 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 				}
 				vmiCopy.ObjectMeta.Labels[virtv1.NodeNameLabel] = pod.Spec.NodeName
 				vmiCopy.Status.NodeName = pod.Spec.NodeName
+
+				// Set the VMI migration transport now before the VMI can be migrated
+				// This status filed is needed to support the migration of legacy virt-launchers
+				// to newer ones. In an absence of this field on the vmi, the target launcher
+				// will set up a TCP proxy, as expected by a legacy virt-launcher.
+				vmiCopy.Status.MigrationTransport = virtv1.MigrationTransportUnix
 			} else if isPodDownOrGoingDown(pod) {
 				vmiCopy.Status.Phase = virtv1.Failed
 			}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -666,6 +666,10 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		// clean the evacuation node name since have already migrated to a new node
 		vmi.Status.EvacuationNodeName = ""
 		vmi.Status.MigrationState.Completed = true
+		// update the vmi migrationTransport to indicate that next migration should use unix URI
+		// new workloads will set the migrationTransport on their creation, however, legacy workloads
+		// can make the switch only after the first migration
+		vmi.Status.MigrationTransport = v1.MigrationTransportUnix
 		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to node %s.", migrationHost))
 		log.Log.Object(vmi).Infof("migration completed to node %s", migrationHost)
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1787,6 +1787,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			vmiUpdated := vmi.DeepCopy()
 			vmiUpdated.Status.MigrationState.Completed = true
+			vmiUpdated.Status.MigrationTransport = v1.MigrationTransportUnix
 			vmiUpdated.Status.MigrationState.StartTimestamp = &now
 			vmiUpdated.Status.MigrationState.EndTimestamp = &now
 			vmiUpdated.Status.NodeName = "othernode"

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/downwardmetrics:go_default_library",
         "//pkg/emptydisk:go_default_library",
         "//pkg/ephemeral-disk:go_default_library",
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/ignition:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8136,6 +8136,9 @@ var CRDsValidation map[string]string = map[string]string{
               description: The target pod that the VMI is moving to
               type: string
           type: object
+        migrationTransport:
+          description: This represents the migration transport
+          type: string
         nodeName:
           description: NodeName is the name where the VirtualMachineInstance is currently
             running.

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -25128,6 +25128,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceStatus(ref common.
 							Format:      "",
 						},
 					},
+					"migrationTransport": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This represents the migration transport",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"qosClass": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -208,6 +208,8 @@ type VirtualMachineInstanceStatus struct {
 	MigrationState *VirtualMachineInstanceMigrationState `json:"migrationState,omitempty"`
 	// Represents the method using which the vmi can be migrated: live migration or block migration
 	MigrationMethod VirtualMachineInstanceMigrationMethod `json:"migrationMethod,omitempty"`
+	// This represents the migration transport
+	MigrationTransport VirtualMachineInstanceMigrationTransport `json:"migrationTransport,omitempty"`
 	// The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements
 	// See PodQOSClass type for available QOS classes
 	// More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md
@@ -600,6 +602,15 @@ const (
 	MigrationPreCopy MigrationMode = "PreCopy"
 	// MigrationPostCopy means the VMI migrations that is currently running is in post copy mode
 	MigrationPostCopy MigrationMode = "PostCopy"
+)
+
+//
+// +k8s:openapi-gen=true
+type VirtualMachineInstanceMigrationTransport string
+
+const (
+	// MigrationTransportUnix means that the VMI will be migrated using the unix URI
+	MigrationTransportUnix VirtualMachineInstanceMigrationTransport = "Unix"
 )
 
 //

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -777,6 +777,9 @@ const (
 
 	// This annotation is to keep virt launcher container alive when an VMI encounters a failure for debugging purpose
 	KeepLauncherAfterFailureAnnotation string = "kubevirt.io/keep-launcher-alive-after-failure"
+
+	// MigrationTransportUnixAnnotation means that the VMI will be migrated using the unix URI
+	MigrationTransportUnixAnnotation string = "kubevirt.io/migrationTransportUnix"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -66,6 +66,7 @@ func (VirtualMachineInstanceStatus) SwaggerDoc() map[string]string {
 		"guestOSInfo":                   "Guest OS Information",
 		"migrationState":                "Represents the status of a live migration",
 		"migrationMethod":               "Represents the method using which the vmi can be migrated: live migration or block migration",
+		"migrationTransport":            "This represents the migration transport",
 		"qosClass":                      "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements\nSee PodQOSClass type for available QOS classes\nMore info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n+optional",
 		"launcherContainerImageVersion": "LauncherContainerImageVersion indicates what container image is currently active for the vmi.",
 		"evacuationNodeName":            "EvacuationNodeName is used to track the eviction process of a VMI. It stores the name of the node that we want\nto evacuate. It is meant to be used by KubeVirt core components only and can't be set or modified by users.\n+optional",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -20186,6 +20186,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceStatus(ref common.
 							Format:      "",
 						},
 					},
+					"migrationTransport": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This represents the migration transport",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"qosClass": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR switches live migration to directly use Unix sockets between the virt-launchers and virt-handlers
This removes the need of proxying the connections between the components. 

```release-note
switch live migration to use unix sockets
```
