### PR TITLE
Add [Serial] tag to test_id:5004

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1322,7 +1322,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			},
 				table.Entry("[test_id:2653] with default migration configuration", nil, v1.MigrationPreCopy),
-				table.Entry("[QUARANTINE][test_id:5004] with postcopy", &v1.MigrationConfiguration{
+				table.Entry("[QUARANTINE][Serial][test_id:5004] with postcopy", &v1.MigrationConfiguration{
 					AllowPostCopy:           pointer.BoolPtr(true),
 					CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
 				}, v1.MigrationPostCopy),


### PR DESCRIPTION
Signed-off-by: Itamar Holder <iholder@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This test has been flakie on periodic lanes for a while although stable on pre-submit lanes.
This is another attempt to stabilize the test in periodic lanes - making it not run in parallel by adding `[Serial]` tag to the test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
