### PR TITLE
whatchanged, Update markdown style of whatchanged script

### DIFF
--- a/hack/whatchanged.sh
+++ b/hack/whatchanged.sh
@@ -35,8 +35,9 @@ function main() {
     cd "$TEMP_DIR"
     git clone --depth=100 -n "$REPO" >/dev/null 2>&1
     cd kubevirtci
-    info=$(git log $PREVIOUS..$CURRENT --format="%h %s" | sed 's!#!https://github.com/kubevirt/kubevirtci/pull/!g')
-    decorated_info=$(echo -e "Bump kubevirtci\n\n\`\`\`\n${info}\n\`\`\`")
+    info=$(git log $PREVIOUS..$CURRENT --format="%h %s" | sed 's! (#!](https://github.com/kubevirt/kubevirtci/pull/!g')
+    info=$(echo "$info" | sed 's/^/\[/')
+    decorated_info=$(echo -e "Bump kubevirtci\n\n${info}")
     echo "$decorated_info"
 }
 


### PR DESCRIPTION
Update markdown style of what changed script to
show links.

Fix also the potential case where there is a pound char,
in the kubevirtci PRs title, that will be updated to
a link where it shouldn't.

Example of output:
[576bc8c kind/podpreset.sh: fix error redirection to stderr](https://github.com/kubevirt/kubevirtci/pull/612)
[e86941a kind infra, podpreset: Increase PodPreset enabled validation timeout](https://github.com/kubevirt/kubevirtci/pull/669)

See previous style here 
https://github.com/kubevirt/kubevirt/pull/6316

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
