### PR TITLE
Fix qemu-img segmentation fault error in tests

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -52,7 +52,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
+	})
 
+	AfterEach(func() {
 		tests.BeforeTestCleanup()
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

One of the tests was setting the memory limit for image verification to
a low value without restoring it afterwards. Therefore all the tests
executed later on were failing because of insufficient memory for
qemu-img.

There was a call to restore the test environemnt in the BeforeEach()
section. Though it needs to be called *after* the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The offending test is `disk verification should fail when the memory limit is too low`:

https://github.com/kubevirt/kubevirt/blob/c9e87c4cb6292af33ccad8faa5fb9bf269c0fbf4/tests/container_disk_test.go#L150-L151

Probably it is the reason of regular failures in cgroupsv2 periodic:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-cgroupsv2/1432267065804197888

https://github.com/kubevirt/project-infra/pull/1526

The test has `[Serial]` label and so all the other failed tests do. I assume that they were executed sequentaly with the modified memory limit.

The cgroupsv2 periodic was supposed to run all the tests therefore `[sig-network]` were mixed with `[sig-compute]` tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
