### PR TITLE
Use smaller writes for fstrim test, improve messaging on failure

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1017,7 +1017,7 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=500 2> /dev/null\n"},
+				&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=100 2> /dev/null\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "sync\n"},
 				&expect.BExp{R: console.PromptExpression},
@@ -1037,7 +1037,7 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 			By("Deleting large file and trimming disk")
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				// Write a small file so that we'll have an increase in image size if trim is unsupported.
-				&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=100 2> /dev/null\n"},
+				&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=20 2> /dev/null\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "sync\n"},
 				&expect.BExp{R: console.PromptExpression},

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -923,7 +923,12 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 			// bytes of difference.
 			// A VM cannot do sub-512 byte accesses anyway, so such small size
 			// differences are practically equal.
-			return math.Abs((float64)(a-b)) < 512
+			if math.Abs((float64)(a-b)) >= 512 {
+				By(fmt.Sprintf("Image sizes not equal, %d - %d >= 512", a, b))
+				return false
+			} else {
+				return true
+			}
 		}
 		getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume, withOCS bool) int64 {
 			var imageSize int64


### PR DESCRIPTION
Should speed things up, and reduce the chance we'll hit timeouts.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
