### PR TITLE
CDI, Introduce KUBEVIRT_DEPLOY_CDI flag

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -40,15 +40,18 @@ if [ -z $TARGET ]; then
   exit 1
 fi
 
+export KUBEVIRT_DEPLOY_CDI=true
 if [[ $TARGET =~ windows.* ]]; then
   echo "picking the default provider for windows tests"
 elif [[ $TARGET =~ cnao ]]; then
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_PROVIDER=${TARGET/-cnao/}
+  export KUBEVIRT_DEPLOY_CDI=false
 elif [[ $TARGET =~ sig-network ]]; then
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_PROVIDER=${TARGET/-sig-network/}
   export KUBEVIRT_DEPLOY_ISTIO=true
+  export KUBEVIRT_DEPLOY_CDI=false
   if [[ $TARGET =~ k8s-1\.1.* ]]; then
     export KUBEVIRT_DEPLOY_ISTIO=false
   fi
@@ -70,6 +73,7 @@ fi
 
 if [[ $TARGET =~ sriov.* ]]; then
   export KUBEVIRT_NUM_NODES=3
+  export KUBEVIRT_DEPLOY_CDI=false
 elif [[ $TARGET =~ vgpu.* ]]; then
   export KUBEVIRT_NUM_NODES=1
 else


### PR DESCRIPTION
In order to make the kubevirt deploy lighter,
and install only whats needed, add a flag that
will determine if to install CDI.
    
This in turn will make less dependencies,
and faster cluster-sync.
    
`export KUBEVIRT_DEPLOY_CDI=false` in order to skip
CDI installation (default is to install it).

For kind providers,  `KUBEVIRT_DEPLOY_CDI` will be set to false automatically,
since we are not using CDI there, and because the loopback devices does conflict with DinD.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
