### PR TITLE
Fix flaky hostpath storage tests

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -110,10 +110,9 @@ var _ = SIGDescribe("Storage", func() {
 
 		runHostPathJobAndExpectCompletion := func(pod *k8sv1.Pod) *k8sv1.Pod {
 			pod, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
-			podWithName := pod.DeepCopy()
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(ThisPod(pod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
-			_, err = ThisPod(pod)()
+			podWithName, err := ThisPod(pod)()
 			Expect(err).ToNot(HaveOccurred())
 			return podWithName
 		}
@@ -965,6 +964,8 @@ var _ = SIGDescribe("Storage", func() {
 						}
 						return k8sv1.ConditionFalse
 					}, 30, 1).Should(Equal(k8sv1.ConditionTrue))
+					pod, err = ThisPod(pod)()
+					Expect(err).ToNot(HaveOccurred())
 
 					By("Determining the size of the mounted directory")
 					diskSizeStr, _, err := tests.ExecuteCommandOnPodV2(virtClient, pod, pod.Spec.Containers[0].Name, []string{"/usr/bin/bash", "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Fetch the latest state of the hostpath job pod before it is returned to the caller: previously it was returned right after the creation and thus the `pod.Spec.NodeName` was empty (since it was not yet scheduled). The NodeName is needed to schedule NFS or VMI pods on the same node later on.

**What this PR does / why we need it**:

The PR fixes flaky storage NFS tests: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-cgroupsv2/1433336606130966528

UPD: also fixes https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6346/pull-kubevirt-check-tests-for-flakes/1433731379153080320

Follow-up of the: https://github.com/kubevirt/kubevirt/pull/6335

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

E.g. here the returned node name was empty: https://github.com/kubevirt/kubevirt/blob/b1c258a3a27e047fb6b37f7a02054f8b91f38e32/tests/storage/storage.go#L300
https://github.com/kubevirt/kubevirt/blob/b1c258a3a27e047fb6b37f7a02054f8b91f38e32/tests/storage/storage.go#L1009

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
