### PR TITLE
Collect reporter artifacts in a JustAfterEach

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -42,6 +42,10 @@ const (
 	networkAttachmentDefinitionEntity = "network-attachment-definitions"
 )
 
+type JustAfterEachReporter interface {
+	JustAfterEach(specSummary ginkgo.GinkgoTestDescription)
+}
+
 type KubernetesReporter struct {
 	failureCount int
 	artifactsDir string
@@ -73,11 +77,13 @@ func (r *KubernetesReporter) SpecWillRun(_ *types.SpecSummary) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, "On failure, artifacts will be collected in %s/%d_*\n", r.artifactsDir, r.failureCount+1)
 }
 
-func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+func (r *KubernetesReporter) SpecDidComplete(_ *types.SpecSummary) {}
+
+func (r *KubernetesReporter) JustAfterEach(specSummary ginkgo.GinkgoTestDescription) {
 	if r.failureCount > r.maxFails {
 		return
 	}
-	if specSummary.HasFailureState() {
+	if specSummary.Failed {
 		r.failureCount++
 	} else {
 		return
@@ -87,7 +93,7 @@ func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	if r.artifactsDir == "" {
 		return
 	}
-	r.DumpTestNamespaces(specSummary.RunTime)
+	r.DumpTestNamespaces(specSummary.Duration)
 }
 
 func (r *KubernetesReporter) DumpTestNamespaces(duration time.Duration) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3459,6 +3459,8 @@ func LibvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.Virtua
 	return strings.Contains(stdout, vmi.Namespace+"_"+vmi.Name), nil
 }
 
+// Deprecated: BeforeAll must not be used. Tests need to be self-contained to allow sane cleanup, accurate reporting and
+// parallel execution.
 func BeforeAll(fn func()) {
 	first := true
 	BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to make it finally possible to clean up environments as
expected in a `AfterEach` the reporters are now collecting the
environment info in a `JustAfterEach`. This means that it does no
longer matter if `BeforeTestCleanup` is called in a `BeforeEach` or
`AfterEach`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
