### PR TITLE
generate, Show git diff in case generate diff exists

### DIFF
--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -4,5 +4,6 @@ if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
     echo "ERROR: git tree state is not clean!"
     echo "You probably need to run 'make generate' or 'make' and commit the changes"
     git status
+    git diff
     exit 1
 fi


### PR DESCRIPTION
In case generate diff exists, show both the files
and the actual diff, it makes it easier and faster
to fix in case its a small change.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
