### PR TITLE
remove functional test id 3150 from quarantine

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1621,7 +1621,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[QUARANTINE][sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
+		It("[sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}


### PR DESCRIPTION
The issue resolved in #5194 likely resolves the flakiness observed in test-id 3150 as well. Now that the fix is merged, we should be able to consider removing 3150 from quarantine once we've proven the fix reduces flakiness.

**Special notes for your reviewer**:
#5291 rebased. It hasn't been touched in months.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
