### PR TITLE
Remove test 3150 from QUARANTINE

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1621,7 +1621,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[QUARANTINE][sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
+		It("[test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}


### PR DESCRIPTION
This test failed 3 times in the last 2 month because of some
infra+TLS issues. The flakiness is so low and we decided to
remove it from QUARANTINE.

It also removes  the `[sig-compute]` label from the description
of the test given that we have now proper sig-operator lanes.

Signed-off-by: Erkan Erol <eerol@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
