### PR TITLE
Service account & unmanaged SCC

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15102,6 +15102,10 @@
       "description": "If specified, the VMI will be dispatched by specified scheduler. If not specified, the VMI will be dispatched by default scheduler.",
       "type": "string"
      },
+     "serviceAccountName": {
+      "description": "ServiceAccountName is the name of the ServiceAccount to use to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+      "type": "string"
+     },
      "startStrategy": {
       "description": "StartStrategy can be set to \"Paused\" if Virtual Machine should be started in paused state.",
       "type": "string"

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -44,6 +44,7 @@ const (
 	DownwardMetricsFeatureGate = "DownwardMetrics"
 	NonRoot                    = "NonRootExperimental"
 	ClusterProfiler            = "ClusterProfiler"
+	NoManagedSCC               = "NoManagedSCC"
 )
 
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -130,4 +131,8 @@ func (config *ClusterConfig) NonRootEnabled() bool {
 
 func (config *ClusterConfig) ClusterProfilerEnabled() bool {
 	return config.isFeatureGateEnabled(ClusterProfiler)
+}
+
+func (config *ClusterConfig) NoManagedSCCEnabled() bool {
+	return config.isFeatureGateEnabled(NoManagedSCC)
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1466,6 +1466,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	} else if istio.ProxyInjectionEnabled(vmi) {
 		automount := true
 		pod.Spec.AutomountServiceAccountToken = &automount
+	} else if vmi.Spec.ServiceAccountName != "" {
+		pod.Spec.ServiceAccountName = vmi.Spec.ServiceAccountName
+		automount := true
+		pod.Spec.AutomountServiceAccountToken = &automount
 	} else {
 		automount := false
 		pod.Spec.AutomountServiceAccountToken = &automount

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1791,7 +1791,10 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance, config *virtconfig.
 		capabilities = append(capabilities, CAP_NET_BIND_SERVICE)
 	}
 	// add a CAP_SYS_NICE capability to allow setting cpu affinity
-	capabilities = append(capabilities, CAP_SYS_NICE)
+	if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.DedicatedCPUPlacement {
+		capabilities = append(capabilities, CAP_SYS_NICE)
+	}
+
 	// add CAP_SYS_ADMIN capability to allow virtiofs
 	if util.IsVMIVirtiofsEnabled(vmi) {
 		capabilities = append(capabilities, CAP_SYS_ADMIN)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3204,53 +3204,69 @@ var _ = Describe("Template", func() {
 
 	Describe("ServiceAccountName", func() {
 
-		It("Should add service account if present", func() {
-			config, kvInformer, svc = configFactory(defaultArch)
-			serviceAccountName := "testAccount"
-			volumes := []v1.Volume{
-				{
-					Name: "serviceaccount-volume",
-					VolumeSource: v1.VolumeSource{
-						ServiceAccount: &v1.ServiceAccountVolumeSource{
-							ServiceAccountName: serviceAccountName,
-						},
-					},
-				},
-			}
-			vmi := v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testvmi", Namespace: "default", UID: "1234",
-				},
-				Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						DisableHotplug: true,
-					},
-				}},
-			}
+		Context("without volume", func() {
 
-			pod, err := svc.RenderLaunchManifest(&vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pod.Spec.ServiceAccountName).To(Equal(serviceAccountName), "ServiceAccount matches")
-			Expect(*pod.Spec.AutomountServiceAccountToken).To(BeTrue(), "Token automount is enabled")
+			It("Should add service account if present", func() {
+				serviceAccountName := "default"
+				vmi := api.NewMinimalVMI("testvmi")
+				vmi.Spec.ServiceAccountName = serviceAccountName
+
+				pod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.ServiceAccountName).To(Equal(serviceAccountName), "ServiceAccount matches")
+				Expect(*pod.Spec.AutomountServiceAccountToken).To(BeTrue(), "Token automount is enabled")
+			})
 		})
 
-		It("Should not add service account if not present", func() {
-			config, kvInformer, svc = configFactory(defaultArch)
-			vmi := v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "testvmi", Namespace: "default", UID: "1234",
-				},
-				Spec: v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						DisableHotplug: true,
-					},
-				}},
-			}
+		Context("from volume", func() {
 
-			pod, err := svc.RenderLaunchManifest(&vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pod.Spec.ServiceAccountName).To(BeEmpty(), "ServiceAccount is empty")
-			Expect(*pod.Spec.AutomountServiceAccountToken).To(BeFalse(), "Token automount is disabled")
+			It("Should add service account if present", func() {
+				serviceAccountName := "testAccount"
+				volumes := []v1.Volume{
+					{
+						Name: "serviceaccount-volume",
+						VolumeSource: v1.VolumeSource{
+							ServiceAccount: &v1.ServiceAccountVolumeSource{
+								ServiceAccountName: serviceAccountName,
+							},
+						},
+					},
+				}
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testvmi", Namespace: "default", UID: "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{Volumes: volumes, Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							DisableHotplug: true,
+						},
+					}},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.ServiceAccountName).To(Equal(serviceAccountName), "ServiceAccount matches")
+				Expect(*pod.Spec.AutomountServiceAccountToken).To(BeTrue(), "Token automount is enabled")
+			})
+
+			It("Should not add service account if not present", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testvmi", Namespace: "default", UID: "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							DisableHotplug: true,
+						},
+					}},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.ServiceAccountName).To(BeEmpty(), "ServiceAccount is empty")
+				Expect(*pod.Spec.AutomountServiceAccountToken).To(BeFalse(), "Token automount is disabled")
+			})
+
 		})
 
 	})

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/monitoring/vmistats:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/cluster:go_default_library",
         "//pkg/util/lookup:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/pdbs:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -26,7 +26,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetAllSCC(namespace string) []*secv1.SecurityContextConstraints {
+func GetAllSCC(namespace string, managed bool) []*secv1.SecurityContextConstraints {
+	if managed {
+		return []*secv1.SecurityContextConstraints{
+			NewKubeVirtHandlerSCC(namespace),
+		}
+	}
 	return []*secv1.SecurityContextConstraints{
 		NewKubeVirtHandlerSCC(namespace),
 		NewKubeVirtControllerSCC(namespace),

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5120,6 +5120,10 @@ var CRDsValidation map[string]string = map[string]string{
                     scheduler. If not specified, the VMI will be dispatched by default
                     scheduler.
                   type: string
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the ServiceAccount
+                    to use to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                  type: string
                 startStrategy:
                   description: StartStrategy can be set to "Paused" if Virtual Machine
                     should be started in paused state.
@@ -8058,6 +8062,10 @@ var CRDsValidation map[string]string = map[string]string{
         schedulerName:
           description: If specified, the VMI will be dispatched by specified scheduler.
             If not specified, the VMI will be dispatched by default scheduler.
+          type: string
+        serviceAccountName:
+          description: 'ServiceAccountName is the name of the ServiceAccount to use
+            to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
           type: string
         startStrategy:
           description: StartStrategy can be set to "Paused" if Virtual Machine should
@@ -12003,6 +12011,10 @@ var CRDsValidation map[string]string = map[string]string{
                   description: If specified, the VMI will be dispatched by specified
                     scheduler. If not specified, the VMI will be dispatched by default
                     scheduler.
+                  type: string
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the ServiceAccount
+                    to use to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string
                 startStrategy:
                   description: StartStrategy can be set to "Paused" if Virtual Machine
@@ -18956,6 +18968,10 @@ var CRDsValidation map[string]string = map[string]string{
                               description: If specified, the VMI will be dispatched
                                 by specified scheduler. If not specified, the VMI
                                 will be dispatched by default scheduler.
+                              type: string
+                            serviceAccountName:
+                              description: 'ServiceAccountName is the name of the
+                                ServiceAccount to use to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             startStrategy:
                               description: StartStrategy can be set to "Paused" if

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -478,8 +478,10 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 		return nil, fmt.Errorf("error generating virt-handler deployment %v", err)
 	}
 
+	managed := !config.NoManagedSCCEnabled()
+
 	strategy.daemonSets = append(strategy.daemonSets, handler)
-	strategy.sccs = append(strategy.sccs, components.GetAllSCC(config.GetNamespace())...)
+	strategy.sccs = append(strategy.sccs, components.GetAllSCC(config.GetNamespace(), managed)...)
 	strategy.apiServices = components.NewVirtAPIAPIServices(config.GetNamespace())
 	strategy.certificateSecrets = components.NewCertSecrets(config.GetNamespace(), operatorNamespace)
 	strategy.certificateSecrets = append(strategy.certificateSecrets, components.NewCACertSecret(operatorNamespace))

--- a/pkg/virt-operator/resource/generate/rbac/operator.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator.go
@@ -249,6 +249,10 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 				ResourceNames: []string{
 					"kubevirt-handler",
 					"kubevirt-controller",
+					"kubevirt-base",
+					"kubevirt-cpu-pinning",
+					"kubevirt-host-disk",
+					"kubevirt-cpu-pinning-and-host-disk",
 				},
 				Verbs: []string{
 					"get",

--- a/pkg/virt-operator/util/BUILD.bazel
+++ b/pkg/virt-operator/util/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -85,6 +85,11 @@ type VirtualMachineInstanceSpec struct {
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
+	// ServiceAccountName is the name of the ServiceAccount to use to run vm.
+	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
 	// Specification of the desired behavior of the VirtualMachineInstance on the host.
 	Domain DomainSpec `json:"domain"`
 	// NodeSelector is a selector which must be true for the vmi to fit on a node.

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -762,6 +762,8 @@ const (
 
 	MigrationSelectorLabel = "kubevirt.io/vmi-name"
 
+	SAMissingLabel = "kubevirt.io/sa-missing"
+
 	// This annotation represents vmi running nonroot implementation
 	NonRootVMIAnnotation = "kubevirt.io/nonroot"
 

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -20,6 +20,7 @@ func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                              "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
 		"priorityClassName":             "If specified, indicates the pod's priority.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.\n+optional",
+		"serviceAccountName":            "ServiceAccountName is the name of the ServiceAccount to use to run vm.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/\n+optional",
 		"domain":                        "Specification of the desired behavior of the VirtualMachineInstance on the host.",
 		"nodeSelector":                  "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
 		"affinity":                      "If affinity is specifies, obey all the affinity rules",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20707,6 +20707,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceSpec(ref common.Referen
 							Format:      "",
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccountName is the name of the ServiceAccount to use to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"domain": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the VirtualMachineInstance on the host.",

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
@@ -25196,6 +25196,13 @@ func schema_client_go_apis_core_v1_VirtualMachineInstanceSpec(ref common.Referen
 							Format:      "",
 						},
 					},
+					"serviceAccountName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccountName is the name of the ServiceAccount to use to run vm. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"domain": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the VirtualMachineInstance on the host.",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -140,6 +140,7 @@ go_test(
         "pool_test.go",
         "portforward_test.go",
         "replicaset_test.go",
+        "scc_test.go",
         "security_features_test.go",
         "softreboot_test.go",
         "stability_test.go",

--- a/tests/scc_test.go
+++ b/tests/scc_test.go
@@ -1,0 +1,293 @@
+package tests_test
+
+import (
+	"context"
+	"fmt"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/util"
+	util2 "kubevirt.io/kubevirt/tests/util"
+
+	"time"
+
+	"kubevirt.io/kubevirt/tests/libvmi"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/tests"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+)
+
+var _ = Describe("[Serial][sig-operator] SCC", func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+		if !tests.IsOpenShift() {
+			Skip("OpenShift operator tests should not be started on k8s")
+		}
+	})
+
+	checkHandlerSCC := func() {
+		By("Checking if virt-handler is assigned to kubevirt-handler SCC")
+		l, err := labels.Parse("kubevirt.io=virt-handler")
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
+		ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Should get virt-handler")
+		ExpectWithOffset(1, pods.Items).ToNot(BeEmpty())
+		ExpectWithOffset(1, pods.Items[0].Annotations["openshift.io/scc"]).To(
+			Equal("kubevirt-handler"), "Should virt-handler be assigned to kubevirt-handler SCC",
+		)
+	}
+
+	Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With OpenShift cluster", func() {
+
+		const OpenShiftSCCLabel = "openshift.io/scc"
+		BeforeEach(func() {
+			if !tests.IsOpenShift() {
+				Skip("OpenShift operator tests should not be started on k8s")
+			}
+		})
+
+		checkSCCs := func(managed bool) {
+			var expectedSCCs, sccs []string
+
+			By("Checking if kubevirt SCCs have been created")
+			secClient := virtClient.SecClient()
+			operatorSCCs := components.GetAllSCC(flags.KubeVirtInstallNamespace, managed)
+			for _, scc := range operatorSCCs {
+				expectedSCCs = append(expectedSCCs, scc.GetName())
+			}
+
+			createdSCCs, err := secClient.SecurityContextConstraints().List(context.Background(), metav1.ListOptions{LabelSelector: controller.OperatorLabel})
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			for _, scc := range createdSCCs.Items {
+				sccs = append(sccs, scc.GetName())
+			}
+			ExpectWithOffset(1, sccs).To(ConsistOf(expectedSCCs))
+		}
+
+		createLauncherToCheckSCC := func() k8sv1.Pod {
+			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.RunVMI(vmi, 180)
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			uid := vmi.GetObjectMeta().GetUID()
+			labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
+			pods, err := virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Should get virt-launcher")
+			ExpectWithOffset(1, len(pods.Items)).To(Equal(1))
+			return pods.Items[0]
+		}
+
+		It("[test_id:2910]Should have kubevirt SCCs created", func() {
+			checkSCCs(!checks.HasFeature(virtconfig.NoManagedSCC))
+
+			checkHandlerSCC()
+
+			By("Checking if virt-launcher is assigned to kubevirt-controller SCC")
+			pod := createLauncherToCheckSCC()
+			Expect(pod.Annotations[OpenShiftSCCLabel]).To(
+				Equal("kubevirt-controller"), "Should virt-launcher be assigned to kubevirt-controller SCC",
+			)
+		})
+	})
+
+	Context("NoManagedSCC feature gate enabled", func() {
+		var dissableFeature func()
+
+		BeforeEach(func() {
+			if !checks.HasFeature(virtconfig.NoManagedSCC) {
+				tests.EnableFeatureGate(virtconfig.NoManagedSCC)
+
+				dissableFeature = func() {
+					tests.DisableFeatureGate(virtconfig.NoManagedSCC)
+					Eventually(func() error {
+						_, err := virtClient.SecClient().SecurityContextConstraints().Get(context.Background(), "kubevirt-controller", metav1.GetOptions{})
+						return err
+					}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+				}
+			}
+			Eventually(func() error {
+				ssc, err := virtClient.SecClient().SecurityContextConstraints().Get(context.Background(), "kubevirt-controller", metav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return nil
+				}
+				if err == nil {
+					return fmt.Errorf("The SSC exists %v", ssc)
+				}
+
+				return err
+			}, 5*time.Minute, time.Minute).ShouldNot(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			if dissableFeature != nil {
+				dissableFeature()
+			}
+		})
+
+		shouldFailToCreate := func(vmi *v1.VirtualMachineInstance) {
+			vmi = tests.RunVMI(vmi, 60)
+			var err error
+
+			refreshVMI := ThisVMI(vmi)
+			EventuallyWithOffset(1, func() bool {
+				vmi, err = refreshVMI()
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+				for _, condition := range vmi.Status.Conditions {
+					if condition.Type == v1.VirtualMachineInstanceSynchronized {
+						Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+						ExpectWithOffset(2, condition.Reason).To(Equal("FailedCreate"))
+						ExpectWithOffset(2, condition.Message).To(ContainSubstring("security context constraint"))
+						return true
+					}
+				}
+				return false
+			}, 30*time.Second, time.Second).Should(BeTrue())
+		}
+
+		type saCreator func() (string, func())
+
+		createSaAndSCC := func(sscName string) func() (string, func()) {
+
+			return func() (string, func()) {
+				By("Creating testing SA")
+				sa := &k8sv1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-correct-scc",
+					},
+				}
+				sa, err := virtClient.CoreV1().ServiceAccounts(util.NamespaceTestDefault).Create(context.TODO(), sa, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				saName := fmt.Sprintf("system:serviceaccount:%s:%s", sa.Namespace, sa.Name)
+				scc, err := virtClient.SecClient().SecurityContextConstraints().Get(context.TODO(), sscName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				scc.Users = append(scc.Users, saName)
+				scc, err = virtClient.SecClient().SecurityContextConstraints().Update(context.TODO(), scc, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				cleanup := func() {
+					err := virtClient.CoreV1().ServiceAccounts(util.NamespaceTestDefault).Delete(context.TODO(), sa.Name, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					scc, err := virtClient.SecClient().SecurityContextConstraints().Get(context.TODO(), sscName, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					users := []string{}
+					for _, user := range scc.Users {
+						if user != saName {
+							users = append(users, user)
+						}
+					}
+					scc.Users = users
+					scc, err = virtClient.SecClient().SecurityContextConstraints().Update(context.TODO(), scc, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}
+				return sa.Name, cleanup
+			}
+		}
+
+		checkIfSCChasSA := func(sccName, saName string) {
+			By("Checking if SA is in SCC")
+			scc, err := virtClient.SecClient().SecurityContextConstraints().Get(context.Background(), sccName, metav1.GetOptions{})
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			saName = fmt.Sprintf("system:serviceaccount:%s:%s", util.NamespaceTestDefault, saName)
+			ExpectWithOffset(1, scc.Users).To(ContainElement(saName))
+		}
+
+		It("multiple times should not remove users from SCCs", func() {
+			By("Adding SA to SCC")
+			sccName := "kubevirt-base"
+			saName, removeSA := createSaAndSCC(sccName)()
+			defer removeSA()
+
+			checkIfSCChasSA(sccName, saName)
+
+			By("Disable NoManagedSCC feature gate")
+			tests.DisableFeatureGate(virtconfig.NoManagedSCC)
+
+			checkIfSCChasSA(sccName, saName)
+
+			By("Enable NoManagedSCC feature gate")
+			tests.EnableFeatureGate(virtconfig.NoManagedSCC)
+
+			checkIfSCChasSA(sccName, saName)
+		})
+
+		table.DescribeTable("testing CPU pinning VM", func(createSA saCreator, allowed bool) {
+			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores:                 2,
+				DedicatedCPUPlacement: true,
+			}
+			vmi.Spec.Hostname = "vmi"
+
+			sa, removeSA := createSA()
+			defer removeSA()
+			vmi.Spec.ServiceAccountName = sa
+
+			if allowed {
+				tests.RunVMIAndExpectLaunch(vmi, 180)
+
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).NotTo(HaveOccurred())
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+				return
+			}
+			shouldFailToCreate(vmi)
+		},
+			table.Entry("with base SCC should fail", createSaAndSCC("kubevirt-base"), false),
+			table.FEntry("with cpu-pinning SCC should success", createSaAndSCC("kubevirt-cpu-pinning"), true),
+			table.Entry("with cpu-pinning & host-disk SCC should success", createSaAndSCC("kubevirt-cpu-pinning-and-host-disk"), true),
+			table.Entry("with host-disk SCC should fail", createSaAndSCC("kubevirt-host-disk"), false),
+		)
+
+		table.DescribeTable("Should succesfully create VMI", func(createSA saCreator) {
+			vmi := libvmi.NewCirros()
+			sa, removeSA := createSA()
+			defer removeSA()
+			vmi.Spec.ServiceAccountName = sa
+
+			tests.RunVMIAndExpectLaunch(vmi, 180)
+
+			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).NotTo(HaveOccurred())
+			tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)
+		},
+			table.Entry("with kubevirt-base SCC", createSaAndSCC("kubevirt-base")),
+			table.Entry("with privileged SCC", createSaAndSCC("privileged")),
+		)
+
+		It("Should fail to create VMI without SA", func() {
+			By("Checking operator deleted the SCC")
+			checkHandlerSCC()
+
+			By("Checking if virt-launcher is assigned to kubevirt-controller SCC")
+			_, err := virtClient.SecClient().SecurityContextConstraints().Get(context.Background(), "kubevirt-controller", metav1.GetOptions{})
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			shouldFailToCreate(vmi)
+		})
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes provides a way to admit workloads through an admission controller(an example of this is SCC).  Virt-controller was the user of the request to create the VM`s Pod(similarly to deployment controller). Therefore users could create a more privileged workload than SCC allowed.

Now we have the option to provide the SA of VM`s user and enforce restrictions that were set by the administrator. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This change should be verified with SCC.


**Release note**:
```release-note
Users are able to provide SA for VM/VMI. This SA can be used to validate with SCC.
```
