### PR TITLE
Add custom queue parameters for disk and network interface

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10208,6 +10208,11 @@
       "description": "Name is the device name",
       "type": "string"
      },
+     "queue": {
+      "description": "virtio queue num for block devices.",
+      "type": "integer",
+      "format": "int32"
+     },
      "serial": {
       "description": "Serial provides the ability to specify a serial number for the disk device.",
       "type": "string"
@@ -10827,6 +10832,11 @@
       "items": {
        "$ref": "#/definitions/v1.Port"
       }
+     },
+     "queue": {
+      "description": "vhost queue for network devices.",
+      "type": "integer",
+      "format": "int32"
      },
      "slirp": {
       "$ref": "#/definitions/v1.InterfaceSlirp"

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1364,14 +1364,16 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		vcpus = uint(1)
 	}
 
-	if virtioBlkMQRequested {
-		numBlkQueues = &vcpus
-	}
-
 	prefixMap := newDeviceNamer(vmi.Status.VolumeStatus, vmi.Spec.Domain.Devices.Disks)
 	for _, disk := range vmi.Spec.Domain.Devices.Disks {
 		newDisk := api.Disk{}
-
+		if virtioBlkMQRequested {
+			if disk.Queue != nil && *disk.Queue > 0 {
+				numBlkQueues = disk.Queue
+			} else {
+				numBlkQueues = &vcpus
+			}
+		}
 		err := Convert_v1_Disk_To_api_Disk(c, &disk, &newDisk, prefixMap, numBlkQueues)
 		if err != nil {
 			return err

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -70,7 +70,12 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 		if ifaceType == "virtio" && virtioNetProhibited {
 			return nil, fmt.Errorf("In-kernel virtio-net device emulation '/dev/vhost-net' not present")
 		} else if ifaceType == "virtio" && virtioNetMQRequested {
-			queueCount := uint(CalculateNetworkQueues(vmi))
+			var queueCount uint
+			if iface.Queue != nil && *iface.Queue > 0 {
+				queueCount = *iface.Queue
+			} else {
+				queueCount = uint(CalculateNetworkQueues(vmi))
+			}
 			domainIface.Driver = &api.InterfaceDriver{Name: "vhost", Queues: &queueCount}
 		}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -3968,6 +3968,9 @@ var CRDsValidation map[string]string = map[string]string{
                               name:
                                 description: Name is the device name
                                 type: string
+                              queue:
+                                description: virtio queue num for block devices.
+                                type: integer
                               serial:
                                 description: Serial provides the ability to specify
                                   a serial number for the disk device.
@@ -4154,6 +4157,9 @@ var CRDsValidation map[string]string = map[string]string{
                                   - port
                                   type: object
                                 type: array
+                              queue:
+                                description: vhost queue for network devices.
+                                type: integer
                               slirp:
                                 type: object
                               sriov:
@@ -5545,6 +5551,9 @@ var CRDsValidation map[string]string = map[string]string{
                       name:
                         description: Name is the device name
                         type: string
+                      queue:
+                        description: virtio queue num for block devices.
+                        type: integer
                       serial:
                         description: Serial provides the ability to specify a serial
                           number for the disk device.
@@ -6680,6 +6689,9 @@ var CRDsValidation map[string]string = map[string]string{
                       name:
                         description: Name is the device name
                         type: string
+                      queue:
+                        description: virtio queue num for block devices.
+                        type: integer
                       serial:
                         description: Serial provides the ability to specify a serial
                           number for the disk device.
@@ -6862,6 +6874,9 @@ var CRDsValidation map[string]string = map[string]string{
                           - port
                           type: object
                         type: array
+                      queue:
+                        description: vhost queue for network devices.
+                        type: integer
                       slirp:
                         type: object
                       sriov:
@@ -8659,6 +8674,9 @@ var CRDsValidation map[string]string = map[string]string{
                       name:
                         description: Name is the device name
                         type: string
+                      queue:
+                        description: virtio queue num for block devices.
+                        type: integer
                       serial:
                         description: Serial provides the ability to specify a serial
                           number for the disk device.
@@ -8841,6 +8859,9 @@ var CRDsValidation map[string]string = map[string]string{
                           - port
                           type: object
                         type: array
+                      queue:
+                        description: vhost queue for network devices.
+                        type: integer
                       slirp:
                         type: object
                       sriov:
@@ -10430,6 +10451,9 @@ var CRDsValidation map[string]string = map[string]string{
                               name:
                                 description: Name is the device name
                                 type: string
+                              queue:
+                                description: virtio queue num for block devices.
+                                type: integer
                               serial:
                                 description: Serial provides the ability to specify
                                   a serial number for the disk device.
@@ -10616,6 +10640,9 @@ var CRDsValidation map[string]string = map[string]string{
                                   - port
                                   type: object
                                 type: array
+                              queue:
+                                description: vhost queue for network devices.
+                                type: integer
                               slirp:
                                 type: object
                               sriov:
@@ -13889,6 +13916,10 @@ var CRDsValidation map[string]string = map[string]string{
                                           name:
                                             description: Name is the device name
                                             type: string
+                                          queue:
+                                            description: virtio queue num for block
+                                              devices.
+                                            type: integer
                                           serial:
                                             description: Serial provides the ability
                                               to specify a serial number for the disk
@@ -14092,6 +14123,9 @@ var CRDsValidation map[string]string = map[string]string{
                                               - port
                                               type: object
                                             type: array
+                                          queue:
+                                            description: vhost queue for network devices.
+                                            type: integer
                                           slirp:
                                             type: object
                                           sriov:
@@ -15611,6 +15645,9 @@ var CRDsValidation map[string]string = map[string]string{
                                   name:
                                     description: Name is the device name
                                     type: string
+                                  queue:
+                                    description: virtio queue num for block devices.
+                                    type: integer
                                   serial:
                                     description: Serial provides the ability to specify
                                       a serial number for the disk device.

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -821,6 +821,11 @@ func (in *Disk) DeepCopyInto(out *Disk) {
 		*out = new(BlockSize)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Queue != nil {
+		in, out := &in.Queue, &out.Queue
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 
@@ -1700,6 +1705,11 @@ func (in *Interface) DeepCopyInto(out *Interface) {
 		in, out := &in.DHCPOptions, &out.DHCPOptions
 		*out = new(DHCPOptions)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Queue != nil {
+		in, out := &in.Queue, &out.Queue
+		*out = new(uint)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -20012,6 +20012,13 @@ func schema_kubevirtio_client_go_api_v1_Disk(ref common.ReferenceCallback) commo
 							Ref:         ref("kubevirt.io/client-go/api/v1.BlockSize"),
 						},
 					},
+					"queue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "virtio queue num for block devices.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -21174,6 +21181,13 @@ func schema_kubevirtio_client_go_api_v1_Interface(ref common.ReferenceCallback) 
 							Description: "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"queue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "vhost queue for network devices.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -583,6 +583,9 @@ type Disk struct {
 	// If specified, the virtual disk will be presented with the given block sizes.
 	// +optional
 	BlockSize *BlockSize `json:"blockSize,omitempty"`
+	// virtio queue num for block devices.
+	// +optional
+	Queue *uint `json:"queue,omitempty"`
 }
 
 // CustomBlockSize represents the desired logical and physical block size for a VM disk.
@@ -1230,6 +1233,9 @@ type Interface struct {
 	// If specified, the virtual network interface address and its tag will be provided to the guest via config drive
 	// +optional
 	Tag string `json:"tag,omitempty"`
+	// vhost queue for network devices.
+	// +optional
+	Queue *uint `json:"queue,omitempty"`
 }
 
 // Extra DHCP options to use in the interface.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -298,6 +298,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",
+		"queue":             "virtio queue num for block devices.\n+optional",
 	}
 }
 
@@ -611,6 +612,7 @@ func (Interface) SwaggerDoc() map[string]string {
 		"pciAddress":  "If specified, the virtual network interface will be placed on the guests pci address with the specified PCI address. For example: 0000:81:01.10\n+optional",
 		"dhcpOptions": "If specified the network interface will pass additional DHCP options to the VMI\n+optional",
 		"tag":         "If specified, the virtual network interface address and its tag will be provided to the guest via config drive\n+optional",
+		"queue":       "vhost queue for network devices.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -15070,6 +15070,13 @@ func schema_kubevirtio_client_go_api_v1_Disk(ref common.ReferenceCallback) commo
 							Ref:         ref("kubevirt.io/client-go/api/v1.BlockSize"),
 						},
 					},
+					"queue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "virtio queue num for block devices.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -16232,6 +16239,13 @@ func schema_kubevirtio_client_go_api_v1_Interface(ref common.ReferenceCallback) 
 							Description: "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"queue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "vhost queue for network devices.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: liuminjian <liuminjian@chinatelcom.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Once multi-queue is enabled, the number of queues is consistent with the number of cores of the virtual machine. Too many queues may negatively affect the performance of the virtual machine. It is expected that the number of queues can be controlled by parameters.I found some articles about this.


![image](https://user-images.githubusercontent.com/7840869/132274089-9227c314-dd09-4aca-bfcd-49d9ee83f7f0.png)
https://specs.openstack.org/openstack/nova-specs/specs/liberty/implemented/libvirt-virtiomq.html

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add custom queue parameters for disk and network interface
```
