### PR TITLE
Fix concurrent access for libguestfs and virt-launcher pods to the same PVC

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/virt-controller/watch/snapshot:go_default_library",
         "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-controller/watch/workload-updater:go_default_library",
+        "//pkg/virtctl/guestfs:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virtctl/guestfs/BUILD.bazel
+++ b/pkg/virtctl/guestfs/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/virtctl/templates:go_default_library",
         "//pkg/virtctl/utils:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 
+	virtv1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
@@ -29,16 +30,18 @@ const (
 	defaultImageName = "libguestfs-tools"
 	defaultImage     = "quay.io/kubevirt/" + defaultImageName + ":latest"
 	// KvmDevice defines the resource as in pkg/virt-controller/services/template.go, but we don't import the package to avoid compile conflicts when the os is windows
-	KvmDevice         = "devices.kubevirt.io/kvm"
-	volume            = "volume"
-	contName          = "libguestfs"
-	diskDir           = "/disk"
-	diskPath          = "/dev/vda"
-	podNamePrefix     = "libguestfs-tools"
-	appliancePath     = "/usr/local/lib/guestfs"
-	tmpDirVolumeName  = "libguestfs-tmp-dir"
-	tmpDirPath        = "/tmp/guestfs"
-	pullPolicyDefault = corev1.PullIfNotPresent
+	KvmDevice           = "devices.kubevirt.io/kvm"
+	volume              = "volume"
+	contName            = "libguestfs"
+	diskDir             = "/disk"
+	diskPath            = "/dev/vda"
+	podNamePrefix       = "libguestfs-tools"
+	appliancePath       = "/usr/local/lib/guestfs"
+	tmpDirVolumeName    = "libguestfs-tmp-dir"
+	tmpDirPath          = "/tmp/guestfs"
+	pullPolicyDefault   = corev1.PullIfNotPresent
+	VirtGuestfsName     = "guestfs"
+	VirtGuestfsPVCLabel = virtv1.AppLabel + "/pvc"
 )
 
 var (
@@ -351,6 +354,10 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 	c := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
+			Labels: map[string]string{
+				virtv1.AppLabel:     VirtGuestfsName,
+				VirtGuestfsPVCLabel: pvc,
+			},
 		},
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prevent to start a VM/VMI that requests a PVC used by a pod created by `virtctl guestfs`. 
This situation arises when we have an already existing pod started by`virtctl guestfs` and we try to start a VM that is using the same PVC used by `virtctl guestfs`.

I added 2 labels to pods created by `virtctl guestfs`: `kubevirt.io: guestfs` and `kubevirt.io/pvc: <pvc-claim>`. The label `kubevirt.io: guestfs` adds the libguestfs pods to the watched pods by virt-controller. The label `kubevirt.io/pvc` helps to identify the PVC used by the guestfs pod.
Thanks to these labels, virt-controller can verify if there is any libguestfs pod that is using one of the volumes requested by the VMI and prevents data corruption.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
