### PR TITLE
Create volume using defaults provided by CDI

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -133,7 +133,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&pvcSize, "pvc-size", "", "DEPRECATED - The size of the PVC to create (ex. 10Gi, 500Mi).")
 	cmd.Flags().StringVar(&size, "size", "", "The size of the DataVolume to create (ex. 10Gi, 500Mi).")
 	cmd.Flags().StringVar(&storageClass, "storage-class", "", "The storage class for the PVC.")
-	cmd.Flags().StringVar(&accessMode, "access-mode", "ReadWriteOnce", "The access mode for the PVC.")
+	cmd.Flags().StringVar(&accessMode, "access-mode", "", "The access mode for the PVC.")
 	cmd.Flags().BoolVar(&blockVolume, "block-volume", false, "Create a PVC with VolumeMode=Block (default Filesystem).")
 	cmd.Flags().StringVar(&imagePath, "image-path", "", "Path to the local VM image.")
 	cmd.MarkFlagRequired("image-path")
@@ -172,10 +172,6 @@ func parseArgs(args []string) error {
 
 	if len(pvcSize) > 0 {
 		size = pvcSize
-	}
-
-	if accessMode == string(v1.ReadOnlyMany) {
-		return fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
 	}
 
 	// check deprecated invocation
@@ -519,7 +515,7 @@ func waitUploadProcessingComplete(client kubernetes.Interface, namespace, name s
 }
 
 func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*cdiv1.DataVolume, error) {
-	pvcSpec, err := createPVCSpec(size, storageClass, accessMode, blockVolume)
+	pvcSpec, err := createStorageSpec(client, size, storageClass, accessMode, blockVolume)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +529,7 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 			Source: &cdiv1.DataVolumeSource{
 				Upload: &cdiv1.DataVolumeSourceUpload{},
 			},
-			PVC: pvcSpec,
+			Storage: pvcSpec,
 		},
 	}
 
@@ -543,6 +539,55 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 	}
 
 	return dv, nil
+}
+
+func createStorageSpec(client kubecli.KubevirtClient, size, storageClass, accessMode string, blockVolume bool) (*cdiv1.StorageSpec, error) {
+	quantity, err := resource.ParseQuantity(size)
+	if err != nil {
+		return nil, fmt.Errorf("validation failed for size=%s: %s", size, err)
+	}
+
+	spec := &cdiv1.StorageSpec{
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceStorage: quantity,
+			},
+		},
+	}
+
+	if storageClass == "" {
+		storageClass, err = getDefaultStorageClassName(client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if storageClass != "" {
+		spec.StorageClassName = &storageClass
+	}
+
+	if accessMode == "" {
+		accessModeAvailable, err := profileSpecifiesCorrectAccessMode(client, storageClass)
+		if err != nil {
+			return nil, err
+		}
+		if !accessModeAvailable {
+			// fallback to safe Default
+			spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+		}
+	} else {
+		if accessMode == string(v1.ReadOnlyMany) {
+			return nil, fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
+		}
+		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
+	}
+
+	if blockVolume {
+		volMode := v1.PersistentVolumeBlock
+		spec.VolumeMode = &volMode
+	}
+
+	return spec, nil
 }
 
 func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*v1.PersistentVolumeClaim, error) {
@@ -588,8 +633,13 @@ func createPVCSpec(size, storageClass, accessMode string, blockVolume bool) (*v1
 		spec.StorageClassName = &storageClass
 	}
 
+	if accessMode == string(v1.ReadOnlyMany) {
+		return nil, fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
+	}
 	if accessMode != "" {
 		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
+	} else {
+		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 	}
 
 	if blockVolume {
@@ -665,5 +715,50 @@ func getUploadProxyURL(client cdiClientset.Interface) (string, error) {
 	if cdiConfig.Status.UploadProxyURL != nil {
 		return *cdiConfig.Status.UploadProxyURL, nil
 	}
+	return "", nil
+}
+
+// check is accessMode from StorageProfile is set and is correct (not ReadOnly),
+func profileSpecifiesCorrectAccessMode(client kubecli.KubevirtClient, storageClass string) (bool, error) {
+	if storageClass == "" {
+		return false, nil
+	}
+
+	storageProfile, err := client.CdiClient().CdiV1beta1().StorageProfiles().Get(context.TODO(), storageClass, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("accessMode not provided, cannot get storage class %s", err)
+	}
+
+	if len(storageProfile.Status.ClaimPropertySets) > 0 &&
+		len(storageProfile.Status.ClaimPropertySets[0].AccessModes) > 0 {
+		accessMode := storageProfile.Status.ClaimPropertySets[0].AccessModes[0]
+
+		if accessMode == v1.ReadOnlyMany {
+			return false,
+				fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
+		}
+		if accessMode == v1.ReadWriteOnce || accessMode == v1.ReadWriteMany {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func getDefaultStorageClassName(client kubecli.KubevirtClient) (string, error) {
+	storageClasses, err := client.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve storage classes")
+	}
+	for _, storageClass := range storageClasses.Items {
+		if storageClass.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return storageClass.Name, nil
+		}
+	}
+
 	return "", nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

A user can create volume for upload without specifying the accessMode
and volumeMode. The DataVolume is created using new spec.storage
field. If StorageProfile for StorageClass is available CDI will provide
recommended params.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is an alternative to #6192

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl imageupload now uses DataVolume.spec.storage
```
