### PR TITLE
Fix the default setting of CPU requests on vmipods

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -221,7 +221,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			Expect(vmiSpec.Domain.CPU.Model).To(Equal(""))
 		}
 
-		Expect(vmiSpec.Domain.Resources.Requests.Cpu().String()).To(Equal("100m"))
+		Expect(vmiSpec.Domain.Resources.Requests.Cpu().IsZero()).To(BeTrue())
 		// no default for requested memory when no memory is specified
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().Value()).To(Equal(int64(0)))
 	})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -858,7 +858,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		if vcpus != 0 && cpuAllocationRatio > 0 {
 			val := float64(vcpus) / float64(cpuAllocationRatio)
 			vcpusStr := fmt.Sprintf("%g", val)
-			if val < 0 {
+			if val < 1 {
 				val *= 1000
 				vcpusStr = fmt.Sprintf("%gm", val)
 			}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1816,11 +1816,6 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("3"))
 			})
 			It("should allocate proportinal amount of cpus to vmipod as vcpus with allocation_ratio set to 10", func() {
-				/*config, kvInformer, svc = configFactory(defaultArch)
-				kvConfig := kv.DeepCopy()
-				kvConfig.Spec.Configuration.DeveloperConfiguration.CPUAllocationRatio = 10
-				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)*/
-
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1815,6 +1815,32 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("3"))
 			})
+			It("should allocate proportinal amount of cpus to vmipod as vcpus with allocation_ratio set to 10", func() {
+				/*config, kvInformer, svc = configFactory(defaultArch)
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.CPUAllocationRatio = 10
+				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)*/
+
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: true,
+							},
+							CPU: &v1.CPU{Cores: 3},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("300m"))
+			})
 			It("should override the calculated amount of cpus if the user has explicitly specified cpu request", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
 				kvConfig := kv.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the default setting of CPU requests on the virt-launcher compute container.
The default vmipods CPU request is being calculated during the pod creation and scales with the number of vCPUS according to the `cpu_allocation_ratio` (which defaults to 10) setting 
This way, the default CPU request of a vmipod , created for a VMI with 1 vCPU, will be 100m.

This PR adds unit and functional tests to verify the correct behavior.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # rhbz#2002313 

```release-note
Fix the default setting of CPU requests on vmipods
```
