### PR TITLE
Don't fail  on relabeling if selinux is permissive

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
@@ -380,7 +379,7 @@ func (app *virtHandlerApp) Run() {
 
 		// relabel tun device
 		unprivilegedContainerSELinuxLabel := "system_u:object_r:container_file_t:s0"
-		err = relabelFiles(unprivilegedContainerSELinuxLabel, "/dev/net/tun", "/dev/null")
+		err = selinux.RelabelFiles(unprivilegedContainerSELinuxLabel, se.IsPermissive(), "/dev/net/tun", "/dev/null")
 		if err != nil {
 			panic(fmt.Errorf("error relabeling required files: %v", err))
 		}
@@ -608,18 +607,5 @@ func copy(sourceFile string, targetFile string) error {
 	if err != nil {
 		return fmt.Errorf("failed to make file executable: %v", err)
 	}
-	return nil
-}
-
-func relabelFiles(newLabel string, files ...string) error {
-	relabelArgs := []string{"selinux", "relabel", newLabel}
-	for _, file := range files {
-		cmd := exec.Command("virt-chroot", append(relabelArgs, file)...)
-		err := cmd.Run()
-		if err != nil {
-			return fmt.Errorf("error relabeling file %s with label %s. Reason: %v", file, newLabel, err)
-		}
-	}
-
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We continue kubevirt if we can't install our policies when selinux is
permissive. As a consequence we also have to treat relabel attempts
gracefully when selinux is  permissive.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5736

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't fail on failed selinux relabel attempts if selinux is permissive
```
