### PR TITLE
Ensure that we can migrate a VM multiple times after update

### DIFF
--- a/tests/framework/matcher/getter.go
+++ b/tests/framework/matcher/getter.go
@@ -123,3 +123,23 @@ func ThisPVCWith(namespace string, name string) func() (*v1.PersistentVolumeClai
 		return
 	}
 }
+
+// ThisMigration fetches the latest state of the Migration. If the object does not exist, nil is returned.
+func ThisMigration(migration *virtv1.VirtualMachineInstanceMigration) func() (*virtv1.VirtualMachineInstanceMigration, error) {
+	return ThisMigrationWith(migration.Namespace, migration.Name)
+}
+
+// ThisMigrationWith fetches the latest state of the Migration based on namespace and name. If the object does not exist, nil is returned.
+func ThisMigrationWith(namespace string, name string) func() (*virtv1.VirtualMachineInstanceMigration, error) {
+	return func() (p *virtv1.VirtualMachineInstanceMigration, err error) {
+		virtClient, err := kubecli.GetKubevirtClient()
+		if err != nil {
+			return nil, err
+		}
+		p, err = virtClient.VirtualMachineInstanceMigration(namespace).Get(name, &k8smetav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to catch issues which would only be visible after a second
migration after a kubevirt update, migrate one VMI which got created
before the update a second time after the upgrade.

Related to #6340, where migrations the first time significantly differ after an upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
