### PR TITLE
Use matcher rather than custom functions for waiting for DV phases

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/cleanup:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/util:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -909,7 +909,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(ThisDV(dataVolume), 340).Should(HaveSucceeded())
+				Eventually(ThisDV(dataVolume), 340).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
@@ -951,7 +951,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(ThisDV(dataVolume), 240).Should(HaveSucceeded())
+				Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -909,7 +909,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				tests.WaitForDataVolumeReadyToStartVMI(vmi, 340)
+				Eventually(ThisDV(dataVolume), 340).Should(HaveSucceeded())
 
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
@@ -951,7 +951,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				tests.WaitForDataVolumeReadyToStartVMI(vmi, 240)
+				Eventually(ThisDV(dataVolume), 240).Should(HaveSucceeded())
 
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
@@ -1214,7 +1214,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				Eventually(ThisPod(wffcPod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
 
 				By("waiting for the dv import to pvc to finish")
-				tests.WaitForSuccessfulDataVolumeImport(dv, 600)
+				Eventually(ThisDV(dv), 600).Should(HaveSucceeded())
 
 				pvName = "test-nfs" + rand.String(48)
 				// Prepare a NFS backed PV
@@ -1926,7 +1926,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulDataVolumeImport(dv, 600)
+				Eventually(ThisDV(dv), 600).Should(HaveSucceeded())
 				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
 				tests.AddUserData(vmi, "disk1", "#!/bin/bash\n echo hello\n")
 				return vmi, dv

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -102,12 +102,12 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if tests.HasBindingModeWaitForFirstConsumer() {
-					tests.WaitForDataVolumePhaseWFFC(dataVolume.Namespace, dataVolume.Name, 30)
+					Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
 				num := 2
 				By("Starting and stopping the VirtualMachineInstance a number of times")
 				for i := 1; i <= num; i++ {
-					tests.WaitForDataVolumeReadyToStartVMI(vmi, 140)
+					Eventually(ThisDV(dataVolume), 140).Should(HaveSucceeded())
 					vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 					// after being restarted multiple times
@@ -162,7 +162,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).To(BeNil())
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if tests.HasBindingModeWaitForFirstConsumer() {
-					tests.WaitForDataVolumePhaseWFFC(dataVolume.Namespace, dataVolume.Name, 30)
+					Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
 				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
 				// import and start
@@ -348,7 +348,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for DV to start crashing")
-				tests.WaitForDataVolumeImportInProgress(vm.Namespace, dataVolume.Name, 30)
+				Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.ImportInProgress))
 
 				By("Stop VM")
 				tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
@@ -785,7 +785,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitForDataVolumeReadyToStartVMI(vmi, 140)
+			Eventually(ThisDV(dataVolume), 140).Should(HaveSucceeded())
 			vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 
 			By("Expecting the VirtualMachineInstance console")

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -107,7 +107,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				num := 2
 				By("Starting and stopping the VirtualMachineInstance a number of times")
 				for i := 1; i <= num; i++ {
-					Eventually(ThisDV(dataVolume), 140).Should(HaveSucceeded())
 					vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 					// after being restarted multiple times
@@ -785,7 +784,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(ThisDV(dataVolume), 140).Should(HaveSucceeded())
 			vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 
 			By("Expecting the VirtualMachineInstance console")

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -494,7 +495,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		dvBlock := tests.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", accessMode, volumeMode)
 		_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dvBlock.Namespace).Create(context.Background(), dvBlock, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
-		tests.WaitForSuccessfulDataVolumeImport(dvBlock, 240)
+		Eventually(ThisDV(dvBlock), 240).Should(HaveSucceeded())
 		return dvBlock
 	}
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -24,6 +24,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -306,7 +307,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				dv := tests.NewRandomBlankDataVolume(util.NamespaceTestDefault, snapshotStorageClass, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				tests.WaitForSuccessfulDataVolumeImport(dv, 240)
+				Eventually(ThisDV(dv), 240).Should(HaveSucceeded())
 				volumeSource := &v1.HotplugVolumeSource{
 					DataVolume: &v1.DataVolumeSource{
 						Name: dv.Name,

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -494,7 +494,7 @@ var _ = SIGDescribe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				By("Waiting until the DataVolume is ready")
 				if tests.HasBindingModeWaitForFirstConsumer() {
-					tests.WaitForDataVolumePhaseWFFC(dataVolume.Namespace, dataVolume.Name, 30)
+					Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
 


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
