### PR TITLE
Ensure VMI deletion before proceeding to other deletes

### DIFF
--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -13,6 +13,7 @@ import (
 
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/util"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -167,8 +168,11 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 				defer func() {
 					err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 				}()
 				tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In the imageupload tests, we start looping over the PVC being gone before we know for fact the VMI is.
Let's ensure VMI deletion so we only proceed to PVC/others after that succeeds, avoiding a timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
