### PR TITLE
Ensure that the perf tool binaries are always present

### DIFF
--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -31,7 +31,11 @@ mkdir -p ${CMD_OUT_DIR}/perfscale-load-generator
 # Build all binaries for amd64
 bazel build \
     --config=${ARCHITECTURE} \
-    //tools/csv-generator/... //cmd/... //staging/src/kubevirt.io/client-go/examples/...
+    //tools/csv-generator/... \
+    //tools/perfscale-audit/... \
+    //tools/perfscale-load-generator/... \
+    //cmd/... \
+    //staging/src/kubevirt.io/client-go/examples/...
 
 # Copy dump binary to a reachable place outside of the build container
 bazel run \


### PR DESCRIPTION
**What this PR does / why we need it**:

bazel `run` targets require at this stage explicit `build` steps for a
dependency to be available locally if the remote fetch strategy does not
fetch all artifacts by default.

Fixes issues like

```
18:24:55: cp: cannot stat 'bazel-out/k8-fastbuild/bin/tools/perfscale-audit/perfscale-audit_/perfscale-audit': No such file or directory
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
