### PR TITLE
Cleanup obsolete permissions from virt-operator's ClusterRole

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -160,14 +160,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - ""
-          resources:
-          - secrets
-          verbs:
-          - create
-          - get
-          - update
-        - apiGroups:
           - kubevirt.io
           resources:
           - kubevirts
@@ -329,14 +321,6 @@ spec:
           - delete
           - update
           - patch
-        - apiGroups:
-          - subresources.kubevirt.io
-          resources:
-          - virtualmachines/start
-          - virtualmachines/stop
-          - virtualmachines/restart
-          verbs:
-          - put
         - apiGroups:
           - subresources.kubevirt.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -62,14 +62,6 @@ metadata:
   name: kubevirt-operator
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
   - kubevirt.io
   resources:
   - kubevirts
@@ -231,14 +223,6 @@ rules:
   - delete
   - update
   - patch
-- apiGroups:
-  - subresources.kubevirt.io
-  resources:
-  - virtualmachines/start
-  - virtualmachines/stop
-  - virtualmachines/restart
-  verbs:
-  - put
 - apiGroups:
   - subresources.kubevirt.io
   resources:

--- a/pkg/virt-operator/resource/generate/rbac/operator.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator.go
@@ -75,23 +75,6 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
-			// Cluster-wide secret access is not needed anymore from kubevirt-0.28 on, but we need to keep it,
-			// so that rollbacks in case of update errors to older versions are still possible, where virt-api and
-			// virt-handler needed access to secrets.
-			// TODO: remove this at some point when we don't allow updaing from installs which are older than kubevirt-0.28
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"secrets",
-				},
-				Verbs: []string{
-					"create",
-					"get",
-					"update",
-				},
-			},
 			{
 				APIGroups: []string{
 					"kubevirt.io",
@@ -308,22 +291,6 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"get", "list", "watch", "create", "delete", "update", "patch",
-				},
-			},
-			{
-				// this is needed for being able to update from older versions (<= v0.18), which included the removed
-				// "put" verb on subresources for admin and edit cluster roles.
-				// Remove this when upgrade path from v0.18 and earlier is not supported anymore
-				APIGroups: []string{
-					"subresources.kubevirt.io",
-				},
-				Resources: []string{
-					"virtualmachines/start",
-					"virtualmachines/stop",
-					"virtualmachines/restart",
-				},
-				Verbs: []string{
-					"put",
 				},
 			},
 			// Until v0.43 a `get` verb was granted to these resources, but there is no get endpoint.


### PR DESCRIPTION
Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**What this PR does / why we need it**:

This PR removes some obsolete permissions from virt-operator's ClusterRole.
These permissions were left in order to support upgrades from old versions (<=0.28, ~1.5yr ago), so can be safely removed at this point.

**Release note**:
```release-note
Cleanup obsolete permissions from virt-operator's ClusterRole
```
