### PR TITLE
Upgrade go-kit to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,6 @@ require (
 )
 
 replace (
-	github.com/go-kit/kit => github.com/go-kit/kit v0.3.0
 	github.com/golang/glog => ./staging/src/github.com/golang/glog
 	github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega => github.com/onsi/gomega v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,9 @@ github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-kit/kit v0.3.0 h1:QZEva+odUF/G+yz7yjQLwUQxnSAS4S45V9+4O02yJ1Q=
-github.com/go-kit/kit v0.3.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -127,7 +127,7 @@ var _ = Describe("LibvirtHelper", func() {
 		buffer := bytes.NewBuffer(nil)
 
 		kubevirtlog.InitializeLogging("test")
-		logger := log.NewContext(log.NewJSONLogger(buffer))
+		logger := log.NewJSONLogger(buffer)
 		klog := kubevirtlog.MakeLogger(logger)
 
 		scanner := bufio.NewScanner(strings.NewReader(logs))
@@ -166,7 +166,7 @@ var _ = Describe("LibvirtHelper", func() {
 		buffer := bytes.NewBuffer(nil)
 
 		kubevirtlog.InitializeLogging("virt-launcher")
-		logger := log.NewContext(log.NewJSONLogger(buffer))
+		logger := log.NewJSONLogger(buffer)
 		klog := kubevirtlog.MakeLogger(logger)
 
 		scanner := bufio.NewScanner(strings.NewReader(qemuLogs))

--- a/staging/src/kubevirt.io/client-go/go.mod
+++ b/staging/src/kubevirt.io/client-go/go.mod
@@ -27,7 +27,6 @@ require (
 )
 
 replace (
-	github.com/go-kit/kit => github.com/go-kit/kit v0.3.0
 	github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega => github.com/onsi/gomega v1.10.1
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20210105115604-44119421ec6b

--- a/staging/src/kubevirt.io/client-go/go.sum
+++ b/staging/src/kubevirt.io/client-go/go.sum
@@ -166,8 +166,9 @@ github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-kit/kit v0.3.0 h1:QZEva+odUF/G+yz7yjQLwUQxnSAS4S45V9+4O02yJ1Q=
-github.com/go-kit/kit v0.3.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -69,7 +69,7 @@ type LoggableObject interface {
 }
 
 type FilteredLogger struct {
-	logContext            *log.Context
+	logger                log.Logger
 	component             string
 	filterLevel           LogLevel
 	currentLogLevel       LogLevel
@@ -108,7 +108,7 @@ func MakeLogger(logger log.Logger) *FilteredLogger {
 	defaultCurrentVerbosity := 2
 
 	return &FilteredLogger{
-		logContext:            log.NewContext(logger),
+		logger:                logger,
 		component:             defaultComponent,
 		filterLevel:           defaultLogLevel,
 		currentLogLevel:       defaultLogLevel,
@@ -152,12 +152,12 @@ func DefaultLogger() *FilteredLogger {
 // SetIOWriter is meant to be used for testing. "log" and "glog" logs are sent to /dev/nil.
 // KubeVirt related log messages will be sent to this writer
 func (l *FilteredLogger) SetIOWriter(w io.Writer) {
-	l.logContext = log.NewContext(log.NewJSONLogger(w))
+	l.logger = log.NewJSONLogger(w)
 	goflag.CommandLine.Set("logtostderr", "false")
 }
 
 func (l *FilteredLogger) SetLogger(logger log.Logger) *FilteredLogger {
-	l.logContext = log.NewContext(logger)
+	l.logger = logger
 	return l
 }
 
@@ -199,9 +199,9 @@ func (l FilteredLogger) log(skipFrames int, params ...interface{}) error {
 			"component", l.component,
 		)
 		if l.err != nil {
-			l.logContext = l.logContext.With("reason", l.err)
+			l.logger = log.With(l.logger, "reason", l.err)
 		}
-		return l.logContext.WithPrefix(logParams...).Log(params...)
+		return log.WithPrefix(l.logger, logParams...).Log(params...)
 	}
 	return nil
 }
@@ -263,12 +263,12 @@ func (l FilteredLogger) ObjectRef(obj *v1.ObjectReference) *FilteredLogger {
 }
 
 func (l FilteredLogger) With(obj ...interface{}) *FilteredLogger {
-	l.logContext = l.logContext.With(obj...)
+	l.logger = log.With(l.logger, obj...)
 	return &l
 }
 
 func (l *FilteredLogger) with(obj ...interface{}) *FilteredLogger {
-	l.logContext = l.logContext.With(obj...)
+	l.logger = log.With(l.logger, obj...)
 	return l
 }
 
@@ -350,7 +350,7 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 	fragments := strings.SplitN(line, ": ", 5)
 	if len(fragments) < 4 {
 		now := time.Now()
-		logger.logContext.Log(
+		logger.logger.Log(
 			"level", "info",
 			"timestamp", now.Format("2006-01-02T15:04:05.000000Z"),
 			"component", logger.component,
@@ -384,7 +384,7 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 
 	if !isPos {
 		msg = strings.TrimSpace(fragments[3] + ": " + fragments[4])
-		logger.logContext.Log(
+		logger.logger.Log(
 			"level", severity,
 			"timestamp", t.Format("2006-01-02T15:04:05.000000Z"),
 			"component", logger.component,
@@ -393,7 +393,7 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 			"msg", msg,
 		)
 	} else {
-		logger.logContext.Log(
+		logger.logger.Log(
 			"level", severity,
 			"timestamp", t.Format("2006-01-02T15:04:05.000000Z"),
 			"pos", pos,
@@ -425,7 +425,7 @@ func LogQemuLogLine(logger *FilteredLogger, line string) {
 	}
 
 	now := time.Now()
-	logger.logContext.Log(
+	logger.logger.Log(
 		"level", "info",
 		"timestamp", now.Format("2006-01-02T15:04:05.000000Z"),
 		"component", logger.component,

--- a/vendor/github.com/go-kit/kit/endpoint/BUILD.bazel
+++ b/vendor/github.com/go-kit/kit/endpoint/BUILD.bazel
@@ -9,5 +9,4 @@ go_library(
     importmap = "kubevirt.io/kubevirt/vendor/github.com/go-kit/kit/endpoint",
     importpath = "github.com/go-kit/kit/endpoint",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/golang.org/x/net/context:go_default_library"],
 )

--- a/vendor/github.com/go-kit/kit/endpoint/endpoint.go
+++ b/vendor/github.com/go-kit/kit/endpoint/endpoint.go
@@ -1,7 +1,7 @@
 package endpoint
 
 import (
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Endpoint is the fundamental building block of servers and clients.
@@ -25,4 +25,16 @@ func Chain(outer Middleware, others ...Middleware) Middleware {
 		}
 		return outer(next)
 	}
+}
+
+// Failer may be implemented by Go kit response types that contain business
+// logic error details. If Failed returns a non-nil error, the Go kit transport
+// layer may interpret this as a business logic error, and may encode it
+// differently than a regular, successful response.
+//
+// It's not necessary for your response types to implement Failer, but it may
+// help for more sophisticated use cases. The addsvc example shows how Failer
+// should be used by a complete application.
+type Failer interface {
+	Failed() error
 }

--- a/vendor/github.com/go-kit/kit/log/BUILD.bazel
+++ b/vendor/github.com/go-kit/kit/log/BUILD.bazel
@@ -15,8 +15,5 @@ go_library(
     importmap = "kubevirt.io/kubevirt/vendor/github.com/go-kit/kit/log",
     importpath = "github.com/go-kit/kit/log",
     visibility = ["//visibility:public"],
-    deps = [
-        "//vendor/github.com/go-logfmt/logfmt:go_default_library",
-        "//vendor/github.com/go-stack/stack:go_default_library",
-    ],
+    deps = ["//vendor/github.com/go-logfmt/logfmt:go_default_library"],
 )

--- a/vendor/github.com/go-kit/kit/log/README.md
+++ b/vendor/github.com/go-kit/kit/log/README.md
@@ -1,20 +1,22 @@
 # package log
 
 `package log` provides a minimal interface for structured logging in services.
-It may be wrapped to encode conventions, enforce type-safety, provide leveled logging, and so on.
-It can be used for both typical application log events, and log-structured data streams.
+It may be wrapped to encode conventions, enforce type-safety, provide leveled
+logging, and so on. It can be used for both typical application log events,
+and log-structured data streams.
 
 ## Structured logging
 
-Structured logging is, basically, conceding to the reality that logs are _data_,
- and warrant some level of schematic rigor.
-Using a stricter, key/value-oriented message format for our logs,
- containing contextual and semantic information,
- makes it much easier to get insight into the operational activity of the systems we build.
-Consequently, `package log` is of the strong belief that
- "[the benefits of structured logging outweigh the minimal effort involved](https://www.thoughtworks.com/radar/techniques/structured-logging)".
+Structured logging is, basically, conceding to the reality that logs are
+_data_, and warrant some level of schematic rigor. Using a stricter,
+key/value-oriented message format for our logs, containing contextual and
+semantic information, makes it much easier to get insight into the
+operational activity of the systems we build. Consequently, `package log` is
+of the strong belief that "[the benefits of structured logging outweigh the
+minimal effort involved](https://www.thoughtworks.com/radar/techniques/structured-logging)".
 
-Migrating from unstructured to structured logging is probably a lot easier than you'd expect.
+Migrating from unstructured to structured logging is probably a lot easier
+than you'd expect.
 
 ```go
 // Unstructured
@@ -37,17 +39,17 @@ logger.Log("question", "what is the meaning of life?", "answer", 42)
 // question="what is the meaning of life?" answer=42
 ```
 
-### Log contexts
+### Contextual Loggers
 
 ```go
 func main() {
 	var logger log.Logger
 	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = log.NewContext(logger).With("instance_id", 123)
+	logger = log.With(logger, "instance_id", 123)
 
 	logger.Log("msg", "starting")
-	NewWorker(log.NewContext(logger).With("component", "worker")).Run()
-	NewSlacker(log.NewContext(logger).With("component", "slacker")).Run()
+	NewWorker(log.With(logger, "component", "worker")).Run()
+	NewSlacker(log.With(logger, "component", "slacker")).Run()
 }
 
 // Output:
@@ -77,9 +79,8 @@ func main() {
 // {"msg":"I sure like pie","ts":"2016/01/01 12:34:56"}
 ```
 
-Or, if, for legacy reasons,
- you need to pipe all of your logging through the stdlib log package,
- you can redirect Go kit logger to the stdlib logger.
+Or, if, for legacy reasons, you need to pipe all of your logging through the
+stdlib log package, you can redirect Go kit logger to the stdlib logger.
 
 ```go
 logger := kitlog.NewLogfmtLogger(kitlog.StdlibWriter{})
@@ -94,7 +95,7 @@ logger.Log("legacy", true, "msg", "at least it's something")
 ```go
 var logger log.Logger
 logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 
 logger.Log("msg", "hello")
 
@@ -102,9 +103,13 @@ logger.Log("msg", "hello")
 // ts=2016-01-01T12:34:56Z caller=main.go:15 msg=hello
 ```
 
+## Levels
+
+Log levels are supported via the [level package](https://godoc.org/github.com/go-kit/kit/log/level).
+
 ## Supported output formats
 
-- [Logfmt](https://brandur.org/logfmt)
+- [Logfmt](https://brandur.org/logfmt) ([see also](https://blog.codeship.com/logfmt-a-log-format-thats-easy-to-read-and-write))
 - JSON
 
 ## Enhancements
@@ -117,27 +122,25 @@ type Logger interface {
 }
 ```
 
-This interface, and its supporting code like [log.Context](https://godoc.org/github.com/go-kit/kit/log#Context),
- is the product of much iteration and evaluation.
-For more details on the evolution of the Logger interface,
- see [The Hunt for a Logger Interface](http://go-talks.appspot.com/github.com/ChrisHines/talks/structured-logging/structured-logging.slide#1),
- a talk by [Chris Hines](https://github.com/ChrisHines).
+This interface, and its supporting code like is the product of much iteration
+and evaluation. For more details on the evolution of the Logger interface,
+see [The Hunt for a Logger Interface](http://go-talks.appspot.com/github.com/ChrisHines/talks/structured-logging/structured-logging.slide#1),
+a talk by [Chris Hines](https://github.com/ChrisHines).
 Also, please see
- [#63](https://github.com/go-kit/kit/issues/63),
- [#76](https://github.com/go-kit/kit/pull/76),
- [#131](https://github.com/go-kit/kit/issues/131),
- [#157](https://github.com/go-kit/kit/pull/157),
- [#164](https://github.com/go-kit/kit/issues/164), and
- [#252](https://github.com/go-kit/kit/pull/252)
- to review historical conversations about package log and the Logger interface.
+[#63](https://github.com/go-kit/kit/issues/63),
+[#76](https://github.com/go-kit/kit/pull/76),
+[#131](https://github.com/go-kit/kit/issues/131),
+[#157](https://github.com/go-kit/kit/pull/157),
+[#164](https://github.com/go-kit/kit/issues/164), and
+[#252](https://github.com/go-kit/kit/pull/252)
+to review historical conversations about package log and the Logger interface.
 
 Value-add packages and suggestions,
- like improvements to [the leveled logger](https://godoc.org/github.com/go-kit/kit/log/levels),
- are of course welcome.
-Good proposals should
+like improvements to [the leveled logger](https://godoc.org/github.com/go-kit/kit/log/level),
+are of course welcome. Good proposals should
 
-- Be composable with [log.Context](https://godoc.org/github.com/go-kit/kit/log#Context),
-- Not break the behavior of [log.Caller](https://godoc.org/github.com/go-kit/kit/log#Caller) in any wrapped context, and
+- Be composable with [contextual loggers](https://godoc.org/github.com/go-kit/kit/log#With),
+- Not break the behavior of [log.Caller](https://godoc.org/github.com/go-kit/kit/log#Caller) in any wrapped contextual loggers, and
 - Be friendly to packages that accept only an unadorned log.Logger.
 
 ## Benchmarks & comparisons

--- a/vendor/github.com/go-kit/kit/log/json_logger.go
+++ b/vendor/github.com/go-kit/kit/log/json_logger.go
@@ -44,9 +44,6 @@ func merge(dst map[string]interface{}, k, v interface{}) {
 	default:
 		key = fmt.Sprint(x)
 	}
-	if x, ok := v.(error); ok {
-		v = safeError(x)
-	}
 
 	// We want json.Marshaler and encoding.TextMarshaller to take priority over
 	// err.Error() and v.String(). But json.Marshall (called later) does that by

--- a/vendor/github.com/go-kit/kit/log/stdlib.go
+++ b/vendor/github.com/go-kit/kit/log/stdlib.go
@@ -39,7 +39,7 @@ func TimestampKey(key string) StdlibAdapterOption {
 	return func(a *StdlibAdapter) { a.timestampKey = key }
 }
 
-// FileKey sets the key for the file and line field. By default, it's "file".
+// FileKey sets the key for the file and line field. By default, it's "caller".
 func FileKey(key string) StdlibAdapterOption {
 	return func(a *StdlibAdapter) { a.fileKey = key }
 }
@@ -55,7 +55,7 @@ func NewStdlibAdapter(logger Logger, options ...StdlibAdapterOption) io.Writer {
 	a := StdlibAdapter{
 		Logger:       logger,
 		timestampKey: "ts",
-		fileKey:      "file",
+		fileKey:      "caller",
 		messageKey:   "msg",
 	}
 	for _, option := range options {

--- a/vendor/github.com/go-kit/kit/log/sync.go
+++ b/vendor/github.com/go-kit/kit/log/sync.go
@@ -36,24 +36,59 @@ func (l *SwapLogger) Swap(logger Logger) {
 	l.logger.Store(loggerStruct{logger})
 }
 
-// SyncWriter synchronizes concurrent writes to an io.Writer.
-type SyncWriter struct {
-	mu sync.Mutex
-	w  io.Writer
+// NewSyncWriter returns a new writer that is safe for concurrent use by
+// multiple goroutines. Writes to the returned writer are passed on to w. If
+// another write is already in progress, the calling goroutine blocks until
+// the writer is available.
+//
+// If w implements the following interface, so does the returned writer.
+//
+//    interface {
+//        Fd() uintptr
+//    }
+func NewSyncWriter(w io.Writer) io.Writer {
+	switch w := w.(type) {
+	case fdWriter:
+		return &fdSyncWriter{fdWriter: w}
+	default:
+		return &syncWriter{Writer: w}
+	}
 }
 
-// NewSyncWriter returns a new SyncWriter. The returned writer is safe for
-// concurrent use by multiple goroutines.
-func NewSyncWriter(w io.Writer) *SyncWriter {
-	return &SyncWriter{w: w}
+// syncWriter synchronizes concurrent writes to an io.Writer.
+type syncWriter struct {
+	sync.Mutex
+	io.Writer
 }
 
 // Write writes p to the underlying io.Writer. If another write is already in
-// progress, the calling goroutine blocks until the SyncWriter is available.
-func (w *SyncWriter) Write(p []byte) (n int, err error) {
-	w.mu.Lock()
-	n, err = w.w.Write(p)
-	w.mu.Unlock()
+// progress, the calling goroutine blocks until the syncWriter is available.
+func (w *syncWriter) Write(p []byte) (n int, err error) {
+	w.Lock()
+	n, err = w.Writer.Write(p)
+	w.Unlock()
+	return n, err
+}
+
+// fdWriter is an io.Writer that also has an Fd method. The most common
+// example of an fdWriter is an *os.File.
+type fdWriter interface {
+	io.Writer
+	Fd() uintptr
+}
+
+// fdSyncWriter synchronizes concurrent writes to an fdWriter.
+type fdSyncWriter struct {
+	sync.Mutex
+	fdWriter
+}
+
+// Write writes p to the underlying io.Writer. If another write is already in
+// progress, the calling goroutine blocks until the fdSyncWriter is available.
+func (w *fdSyncWriter) Write(p []byte) (n int, err error) {
+	w.Lock()
+	n, err = w.fdWriter.Write(p)
+	w.Unlock()
 	return n, err
 }
 

--- a/vendor/github.com/go-kit/kit/log/value.go
+++ b/vendor/github.com/go-kit/kit/log/value.go
@@ -1,14 +1,15 @@
 package log
 
 import (
+	"runtime"
+	"strconv"
+	"strings"
 	"time"
-
-	"github.com/go-stack/stack"
 )
 
-// A Valuer generates a log value. When passed to Context.With in a value
-// element (odd indexes), it represents a dynamic value which is re-evaluated
-// with each log event.
+// A Valuer generates a log value. When passed to With or WithPrefix in a
+// value element (odd indexes), it represents a dynamic value which is re-
+// evaluated with each log event.
 type Valuer func() interface{}
 
 // bindValues replaces all value elements (odd indexes) containing a Valuer
@@ -32,30 +33,77 @@ func containsValuer(keyvals []interface{}) bool {
 	return false
 }
 
-// Timestamp returns a Valuer that invokes the underlying function when bound,
-// returning a time.Time. Users will probably want to use DefaultTimestamp or
-// DefaultTimestampUTC.
+// Timestamp returns a timestamp Valuer. It invokes the t function to get the
+// time; unless you are doing something tricky, pass time.Now.
+//
+// Most users will want to use DefaultTimestamp or DefaultTimestampUTC, which
+// are TimestampFormats that use the RFC3339Nano format.
 func Timestamp(t func() time.Time) Valuer {
 	return func() interface{} { return t() }
+}
+
+// TimestampFormat returns a timestamp Valuer with a custom time format. It
+// invokes the t function to get the time to format; unless you are doing
+// something tricky, pass time.Now. The layout string is passed to
+// Time.Format.
+//
+// Most users will want to use DefaultTimestamp or DefaultTimestampUTC, which
+// are TimestampFormats that use the RFC3339Nano format.
+func TimestampFormat(t func() time.Time, layout string) Valuer {
+	return func() interface{} {
+		return timeFormat{
+			time:   t(),
+			layout: layout,
+		}
+	}
+}
+
+// A timeFormat represents an instant in time and a layout used when
+// marshaling to a text format.
+type timeFormat struct {
+	time   time.Time
+	layout string
+}
+
+func (tf timeFormat) String() string {
+	return tf.time.Format(tf.layout)
+}
+
+// MarshalText implements encoding.TextMarshaller.
+func (tf timeFormat) MarshalText() (text []byte, err error) {
+	// The following code adapted from the standard library time.Time.Format
+	// method. Using the same undocumented magic constant to extend the size
+	// of the buffer as seen there.
+	b := make([]byte, 0, len(tf.layout)+10)
+	b = tf.time.AppendFormat(b, tf.layout)
+	return b, nil
+}
+
+// Caller returns a Valuer that returns a file and line from a specified depth
+// in the callstack. Users will probably want to use DefaultCaller.
+func Caller(depth int) Valuer {
+	return func() interface{} {
+		_, file, line, _ := runtime.Caller(depth)
+		idx := strings.LastIndexByte(file, '/')
+		// using idx+1 below handles both of following cases:
+		// idx == -1 because no "/" was found, or
+		// idx >= 0 and we want to start at the character after the found "/".
+		return file[idx+1:] + ":" + strconv.Itoa(line)
+	}
 }
 
 var (
 	// DefaultTimestamp is a Valuer that returns the current wallclock time,
 	// respecting time zones, when bound.
-	DefaultTimestamp Valuer = func() interface{} { return time.Now().Format(time.RFC3339) }
+	DefaultTimestamp = TimestampFormat(time.Now, time.RFC3339Nano)
 
 	// DefaultTimestampUTC is a Valuer that returns the current time in UTC
 	// when bound.
-	DefaultTimestampUTC Valuer = func() interface{} { return time.Now().UTC().Format(time.RFC3339) }
-)
+	DefaultTimestampUTC = TimestampFormat(
+		func() time.Time { return time.Now().UTC() },
+		time.RFC3339Nano,
+	)
 
-// Caller returns a Valuer that returns a file and line from a specified depth
-// in the callstack. Users will probably want to use DefaultCaller.
-func Caller(depth int) Valuer {
-	return func() interface{} { return stack.Caller(depth) }
-}
-
-var (
 	// DefaultCaller is a Valuer that returns the file and line where the Log
 	// method was invoked. It can only be used with log.With.
 	DefaultCaller = Caller(3)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.0
 ## explicit
 github.com/ghodss/yaml
-# github.com/go-kit/kit v0.9.0 => github.com/go-kit/kit v0.3.0
+# github.com/go-kit/kit v0.9.0
 ## explicit
 github.com/go-kit/kit/endpoint
 github.com/go-kit/kit/log
@@ -1018,7 +1018,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit
 sigs.k8s.io/yaml
-# github.com/go-kit/kit => github.com/go-kit/kit v0.3.0
 # github.com/golang/glog => ./staging/src/github.com/golang/glog
 # github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.12.1
 # github.com/onsi/gomega => github.com/onsi/gomega v1.10.1


### PR DESCRIPTION
This PR removes the `replace` directive that replaces go-kit `v0.9.0` with `v0.3.0` and updates the use of the `github.com/go-kit/kit/log` package to be compatible with the APIs supported by `v0.4.0` and beyond.

**What this PR does / why we need it**:
The `v0.3.0` APIs in `github.com/go-kit/kit/log` are incompatible with those in `v0.4.0` and beyond. This makes it impossible to import packages like `kubevirt.io/client-go/kubecli` into other projects where other dependencies rely on newer versions of go-kit (`go mod` will pick the higher version and this results in compilation errors in `kubevirt.io/client-go/log` due to conflicting APIs).

**Which issue(s) this PR fixes**
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
Removed go module pinning to an old version (v0.3.0) of github.com/go-kit/kit
```
