### PR TITLE
Remove test_id:4621 from quarantine (fixed in #6312)

### DIFF
--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -149,7 +149,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 	}
 
 	Context("[rook-ceph] Upload an image and start a VMI with PVC", func() {
-		DescribeTable("[QUARANTINE][test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
+		DescribeTable("[test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := tests.GetCephStorageClass()
 			if !exists {
 				Skip("Skip OCS tests when Ceph is not present")


### PR DESCRIPTION
This test hasn't failed in the k8s-1.21-sig-storage periodics
and therefore we think it is no longer flaky.
(The other sig-storage lanes are known as flaky and not taken
into account)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
