### PR TITLE
Ignore "didn't find PVC associated with DataVolume" spurious warning

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -253,7 +253,7 @@ type WarningsPolicy struct {
 func (wp *WarningsPolicy) shouldIgnoreWarning(event *k8sv1.Event) bool {
 	if event.Type == string(WarningEvent) {
 		for _, message := range wp.WarningsIgnoreList {
-			if message == event.Message {
+			if strings.Contains(event.Message, message) {
 				return true
 			}
 		}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1573,7 +1573,11 @@ func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdi
 	By("Waiting until the DataVolume is ready")
 	Eventually(ThisDV(dv), timeout).Should(HaveSucceeded())
 	By("Waiting until the VirtualMachineInstance will start")
-	WaitForSuccessfulVMIStartWithTimeout(obj, timeout)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	warningsIgnoreList := []string{"didn't find PVC associated with DataVolume"}
+	wp := WarningsPolicy{FailOnWarnings: true, WarningsIgnoreList: warningsIgnoreList}
+	_ = waitForVMIStart(ctx, obj, timeout, wp)
 	return obj
 }
 


### PR DESCRIPTION
which can happen before DV success and is normal.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
[Example failure](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.21-sig-storage/1437654969137238016)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
