### PR TITLE
Catch the deletion key before type assertion causes a panic

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1197,7 +1197,7 @@ func (c *VMIController) addVirtualMachineInstance(obj interface{}) {
 func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
 	c.lowerVMIExpectation(obj)
 
-	_, ok := obj.(*virtv1.VirtualMachineInstance)
+	vmi, ok := obj.(*virtv1.VirtualMachineInstance)
 
 	// When a delete is dropped, the relist will notice a vmi in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
@@ -1208,16 +1208,14 @@ func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
 			log.Log.Reason(fmt.Errorf("couldn't get object from tombstone %+v", obj)).Error("Failed to process delete notification")
 			return
 		}
-		_, ok = tombstone.Obj.(*virtv1.VirtualMachineInstance)
+		vmi, ok = tombstone.Obj.(*virtv1.VirtualMachineInstance)
 		if !ok {
 			log.Log.Reason(fmt.Errorf("tombstone contained object that is not a vmi %#v", obj)).Error("Failed to process delete notification")
 			return
 		}
-		// The VMI object has been deleted
-		return
 	}
 
-	c.enqueueVirtualMachine(obj)
+	c.enqueueVirtualMachine(vmi)
 }
 
 func (c *VMIController) updateVirtualMachineInstance(_, curr interface{}) {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1195,8 +1195,6 @@ func (c *VMIController) addVirtualMachineInstance(obj interface{}) {
 }
 
 func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
-	c.lowerVMIExpectation(obj)
-
 	vmi, ok := obj.(*virtv1.VirtualMachineInstance)
 
 	// When a delete is dropped, the relist will notice a vmi in the store not
@@ -1214,7 +1212,7 @@ func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
 			return
 		}
 	}
-
+	c.lowerVMIExpectation(vmi)
 	c.enqueueVirtualMachine(vmi)
 }
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1196,6 +1196,27 @@ func (c *VMIController) addVirtualMachineInstance(obj interface{}) {
 
 func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
 	c.lowerVMIExpectation(obj)
+
+	_, ok := obj.(*virtv1.VirtualMachineInstance)
+
+	// When a delete is dropped, the relist will notice a vmi in the store not
+	// in the list, leading to the insertion of a tombstone object which contains
+	// the deleted key/value. Note that this value might be stale.
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.Log.Reason(fmt.Errorf("couldn't get object from tombstone %+v", obj)).Error("Failed to process delete notification")
+			return
+		}
+		_, ok = tombstone.Obj.(*virtv1.VirtualMachineInstance)
+		if !ok {
+			log.Log.Reason(fmt.Errorf("tombstone contained object that is not a vmi %#v", obj)).Error("Failed to process delete notification")
+			return
+		}
+		// The VMI object has been deleted
+		return
+	}
+
 	c.enqueueVirtualMachine(obj)
 }
 


### PR DESCRIPTION
Handle `cache.DeletedFinalStateUnknown` keys in the virt-controller for VMIs.  

fixes: https://github.com/kubevirt/kubevirt/issues/6418
Signed-off-by: Ryan Hallisey <rhallisey@nvidia.com>

```release-note
Fix virt-controller panic caused by lots of deleted VMI events
```
