### PR TITLE
migration: persist XML changes to the target

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -767,12 +767,14 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 	key := migrationproxy.ConstructProxyKey(string(vmi.UID), migrationproxy.LibvirtDirectMigrationPort)
 	migrURI := fmt.Sprintf("unix://%s", migrationproxy.SourceUnixFile(virtShareDir, key))
 	params := &libvirt.DomainMigrateParameters{
-		URI:          migrURI,
-		URISet:       true,
-		Bandwidth:    bandwidth, // MiB/s
-		BandwidthSet: bandwidth > 0,
-		DestXML:      xmlstr,
-		DestXMLSet:   true,
+		URI:           migrURI,
+		URISet:        true,
+		Bandwidth:     bandwidth, // MiB/s
+		BandwidthSet:  bandwidth > 0,
+		DestXML:       xmlstr,
+		DestXMLSet:    true,
+		PersistXML:    xmlstr,
+		PersistXMLSet: true,
 	}
 
 	copyDisks := getDiskTargetsForMigration(dom, vmi)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -728,6 +728,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				persistent, err := tests.LibvirtDomainIsPersistent(virtClient, vmi)
 				Expect(err).ToNot(HaveOccurred(), "Should list libvirt domains successfully")
 				Expect(persistent).To(BeTrue(), "The VMI was not found in the list of libvirt persistent domains")
+				tests.EnsureNoMigrationMetadataInPersistentXML(vmi)
 
 				// delete VMI
 				By("Deleting the VMI")


### PR DESCRIPTION
**What this PR does / why we need it**:
The `PersistXML` migration parameter was overlooked when switching from transient to persistent target domains.
Without `PersistXML`, the target XML will actually be a copy of the source, ignoring our changes, as described in:
https://libvirt.org/html/libvirt-libvirt-domain.html#VIR_MIGRATE_PARAM_PERSIST_XML

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
