### PR TITLE
Handle iothreads for hotplugged disks.

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -590,6 +590,11 @@ func (in *ControllerDriver) DeepCopyInto(out *ControllerDriver) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.Queues != nil {
+		in, out := &in.Queues, &out.Queues
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -539,6 +539,7 @@ type Controller struct {
 // BEGIN ControllerDriver
 type ControllerDriver struct {
 	IOThread *uint `xml:"iothread,attr,omitempty"`
+	Queues   *uint `xml:"queues,attr,omitempty"`
 }
 
 // END ControllerDriver
@@ -592,14 +593,14 @@ type DiskTarget struct {
 }
 
 type DiskDriver struct {
-	Cache       string `xml:"cache,attr,omitempty"`
-	ErrorPolicy string `xml:"error_policy,attr,omitempty"`
-	IO          string `xml:"io,attr,omitempty"`
-	Name        string `xml:"name,attr"`
-	Type        string `xml:"type,attr"`
-	IOThread    *uint  `xml:"iothread,attr,omitempty"`
-	Queues      *uint  `xml:"queues,attr,omitempty"`
-	Discard     string `xml:"discard,attr,omitempty"`
+	Cache       string      `xml:"cache,attr,omitempty"`
+	ErrorPolicy string      `xml:"error_policy,attr,omitempty"`
+	IO          v1.DriverIO `xml:"io,attr,omitempty"`
+	Name        string      `xml:"name,attr"`
+	Type        string      `xml:"type,attr"`
+	IOThread    *uint       `xml:"iothread,attr,omitempty"`
+	Queues      *uint       `xml:"queues,attr,omitempty"`
+	Discard     string      `xml:"discard,attr,omitempty"`
 }
 
 type DiskSourceHost struct {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -201,7 +201,7 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 	disk.Driver = &api.DiskDriver{
 		Name:        "qemu",
 		Cache:       string(diskDevice.Cache),
-		IO:          string(diskDevice.IO),
+		IO:          diskDevice.IO,
 		ErrorPolicy: "stop",
 	}
 	if diskDevice.Disk != nil || diskDevice.LUN != nil {
@@ -437,7 +437,7 @@ func SetOptimalIOMode(disk *api.Disk) error {
 	if v1.DriverCache(disk.Driver.Cache) == v1.CacheNone {
 		// set native for block device or pre-allocateed image file
 		if (disk.Source.Dev != "") || isPreAllocated(disk.Source.File) {
-			disk.Driver.IO = string(v1.IONative)
+			disk.Driver.IO = v1.IONative
 		}
 	}
 	// For now we don't explicitly set io=threads even for sparse files as it's
@@ -1396,22 +1396,26 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		if useIOThreads {
-			ioThreadId := defaultIOThread
-			dedicatedThread := false
-			if disk.DedicatedIOThread != nil {
-				dedicatedThread = *disk.DedicatedIOThread
-			}
+			if _, ok := c.HotplugVolumes[disk.Name]; !ok {
+				ioThreadId := defaultIOThread
+				dedicatedThread := false
+				if disk.DedicatedIOThread != nil {
+					dedicatedThread = *disk.DedicatedIOThread
+				}
 
-			if dedicatedThread {
-				ioThreadId = currentDedicatedThread
-				currentDedicatedThread += 1
+				if dedicatedThread {
+					ioThreadId = currentDedicatedThread
+					currentDedicatedThread += 1
+				} else {
+					ioThreadId = currentAutoThread
+					// increment the threadId to be used next but wrap around at the thread limit
+					// the odd math here is because thread ID's start at 1, not 0
+					currentAutoThread = (currentAutoThread % uint(autoThreads)) + 1
+				}
+				newDisk.Driver.IOThread = &ioThreadId
 			} else {
-				ioThreadId = currentAutoThread
-				// increment the threadId to be used next but wrap around at the thread limit
-				// the odd math here is because thread ID's start at 1, not 0
-				currentAutoThread = (currentAutoThread % uint(autoThreads)) + 1
+				newDisk.Driver.IO = v1.IOThreads
 			}
-			newDisk.Driver.IOThread = &ioThreadId
 		}
 
 		hpStatus, hpOk := c.HotplugVolumes[disk.Name]
@@ -1521,11 +1525,18 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	if needsSCSIControler(vmi) {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
+		scsiController := api.Controller{
 			Type:  "scsi",
 			Index: "0",
 			Model: translateModel(c, "virtio"),
-		})
+		}
+		if useIOThreads {
+			scsiController.Driver = &api.ControllerDriver{
+				IOThread: &currentAutoThread,
+				Queues:   &vcpus,
+			}
+		}
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, scsiController)
 	}
 
 	if vmi.Spec.Domain.Clock != nil {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1994,13 +1994,13 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			By("checking if number of attached disks is equal to real disks number")
 			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
 
-			ioNative := string(v1.IONative)
-			ioThreads := string(v1.IOThreads)
+			ioNative := v1.IONative
+			ioThreads := v1.IOThreads
 			ioNone := ""
 
 			By("checking if default io has not been set for sparsed file")
 			Expect(disks[0].Alias.GetName()).To(Equal("ephemeral-disk1"))
-			Expect(disks[0].Driver.IO).To(Equal(ioNone))
+			Expect(string(disks[0].Driver.IO)).To(Equal(ioNone))
 
 			By("checking if default io mode has been set to 'native' for block device")
 			Expect(disks[1].Alias.GetName()).To(Equal("block-pvc"))
@@ -2012,7 +2012,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			// As such, it behaves as plugging in a hostDisk - check disks[6].
 			if tests.IsRunningOnKindInfra() {
 				// The chache mode is set to cacheWritethrough
-				Expect(disks[2].Driver.IO).To(Equal(ioNone))
+				Expect(string(disks[2].Driver.IO)).To(Equal(ioNone))
 			} else {
 				// The chache mode is set to cacheNone
 				Expect(disks[2].Driver.IO).To(Equal(ioNative))


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of trying to set the iothreads on the disk, set the
proper iothreads on the scsi controller and set the io to
'threads' on hotplugged disks.

Added unit and functional tests to ensure this works properly

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Hotplug disks are possible when iothreads are enabled.
```
