### PR TITLE
go-test: ignore cmd/container-disk-v2alpha which is not go

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -56,7 +56,8 @@ esac
 if [ $# -eq 0 ]; then
     if [ "${target}" = "test" ]; then
         (
-            go ${target} -v ./cmd/...
+            # Ignoring container-disk-v2alpha since it is written in C, not in go
+            go ${target} -v --ignore=container-disk-v2alpha ./cmd/...
         )
         (
             go ${target} -v -race ./pkg/...


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this fix, `make go-test` fails with:
```
package kubevirt.io/kubevirt/cmd/container-disk-v2alpha: C source files not allowed when not using cgo or SWIG: main.c
make: *** [Makefile:72: go-test] Error 1
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
