### PR TITLE
automation: avoid waiting forever that Completed pods become Running

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -257,11 +257,11 @@ timeout=300
 sample=30
 
 for i in ${namespaces[@]}; do
-  # Wait until kubevirt pods are running
+  # Wait until kubevirt pods are running or completed
   current_time=0
-  while [ -n "$(kubectl get pods -n $i --no-headers | grep -v Running)" ]; do
-    echo "Waiting for kubevirt pods to enter the Running state ..."
-    kubectl get pods -n $i --no-headers | >&2 grep -v Running || true
+  while [ -n "$(kubectl get pods -n $i --no-headers | grep -v -E 'Running|Completed')" ]; do
+    echo "Waiting for kubevirt pods to enter the Running/Completed state ..."
+    kubectl get pods -n $i --no-headers | >&2 grep -v -E 'Running|Completed' || true
     sleep $sample
 
     current_time=$((current_time + sample))


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the introduction of whereabouts, completed ip-reconcilers can appear in the default namespace.
Without this fix, the script times out waiting for those to become "Running".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
