### PR TITLE
automation: ignore completed pods when checking for readiness

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -274,9 +274,9 @@ for i in ${namespaces[@]}; do
 
   # Make sure all containers are ready
   current_time=0
-  while [ -n "$(kubectl get pods -n $i -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false)" ]; do
+  while [ -n "$(kubectl get pods -n $i --field-selector=status.phase==Running -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false)" ]; do
     echo "Waiting for KubeVirt containers to become ready ..."
-    kubectl get pods -n $i -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false || true
+    kubectl get pods -n $i --field-selector=status.phase==Running -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false || true
     sleep $sample
 
     current_time=$((current_time + sample))


### PR DESCRIPTION
**What this PR does / why we need it**:
The latest kubevirtci bump introduced whereabouts on network lanes, which itself creates ip-reconciler pods that quickly complete.
https://github.com/kubevirt/kubevirt/pull/6431 was created to ignore those completed pods in the automation script.
However, that last PR is incomplete, and the script can still fail on the readiness check.
This PR addresses that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
