### PR TITLE
Fix deprecated use of watch API

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -61,8 +61,8 @@ func NewListWatchFromClient(c cache.Getter, resource string, namespace string, f
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		options.FieldSelector = fieldSelector.String()
 		options.LabelSelector = labelSelector.String()
+		options.Watch = true
 		return c.Get().
-			Prefix("watch").
 			Namespace(namespace).
 			Resource(resource).
 			VersionedParams(&options, metav1.ParameterCodec).


### PR DESCRIPTION
**What this PR does / why we need it**: This MR fixes a problem that leads to reporting incorrect metrics in Kubernetes. The problem is that `watchFunc` uses deprecated (since K8s v1.12) API call which seems to be incorrectly interpreted by `apiserver`. My fix is simply replacing old, deprecated method of indicating WATCH operation by a new one. After the fix the `apiserver_request_duration_seconds` metrics for LIST operation drop to normal levels:
![Screen Shot 2021-09-20 at 15 16 52](https://user-images.githubusercontent.com/3855799/134008803-2b86f3f3-19a5-40bf-95fd-726219e035e3.png)

**Which issue(s) this PR fixes**:
Fixes #6436 

**Special notes for your reviewer**: None

**Release note**:
```release-note
Fix deprecated use of watch API to prevent reporting incorrect metrics.
```
