### PR TITLE
Reduce PATCH collisions in the virt-controller

### DIFF
--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1488,7 +1488,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			patch := `[{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "madeup" }, { "op": "add", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }]`
-
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
@@ -1516,7 +1517,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			patch := `[{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "a" }, { "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }, { "op": "replace", "path": "/metadata/labels", "value": {} }]`
-
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
@@ -1534,6 +1536,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			patch := `[{ "op": "test", "path": "/status/conditions", "value": null }, { "op": "replace", "path": "/status/conditions", "value": [{"type":"Ready","status":"True","lastProbeTime":null,"lastTransitionTime":null}] }]`
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
@@ -1551,6 +1555,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			podFeeder.Add(pod)
 
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any()).DoAndReturn(func(_ string, _ interface{}, patchBytes []byte) (*v1.VirtualMachineInstance, error) {
 				patch, err := jsonpatch.DecodePatch(patchBytes)
 				Expect(err).ToNot(HaveOccurred())
@@ -1583,6 +1589,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podFeeder.Add(pod)
 
 			patch := `[{ "op": "test", "path": "/status/activePods", "value": {} }, { "op": "replace", "path": "/status/activePods", "value": {"someUID":"someHost"} }]`
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
@@ -2439,6 +2447,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podInformer.GetIndexer().Add(virtlauncherPod)
 			//Modify by adding a new hotplugged disk
 			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{}},{"name":"hotplug","target":"","phase":"Bound","reason":"PVCNotReady","message":"PVC is in phase Bound","persistentVolumeClaimInfo":{},"hotplugVolume":{}}] }]`
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
@@ -2529,6 +2539,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			podInformer.GetIndexer().Add(virtlauncherPod)
 			//Modify by adding a new hotplugged disk
 			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":"","persistentVolumeClaimInfo":{}},{"name":"hotplug","target":"","phase":"Detaching","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }]`
+			key := kvcontroller.VirtualMachineInstanceKey(vmi)
+			controller.vmiExpectations.LowerExpectations(key, 1, 0)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)


### PR DESCRIPTION
When deleting a large number of VMI, the virt-controller sees lots of 422 errors.  Don't wake up the controller to sync after we fail on the first PATCH attempt.  Let's wait for another object change before attempting to PATCH again.

```
{"component":"virt-controller","level":"info","msg":"reenqueuing VirtualMachineInstance default/d44cdb1a-1fcb-4d0d-863d-7f50fb32c43e","pos":"vmi.go:209","reason":"patching of vmi conditions and activePods failed: the server rejected our request due to an error in our request","service":"http","timestamp":"2021-09-16T11:23:12.783295Z"}
{"component":"virt-controller","level":"info","msg":"reenqueuing VirtualMachineInstance default/ec2a9b43-c1c9-4afe-8390-1e16aff01e6c","pos":"vmi.go:209","reason":"patching of vmi conditions and activePods failed: the server rejected our request due to an error in our request","service":"http","timestamp":"2021-09-16T11:23:33.310446Z"}
{"component":"virt-controller","level":"info","msg":"reenqueuing VirtualMachineInstance default/1700b29c-0ee2-43ba-ac5e-38a0bd3cfac0","pos":"vmi.go:209","reason":"patching of vmi conditions and activePods failed: the server rejected our request due to an error in our request","service":"http","timestamp":"2021-09-16T11:23:47.010004Z"}
{"component":"virt-controller","level":"info","msg":"reenqueuing VirtualMachineInstance default/af67276d-a9ef-4291-9575-112851bcfbe7","pos":"vmi.go:209","reason":"patching of vmi conditions and activePods failed: the server rejected our request due to an error in our request","service":"http","timestamp":"2021-09-16T11:23:47.031845Z"}
```

Fixes https://github.com/kubevirt/kubevirt/issues/6422

```release-note
Reduce PATCH collisions in the virt-controller 
```
