### PR TITLE
Add more phase transition buckets

### DIFF
--- a/pkg/monitoring/perfscale/vmi-phase-transitions.go
+++ b/pkg/monitoring/perfscale/vmi-phase-transitions.go
@@ -86,6 +86,9 @@ func phaseTransitionTimeBuckets() []float64 {
 		(3 * time.Minute).Seconds(),
 		(5 * time.Minute).Seconds(),
 		(10 * time.Minute).Seconds(),
+		(20 * time.Minute).Seconds(),
+		(30 * time.Minute).Seconds(),
+		(1 * time.Hour).Seconds(),
 	}
 }
 


### PR DESCRIPTION
In SIG-scale's testing, we saw VMI creation time running up against the highest transition bucket (10 minutes).  Add a few more buckets that we hopefully never have to use.

```release-note
NONE
```
