### PR TITLE
Add DryRun functional tests for KubeVirt resources

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -124,6 +124,7 @@ go_test(
         "console_test.go",
         "container_disk_test.go",
         "credentials_test.go",
+        "dryrun_test.go",
         "infra_test.go",
         "kubectl_test.go",
         "kubevirt_configmap_test.go",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/portforward:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
         "//vendor/k8s.io/client-go/transport/spdy:go_default_library",

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = Describe("[sig-compute]VMI Dry-Run requests", func() {
+	var err error
+	var virtClient kubecli.KubevirtClient
+	var restClient *rest.RESTClient
+	var vmi *v1.VirtualMachineInstance
+
+	resource := "virtualmachineinstances"
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+		restClient = virtClient.RestClient()
+
+		tests.BeforeTestCleanup()
+		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+	})
+
+	It("create a VirtualMachineInstance", func() {
+		By("Make a Dry-Run request to create a Virtual Machine")
+		err = tests.DryRunCreate(restClient, resource, vmi.Namespace, vmi, nil)
+		Expect(err).To(BeNil())
+
+		By("Check that no Virtual Machine was actually created")
+		_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("delete a VirtualMachineInstance", func() {
+		By("Create a VirtualMachineInstance")
+		_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+		Expect(err).To(BeNil())
+
+		By("Make a Dry-Run request to delete a Virtual Machine")
+		deletePolicy := metav1.DeletePropagationForeground
+		opts := metav1.DeleteOptions{
+			DryRun:            []string{metav1.DryRunAll},
+			PropagationPolicy: &deletePolicy,
+		}
+		err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &opts)
+		Expect(err).To(BeNil())
+
+		By("Check that no Virtual Machine was actually deleted")
+		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("update a VirtualMachineInstance", func() {
+		By("Create a VirtualMachineInstance")
+		_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+		Expect(err).To(BeNil())
+
+		By("Make a Dry-Run request to update a Virtual Machine")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			vmi.Labels = map[string]string{
+				"key": "42",
+			}
+			return tests.DryRunUpdate(restClient, resource, vmi.Name, vmi.Namespace, vmi, nil)
+		})
+
+		By("Check that no update actually took place")
+		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi.Labels["key"]).ToNot(Equal("42"))
+	})
+
+	It("patch a VirtualMachineInstance", func() {
+		By("Create a VirtualMachineInstance")
+		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+		Expect(err).To(BeNil())
+
+		By("Make a Dry-Run request to patch a Virtual Machine")
+		patch := []byte(`{"metadata": {"labels": {"key": "42"}}}`)
+		err = tests.DryRunPatch(restClient, resource, vmi.Name, vmi.Namespace, types.MergePatchType, patch, nil)
+		Expect(err).To(BeNil())
+
+		By("Check that no update actually took place")
+		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi.Labels["key"]).ToNot(Equal("42"))
+	})
+})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -74,6 +74,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
@@ -5186,4 +5187,39 @@ func MountCloudInitFunc(devName string) func(*v1.VirtualMachineInstance) {
 		}, 15)
 		Expect(err).ToNot(HaveOccurred())
 	}
+}
+
+func DryRunCreate(client *rest.RESTClient, resource, namespace string, obj interface{}, result runtime.Object) error {
+	opts := metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
+	return client.Post().
+		Namespace(namespace).
+		Resource(resource).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(obj).
+		Do(context.Background()).
+		Into(result)
+}
+
+func DryRunUpdate(client *rest.RESTClient, resource, name, namespace string, obj interface{}, result runtime.Object) error {
+	opts := metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}}
+	return client.Put().
+		Name(name).
+		Namespace(namespace).
+		Resource(resource).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(obj).
+		Do(context.Background()).
+		Into(result)
+}
+
+func DryRunPatch(client *rest.RESTClient, resource, name, namespace string, pt types.PatchType, data []byte, result runtime.Object) error {
+	opts := metav1.PatchOptions{DryRun: []string{metav1.DryRunAll}}
+	return client.Patch(pt).
+		Name(name).
+		Namespace(namespace).
+		Resource(resource).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(data).
+		Do(context.Background()).
+		Into(result)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add functional tests to validate that dry-run requests for objects CRUD operations are honored.

This PR includes functional tests for VMI, VM, VMIMl, VMIRS, Presets, Snapshot, and KubeVirt CR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
