### PR TITLE
cluster-clean: avoid matching "kubevirt-*" namespaces in wait loop

### DIFF
--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -130,7 +130,7 @@ function delete_namespaces() {
             local timeout=180
             echo "Waiting for ${ns} namespace to disappear ..."
             set +x
-            while [ -n "$(_kubectl get ns | grep -w ${ns})" ]; do
+            while _kubectl get ns ${ns}; do
                 sleep $sample
                 current_time=$((current_time + sample))
                 if [[ $current_time -gt $timeout ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor fix to cluster-clean.sh

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
