### PR TITLE
Fix sriov tagging

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1344,16 +1344,16 @@ func (l *LibvirtDomainManager) GetDomainStats() ([]*stats.DomainStats, error) {
 }
 
 func addToDeviceMetadata(metadataType cloudinit.DeviceMetadataType, address *api.Address, mac string, tag string, devicesMetadata []cloudinit.DeviceData) []cloudinit.DeviceData {
-			pciAddrStr := fmt.Sprintf("%s:%s:%s:%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
-			deviceData := cloudinit.DeviceData{
-				Type:    metadataType,
-				Bus:     address.Type,
-				Address: pciAddrStr,
-				MAC:     mac,
-				Tags:    []string{tag},
-			}
-			devicesMetadata = append(devicesMetadata, deviceData)
-			return devicesMetadata
+	pciAddrStr := fmt.Sprintf("%s:%s:%s:%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
+	deviceData := cloudinit.DeviceData{
+		Type:    metadataType,
+		Bus:     address.Type,
+		Address: pciAddrStr,
+		MAC:     mac,
+		Tags:    []string{tag},
+	}
+	devicesMetadata = append(devicesMetadata, deviceData)
+	return devicesMetadata
 }
 
 func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstance, dom cli.VirDomain) ([]cloudinit.DeviceData, error) {
@@ -1380,21 +1380,22 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 				mac = nic.MAC.MAC
 			}
 			devicesMetadata = addToDeviceMetadata(cloudinit.NICMetadataType,
-							      nic.Address,
-					                      mac,
-					                      data.Tag,
-					                      devicesMetadata)
+				nic.Address,
+				mac,
+				data.Tag,
+				devicesMetadata)
 		}
 	}
 
 	hostDevices := devices.HostDevices
 	for _, dev := range hostDevices {
-		if data, exist := taggedInterfaces[dev.Alias.GetName()]; exist {
+		devAliasNoPrefix := strings.Replace(dev.Alias.GetName(), sriov.AliasPrefix, "", -1)
+		if data, exist := taggedInterfaces[devAliasNoPrefix]; exist {
 			devicesMetadata = addToDeviceMetadata(cloudinit.NICMetadataType,
-							      dev.Address,
-					                      "",
-					                      data.Tag,
-					                      devicesMetadata)
+				dev.Address,
+				"",
+				data.Tag,
+				devicesMetadata)
 		}
 	}
 	return devicesMetadata, nil

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -20,7 +20,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/network",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cloud-init:go_default_library",
         "//pkg/network/istio:go_default_library",
+        "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
SR-IOV interfaces are being added to the guest as `hostdev`s instead of `interface`s 
`hostdev`s were not previously considered when devices metadata was generated.
This PR should expose the tagged SRIOV interfaces in the config drive metadata.
Fixes #6413

**Release note**:
```release-note
Tagged SR-IOV interfaces will now appear in the config drive metadata 
```
