### PR TITLE
flake-checker: add secondary nic

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -146,6 +146,7 @@ for lane in "${TEST_LANES[@]}"; do
     export KUBEVIRT_NUM_NODES=2
     export KUBEVIRT_WITH_CNAO="true"
     export KUBEVIRT_DEPLOY_CDI="true"
+    export KUBEVIRT_NUM_SECONDARY_NICS=1
     make cluster-up
 
     for i in $(seq 1 "$NUM_TESTS"); do


### PR DESCRIPTION
**What this PR does / why we need it**:
This is required to run tests that require secondary networks, like the one in https://github.com/kubevirt/kubevirt/pull/6036

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
