### PR TITLE
Resolve hotplug race between kubelet and virt-handler

### DIFF
--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -82,15 +82,15 @@ func (h *hotplugDiskManager) GetFileSystemDiskTargetPathFromHostView(virtlaunche
 	if err != nil {
 		return targetPath, err
 	}
-	diskPath := filepath.Join(targetPath, volumeName)
-	exists, _ := diskutils.FileExists(diskPath)
+	diskFile := filepath.Join(targetPath, fmt.Sprintf("%s.img", volumeName))
+	exists, _ := diskutils.FileExists(diskFile)
 	if !exists && create {
-		err = os.Mkdir(diskPath, 0750)
+		file, err := os.Create(diskFile)
 		if err != nil {
-			return diskPath, err
+			return diskFile, err
 		}
+		defer file.Close()
 	}
-	diskFile := filepath.Join(targetPath, volumeName)
 	return diskFile, err
 }
 

--- a/pkg/hotplug-disk/hotplug-disk_test.go
+++ b/pkg/hotplug-disk/hotplug-disk_test.go
@@ -77,7 +77,7 @@ var _ = Describe("HotplugDisk", func() {
 		_ = os.MkdirAll(TargetPodBasePath(podsBaseDir, testUID), 0755)
 		res, err := hotplug.GetFileSystemDiskTargetPathFromHostView(testUID, "testvolume", true)
 		Expect(err).ToNot(HaveOccurred())
-		testPath := filepath.Join(TargetPodBasePath(podsBaseDir, testUID), "testvolume")
+		testPath := filepath.Join(TargetPodBasePath(podsBaseDir, testUID), "testvolume.img")
 		exists, _ := diskutils.FileExists(testPath)
 		Expect(exists).To(BeTrue())
 		Expect(res).To(Equal(testPath))
@@ -86,7 +86,7 @@ var _ = Describe("HotplugDisk", func() {
 	It("GetFileSystemDiskTargetPathFromHostView should return the volume directory", func() {
 		testUID := types.UID("abcd")
 		_ = os.MkdirAll(TargetPodBasePath(podsBaseDir, testUID), 0755)
-		testPath := filepath.Join(TargetPodBasePath(podsBaseDir, testUID), "testvolume")
+		testPath := filepath.Join(TargetPodBasePath(podsBaseDir, testUID), "testvolume.img")
 		err = os.MkdirAll(testPath, os.FileMode(0755))
 		res, err := hotplug.GetFileSystemDiskTargetPathFromHostView(testUID, "testvolume", false)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -561,13 +561,13 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 		// This is not the node the pod is running on.
 		return nil
 	}
-	targetPath, err := m.hotplugDiskManager.GetFileSystemDiskTargetPathFromHostView(virtlauncherUID, volume, true)
+	targetDisk, err := m.hotplugDiskManager.GetFileSystemDiskTargetPathFromHostView(virtlauncherUID, volume, true)
 	if err != nil {
 		return err
 	}
 
-	if isMounted, err := isMounted(targetPath); err != nil {
-		return fmt.Errorf("failed to determine if %s is already mounted: %v", targetPath, err)
+	if isMounted, err := isMounted(targetDisk); err != nil {
+		return fmt.Errorf("failed to determine if %s is already mounted: %v", targetDisk, err)
 	} else if !isMounted {
 		sourcePath, err := m.getSourcePodFilePath(sourceUID, vmi, volume)
 		if err != nil {
@@ -576,10 +576,10 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 			// to get mounted on the node, and this will error until the volume is mounted.
 			return nil
 		}
-		if err := m.writePathToMountRecord(targetPath, vmi, record); err != nil {
+		if err := m.writePathToMountRecord(targetDisk, vmi, record); err != nil {
 			return err
 		}
-		if out, err := mountCommand(sourcePath, targetPath); err != nil {
+		if out, err := mountCommand(filepath.Join(sourcePath, "disk.img"), targetDisk); err != nil {
 			return fmt.Errorf("failed to bindmount hotplug-disk %v: %v : %v", volume, string(out), err)
 		}
 	} else {
@@ -801,5 +801,5 @@ func (m *volumeMounter) IsMounted(vmi *v1.VirtualMachineInstance, volume string,
 		isBlockExists, _ := isBlockDevice(deviceName)
 		return isBlockExists, nil
 	}
-	return isMounted(filepath.Join(targetPath, volume))
+	return isMounted(filepath.Join(targetPath, fmt.Sprintf("%s.img", volume)))
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -625,7 +625,7 @@ func GetFilesystemVolumePath(volumeName string) string {
 
 // GetHotplugFilesystemVolumePath returns the path and file name of a hotplug disk image
 func GetHotplugFilesystemVolumePath(volumeName string) string {
-	return filepath.Join(string(filepath.Separator), "var", "run", "kubevirt", "hotplug-disks", volumeName, "disk.img")
+	return filepath.Join(string(filepath.Separator), "var", "run", "kubevirt", "hotplug-disks", fmt.Sprintf("%s.img", volumeName))
 }
 
 func GetBlockDeviceVolumePath(volumeName string) string {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3045,7 +3045,7 @@ var _ = Describe("Converter", func() {
 					expectedDisk.Source.Dev = fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s", volumeName)
 				} else {
 					expectedDisk.Type = "file"
-					expectedDisk.Source.File = fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s/disk.img", volumeName)
+					expectedDisk.Source.File = fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s.img", volumeName)
 				}
 				if !ignoreDiscard {
 					expectedDisk.Driver.Discard = "unmap"

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -504,7 +504,7 @@ var _ = Describe("Manager", func() {
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
-				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img"))
+				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
 				return true, nil
 			}
 			domainSpec.Devices.Disks = []api.Disk{
@@ -531,7 +531,7 @@ var _ = Describe("Manager", func() {
 				Device: "disk",
 				Type:   "file",
 				Source: api.DiskSource{
-					File: "/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img",
+					File: "/var/run/kubevirt/hotplug-disks/hpvolume1.img",
 				},
 				Target: api.DiskTarget{
 					Bus:    "scsi",
@@ -636,7 +636,7 @@ var _ = Describe("Manager", func() {
 				Device: "disk",
 				Type:   "file",
 				Source: api.DiskSource{
-					File: "/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img",
+					File: "/var/run/kubevirt/hotplug-disks/hpvolume1.img",
 				},
 				Target: api.DiskTarget{
 					Bus:    "scsi",
@@ -743,7 +743,7 @@ var _ = Describe("Manager", func() {
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
-				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img"))
+				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
 				return true, nil
 			}
 			mockConn.EXPECT().DomainDefineXML(string(xmlDomain)).Return(mockDomain, nil)
@@ -822,7 +822,7 @@ var _ = Describe("Manager", func() {
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
-				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img"))
+				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
 				return false, nil
 			}
 			domainSpec.Devices.Disks = []api.Disk{


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Before we mounted the directory containing the disk.img file into the
virt-launcher pod. If the virt-launcher pod was killed unexpectedly it
would generate a race between kubelet and virt-handler. If kubelet ran
first it, it would empty the contents of the emptyDir we had mounted
the volume directory in. It would also empty the contents of that directory.
It would be unable to remove the directory because it was bind mounted but
the contents were lost.

This commit changes the way we hotplug images, by bind mounting the image
directly, and thus preventing the race from becoming an issue. If kubelet
runs first, it won't be able to remove the disk image because the resource
will be busy. This gives virt-handler time to unmount the volumes.

I have verified that eventually the kubelet will clean up the resources
used by the pod where it failed to clean up the emptyDir initially.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed hotplug race between kubelet and virt-handler when virt-launcher dies unexpectedly.
```
