### PR TITLE
Properly process Gateway DHCP Option as IPv4 in DHCP Server

### DIFF
--- a/pkg/network/dhcp/server/server.go
+++ b/pkg/network/dhcp/server/server.go
@@ -114,7 +114,7 @@ func prepareDHCPOptions(
 		dhcpOptions[dhcp.OptionSubnetMask] = clientMask
 	}
 	if len(routerIP) != 0 {
-		dhcpOptions[dhcp.OptionRouter] = routerIP
+		dhcpOptions[dhcp.OptionRouter] = routerIP.To4()
 	}
 
 	netRoutes := formClasslessRoutes(routes)

--- a/pkg/network/dhcp/server/server_test.go
+++ b/pkg/network/dhcp/server/server_test.go
@@ -245,6 +245,13 @@ var _ = Describe("DHCP Server", func() {
 			Expect(options[240]).To(Equal([]byte("private.options.kubevirt.io")))
 		})
 
+		It("expects the gateway as an IPv4 addresses", func() {
+			gw := net.ParseIP("192.168.2.1")
+			options, err := prepareDHCPOptions(gw.DefaultMask(), gw, nil, nil, nil, 1500, "myhost", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(options[dhcp4.OptionRouter]).To(Equal([]byte{192, 168, 2, 1}))
+		})
+
 		Context("Options set to invalid value", func() {
 			var (
 				err           error


### PR DESCRIPTION
PR requested by @maiqueb 

**What this PR does / why we need it**:
This PR fixes https://github.com/kubevirt/kubevirt/issues/6462, the behavior and need for the PR is extensively detailed there. The `.IPv4()` on the gateway IP can safely be done in `server.go` as it is the last place it is touched before handed over to the DHCP library.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/6462

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix corrupted DHCP Gateway Option from local DHCP server, leading to rejected IP configuration on Windows VMs.
```
