### PR TITLE
dns, tests: only accept preferred names syntax

### DIFF
--- a/pkg/network/dhcp/server/BUILD.bazel
+++ b/pkg/network/dhcp/server/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/krolaw/dhcp4:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],

--- a/pkg/network/dhcp/server/server_test.go
+++ b/pkg/network/dhcp/server/server_test.go
@@ -176,9 +176,9 @@ var _ = Describe("DHCP Server", func() {
 			Entry("with a partial search domain", "local"),
 		)
 
-		It("should accept domains with full length of 253 chars", func() {
+		XIt("should accept domains with full length of 253 chars", func() {
 			b := append(createBytes(249), []byte(".com")...)
-			Expect(isValidSearchDomain(string(b))).To(BeFalse())
+			Expect(isValidSearchDomain(string(b))).To(BeTrue())
 		})
 	})
 

--- a/pkg/network/dhcp/server/server_test.go
+++ b/pkg/network/dhcp/server/server_test.go
@@ -160,6 +160,11 @@ var _ = Describe("DHCP Server", func() {
 			Expect(isValidSearchDomain(dom)).To(BeFalse())
 		})
 
+		It("should reject domains that end with '-'", func() {
+			dom := "foo.com-"
+			Expect(isValidSearchDomain(dom)).To(BeFalse())
+		})
+
 		It("should reject domains with full length greater than 253 chars", func() {
 			b := append(createBytes(250), []byte(".com")...)
 			Expect(isValidSearchDomain(string(b))).To(BeFalse())

--- a/pkg/network/dhcp/server/server_test.go
+++ b/pkg/network/dhcp/server/server_test.go
@@ -23,9 +23,11 @@ import (
 	"net"
 
 	"github.com/krolaw/dhcp4"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/client-go/api/v1"
 )
@@ -155,53 +157,28 @@ var _ = Describe("DHCP Server", func() {
 			return b
 		}
 
-		It("should reject domains that start with '-'", func() {
-			dom := "-foo.com"
-			Expect(isValidSearchDomain(dom)).To(BeFalse())
-		})
+		DescribeTable("should *REJECT* domains", func(domaintToTest string) {
+			Expect(isValidSearchDomain(domaintToTest)).To(BeFalse())
+		},
+			Entry("that start with '-'", "-foo.com"),
+			Entry("that end with '-'", "foo.com-"),
+			Entry("with full length greater than 253 chars", string(append(createBytes(250), []byte(".com")...))),
+			Entry("that have labels longer than 63 chars", string(append(createBytes(64), []byte(".com")...))),
+			Entry("with invalid characters", "foo\n.com"),
+		)
 
-		It("should reject domains that end with '-'", func() {
-			dom := "foo.com-"
-			Expect(isValidSearchDomain(dom)).To(BeFalse())
-		})
-
-		It("should reject domains with full length greater than 253 chars", func() {
-			b := append(createBytes(250), []byte(".com")...)
-			Expect(isValidSearchDomain(string(b))).To(BeFalse())
-		})
+		DescribeTable("should *ACCEPT* domains", func(domaintToTest string) {
+			Expect(isValidSearchDomain(domaintToTest)).To(BeTrue())
+		},
+			Entry("that have 63 character labels", string(append(createBytes(63), []byte(".com")...))),
+			Entry("with a valid domain name", "example.default.svc.cluster.local"),
+			Entry("with a valid FQDN", "example.default.svc.cluster.local."),
+			Entry("with a partial search domain", "local"),
+		)
 
 		It("should accept domains with full length of 253 chars", func() {
 			b := append(createBytes(249), []byte(".com")...)
 			Expect(isValidSearchDomain(string(b))).To(BeFalse())
-		})
-
-		It("should reject domains that have labels longer than 63 chars", func() {
-			b := append(createBytes(64), []byte(".com")...)
-			Expect(isValidSearchDomain(string(b))).To(BeFalse())
-		})
-
-		It("should accept domains that have 63 character labels", func() {
-			b := append(createBytes(63), []byte(".com")...)
-			Expect(isValidSearchDomain(string(b))).To(BeTrue())
-		})
-
-		It("should reject domains with invalid characters", func() {
-			dom := "foo\n.com"
-			Expect(isValidSearchDomain(dom)).To(BeFalse())
-		})
-
-		It("should accept a valid domain", func() {
-			dom := "example.default.svc.cluster.local"
-			Expect(isValidSearchDomain(dom)).To(BeTrue())
-		})
-
-		It("should accept a valid FQDN", func() {
-			dom := "example.default.svc.cluster.local."
-			Expect(isValidSearchDomain(dom)).To(BeTrue())
-		})
-
-		It("should accept a partial search domain", func() {
-			Expect(isValidSearchDomain("local")).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR helps clarify what our DNS name requirements are, by enforcing those via a unit test.

Furthermore, it refactors the DNS related tests into a table, and exposes a bug on our search domain validation regex.

**Special notes for your reviewer**:
We already have a test that does the opposite - prevent domain names **starting** with `-` . 
This new test makes it more explicit that ending the domain name with `-` is **also** not legit.

From the [DNS RFC, section 2.3.1](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1) I see that (quoting below):

```
The labels must follow the rules for ARPANET host names.  They must
start with a letter, end with a letter or digit, and have as interior
characters only letters, digits, and hyphen.  There are also some
restrictions on the length.  Labels must be 63 characters or less.
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
