### PR TITLE
Ensure that the BeforeTest function is actually called

### DIFF
--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -264,7 +264,7 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 
 		Context("with Fedora Template", func() {
 			BeforeEach(func() {
-				AssertTemplateSetupSuccess(vmsgen.GetTemplateFedoraWithContainerDisk(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)), nil)
+				AssertTemplateSetupSuccess(vmsgen.GetTemplateFedoraWithContainerDisk(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)), nil)()
 			})
 
 			AssertTemplateTestSuccess()


### PR DESCRIPTION
Disclaimer: The template tests should be remove for a few reasons:

 * they do not test any kubevirt functionality, just if `oc template` works for CRDs, which is not something which we have to do.
 * they are never run in our CI lifecycle because we have no openshift
 * We do not provide any official templates out of our test templates, so they have also no value there
 * The tests are written overcomplicated and would require a complete rewrite

However here a fix which ensures that  the fedora template is actually written before `oc` tries to use the template.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
