### PR TITLE
Skip test_id:3145 for nonroot lanes

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -406,6 +406,10 @@ if [ -z "$KUBEVIRT_QUARANTINE" ]; then
     else
         export KUBEVIRT_E2E_SKIP="QUARANTINE"
     fi
+    # quarantine test_id:3145 only for nonroot lanes
+    if [[ $KUBEVIRT_NONROOT =~ true ]]; then
+        export KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|test_id:3145"
+    fi
 fi
 
 # Prepare RHEL PV for Template testing


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: test_id:3145 is a release blocker test but it is very flaky in nonroot lanes. This PR skips it only for those lanes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
