### PR TITLE
sriov, Ignore warnings while waiting for VMI start

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -734,11 +734,9 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			// Running multi sriov jobs with Kind, DinD is resource extensive, causing DeadlineExceeded transient warning
-			// Kubevirt re-enqueue the request once it happens, so its safe to ignore this warning.
-			// see https://github.com/kubevirt/kubevirt/issues/5027
-			warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
-			tests.WaitUntilVMIReadyIgnoreSelectedWarnings(vmi, console.LoginToFedora, warningsIgnoreList)
+			tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 360)
+			vmi = tests.LoginToVM(vmi, console.LoginToFedora)
+
 			tests.WaitAgentConnected(virtClient, vmi)
 			return vmi
 		}


### PR DESCRIPTION
Lately sriov lane became flaky due to the warning:

"unknown error encountered sending command SyncVMI:
 rpc error: code = DeadlineExceeded desc = context deadline exceeded"

This commit ignores warnings (but still assert on errors),
in order to stabilize the lane.
This warning for example is transient and there is a built-in mechanism of retry.

Note:
There is a mechanism that should ignore this specific warning, but it stopped operating.
We will investigate why the ignore warnings mechanism didn't skip this warning.

Example:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6331/pull-kubevirt-e2e-kind-1.19-sriov/1443154295166865408

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
