### PR TITLE
sriov, Fix flaky context deadline exceeded tests

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -211,7 +211,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 		// Arbitrarily select one compute node in the cluster, on which it is possible to create a VMI
 		// (i.e. a schedulable node).
 		nodeName := nodes.Items[0].Name
-		tests.StartVmOnNode(vmi, nodeName)
+		tests.CreateVmiOnNode(vmi, nodeName)
 
 		return vmi
 	}
@@ -446,7 +446,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ptpSubnetIP2+ptpSubnetMask), false))
-				vmiTwo = tests.StartVmOnNode(vmiTwo, nodes.Items[0].Name)
+				vmiTwo = tests.CreateVmiOnNode(vmiTwo, nodes.Items[0].Name)
 
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
@@ -457,7 +457,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask), false))
-				vmiOne = tests.StartVmOnNode(vmiOne, nodes.Items[0].Name)
+				vmiOne = tests.CreateVmiOnNode(vmiOne, nodes.Items[0].Name)
 
 				vmiOne = tests.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
 				tests.WaitAgentConnected(virtClient, vmiOne)
@@ -994,8 +994,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 			sriovNodes := getNodesWithAllocatedResource(virtClient, sriovResourceName)
 			Expect(sriovNodes).ToNot(BeEmpty())
 			sriovNode := sriovNodes[0].Name
-			vmi1 = tests.StartVmOnNode(vmi1, sriovNode)
-			vmi2 = tests.StartVmOnNode(vmi2, sriovNode)
+			vmi1 = tests.CreateVmiOnNode(vmi1, sriovNode)
+			vmi2 = tests.CreateVmiOnNode(vmi2, sriovNode)
 
 			vmi1 = waitVmi(vmi1)
 			vmi2 = waitVmi(vmi2)
@@ -1221,7 +1221,7 @@ var _ = SIGDescribe("[Serial]Macvtap", func() {
 			vmi = newCirrosVMIWithMacvtapNetwork(networkName)
 		}
 		vmi = tests.WaitUntilVMIReady(
-			tests.StartVmOnNode(vmi, nodeName),
+			tests.CreateVmiOnNode(vmi, nodeName),
 			console.LoginToCirros)
 		// configure the client VMI
 		Expect(configVMIInterfaceWithSudo(vmi, ifaceName, ipCIDR)).To(Succeed())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4110,8 +4110,8 @@ func SkipIfMigrationIsNotPossible() {
 	}
 }
 
-// StartVmOnNode starts a VMI on the specified node
-func StartVmOnNode(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualMachineInstance {
+// CreateVmiOnNode creates a VMI on the specified node
+func CreateVmiOnNode(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualMachineInstance {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4131,7 +4131,6 @@ func StartVmOnNode(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualM
 
 	vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	WaitForSuccessfulVMIStart(vmi)
 	return vmi
 }
 


### PR DESCRIPTION
Lately SR-IOV lane became flaky due to the warning:
    
`unknown error encountered sending command SyncVMI:
rpc error: code = DeadlineExceeded desc = context deadline exceeded` [1]

This is a warning level event, which has a built-in
retry mechanism in kubevirt.
    
SR-IOV tests are used to ignore this warning,
but a new function, `StartVmOnNode`, didn't.
Therefore remove waiting for the VMI start from `StartVmOnNode` function.

Notable points:
* It didn't ignore this specific warning mentioned above, which in turn
caused this warning to fail the tests.
* Each caller of `StartVmOnNode` already waiting for start anyhow,
with the correct ignore warnings settings upon need,
it was redundant and not correct, so it is safe to remove it.
* It also caused the VMI starting to be serial, instead of first create
them and only then wait for `Running` phase.

Rename `StartVmOnNode` to `CreateVmiOnNode` in order to reflect that it
only creates the VMI on a specific node now.

Potential follow-up work can research and optimize
the number of calls to `SyncVMI`, which will reduce the
compute needed for this type of messages.
Note that it happened only on one machine, which might have more
problems.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6331/pull-kubevirt-e2e-kind-1.19-sriov/1443154295166865408

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
