### PR TITLE
Add archive upload option to image upload command

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -60,6 +60,7 @@ const (
 
 	uploadRequestAnnotation         = "cdi.kubevirt.io/storage.upload.target"
 	forceImmediateBindingAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
+	contentTypeAnnotation           = "cdi.kubevirt.io/storage.contentType"
 
 	uploadReadyWaitInterval = 2 * time.Second
 
@@ -83,6 +84,7 @@ var (
 	pvcSize        string
 	storageClass   string
 	imagePath      string
+	archivePath    string
 	accessMode     string
 
 	uploadPodWaitSecs uint
@@ -90,6 +92,7 @@ var (
 	noCreate          bool
 	createPVC         bool
 	forceBind         bool
+	archiveUpload     bool
 )
 
 // HTTPClientCreator is a function that creates http clients
@@ -136,9 +139,9 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&size, "size", "", "The size of the DataVolume to create (ex. 10Gi, 500Mi).")
 	cmd.Flags().StringVar(&storageClass, "storage-class", "", "The storage class for the PVC.")
 	cmd.Flags().StringVar(&accessMode, "access-mode", "", "The access mode for the PVC.")
-	cmd.Flags().BoolVar(&blockVolume, "block-volume", false, "Create a PVC with VolumeMode=Block (default Filesystem).")
+	cmd.Flags().BoolVar(&blockVolume, "block-volume", false, "Create a PVC with VolumeMode=Block (default is the storageProfile default. for archive upload default is filesystem).")
 	cmd.Flags().StringVar(&imagePath, "image-path", "", "Path to the local VM image.")
-	cmd.MarkFlagRequired("image-path")
+	cmd.Flags().StringVar(&archivePath, "archive-path", "", "Path to the local archive.")
 	cmd.Flags().BoolVar(&noCreate, "no-create", false, "Don't attempt to create a new DataVolume/PVC.")
 	cmd.Flags().UintVar(&uploadPodWaitSecs, "wait-secs", 300, "Seconds to wait for upload pod to start.")
 	cmd.Flags().BoolVar(&forceBind, "force-bind", false, "Force bind the PVC, ignoring the WaitForFirstConsumer logic.")
@@ -160,7 +163,10 @@ func usage() string {
   {{ProgramName}} image-upload pvc fedora-pvc --no-create --image-path=/images/fedora30.qcow2
 
   # Upload to a DataVolume with explicit URL to CDI Upload Proxy
-  {{ProgramName}} image-upload dv fedora-dv --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2`
+  {{ProgramName}} image-upload dv fedora-dv --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2
+
+  # Upload a local disk archive to a newly created DataVolume:
+  {{ProgramName}} image-upload dv fedora-dv --size=10Gi --archive-path=/images/fedora30.tar`
 	return usage
 }
 
@@ -186,6 +192,19 @@ func parseArgs(args []string) error {
 		createPVC = true
 
 		return nil
+	}
+
+	archiveUpload = false
+	if imagePath == "" && archivePath == "" {
+		return fmt.Errorf("either image-path or archive-path most be provided")
+	} else if imagePath != "" && archivePath != "" {
+		return fmt.Errorf("cannot handle both image-path and archive-path, provide only one")
+	} else if archivePath != "" {
+		archiveUpload = true
+		imagePath = archivePath
+		if blockVolume {
+			return fmt.Errorf("In archive upload the volume mode should always be filesystem")
+		}
 	}
 
 	if len(args) != 2 {
@@ -228,7 +247,7 @@ func (c *command) run(args []string) error {
 		return fmt.Errorf("cannot obtain KubeVirt client: %v", err)
 	}
 
-	pvc, err := getAndValidateUploadPVC(virtClient, namespace, name, noCreate)
+	pvc, err := getAndValidateUploadPVC(virtClient, namespace, name, noCreate, archiveUpload)
 	if err != nil {
 		if !(k8serrors.IsNotFound(err) && !noCreate) {
 			return err
@@ -241,12 +260,12 @@ func (c *command) run(args []string) error {
 		var obj metav1.Object
 
 		if createPVC {
-			obj, err = createUploadPVC(virtClient, namespace, name, size, storageClass, accessMode, blockVolume)
+			obj, err = createUploadPVC(virtClient, namespace, name, size, storageClass, accessMode, blockVolume, archiveUpload)
 			if err != nil {
 				return err
 			}
 		} else {
-			obj, err = createUploadDataVolume(virtClient, namespace, name, size, storageClass, accessMode, blockVolume)
+			obj, err = createUploadDataVolume(virtClient, namespace, name, size, storageClass, accessMode, blockVolume, archiveUpload)
 			if err != nil {
 				return err
 			}
@@ -519,7 +538,7 @@ func waitUploadProcessingComplete(client kubernetes.Interface, namespace, name s
 	return err
 }
 
-func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*cdiv1.DataVolume, error) {
+func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size, storageClass, accessMode string, blockVolume, archiveUpload bool) (*cdiv1.DataVolume, error) {
 	pvcSpec, err := createStorageSpec(client, size, storageClass, accessMode, blockVolume)
 	if err != nil {
 		return nil, err
@@ -528,6 +547,11 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 	annotations := map[string]string{}
 	if forceBind {
 		annotations[forceImmediateBindingAnnotation] = ""
+	}
+
+	contentType := cdiv1.DataVolumeKubeVirt
+	if archiveUpload {
+		contentType = cdiv1.DataVolumeArchive
 	}
 
 	dv := &cdiv1.DataVolume{
@@ -540,7 +564,8 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 			Source: &cdiv1.DataVolumeSource{
 				Upload: &cdiv1.DataVolumeSourceUpload{},
 			},
-			Storage: pvcSpec,
+			ContentType: contentType,
+			Storage:     pvcSpec,
 		},
 	}
 
@@ -585,15 +610,22 @@ func createStorageSpec(client kubecli.KubevirtClient, size, storageClass, access
 	return spec, nil
 }
 
-func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*v1.PersistentVolumeClaim, error) {
+func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string, blockVolume, archiveUpload bool) (*v1.PersistentVolumeClaim, error) {
 	pvcSpec, err := createPVCSpec(size, storageClass, accessMode, blockVolume)
 	if err != nil {
 		return nil, err
 	}
 
+	contentType := string(cdiv1.DataVolumeKubeVirt)
+	if archiveUpload {
+		contentType = string(cdiv1.DataVolumeArchive)
+	}
+
 	annotations := map[string]string{
 		uploadRequestAnnotation: "",
+		contentTypeAnnotation:   contentType,
 	}
+
 	if forceBind {
 		annotations[forceImmediateBindingAnnotation] = ""
 	}
@@ -668,7 +700,7 @@ func ensurePVCSupportsUpload(client kubernetes.Interface, pvc *v1.PersistentVolu
 	return pvc, nil
 }
 
-func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name string, shouldExist bool) (*v1.PersistentVolumeClaim, error) {
+func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name string, shouldExist, archiveUpload bool) (*v1.PersistentVolumeClaim, error) {
 	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		fmt.Printf("PVC %s/%s not found \n", namespace, name)
@@ -699,6 +731,15 @@ func getAndValidateUploadPVC(client kubecli.KubevirtClient, namespace, name stri
 
 	if !shouldExist && !isUploadPVC {
 		return nil, fmt.Errorf("PVC %s not available for upload", name)
+	}
+
+	// for PVCs that exist and the user wants to upload archive
+	// the pvc has to have the contentType archive annotation
+	if archiveUpload {
+		contentType, found := pvc.Annotations[contentTypeAnnotation]
+		if !found || contentType != string(cdiv1.DataVolumeArchive) {
+			return nil, fmt.Errorf("PVC %s doesn't have archive contentType annotation", name)
+		}
 	}
 
 	return pvc, nil

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -35,6 +35,7 @@ const (
 	commandName                     = "image-upload"
 	uploadRequestAnnotation         = "cdi.kubevirt.io/storage.upload.target"
 	forceImmediateBindingAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
+	contentTypeAnnotation           = "cdi.kubevirt.io/storage.contentType"
 	podPhaseAnnotation              = "cdi.kubevirt.io/storage.pod.phase"
 	podReadyAnnotation              = "cdi.kubevirt.io/storage.pod.ready"
 )
@@ -58,7 +59,8 @@ var _ = Describe("ImageUpload", func() {
 		pvcCreateCalled = &atomicBool{lock: &sync.Mutex{}}
 		updateCalled    = &atomicBool{lock: &sync.Mutex{}}
 
-		imagePath string
+		imagePath       string
+		archiveFilePath string
 	)
 
 	BeforeEach(func() {
@@ -74,11 +76,14 @@ var _ = Describe("ImageUpload", func() {
 		defer imageFile.Close()
 
 		imagePath = imageFile.Name()
+
+		archiveFilePath = tests.ArchiveFiles("archive", os.TempDir(), imagePath)
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
 		os.Remove(imagePath)
+		os.Remove(archiveFilePath)
 	})
 
 	pvcSpec := func() *v1.PersistentVolumeClaim {
@@ -193,6 +198,9 @@ var _ = Describe("ImageUpload", func() {
 		time.Sleep(10 * time.Millisecond)
 		pvc := pvcSpecWithUploadAnnotation()
 
+		if dv.Spec.ContentType == cdiv1.DataVolumeArchive {
+			pvc.Annotations[contentTypeAnnotation] = string(cdiv1.DataVolumeArchive)
+		}
 		pvc.Spec.VolumeMode = getVolumeMode(dv.Spec)
 		pvc.Spec.AccessModes = append([]v1.PersistentVolumeAccessMode(nil), getAccessModes(dv.Spec)...)
 		pvc.Spec.StorageClassName = getStorageClassName(dv.Spec)
@@ -292,6 +300,19 @@ var _ = Describe("ImageUpload", func() {
 		validatePVCSpec(&pvc.Spec, mode)
 	}
 
+	validateArchivePVC := func() {
+		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Get(context.Background(), targetName, metav1.GetOptions{})
+		Expect(err).To(BeNil())
+
+		_, ok := pvc.Annotations[uploadRequestAnnotation]
+		Expect(ok).To(BeTrue())
+		contentType, ok := pvc.Annotations[contentTypeAnnotation]
+		Expect(ok).To(BeTrue())
+		Expect(contentType).To(Equal(string(cdiv1.DataVolumeArchive)))
+
+		validatePVCSpec(&pvc.Spec, v1.PersistentVolumeFilesystem)
+	}
+
 	validatePVC := func() {
 		validatePVCArgs(v1.PersistentVolumeFilesystem)
 	}
@@ -302,6 +323,14 @@ var _ = Describe("ImageUpload", func() {
 
 	validateDataVolumeArgs := func(dv *cdiv1.DataVolume, mode v1.PersistentVolumeMode) {
 		validateDvStorageSpec(dv.Spec, mode)
+	}
+
+	validateArchiveDataVolume := func() {
+		dv, err := cdiClient.CdiV1beta1().DataVolumes(targetNamespace).Get(context.Background(), targetName, metav1.GetOptions{})
+		Expect(err).To(BeNil())
+
+		validateDvStorageSpec(dv.Spec, v1.PersistentVolumeFilesystem)
+		Expect(dv.Spec.ContentType).To(Equal(cdiv1.DataVolumeArchive))
 	}
 
 	validateDataVolume := func() {
@@ -444,6 +473,16 @@ var _ = Describe("ImageUpload", func() {
 			Entry("DV does not exist sync", false),
 		)
 
+		It("upload archive file DV doest not exist", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--archive-path", archiveFilePath)
+			Expect(cmd()).To(BeNil())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
+			validateArchivePVC()
+			validateArchiveDataVolume()
+		})
+
 		It("DV does not exist --pvc-size", func() {
 			testInit(http.StatusOK)
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--pvc-size", pvcSize,
@@ -529,6 +568,26 @@ var _ = Describe("ImageUpload", func() {
 			Entry("PVC without upload annotation and no annotation map", pvcSpecNoAnnotationMap()),
 		)
 
+		It("Archive upload PVC does not exist", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName, "--size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--archive-path", archiveFilePath)
+			Expect(cmd()).To(BeNil())
+			Expect(pvcCreateCalled.IsTrue()).To(BeTrue())
+			validateArchivePVC()
+		})
+
+		It("Archive upload PVC exist", func() {
+			pvc := pvcSpecWithUploadAnnotation()
+			pvc.Annotations[contentTypeAnnotation] = string(cdiv1.DataVolumeArchive)
+			testInit(http.StatusOK, pvc)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName,
+				"--uploadproxy-url", server.URL, "--no-create", "--insecure", "--archive-path", archiveFilePath)
+			Expect(cmd()).To(BeNil())
+			Expect(pvcCreateCalled.IsTrue()).To(BeFalse())
+			validateArchivePVC()
+		})
+
 		It("Show error when uploading to ReadOnly volume", func() {
 			testInit(http.StatusOK)
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
@@ -552,6 +611,15 @@ var _ = Describe("ImageUpload", func() {
 			err := cmd()
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("No DataVolume is associated with the existing PVC"))
+		})
+
+		It("PVC exists without archive contentType for archive upload", func() {
+			testInit(http.StatusOK, pvcSpecWithUploadAnnotation())
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName,
+				"--uploadproxy-url", server.URL, "--no-create", "--insecure", "--archive-path", archiveFilePath)
+			err := cmd()
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("doesn't have archive contentType annotation"))
 		})
 
 		It("DV in phase WaitForFirstConsumer", func() {
@@ -594,7 +662,7 @@ var _ = Describe("ImageUpload", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).Should(Equal(errString))
 		},
-			Entry("No args", "required flag(s) \"image-path\" not set", []string{}),
+			Entry("No args", "either image-path or archive-path most be provided", []string{}),
 			Entry("Missing arg", "expecting two args",
 				[]string{"targetName", "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("No name", "expecting two args",
@@ -603,8 +671,12 @@ var _ = Describe("ImageUpload", func() {
 				[]string{"dv", targetName, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("Size invalid", "validation failed for size=500Zb: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
 				[]string{"dv", targetName, "--size", "500Zb", "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
-			Entry("No image path", "required flag(s) \"image-path\" not set",
+			Entry("No image path nor archive-path", "either image-path or archive-path most be provided",
 				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure"}),
+			Entry("Image path and archive path provided", "cannot handle both image-path and archive-path, provide only one",
+				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null", "--archive-path", "/dev/null.tar"}),
+			Entry("Archive path and block volume true provided", "In archive upload the volume mode should always be filesystem",
+				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--archive-path", "/dev/null.tar", "--block-volume"}),
 			Entry("PVC name and args", "cannot use --pvc-name and args",
 				[]string{"foo", "--pvc-name", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("Unexpected resource type", "invalid resource type foo",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -20,6 +20,7 @@
 package tests
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	cryptorand "crypto/rand"
@@ -5298,5 +5299,34 @@ func CreateCephPVC(virtClient kubecli.KubevirtClient, name string, size resource
 	Expect(err).ToNot(HaveOccurred())
 
 	return createdPvc
+}
 
+func ArchiveFiles(targetFile, tgtDir string, sourceFilesNames ...string) string {
+	tgtPath := filepath.Join(tgtDir, filepath.Base(targetFile)+".tar")
+	tgtFile, err := os.Create(tgtPath)
+	Expect(err).ToNot(HaveOccurred())
+	defer tgtFile.Close()
+
+	w := tar.NewWriter(tgtFile)
+	defer w.Close()
+
+	for _, src := range sourceFilesNames {
+		srcFile, err := os.Open(src)
+		Expect(err).ToNot(HaveOccurred())
+		defer srcFile.Close()
+
+		srcFileInfo, err := srcFile.Stat()
+		Expect(err).ToNot(HaveOccurred())
+
+		hdr, err := tar.FileInfoHeader(srcFileInfo, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = w.WriteHeader(hdr)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = io.Copy(w, srcFile)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return tgtPath
 }


### PR DESCRIPTION
Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
this should be merged after PR: https://github.com/kubevirt/containerized-data-importer/pull/1969 is merged,
released and CDI version is bumped in kubevirt

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use virtctl image-upload to upload archive content
```
