### PR TITLE
Fix flaky Macvtap test: Increase macvtap interface IP report timeout

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1310,9 +1310,11 @@ var _ = SIGDescribe("[Serial]Macvtap", func() {
 			var serverVMIPodName string
 			var serverIP string
 
-			getVMMacvtapIfaceIP := func(vmi *v1.VirtualMachineInstance, macAddress string) (string, error) {
+			macvtapIfaceIPReportTimeout := 4 * time.Minute
+
+			waitVMMacvtapIfaceIPReport := func(vmi *v1.VirtualMachineInstance, macAddress string, timeout time.Duration) (string, error) {
 				var vmiIP string
-				err := wait.PollImmediate(time.Second, 2*time.Minute, func() (done bool, err error) {
+				err := wait.PollImmediate(time.Second, timeout, func() (done bool, err error) {
 					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
 					if err != nil {
 						return false, err
@@ -1356,7 +1358,7 @@ var _ = SIGDescribe("[Serial]Macvtap", func() {
 				Expect(serverVMI.Status.Interfaces).NotTo(BeEmpty(), "a migrate-able VMI must have network interfaces")
 				serverVMIPodName = tests.GetVmPodName(virtClient, serverVMI)
 
-				serverIP, err = getVMMacvtapIfaceIP(serverVMI, macAddress)
+				serverIP, err = waitVMMacvtapIfaceIPReport(serverVMI, macAddress, macvtapIfaceIPReportTimeout)
 				Expect(err).NotTo(HaveOccurred(), "should have managed to figure out the IP of the server VMI")
 			})
 


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following #6318 

We see macvtap test failures due to timeout of reporting the macvtap interface IP address
for a while now [1] [2] [3].
This PR increase the time we wait for it to be reported.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6267/pull-kubevirt-e2e-k8s-1.21-sig-network/1432264444922040320
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6312/pull-kubevirt-e2e-k8s-1.21-sig-network/1432303029054345216
[3] https://search.ci.kubevirt.io/?search=should+have+managed+to+figure+out+the+IP+of+the+server+VMI&maxAge=336h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/6500
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
