### PR TITLE
virt-launcher, Add subdomain name to search list

### DIFF
--- a/pkg/network/cache/types.go
+++ b/pkg/network/cache/types.go
@@ -35,6 +35,7 @@ type DHCPConfig struct {
 	Mtu                 uint16
 	IPAMDisabled        bool
 	Gateway             net.IP
+	Subdomain           string
 }
 
 func (d DHCPConfig) String() string {

--- a/pkg/network/dhcp/bridge.go
+++ b/pkg/network/dhcp/bridge.go
@@ -16,6 +16,7 @@ type BridgeConfigGenerator struct {
 	launcherPID      string
 	vmiSpecIfaces    []v1.Interface
 	vmiSpecIface     *v1.Interface
+	subdomain        string
 }
 
 func (d *BridgeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
@@ -40,6 +41,7 @@ func (d *BridgeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 		return nil, err
 	}
 	dhcpConfig.Mtu = uint16(podNicLink.Attrs().MTU)
+	dhcpConfig.Subdomain = d.subdomain
 
 	return dhcpConfig, nil
 }

--- a/pkg/network/dhcp/configurator.go
+++ b/pkg/network/dhcp/configurator.go
@@ -50,21 +50,24 @@ type ConfigGenerator interface {
 }
 
 func NewBridgeConfigurator(cacheFactory cache.InterfaceCacheFactory, launcherPID string, advertisingIfaceName string, handler netdriver.NetworkHandler, podInterfaceName string,
-	vmiSpecIfaces []v1.Interface, vmiSpecIface *v1.Interface) *configurator {
+	vmiSpecIfaces []v1.Interface, vmiSpecIface *v1.Interface, subdomain string) *configurator {
 	return &configurator{
 		podInterfaceName:     podInterfaceName,
 		advertisingIfaceName: advertisingIfaceName,
 		handler:              handler,
 		dhcpStartedDirectory: defaultDHCPStartedDirectory,
-		configGenerator:      &BridgeConfigGenerator{handler: handler, cacheFactory: cacheFactory, podInterfaceName: podInterfaceName, launcherPID: launcherPID, vmiSpecIfaces: vmiSpecIfaces, vmiSpecIface: vmiSpecIface},
+		configGenerator: &BridgeConfigGenerator{handler: handler, cacheFactory: cacheFactory, podInterfaceName: podInterfaceName, launcherPID: launcherPID,
+			vmiSpecIfaces: vmiSpecIfaces, vmiSpecIface: vmiSpecIface, subdomain: subdomain},
 	}
 }
 
-func NewMasqueradeConfigurator(advertisingIfaceName string, handler netdriver.NetworkHandler, vmiSpecIface *v1.Interface, vmiSpecNetwork *v1.Network, podInterfaceName string) *configurator {
+func NewMasqueradeConfigurator(advertisingIfaceName string, handler netdriver.NetworkHandler, vmiSpecIface *v1.Interface, vmiSpecNetwork *v1.Network, podInterfaceName string,
+	subdomain string) *configurator {
 	return &configurator{
 		podInterfaceName:     podInterfaceName,
 		advertisingIfaceName: advertisingIfaceName,
-		configGenerator:      &MasqueradeConfigGenerator{handler: handler, vmiSpecIface: vmiSpecIface, vmiSpecNetwork: vmiSpecNetwork, podInterfaceName: podInterfaceName},
+		configGenerator: &MasqueradeConfigGenerator{handler: handler, vmiSpecIface: vmiSpecIface, vmiSpecNetwork: vmiSpecNetwork,
+			subdomain: subdomain, podInterfaceName: podInterfaceName},
 		handler:              handler,
 		dhcpStartedDirectory: defaultDHCPStartedDirectory,
 	}

--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -36,13 +36,13 @@ var _ = Describe("DHCP configurator", func() {
 	})
 
 	newBridgeConfigurator := func(launcherPID string, advertisingIfaceName string) Configurator {
-		configurator := NewBridgeConfigurator(cache.NewInterfaceCacheFactoryWithBasePath(fakeDhcpStartedDir), launcherPID, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), "", nil, nil)
+		configurator := NewBridgeConfigurator(cache.NewInterfaceCacheFactoryWithBasePath(fakeDhcpStartedDir), launcherPID, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), "", nil, nil, "")
 		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
 		return configurator
 	}
 
 	newMasqueradeConfigurator := func(advertisingIfaceName string) Configurator {
-		configurator := NewMasqueradeConfigurator(advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), nil, nil, "")
+		configurator := NewMasqueradeConfigurator(advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), nil, nil, "", "")
 		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
 		return configurator
 	}

--- a/pkg/network/dhcp/masquerade.go
+++ b/pkg/network/dhcp/masquerade.go
@@ -34,6 +34,7 @@ type MasqueradeConfigGenerator struct {
 	vmiSpecIface     *v1.Interface
 	vmiSpecNetwork   *v1.Network
 	podInterfaceName string
+	subdomain        string
 }
 
 func (d *MasqueradeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
@@ -67,6 +68,7 @@ func (d *MasqueradeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 		}
 		dhcpConfig.IPv6 = *ipv6
 		dhcpConfig.AdvertisingIPv6Addr = ipv6Gateway.IP.To16()
+		dhcpConfig.Subdomain = d.subdomain
 	}
 
 	return dhcpConfig, nil

--- a/pkg/network/dhcp/server/BUILD.bazel
+++ b/pkg/network/dhcp/server/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/network/dhcp/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/dns:go_default_library",
         "//staging/src/kubevirt.io/client-go/apis/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/krolaw/dhcp4:go_default_library",

--- a/pkg/network/dhcp/server/server.go
+++ b/pkg/network/dhcp/server/server.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/client-go/apis/core/v1"
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/network/dns"
 )
 
 const (
@@ -134,7 +135,7 @@ func prepareDHCPOptions(
 	dhcpOptions[dhcp.OptionHostName] = []byte(hostname)
 
 	// Windows will ask for the domain name and use it for DNS resolution
-	domainName := getDomainName(searchDomains)
+	domainName := dns.GetDomainName(searchDomains)
 	if len(domainName) > 0 {
 		dhcpOptions[dhcp.OptionDomainName] = []byte(domainName)
 	}
@@ -317,15 +318,4 @@ func isValidSearchDomain(domain string) bool {
 		return false
 	}
 	return searchDomainValidationRegex.MatchString(domain)
-}
-
-//getDomainName returns the longest search domain entry, which is the most exact equivalent to a domain
-func getDomainName(searchDomains []string) string {
-	selected := ""
-	for _, d := range searchDomains {
-		if len(d) > len(selected) {
-			selected = d
-		}
-	}
-	return selected
 }

--- a/pkg/network/dhcp/server/server_test.go
+++ b/pkg/network/dhcp/server/server_test.go
@@ -134,20 +134,6 @@ var _ = Describe("DHCP Server", func() {
 		})
 	})
 
-	Context("function getDomainName", func() {
-		It("should return the longest search domain entry", func() {
-			searchDomains := []string{
-				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
-				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
-				"t4lanpt7z4ix58nvxl4d.com",
-				"14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
-				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
-			}
-			domain := getDomainName(searchDomains)
-			Expect(domain).To(Equal("14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com"))
-		})
-	})
-
 	Context("function isValidSearchDomain(domain string) bool", func() {
 		createBytes := func(size int) []byte {
 			b := make([]byte, size)

--- a/pkg/network/dns/resolveconf.go
+++ b/pkg/network/dns/resolveconf.go
@@ -72,3 +72,14 @@ func ParseSearchDomains(content string) ([]string, error) {
 
 	return searchDomains, nil
 }
+
+//GetDomainName returns the longest search domain entry, which is the most exact equivalent to a domain
+func GetDomainName(searchDomains []string) string {
+	selected := ""
+	for _, d := range searchDomains {
+		if len(d) > len(selected) {
+			selected = d
+		}
+	}
+	return selected
+}

--- a/pkg/network/dns/resolveconf.go
+++ b/pkg/network/dns/resolveconf.go
@@ -83,3 +83,23 @@ func GetDomainName(searchDomains []string) string {
 	}
 	return selected
 }
+
+//DomainNameWithSubdomain returns the DNS domain according subdomain.
+//In case subdomain already exists in the domain, returns empty string, as nothing should be added.
+//In case subdomain is empty, returns empty string, as nothing should be added.
+//The motivation is that glibc prior to 2.26 had 6 domain / 256 bytes limit,
+//Due to this limitation subdomain.namespace.svc.cluster.local DNS was not added by k8s to the pod /etc/resolv.conf.
+//This function calculates the missing domain, which will be added by kubevirt.
+//see https://github.com/kubernetes/kubernetes/issues/48019 for more details.
+func DomainNameWithSubdomain(searchDomains []string, subdomain string) string {
+	if subdomain == "" {
+		return ""
+	}
+
+	domainName := GetDomainName(searchDomains)
+	if !strings.Contains(domainName, subdomain) {
+		return subdomain + "." + domainName
+	}
+
+	return ""
+}

--- a/pkg/network/dns/resolveconf_test.go
+++ b/pkg/network/dns/resolveconf_test.go
@@ -77,4 +77,18 @@ var _ = Describe("Resolveconf", func() {
 			Expect(err).To(BeNil())
 		})
 	})
+
+	Context("function GetDomainName", func() {
+		It("should return the longest search domain entry", func() {
+			searchDomains := []string{
+				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
+				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				"t4lanpt7z4ix58nvxl4d.com",
+				"14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+			}
+			domain := GetDomainName(searchDomains)
+			Expect(domain).To(Equal("14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com"))
+		})
+	})
 })

--- a/pkg/network/dns/resolveconf_test.go
+++ b/pkg/network/dns/resolveconf_test.go
@@ -91,4 +91,38 @@ var _ = Describe("Resolveconf", func() {
 			Expect(domain).To(Equal("14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com"))
 		})
 	})
+
+	Context("subdomain", func() {
+		It("should be added to the longest domain", func() {
+			searchDomains := []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+
+			const subdomain = "subdomain"
+			domain := DomainNameWithSubdomain(searchDomains, subdomain)
+			Expect(domain).To(Equal(subdomain + "." + searchDomains[0]))
+		})
+
+		It("should not be added if subdomain is empty", func() {
+			searchDomains := []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+
+			const subdomain = ""
+			domain := DomainNameWithSubdomain(searchDomains, subdomain)
+			Expect(domain).To(Equal(""))
+		})
+
+		It("should be added even if the longest existing domain isn't the first", func() {
+			searchDomains := []string{"svc.cluster.local", "cluster.local", "default.svc.cluster.local"}
+
+			const subdomain = "subdomain"
+			domain := DomainNameWithSubdomain(searchDomains, subdomain)
+			Expect(domain).To(Equal(subdomain + "." + searchDomains[2]))
+		})
+
+		It("should not be added if the longest existing domain already has it", func() {
+			searchDomains := []string{"svc.cluster.local", "cluster.local", "subdomain.default.svc.cluster.local"}
+
+			const subdomain = "subdomain"
+			domain := DomainNameWithSubdomain(searchDomains, subdomain)
+			Expect(domain).To(Equal(""))
+		})
+	})
 })

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/network/cache:go_default_library",
         "//pkg/network/dhcp/server:go_default_library",
         "//pkg/network/dhcp/serverv6:go_default_library",
+        "//pkg/network/dns:go_default_library",
         "//pkg/network/link:go_default_library",
         "//pkg/util/sysctl:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	dhcpserver "kubevirt.io/kubevirt/pkg/network/dhcp/server"
 	dhcpserverv6 "kubevirt.io/kubevirt/pkg/network/dhcp/serverv6"
+	"kubevirt.io/kubevirt/pkg/network/dns"
 	"kubevirt.io/kubevirt/pkg/network/link"
 	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
 )
@@ -341,6 +342,11 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceNa
 	nameservers, searchDomains, err := converter.GetResolvConfDetailsFromPod()
 	if err != nil {
 		return fmt.Errorf("Failed to get DNS servers from resolv.conf: %v", err)
+	}
+
+	domain := dns.DomainNameWithSubdomain(searchDomains, nic.Subdomain)
+	if domain != "" {
+		searchDomains = append([]string{domain}, searchDomains...)
 	}
 
 	// panic in case the DHCP server failed during the vm creation

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -270,14 +270,16 @@ func (l *podNIC) newDHCPConfigurator() dhcpconfigurator.Configurator {
 			l.handler,
 			l.podInterfaceName,
 			l.vmi.Spec.Domain.Devices.Interfaces,
-			l.vmiSpecIface)
+			l.vmiSpecIface,
+			l.vmi.Spec.Subdomain)
 	} else if l.vmiSpecIface.Masquerade != nil {
 		dhcpConfigurator = dhcpconfigurator.NewMasqueradeConfigurator(
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
 			l.handler,
 			l.vmiSpecIface,
 			l.vmiSpecNetwork,
-			l.podInterfaceName)
+			l.podInterfaceName,
+			l.vmi.Spec.Subdomain)
 	}
 	return dhcpConfigurator
 }

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "vmi_multus.go",
         "vmi_networking.go",
         "vmi_slirp_interface.go",
+        "vmi_subdomain.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/network",
     visibility = ["//visibility:public"],

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	expect "github.com/google/goexpect"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/apis/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	netservice "kubevirt.io/kubevirt/tests/libnet/service"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = SIGDescribe("Subdomain", func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
+
+		tests.BeforeTestCleanup()
+	})
+
+	Context("with a headless service given", func() {
+		const (
+			subdomain          = "testsubdomain"
+			selectorLabelKey   = "expose"
+			selectorLabelValue = "this"
+			servicePort        = 22
+		)
+
+		BeforeEach(func() {
+			serviceName := subdomain
+			service := netservice.BuildHeadlessSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
+			_, err := virtClient.CoreV1().Services(util.NamespaceTestDefault).Create(context.Background(), service, k8smetav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		table.DescribeTable("VMI should have the expected FQDN", func(f func() *v1.VirtualMachineInstance, subdom string) {
+			vmiSpec := f()
+			var expectedFQDN string
+			if subdom != "" {
+				vmiSpec.Spec.Subdomain = subdom
+				expectedFQDN = fmt.Sprintf("%s.%s.%s.svc.cluster.local", vmiSpec.Name, subdom, util.NamespaceTestDefault)
+			} else {
+				expectedFQDN = vmiSpec.Name
+			}
+			vmiSpec.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
+
+			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiSpec)
+			Expect(err).ToNot(HaveOccurred())
+			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "hostname -f\n"},
+				&expect.BExp{R: expectedFQDN},
+			}, 10)).To(Succeed(), "failed to get expected FQDN")
+		},
+			table.Entry("with Masquerade binding and subdomain", fedoraMasqueradeVMI, subdomain),
+			table.Entry("with Bridge binding and subdomain", fedoraBridgeBindingVMI, subdomain),
+			table.Entry("with Masquerade binding without subdomain", fedoraMasqueradeVMI, ""),
+			table.Entry("with Bridge binding without subdomain", fedoraBridgeBindingVMI, ""),
+		)
+	})
+})
+
+func fedoraMasqueradeVMI() *v1.VirtualMachineInstance {
+	return libvmi.NewFedora(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()))
+}
+
+func fedoraBridgeBindingVMI() *v1.VirtualMachineInstance {
+	return libvmi.NewFedora(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()))
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

Kubevirt supports k8s subdomain feature (https://github.com/kubevirt/kubevirt/pull/784).

Since k8s doesn't update `/etc/resolv.conf` with the subdomain [1],
a VM can't resolves its own DNS / FQDN because the subdomain is missing as part of the FQDN.

This PR adds the missing subdomain to the search list (via DHCP option 119),
This way the FQDN can be resolved to
`vm_name.subdomain.namespace.svc.cluster_domain` as given by k8s.
Option 15 is affected as well, because option 15 takes the longest of `searchDomains`
which is now the one with subdomain.

In order to have the DNS entry added by k8s,
a headless service in the same namespace of the VMIs should exists.
It should be named as the subdomain.
The service should have a selector matching the VMIs in the subdomain.

This feature is supported for Bridge Binding and Masquerade, because DHCP is needed.

Note that older guests (glibc < 2.26) are limited to 6 domains / 256 bytes,
with the new additional domain, kubevirt propagates 4 via DHCP.
https://access.redhat.com/solutions/58028

[1] https://github.com/kubernetes/kubernetes/issues/48019

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):**
https://bugzilla.redhat.com/show_bug.cgi?id=1998300

**Special notes for your reviewer:**

**Release note:**
```release-note
Add missing domain to guest search list, in case subdomain is used.
Guests that use glibc prior to 2.26, have DNS search list size limited to 6.
Kubevirt by default used 3, and now added the 4th in case subdomain is used.
In case a guest used already all the 6, the last one will be dropped.
```
