### PR TITLE
[release-0.36] Fix domain lookup to ensure target pod of migration is cleanup

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -212,24 +212,40 @@ func initializeDirs(virtShareDir string,
 	}
 }
 
+func detectDomainWithUUID(domainManager virtwrap.DomainManager) *api.Domain {
+	domains, err := domainManager.ListAllDomains()
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to list domains when detecting UUID")
+		return nil
+	}
+	for _, domain := range domains {
+		if domain.Spec.UUID != "" {
+			return domain
+		}
+	}
+	return nil
+}
+
 func waitForDomainUUID(timeout time.Duration, events chan watch.Event, stop chan struct{}, domainManager virtwrap.DomainManager) *api.Domain {
 
 	ticker := time.NewTicker(timeout).C
 	checkEarlyExit := time.NewTicker(time.Second * 2).C
+	domainCheckTicker := time.NewTicker(time.Second * 10).C
 	for {
 		select {
 		case <-ticker:
 			panic(fmt.Errorf("timed out waiting for domain to be defined"))
-		case e := <-events:
-			if e.Object != nil && e.Type == watch.Added {
-				domain := e.Object.(*api.Domain)
-				log.Log.Infof("Detected domain with UUID %s", domain.Spec.UUID)
+		case <-domainCheckTicker:
+			log.Log.V(3).Infof("Periodically checking for domain with UUID")
+			domain := detectDomainWithUUID(domainManager)
+			if domain != nil {
 				return domain
-			} else if e.Type == watch.Modified {
-				domain, ok := e.Object.(*api.Domain)
-				if ok && domain.ObjectMeta.DeletionTimestamp != nil {
-					return nil
-				}
+			}
+		case <-events:
+			log.Log.V(3).Infof("Checking for domain with UUID due to incoming libvirt event")
+			domain := detectDomainWithUUID(domainManager)
+			if domain != nil {
+				return domain
 			}
 		case <-stop:
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
virt-launcher will actively check for newly created domains during the start

So far waitForDomainUUID reacted to libvirt events. In some cases, an empty
domain object could be received which would prevent the virt-launcher from
terminating when not running domains has been detected. This patch will not
consider domain objects without UUID. It will also actively query for new
domains.

This prevents cases where migration will not be processed if previous migration failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a cherrypick from https://github.com/kubevirt/kubevirt/pull/5328
**Release note**:

```release-note
Fix cases where migration will not be processed if previous migration failed.
```
