### PR TITLE
[virt-launcher]: lower the log severity of GA unsupported commands

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -374,6 +374,17 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 	pos := strings.TrimSpace(fragments[3])
 	msg := strings.TrimSpace(fragments[4])
 
+	//TODO: implement proper behavior for unsupported GA commands
+	// by either considering the GA version as unsupported or just don't
+	// send commands which not supported
+	if strings.Contains(msg, "unable to execute QEMU agent command") {
+		if logger.verbosityLevel < 4 {
+			return
+		}
+
+		severity = LogLevelNames[WARNING]
+	}
+
 	// check if we really got a position
 	isPos := false
 	if split := strings.Split(pos, ":"); len(split) == 2 {


### PR DESCRIPTION
It's a temporary solution until we will implement a proper behavior
of the virt-launcher in cases of unsupported GA commands.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The urgency for lowering this message came from a large scale
environment where this message appears to abuse the monitoring
system of the cluster.

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2008522

**Release note**:
```release-note
NONE
```
