### PR TITLE
Default to KUBEVIRT_DEPLOY_CDI=true here as well

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -20,6 +20,7 @@
 set -ex pipefail
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
+KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-true}
 
 source hack/common.sh
 # shellcheck disable=SC1090


### PR DESCRIPTION
Currently we have a confused notion of what it ought to be when not
set, resulting in the CDI object not being patched to allow the
insecure registry registry:5000.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
