### PR TITLE
Add linux nodeSelector test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -246,6 +246,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/selection:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
@@ -2212,6 +2213,29 @@ spec:
 			}
 			errMsg := fmt.Sprintf("Unsupported value: \"%s\"", incorrectOperator)
 			patchKvWorkloads(&incorrectWorkload, true, errMsg)
+		})
+
+		It("[test_id:TODO]should place components only on linux nodes", func() {
+			// Only below mentioned components have nodeSelector specified
+			labelReq, err := labels.NewRequirement(v1.AppLabel, selection.In, []string{
+				components.VirtAPIName,
+				components.VirtControllerName,
+				components.VirtHandlerName,
+			})
+			if err != nil {
+				panic(err)
+			}
+
+			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: labels.NewSelector().Add(
+					*labelReq,
+				).String(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			for _, pod := range pods.Items {
+				Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/os", "linux"), fmt.Sprintf("pod %s does not have linux node selector", pod.Name))
+			}
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a test ensuring control plane components only get scheduled on linux nodes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Improves the stale PR #6381


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
