### PR TITLE
tests, sriov: test vlan with vmi recreation

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnet/service:go_default_library",
         "//tests/libvmi:go_default_library",


### PR DESCRIPTION
Signed-off-by: alonsadan <asadan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Connectivcity over sriov between two VMIs on the same vlan, should not be affected
When deleting and re-creating the machines. This commit added a e2e test for that case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
For example, an issue that might be related : 
https://github.com/kubevirt/kubevirt/issues/6351

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
