### PR TITLE
Mark paused VMs as unready

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -496,6 +496,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods/status
+          verbs:
+          - patch
+        - apiGroups:
+          - ""
+          resources:
           - nodes
           verbs:
           - get

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -398,6 +398,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -19,6 +19,8 @@
 package controller
 
 import (
+	"reflect"
+
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -62,6 +64,10 @@ func (d *VirtualMachineConditionManager) RemoveCondition(vm *v1.VirtualMachine, 
 }
 
 type VirtualMachineInstanceConditionManager struct {
+}
+
+func NewVirtualMachineInstanceConditionManager() *VirtualMachineInstanceConditionManager {
+	return &VirtualMachineInstanceConditionManager{}
 }
 
 // UpdateCondition updates the given VirtualMachineCondition, unless it is already set with the same status and reason.
@@ -172,32 +178,6 @@ func (d *VirtualMachineInstanceConditionManager) AddPodCondition(vmi *v1.Virtual
 	}
 }
 
-func (d *VirtualMachineInstanceConditionManager) PodHasCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) bool {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == conditionType {
-			if cond.Status == status {
-				return true
-			} else {
-				return false
-			}
-		}
-	}
-	return false
-}
-
-func (d *VirtualMachineInstanceConditionManager) GetPodConditionWithStatus(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) *k8sv1.PodCondition {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == conditionType {
-			if cond.Status == status {
-				return &cond
-			} else {
-				return nil
-			}
-		}
-	}
-	return nil
-}
-
 func (d *VirtualMachineInstanceConditionManager) GetPodCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType) *k8sv1.PodCondition {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == conditionType {
@@ -207,11 +187,34 @@ func (d *VirtualMachineInstanceConditionManager) GetPodCondition(pod *k8sv1.Pod,
 	return nil
 }
 
-func NewVirtualMachineInstanceConditionManager() *VirtualMachineInstanceConditionManager {
-	return &VirtualMachineInstanceConditionManager{}
+func (d *VirtualMachineInstanceConditionManager) ConditionsEqual(vmi1, vmi2 *v1.VirtualMachineInstance) bool {
+	if len(vmi1.Status.Conditions) != len(vmi2.Status.Conditions) {
+		return false
+	}
+
+	for _, cond1 := range vmi1.Status.Conditions {
+		found := false
+
+		for _, cond2 := range vmi2.Status.Conditions {
+			if reflect.DeepEqual(cond1, cond2) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 type VirtualMachineInstanceMigrationConditionManager struct {
+}
+
+func NewVirtualMachineInstanceMigrationConditionManager() *VirtualMachineInstanceMigrationConditionManager {
+	return &VirtualMachineInstanceMigrationConditionManager{}
 }
 
 func (d *VirtualMachineInstanceMigrationConditionManager) HasCondition(migration *v1.VirtualMachineInstanceMigration, cond v1.VirtualMachineInstanceMigrationConditionType) bool {
@@ -245,11 +248,12 @@ func (d *VirtualMachineInstanceMigrationConditionManager) RemoveCondition(migrat
 	}
 	migration.Status.Conditions = conds
 }
-func NewVirtualMachineInstanceMigrationConditionManager() *VirtualMachineInstanceMigrationConditionManager {
-	return &VirtualMachineInstanceMigrationConditionManager{}
-}
 
 type DataVolumeConditionManager struct {
+}
+
+func NewDataVolumeConditionManager() *DataVolumeConditionManager {
+	return &DataVolumeConditionManager{}
 }
 
 func (d *DataVolumeConditionManager) GetCondition(dv *cdiv1.DataVolume, cond cdiv1.DataVolumeConditionType) *cdiv1.DataVolumeCondition {
@@ -278,6 +282,81 @@ func (d *DataVolumeConditionManager) HasConditionWithStatusAndReason(dv *cdiv1.D
 	return c != nil && c.Status == status && c.Reason == reason
 }
 
-func NewDataVolumeConditionManager() *DataVolumeConditionManager {
-	return &DataVolumeConditionManager{}
+type PodConditionManager struct {
+}
+
+func NewPodConditionManager() *PodConditionManager {
+	return &PodConditionManager{}
+}
+
+func (d *PodConditionManager) GetCondition(pod *k8sv1.Pod, cond k8sv1.PodConditionType) *k8sv1.PodCondition {
+	if pod == nil {
+		return nil
+	}
+	for _, c := range pod.Status.Conditions {
+		if c.Type == cond {
+			return &c
+		}
+	}
+	return nil
+}
+
+func (d *PodConditionManager) HasCondition(pod *k8sv1.Pod, cond k8sv1.PodConditionType) bool {
+	return d.GetCondition(pod, cond) != nil
+}
+
+func (d *PodConditionManager) HasConditionWithStatus(pod *k8sv1.Pod, cond k8sv1.PodConditionType, status k8sv1.ConditionStatus) bool {
+	c := d.GetCondition(pod, cond)
+	return c != nil && c.Status == status
+}
+
+func (d *PodConditionManager) RemoveCondition(pod *k8sv1.Pod, cond k8sv1.PodConditionType) {
+	var conds []k8sv1.PodCondition
+	for _, c := range pod.Status.Conditions {
+		if c.Type == cond {
+			continue
+		}
+		conds = append(conds, c)
+	}
+	pod.Status.Conditions = conds
+}
+
+// UpdateCondition updates the given PodCondition, unless it is already set with the same status and reason.
+func (d *PodConditionManager) UpdateCondition(pod *k8sv1.Pod, cond *k8sv1.PodCondition) {
+	for i, c := range pod.Status.Conditions {
+		if c.Type != cond.Type {
+			continue
+		}
+
+		if c.Status != cond.Status || c.Reason != cond.Reason {
+			pod.Status.Conditions[i] = *cond
+		}
+
+		return
+	}
+
+	pod.Status.Conditions = append(pod.Status.Conditions, *cond)
+}
+
+func (d *PodConditionManager) ConditionsEqual(pod1, pod2 *k8sv1.Pod) bool {
+	if len(pod1.Status.Conditions) != len(pod2.Status.Conditions) {
+		return false
+	}
+
+	for _, cond1 := range pod1.Status.Conditions {
+		found := false
+
+		for _, cond2 := range pod2.Status.Conditions {
+			if reflect.DeepEqual(cond1, cond2) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -19,8 +19,6 @@
 package controller
 
 import (
-	"reflect"
-
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -193,16 +191,7 @@ func (d *VirtualMachineInstanceConditionManager) ConditionsEqual(vmi1, vmi2 *v1.
 	}
 
 	for _, cond1 := range vmi1.Status.Conditions {
-		found := false
-
-		for _, cond2 := range vmi2.Status.Conditions {
-			if reflect.DeepEqual(cond1, cond2) {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if !d.HasConditionWithStatusAndReason(vmi2, cond1.Type, cond1.Status, cond1.Reason) {
 			return false
 		}
 	}
@@ -310,6 +299,11 @@ func (d *PodConditionManager) HasConditionWithStatus(pod *k8sv1.Pod, cond k8sv1.
 	return c != nil && c.Status == status
 }
 
+func (d *PodConditionManager) HasConditionWithStatusAndReason(pod *k8sv1.Pod, cond k8sv1.PodConditionType, status k8sv1.ConditionStatus, reason string) bool {
+	c := d.GetCondition(pod, cond)
+	return c != nil && c.Status == status && c.Reason == reason
+}
+
 func (d *PodConditionManager) RemoveCondition(pod *k8sv1.Pod, cond k8sv1.PodConditionType) {
 	var conds []k8sv1.PodCondition
 	for _, c := range pod.Status.Conditions {
@@ -344,16 +338,7 @@ func (d *PodConditionManager) ConditionsEqual(pod1, pod2 *k8sv1.Pod) bool {
 	}
 
 	for _, cond1 := range pod1.Status.Conditions {
-		found := false
-
-		for _, cond2 := range pod2.Status.Conditions {
-			if reflect.DeepEqual(cond1, cond2) {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if !d.HasConditionWithStatusAndReason(pod2, cond1.Type, cond1.Status, cond1.Reason) {
 			return false
 		}
 	}

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -228,7 +228,13 @@ func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, 
 		return
 	}
 
-	if !vm.Status.Ready {
+	vmi, err := app.FetchVirtualMachineInstance(namespace, name)
+	if err != nil {
+		writeError(err, response)
+		return
+	}
+
+	if vmi.Status.Phase != v1.Running {
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("VM is not running")), response)
 		return
 	}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1407,11 +1407,19 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			request.PathParameters()["namespace"] = "default"
 
 			vm := v1.VirtualMachine{}
+			vmi := v1.VirtualMachineInstance{}
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/testvm"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 				),
 			)
 
@@ -1426,9 +1434,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			request.PathParameters()["name"] = "testvm"
 			request.PathParameters()["namespace"] = "default"
 
-			vm := v1.VirtualMachine{
-				Status: v1.VirtualMachineStatus{
-					Ready: true,
+			vm := v1.VirtualMachine{}
+
+			vmi := v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					Phase: v1.Running,
 				},
 			}
 
@@ -1436,6 +1446,13 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/testvm"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 				),
 			)
 
@@ -1456,9 +1473,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			request.PathParameters()["name"] = "testvm"
 			request.PathParameters()["namespace"] = "default"
 
-			vm := v1.VirtualMachine{
-				Status: v1.VirtualMachineStatus{
-					Ready: true,
+			vm := v1.VirtualMachine{}
+
+			vmi := v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					Phase: v1.Running,
 				},
 			}
 
@@ -1466,6 +1485,13 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/testvm"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
+				),
+			)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 				),
 			)
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1385,6 +1385,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		}
 	}
 
+	readinessGates := []k8sv1.PodReadinessGate{
+		{
+			ConditionType: v1.VirtualMachineUnpaused,
+		},
+	}
+
 	// TODO use constants for podLabels
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1410,6 +1416,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			ImagePullSecrets:              imagePullSecrets,
 			DNSConfig:                     vmi.Spec.DNSConfig,
 			DNSPolicy:                     vmi.Spec.DNSPolicy,
+			ReadinessGates:                readinessGates,
 		},
 	}
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1497,7 +1497,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			setReadyCondition(vmi, k8sv1.ConditionTrue, "")
 			vmi.Status.Phase = virtv1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Status.Conditions = []k8sv1.PodCondition{{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue}}
+			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
 			pod.Spec.Containers = append(pod.Spec.Containers, k8sv1.Container{
 				Image: "madeup",
@@ -1519,7 +1519,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			setReadyCondition(vmi, k8sv1.ConditionTrue, "")
 			vmi.Status.Phase = virtv1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Status.Conditions = []k8sv1.PodCondition{{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue}}
+			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
 			if vmi.Labels == nil {
 				vmi.Labels = make(map[string]string)
@@ -1548,7 +1548,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.Conditions = nil
 			vmi.Status.Phase = virtv1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Status.Conditions = []k8sv1.PodCondition{{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue}}
+			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
 			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
@@ -1566,7 +1566,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.Phase = virtv1.Running
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.DeletionTimestamp = now()
-			pod.Status.Conditions = []k8sv1.PodCondition{{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue}}
+			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
 			addVirtualMachine(vmi)
 			addActivePods(vmi, pod.UID, "")
@@ -1616,7 +1616,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.Conditions = append(vmi.Status.Conditions,
 				virtv1.VirtualMachineInstanceCondition{Type: virtv1.VirtualMachineInstanceSynchronized, Status: k8sv1.ConditionFalse})
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
-			pod.Status.Conditions = []k8sv1.PodCondition{{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue}}
+			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -2644,6 +2644,12 @@ func NewPodForVirtualMachine(vmi *virtv1.VirtualMachineInstance, phase k8sv1.Pod
 			Phase: phase,
 			ContainerStatuses: []k8sv1.ContainerStatus{
 				{Ready: false, Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}}},
+			},
+			Conditions: []k8sv1.PodCondition{
+				{
+					Type:   virtv1.VirtualMachineUnpaused,
+					Status: k8sv1.ConditionTrue,
+				},
 			},
 		},
 	}

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -126,6 +126,17 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"",
 				},
 				Resources: []string{
+					"pods/status",
+				},
+				Verbs: []string{
+					"patch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
 					"nodes",
 				},
 				Verbs: []string{

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -764,6 +764,10 @@ const (
 
 	// RealtimeLabel marks the node as capable of running realtime workloads
 	RealtimeLabel string = "kubevirt.io/realtime"
+
+	// VirtualMachineUnpaused is a custom pod condition set for the virt-launcher pod.
+	// It's used as a readiness gate to prevent paused VMs from being marked as ready.
+	VirtualMachineUnpaused k8sv1.PodConditionType = "kubevirt.io/virtual-machine-unpaused"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -72,10 +72,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:4597]should signal paused state with condition", func() {
 				runVMI()
 
-				virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-				virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(vmi.Name, &v1.UnpauseOptions{})
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(vmi.Name, &v1.UnpauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 			})
 		})
@@ -189,6 +191,22 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, time.Duration(5)*time.Second).Should(BeTrue())
 			})
 		})
+
+		It("should not appear as ready when paused", func() {
+			runVMI()
+
+			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 30)
+
+			By("Pausing the VMI and expecting to become unready")
+			err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstanceReady, 30)
+
+			By("Unpausing the VMI and expecting to become ready")
+			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(vmi.Name, &v1.UnpauseOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 30)
+		})
 	})
 
 	Context("A valid VM", func() {
@@ -207,10 +225,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				runVM()
 
-				virtClient.VirtualMachineInstance(vm.Namespace).Pause(vm.Name, &v1.PauseOptions{})
+				err = virtClient.VirtualMachineInstance(vm.Namespace).Pause(vm.Name, &v1.PauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				virtClient.VirtualMachineInstance(vm.Namespace).Unpause(vm.Name, &v1.UnpauseOptions{})
+				err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(vm.Name, &v1.UnpauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForVMConditionRemovedOrFalse(virtClient, vm, v1.VirtualMachinePaused, 30)
 			})
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -961,7 +961,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Eventually(func() bool {
 					newVM, err = virtClient.VirtualMachine(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return newVM.Status.Ready
+					return newVM.Status.Created
 				}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Getting running VirtualMachineInstance with paused condition")
@@ -1461,7 +1461,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Eventually(func() bool {
 						virtualMachine, err = virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
-						return virtualMachine.Status.Ready
+						return virtualMachine.Status.Created
 					}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 					By("Getting running VirtualMachineInstance with paused condition")

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -261,7 +261,7 @@ var _ = Describe("[rfe_id:3423][crit:high][arm64][vendor:cnv-qe@redhat.com][leve
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusPaused), readyConditionTrue),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusPaused), MatchRegexp(vmReadyRegex)),
 			"VM should be in the %s status", v12.VirtualMachineStatusPaused)
 
 		By("Unpausing the VirtualMachine")
@@ -270,7 +270,7 @@ var _ = Describe("[rfe_id:3423][crit:high][arm64][vendor:cnv-qe@redhat.com][leve
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), readyConditionTrue),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), MatchRegexp(vmReadyRegex)),
 			"VM should be in the %s status", v12.VirtualMachineStatusRunning)
 
 		// The previous tests would be done, once succeed the following tests would be skipped on the Arm64 cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR marks VMIs as unready when they are paused.

This is done by adding a custom pod condition to the virt-launcher pod, which serves as a [readiness gate](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate).
The condition's value is toggled according to whether the VMI is paused or not, which sets the virt-launcher as unready when the condition value is false. The pod readiness condition is then synced back to the VMI and the VM for proper reporting.

This also ensures that service-fronted VMs aren't targeted with service traffic when they are paused.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #5920

**Special notes for your reviewer**:

This PR also slightly refactors the code in `pkg/controller/conditions.go` (at least until Go generics land).

**Release note**:
```release-note
Paused VMIs are now marked as unready even when no readinessProbe is specified
```
