### PR TITLE
[release-0.43] Convert gateway to IPv4 in DHCP Server

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -114,6 +114,10 @@ func prepareDHCPOptions(
 		dhcp.OptionInterfaceMTU:     mtuArray,
 	}
 
+	if len(routerIP) != 0 {
+		dhcpOptions[dhcp.OptionRouter] = routerIP.To4()
+	}
+
 	netRoutes := formClasslessRoutes(routes)
 
 	if netRoutes != nil {

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
@@ -244,5 +244,12 @@ var _ = Describe("DHCP", func() {
 			}))
 			Expect(options[240]).To(Equal([]byte("private.options.kubevirt.io")))
 		})
+
+		It("expects the gateway as an IPv4 addresses", func() {
+			gw := net.ParseIP("192.168.2.1")
+			options, err := prepareDHCPOptions(gw.DefaultMask(), gw, nil, nil, nil, 1500, "myhost", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(options[dhcp4.OptionRouter]).To(Equal([]byte{192, 168, 2, 1}))
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Backports #6465 to release 0.43.

** Notes for your reviewer **
This back-port had to be manual for conflicts with #5925, which is already available on releases 0.44 and 0.45. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
