### PR TITLE
Skip VirtIO-FS tests if the feature gate is disabled

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -427,6 +427,7 @@ var _ = SIGDescribe("Storage", func() {
 			var pvc = "empty-pvc1"
 
 			BeforeEach(func() {
+				checks.SkipTestIfNoFeatureGate(virtconfig.VirtIOFSGate)
 				tests.SkipIfNonRoot(virtClient, "VirtioFS")
 				tests.CreateHostPathPv(pvc, filepath.Join(tests.HostPathBase, pvc))
 				tests.CreateHostPathPVC(pvc, "1G")
@@ -477,6 +478,7 @@ var _ = SIGDescribe("Storage", func() {
 		Context("Run a VMI with VirtIO-FS and a datavolume", func() {
 			var dataVolume *cdiv1.DataVolume
 			BeforeEach(func() {
+				checks.SkipTestIfNoFeatureGate(virtconfig.VirtIOFSGate)
 				tests.SkipIfNonRoot(virtClient, "VirtioFS")
 				if !tests.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")


### PR DESCRIPTION
Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
