### PR TITLE
tests: migration: add debug log for flaky test

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -313,12 +313,12 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 	}
 
 	getLibvirtdPid := func(pod *k8sv1.Pod) string {
-		stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient, pod, "compute",
+		stdout, stderr, err := tests.ExecuteCommandOnPodV2(virtClient, pod, "compute",
 			[]string{
 				"ps",
 				"-x",
 			})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), `"ps -x" failed with stdout="`+stdout+`" and stderr="`+stderr+`"`)
 
 		pid := ""
 		for _, str := range strings.Split(stdout, "\n") {


### PR DESCRIPTION
**What this PR does / why we need it**:
`[test_id:4746]should migrate even if libvirt has restarted at some point.` has been quite flaky lately.
It fails while running `ps -x` in the virt-launcher pod.
This PR adds some debug logs to have more info next time it happens.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
