### PR TITLE
Remove HostNetwork from attachment Pod

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1550,7 +1550,6 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 					},
 				},
 			},
-			HostNetwork:                   true,
 			TerminationGracePeriodSeconds: &zero,
 		},
 	}
@@ -1695,7 +1694,6 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 					},
 				},
 			},
-			HostNetwork:                   true,
 			TerminationGracePeriodSeconds: &zero,
 		},
 	}

--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -81,7 +81,6 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 		"NET_BIND_SERVICE",
 	}
 	scc.AllowHostDirVolumePlugin = true
-	scc.AllowHostNetwork = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}
 
 	return scc


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes HostNetwork from attachment Pod.

HostNetwork requires a more privileged security policy -
for example in the case of SCC or PSS.

There doesn't seem to be a relevant reason to trade security here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
