### PR TITLE
tests, reporter, Add missing nil pointer check

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -392,6 +392,11 @@ func (r *KubernetesReporter) logVirtLauncherPrivilegedCommands(virtCli kubecli.K
 		return
 	}
 
+	if virtHandlerPods == nil {
+		fmt.Fprintf(os.Stderr, "virt-handler pod list is empty, skipping logVirtLauncherPrivilegedCommands\n")
+		return
+	}
+
 	nodeMap := map[string]v1.Pod{}
 	for _, virtHandlerPod := range virtHandlerPods.Items {
 		if virtHandlerPod.Status.Phase != "Running" {


### PR DESCRIPTION
In case the virt-handler pod list is nil,
the reporter should not dereference it,
else it will result in panic.

Example
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6568/pull-kubevirt-e2e-k8s-1.22-sig-compute/1447497049858641920

```
10:05:18: virt-handler pod list is empty, skipping logNodeCommands
10:05:18: panic: runtime error: invalid memory address or nil pointer dereference
10:05:18: [signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x16bfffa]
10:05:18: 
10:05:18: goroutine 1 [running]:
10:05:18: kubevirt.io/kubevirt/tests/reporter.(*KubernetesReporter).logVirtLauncherPrivilegedCommands(0xc000743f58, 0x1d66100, 0xc0007a5dd0, 0xc000196660, 0x1c, 0x0)
10:05:18: 	tests/reporter/kubernetes.go:396 +0xba
10:05:18: kubevirt.io/kubevirt/tests/reporter.(*KubernetesReporter).dumpNamespaces(0xc000743f58, 0x8cdccf6200, 0xc000743f48, 0x1, 0x1)
10:05:18: 	tests/reporter/kubernetes.go:166 +0xaae
10:05:18: kubevirt.io/kubevirt/tests/reporter.(*KubernetesReporter).DumpAllNamespaces(...)
10:05:18: 	tests/reporter/kubernetes.go:107
10:05:18: main.main()
10:05:18: 	cmd/dump/dump.go:23 +0x1a6
make: *** [Makefile:153: cluster-sync] Error 2
```
Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
