### PR TITLE
Use honorLabels instead of labelDrop

### DIFF
--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -44,12 +44,7 @@ func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkip
 					TLSConfig: &v1.TLSConfig{
 						InsecureSkipVerify: insecureSkipVerify,
 					},
-					RelabelConfigs: []*v1.RelabelConfig{
-						{
-							Regex:  "namespace",
-							Action: "labeldrop",
-						},
-					},
+					HonorLabels: true,
 				},
 			},
 		},


### PR DESCRIPTION
Thanks to labeldrop, we can label metrics belong to
workloads correctly but as a side effect we lose
namespace labels for metrics belong to control plane.
In the past, honorLabels were not recommended by
openshift monitoring team because of security concerns but now
it is recommended.

Signed-off-by: Erkan Erol <eerol@redhat.com>


Necessary to fix #5383

**Release note**:
```release-note
Use honorLabels instead of labelDrop for namespace label on metrics
```
