### PR TITLE
Prefer podman as CRI on dockerized

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,12 +12,12 @@ fi
 
 # Select an available container runtime
 if [ -z ${KUBEVIRT_CRI} ]; then
-    if docker ps >/dev/null; then
-        KUBEVIRT_CRI=docker
-        echo "selecting docker as container runtime"
-    elif podman ps >/dev/null; then
+    if podman ps >/dev/null; then
         KUBEVIRT_CRI=podman
         echo "selecting podman as container runtime"
+    elif docker ps >/dev/null; then
+        KUBEVIRT_CRI=docker
+        echo "selecting docker as container runtime"
     else
         echo "no working container runtime found. Neither docker nor podman seems to work."
         exit 1


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: As part of https://github.com/kubevirt/project-infra/pull/1632, when podman is the installed CRI in CI bootstrap image we are symlinking docker to podman binaries to make the transition easier. In the CRI check done in `hack/dockerized` we are first checking for a working docker binary, which would pass with the symlink to podman. 

With these changes we first verify if podman command is functional, and if so we select it as CRI.

/cc @rmohr   

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
