### PR TITLE
Fix recording rules based on up metrics

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -54,18 +54,29 @@ tests:
               resource: "memory"
               container: virt-controller
 
-  # All components are down
+  # Alerts to test whether our operators are up or not
   - interval: 1m
     input_series:
       - series: 'up{namespace="ci", pod="virt-api-1"}'
-        values: "0 0 0 0 0 0"
+        values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
       - series: 'up{namespace="ci", pod="virt-controller-1"}'
-        values: "0 0 0 0 0 0"
+        values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
       - series: 'up{namespace="ci", pod="virt-operator-1"}'
-        values: "0 0 0 0 0 0"
+        values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
 
     alert_rule_test:
-      - eval_time: 5m
+      # it must not trigger before 10m
+      - eval_time: 8m
+        alertname: VirtAPIDown
+        exp_alerts: []
+      - eval_time: 8m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 8m
+        alertname: VirtOperatorDown
+        exp_alerts: [ ]
+      # it must trigger when there is no data
+      - eval_time: 10m
         alertname: VirtAPIDown
         exp_alerts:
           - exp_annotations:
@@ -73,15 +84,15 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
-      - eval_time: 5m
+      - eval_time: 10m
         alertname: VirtControllerDown
         exp_alerts:
           - exp_annotations:
-              summary: "No running virt-controller was detected for the last 5 min."
+              summary: "No running virt-controller was detected for the last 10 min."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
-      - eval_time: 5m
+      - eval_time: 10m
         alertname: VirtOperatorDown
         exp_alerts:
           - exp_annotations:
@@ -89,6 +100,42 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+      # it must trigger when operators are not healthy
+      - eval_time: 16m
+        alertname: VirtAPIDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "All virt-api servers are down."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
+            exp_labels:
+              severity: "critical"
+      - eval_time: 16m
+        alertname: VirtControllerDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "No running virt-controller was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
+            exp_labels:
+              severity: "critical"
+      - eval_time: 16m
+        alertname: VirtOperatorDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "All virt-operator servers are down."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
+            exp_labels:
+              severity: "critical"
+      # it must not trigger when operators are healthy
+      - eval_time: 17m
+        alertname: VirtAPIDown
+        exp_alerts: []
+      - eval_time: 17m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 17m
+        alertname: VirtOperatorDown
+        exp_alerts: [ ]
+
 
     # vmi running on a node without a virt-handler pod
   - interval: 1m
@@ -120,16 +167,16 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
-        values: "1 1 1 1 1 1"
+        values: "1 1 1 1 1 1 1 1 1 1 1"
       - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-2"}'
-        values: "0 0 0 0 0 0"
+        values: "0 0 0 0 0 0 0 0 0 0 0"
       - series: 'up{namespace="ci", pod="virt-controller-1"}'
-        values: "1 1 1 1 1 1"
+        values: "1 1 1 1 1 1 1 1 1 1 1"
       - series: 'up{namespace="ci", pod="virt-controller-2"}'
-        values: "1 1 1 1 1 1"
+        values: "1 1 1 1 1 1 1 1 1 1 1"
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 10m
         alertname: LowReadyVirtControllersCount
         exp_alerts:
           - exp_annotations:
@@ -142,30 +189,39 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
-        values: "0 0 0 0 0 0"
+        values: "0 0 0 0 0 0 0 0 0 0 0"
 
     alert_rule_test:
-      - eval_time: 5m
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: NoReadyVirtController
+        exp_alerts: [ ]
+      - eval_time: 10m
         alertname: NoReadyVirtController
         exp_alerts:
           - exp_annotations:
-              summary: "No ready virt-controller was detected for the last 5 min."
+              summary: "No ready virt-controller was detected for the last 10 min."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
 
+  # All virt operators are not ready
   - interval: 1m
     input_series:
-      - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
-        values: "0 0 0 0 0 0"
+      - series: 'kubevirt_virt_operator_ready{namespace="ci", pod="virt-operator-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
 
     alert_rule_test:
-      - eval_time: 5m
-        alertname: NoReadyVirtController
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: NoReadyVirtOperator
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoReadyVirtOperator
         exp_alerts:
           - exp_annotations:
-              summary: "No ready virt-controller was detected for the last 5 min."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
+              summary: "No ready virt-operator was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
             exp_labels:
               severity: "critical"
 

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -85,13 +85,13 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Record: "kubevirt_virt_api_up_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-api-.*'})", ns),
+							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-api-.*'}) or vector(0)", ns),
 						),
 					},
 					{
 						Alert: "VirtAPIDown",
 						Expr:  intstr.FromString("kubevirt_virt_api_up_total == 0"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
 							"summary":     "All virt-api servers are down.",
 							"runbook_url": runbookUrlBasePath + "VirtAPIDown",
@@ -136,7 +136,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Record: "kubevirt_virt_controller_up_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'})", ns),
+							fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'}) or vector(0)", ns),
 						),
 					},
 					{
@@ -148,7 +148,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "LowReadyVirtControllersCount",
 						Expr:  intstr.FromString("kubevirt_virt_controller_ready_total <  kubevirt_virt_controller_up_total"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
 							"summary":     "Some virt controllers are running but not ready.",
 							"runbook_url": runbookUrlBasePath + "LowReadyVirtControllersCount",
@@ -160,9 +160,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "NoReadyVirtController",
 						Expr:  intstr.FromString("kubevirt_virt_controller_ready_total == 0"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
-							"summary":     "No ready virt-controller was detected for the last 5 min.",
+							"summary":     "No ready virt-controller was detected for the last 10 min.",
 							"runbook_url": runbookUrlBasePath + "NoReadyVirtController",
 						},
 						Labels: map[string]string{
@@ -172,9 +172,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "VirtControllerDown",
 						Expr:  intstr.FromString("kubevirt_virt_controller_up_total == 0"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
-							"summary":     "No running virt-controller was detected for the last 5 min.",
+							"summary":     "No running virt-controller was detected for the last 10 min.",
 							"runbook_url": runbookUrlBasePath + "VirtControllerDown",
 						},
 						Labels: map[string]string{
@@ -184,7 +184,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "LowVirtControllersCount",
 						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_controller_ready_total < 2)"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
 							"summary":     "More than one virt-controller should be ready if more than one worker node.",
 							"runbook_url": runbookUrlBasePath + "LowVirtControllersCount",
@@ -244,13 +244,13 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Record: "kubevirt_virt_operator_up_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-operator-.*'})", ns),
+							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-operator-.*'}) or vector(0)", ns),
 						),
 					},
 					{
 						Alert: "VirtOperatorDown",
 						Expr:  intstr.FromString("kubevirt_virt_operator_up_total == 0"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
 							"summary":     "All virt-operator servers are down.",
 							"runbook_url": runbookUrlBasePath + "VirtOperatorDown",
@@ -334,7 +334,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "LowReadyVirtOperatorsCount",
 						Expr:  intstr.FromString("kubevirt_virt_operator_ready_total <  kubevirt_virt_operator_up_total"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
 							"summary":     "Some virt-operators are running but not ready.",
 							"runbook_url": runbookUrlBasePath + "LowReadyVirtOperatorsCount",
@@ -346,9 +346,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "NoReadyVirtOperator",
 						Expr:  intstr.FromString("kubevirt_virt_operator_ready_total == 0"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
-							"summary":     "No ready virt-operator was detected for the last 5 min.",
+							"summary":     "No ready virt-operator was detected for the last 10 min.",
 							"runbook_url": runbookUrlBasePath + "NoReadyVirtOperator",
 						},
 						Labels: map[string]string{
@@ -358,9 +358,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "NoLeadingVirtOperator",
 						Expr:  intstr.FromString("kubevirt_virt_operator_leading_total == 0"),
-						For:   "5m",
+						For:   "10m",
 						Annotations: map[string]string{
-							"summary":     "No leading virt-operator was detected for the last 5 min.",
+							"summary":     "No leading virt-operator was detected for the last 10 min.",
 							"runbook_url": runbookUrlBasePath + "NoLeadingVirtOperator",
 						},
 						Labels: map[string]string{
@@ -369,7 +369,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Record: "kubevirt_virt_handler_up_total",
-						Expr:   intstr.FromString(fmt.Sprintf("sum(up{pod=~'virt-handler-.*', namespace='%s'})", ns)),
+						Expr:   intstr.FromString(fmt.Sprintf("sum(up{pod=~'virt-handler-.*', namespace='%s'}) or vector(0)", ns)),
 					},
 					{
 						Alert: "VirtHandlerDaemonSetRolloutFailing",


### PR DESCRIPTION
**What this PR does / why we need it**:

When there is no metric, sum() returns empty instead of zero and it breaks some assertions in alert rules like x == 0. Therefore, we should add "or vector(0)" into the recording rules which are supposed to be zero when there is no data.

Fixes #5383

@davidvossel  asked me to increase timeouts from 5minutes to 10 minutes by referring to some past issues. This PR increases the timeouts.

Also, I noticed there is duplication for NoReadyVirtController in `prom-rules-tests.yaml` but there is no test for NoReadyVirtOperator. I assumed it was a copy-paste error. This PR fixes it as well. 

**Special notes for your reviewer**:

Here is how to review the unit tests. Now, our inputs for up metrics are as below:

```  
- series: 'up{namespace="ci", pod="virt-api-1"}'
  values: "_ _ _ _ _ _ _ _ _ _ _ 0 0 0 0 0 0 1"
```

It means,
- the metric doesn't return anything until 11m 
- it returns 0 between 11m and 16m inclusively
- it returns 1 at 17m

The alerts are supposed to be fired after 10minutes when the endpoint is not healthy. Therefore,
- Those are not supposed to be fired at 8m
- Those are supposed to be fired at 10m even when there is no data thanks to my fix
- Those are supposed to be fired at 16m when up==0
- Those are not supposed to be fired at 17m since up==1



**Release note**:
```release-note
Fix recording rules based on up metrics
```
