### PR TITLE
[monitoring] fix NoReadyVirtOperator alert calculation

### DIFF
--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -345,7 +345,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "NoReadyVirtOperator",
-						Expr:  intstr.FromString("kubevirt_virt_operator_up_total == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_operator_ready_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary":     "No ready virt-operator was detected for the last 5 min.",


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The alert was based on an incorrect record.
It should be based on the record of the total ready virt operator pods

**Release note**:
```release-note
NONE
```
