### PR TITLE
[WIP] Remove relabelfrom/to and attach_queue from launcher type

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -36,13 +36,6 @@
     ; However, without this permission, there would be a lot of warnings poluting the logs.
     (allow process self (netlink_audit_socket (nlmsg_relay)))
     ;
-    ; Allowing tun sockets to be relabelled from "virt_launcher.process" to itself.
-    ; That might seem useless, but when libvirtd adds a tun socket to a network multiqueue,
-    ;   that triggers a relabelling, even if the label is already correct.
-    ; "relabelfrom" and "relabelto" were added upstream and won't be necessary in the future.
-    ; It is unclear if "attach_queue" is actually needed
-    (allow process self (tun_socket (relabelfrom relabelto attach_queue)))
-    ;
     ; Allowing libvirtd to access the hugetlbfs to setup huge tables.
     ; Huge tables won't work without it, unless the memory backend is memfd.
     ; The 2 following rules could be removed if memfd was the only supported memoty backend.


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing if we need selinux rule 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note

```
