### PR TITLE
Connect over NodePort svc after vm restrart

### DIFF
--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -76,6 +76,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	const xfailError = "Secondary ip on dual stack service is not working. Tracking issue - https://github.com/kubevirt/kubevirt/issues/5477"
 
 	BeforeEach(func() {
+		tests.BeforeTestCleanup()
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 	})
@@ -168,8 +169,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("Expose service on a VM", func() {
 		var tcpVM *v1.VirtualMachineInstance
-		tests.BeforeAll(func() {
-			tests.BeforeTestCleanup()
+		BeforeEach(func() {
 			tcpVM = newLabeledVMI("vm", virtClient, true)
 			tests.GenerateHelloWorldServer(tcpVM, testPort, "tcp")
 		})
@@ -434,8 +434,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("Expose UDP service on a VMI", func() {
 		var udpVM *v1.VirtualMachineInstance
-		tests.BeforeAll(func() {
-			tests.BeforeTestCleanup()
+		BeforeEach(func() {
 			udpVM = newLabeledVMI("udp-vm", virtClient, true)
 			tests.GenerateHelloWorldServer(udpVM, testPort, "udp")
 		})
@@ -560,9 +559,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		const numberOfVMs = 2
 
 		var vmrs *v1.VirtualMachineInstanceReplicaSet
-		tests.BeforeAll(func() {
-			tests.BeforeTestCleanup()
-
+		BeforeEach(func() {
 			By("Creating a VMRS object with 2 replicas")
 			template := newLabeledVMI("vmirs", virtClient, false)
 			vmrs = tests.NewRandomReplicaSetFromVMI(template, int32(numberOfVMs))
@@ -683,8 +680,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 		Context("Expose a VM as a ClusterIP service.", func() {
 			var serviceName string
-
-			BeforeEach(tests.BeforeTestCleanup)
 
 			BeforeEach(func() {
 				vm, err = createStoppedVM(virtClient, util.NamespaceTestDefault)

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -31,59 +31,55 @@ var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][l
 	var (
 		virtClient                                          kubecli.KubevirtClient
 		serverVMI, clientVMI, clientVMIAlternativeNamespace *v1.VirtualMachineInstance
+		err                                                 error
 		serverVMILabels                                     = map[string]string{"type": "test"}
 	)
 	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred(), "should succeed retrieving the kubevirt client")
 
 		tests.SkipIfUseFlannel(virtClient)
 		skipNetworkPolicyRunningOnKindInfra()
-
 	})
+
+	createServerVmi := func(virtClient kubecli.KubevirtClient, namespace string) (*v1.VirtualMachineInstance, error) {
+		serverVMI = getVMICirros(
+			namespace,
+			serverVMILabels,
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(
+				v1.Port{
+					Name:     "http80",
+					Port:     80,
+					Protocol: "TCP",
+				},
+				v1.Port{
+					Name:     "http81",
+					Port:     81,
+					Protocol: "TCP",
+				},
+			)),
+		)
+		serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
+		if err != nil {
+			return nil, err
+		}
+		serverVMI = tests.WaitUntilVMIReady(serverVMI, libnet.WithIPv6(console.LoginToCirros))
+
+		By("Start HTTP server at serverVMI on ports 80 and 81")
+		tests.HTTPServer.Start(serverVMI, 80)
+		tests.HTTPServer.Start(serverVMI, 81)
+
+		return serverVMI, nil
+	}
+
 	Context("when three cirros VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
-		tests.BeforeAll(func() {
-			tests.BeforeTestCleanup()
-
-			// Create three vmis, serverVMI and clientVMI are in same namespace, clientVMIAlternativeNamespace is in different namespace
-			serverVMI = createVMICirros(virtClient,
-				util.NamespaceTestDefault,
-				serverVMILabels,
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(
-					v1.Port{
-						Name:     "http80",
-						Port:     80,
-						Protocol: "TCP",
-					},
-					v1.Port{
-						Name:     "http81",
-						Port:     81,
-						Protocol: "TCP",
-					},
-				)),
-			)
-			clientVMI = createVMICirros(virtClient, util.NamespaceTestDefault, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
-			clientVMIAlternativeNamespace = createVMICirros(virtClient, tests.NamespaceTestAlternative, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			serverVMIFuture := tests.WaitUntilVMIReadyAsync(ctx, serverVMI, libnet.WithIPv6(console.LoginToCirros))
-			clientVMIFuture := tests.WaitUntilVMIReadyAsync(ctx, clientVMI, libnet.WithIPv6(console.LoginToCirros))
-			clientVMIAlternativeNamespaceFuture := tests.WaitUntilVMIReadyAsync(ctx, clientVMIAlternativeNamespace, libnet.WithIPv6(console.LoginToCirros))
-
-			serverVMI = serverVMIFuture()
-			clientVMI = clientVMIFuture()
-			clientVMIAlternativeNamespace = clientVMIAlternativeNamespaceFuture()
-
-			By("Start HTTP server at serverVMI on ports 80 and 81")
-			tests.HTTPServer.Start(serverVMI, 80)
-			tests.HTTPServer.Start(serverVMI, 81)
-
+		BeforeEach(func() {
+			serverVMI, err = createServerVmi(virtClient, util.NamespaceTestDefault)
+			Expect(err).ToNot(HaveOccurred())
 			assertIPsNotEmptyForVMI(serverVMI)
-			assertIPsNotEmptyForVMI(clientVMI)
-			assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
-
 		})
 
 		Context("and connectivity between VMI/s is blocked by Default-deny networkpolicy", func() {
@@ -92,6 +88,9 @@ var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][l
 			BeforeEach(func() {
 				// deny-by-default networkpolicy will deny all the traffic to the vms in the namespace
 				policy = createNetworkPolicy(serverVMI.Namespace, "deny-by-default", metav1.LabelSelector{}, []networkv1.NetworkPolicyIngressRule{})
+				clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+				Expect(err).ToNot(HaveOccurred())
+				assertIPsNotEmptyForVMI(clientVMI)
 			})
 
 			AfterEach(func() {
@@ -131,21 +130,35 @@ var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][l
 						},
 					},
 				)
-
 			})
 
 			AfterEach(func() {
 				waitForNetworkPolicyDeletion(policy)
 			})
 
-			It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
-				assertPingSucceed(clientVMI, serverVMI)
+			When("client vmi is on default namespace", func() {
+				BeforeEach(func() {
+					clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+					Expect(err).ToNot(HaveOccurred())
+					assertIPsNotEmptyForVMI(clientVMI)
+				})
+
+				It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
+					assertPingSucceed(clientVMI, serverVMI)
+				})
 			})
 
-			It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
-				assertPingFail(clientVMIAlternativeNamespace, serverVMI)
-			})
+			When("client vmi is on alternative namespace", func() {
+				BeforeEach(func() {
+					clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, virtClient)
+					Expect(err).ToNot(HaveOccurred())
+					assertIPsNotEmptyForVMI(clientVMI)
+				})
 
+				It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
+					assertPingFail(clientVMIAlternativeNamespace, serverVMI)
+				})
+			})
 		})
 
 		Context("and ingress traffic to VMI identified via label at networkprofile's labelSelector is blocked", func() {
@@ -173,22 +186,46 @@ var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][l
 				waitForNetworkPolicyDeletion(policy)
 			})
 
-			It("[test_id:1515] should fail to reach serverVMI from clientVMIAlternativeNamespace", func() {
-				By("Connect serverVMI from clientVMIAlternativeNamespace")
-				assertPingFail(clientVMIAlternativeNamespace, serverVMI)
+			When("client vmi is on alternative namespace", func() {
+				BeforeEach(func() {
+					clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, virtClient)
+					Expect(err).ToNot(HaveOccurred())
+					assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
+				})
+
+				It("[test_id:1515] should fail to reach serverVMI from clientVMIAlternativeNamespace", func() {
+					By("Connect serverVMI from clientVMIAlternativeNamespace")
+					assertPingFail(clientVMIAlternativeNamespace, serverVMI)
+				})
 			})
 
-			It("[test_id:1516] should fail to reach serverVMI from clientVMI", func() {
-				By("Connect serverVMI from clientVMI")
-				assertPingFail(clientVMI, serverVMI)
-			})
+			When("client vmi is on default namespace", func() {
+				BeforeEach(func() {
+					clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+					Expect(err).ToNot(HaveOccurred())
+					assertIPsNotEmptyForVMI(clientVMI)
+				})
 
-			It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", func() {
-				By("Connect clientVMI from clientVMIAlternativeNamespace")
-				assertPingSucceed(clientVMIAlternativeNamespace, clientVMI)
-			})
+				It("[test_id:1515] should fail to reach serverVMI from clientVMI", func() {
+					By("Connect serverVMI from clientVMIAlternativeNamespace")
+					assertPingFail(clientVMI, serverVMI)
+				})
 
+				When("another client vmi is on an alternative namespace", func() {
+					BeforeEach(func() {
+						clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, virtClient)
+						Expect(err).ToNot(HaveOccurred())
+						assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
+					})
+
+					It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", func() {
+						By("Connect clientVMI from clientVMIAlternativeNamespace")
+						assertPingSucceed(clientVMIAlternativeNamespace, clientVMI)
+					})
+				})
+			})
 		})
+
 		Context("and TCP connectivity on ports 80 and 81 between VMI/s is allowed by networkpolicy", func() {
 			var policy *networkv1.NetworkPolicy
 			BeforeEach(func() {
@@ -205,6 +242,10 @@ var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][l
 						},
 					},
 				)
+
+				clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+				Expect(err).ToNot(HaveOccurred())
+				assertIPsNotEmptyForVMI(clientVMI)
 			})
 			AfterEach(func() {
 				waitForNetworkPolicyDeletion(policy)
@@ -228,6 +269,10 @@ var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][l
 						},
 					},
 				)
+
+				clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+				Expect(err).ToNot(HaveOccurred())
+				assertIPsNotEmptyForVMI(clientVMI)
 			})
 			AfterEach(func() {
 				waitForNetworkPolicyDeletion(policy)
@@ -247,11 +292,10 @@ func skipNetworkPolicyRunningOnKindInfra() {
 	}
 }
 
-func createVMICirros(virtClient kubecli.KubevirtClient, namespace string, labels map[string]string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
-	var err error
+func getVMICirros(namespace string, labels map[string]string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-	vmi.Namespace = namespace
 	vmi.Labels = labels
+	vmi.Namespace = namespace
 
 	// Clean up interfaces since we configure them with `libvmi.Option`
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{}
@@ -259,9 +303,6 @@ func createVMICirros(virtClient kubecli.KubevirtClient, namespace string, labels
 	for _, opt := range opts {
 		opt(vmi)
 	}
-
-	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-	Expect(err).ToNot(HaveOccurred())
 
 	return vmi
 }
@@ -383,4 +424,16 @@ func checkHTTPPing(vmi *v1.VirtualMachineInstance, ip string, port int) error {
 
 func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 	ExpectWithOffset(1, vmi.Status.Interfaces[0].IPs).ToNot(BeEmpty(), "should contain a not empy list of ip addresses")
+}
+
+func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
+	clientVMI := getVMICirros(namespace, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
+
+	clientVMI, err := virtClient.VirtualMachineInstance(namespace).Create(clientVMI)
+	if err != nil {
+		return nil, err
+	}
+
+	clientVMI = tests.WaitUntilVMIReady(clientVMI, libnet.WithIPv6(console.LoginToCirros))
+	return clientVMI, nil
 }

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -61,18 +61,15 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	var virtClient kubecli.KubevirtClient
 	var currentConfiguration v1.KubeVirtConfiguration
 
-	var inboundVMI *v1.VirtualMachineInstance
-	var inboundVMIWithPodNetworkSet *v1.VirtualMachineInstance
-	var inboundVMIWithCustomMacAddress *v1.VirtualMachineInstance
-	var outboundVMI *v1.VirtualMachineInstance
-
 	const (
 		testPort                   = 1500
 		LibvirtDirectMigrationPort = 49152
 		LibvirtBlockMigrationPort  = 49153
 	)
 
-	tests.BeforeAll(func() {
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
@@ -116,162 +113,172 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	}
 
 	Describe("Multiple virtual machines connectivity using bridge binding interface", func() {
-		tests.BeforeAll(func() {
-			tests.BeforeTestCleanup()
+		var inboundVMI *v1.VirtualMachineInstance
+		var outboundVMI *v1.VirtualMachineInstance
+		var inboundVMIWithPodNetworkSet *v1.VirtualMachineInstance
+		var inboundVMIWithCustomMacAddress *v1.VirtualMachineInstance
 
-			inboundVMI = libvmi.NewCirros()
-			outboundVMI = libvmi.NewCirros()
+		Context("with a test outbound VMI", func() {
+			BeforeEach(func() {
+				inboundVMI = libvmi.NewCirros()
+				outboundVMI = libvmi.NewCirros()
+				inboundVMIWithPodNetworkSet = vmiWithPodNetworkSet()
+				inboundVMIWithCustomMacAddress = vmiWithCustomMacAddress("de:ad:00:00:be:af")
 
-			inboundVMIWithPodNetworkSet = libvmi.NewCirros(
-				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()))
+				outboundVMI = runVMI(outboundVMI)
+			})
 
-			inboundVMIWithCustomMacAddress = libvmi.NewCirros(
-				libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultBridgeNetworkInterface(), "de:ad:00:00:be:af")),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()))
+			table.DescribeTable("should be able to reach", func(vmiRef **v1.VirtualMachineInstance) {
+				var cmdCheck, addrShow, addr string
+				if vmiRef == nil {
+					addr = "kubevirt.io"
+				} else {
+					vmi := *vmiRef
+					vmi = runVMI(vmi)
+					if vmiHasCustomMacAddress(vmi) {
+						tests.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
+					}
 
-			// Create VMIs
-			for _, networkVMI := range []*v1.VirtualMachineInstance{inboundVMI, outboundVMI, inboundVMIWithPodNetworkSet, inboundVMIWithCustomMacAddress} {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(networkVMI)
-				Expect(err).ToNot(HaveOccurred())
-				*networkVMI = *vmi
-			}
-
-			// Wait for VMIs to become ready
-			inboundVMI = tests.WaitUntilVMIReady(inboundVMI, libnet.WithIPv6(console.LoginToCirros))
-			outboundVMI = tests.WaitUntilVMIReady(outboundVMI, libnet.WithIPv6(console.LoginToCirros))
-			inboundVMIWithPodNetworkSet = tests.WaitUntilVMIReady(inboundVMIWithPodNetworkSet, libnet.WithIPv6(console.LoginToCirros))
-			inboundVMIWithCustomMacAddress = tests.WaitUntilVMIReady(inboundVMIWithCustomMacAddress, libnet.WithIPv6(console.LoginToCirros))
-
-			tests.StartTCPServer(inboundVMI, testPort)
-		})
-
-		table.DescribeTable("should be able to reach", func(vmiRef **v1.VirtualMachineInstance) {
-			var cmdCheck, addrShow, addr string
-			if vmiRef == nil {
-				addr = "kubevirt.io"
-			} else {
-				vmi := *vmiRef
-				if vmiHasCustomMacAddress(vmi) {
-					tests.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
+					addr = vmi.Status.Interfaces[0].IP
 				}
 
-				addr = vmi.Status.Interfaces[0].IP
-			}
+				payloadSize := 0
+				ipHeaderSize := 28 // IPv4 specific
 
-			payloadSize := 0
-			ipHeaderSize := 28 // IPv4 specific
+				vmiPod := tests.GetRunningPodByVirtualMachineInstance(outboundVMI, util.NamespaceTestDefault)
+				var mtu int
+				for _, ifaceName := range []string{"k6t-eth0", "tap0"} {
+					By(fmt.Sprintf("checking %s MTU inside the pod", ifaceName))
+					output, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						"compute",
+						[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
+					)
+					log.Log.Infof("%s mtu is %v", ifaceName, output)
+					Expect(err).ToNot(HaveOccurred())
 
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(outboundVMI, util.NamespaceTestDefault)
-			var mtu int
-			for _, ifaceName := range []string{"k6t-eth0", "tap0"} {
-				By(fmt.Sprintf("checking %s MTU inside the pod", ifaceName))
-				output, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					"compute",
-					[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
-				)
-				log.Log.Infof("%s mtu is %v", ifaceName, output)
+					output = strings.TrimSuffix(output, "\n")
+					mtu, err = strconv.Atoi(output)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(mtu > 1000).To(BeTrue())
+
+					payloadSize = mtu - ipHeaderSize
+				}
+				expectedMtuString := fmt.Sprintf("mtu %d", mtu)
+
+				By("checking eth0 MTU inside the VirtualMachineInstance")
+				Expect(libnet.WithIPv6(console.LoginToCirros)(outboundVMI)).To(Succeed())
+
+				addrShow = "ip address show eth0\n"
+				Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: addrShow},
+					&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 180)).To(Succeed())
+
+				By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
+				// NOTE: VirtualMachineInstance is not directly accessible from inside the pod because
+				// we transferred its IP address under DHCP server control, so the
+				// only thing we can validate is connectivity between VMIs
+				//
+				// NOTE: cirros ping doesn't support -M do that could be used to
+				// validate end-to-end connectivity with Don't Fragment flag set
+				cmdCheck = fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
+				err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: cmdCheck},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 180)
 				Expect(err).ToNot(HaveOccurred())
 
-				output = strings.TrimSuffix(output, "\n")
-				mtu, err = strconv.Atoi(output)
+				By("checking the VirtualMachineInstance can fetch via HTTP")
+				err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 15)
 				Expect(err).ToNot(HaveOccurred())
+			},
+				table.Entry("[test_id:1539]the Inbound VirtualMachineInstance", &inboundVMI),
+				table.Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", &inboundVMIWithPodNetworkSet),
+				table.Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", &inboundVMIWithCustomMacAddress),
+				table.Entry("[test_id:1542]the internet", nil),
+			)
+		})
 
-				Expect(mtu > 1000).To(BeTrue())
+		Context("with propagated IP from a pod", func() {
+			BeforeEach(func() {
+				inboundVMI = libvmi.NewCirros()
+				inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
+				Expect(err).ToNot(HaveOccurred())
+				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, libnet.WithIPv6(console.LoginToCirros))
+				tests.StartTCPServer(inboundVMI, testPort)
+			})
 
-				payloadSize = mtu - ipHeaderSize
-			}
-			expectedMtuString := fmt.Sprintf("mtu %d", mtu)
+			table.DescribeTable("should be able to reach", func(op v12.NodeSelectorOperator, hostNetwork bool) {
 
-			By("checking eth0 MTU inside the VirtualMachineInstance")
-			Expect(libnet.WithIPv6(console.LoginToCirros)(outboundVMI)).To(Succeed())
+				ip := inboundVMI.Status.Interfaces[0].IP
 
-			addrShow = "ip address show eth0\n"
-			Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: addrShow},
-				&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-			}, 180)).To(Succeed())
+				//TODO if node count 1, skip the nv12.NodeSelectorOpOut
+				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), v13.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nodes.Items).ToNot(BeEmpty())
+				if len(nodes.Items) == 1 && op == v12.NodeSelectorOpNotIn {
+					Skip("Skip network test that requires multiple nodes when only one node is present.")
+				}
 
-			By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
-			// NOTE: VirtualMachineInstance is not directly accessible from inside the pod because
-			// we transferred its IP address under DHCP server control, so the
-			// only thing we can validate is connectivity between VMIs
-			//
-			// NOTE: cirros ping doesn't support -M do that could be used to
-			// validate end-to-end connectivity with Don't Fragment flag set
-			cmdCheck = fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
-			err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: cmdCheck},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-			}, 180)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("checking the VirtualMachineInstance can fetch via HTTP")
-			err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
-		},
-			table.Entry("[test_id:1539]the Inbound VirtualMachineInstance", &inboundVMI),
-			table.Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", &inboundVMIWithPodNetworkSet),
-			table.Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", &inboundVMIWithCustomMacAddress),
-			table.Entry("[test_id:1542]the internet", nil),
-		)
-
-		table.DescribeTable("should be reachable via the propagated IP from a Pod", func(op v12.NodeSelectorOperator, hostNetwork bool) {
-
-			ip := inboundVMI.Status.Interfaces[0].IP
-
-			//TODO if node count 1, skip the nv12.NodeSelectorOpOut
-			nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), v13.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nodes.Items).ToNot(BeEmpty())
-			if len(nodes.Items) == 1 && op == v12.NodeSelectorOpNotIn {
-				Skip("Skip network test that requires multiple nodes when only one node is present.")
-			}
-
-			job := tests.NewHelloWorldJob(ip, strconv.Itoa(testPort))
-			job.Spec.Template.Spec.Affinity = &v12.Affinity{
-				NodeAffinity: &v12.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{
-						NodeSelectorTerms: []v12.NodeSelectorTerm{
-							{
-								MatchExpressions: []v12.NodeSelectorRequirement{
-									{Key: "kubernetes.io/hostname", Operator: op, Values: []string{inboundVMI.Status.NodeName}},
+				job := tests.NewHelloWorldJob(ip, strconv.Itoa(testPort))
+				job.Spec.Template.Spec.Affinity = &v12.Affinity{
+					NodeAffinity: &v12.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{
+							NodeSelectorTerms: []v12.NodeSelectorTerm{
+								{
+									MatchExpressions: []v12.NodeSelectorRequirement{
+										{Key: "kubernetes.io/hostname", Operator: op, Values: []string{inboundVMI.Status.NodeName}},
+									},
 								},
 							},
 						},
 					},
-				},
-			}
-			job.Spec.Template.Spec.HostNetwork = hostNetwork
+				}
+				job.Spec.Template.Spec.HostNetwork = hostNetwork
 
-			job, err = virtClient.BatchV1().Jobs(inboundVMI.ObjectMeta.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
-		},
-			table.Entry("[test_id:1543]on the same node from Pod", v12.NodeSelectorOpIn, false),
-			table.Entry("[test_id:1544]on a different node from Pod", v12.NodeSelectorOpNotIn, false),
-			table.Entry("[test_id:1545]on the same node from Node", v12.NodeSelectorOpIn, true),
-			table.Entry("[test_id:1546]on a different node from Node", v12.NodeSelectorOpNotIn, true),
-		)
+				job, err = virtClient.BatchV1().Jobs(inboundVMI.ObjectMeta.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
+			},
+				table.Entry("[test_id:1543]on the same node from Pod", v12.NodeSelectorOpIn, false),
+				table.Entry("[test_id:1544]on a different node from Pod", v12.NodeSelectorOpNotIn, false),
+				table.Entry("[test_id:1545]on the same node from Node", v12.NodeSelectorOpIn, true),
+				table.Entry("[test_id:1546]on a different node from Node", v12.NodeSelectorOpNotIn, true),
+			)
+		})
 
 		Context("VirtualMachineInstance with default interface model", func() {
+			BeforeEach(func() {
+				inboundVMI = libvmi.NewCirros()
+				outboundVMI = libvmi.NewCirros()
+
+				inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
+				Expect(err).ToNot(HaveOccurred())
+				outboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(outboundVMI)
+				Expect(err).ToNot(HaveOccurred())
+
+				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, libnet.WithIPv6(console.LoginToCirros))
+				outboundVMI = tests.WaitUntilVMIReady(outboundVMI, libnet.WithIPv6(console.LoginToCirros))
+			})
+
 			// Unless an explicit interface model is specified, the default interface model is virtio.
 			It("[test_id:1550]should expose the right device type to the guest", func() {
 				By("checking the device vendor in /sys/class")
@@ -285,20 +292,18 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				}
 			})
 
-			It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", func() {
-				// Create a virtual machine with an unsupported interface model
-				customIfVMI := NewRandomVMIWithInvalidNetworkInterface()
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(customIfVMI)
-				Expect(err).To(HaveOccurred())
+			Context("VirtualMachineInstance with unsupported interface model", func() {
+				It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", func() {
+					// Create a virtual machine with an unsupported interface model
+					customIfVMI := NewRandomVMIWithInvalidNetworkInterface()
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(customIfVMI)
+					Expect(err).To(HaveOccurred())
+				})
 			})
 		})
 	})
 
 	Context("VirtualMachineInstance with custom interface model", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1770]should expose the right device type to the guest", func() {
 			By("checking the device vendor in /sys/class")
 			// Create a machine with e1000 interface model
@@ -313,10 +318,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with custom MAC address", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1771]should configure custom MAC address", func() {
 			By("checking eth0 MAC address")
 			deadbeafVMI := tests.NewRandomVMIWithCustomMacAddress()
@@ -329,10 +330,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1772]should configure custom MAC address", func() {
 			By("checking eth0 MAC address")
 			beafdeadVMI := tests.NewRandomVMIWithCustomMacAddress()
@@ -346,10 +343,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with invalid MAC address", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:700]should failed to start with invalid MAC address", func() {
 			By("Start VMI")
 			beafdeadVMI := tests.NewRandomVMIWithCustomMacAddress()
@@ -373,7 +366,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 			currentConfiguration = kv.Spec.Configuration
 		}
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			setPermitSlirpInterface(true)
 		})
 		AfterEach(func() {
@@ -393,10 +385,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with disabled automatic attachment of interfaces", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1774]should not configure any external interfaces", func() {
 			By("checking loopback is the only guest interface")
 			autoAttach := false
@@ -464,10 +452,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with custom PCI address", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
 			err := console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
@@ -492,10 +476,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with learning disabled on pod interface", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1777]should disable learning on pod iface", func() {
 			By("checking learning flag")
 			learningDisabledVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskAlpine), "#!/bin/bash\necho 'hello'\n")
@@ -511,10 +491,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with dhcp options", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1778]should offer extra dhcp options to pod iface", func() {
 			dhcpVMI := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
 			tests.AddExplicitPodNetworkInterface(dhcpVMI)
@@ -554,9 +530,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with custom dns", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
 		It("[test_id:1779]should have custom resolv.conf", func() {
 			userData := "#cloud-config\n"
 			dnsVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
@@ -590,9 +563,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with masquerade binding mechanism", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
 		masqueradeVMI := func(ports []v1.Port, ipv4NetworkCIDR string) *v1.VirtualMachineInstance {
 			containerImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 			userData := "#!/bin/bash\necho 'hello'\n"
@@ -966,20 +936,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			AfterEach(func() {
-				if vmi != nil {
-					By("Delete VMI")
-					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &v13.DeleteOptions{})).To(Succeed())
-				}
-			})
-
-			AfterEach(func() {
-				if anotherVmi != nil {
-					By("Delete another VMI")
-					Expect(virtClient.VirtualMachineInstance(anotherVmi.Namespace).Delete(anotherVmi.Name, &v13.DeleteOptions{})).To(Succeed())
-				}
-			})
-
 			table.DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
 					libnet.SkipWhenNotDualStackCluster(virtClient)
@@ -1026,10 +982,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	Context("VirtualMachineInstance with TX offload disabled", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:1781]should get turned off for interfaces that serve dhcp", func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskAlpine), "#!/bin/bash\necho")
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
@@ -1136,4 +1088,26 @@ func gatewayIPFromCIDR(cidr string) string {
 func vmiHasCustomMacAddress(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Devices.Interfaces != nil &&
 		vmi.Spec.Domain.Devices.Interfaces[0].MacAddress != ""
+}
+
+func runVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+	virtClient, err := kubecli.GetKubevirtClient()
+	util.PanicOnError(err)
+
+	vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+	Expect(err).ToNot(HaveOccurred())
+	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+	return vmi
+}
+
+func vmiWithPodNetworkSet() *v1.VirtualMachineInstance {
+	return libvmi.NewCirros(
+		libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()))
+}
+
+func vmiWithCustomMacAddress(mac string) *v1.VirtualMachineInstance {
+	return libvmi.NewCirros(
+		libvmi.WithInterface(*libvmi.InterfaceWithMac(v1.DefaultBridgeNetworkInterface(), mac)),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt/issues/6410 introduced a case where an ssh connection to an 
exposed vmi fails after the vmi is being restarted by deleting It's launcher pod. This case was not covered by our
e2e and now this PR adds it to the expose tests.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR is rebased on top of https://github.com/kubevirt/kubevirt/pull/6331
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
