### PR TITLE
Allow overwrite the default DNS service in tests

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -51,6 +51,8 @@ var ApplyDefaulte2eConfiguration bool
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
+var DNSServiceName = ""
+var DNSServiceNamespace = ""
 
 func init() {
 	kubecli.Init()
@@ -78,6 +80,8 @@ func init() {
 	flag.StringVar(&IPV6ConnectivityCheckAddress, "conn-check-ipv6-address", "", "Address that is used for testing IPV6 connectivity to the outside world")
 	flag.StringVar(&ConnectivityCheckDNS, "conn-check-dns", "", "dns that is used for testing connectivity to the outside world")
 	flag.BoolVar(&ApplyDefaulte2eConfiguration, "apply-default-e2e-configuration", false, "Apply the default e2e test configuration (feature gates, selinux contexts, ...)")
+	flag.StringVar(&DNSServiceName, "dns-service-name", "kube-dns", "cluster DNS service name")
+	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 }
 
 func NormalizeFlags() {

--- a/tests/libnet/dns.go
+++ b/tests/libnet/dns.go
@@ -26,12 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/flags"
 )
 
 const (
-	k8sDNSServiceName = "kube-dns"
-	k8sDNSNamespace   = "kube-system"
-
 	openshiftDNSServiceName = "dns-default"
 	openshiftDNSNamespace   = "openshift-dns"
 )
@@ -49,7 +47,7 @@ func ClusterDNSServiceIP() (string, error) {
 		return "", err
 	}
 
-	service, err := virtClient.CoreV1().Services(k8sDNSNamespace).Get(context.Background(), k8sDNSServiceName, metav1.GetOptions{})
+	service, err := virtClient.CoreV1().Services(flags.DNSServiceNamespace).Get(context.Background(), flags.DNSServiceName, metav1.GetOptions{})
 	if err != nil {
 		prevErr := err
 		service, err = virtClient.CoreV1().Services(openshiftDNSNamespace).Get(context.Background(), openshiftDNSServiceName, metav1.GetOptions{})


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The name of the cluster's DNS service may differ from the default `kube-system/kube-dns`.

Setting the DNS service name and namespace via cmdline argumetns will allow to run the testsuite in various environments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
