### PR TITLE
Fix broken ErrorDataVolumeNotFound functest

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -842,16 +842,14 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			table.Entry(
 				"missing PVC",
 				func() *v1.VirtualMachineInstance {
-					vmi := tests.NewRandomVMIWithEphemeralDisk("vmi-with-missing-pvc")
-					return tests.AddPVCDisk(vmi, "disk1", "virtio", "missing-pvc")
+					return tests.NewRandomVMIWithPVC("missing-pvc")
 				},
 				v1.VirtualMachineStatusPvcNotFound,
 			),
 			table.Entry(
 				"missing DataVolume",
 				func() *v1.VirtualMachineInstance {
-					vmi, _ := newVirtualMachineInstanceWithOCSFileDisk()
-					return vmi
+					return tests.NewRandomVMIWithDataVolume("missing-datavolume")
 				},
 				v1.VirtualMachineStatusDataVolumeNotFound,
 			),


### PR DESCRIPTION
Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**What this PR does / why we need it**:

Fix the `ErrorDataVolumeNotFound` functest which was [broken ](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6608/pull-kubevirt-e2e-k8s-1.20-cgroupsv2-rook-ceph/1448670505421770752) two-way:
1. The test relies on the referenced DataVolume to not be created, but uses a utility function (`NewRandomVirtualMachineInstanceWithOCSDisk()`) that does create it 🤦🏼‍♂️ .
2. This utility function also happens to `Skip()` the test when Ceph StorageClass is missing.

The fixed test now makes sure to use a volume with a reference to a DV that doesn't exist.

**Release note**:
```release-note
NONE
```
