### PR TITLE
tests, windows, Refactor e2e tests

### DIFF
--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -147,7 +147,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 
 		By("Stopping the vmi")
-		err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+		err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 		Expect(err).To(BeNil())
 	}, 300)
 
@@ -287,7 +287,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 
 func winrnLoginCommand(virtClient kubecli.KubevirtClient, windowsVMI *v1.VirtualMachineInstance) []string {
 	var err error
-	windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(windowsVMI.Name, &metav1.GetOptions{})
+	windowsVMI, err = virtClient.VirtualMachineInstance(windowsVMI.Namespace).Get(windowsVMI.Name, &metav1.GetOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	vmiIp := windowsVMI.Status.Interfaces[0].IP


### PR DESCRIPTION
Rearrange e2e tests contexts in order to be able
to reuse code blocks.
Extract code snippets to logical function.

Use namespace from vmi spec after vmi is created instead using global.

Motivation is that it is cleaner and we can add a test like this for subdomain
https://github.com/kubevirt/kubevirt/pull/6624/commits/92c69e9cf2fa1d36636b6a831f89ebbcb734ac64

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
