### PR TITLE
Refactor controller ref manager to reflect separation of VMI and VM

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -161,7 +161,7 @@ func NewVirtualMachineControllerRefManager(
 	}
 }
 
-// ClaimVirtualMachines tries to take ownership of a list of VirtualMachines.
+// ClaimVirtualMachineInstances tries to take ownership of a list of VirtualMachineInstances.
 //
 // It will reconcile the following:
 //   * Adopt orphans if the selector matches.
@@ -176,7 +176,7 @@ func NewVirtualMachineControllerRefManager(
 //
 // If the error is nil, either the reconciliation succeeded, or no
 // reconciliation was necessary. The list of VirtualMachines that you now own is returned.
-func (m *VirtualMachineControllerRefManager) ClaimVirtualMachines(vmis []*virtv1.VirtualMachineInstance, filters ...func(machine *virtv1.VirtualMachineInstance) bool) ([]*virtv1.VirtualMachineInstance, error) {
+func (m *VirtualMachineControllerRefManager) ClaimVirtualMachineInstances(vmis []*virtv1.VirtualMachineInstance, filters ...func(machine *virtv1.VirtualMachineInstance) bool) ([]*virtv1.VirtualMachineInstance, error) {
 	var claimed []*virtv1.VirtualMachineInstance
 	var errlist []error
 
@@ -194,10 +194,10 @@ func (m *VirtualMachineControllerRefManager) ClaimVirtualMachines(vmis []*virtv1
 		return true
 	}
 	adopt := func(obj metav1.Object) error {
-		return m.AdoptVirtualMachine(obj.(*virtv1.VirtualMachineInstance))
+		return m.AdoptVirtualMachineInstance(obj.(*virtv1.VirtualMachineInstance))
 	}
 	release := func(obj metav1.Object) error {
-		return m.ReleaseVirtualMachine(obj.(*virtv1.VirtualMachineInstance))
+		return m.ReleaseVirtualMachineInstance(obj.(*virtv1.VirtualMachineInstance))
 	}
 
 	for _, vmi := range vmis {
@@ -256,7 +256,7 @@ func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes
 	return claimed, utilerrors.NewAggregate(errlist)
 }
 
-// ClaimVirtualMachineByName tries to take ownership of a VirtualMachineInstance.
+// ClaimVirtualMachineInstanceByName tries to take ownership of a VirtualMachineInstance.
 //
 // It will reconcile the following:
 //   * Adopt orphans if the selector matches.
@@ -271,7 +271,7 @@ func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes
 //
 // If the error is nil, either the reconciliation succeeded, or no
 // reconciliation was necessary. The list of VirtualMachines that you now own is returned.
-func (m *VirtualMachineControllerRefManager) ClaimVirtualMachineByName(vmi *virtv1.VirtualMachineInstance, filters ...func(machine *virtv1.VirtualMachineInstance) bool) (*virtv1.VirtualMachineInstance, error) {
+func (m *VirtualMachineControllerRefManager) ClaimVirtualMachineInstanceByName(vmi *virtv1.VirtualMachineInstance, filters ...func(machine *virtv1.VirtualMachineInstance) bool) (*virtv1.VirtualMachineInstance, error) {
 	match := func(obj metav1.Object) bool {
 		vmi := obj.(*virtv1.VirtualMachineInstance)
 		// Check selector first so filters only run on potentially matching VirtualMachines.
@@ -286,10 +286,10 @@ func (m *VirtualMachineControllerRefManager) ClaimVirtualMachineByName(vmi *virt
 		return true
 	}
 	adopt := func(obj metav1.Object) error {
-		return m.AdoptVirtualMachine(obj.(*virtv1.VirtualMachineInstance))
+		return m.AdoptVirtualMachineInstance(obj.(*virtv1.VirtualMachineInstance))
 	}
 	release := func(obj metav1.Object) error {
-		return m.ReleaseVirtualMachine(obj.(*virtv1.VirtualMachineInstance))
+		return m.ReleaseVirtualMachineInstance(obj.(*virtv1.VirtualMachineInstance))
 	}
 
 	ok, err := m.ClaimObject(vmi, match, adopt, release)
@@ -302,9 +302,9 @@ func (m *VirtualMachineControllerRefManager) ClaimVirtualMachineByName(vmi *virt
 	return nil, nil
 }
 
-// AdoptVirtualMachine sends a patch to take control of the vmi. It returns the error if
+// AdoptVirtualMachineInstance sends a patch to take control of the vmi. It returns the error if
 // the patching fails.
-func (m *VirtualMachineControllerRefManager) AdoptVirtualMachine(vmi *virtv1.VirtualMachineInstance) error {
+func (m *VirtualMachineControllerRefManager) AdoptVirtualMachineInstance(vmi *virtv1.VirtualMachineInstance) error {
 	if err := m.CanAdopt(); err != nil {
 		return fmt.Errorf("can't adopt VirtualMachineInstance %v/%v (%v): %v", vmi.Namespace, vmi.Name, vmi.UID, err)
 	}
@@ -317,9 +317,9 @@ func (m *VirtualMachineControllerRefManager) AdoptVirtualMachine(vmi *virtv1.Vir
 	return m.virtualMachineControl.PatchVirtualMachine(vmi.Namespace, vmi.Name, []byte(addControllerPatch))
 }
 
-// ReleaseVirtualMachine sends a patch to free the virtual machine from the control of the controller.
+// ReleaseVirtualMachineInstance sends a patch to free the virtual machine from the control of the controller.
 // It returns the error if the patching fails. 404 and 422 errors are ignored.
-func (m *VirtualMachineControllerRefManager) ReleaseVirtualMachine(vmi *virtv1.VirtualMachineInstance) error {
+func (m *VirtualMachineControllerRefManager) ReleaseVirtualMachineInstance(vmi *virtv1.VirtualMachineInstance) error {
 	log.Log.V(2).Object(vmi).Infof("patching vmi to remove its controllerRef to %s/%s:%s",
 		m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
 	// TODO CRDs don't support strategic merge, therefore replace the onwerReferences list with a merge patch

--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -69,7 +69,7 @@ func newVirtualMachine(virtualmachineName string, label map[string]string, owner
 	return vmi
 }
 
-func TestClaimVirtualMachine(t *testing.T) {
+func TestClaimVirtualMachineInstance(t *testing.T) {
 	controllerKind := schema.GroupVersionKind{}
 	type test struct {
 		name            string
@@ -175,7 +175,7 @@ func TestClaimVirtualMachine(t *testing.T) {
 		}(),
 	}
 	for _, test := range tests {
-		claimed, err := test.manager.ClaimVirtualMachines(test.virtualmachines)
+		claimed, err := test.manager.ClaimVirtualMachineInstances(test.virtualmachines)
 		if test.expectError && err == nil {
 			t.Errorf("Test case `%s`, expected error but got nil", test.name)
 		} else if !reflect.DeepEqual(test.claimed, claimed) {

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -206,7 +206,7 @@ func (c *VMIReplicaSet) execute(key string) error {
 		return fresh, nil
 	})
 	cm := controller.NewVirtualMachineControllerRefManager(controller.RealVirtualMachineControl{Clientset: c.clientset}, rs, selector, virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind, canAdoptFunc)
-	vmis, err = cm.ClaimVirtualMachines(vmis)
+	vmis, err = cm.ClaimVirtualMachineInstances(vmis)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -256,7 +256,7 @@ func (c *VMController) execute(key string) error {
 	} else {
 		vmi = vmiObj.(*virtv1.VirtualMachineInstance)
 
-		vmi, err = cm.ClaimVirtualMachineByName(vmi)
+		vmi, err = cm.ClaimVirtualMachineInstanceByName(vmi)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A long time ago we made the decision to split the "VirtualMachine" object into two objects, "VirtualMachine" and "VirtualMachineInstance". Throughout the years, we've caught a few instances where the new naming conventions didn't get fully addressed. This is one of them that I ran across while implementing the vm pool controller.

The VM and ReplicaSet controllers claim VMIs, not VMs. This is just a cosmetic change to reflect that. 

```release-note
NONE
```
