### PR TITLE
Fixed an issue where the virtual machine mouse and keyboard could not be used on ARM

### DIFF
--- a/examples/vmi-arm.yaml
+++ b/examples/vmi-arm.yaml
@@ -1,0 +1,37 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: arm
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: arm
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        devices:
+          autoattachGraphicsDevice: true
+          inputs:
+          - type: tablet
+            bus:  virtio
+            name: tablet01
+          - type: keyboard
+            bus: usb
+            name: keyboard01
+          disks:
+          - bootOrder: 1
+            disk:
+              bus: virtio
+            name: cdromiso
+        machine:
+          type: virt
+        resources:
+          requests:
+            memory: 2G
+      volumes:
+      - name: cdromiso
+        persistentVolumeClaim:
+          claimName: iso-arm


### PR DESCRIPTION
What this PR does / why we need it:

This is arm-related configuration. I verified that KUbevirt is enabled on ARM and it is successful.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

It supports ARM enabled Gpus.
Fixed an issue where the virtual machine mouse and keyboard could not be used on ARM

Special notes for your reviewer:

Release note:
```
NONE

```