### PR TITLE
Fix migration limitation for test_id 5004

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -757,6 +757,7 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 		params.DisksURISet = true
 	}
 
+	log.Log.Object(vmi).Infof("generated migration parameters: %+v", params)
 	return params, nil
 }
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1088,6 +1088,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			var vmi *v1.VirtualMachineInstance
 			var dv *cdiv1.DataVolume
 			var wffcPod *k8sv1.Pod
+			var migrationBandwidth resource.Quantity
 
 			BeforeEach(func() {
 				quantity, err := resource.ParseQuantity("5Gi")
@@ -1142,7 +1143,8 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
 
 				cfg := getCurrentKv()
-				cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewMilliQuantity(1, resource.BinarySI)
+				migrationBandwidth = resource.MustParse("1Ki")
+				cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1088,7 +1088,6 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			var vmi *v1.VirtualMachineInstance
 			var dv *cdiv1.DataVolume
 			var wffcPod *k8sv1.Pod
-			var migrationBandwidth resource.Quantity
 
 			BeforeEach(func() {
 				quantity, err := resource.ParseQuantity("5Gi")
@@ -1143,7 +1142,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
 
 				cfg := getCurrentKv()
-				migrationBandwidth = resource.MustParse("40Mi")
+				migrationBandwidth := resource.MustParse("40Mi")
 				cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1143,7 +1143,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
 
 				cfg := getCurrentKv()
-				migrationBandwidth = resource.MustParse("1Ki")
+				migrationBandwidth = resource.MustParse("40Mi")
 				cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})


### PR DESCRIPTION
It is suspected that migration bandwidth limitation was not applied since was overriden by test entry that overrides MigrationConfigurations.