### PR TITLE
Add support for passing the tests images registry on Kubevirt Conformance plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ functest-image-push: functest-image-build
 	hack/func-tests-image.sh push
 
 conformance:
-	hack/dockerized "export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} SKIP_OUTSIDE_CONN_TESTS=${SKIP_OUTSIDE_CONN_TESTS} KUBEVIRT_E2E_FOCUS=${KUBEVIRT_E2E_FOCUS} DOCKER_TAG=${DOCKER_TAG} && hack/conformance.sh"
+	hack/dockerized "export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} SKIP_OUTSIDE_CONN_TESTS=${SKIP_OUTSIDE_CONN_TESTS} KUBEVIRT_E2E_FOCUS=${KUBEVIRT_E2E_FOCUS} DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} && hack/conformance.sh"
 
 perftest: build-functests
 	hack/perftests.sh

--- a/automation/conformance.sh
+++ b/automation/conformance.sh
@@ -12,4 +12,6 @@ export KUBEVIRT_NUM_NODES=2
 
 make cluster-up
 make cluster-sync
+
+export DOCKER_PREFIX="${DOCKER_PREFIX:-registry:5000/kubevirt}"
 make conformance

--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -13,6 +13,10 @@ export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
 
 sonobuoy_args="--wait --plugin _out/manifests/release/conformance.yaml"
 
+if [[ ! -z "$DOCKER_PREFIX" ]]; then
+    sonobuoy_args="${sonobuoy_args} --plugin-env kubevirt-conformance.CONTAINER_PREFIX=${DOCKER_PREFIX}"
+fi
+
 if [[ ! -z "$DOCKER_TAG" ]]; then
     sonobuoy_args="${sonobuoy_args} --plugin-env kubevirt-conformance.CONTAINER_TAG=${DOCKER_TAG}"
 fi

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -42,6 +42,9 @@ func execute() error {
 	} else {
 		args = append(args, "--ginkgo.focus", "\\[Conformance\\]")
 	}
+	if value, exists := os.LookupEnv("CONTAINER_PREFIX"); exists {
+		args = append(args, "--container-prefix", value)
+	}
 	if value, exists := os.LookupEnv("CONTAINER_TAG"); exists {
 		args = append(args, "--container-tag", value)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following https://github.com/kubevirt/kubevirt/pull/6199, 
we see errors on the last [periodic-kubevirt-push-nightly-conformance job](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-conformance/1450650557575335936)
 [junit log](https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-push-nightly-conformance/1450650557575335936/artifacts/junit.conformance.xml) show that images are being pulled from `quay.io/kubevirt` instead of the local registry:
```
Failed to pull image \"quay.io/kubevirt/cirros-container-disk-demo:devel\": rpc error: code = Unknown desc = Error reading manifest devel in quay.io/kubevirt/cirros-container-disk-demo: manifest unknown: manifest unknown"
Kubevirt Conformance test suite pulls images from quay.io/kubevirt by default.
```

This PR add support for passing `DOCKER_PREFIX` to the plugin test suite.
It will enable pulling images from other registries including local registry.

This PR also set `make conformance` to pull from the local registry by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubevirt Conformance plugin now supports passing tests images registry.
```
