### PR TITLE
Use non-empty values in labels for Prometheus

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -898,7 +898,7 @@ spec:
                 scheduler.alpha.kubernetes.io/critical-pod: ""
               labels:
                 kubevirt.io: virt-operator
-                prometheus.kubevirt.io: ""
+                prometheus.kubevirt.io: "true"
               name: virt-operator
             spec:
               affinity:

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -461,7 +461,7 @@ var _ = Describe("Apply", func() {
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"prometheus.kubevirt.io": "",
+							"prometheus.kubevirt.io": "true",
 						},
 						Ports: []corev1.ServicePort{
 							{
@@ -490,7 +490,7 @@ var _ = Describe("Apply", func() {
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"prometheus.kubevirt.io": "",
+							"prometheus.kubevirt.io": "true",
 						},
 						Ports: []corev1.ServicePort{
 							{

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -57,12 +57,12 @@ func NewPrometheusService(namespace string) *corev1.Service {
 			Name:      "kubevirt-prometheus-metrics",
 			Labels: map[string]string{
 				virtv1.AppLabel:    "",
-				prometheusLabelKey: "",
+				prometheusLabelKey: prometheusLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				prometheusLabelKey: "",
+				prometheusLabelKey: prometheusLabelValue,
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -120,7 +120,7 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				virtv1.AppLabel:    podName,
-				prometheusLabelKey: "",
+				prometheusLabelKey: prometheusLabelValue,
 			},
 			Annotations: map[string]string{
 				"scheduler.alpha.kubernetes.io/critical-pod": "",
@@ -442,7 +442,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						virtv1.AppLabel:    VirtOperatorName,
-						prometheusLabelKey: "",
+						prometheusLabelKey: prometheusLabelValue,
 					},
 					Annotations: map[string]string{
 						"scheduler.alpha.kubernetes.io/critical-pod": "",

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -11,6 +11,7 @@ import (
 
 const KUBEVIRT_PROMETHEUS_RULE_NAME = "prometheus-kubevirt-rules"
 const prometheusLabelKey = "prometheus.kubevirt.io"
+const prometheusLabelValue = "true"
 const runbookUrlBasePath = "https://kubevirt.io/monitoring/runbooks/"
 
 func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkipVerify bool) *v1.ServiceMonitor {
@@ -24,14 +25,14 @@ func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkip
 			Name:      KUBEVIRT_PROMETHEUS_RULE_NAME,
 			Labels: map[string]string{
 				"openshift.io/cluster-monitoring": "",
-				prometheusLabelKey:                "",
+				prometheusLabelKey:                prometheusLabelValue,
 				"k8s-app":                         "kubevirt",
 			},
 		},
 		Spec: v1.ServiceMonitorSpec{
 			Selector: v12.LabelSelector{
 				MatchLabels: map[string]string{
-					prometheusLabelKey: "",
+					prometheusLabelKey: prometheusLabelValue,
 				},
 			},
 			NamespaceSelector: v1.NamespaceSelector{
@@ -62,7 +63,7 @@ func NewPrometheusRuleCR(namespace string, workloadUpdatesEnabled bool) *v1.Prom
 			Name:      KUBEVIRT_PROMETHEUS_RULE_NAME,
 			Namespace: namespace,
 			Labels: map[string]string{
-				prometheusLabelKey: "",
+				prometheusLabelKey: prometheusLabelValue,
 				"k8s-app":          "kubevirt",
 			},
 		},

--- a/pkg/virt-operator/resource/generate/components/webhooks.go
+++ b/pkg/virt-operator/resource/generate/components/webhooks.go
@@ -29,7 +29,7 @@ func NewOperatorWebhookService(operatorNamespace string) *corev1.Service {
 			Name:      KubevirtOperatorWebhookServiceName,
 			Labels: map[string]string{
 				virtv1.AppLabel:          "",
-				"prometheus.kubevirt.io": "",
+				"prometheus.kubevirt.io": prometheusLabelValue,
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -823,7 +823,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		It("[test_id:4138]should be exposed and registered on the metrics endpoint", func() {
 			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			l, err := labels.Parse("prometheus.kubevirt.io")
+			l, err := labels.Parse("prometheus.kubevirt.io=true")
 			Expect(err).ToNot(HaveOccurred())
 			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Workaround for a bug in prometheus-operator

See https://github.com/prometheus-operator/prometheus-operator/issues/4325

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2008166

Signed-off-by: Erkan Erol <eerol@redhat.com>

**Release note**:
```release-note
NONE
```
