### PR TITLE
Re enable feature gates at teardown

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -700,6 +700,12 @@ var _ = SIGDescribe("Storage", func() {
 		})
 
 		Context("[Serial]With feature gates disabled for", func() {
+
+			AfterEach(func() {
+				tests.EnableFeatureGate(virtconfig.HostDiskGate)
+				tests.EnableFeatureGate(virtconfig.VirtIOFSGate)
+			})
+
 			It("[test_id:4620]HostDisk, it should fail to start a VMI", func() {
 				tests.DisableFeatureGate(virtconfig.HostDiskGate)
 				vmi = tests.NewRandomVMIWithHostDisk("somepath", v1.HostDiskExistsOrCreate, "")


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Re enable feature gates that were turned off for testing purposes (so we don't end up skipping lots of tests for no good reason)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
