### PR TITLE
Make the number of replicas for virt- pods configurable

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11133,8 +11133,13 @@
     "type": "object",
     "properties": {
      "nodePlacement": {
-      "description": "nodePlacement decsribes scheduling confiuguration for specific KubeVirt components",
+      "description": "nodePlacement describes scheduling configuration for specific KubeVirt components",
       "$ref": "#/definitions/v1.NodePlacement"
+     },
+     "replicas": {
+      "description": "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2.",
+      "type": "integer",
+      "format": "byte"
      }
     }
    },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -493,7 +493,7 @@ spec:
                   infrastructure components
                 properties:
                   nodePlacement:
-                    description: nodePlacement decsribes scheduling confiuguration
+                    description: nodePlacement describes scheduling configuration
                       for specific KubeVirt components
                     properties:
                       affinity:
@@ -1196,6 +1196,11 @@ spec:
                           type: object
                         type: array
                     type: object
+                  replicas:
+                    description: replicas indicates how many replicas should be created
+                      for each KubeVirt infrastructure component (like virt-api or
+                      virt-controller). Defaults to 2.
+                    type: integer
                 type: object
               monitorAccount:
                 description: The name of the Prometheus service account that needs
@@ -1251,7 +1256,7 @@ spec:
                   workloads
                 properties:
                   nodePlacement:
-                    description: nodePlacement decsribes scheduling confiuguration
+                    description: nodePlacement describes scheduling configuration
                       for specific KubeVirt components
                     properties:
                       affinity:
@@ -1954,6 +1959,11 @@ spec:
                           type: object
                         type: array
                     type: object
+                  replicas:
+                    description: replicas indicates how many replicas should be created
+                      for each KubeVirt infrastructure component (like virt-api or
+                      virt-controller). Defaults to 2.
+                    type: integer
                 type: object
             type: object
           status:
@@ -2529,7 +2539,7 @@ spec:
                   infrastructure components
                 properties:
                   nodePlacement:
-                    description: nodePlacement decsribes scheduling confiuguration
+                    description: nodePlacement describes scheduling configuration
                       for specific KubeVirt components
                     properties:
                       affinity:
@@ -3232,6 +3242,11 @@ spec:
                           type: object
                         type: array
                     type: object
+                  replicas:
+                    description: replicas indicates how many replicas should be created
+                      for each KubeVirt infrastructure component (like virt-api or
+                      virt-controller). Defaults to 2.
+                    type: integer
                 type: object
               monitorAccount:
                 description: The name of the Prometheus service account that needs
@@ -3287,7 +3302,7 @@ spec:
                   workloads
                 properties:
                   nodePlacement:
-                    description: nodePlacement decsribes scheduling confiuguration
+                    description: nodePlacement describes scheduling configuration
                       for specific KubeVirt components
                     properties:
                       affinity:
@@ -3990,6 +4005,11 @@ spec:
                           type: object
                         type: array
                     type: object
+                  replicas:
+                    description: replicas indicates how many replicas should be created
+                      for each KubeVirt infrastructure component (like virt-api or
+                      virt-controller). Defaults to 2.
+                    type: integer
                 type: object
             type: object
           status:

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -617,7 +617,7 @@ func (r *Reconciler) createOrRollBackSystem(apiDeploymentsRolledOver bool) (bool
 	// create/update API Deployments
 	for _, deployment := range r.targetStrategy.ApiDeployments() {
 		deployment := deployment.DeepCopy()
-		err := r.syncDeployment(deployment)
+		deployment, err := r.syncDeployment(deployment)
 		if err != nil {
 			return false, err
 		}
@@ -635,7 +635,7 @@ func (r *Reconciler) createOrRollBackSystem(apiDeploymentsRolledOver bool) (bool
 
 	// create/update Controller Deployments
 	for _, deployment := range r.targetStrategy.ControllerDeployments() {
-		err := r.syncDeployment(deployment)
+		deployment, err := r.syncDeployment(deployment)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/virt-operator/resource/apply/update.go
+++ b/pkg/virt-operator/resource/apply/update.go
@@ -24,7 +24,7 @@ func (r *Reconciler) updateKubeVirtSystem(daemonSetsRolledOver, controllerDeploy
 
 	// create/update Controller Deployments
 	for _, deployment := range r.targetStrategy.ControllerDeployments() {
-		err := r.syncDeployment(deployment)
+		deployment, err := r.syncDeployment(deployment)
 		if err != nil {
 			return false, err
 		}
@@ -43,7 +43,7 @@ func (r *Reconciler) updateKubeVirtSystem(daemonSetsRolledOver, controllerDeploy
 	// create/update API Deployments
 	for _, deployment := range r.targetStrategy.ApiDeployments() {
 		deployment := deployment.DeepCopy()
-		err := r.syncDeployment(deployment)
+		deployment, err := r.syncDeployment(deployment)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -593,7 +593,10 @@ func AddVersionSeparatorPrefix(version string) string {
 
 func NewPodDisruptionBudgetForDeployment(deployment *appsv1.Deployment) *v1beta1.PodDisruptionBudget {
 	pdbName := deployment.Name + "-pdb"
-	minAvailable := intstr.FromInt(int(1))
+	minAvailable := intstr.FromInt(1)
+	if deployment.Spec.Replicas != nil {
+		minAvailable = intstr.FromInt(int(*deployment.Spec.Replicas - 1))
+	}
 	selector := deployment.Spec.Selector.DeepCopy()
 	podDisruptionBudget := &v1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -911,7 +911,7 @@ var CRDsValidation map[string]string = map[string]string{
             components
           properties:
             nodePlacement:
-              description: nodePlacement decsribes scheduling confiuguration for specific
+              description: nodePlacement describes scheduling configuration for specific
                 KubeVirt components
               properties:
                 affinity:
@@ -1569,6 +1569,11 @@ var CRDsValidation map[string]string = map[string]string{
                     type: object
                   type: array
               type: object
+            replicas:
+              description: replicas indicates how many replicas should be created
+                for each KubeVirt infrastructure component (like virt-api or virt-controller).
+                Defaults to 2.
+              type: integer
           type: object
         monitorAccount:
           description: The name of the Prometheus service account that needs read-access
@@ -1621,7 +1626,7 @@ var CRDsValidation map[string]string = map[string]string{
           description: selectors and tolerations that should apply to KubeVirt workloads
           properties:
             nodePlacement:
-              description: nodePlacement decsribes scheduling confiuguration for specific
+              description: nodePlacement describes scheduling configuration for specific
                 KubeVirt components
               properties:
                 affinity:
@@ -2279,6 +2284,11 @@ var CRDsValidation map[string]string = map[string]string{
                     type: object
                   type: array
               type: object
+            replicas:
+              description: replicas indicates how many replicas should be created
+                for each KubeVirt infrastructure component (like virt-api or virt-controller).
+                Defaults to 2.
+              type: integer
           type: object
       type: object
     status:

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -81,6 +81,10 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *
 		}
 	}
 
+	if newKV.Spec.Infra != nil {
+		results = append(results, validateInfraReplicas(newKV.Spec.Infra.Replicas)...)
+	}
+
 	return validating_webhooks.NewAdmissionResponse(results)
 }
 
@@ -287,6 +291,19 @@ func validateInfraPlacement(namespace string, placementConfig *v1.NodePlacement,
 		statuses = append(statuses, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: err.Error(),
+		})
+	}
+
+	return statuses
+}
+
+func validateInfraReplicas(replicas *uint8) []metav1.StatusCause {
+	statuses := []metav1.StatusCause{}
+
+	if replicas != nil && *replicas == 0 {
+		statuses = append(statuses, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "infra replica count can't be 0",
 		})
 	}
 

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/componentconfig.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/componentconfig.go
@@ -40,8 +40,12 @@ type NodePlacement struct {
 //
 // +k8s:openapi-gen=true
 type ComponentConfig struct {
-	// nodePlacement decsribes scheduling confiuguration for specific
+	// nodePlacement describes scheduling configuration for specific
 	// KubeVirt components
 	//+optional
 	NodePlacement *NodePlacement `json:"nodePlacement,omitempty"`
+	// replicas indicates how many replicas should be created for each KubeVirt infrastructure
+	// component (like virt-api or virt-controller). Defaults to 2.
+	//+optional
+	Replicas *uint8 `json:"replicas,omitempty"`
 }

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/deepcopy_generated.go
@@ -462,6 +462,11 @@ func (in *ComponentConfig) DeepCopyInto(out *ComponentConfig) {
 		*out = new(NodePlacement)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(byte)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
@@ -19329,8 +19329,15 @@ func schema_client_go_apis_core_v1_ComponentConfig(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"nodePlacement": {
 						SchemaProps: spec.SchemaProps{
-							Description: "nodePlacement decsribes scheduling confiuguration for specific KubeVirt components",
+							Description: "nodePlacement describes scheduling configuration for specific KubeVirt components",
 							Ref:         ref("kubevirt.io/client-go/apis/core/v1.NodePlacement"),
+						},
+					},
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2.",
+							Type:        []string{"integer"},
+							Format:      "byte",
 						},
 					},
 				},

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14392,8 +14392,15 @@ func schema_client_go_apis_core_v1_ComponentConfig(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"nodePlacement": {
 						SchemaProps: spec.SchemaProps{
-							Description: "nodePlacement decsribes scheduling confiuguration for specific KubeVirt components",
+							Description: "nodePlacement describes scheduling configuration for specific KubeVirt components",
 							Ref:         ref("kubevirt.io/client-go/apis/core/v1.NodePlacement"),
+						},
+					},
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2.",
+							Type:        []string{"integer"},
+							Format:      "byte",
 						},
 					},
 				},


### PR DESCRIPTION
and adjust PDBs accordingly

**What this PR does / why we need it**:
This PR allows for configuring the number of replicas to be created for virt-api and virt-controller.
It also adjusts the PDBs accordingly, or just skips creating them if only 1 replica is requested.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The number of virt-api and virt-controller replicas is now configurable in the CSV
```
