### PR TITLE
Extend FOSSA timeout value to 30min

### DIFF
--- a/hack/fossa.sh
+++ b/hack/fossa.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
 FOSSA_API_KEY="$(cat $FOSSA_TOKEN_FILE)" fossa analyze
-FOSSA_API_KEY="$(cat $FOSSA_TOKEN_FILE)" fossa test
+FOSSA_API_KEY="$(cat $FOSSA_TOKEN_FILE)" fossa test --timeout=1800


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since we are running into FOSSA analysis timeout more often lately, this PR increases the timeout to 30 minutes ([default is 10 mins](https://github.com/fossas/fossa-cli/blob/master/cmd/fossa/cmd/test/test.go#L47))

Search link: https://search.ci.kubevirt.io/?search=Could+not+test+revision%3A+Could+not+load+build%3A%3A+timed+out+while+checking+for+build&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Build links:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-kubevirt-fossa/1451693905958408192
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-kubevirt-fossa/1451110940631109632
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-kubevirt-fossa/1450117585277292544

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fgimenez

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
