### PR TITLE
[release 0.36] Only send vmi defined event when domain is being created the first time

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -630,6 +630,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Expect(options.VirtualMachineSMBios.Manufacturer).To(Equal(virtconfig.SmbiosConfigDefaultManufacturer))
 			})
 			controller.Execute()
+			testutils.ExpectEvent(recorder, "VirtualMachineInstance defined")
 			Expect(len(controller.phase1NetworkSetupCache)).To(Equal(1))
 		})
 


### PR DESCRIPTION
Manual backport of #6610 

```release-note
NONE
```
