### PR TITLE
Add dry run functionality for stop start restart commands

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8402,6 +8402,16 @@
     "put": {
      "description": "Start a VirtualMachine object.",
      "operationId": "v1Start",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.StartOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -9487,6 +9497,16 @@
     "put": {
      "description": "Start a VirtualMachine object.",
      "operationId": "v1alpha3Start",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.StartOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -13117,8 +13137,16 @@
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
      },
+     "dryRun": {
+      "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "gracePeriodSeconds": {
-      "description": "The duration in seconds before the object should be force-restared. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
+      "description": "The duration in seconds before the object should be force-restarted. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
       "type": "integer",
       "format": "int64"
      },
@@ -13222,6 +13250,32 @@
      }
     }
    },
+   "v1.StartOptions": {
+    "description": "StartOptions may be provided on start request.",
+    "type": "object",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "dryRun": {
+      "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "paused": {
+      "description": "Indicates that VM will be started in paused state.",
+      "type": "boolean"
+     }
+    }
+   },
    "v1.StopOptions": {
     "description": "StopOptions may be provided when deleting an API object.",
     "type": "object",
@@ -13229,6 +13283,14 @@
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
+     },
+     "dryRun": {
+      "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "atomic"
      },
      "gracePeriod": {
       "description": "this updates the VMIs terminationGracePeriodSeconds during shutdown",

--- a/pkg/util/status/BUILD.bazel
+++ b/pkg/util/status/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],

--- a/pkg/util/status/status.go
+++ b/pkg/util/status/status.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	v1 "kubevirt.io/client-go/apis/core/v1"
 	"kubevirt.io/client-go/kubecli"
 )
@@ -29,11 +31,11 @@ func (u *updater) update(obj runtime.Object) (err error) {
 	}
 }
 
-func (u *updater) patch(obj runtime.Object, pt types.PatchType, data []byte) (err error) {
+func (u *updater) patch(obj runtime.Object, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (err error) {
 	if u.getSubresource() {
-		return u.patchWithSubresource(obj, pt, data)
+		return u.patchWithSubresource(obj, pt, data, patchOptions)
 	} else {
-		return u.patchWithoutSubresource(obj, pt, data)
+		return u.patchWithoutSubresource(obj, pt, data, patchOptions)
 	}
 }
 
@@ -80,14 +82,14 @@ func (u *updater) updateWithSubresource(obj runtime.Object) (updateStatusErr err
 // patchWithoutSubresource will try to update the  status via PATCH sent to the main REST endpoint.
 // If the resource version of the returned object did not change, it knows that it should have used the /status subresource
 // and will switch the updater itself over to permanently use the /status subresource.
-func (u *updater) patchWithoutSubresource(obj runtime.Object, patchType types.PatchType, data []byte) (err error) {
-	oldResourceVersion, newResourceVersion, err := u.patchUnstructured(obj, patchType, data)
+func (u *updater) patchWithoutSubresource(obj runtime.Object, patchType types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (err error) {
+	oldResourceVersion, newResourceVersion, err := u.patchUnstructured(obj, patchType, data, patchOptions)
 	if err != nil {
 		return err
 	}
 	if oldResourceVersion == newResourceVersion {
 		u.setSubresource(true)
-		return u.patchStatusUnstructured(obj, patchType, data)
+		return u.patchStatusUnstructured(obj, patchType, data, patchOptions)
 	}
 	return nil
 }
@@ -95,13 +97,13 @@ func (u *updater) patchWithoutSubresource(obj runtime.Object, patchType types.Pa
 // patchWithSubresource will try to update the  status via PATCH sent to the /status subresource.
 // If a 404 error is returned, it will try the main rest entrypoint instead. In case that this
 // call succeeds, it will switch the updater to permanently use the main entrypoint.
-func (u *updater) patchWithSubresource(obj runtime.Object, patchType types.PatchType, data []byte) (patchStatusErr error) {
-	patchStatusErr = u.patchStatusUnstructured(obj, patchType, data)
+func (u *updater) patchWithSubresource(obj runtime.Object, patchType types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (patchStatusErr error) {
+	patchStatusErr = u.patchStatusUnstructured(obj, patchType, data, patchOptions)
 	if patchStatusErr != nil && !errors.IsNotFound(patchStatusErr) {
 		return patchStatusErr
 	}
 	if errors.IsNotFound(patchStatusErr) {
-		oldResourceVersion, newResourceVersions, err := u.patchUnstructured(obj, patchType, data)
+		oldResourceVersion, newResourceVersions, err := u.patchUnstructured(obj, patchType, data, patchOptions)
 		if errors.IsNotFound(err) {
 			// object does not exist
 			return err
@@ -117,7 +119,7 @@ func (u *updater) patchWithSubresource(obj runtime.Object, patchType types.Patch
 	}
 }
 
-func (u *updater) patchUnstructured(obj runtime.Object, patchType types.PatchType, data []byte) (oldResourceVersion, newResourceVerions string, err error) {
+func (u *updater) patchUnstructured(obj runtime.Object, patchType types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (oldResourceVersion, newResourceVerions string, err error) {
 	a, err := meta.Accessor(obj)
 	if err != nil {
 		return "", "", err
@@ -125,14 +127,14 @@ func (u *updater) patchUnstructured(obj runtime.Object, patchType types.PatchTyp
 	switch obj.(type) {
 	case *v1.VirtualMachine:
 		oldObj := obj.(*v1.VirtualMachine)
-		newObj, err := u.cli.VirtualMachine(a.GetNamespace()).Patch(a.GetName(), patchType, data)
+		newObj, err := u.cli.VirtualMachine(a.GetNamespace()).Patch(a.GetName(), patchType, data, patchOptions)
 		if err != nil {
 			return "", "", err
 		}
 		return oldObj.ResourceVersion, newObj.ResourceVersion, nil
 	case *v1.KubeVirt:
 		oldObj := obj.(*v1.KubeVirt)
-		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Patch(a.GetName(), patchType, data)
+		newObj, err := u.cli.KubeVirt(a.GetNamespace()).Patch(a.GetName(), patchType, data, patchOptions)
 		if err != nil {
 			return "", "", err
 		}
@@ -142,17 +144,17 @@ func (u *updater) patchUnstructured(obj runtime.Object, patchType types.PatchTyp
 	}
 }
 
-func (u *updater) patchStatusUnstructured(obj runtime.Object, patchType types.PatchType, data []byte) (err error) {
+func (u *updater) patchStatusUnstructured(obj runtime.Object, patchType types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (err error) {
 	a, err := meta.Accessor(obj)
 	if err != nil {
 		return err
 	}
 	switch obj.(type) {
 	case *v1.VirtualMachine:
-		_, err = u.cli.VirtualMachine(a.GetNamespace()).PatchStatus(a.GetName(), patchType, data)
+		_, err = u.cli.VirtualMachine(a.GetNamespace()).PatchStatus(a.GetName(), patchType, data, patchOptions)
 		return err
 	case *v1.KubeVirt:
-		_, err = u.cli.KubeVirt(a.GetNamespace()).PatchStatus(a.GetName(), patchType, data)
+		_, err = u.cli.KubeVirt(a.GetNamespace()).PatchStatus(a.GetName(), patchType, data, patchOptions)
 		return err
 	default:
 		panic("Unknown object")
@@ -245,8 +247,8 @@ func (v *VMStatusUpdater) UpdateStatus(vm *v1.VirtualMachine) error {
 	return v.updater.update(vm)
 }
 
-func (v *VMStatusUpdater) PatchStatus(vm *v1.VirtualMachine, pt types.PatchType, data []byte) error {
-	return v.updater.patch(vm, pt, data)
+func (v *VMStatusUpdater) PatchStatus(vm *v1.VirtualMachine, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) error {
+	return v.updater.patch(vm, pt, data, patchOptions)
 }
 
 func NewVMStatusUpdater(cli kubecli.KubevirtClient) *VMStatusUpdater {
@@ -286,7 +288,7 @@ func (v *KVStatusUpdater) UpdateStatus(kv *v1.KubeVirt) error {
 }
 
 func (v *KVStatusUpdater) PatchStatus(kv *v1.KubeVirt, pt types.PatchType, data []byte) error {
-	return v.updater.patch(kv, pt, data)
+	return v.updater.patch(kv, pt, data, &metav1.PatchOptions{})
 }
 
 func NewKubeVirtStatusUpdater(cli kubecli.KubevirtClient) *KVStatusUpdater {

--- a/pkg/util/status/status_test.go
+++ b/pkg/util/status/status_test.go
@@ -90,10 +90,11 @@ var _ = Describe("Status", func() {
 		Context("for PATCH operations", func() {
 			It("should continuously use the /status subresource if no errors occur", func() {
 				updater := NewVMStatusUpdater(virtClient)
+				patchOptions := &v12.PatchOptions{}
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, nil).Times(2)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, nil).Times(2)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 
 			It("should fall back on a 404 error on the /status subresource to an ordinary update", func() {
@@ -101,39 +102,43 @@ var _ = Describe("Status", func() {
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
 				newVM := vm.DeepCopy()
 				newVM.SetResourceVersion("2")
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(newVM, nil).Times(2)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				patchOptions := &v12.PatchOptions{}
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(newVM, nil).Times(2)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 
 			It("should fall back on a 404 error on the /status subresource to an ordinary update but keep in mind that objects may have disappeared", func() {
 				updater := NewVMStatusUpdater(virtClient)
+				patchOptions := &v12.PatchOptions{}
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, nil).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, nil).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 
 			It("should fall back on a 404 error on the /status subresource to an ordinary update but keep in mind that the subresource may get enabled directly afterwards", func() {
 				updater := NewVMStatusUpdater(virtClient)
+				patchOptions := &v12.PatchOptions{}
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, nil).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, nil).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(1)
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, nil).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, nil).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 
 			It("should stick with /status if an arbitrary error occurs", func() {
 				updater := NewVMStatusUpdater(virtClient)
+				patchOptions := &v12.PatchOptions{}
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, fmt.Errorf("I am not a 404 error")).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(vm, nil).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, fmt.Errorf("I am not a 404 error")).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(vm, nil).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 		})
 
@@ -189,9 +194,10 @@ var _ = Describe("Status", func() {
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
 				newVM := vm.DeepCopy()
 				newVM.SetResourceVersion("2")
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(newVM, nil).Times(2)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				patchOptions := &v12.PatchOptions{}
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(newVM, nil).Times(2)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 
 			It("should stick with a normal update if we get a 404 error", func() {
@@ -200,9 +206,10 @@ var _ = Describe("Status", func() {
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
 				newVM := vm.DeepCopy()
 				newVM.SetResourceVersion("2")
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(2)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
+				patchOptions := &v12.PatchOptions{}
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(nil, errors.NewNotFound(schema.GroupResource{}, "something")).Times(2)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
 			})
 
 			It("should stick with a normal update if we get an arbitrary error", func() {
@@ -211,9 +218,10 @@ var _ = Describe("Status", func() {
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
 				newVM := vm.DeepCopy()
 				newVM.SetResourceVersion("2")
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(nil, fmt.Errorf("I am an arbitrary error")).Times(2)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).ToNot(Succeed())
+				patchOptions := &v12.PatchOptions{}
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(nil, fmt.Errorf("I am an arbitrary error")).Times(2)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).ToNot(Succeed())
 			})
 
 			It("should fall back to /status if the status did not change and stick to it", func() {
@@ -221,11 +229,12 @@ var _ = Describe("Status", func() {
 				updater.updater.subresource = false
 				vm := &v1.VirtualMachine{ObjectMeta: v12.ObjectMeta{Name: "test", ResourceVersion: "1"}, Status: v1.VirtualMachineStatus{Ready: true}}
 				newVM := vm.DeepCopy()
-				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test")).Return(newVM, nil).Times(1)
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(newVM, nil).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
-				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test")).Return(newVM, nil).Times(1)
-				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"))).To(Succeed())
+				patchOptions := &v12.PatchOptions{}
+				vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(newVM, nil).Times(1)
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(newVM, nil).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
+				vmInterface.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, []byte("test"), patchOptions).Return(newVM, nil).Times(1)
+				Expect(updater.PatchStatus(vm, types.JSONPatchType, []byte("test"), patchOptions)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -242,6 +242,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(rest.NamespacedResourcePath(subresourcesvmGVR)+rest.SubResourcePath("start")).
 			To(subresourceApp.StartVMRequestHandler).
+			Reads(v1.StartOptions{}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Operation(version.Version+"Start").
 			Doc("Start a VirtualMachine object.").

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -325,7 +325,7 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 	}
 
 	log.Log.Object(vm).V(4).Infof("Patching VM: %s", bodyString)
-	err = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString))
+	err = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	if err != nil {
 		if strings.Contains(err.Error(), "jsonpatch test operation does not apply") {
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, err), response)
@@ -417,8 +417,8 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 
 	startPaused := false
 	startChangeRequestData := make(map[string]string)
+	bodyStruct := &v1.StartOptions{}
 	if request.Request.Body != nil {
-		bodyStruct := &v1.StartOptions{}
 		err := yaml.NewYAMLOrJSONDecoder(request.Request.Body, 1024).Decode(&bodyStruct)
 		switch err {
 		case io.EOF, nil:
@@ -459,11 +459,11 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 				return
 			}
 			log.Log.Object(vm).V(4).Infof("Patching VM status: %s", patchString)
-			patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patchString))
+			patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patchString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 		} else {
 			patchString := getRunningJson(vm, true)
 			log.Log.Object(vm).V(4).Infof("Patching VM: %s", patchString)
-			_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(vm.GetName(), types.MergePatchType, []byte(patchString))
+			_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(vm.GetName(), types.MergePatchType, []byte(patchString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 		}
 
 	case v1.RunStrategyRerunOnFailure, v1.RunStrategyManual:
@@ -490,7 +490,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			return
 		}
 		log.Log.Object(vm).V(4).Infof("Patching VM status: %s", bodyString)
-		patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString))
+		patchErr = app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	case v1.RunStrategyAlways:
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v does not support manual start requests", v1.RunStrategyAlways)), response)
 		return
@@ -585,11 +585,11 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 			return
 		}
 		log.Log.Object(vm).V(4).Infof("Patching VM status: %s", bodyString)
-		patchErr = app.statusUpdater.PatchStatus(vm, patchType, []byte(bodyString))
+		patchErr = app.statusUpdater.PatchStatus(vm, patchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	case v1.RunStrategyRerunOnFailure, v1.RunStrategyAlways:
 		bodyString := getRunningJson(vm, false)
 		log.Log.Object(vm).V(4).Infof("Patching VM: %s", bodyString)
-		_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(vm.GetName(), patchType, []byte(bodyString))
+		_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(vm.GetName(), patchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	}
 
 	if patchErr != nil {
@@ -1165,7 +1165,7 @@ func (app *SubresourceAPIApp) vmVolumePatchStatus(name, namespace string, volume
 	}
 
 	log.Log.Object(vm).V(4).Infof("Patching VM: %s", patch)
-	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch)); err != nil {
+	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{}); err != nil {
 		log.Log.Object(vm).V(1).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Workload Updater", func() {
 			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
 			addKubeVirt(kv)
 
-			kubeVirtInterface.EXPECT().PatchStatus(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(name string, pt types.PatchType, data []byte) {
+			kubeVirtInterface.EXPECT().PatchStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) {
 				str := string(data)
 				Expect(str).To(Equal("[{ \"op\": \"test\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 0}, { \"op\": \"replace\", \"path\": \"/status/outdatedVirtualMachineInstanceWorkloads\", \"value\": 100}]"))
 

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -89,8 +89,8 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&forceRestart, "force", forceRestart, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
-	cmd.Flags().IntVar(&gracePeriod, "grace-period", gracePeriod, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().BoolVar(&forceRestart, "force", false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
+	cmd.Flags().IntVar(&gracePeriod, "grace-period", -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -106,8 +106,8 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 			return c.Run(args)
 		},
 	}
-	cmd.Flags().BoolVar(&forceRestart, "force", forceRestart, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
-	cmd.Flags().IntVar(&gracePeriod, "grace-period", gracePeriod, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().BoolVar(&forceRestart, "force", false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
+	cmd.Flags().IntVar(&gracePeriod, "grace-period", -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -54,11 +54,12 @@ const (
 
 var (
 	forceRestart bool
-	gracePeriod  int = -1
+	gracePeriod  int64 = -1
 	volumeName   string
 	serial       string
 	persist      bool
 	startPaused  bool
+	dryRun       bool
 )
 
 func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
@@ -73,6 +74,7 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&startPaused, "paused", false, "--paused=false: If set to true, start virtual machine in paused state")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -90,7 +92,8 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&forceRestart, "force", false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
-	cmd.Flags().IntVar(&gracePeriod, "grace-period", -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().Int64Var(&gracePeriod, "grace-period", -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -107,7 +110,8 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&forceRestart, "force", false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
-	cmd.Flags().IntVar(&gracePeriod, "grace-period", -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().Int64Var(&gracePeriod, "grace-period", -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -328,8 +332,15 @@ func removeVolume(vmiName, volumeName, namespace string, virtClient kubecli.Kube
 	return nil
 }
 
-func gracePeriodIsSet(period int) bool {
+func gracePeriodIsSet(period int64) bool {
 	return period != notDefinedGracePeriod
+}
+
+func getDryRunOption(dryRun bool) []string {
+	if dryRun {
+		return []string{metav1.DryRunAll}
+	}
+	return nil
 }
 
 func (o *Command) Run(args []string) error {
@@ -346,9 +357,13 @@ func (o *Command) Run(args []string) error {
 		return fmt.Errorf("Cannot obtain KubeVirt client: %v", err)
 	}
 
+	dryRunOption := getDryRunOption(dryRun)
+	if len(dryRunOption) > 0 && dryRunOption[0] == metav1.DryRunAll {
+		fmt.Printf("Dry Run execution\n")
+	}
 	switch o.command {
 	case COMMAND_START:
-		err = virtClient.VirtualMachine(namespace).Start(vmiName, &v1.StartOptions{Paused: startPaused})
+		err = virtClient.VirtualMachine(namespace).Start(vmiName, &v1.StartOptions{Paused: startPaused, DryRun: dryRunOption})
 		if err != nil {
 			return fmt.Errorf("Error starting VirtualMachine %v", err)
 		}
@@ -358,7 +373,7 @@ func (o *Command) Run(args []string) error {
 		}
 		if forceRestart {
 			if gracePeriodIsSet(gracePeriod) {
-				err = virtClient.VirtualMachine(namespace).ForceStop(vmiName, gracePeriod)
+				err = virtClient.VirtualMachine(namespace).ForceStop(vmiName, &v1.StopOptions{GracePeriod: &gracePeriod, DryRun: dryRunOption})
 				if err != nil {
 					return fmt.Errorf("Error force stoping VirtualMachine, %v", err)
 				}
@@ -367,7 +382,7 @@ func (o *Command) Run(args []string) error {
 			}
 			break
 		}
-		err = virtClient.VirtualMachine(namespace).Stop(vmiName)
+		err = virtClient.VirtualMachine(namespace).Stop(vmiName, &v1.StopOptions{DryRun: dryRunOption})
 		if err != nil {
 			return fmt.Errorf("Error stopping VirtualMachine %v", err)
 		}
@@ -377,7 +392,7 @@ func (o *Command) Run(args []string) error {
 		}
 		if forceRestart {
 			if gracePeriod != -1 {
-				err = virtClient.VirtualMachine(namespace).ForceRestart(vmiName, gracePeriod)
+				err = virtClient.VirtualMachine(namespace).ForceRestart(vmiName, &v1.RestartOptions{GracePeriodSeconds: &gracePeriod, DryRun: dryRunOption})
 				if err != nil {
 					return fmt.Errorf("Error restarting VirtualMachine, %v", err)
 				}
@@ -386,7 +401,7 @@ func (o *Command) Run(args []string) error {
 			}
 			break
 		}
-		err = virtClient.VirtualMachine(namespace).Restart(vmiName)
+		err = virtClient.VirtualMachine(namespace).Restart(vmiName, &v1.RestartOptions{DryRun: dryRunOption})
 		if err != nil {
 			return fmt.Errorf("Error restarting VirtualMachine %v", err)
 		}
@@ -441,5 +456,6 @@ func (o *Command) Run(args []string) error {
 	}
 
 	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
+
 	return nil
 }

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/deepcopy_generated.go
@@ -2996,6 +2996,11 @@ func (in *RestartOptions) DeepCopyInto(out *RestartOptions) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.DryRun != nil {
+		in, out := &in.DryRun, &out.DryRun
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -3147,6 +3152,11 @@ func (in *ServiceAccountVolumeSource) DeepCopy() *ServiceAccountVolumeSource {
 func (in *StartOptions) DeepCopyInto(out *StartOptions) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.DryRun != nil {
+		in, out := &in.DryRun, &out.DryRun
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -3168,6 +3178,11 @@ func (in *StopOptions) DeepCopyInto(out *StopOptions) {
 		in, out := &in.GracePeriod, &out.GracePeriod
 		*out = new(int64)
 		**out = **in
+	}
+	if in.DryRun != nil {
+		in, out := &in.DryRun, &out.DryRun
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
@@ -23157,9 +23157,28 @@ func schema_client_go_apis_core_v1_RestartOptions(ref common.ReferenceCallback) 
 					},
 					"gracePeriodSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The duration in seconds before the object should be force-restared. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
+							Description: "The duration in seconds before the object should be force-restarted. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"dryRun": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -23379,6 +23398,25 @@ func schema_client_go_apis_core_v1_StartOptions(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"dryRun": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -23411,6 +23449,25 @@ func schema_client_go_apis_core_v1_StopOptions(ref common.ReferenceCallback) com
 							Description: "this updates the VMIs terminationGracePeriodSeconds during shutdown",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"dryRun": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
@@ -1822,13 +1822,22 @@ const (
 type RestartOptions struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// The duration in seconds before the object should be force-restared. Value must be non-negative integer.
+	// The duration in seconds before the object should be force-restarted. Value must be non-negative integer.
 	// The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the
 	// specified type will be used to determine on how much time to give the VMI to restart.
 	// Defaults to a per object value if not specified. zero means restart immediately.
 	// Allowed Values: nil and 0
 	// +optional
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds,omitempty" protobuf:"varint,1,opt,name=gracePeriodSeconds"`
+
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	// +optional
+	// +listType=atomic
+	DryRun []string `json:"dryRun,omitempty" protobuf:"bytes,2,rep,name=dryRun"`
 }
 
 // StartOptions may be provided on start request.
@@ -1840,6 +1849,14 @@ type StartOptions struct {
 	// Indicates that VM will be started in paused state.
 	// +optional
 	Paused bool `json:"paused,omitempty" protobuf:"varint,7,opt,name=paused"`
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	// +optional
+	// +listType=atomic
+	DryRun []string `json:"dryRun,omitempty" protobuf:"bytes,5,rep,name=dryRun"`
 }
 
 const (
@@ -1856,6 +1873,14 @@ type StopOptions struct {
 	// this updates the VMIs terminationGracePeriodSeconds during shutdown
 	// +optional
 	GracePeriod *int64 `json:"gracePeriod,omitempty" protobuf:"varint,1,opt,name=gracePeriod"`
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	// +optional
+	// +listType=atomic
+	DryRun []string `json:"dryRun,omitempty" protobuf:"bytes,2,rep,name=dryRun"`
 }
 
 // VirtualMachineInstanceGuestAgentInfo represents information from the installed guest agent

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/types_swagger_generated.go
@@ -505,7 +505,8 @@ func (KubeVirtCondition) SwaggerDoc() map[string]string {
 func (RestartOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                   "RestartOptions may be provided when deleting an API object.\n\n+k8s:openapi-gen=true",
-		"gracePeriodSeconds": "The duration in seconds before the object should be force-restared. Value must be non-negative integer.\nThe value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the\nspecified type will be used to determine on how much time to give the VMI to restart.\nDefaults to a per object value if not specified. zero means restart immediately.\nAllowed Values: nil and 0\n+optional",
+		"gracePeriodSeconds": "The duration in seconds before the object should be force-restarted. Value must be non-negative integer.\nThe value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the\nspecified type will be used to determine on how much time to give the VMI to restart.\nDefaults to a per object value if not specified. zero means restart immediately.\nAllowed Values: nil and 0\n+optional",
+		"dryRun":             "When present, indicates that modifications should not be\npersisted. An invalid or unrecognized dryRun directive will\nresult in an error response and no further processing of the\nrequest. Valid values are:\n- All: all dry run stages will be processed\n+optional\n+listType=atomic",
 	}
 }
 
@@ -513,6 +514,7 @@ func (StartOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":       "StartOptions may be provided on start request.\n\n+k8s:openapi-gen=true",
 		"paused": "Indicates that VM will be started in paused state.\n+optional",
+		"dryRun": "When present, indicates that modifications should not be\npersisted. An invalid or unrecognized dryRun directive will\nresult in an error response and no further processing of the\nrequest. Valid values are:\n- All: all dry run stages will be processed\n+optional\n+listType=atomic",
 	}
 }
 
@@ -520,6 +522,7 @@ func (StopOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":            "StopOptions may be provided when deleting an API object.\n\n+k8s:openapi-gen=true",
 		"gracePeriod": "this updates the VMIs terminationGracePeriodSeconds during shutdown\n+optional",
+		"dryRun":      "When present, indicates that modifications should not be\npersisted. An invalid or unrecognized dryRun directive will\nresult in an error response and no further processing of the\nrequest. Valid values are:\n- All: all dry run stages will be processed\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -18220,9 +18220,28 @@ func schema_client_go_apis_core_v1_RestartOptions(ref common.ReferenceCallback) 
 					},
 					"gracePeriodSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The duration in seconds before the object should be force-restared. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
+							Description: "The duration in seconds before the object should be force-restarted. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"dryRun": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -18442,6 +18461,25 @@ func schema_client_go_apis_core_v1_StartOptions(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"dryRun": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -18474,6 +18512,25 @@ func schema_client_go_apis_core_v1_StopOptions(ref common.ReferenceCallback) com
 							Description: "this updates the VMIs terminationGracePeriodSeconds during shutdown",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"dryRun": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1362,8 +1362,8 @@ func (_mr *_MockVirtualMachineInterfaceRecorder) Delete(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v117.VirtualMachine, error) {
-	_s := []interface{}{name, pt, data}
+func (_m *MockVirtualMachineInterface) Patch(name string, pt types.PatchType, data []byte, patchOptions *v11.PatchOptions, subresources ...string) (*v117.VirtualMachine, error) {
+	_s := []interface{}{name, pt, data, patchOptions}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -1373,8 +1373,8 @@ func (_m *MockVirtualMachineInterface) Patch(name string, pt types.PatchType, da
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+func (_mr *_MockVirtualMachineInterfaceRecorder) Patch(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
@@ -1389,29 +1389,29 @@ func (_mr *_MockVirtualMachineInterfaceRecorder) UpdateStatus(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
 }
 
-func (_m *MockVirtualMachineInterface) PatchStatus(name string, pt types.PatchType, data []byte) (*v117.VirtualMachine, error) {
-	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data)
+func (_m *MockVirtualMachineInterface) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *v11.PatchOptions) (*v117.VirtualMachine, error) {
+	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data, patchOptions)
 	ret0, _ := ret[0].(*v117.VirtualMachine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInterfaceRecorder) PatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2)
+func (_mr *_MockVirtualMachineInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockVirtualMachineInterface) Restart(name string) error {
-	ret := _m.ctrl.Call(_m, "Restart", name)
+func (_m *MockVirtualMachineInterface) Restart(name string, restartOptions *v117.RestartOptions) error {
+	ret := _m.ctrl.Call(_m, "Restart", name, restartOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVirtualMachineInterfaceRecorder) Restart(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Restart", arg0)
+func (_mr *_MockVirtualMachineInterfaceRecorder) Restart(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Restart", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInterface) ForceRestart(name string, graceperiod int) error {
-	ret := _m.ctrl.Call(_m, "ForceRestart", name, graceperiod)
+func (_m *MockVirtualMachineInterface) ForceRestart(name string, restartOptions *v117.RestartOptions) error {
+	ret := _m.ctrl.Call(_m, "ForceRestart", name, restartOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -1430,18 +1430,18 @@ func (_mr *_MockVirtualMachineInterfaceRecorder) Start(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Start", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInterface) Stop(name string) error {
-	ret := _m.ctrl.Call(_m, "Stop", name)
+func (_m *MockVirtualMachineInterface) Stop(name string, stopOptions *v117.StopOptions) error {
+	ret := _m.ctrl.Call(_m, "Stop", name, stopOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVirtualMachineInterfaceRecorder) Stop(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop", arg0)
+func (_mr *_MockVirtualMachineInterfaceRecorder) Stop(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop", arg0, arg1)
 }
 
-func (_m *MockVirtualMachineInterface) ForceStop(name string, graceperiod int) error {
-	ret := _m.ctrl.Call(_m, "ForceStop", name, graceperiod)
+func (_m *MockVirtualMachineInterface) ForceStop(name string, stopOptions *v117.StopOptions) error {
+	ret := _m.ctrl.Call(_m, "ForceStop", name, stopOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -1679,8 +1679,8 @@ func (_mr *_MockKubeVirtInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
 }
 
-func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v117.KubeVirt, error) {
-	_s := []interface{}{name, pt, data}
+func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []byte, patchOptions *v11.PatchOptions, subresources ...string) (*v117.KubeVirt, error) {
+	_s := []interface{}{name, pt, data, patchOptions}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
@@ -1690,8 +1690,8 @@ func (_m *MockKubeVirtInterface) Patch(name string, pt types.PatchType, data []b
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+func (_mr *_MockKubeVirtInterfaceRecorder) Patch(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
@@ -1706,13 +1706,13 @@ func (_mr *_MockKubeVirtInterfaceRecorder) UpdateStatus(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateStatus", arg0)
 }
 
-func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, data []byte) (*v117.KubeVirt, error) {
-	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data)
+func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *v11.PatchOptions) (*v117.KubeVirt, error) {
+	ret := _m.ctrl.Call(_m, "PatchStatus", name, pt, data, patchOptions)
 	ret0, _ := ret[0].(*v117.KubeVirt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2)
+func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -224,14 +224,14 @@ type VirtualMachineInterface interface {
 	Create(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Update(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachine, err error)
+	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.VirtualMachine, err error)
 	UpdateStatus(*v1.VirtualMachine) (*v1.VirtualMachine, error)
-	PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.VirtualMachine, err error)
-	Restart(name string) error
-	ForceRestart(name string, graceperiod int) error
+	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.VirtualMachine, err error)
+	Restart(name string, restartOptions *v1.RestartOptions) error
+	ForceRestart(name string, restartOptions *v1.RestartOptions) error
 	Start(name string, startOptions *v1.StartOptions) error
-	Stop(name string) error
-	ForceStop(name string, graceperiod int) error
+	Stop(name string, stopOptions *v1.StopOptions) error
+	ForceStop(name string, stopOptions *v1.StopOptions) error
 	Migrate(name string) error
 	AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) error
 	RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptions) error
@@ -255,7 +255,7 @@ type KubeVirtInterface interface {
 	Create(instance *v1.KubeVirt) (*v1.KubeVirt, error)
 	Update(*v1.KubeVirt) (*v1.KubeVirt, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
-	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.KubeVirt, err error)
+	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
 	UpdateStatus(*v1.KubeVirt) (*v1.KubeVirt, error)
-	PatchStatus(name string, pt types.PatchType, data []byte) (result *v1.KubeVirt, err error)
+	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kv.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv.go
@@ -121,12 +121,13 @@ func (o *kv) List(options *k8smetav1.ListOptions) (*v12.KubeVirtList, error) {
 	return newKvList, err
 }
 
-func (v *kv) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v12.KubeVirt, err error) {
+func (v *kv) Patch(name string, pt types.PatchType, data []byte, patchOptions *k8smetav1.PatchOptions, subresources ...string) (result *v12.KubeVirt, err error) {
 	result = &v12.KubeVirt{}
 	err = v.restClient.Patch(pt).
 		Namespace(v.namespace).
 		Resource(v.resource).
 		SubResource(subresources...).
+		VersionedParams(patchOptions, scheme.ParameterCodec).
 		Name(name).
 		Body(data).
 		Do(context.Background()).
@@ -134,12 +135,13 @@ func (v *kv) Patch(name string, pt types.PatchType, data []byte, subresources ..
 	return result, err
 }
 
-func (v *kv) PatchStatus(name string, pt types.PatchType, data []byte) (result *v12.KubeVirt, err error) {
+func (v *kv) PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *k8smetav1.PatchOptions) (result *v12.KubeVirt, err error) {
 	result = &v12.KubeVirt{}
 	err = v.restClient.Patch(pt).
 		Namespace(v.namespace).
 		Resource(v.resource).
 		SubResource("status").
+		VersionedParams(patchOptions, scheme.ParameterCodec).
 		Name(name).
 		Body(data).
 		Do(context.Background()).

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Kubevirt Client", func() {
 		))
 
 		_, err := client.KubeVirt(k8sv1.NamespaceDefault).Patch(kubevirt.Name, types.MergePatchType,
-			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"))
+			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"), &k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 		))
 
 		patchedVM, err := client.VirtualMachine(k8sv1.NamespaceDefault).Patch(vm.Name, types.MergePatchType,
-			[]byte("{\"spec\":{\"running\":true}}"))
+			[]byte("{\"spec\":{\"running\":true}}"), &k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
@@ -146,7 +146,7 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 		))
 
 		patchedVM, err := client.VirtualMachine(k8sv1.NamespaceDefault).Patch(vm.Name, types.MergePatchType,
-			[]byte("{\"spec\":{\"running\":true}}"))
+			[]byte("{\"spec\":{\"running\":true}}"), &k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
@@ -170,7 +170,7 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 			ghttp.VerifyRequest("PUT", subVMIPath+"/restart"),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachine(k8sv1.NamespaceDefault).Restart("testvm")
+		err := client.VirtualMachine(k8sv1.NamespaceDefault).Restart("testvm", &virtv1.RestartOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -359,7 +359,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		patchKvProductNameAndVersion = func(name, productName string, productVersion string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/productName", "value": "%s"},{ "op": "replace", "path": "/spec/productVersion", "value": "%s"}]`, productName, productVersion))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -368,7 +368,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		patchKvVersionAndRegistry = func(name string, version string, registry string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/imageTag", "value": "%s"},{ "op": "replace", "path": "/spec/imageRegistry", "value": "%s"}]`, version, registry))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -377,7 +377,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		patchKvVersion = func(name string, version string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "add", "path": "/spec/imageTag", "value": "%s"}]`, version))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -391,7 +391,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -405,7 +405,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
-			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(errMsg))
 
@@ -456,7 +456,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -473,7 +473,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).Should(HaveOccurred())
@@ -1448,7 +1448,7 @@ spec:
 						return err
 					}
 					ops := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations", "value": %s }]`, string(annotationBytes))
-					_, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte(ops))
+					_, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte(ops), &metav1.PatchOptions{})
 					return err
 				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -268,7 +268,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 			It("[test_id:5257]should reject restore if VM running", func() {
 				patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
-				vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch)
+				vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				restore := createRestoreDef(vm, snapshot.Name)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -197,7 +197,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 
 		It("[test_id:4610]create a snapshot when VM is running should succeed", func() {
 			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch)
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*vm.Spec.Running).Should(BeTrue())
 
@@ -206,7 +206,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 
 		It("VM should contain snapshot status for all volumes", func() {
 			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
-			vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch)
+			vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -102,7 +102,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name)
+				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineInstancePhase {
@@ -119,7 +119,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name)
+				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -127,7 +127,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vmi := tests.NewRandomVMI()
 				tests.RunVMIAndExpectLaunch(vmi, 60)
 
-				err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name)
+				err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -143,7 +143,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Trying to start VM via Restart subresource")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name)
+				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -173,7 +173,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Restarting VM")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name)
+				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineInstancePhase {
@@ -209,7 +209,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Restarting VM")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name)
+				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineInstancePhase {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -760,7 +760,7 @@ func AdjustKubeVirtResource() {
 	data, err := json.Marshal(kv.Spec)
 	Expect(err).ToNot(HaveOccurred())
 	patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(patchData))
+	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
 	util2.PanicOnError(err)
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
 	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -789,7 +789,7 @@ func RestoreKubeVirtResource() {
 		data, err := json.Marshal(originalKV.Spec)
 		Expect(err).ToNot(HaveOccurred())
 		patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(originalKV.Name, types.JSONPatchType, []byte(patchData))
+		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(originalKV.Name, types.JSONPatchType, []byte(patchData), &metav1.PatchOptions{})
 		util2.PanicOnError(err)
 	}
 }
@@ -4417,7 +4417,7 @@ func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.Kub
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, kv)
 	Expect(err).ToNot(HaveOccurred())
 
-	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch)
+	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch, &metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
 	waitForConfigToBePropagated(kv.ResourceVersion)

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -394,7 +394,7 @@ var _ = Describe("[rfe_id:3423][crit:high][arm64][vendor:cnv-qe@redhat.com][leve
 			"VMI should be in the Running phase")
 
 		// Restart the VMI
-		err = virtCli.VirtualMachine(vm.ObjectMeta.Namespace).Restart(vm.ObjectMeta.Name)
+		err = virtCli.VirtualMachine(vm.ObjectMeta.Namespace).Restart(vm.ObjectMeta.Name, &v12.RestartOptions{})
 		Expect(err).ToNot(HaveOccurred(), "VMI should have been restarted")
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allows user to use `--dry-run` flag for start, stop and restart virtctl command.
Passing this flag to one of these command will do all checks showing possible failures, but changes will not be effective.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Users can use --dry-run flag
```
