### PR TITLE
examples, cloud-init: use cloud-config instead of bash

### DIFF
--- a/examples/vmi-macvtap.yaml
+++ b/examples/vmi-macvtap.yaml
@@ -33,8 +33,11 @@ spec:
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
-        yum install -y nginx
-        systemctl enable --now nginx
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+        packages:
+          - nginx
+        runcmd:
+          - [ "systemctl", "enable", "--now", "nginx" ]
     name: cloudinitdisk

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -43,8 +43,11 @@ spec:
             dhcp4: true
             gateway6: fd10:0:2::1
       userData: |-
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
-        yum install -y nginx
-        systemctl enable --now nginx
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+        packages:
+          - nginx
+        runcmd:
+          - [ "systemctl", "enable", "--now", "nginx" ]
     name: cloudinitdisk

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -36,8 +36,13 @@ spec:
       image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
-      userData: |
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
-        dhclient eth1
+      networkData: |
+        version: 2
+        ethernets:
+          eth1:
+            dhcp4: true
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
     name: cloudinitdisk

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -32,7 +32,8 @@ spec:
       image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
-      userData: |
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
     name: cloudinitdisk

--- a/examples/vmi-slirp.yaml
+++ b/examples/vmi-slirp.yaml
@@ -36,9 +36,11 @@ spec:
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
-        yum install -y nginx
-        systemctl enable nginx
-        systemctl start nginx
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+        packages:
+          - nginx
+        runcmd:
+          - [ "systemctl", "enable", "--now", "nginx" ]
     name: cloudinitdisk

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -36,8 +36,13 @@ spec:
       image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
-      userData: |
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
-        dhclient eth1
+      networkData: |
+        version: 2
+        ethernets:
+          eth1:
+            dhcp4: true
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
     name: cloudinitdisk

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	k8sv1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -98,6 +99,18 @@ const windowsFirmware = "5d307ca9-b3ef-428c-8861-06e72d69f223"
 const defaultInterfaceName = "default"
 const enableNetworkInterfaceMultiqueueForTemplate = true
 const EthernetAdaptorModelToEnableMultiqueue = "virtio"
+
+const (
+	cloudConfigHeader = "#cloud-config"
+
+	cloudConfigInstallAndStartService = `packages:
+  - nginx
+runcmd:
+  - [ "systemctl", "enable", "--now", "nginx" ]`
+
+	cloudConfigUserPassword = `password: fedora
+chpasswd: { expire: False }`
+)
 
 var DockerPrefix = "registry:5000/kubevirt"
 var DockerTag = "devel"
@@ -392,7 +405,7 @@ func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiFedora)
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
+	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi
 }
 
@@ -442,7 +455,9 @@ func GetVMISlirp() *v1.VirtualMachineInstance {
 	vm.Spec.Networks = []v1.Network{{Name: "testSlirp", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 	initFedora(&vm.Spec)
-	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
+	addNoCloudDiskWitUserData(
+		&vm.Spec,
+		generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService))
 
 	slirp := &v1.InterfaceSlirp{}
 	ports := []v1.Port{{Name: "http", Protocol: "TCP", Port: 80}}
@@ -456,9 +471,11 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vm.Spec)
-	userData := "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nyum install -y nginx\nsystemctl enable --now nginx"
 	networkData := "version: 2\nethernets:\n  eth0:\n    addresses: [ fd10:0:2::2/120 ]\n    dhcp4: true\n    gateway6: fd10:0:2::1\n"
-	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, userData, networkData)
+	addNoCloudDiskWitUserDataNetworkData(
+		&vm.Spec,
+		generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService),
+		networkData)
 
 	masquerade := &v1.InterfaceMasquerade{}
 	ports := []v1.Port{{Name: "http", Protocol: "TCP", Port: 80}}
@@ -472,7 +489,8 @@ func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "sriov/sriov-network"}}}}
 	initFedora(&vm.Spec)
-	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
+	networkData := "version: 2\nethernets:\n  eth1:\n    dhcp4: true\n"
+	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword), networkData)
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "sriov-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}}
@@ -485,7 +503,7 @@ func GetVMIMultusPtp() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{{Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
 	initFedora(&vm.Spec)
-	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\n")
+	addNoCloudDiskWitUserData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword))
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 
@@ -497,7 +515,8 @@ func GetVMIMultusMultipleNet() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
 	initFedora(&vm.Spec)
-	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
+	networkData := "version: 2\nethernets:\n  eth1:\n    dhcp4: true\n"
+	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword), networkData)
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -690,7 +709,7 @@ func GetTemplateFedoraWithContainerDisk(containerDisk string) *Template {
 func getFedoraVMWithoutDisk() *v1.VirtualMachine {
 	vm := getBaseVM("", map[string]string{"kubevirt-vm": "vm-${NAME}", "kubevirt.io/os": "fedora27"})
 	spec := &vm.Spec.Template.Spec
-	addNoCloudDiskWitUserData(spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
+	addNoCloudDiskWitUserData(spec, generateCloudConfigString(cloudConfigUserPassword))
 
 	setDefaultNetworkAndInterface(spec, v1.InterfaceBindingMethod{
 		Masquerade: &v1.InterfaceMasquerade{},
@@ -1016,7 +1035,7 @@ func GetVMIWithHookSidecar() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
+	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 
 	vmi.ObjectMeta.Annotations = map[string]string{
 		"hooks.kubevirt.io/hookSidecars":              fmt.Sprintf("[{\"args\": [\"--version\", \"v1alpha2\"], \"image\": \"%s/example-hook-sidecar:%s\"}]", DockerPrefix, DockerTag),
@@ -1036,7 +1055,7 @@ func GetVMIGPU() *v1.VirtualMachineInstance {
 	}
 	vmi.Spec.Domain.Devices.GPUs = GPUs
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
+	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword))
 	return vmi
 }
 
@@ -1046,7 +1065,7 @@ func GetVMIMacvtap() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vmi.Spec.Networks = []v1.Network{{Name: macvtapNetworkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "macvtapnetwork"}}}}
 	initFedora(&vmi.Spec)
-	addNoCloudDiskWitUserData(&vmi.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nyum install -y nginx\nsystemctl enable --now nginx")
+	addNoCloudDiskWitUserData(&vmi.Spec, generateCloudConfigString(cloudConfigUserPassword, cloudConfigInstallAndStartService))
 
 	macvtap := &v1.InterfaceMacvtap{}
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: macvtapNetworkName, InterfaceBindingMethod: v1.InterfaceBindingMethod{Macvtap: macvtap}}}
@@ -1061,4 +1080,9 @@ func GetVMIARM() *v1.VirtualMachineInstance {
 	addNoCloudDisk(&vmi.Spec)
 	addEmptyDisk(&vmi.Spec, "2Gi")
 	return vmi
+}
+
+func generateCloudConfigString(cloudConfigElement ...string) string {
+	return strings.Join(
+		append([]string{cloudConfigHeader}, cloudConfigElement...), "\n")
 }

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -110,6 +110,12 @@ runcmd:
 
 	cloudConfigUserPassword = `password: fedora
 chpasswd: { expire: False }`
+
+	secondaryIfaceDhcpNetworkData = `version: 2
+ethernets:
+  eth1:
+    dhcp4: true
+`
 )
 
 var DockerPrefix = "registry:5000/kubevirt"
@@ -489,8 +495,7 @@ func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "sriov/sriov-network"}}}}
 	initFedora(&vm.Spec)
-	networkData := "version: 2\nethernets:\n  eth1:\n    dhcp4: true\n"
-	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword), networkData)
+	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword), secondaryIfaceDhcpNetworkData)
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "sriov-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}}
@@ -515,8 +520,7 @@ func GetVMIMultusMultipleNet() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
 	initFedora(&vm.Spec)
-	networkData := "version: 2\nethernets:\n  eth1:\n    dhcp4: true\n"
-	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword), networkData)
+	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, generateCloudConfigString(cloudConfigUserPassword), secondaryIfaceDhcpNetworkData)
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR replaces bash scripts with cloud-config on cloud-init user data for the kubevirt examples.

This makes the examples more portable across different VM instances.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
