### PR TITLE
Fix virt-handler updates VMI status phase failure bug after it recovered from crash

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -662,6 +662,7 @@ spec:
           resources:
           - virtualmachineinstances
           verbs:
+          - get
           - update
           - list
           - watch

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -564,6 +564,7 @@ rules:
   resources:
   - virtualmachineinstances
   verbs:
+  - get
   - update
   - list
   - watch

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -130,24 +130,22 @@ func ListAllSockets() ([]string, error) {
 		return nil, err
 	}
 
-	if exists == false {
-		return socketFiles, nil
-	}
-
-	files, err := os.ReadDir(socketsDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, file := range files {
-		if file.IsDir() || !strings.Contains(file.Name(), "_sock") {
-			continue
+	if exists {
+		files, err := os.ReadDir(socketsDir)
+		if err != nil {
+			return nil, err
 		}
-		// legacy support.
-		// The old way of handling launcher sockets was to
-		// dump them all in the same directory. So if we encounter
-		// a legacy socket, still process it. This is necessary
-		// for update support.
-		socketFiles = append(socketFiles, filepath.Join(socketsDir, file.Name()))
+		for _, file := range files {
+			if file.IsDir() || !strings.Contains(file.Name(), "_sock") {
+				continue
+			}
+			// legacy support.
+			// The old way of handling launcher sockets was to
+			// dump them all in the same directory. So if we encounter
+			// a legacy socket, still process it. This is necessary
+			// for update support.
+			socketFiles = append(socketFiles, filepath.Join(socketsDir, file.Name()))
+		}
 	}
 
 	podsDir := podsBaseDir
@@ -194,17 +192,17 @@ func SocketMonitoringEnabled(socket string) bool {
 }
 
 func IsSocketUnresponsive(socket string) bool {
-	file := filepath.Join(filepath.Dir(socket), StandardLauncherUnresponsiveFileName)
-	exists, _ := diskutils.FileExists(file)
-	// if the unresponsive socket monitor marked this socket
-	// as being unresponsive, return true
-	if exists {
+	exists, _ := diskutils.FileExists(socket)
+	// if the socket file doesn't exist, it's definitely unresponsive
+	if !exists {
 		return true
 	}
 
-	exists, _ = diskutils.FileExists(socket)
-	// if the socket file doesn't exist, it's definitely unresponsive as well
-	if !exists {
+	file := filepath.Join(filepath.Dir(socket), StandardLauncherUnresponsiveFileName)
+	exists, _ = diskutils.FileExists(file)
+	// if the unresponsive socket monitor marked this socket
+	// as being unresponsive, return true
+	if exists {
 		return true
 	}
 

--- a/pkg/virt-operator/resource/generate/rbac/handler.go
+++ b/pkg/virt-operator/resource/generate/rbac/handler.go
@@ -78,7 +78,7 @@ func newHandlerClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstances",
 				},
 				Verbs: []string{
-					"update", "list", "watch",
+					"get", "update", "list", "watch",
 				},
 			},
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This fix issue mentioned in #6685 
virt-handler failed process vmi if pod was removed from node but vmi stuck in running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6685

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
