### PR TITLE
tests, network, istio: revert parallelization

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -70,7 +70,7 @@ const (
 	istioApiVersion   = "v1beta1"
 )
 
-var _ = SIGDescribe("Istio", func() {
+var _ = SIGDescribe("[Serial] Istio", func() {
 	var (
 		err        error
 		vmi        *v1.VirtualMachineInstance


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The istio tests create istio specific resources that affect
the istio-proxy container configuration in all namespaces. When
running in parallel, the tests can flake.

This commit reverts the changes made in 5936e7c9e1f8366f351ec278e9fda00f757ef82c
and make the istio tests run in serial. In a future commit the tests
should be implemented in a way that allows them to be run in parallel.

Signed-off-by: alonsadan <asadan@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
An example pf flakes can be shown [here](https://search.ci.kubevirt.io/?search=Should+be+able+to+reach+http+server+outside+of+mesh&maxAge=168h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
