### PR TITLE
tests, network, vmi_lifecycle: remove parallelization

### DIFF
--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -56,7 +56,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 
 	Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
 		Context("when virt-handler is responsive", func() {
-			It("VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
+			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
 				bridgeVMI := vmi
 				// Remove the masquerade interface to use the default bridge one
 				bridgeVMI.Spec.Domain.Devices.Interfaces = nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
One of the tests in network/vmi_lifecycle restarts kubelet.
This in turn makes vhost and kvm resources restart.
This could make other tests fail over missing vhost/kvm resources. 
Therefore this test should be run in serial.

5936e7c9e1f8366f351ec278e9fda00f757ef82c made this test run in parallel, and
this commit reverts it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
example flakes: 
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6508/pull-kubevirt-e2e-k8s-1.21-sig-network/1453303268322054144
```
tests/network/vmi_lifecycle.go:95
VMI testvmi-9qbzp unexpectedly stopped. State: Failed
Expected
    <bool>: true
to be false
tests/utils.go:2972
```
```
"message": "Allocate failed due to requested number of devices unavailable for devices.kubevirt.io/vhost-net. Requested: 1, Available: 0, which is unexpected",
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
