### PR TITLE
[release-0.36] virt-handler: create missing volume status to store iso sizes

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -585,11 +585,20 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 			continue
 		}
 
+		found = false
 		for i, _ := range vmi.Status.VolumeStatus {
 			if vmi.Status.VolumeStatus[i].Name == volume.Name {
 				vmi.Status.VolumeStatus[i].Size = int64(size)
+				found = true
 				continue
 			}
+		}
+		if !found {
+			vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
+				Name: volume.Name,
+				Size: int64(size),
+			})
+			log.DefaultLogger().V(2).Infof("status for volume %s created because not found", volume.Name)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this change, the ISO size of a given volume was only stored if a VolumeStatus existed for it on its VMI.
This is usually fine, since a VolumeStatus is created for each volume on VMI start.
However, since VolumeStatus was introduced by release-0.36, VMIs created under an older release do not have it populated.
This is a problem when upgrading from release-0.35 to release-0.36 and then migrating a VMI that has a cloud-init/config-map.

This PR creates the VolumeStatus if none exist to address the above issue.

Note: this problem is not as concerning as initially assumed, as it resolves itself after 2 passes of VMI status update.
This fix allows the status to update correctly on first pass, which could be useful if a VMI gets migrated mere seconds after a KubeVirt upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The newly created volume status will not have the usual `target` field populated, but this is fine since it will be filled by `updateVMIStatus()` right after it calls `IsoGuestVolumePath()`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
