### PR TITLE
Fix virtual machine restore rejected by webhook

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -522,7 +522,8 @@ func validateRestoreStatus(ar *admissionv1.AdmissionRequest, vm *v1.VirtualMachi
 	}
 
 	if !reflect.DeepEqual(oldVM.Spec, vm.Spec) {
-		if *vm.Spec.Running {
+		strategy, _ := vm.RunStrategy()
+		if strategy != v1.RunStrategyHalted {
 			return []metav1.StatusCause{{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
 				Message: fmt.Sprintf("Cannot start VM until restore %q completes", *vm.Status.RestoreInProgress),

--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -499,8 +499,13 @@ func (t *vmRestoreTarget) Reconcile() (bool, error) {
 	newVM := t.vm.DeepCopy()
 	newVM.Spec = snapshotVM.Spec
 	// update Running state in case snapshot was on online VM
-	running := false
-	newVM.Spec.Running = &running
+	if newVM.Spec.RunStrategy != nil {
+		strategy := kubevirtv1.RunStrategyHalted
+		newVM.Spec.RunStrategy = &strategy
+	} else if newVM.Spec.Running != nil {
+		running := false
+		newVM.Spec.Running = &running
+	}
 	newVM.Spec.DataVolumeTemplates = newTemplates
 	newVM.Spec.Template.Spec.Volumes = newVolumes
 	if newVM.Annotations == nil {


### PR DESCRIPTION
Signed-off-by: liuminjian <liuminjian@chinatelecom.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
i have a vm with runStrategy RerunOnFailure and i create a online snapshot.  i fail to restore the vm because the snapshot restore controller will set the Spec.Running false. the webhook refuses to set Running and RunStrategy at the same time.

![image](https://user-images.githubusercontent.com/7840869/139388353-2e557255-50f9-443f-8b47-79581075036c.png)

![image](https://user-images.githubusercontent.com/7840869/139388536-057d2753-056d-4043-9cfc-4850f501d26c.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
