### PR TITLE
Fix vmsnapshot upgrade bug

### DIFF
--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -86,7 +86,10 @@ func vmSnapshotProgressing(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
 }
 
 func vmSnapshotDeadlineExceeded(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
-	if vmSnapshotSucceeded(vmSnapshot) {
+	if vmSnapshotFailed(vmSnapshot) {
+		return true
+	}
+	if vmSnapshot.Status == nil || vmSnapshot.Status.Phase != snapshotv1.InProgress {
 		return false
 	}
 	return timeUntilDeadline(vmSnapshot) < 0


### PR DESCRIPTION
Signed-off-by: mhenriks@redhat.com <Michael Henriksen>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`status.Phase` was recently added to VirtualMachineSnapshot resource.

Unfortunately, we were not correctly handling the case when phase is unset on upgrade.  Were transitioning the snapshot to Failed state when should have transitioned to Succeeded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=2018521

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix BZ 2018521 - On upgrade VirtualMachineSnapshots going to Failed
```
