### PR TITLE
Enable live migration from root to nonroot

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16035,6 +16035,11 @@
       "description": "A brief CamelCase message indicating details about why the VMI is in this state. e.g. 'NodeUnresponsive'",
       "type": "string"
      },
+     "runtimeUser": {
+      "description": "RuntimeUser is used to determine what user will be used in launcher",
+      "type": "integer",
+      "format": "int64"
+     },
      "topologyHints": {
       "$ref": "#/definitions/v1.TopologyHints"
      },

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,8 +26,10 @@ const NonRootUserString = "qemu"
 const RootUser = 0
 
 func IsNonRootVMI(vmi *v1.VirtualMachineInstance) bool {
-	_, ok := vmi.Annotations[v1.NonRootVMIAnnotation]
-	return ok
+	_, ok := vmi.Annotations[v1.DeprecatedNonRootVMIAnnotation]
+
+	nonRoot := vmi.Status.RuntimeUser != 0
+	return ok || nonRoot
 }
 
 func IsSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
@@ -181,8 +183,5 @@ func CanBeNonRoot(vmi *v1.VirtualMachineInstance) error {
 }
 
 func MarkAsNonroot(vmi *v1.VirtualMachineInstance) {
-	if vmi.ObjectMeta.Annotations == nil {
-		vmi.ObjectMeta.Annotations = make(map[string]string)
-	}
-	vmi.ObjectMeta.Annotations[v1.NonRootVMIAnnotation] = ""
+	vmi.Status.RuntimeUser = 107
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -170,4 +170,19 @@ func AlignImageSizeTo1MiB(size int64, logger *log.FilteredLogger) int64 {
 		}
 		return newSize
 	}
+
+}
+func CanBeNonRoot(vmi *v1.VirtualMachineInstance) error {
+	// VirtioFS doesn't work with session mode
+	if IsVMIVirtiofsEnabled(vmi) {
+		return fmt.Errorf("VirtioFS doesn't work with session mode(used by nonroot)")
+	}
+	return nil
+}
+
+func MarkAsNonroot(vmi *v1.VirtualMachineInstance) {
+	if vmi.ObjectMeta.Annotations == nil {
+		vmi.ObjectMeta.Annotations = make(map[string]string)
+	}
+	vmi.ObjectMeta.Annotations[v1.NonRootVMIAnnotation] = ""
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -139,7 +139,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 		})
 
 		if mutator.ClusterConfig.NonRootEnabled() {
-			if err := canBeNonRoot(newVMI); err != nil {
+			if err := util.CanBeNonRoot(newVMI); err != nil {
 				return &admissionv1.AdmissionResponse{
 					Result: &metav1.Status{
 						Message: err.Error(),
@@ -147,10 +147,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 					},
 				}
 			} else {
-				if newVMI.ObjectMeta.Annotations == nil {
-					newVMI.ObjectMeta.Annotations = make(map[string]string)
-				}
-				newVMI.ObjectMeta.Annotations[v1.NonRootVMIAnnotation] = ""
+				util.MarkAsNonroot(newVMI)
 			}
 		}
 
@@ -356,14 +353,6 @@ func (mutator *VMIsMutator) setDefaultResourceRequests(vmi *v1.VirtualMachineIns
 		}
 	}
 
-}
-
-func canBeNonRoot(vmi *v1.VirtualMachineInstance) error {
-	// VirtioFS doesn't work with session mode
-	if util.IsVMIVirtiofsEnabled(vmi) {
-		return fmt.Errorf("VirtioFS doesn't work with session mode(used by nonroot)")
-	}
-	return nil
 }
 
 func addNodeSelector(vmi *v1.VirtualMachineInstance, label string) {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -146,9 +146,9 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 						Code:    http.StatusUnprocessableEntity,
 					},
 				}
-			} else {
-				util.MarkAsNonroot(newVMI)
 			}
+
+			util.MarkAsNonroot(newVMI)
 		}
 
 		var value interface{}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -82,25 +82,27 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		return mutator.Mutate(ar)
 	}
 
-	getVMISpecMetaFromResponse := func() (*v1.VirtualMachineInstanceSpec, *k8smetav1.ObjectMeta) {
+	getMetaSpecStatusFromAdmit := func() (*k8smetav1.ObjectMeta, *v1.VirtualMachineInstanceSpec, *v1.VirtualMachineInstanceStatus) {
 		resp := admitVMI()
 		Expect(resp.Allowed).To(BeTrue())
 
 		By("Getting the VMI spec from the response")
 		vmiSpec := &v1.VirtualMachineInstanceSpec{}
 		vmiMeta := &k8smetav1.ObjectMeta{}
+		vmiStatus := &v1.VirtualMachineInstanceStatus{}
 		patch := []utiltypes.PatchOperation{
 			{Value: vmiSpec},
 			{Value: vmiMeta},
+			{Value: vmiStatus},
 		}
 		err := json.Unmarshal(resp.Patch, &patch)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(patch).NotTo(BeEmpty())
 
-		return vmiSpec, vmiMeta
+		return vmiMeta, vmiSpec, vmiStatus
 	}
 
-	getVMIStatusFromResponse := func(oldVMI *v1.VirtualMachineInstance, newVMI *v1.VirtualMachineInstance, user string) *v1.VirtualMachineInstanceStatus {
+	getVMIStatusFromResponseWithUpdate := func(oldVMI *v1.VirtualMachineInstance, newVMI *v1.VirtualMachineInstance, user string) *v1.VirtualMachineInstanceStatus {
 		oldVMIBytes, err := json.Marshal(oldVMI)
 		Expect(err).ToNot(HaveOccurred())
 		newVMIBytes, err := json.Marshal(newVMI)
@@ -188,20 +190,20 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	})
 
 	It("should apply presets on VMI create", func() {
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.CPU).ToNot(BeNil())
 		Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(4)))
 	})
 
 	It("should apply namespace limit ranges on VMI create", func() {
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal(memoryLimit))
 	})
 
 	It("should apply defaults on VMI create", func() {
 		// no limits wanted on this test, to not copy the limit to requests
 		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		if webhooks.IsPPC64() {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("pseries"))
 			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))
@@ -232,7 +234,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			},
 		})
 
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.CPU.Model).To(Equal(cpuModelFromConfig))
 		Expect(vmiSpec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
 		Expect(*vmiSpec.Domain.Resources.Requests.Cpu()).To(Equal(cpuReq))
@@ -240,7 +242,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 	table.DescribeTable("it should", func(given []v1.Volume, expected []v1.Volume) {
 		vmi.Spec.Volumes = given
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Volumes).To(Equal(expected))
 	},
 		table.Entry("set the ImagePullPolicy to Always if :latest is specified",
@@ -429,7 +431,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				},
 			})
 
-			vmiSpec, _ := getVMISpecMetaFromResponse()
+			_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 			switch expectedIface {
 			case "bridge":
 				Expect(vmiSpec.Domain.Devices.Interfaces[0].Bridge).NotTo(BeNil())
@@ -447,7 +449,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	table.DescribeTable("should not add the default interfaces if", func(interfaces []v1.Interface, networks []v1.Network) {
 		vmi.Spec.Domain.Devices.Interfaces = append([]v1.Interface{}, interfaces...)
 		vmi.Spec.Networks = append([]v1.Network{}, networks...)
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		if len(interfaces) == 0 {
 			Expect(vmiSpec.Domain.Devices.Interfaces).To(BeNil())
 		} else {
@@ -482,7 +484,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Model: "EPYC"}
 		vmi.Spec.Domain.Machine = &v1.Machine{Type: "q35"}
 
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.CPU.Model).To(Equal(vmi.Spec.Domain.CPU.Model))
 		Expect(vmiSpec.Domain.Machine.Type).To(Equal(vmi.Spec.Domain.Machine.Type))
 		Expect(vmiSpec.Domain.Resources.Requests.Cpu()).To(Equal(vmi.Spec.Domain.Resources.Requests.Cpu()))
@@ -494,7 +496,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
 			k8sv1.ResourceCPU: resource.MustParse("2200m"),
 		}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 
 		Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
 		Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
@@ -506,7 +508,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
 			k8sv1.ResourceCPU: resource.MustParse("2.3"),
 		}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 
 		Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
 		Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
@@ -528,7 +530,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 		guestMemory := resource.MustParse("3072M")
 		vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Memory.Guest.String()).To(Equal("3072M"))
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
 	})
@@ -537,7 +539,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		// no limits wanted on this test, to not copy the limit to requests
 		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "3072M"}}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Memory.Hugepages.PageSize).To(Equal("3072M"))
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal("3072M"))
 	})
@@ -548,13 +550,13 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		}
 		guestMemory := resource.MustParse("4096M")
 		vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal("512M"))
 		Expect(vmiSpec.Domain.Memory.Guest.String()).To(Equal("4096M"))
 	})
 
 	It("should apply foreground finalizer on VMI create", func() {
-		_, vmiMeta := getVMISpecMetaFromResponse()
+		vmiMeta, _, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiMeta.Finalizers).To(ContainElement(v1.VirtualMachineInstanceFinalizer))
 	})
 
@@ -565,7 +567,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				k8sv1.ResourceCPU: resource.MustParse("1"),
 			},
 		}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Resources.Requests.Cpu().String()).To(Equal("1"))
 		Expect(vmiSpec.Domain.Resources.Limits.Cpu().String()).To(Equal("1"))
 	})
@@ -577,7 +579,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				k8sv1.ResourceMemory: resource.MustParse("64M"),
 			},
 		}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal("64M"))
 		Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal("64M"))
 	})
@@ -590,7 +592,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				},
 			},
 		}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(*(vmiSpec.Domain.Features.Hyperv.VPIndex.Enabled)).To(BeTrue())
 		Expect(*(vmiSpec.Domain.Features.Hyperv.SyNIC.Enabled)).To(BeTrue())
 		Expect(*(vmiSpec.Domain.Features.Hyperv.SyNICTimer.Enabled)).To(BeTrue())
@@ -756,7 +758,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		newVMI.Status = v1.VirtualMachineInstanceStatus{
 			Phase: v1.Failed,
 		}
-		status := getVMIStatusFromResponse(oldVMI, newVMI, user)
+		status := getVMIStatusFromResponseWithUpdate(oldVMI, newVMI, user)
 		if shouldChange {
 			Expect(&newVMI.Status).To(Equal(status))
 		} else {
@@ -776,7 +778,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		defer func() {
 			webhooks.Arch = rt.GOARCH
 		}()
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(*(vmiSpec.Domain.Firmware.Bootloader.EFI.SecureBoot)).To(BeFalse())
 		Expect(vmiSpec.Domain.CPU.Model).To(Equal("host-passthrough"))
 	})
@@ -930,7 +932,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		})
 
 		It("Should tag vmi as non-root ", func() {
-			_, meta := getVMISpecMetaFromResponse()
+			meta, _, _ := getMetaSpecStatusFromAdmit()
 			Expect(meta.Annotations).NotTo(BeNil())
 			Expect(meta.Annotations).To(HaveKeyWithValue("kubevirt.io/nonroot", ""))
 		})
@@ -948,26 +950,26 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 	It("should add realtime node label selector with realtime workload", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Realtime: &v1.Realtime{}}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).NotTo(BeNil())
 		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.RealtimeLabel: ""}))
 	})
 	It("should not add realtime node label selector when no realtime workload", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Realtime: nil}
 		vmi.Spec.NodeSelector = map[string]string{v1.NodeSchedulable: "true"}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true"}))
 	})
 	It("should not overwrite existing node label selectors with realtime workload", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Realtime: &v1.Realtime{}}
 		vmi.Spec.NodeSelector = map[string]string{v1.NodeSchedulable: "true"}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true", v1.RealtimeLabel: ""}))
 	})
 
 	It("should add SEV node label selector with SEV workload", func() {
 		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{SEV: &v1.SEV{}}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).NotTo(BeNil())
 		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.SEVLabel: ""}))
 	})
@@ -975,14 +977,14 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	It("should not add SEV node label selector when no SEV workload", func() {
 		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
 		vmi.Spec.NodeSelector = map[string]string{v1.NodeSchedulable: "true"}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true"}))
 	})
 
 	It("should not overwrite existing node label selectors with SEV workload", func() {
 		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{SEV: &v1.SEV{}}
 		vmi.Spec.NodeSelector = map[string]string{v1.NodeSchedulable: "true"}
-		vmiSpec, _ := getVMISpecMetaFromResponse()
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true", v1.SEVLabel: ""}))
 	})
 })

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -932,9 +932,8 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		})
 
 		It("Should tag vmi as non-root ", func() {
-			meta, _, _ := getMetaSpecStatusFromAdmit()
-			Expect(meta.Annotations).NotTo(BeNil())
-			Expect(meta.Annotations).To(HaveKeyWithValue("kubevirt.io/nonroot", ""))
+			_, _, status := getMetaSpecStatusFromAdmit()
+			Expect(status.RuntimeUser).NotTo(BeZero())
 		})
 
 		It("Should reject VirtioFS vmi", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Template", func() {
 
 		newMinimalWithContainerDisk := func(name string) *v1.VirtualMachineInstance {
 			vmi := api.NewMinimalVMI(name)
-			vmi.Annotations = map[string]string{v1.NonRootVMIAnnotation: ""}
+			vmi.Annotations = map[string]string{v1.DeprecatedNonRootVMIAnnotation: ""}
 
 			volumes := []v1.Volume{
 				{

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9843,6 +9843,11 @@ var CRDsValidation map[string]string = map[string]string{
           description: A brief CamelCase message indicating details about why the
             VMI is in this state. e.g. 'NodeUnresponsive'
           type: string
+        runtimeUser:
+          description: RuntimeUser is used to determine what user will be used in
+            launcher
+          format: int64
+          type: integer
         topologyHints:
           properties:
             tscFrequency:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -249,6 +249,10 @@ type VirtualMachineInstanceStatus struct {
 	// an online vm snapshot
 	// +optional
 	VirtualMachineRevisionName string `json:"virtualMachineRevisionName,omitempty"`
+
+	// RuntimeUser is used to determine what user will be used in launcher
+	// +optional
+	RuntimeUser uint64 `json:"runtimeUser"`
 }
 
 // PersistentVolumeClaimInfo contains the relavant information virt-handler needs cached about a PVC
@@ -793,7 +797,7 @@ const (
 	MigrationSelectorLabel = "kubevirt.io/vmi-name"
 
 	// This annotation represents vmi running nonroot implementation
-	NonRootVMIAnnotation = "kubevirt.io/nonroot"
+	DeprecatedNonRootVMIAnnotation = "kubevirt.io/nonroot"
 
 	// This annotation is to keep virt launcher container alive when an VMI encounters a failure for debugging purpose
 	KeepLauncherAfterFailureAnnotation string = "kubevirt.io/keep-launcher-alive-after-failure"

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -73,6 +73,7 @@ func (VirtualMachineInstanceStatus) SwaggerDoc() map[string]string {
 		"fsFreezeStatus":                "FSFreezeStatus is the state of the fs of the guest\nit can be either frozen or thawed\n+optional",
 		"topologyHints":                 "+optional",
 		"virtualMachineRevisionName":    "VirtualMachineRevisionName is used to get the vm revision of the vmi when doing\nan online vm snapshot\n+optional",
+		"runtimeUser":                   "RuntimeUser is used to determine what user will be used in launcher\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21375,6 +21375,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceStatus(ref common.Refer
 							Format:      "",
 						},
 					},
+					"runtimeUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RuntimeUser is used to determine what user will be used in launcher",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/schema_test.go
+++ b/staging/src/kubevirt.io/client-go/api/schema_test.go
@@ -231,7 +231,8 @@ var exampleJSONFmt = `{
     ]
   },
   "status": {
-    "guestOSInfo": {}
+    "guestOSInfo": {},
+    "runtimeUser": 0
   }
 }`
 

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -56,11 +56,16 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 
 			vmi := tests.NewRandomVMI()
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Check that runtimeuser was set on creation")
+			Expect(vmi.Status.RuntimeUser).To(Equal(uint64(107)))
 
 			tests.WaitForSuccessfulVMIStart(vmi)
 
-			Expect(err).NotTo(HaveOccurred())
+			By("Check that user used is equal to 107")
 			Expect(tests.GetIdOfLauncher(vmi)).To(Equal("107"))
+
 		})
 	})
 })

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -2,7 +2,6 @@ package tests_test
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -60,19 +59,8 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 
 			tests.WaitForSuccessfulVMIStart(vmi)
 
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-			podOutput, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[0].Name,
-				[]string{"id"},
-			)
-
-			groups := strings.Split(podOutput, "=")
-			uid := strings.Split(groups[1], "(")[0]
-
 			Expect(err).NotTo(HaveOccurred())
-			Expect(uid).To(Equal("107"))
+			Expect(tests.GetIdOfLauncher(vmi)).To(Equal("107"))
 		})
 	})
 })

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5321,3 +5321,19 @@ func GetPodsCgroupVersion(pod *k8sv1.Pod, virtClient kubecli.KubevirtClient) cgr
 		return cgroup.V1
 	}
 }
+
+func GetIdOfLauncher(vmi *v1.VirtualMachineInstance) string {
+	virtClient, err := kubecli.GetKubevirtClient()
+	util2.PanicOnError(err)
+
+	vmiPod := GetRunningPodByVirtualMachineInstance(vmi, util2.NamespaceTestDefault)
+	podOutput, err := ExecuteCommandOnPod(
+		virtClient,
+		vmiPod,
+		vmiPod.Spec.Containers[0].Name,
+		[]string{"id", "-u"},
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	return strings.TrimSpace(podOutput)
+}

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -36,12 +36,10 @@ import (
 
 	"kubevirt.io/api/core"
 
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
@@ -379,11 +377,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying VMI")
-			if checks.HasFeature(virtconfig.NonRoot) {
-				Expect(newVmi.Annotations).To(Equal(map[string]string{"kubevirt.io/nonroot": ""}))
-			} else {
-				Expect(newVmi.Annotations).To(BeNil())
-			}
+			Expect(newVmi.Annotations).To(BeNil())
 
 			label, ok := vmi.Labels[overrideKey]
 			Expect(ok).To(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables to migrate VMIs that are using root implementation of launcher to nonroot.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I am not sure if we should remove the annotation in case of failed/aborted migration.

**Release note**:
```release-note
Workloads will be migrated to nonroot implementation if NonRoot feature gate is set. (Except VirtioFS)
```

/cc @davidvossel @rmohr 
