### PR TITLE
[virt-launcher]: Stop logging successful shutdown when it isn't true

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -459,9 +459,9 @@ func main() {
 
 		if err != nil {
 			log.Log.Reason(err).Errorf("Gave up attempting to signal graceful shutdown")
+		} else {
+			log.Log.Object(vmi).Info("Successfully signaled graceful shutdown")
 		}
-
-		log.Log.Object(vmi).Info("Successfully signaled graceful shutdown")
 	}
 
 	finalShutdownCallback := func(pid int) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Small fix: today we log "Successfully signaled graceful shutdown" even if graceful shutdown is not successful.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher fix - stop logging successful shutdown when it isn't true
```
