### PR TITLE
WIP, fix Mac duplicate entry in vm spec after mac change

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -976,6 +976,23 @@ func (d *VirtualMachineController) updateInterfacesFromDomain(vmi *v1.VirtualMac
 				}
 				delete(domainInterfaceStatusByMac, interfaceMAC)
 			}
+
+			var ifaceMAC string
+			for _, domainInterfaceStatus := range domainInterfaceStatusByMac {
+				if newInterface.InterfaceName == domainInterfaceStatus.InterfaceName {
+					ifaceMAC = domainInterfaceStatus.Mac
+					newInterface.MAC = ifaceMAC
+					if !isForwardingBindingInterface {
+						newInterface.IP = domainInterfaceStatus.Ip
+						newInterface.IPs = domainInterfaceStatus.IPs
+					}
+					break
+				}
+			}
+			if ifaceMAC != "" {
+				delete(domainInterfaceStatusByMac, ifaceMAC)
+			}
+
 			newInterfaces = append(newInterfaces, newInterface)
 		}
 

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -257,24 +257,6 @@ func MergeAgentStatusesWithDomainData(domInterfaces []api.Interface, interfaceSt
 		}
 	}
 
-	// If interface present in domain was not found in interfaceStatuses, add it
-	for mac, alias := range aliasByMac {
-		isCoveredByAgentData := false
-		for _, coveredAlias := range aliasesCoveredByAgent {
-			if alias == coveredAlias {
-				isCoveredByAgentData = true
-				break
-			}
-		}
-		if !isCoveredByAgentData {
-			interfaceStatuses = append(interfaceStatuses,
-				api.InterfaceStatus{
-					Mac:  mac,
-					Name: alias,
-				},
-			)
-		}
-	}
 	return interfaceStatuses
 }
 


### PR DESCRIPTION
In case a Mac address is changed, the vmi spec will have both the old entry and the new one.
The reason is that one is reported by the guest agent (the updated one), and one exists in the spec,
and is filled with the IPs, but not updated with the MAC.
This PR does two things in order to fix it:

1. Remove the redudnet merge of interfaces in virt-launcher,
the interfaces exists in the spec already, and are handled in the virt-handler, so it is not needed.
2. In case there are two entries with the same interface name, they are merged into one.

Signed-off-by: Or Shoval <oshoval@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2013455

```release-note
None
```
