### PR TITLE
Add a WaitingForVolumeBinding printable status 

### DIFF
--- a/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
@@ -1294,6 +1294,9 @@ const (
 	// VirtualMachineStatusDataVolumeError indicates that an error has been reported by one of the DataVolumes
 	// referenced by the virtual machines.
 	VirtualMachineStatusDataVolumeError VirtualMachinePrintableStatus = "DataVolumeError"
+	// VirtualMachineStatusWaitingForVolumeBinding indicates that some PersistentVolumeClaims backing
+	// the virtual machine volume are still not bound.
+	VirtualMachineStatusWaitingForVolumeBinding VirtualMachinePrintableStatus = "WaitingForVolumeBinding"
 )
 
 // VirtualMachineStartFailure tracks VMIs which failed to transition successfully


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the VM status field (`.status.printableStatus`) with a new `WaitingForVolumeBinding` status, reported when a VM with a PVC/DV type of volume is started, and the backing PVC is not bound. 

This PR replaces #6454 and #6605. In contrast to #6454, it avoids presenting the status as an error, as well as heuristics to detect when binding failures occur - and simply make it visible when the VM cannot start due to unbound volumes (be it a short intermediary state, or a long lasting state that requires intervention). Also, in line with the discussion in #6605, it ensures that stopped VMs don't report `WaitingForVolumeBinding` nor `Provisioning`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2013160

**Special notes for your reviewer**:

**Release note**:
```release-note
Report WaitingForVolumeBinding VM status when PVC/DV-type volumes reference unbound PVCs
```
