### PR TITLE
virt-launcher: decrease timeout for http get when detecting Istio

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -65,7 +65,7 @@ import (
 )
 
 const defaultStartTimeout = 3 * time.Minute
-const httpRequestTimeout = 10 * time.Second
+const httpRequestTimeout = 2 * time.Second
 
 func init() {
 	// must registry the event impl before doing anything else.


### PR DESCRIPTION
**What this PR does / why we need it**:
The 10 second timeout is too long and may cause the launcher to
not terminate for longer than necessary.
Shortening the timeout to 2 seconds for http get requests, which
should be more than enough.

With this change, in the worst case scenario, the detection would
take at most 8 seconds (4*2) plus a few ms for jitter.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- https://bugzilla.redhat.com/show_bug.cgi?id=2017255

**Special notes for your reviewer**:

**Release note**:

-->
```release-note
Shorten timeout for Istio proxy detection
```
