### PR TITLE
[release-0.44] Reference containerDisks and kernel boot images in reproducible format during migrations

### DIFF
--- a/pkg/container-disk/container-disk_test.go
+++ b/pkg/container-disk/container-disk_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -183,7 +184,7 @@ var _ = Describe("ContainerDisk", func() {
 						k8sv1.ResourceMemory: resource.MustParse("64M"),
 					},
 				}
-				containers := GenerateContainers(vmi, "libvirt-runtime", "/var/run/libvirt")
+				containers := GenerateContainers(vmi, nil, "libvirt-runtime", "/var/run/libvirt")
 
 				containerResourceSpecs := []k8sv1.ResourceList{containers[0].Resources.Limits, containers[0].Resources.Requests}
 
@@ -195,7 +196,7 @@ var _ = Describe("ContainerDisk", func() {
 
 				vmi := v1.NewMinimalVMI("fake-vmi")
 				appendContainerDisk(vmi, "r0")
-				containers := GenerateContainers(vmi, "libvirt-runtime", "/var/run/libvirt")
+				containers := GenerateContainers(vmi, nil, "libvirt-runtime", "/var/run/libvirt")
 
 				expectedEphemeralStorageRequest := resource.MustParse(ephemeralStorageOverheadSize)
 
@@ -212,7 +213,7 @@ var _ = Describe("ContainerDisk", func() {
 				vmi := v1.NewMinimalVMI("fake-vmi")
 				appendContainerDisk(vmi, "r1")
 				appendContainerDisk(vmi, "r0")
-				containers := GenerateContainers(vmi, "libvirt-runtime", "bin-volume")
+				containers := GenerateContainers(vmi, nil, "libvirt-runtime", "bin-volume")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(containers)).To(Equal(2))
@@ -262,6 +263,89 @@ var _ = Describe("ContainerDisk", func() {
 				})
 			})
 		})
+
+		Context("should use the right containerID", func() {
+			It("for a new migration pod with two containerDisks", func() {
+				vmi := v1.NewMinimalVMI("myvmi")
+				appendContainerDisk(vmi, "disk1")
+				appendNonContainerDisk(vmi, "disk3")
+				appendContainerDisk(vmi, "disk2")
+
+				pod := createMigrationSourcePod(vmi)
+
+				imageIDs, err := ExtractImageIDsFromSourcePod(vmi, pod)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(imageIDs).To(HaveKeyWithValue("disk1", "someimage@sha256:0"))
+				Expect(imageIDs).To(HaveKeyWithValue("disk2", "someimage@sha256:1"))
+				Expect(imageIDs).To(HaveLen(2))
+
+				newContainers := GenerateContainers(vmi, imageIDs, "a-name", "something")
+				Expect(newContainers[0].Image).To(Equal("someimage@sha256:0"))
+				Expect(newContainers[1].Image).To(Equal("someimage@sha256:1"))
+			})
+			It("for a new migration pod with a containerDisk and a kernel image", func() {
+				vmi := v1.NewMinimalVMI("myvmi")
+				appendContainerDisk(vmi, "disk1")
+				appendNonContainerDisk(vmi, "disk3")
+
+				vmi.Spec.Domain.Firmware = &v1.Firmware{KernelBoot: &v1.KernelBoot{Container: &v1.KernelBootContainer{Image: "someimage:v1.2.3.4"}}}
+
+				pod := createMigrationSourcePod(vmi)
+
+				imageIDs, err := ExtractImageIDsFromSourcePod(vmi, pod)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(imageIDs).To(HaveKeyWithValue("disk1", "someimage@sha256:0"))
+				Expect(imageIDs).To(HaveKeyWithValue("kernel-boot-volume", "someimage@sha256:bootcontainer"))
+				Expect(imageIDs).To(HaveLen(2))
+
+				newContainers := GenerateContainers(vmi, imageIDs, "a-name", "something")
+				newBootContainer := GenerateKernelBootContainer(vmi, imageIDs, "a-name", "something")
+				newContainers = append(newContainers, *newBootContainer)
+				Expect(newContainers[0].Image).To(Equal("someimage@sha256:0"))
+				Expect(newContainers[1].Image).To(Equal("someimage@sha256:bootcontainer"))
+			})
+
+			It("should fail if it can't detect a reproducible imageID", func() {
+				vmi := v1.NewMinimalVMI("myvmi")
+				appendContainerDisk(vmi, "disk1")
+				pod := createMigrationSourcePod(vmi)
+				pod.Status.ContainerStatuses[0].ImageID = "rubish"
+				_, err := ExtractImageIDsFromSourcePod(vmi, pod)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(`failed to identify image digest for container "someimage:v1.2.3.4" with id "rubish"`))
+			})
+
+			table.DescribeTable("It should detect the image ID from", func(imageID string) {
+				expected := "myregistry.io/myimage@sha256:4gjffGJlg4"
+				res, err := toImageWithDigest("myregistry.io/myimage", imageID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).To(Equal(expected))
+				res, err = toImageWithDigest("myregistry.io/myimage:1234", imageID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).To(Equal(expected))
+				res, err = toImageWithDigest("myregistry.io/myimage:latest", imageID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).To(Equal(expected))
+			},
+				table.Entry("docker", "docker://sha256:4gjffGJlg4"),
+				table.Entry("dontainerd", "sha256:4gjffGJlg4"),
+				table.Entry("cri-o", "myregistry/myimage@sha256:4gjffGJlg4"),
+			)
+
+			table.DescribeTable("It should detect the base image from", func(given, expected string) {
+				res, err := toImageWithDigest(given, "docker://sha256:4gjffGJlg4")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.Split(res, "@sha256:")[0]).To(Equal(expected))
+			},
+				table.Entry("image with registry and no tags or shasum", "myregistry.io/myimage", "myregistry.io/myimage"),
+				table.Entry("image with registry and tag", "myregistry.io/myimage:latest", "myregistry.io/myimage"),
+				table.Entry("image with registry and shasum", "myregistry.io/myimage@sha256:123534", "myregistry.io/myimage"),
+				table.Entry("image with registry and no tags or shasum and custom port", "myregistry.io:5000/myimage", "myregistry.io:5000/myimage"),
+				table.Entry("image with registry and tag and custom port", "myregistry.io:5000/myimage:latest", "myregistry.io:5000/myimage"),
+				table.Entry("image with registry and shasum and custom port", "myregistry.io:5000/myimage@sha256:123534", "myregistry.io:5000/myimage"),
+				table.Entry("image with registry and shasum and custom port and group", "myregistry.io:5000/mygroup/myimage@sha256:123534", "myregistry.io:5000/mygroup/myimage"),
+			)
+		})
 	})
 })
 
@@ -281,4 +365,43 @@ func appendContainerDisk(vmi *v1.VirtualMachineInstance, diskName string) {
 			},
 		},
 	})
+}
+func appendNonContainerDisk(vmi *v1.VirtualMachineInstance, diskName string) {
+	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+		Name: diskName,
+		DiskDevice: v1.DiskDevice{
+			Disk: &v1.DiskTarget{},
+		},
+	})
+	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+		Name: diskName,
+		VolumeSource: v1.VolumeSource{
+			DataVolume: &v1.DataVolumeSource{},
+		},
+	})
+}
+
+func createMigrationSourcePod(vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
+	pod := &k8sv1.Pod{Status: k8sv1.PodStatus{}}
+	containers := GenerateContainers(vmi, nil, "a-name", "something")
+
+	for idx, container := range containers {
+		status := k8sv1.ContainerStatus{
+			Name:    container.Name,
+			Image:   container.Image,
+			ImageID: fmt.Sprintf("finalimg@sha256:%v", idx),
+		}
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, status)
+	}
+	bootContainer := GenerateKernelBootContainer(vmi, nil, "a-name", "something")
+	if bootContainer != nil {
+		status := k8sv1.ContainerStatus{
+			Name:    bootContainer.Name,
+			Image:   bootContainer.Image,
+			ImageID: fmt.Sprintf("finalimg@sha256:%v", "bootcontainer"),
+		}
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, status)
+	}
+
+	return pod
 }

--- a/pkg/testutils/matchers.go
+++ b/pkg/testutils/matchers.go
@@ -82,7 +82,7 @@ loop:
 }
 
 func ExpectEvent(recorder *record.FakeRecorder, reason string) {
-	gomega.Expect(recorder.Events).To(gomega.Receive(gomega.ContainSubstring(reason)))
+	gomega.ExpectWithOffset(1, recorder.Events).To(gomega.Receive(gomega.ContainSubstring(reason)))
 }
 
 // ExpectEvents checks for given reasons in arbitrary order
@@ -103,12 +103,12 @@ func ExpectEvents(recorder *record.FakeRecorder, reasons ...string) {
 				filtered = append(filtered, reason)
 			}
 
-			gomega.Expect(found).To(gomega.BeTrue(), "Expected to match event reason '%s' with one of %v", e, reasons)
+			gomega.ExpectWithOffset(1, found).To(gomega.BeTrue(), "Expected to match event reason '%s' with one of %v", e, reasons)
 			reasons = filtered
 
 		default:
 			// There should be something, trigger an error
-			gomega.Expect(recorder.Events).To(gomega.Receive())
+			gomega.ExpectWithOffset(1, recorder.Events).To(gomega.Receive())
 		}
 	}
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -106,7 +106,8 @@ const EXT_LOG_VERBOSITY_THRESHOLD = 5
 const ephemeralStorageOverheadSize = "50M"
 
 type TemplateService interface {
-	RenderLaunchManifest(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
+	RenderMigrationManifest(vmi *v1.VirtualMachineInstance, sourcePod *k8sv1.Pod) (*k8sv1.Pod, error)
+	RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error)
 	RenderHotplugAttachmentPodTemplate(volume []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim, tempPod bool) (*k8sv1.Pod, error)
 	RenderHotplugAttachmentTriggerPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock bool, tempPod bool) (*k8sv1.Pod, error)
 	RenderLaunchManifestNoVm(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
@@ -370,10 +371,19 @@ func (t *templateService) GetLauncherImage() string {
 }
 
 func (t *templateService) RenderLaunchManifestNoVm(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error) {
-	return t.renderLaunchManifest(vmi, true)
+	return t.renderLaunchManifest(vmi, nil, true)
 }
+
+func (t *templateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) (*k8sv1.Pod, error) {
+	reproducibleImageIDs, err := containerdisk.ExtractImageIDsFromSourcePod(vmi, pod)
+	if err != nil {
+		return nil, fmt.Errorf("can not proceed with the migration when no reproducible image digest can be detected: %v", err)
+	}
+	return t.renderLaunchManifest(vmi, reproducibleImageIDs, false)
+}
+
 func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error) {
-	return t.renderLaunchManifest(vmi, false)
+	return t.renderLaunchManifest(vmi, nil, false)
 }
 
 func (t *templateService) IsPPC64() bool {
@@ -390,7 +400,7 @@ func generateQemuTimeoutWithJitter() string {
 	return fmt.Sprintf("%ds", timeout)
 }
 
-func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, tempPod bool) (*k8sv1.Pod, error) {
+func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, tempPod bool) (*k8sv1.Pod, error) {
 	precond.MustNotBeNil(vmi)
 	domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
 	namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
@@ -1159,10 +1169,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 	// Make sure the compute container is always the first since the mutating webhook shipped with the sriov operator
 	// for adding the requested resources to the pod will add them to the first container of the list
 	containers := []k8sv1.Container{compute}
-	containersDisks := containerdisk.GenerateContainers(vmi, "container-disks", "virt-bin-share-dir")
+	containersDisks := containerdisk.GenerateContainers(vmi, imageIDs, "container-disks", "virt-bin-share-dir")
 	containers = append(containers, containersDisks...)
 
-	kernelBootContainer := containerdisk.GenerateKernelBootContainer(vmi, "container-disks", "virt-bin-share-dir")
+	kernelBootContainer := containerdisk.GenerateKernelBootContainer(vmi, imageIDs, "container-disks", "virt-bin-share-dir")
 	if kernelBootContainer != nil {
 		log.Log.Object(vmi).Infof("kernel boot container generated")
 		containers = append(containers, *kernelBootContainer)
@@ -1340,7 +1350,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		initContainers = append(initContainers, cpInitContainer)
 
 		// this causes containerDisks to be pre-pulled before virt-launcher starts.
-		initContainers = append(initContainers, containerdisk.GenerateInitContainers(vmi, "container-disks", "virt-bin-share-dir")...)
+		initContainers = append(initContainers, containerdisk.GenerateInitContainers(vmi, imageIDs, "container-disks", "virt-bin-share-dir")...)
 	}
 
 	// TODO use constants for podLabels

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -479,9 +479,9 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 	return nil
 }
 
-func (c *MigrationController) createTargetPod(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
+func (c *MigrationController) createTargetPod(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, sourcePod *k8sv1.Pod) error {
 
-	templatePod, err := c.templateService.RenderLaunchManifest(vmi)
+	templatePod, err := c.templateService.RenderMigrationManifest(vmi, sourcePod)
 	if err != nil {
 		return fmt.Errorf("failed to render launch manifest: %v", err)
 	}
@@ -672,7 +672,7 @@ func filterOutOldPDBs(pdbList []*v1beta1.PodDisruptionBudget) []*v1beta1.PodDisr
 	return filteredPdbs
 }
 
-func (c *MigrationController) handleTargetPodCreation(key string, migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
+func (c *MigrationController) handleTargetPodCreation(key string, migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, sourcePod *k8sv1.Pod) error {
 
 	c.migrationStartLock.Lock()
 	defer c.migrationStartLock.Unlock()
@@ -742,7 +742,7 @@ func (c *MigrationController) handleTargetPodCreation(key string, migration *vir
 				return nil
 			}
 		}
-		return c.createTargetPod(migration, vmi)
+		return c.createTargetPod(migration, vmi, sourcePod)
 	}
 	return nil
 }
@@ -794,8 +794,8 @@ func (c *MigrationController) createAttachmentPod(migration *virtv1.VirtualMachi
 func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pods []*k8sv1.Pod) error {
 
 	var pod *k8sv1.Pod = nil
-	podExists := len(pods) > 0
-	if podExists {
+	targetPodExists := len(pods) > 0
+	if targetPodExists {
 		pod = pods[0]
 	}
 
@@ -817,8 +817,20 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 
 	switch migration.Status.Phase {
 	case virtv1.MigrationPending:
-		if !podExists {
-			return c.handleTargetPodCreation(key, migration, vmi)
+		if !targetPodExists {
+			sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer)
+			if err != nil {
+				log.Log.Reason(err).Error("Failed to fetch pods for namespace from cache.")
+				return err
+			}
+			if !podExists(sourcePod) {
+				// for instance sudden deletes can cause this. In this
+				// case we don't have to do anything in the creation flow anymore.
+				// Once the VMI is in a final state or deleted the migration
+				// will be marked as failed too.
+				return nil
+			}
+			return c.handleTargetPodCreation(key, migration, vmi, sourcePod)
 		} else if isPodReady(pod) {
 			if controller.VMIHasHotplugVolumes(vmi) {
 				attachmentPods, err := controller.AttachmentPods(pod, c.podInformer)
@@ -834,11 +846,11 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 	case virtv1.MigrationScheduled:
 		// once target pod is running, then alert the VMI of the migration by
 		// setting the target and source nodes. This kicks off the preparation stage.
-		if podExists && isPodReady(pod) {
+		if targetPodExists && isPodReady(pod) {
 			return c.handleTargetPodHandoff(migration, vmi, pod)
 		}
 	case virtv1.MigrationPreparingTarget, virtv1.MigrationTargetReady, virtv1.MigrationFailed:
-		if (!podExists || podIsDown(pod)) &&
+		if (!targetPodExists || podIsDown(pod)) &&
 			vmi.Status.MigrationState != nil &&
 			len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts) == 0 &&
 			vmi.Status.MigrationState.StartTimestamp == nil &&

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -261,6 +261,8 @@ var _ = Describe("Migration watcher", func() {
 	})
 
 	addVirtualMachineInstance := func(vmi *v1.VirtualMachineInstance) {
+		sourcePod := newSourcePodForVirtualMachine(vmi)
+		podInformer.GetStore().Add(sourcePod)
 		mockQueue.ExpectAdds(1)
 		vmiSource.Add(vmi)
 		mockQueue.Wait()
@@ -286,7 +288,6 @@ var _ = Describe("Migration watcher", func() {
 		var (
 			vmi           *v1.VirtualMachineInstance
 			migration     *v1.VirtualMachineInstanceMigration
-			sourcePod     *k8sv1.Pod
 			targetPod     *k8sv1.Pod
 			attachmentPod *k8sv1.Pod
 		)
@@ -294,7 +295,6 @@ var _ = Describe("Migration watcher", func() {
 		BeforeEach(func() {
 			vmi = newVirtualMachineWithHotplugVolume("testvmi", v1.Running)
 			migration = newMigration("testmigration", vmi.Name, v1.MigrationPending)
-			sourcePod = newSourcePodForVirtualMachine(vmi)
 			targetPod = newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 			attachmentPod = newAttachmentPodForVirtualMachine(targetPod, migration, k8sv1.PodRunning)
 		})
@@ -302,7 +302,6 @@ var _ = Describe("Migration watcher", func() {
 		It("should create target attachment pod", func() {
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
-			podInformer.GetStore().Add(sourcePod)
 			podFeeder.Add(targetPod)
 			shouldExpectAttachmentPodCreation(vmi.UID, migration.UID)
 


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/kubevirt/pull/6535

```release-note
Migrations use digests to reference containerDisks and kernel boot images to ensure disk consistency
```
