### PR TITLE
virt-launcher, gpu: Do not process GPU devices twice

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -674,11 +674,16 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		}
 		c.GenericHostDevices = genericHostDevices
 
-		gpuHostDevices, err := gpu.CreateHostDevices(vmi.Spec.Domain.Devices.GPUs)
-		if err != nil {
-			return nil, err
+		// Mixing legacy and existing GPU/s specification is not supported.
+		// If legacy host-devices are detected, the GPUs are assumed to have been processed already
+		// and therefore not to be processed again.
+		if len(c.LegacyHostDevices) == 0 {
+			gpuHostDevices, err := gpu.CreateHostDevices(vmi.Spec.Domain.Devices.GPUs)
+			if err != nil {
+				return nil, err
+			}
+			c.GPUHostDevices = gpuHostDevices
 		}
-		c.GPUHostDevices = gpuHostDevices
 	}
 
 	return c, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

When GPUs are processed with the older legacy DP, they should not be
processed again based on the up-to-date format.

Therefore, this change explicitly declares that in case legacy devices
are detected, it is assumed that the GPU devices in the VMI spec are
there to serve the legacy flow only.

This approach allows older usages of the legacy format to continue
working for now. Users however are expected to migrate to the newer
kubevirt format as soon as possible, as the previous is not covered in
kubevirt tests and is targeted for deprecation soon.

Mixing of legacy DP and current kubevirt DP for GPU/s is not supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6459

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```