### PR TITLE
Set default CPU model in VMI spec, even if not defined in KubevirtCR

### DIFF
--- a/pkg/virt-api/webhooks/arm64.go
+++ b/pkg/virt-api/webhooks/arm64.go
@@ -32,7 +32,7 @@ import (
 var _false bool = false
 
 const (
-	defaultCPUModel = "host-passthrough"
+	defaultCPUModel = v1.CPUModeHostPassthrough
 )
 
 // verifyInvalidSetting verify if VMI spec contain unavailable setting for arm64, check following items:
@@ -73,17 +73,11 @@ func verifyInvalidSetting(field *k8sfield.Path, spec *v1.VirtualMachineInstanceS
 
 // setDefaultCPUModel set default cpu model to host-passthrough
 func setDefaultCPUModel(vmi *v1.VirtualMachineInstance) {
-	//if vmi doesn't have cpu topology or cpu model set
-	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		// create cpu topology struct
-		if vmi.Spec.Domain.CPU == nil {
-			vmi.Spec.Domain.CPU = &v1.CPU{}
-		}
-		//set is as vmi cpu model
-		if vmi.Spec.Domain.CPU.Model == "" {
-			vmi.Spec.Domain.CPU.Model = defaultCPUModel
-		}
+	if vmi.Spec.Domain.CPU == nil {
+		vmi.Spec.Domain.CPU = &v1.CPU{}
 	}
+
+	vmi.Spec.Domain.CPU.Model = defaultCPUModel
 }
 
 // setDefaultBootloader set default bootloader to uefi boot

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -83,7 +83,6 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 
 		// Set VMI defaults
 		log.Log.Object(newVMI).V(4).Info("Apply defaults")
-		mutator.setDefaultCPUModel(newVMI)
 		mutator.setDefaultMachineType(newVMI)
 		mutator.setDefaultResourceRequests(newVMI)
 		mutator.setDefaultGuestCPUTopology(newVMI)
@@ -115,6 +114,8 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 				// if SetVirtualMachineInstanceArm64Defaults fails, it's due to a validation error, which will get caught in the validation webhook after mutation finishes.
 				log.Log.V(2).Infof("Failed to setting for Arm64: %s", err)
 			}
+		} else {
+			mutator.setDefaultCPUModel(newVMI)
 		}
 		if newVMI.IsRealtimeEnabled() {
 			log.Log.V(4).Info("Add realtime node label selector")

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -231,8 +231,6 @@ func (mutator *VMIsMutator) setDefaultNetworkInterface(obj *v1.VirtualMachineIns
 }
 
 func (mutator *VMIsMutator) setDefaultCPUModel(vmi *v1.VirtualMachineInstance) {
-	const defaultCPUModel = v1.CPUModeHostModel
-
 	// create cpu topology struct
 	if vmi.Spec.Domain.CPU == nil {
 		vmi.Spec.Domain.CPU = &v1.CPU{}
@@ -244,7 +242,7 @@ func (mutator *VMIsMutator) setDefaultCPUModel(vmi *v1.VirtualMachineInstance) {
 			//set is as vmi cpu model
 			vmi.Spec.Domain.CPU.Model = clusterConfigCPUModel
 		} else {
-			vmi.Spec.Domain.CPU.Model = defaultCPUModel
+			vmi.Spec.Domain.CPU.Model = v1.DefaultCPUModel
 		}
 	}
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -231,14 +231,19 @@ func (mutator *VMIsMutator) setDefaultNetworkInterface(obj *v1.VirtualMachineIns
 }
 
 func (mutator *VMIsMutator) setDefaultCPUModel(vmi *v1.VirtualMachineInstance) {
-	//if vmi doesn't have cpu topology or cpu model set
-	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		if defaultCPUModel := mutator.ClusterConfig.GetCPUModel(); defaultCPUModel != "" {
-			// create cpu topology struct
-			if vmi.Spec.Domain.CPU == nil {
-				vmi.Spec.Domain.CPU = &v1.CPU{}
-			}
+	const defaultCPUModel = v1.CPUModeHostModel
+
+	// create cpu topology struct
+	if vmi.Spec.Domain.CPU == nil {
+		vmi.Spec.Domain.CPU = &v1.CPU{}
+	}
+
+	// if vmi doesn't have cpu model set
+	if vmi.Spec.Domain.CPU.Model == "" {
+		if clusterConfigCPUModel := mutator.ClusterConfig.GetCPUModel(); clusterConfigCPUModel != "" {
 			//set is as vmi cpu model
+			vmi.Spec.Domain.CPU.Model = clusterConfigCPUModel
+		} else {
 			vmi.Spec.Domain.CPU.Model = defaultCPUModel
 		}
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -205,7 +205,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))
 		} else if webhooks.IsARM64() {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("virt"))
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal("host-passthrough"))
+			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.CPUModeHostPassthrough))
 		} else {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("q35"))
 			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -196,21 +196,22 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal(memoryLimit))
 	})
 
-	FIt("should apply defaults on VMI create", func() {
+	It("should apply defaults on VMI create", func() {
 		// no limits wanted on this test, to not copy the limit to requests
 		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		vmiSpec, _ := getVMISpecMetaFromResponse()
 		if webhooks.IsPPC64() {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("pseries"))
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(""))
+			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))
 		} else if webhooks.IsARM64() {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("virt"))
 			Expect(vmiSpec.Domain.CPU.Model).To(Equal("host-passthrough"))
 		} else {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("q35"))
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(""))
+			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))
 		}
 
+		Expect(v1.DefaultCPUModel).To(Equal(v1.CPUModeHostModel))
 		Expect(vmiSpec.Domain.Resources.Requests.Cpu().IsZero()).To(BeTrue())
 		// no default for requested memory when no memory is specified
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().Value()).To(Equal(int64(0)))

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -196,7 +196,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal(memoryLimit))
 	})
 
-	It("should apply defaults on VMI create", func() {
+	FIt("should apply defaults on VMI create", func() {
 		// no limits wanted on this test, to not copy the limit to requests
 		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		vmiSpec, _ := getVMISpecMetaFromResponse()

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/schema.go
@@ -32,6 +32,7 @@ const (
 	IOThreadsPolicyAuto    IOThreadsPolicy = "auto"
 	CPUModeHostPassthrough                 = "host-passthrough"
 	CPUModeHostModel                       = "host-model"
+	DefaultCPUModel                        = CPUModeHostModel
 )
 
 //go:generate swagger-doc

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -219,7 +219,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		Context("CPU", func() {
 			It("[test_id:TODO] should apply flavor to CPU", func() {
-				cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1}
+				cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1, Model: v1.DefaultCPUModel}
 
 				flavor := newVirtualMachineFlavor()
 				flavor.Profiles[0].CPU = cpu

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -875,7 +875,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 			})
 
-			It("[sig-compute][test_id:3201]should not set cpu model when vmi does not have it set and default cpu model is not set", func() {
+			It("[sig-compute][test_id:3201]should set cpu model to default when vmi does not have it set and default cpu model is not set", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
@@ -884,7 +884,9 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Spec.Domain.CPU.Model).To(BeEmpty(), "Expected CPU model to be nil")
+				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel),
+					fmt.Sprintf("Expected CPU model to equal to the default (%v)", v1.DefaultCPUModel),
+				)
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Today if a CPU model is defined by KubevirtCR it is the default CPU mode for every VMI. If it no model is defined in KubevirtCR we keep CPU model empty.
    
While we do set the underlying domain to host-model as a default if no model is defined in KubevirtCR (as documented in our [user-guide](https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#enabling-default-cluster-cpu-model)) it is not reflected in the VMI manifest, making it harder for other components to identify VMI's actual CPU model.

Without this change components across our code-base would have to implicitly assume that `vmi.Domain.CPU == nil` means model is host-model which is error-prone and less maintainable.

P.S. This fixes a bug that already exists in [migration.go's code](https://github.com/kubevirt/kubevirt/blob/release-0.46/pkg/virt-controller/watch/migration.go#L518) where a condition checks if the VMI has host-model CPU type defined. The condition is false although it is actually true simple because it is not reflected at the VMI spec level.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set default CPU model in VMI spec, even if not defined in KubevirtCR
```
