### PR TITLE
Remove obsolete scheduler.alpha.kubernetes.io/critical-pod annotation

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -894,8 +894,6 @@ spec:
             type: RollingUpdate
           template:
             metadata:
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ""
               labels:
                 kubevirt.io: virt-operator
                 prometheus.kubevirt.io: "true"

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -122,9 +122,6 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 				virtv1.AppLabel:    podName,
 				prometheusLabelKey: prometheusLabelValue,
 			},
-			Annotations: map[string]string{
-				"scheduler.alpha.kubernetes.io/critical-pod": "",
-			},
 			Name: podName,
 		},
 		Spec: corev1.PodSpec{
@@ -443,9 +440,6 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 					Labels: map[string]string{
 						virtv1.AppLabel:    VirtOperatorName,
 						prometheusLabelKey: prometheusLabelValue,
-					},
-					Annotations: map[string]string{
-						"scheduler.alpha.kubernetes.io/critical-pod": "",
 					},
 					Name: VirtOperatorName,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the obsolete `scheduler.alpha.kubernetes.io/critical-pod` annotation from virt-{operator,controller,api,handler} pods. 

This annotation has been [obsoleted in 1.16](https://github.com/kubernetes/kubernetes/blob/e9ce31bcb3feb411c4de4902651e43dbb78ed151/CHANGELOG-1.16.md#deprecations-and-removals) (i.e., it doesn't have any effect, except for generating warnings when updating/patching the virt-xyz deployments), in favor of the `priorityClassName` in the PodSpec (which we already make use of, as of #3236).

**Special notes for your reviewer**:

Note that this has already been attempted in #5901, which didn't make it through after all.
The current PR has a much narrower scope, and is only concerned with removing the obsolete annotation.

**Release note**:
```release-note
Remove obsolete scheduler.alpha.kubernetes.io/critical-pod annotation
```
