### PR TITLE
pdb: reconcile all old pdbs

### DIFF
--- a/pkg/util/pdbs/pdbs.go
+++ b/pkg/util/pdbs/pdbs.go
@@ -29,6 +29,15 @@ func PDBsForVMI(vmi *virtv1.VirtualMachineInstance, pdbInformer cache.SharedInde
 
 func IsPDBFromOldMigrationController(pdb *v1beta1.PodDisruptionBudget) bool {
 	// The pdb might be from an old migration-controller that used to create 2-pdbs per migration
-	_, isOld := pdb.ObjectMeta.Labels[virtv1.MigrationNameLabel]
-	return isOld && strings.HasPrefix(pdb.Name, "kubevirt-migration-pdb-")
+	_, migrationLabelExists := pdb.ObjectMeta.Labels[virtv1.MigrationNameLabel]
+	if migrationLabelExists && strings.HasPrefix(pdb.Name, "kubevirt-migration-pdb-") {
+		return true
+	}
+
+	owner := v1.GetControllerOf(pdb)
+	ownedByVMI := owner != nil && owner.Kind == virtv1.VirtualMachineInstanceGroupVersionKind.Kind
+	if ownedByVMI && !migrationLabelExists && pdb.Spec.MinAvailable.IntValue() == 2 {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This change removes stale PDBs created by virt-controller < 0.41.1 which
had minAvailable permanently set to 2.

Func test also added.

Signed-off-by: Antonio Cardace <acardace@redhat.com>
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2019453
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
remove stale pdbs created by < 0.41.1 virt-controller
```
