### PR TITLE
[virt-controller]: Use separate REST client with fixed rate limiter for the leader elector

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -310,7 +310,7 @@ func Execute() {
 	app.nodeInformer = app.informerFactory.KubeVirtNode()
 
 	app.vmiCache = app.vmiInformer.GetStore()
-	app.vmiRecorder = app.getNewRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")
+	app.vmiRecorder = app.newRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")
 
 	app.rsInformer = app.informerFactory.VMIReplicaSet()
 
@@ -452,7 +452,7 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 	}
 }
 
-func (vca *VirtControllerApp) getNewRecorder(namespace string, componentName string) record.EventRecorder {
+func (vca *VirtControllerApp) newRecorder(namespace string, componentName string) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&k8coresv1.EventSinkImpl{Interface: vca.clientSet.CoreV1().Events(namespace)})
 	return eventBroadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: componentName})
@@ -494,7 +494,7 @@ func (vca *VirtControllerApp) initCommon() {
 		topologyHinter,
 	)
 
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "node-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "node-controller")
 	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, recorder)
 	vca.migrationController = NewMigrationController(
 		vca.templateService,
@@ -513,12 +513,12 @@ func (vca *VirtControllerApp) initCommon() {
 }
 
 func (vca *VirtControllerApp) initReplicaSet() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "virtualmachinereplicaset-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "virtualmachinereplicaset-controller")
 	vca.rsController = NewVMIReplicaSet(vca.vmiInformer, vca.rsInformer, recorder, vca.clientSet, controller.BurstReplicas)
 }
 
 func (vca *VirtControllerApp) initVirtualMachines() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")
 
 	vca.vmController = NewVMController(
 		vca.vmiInformer,
@@ -532,7 +532,7 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 }
 
 func (vca *VirtControllerApp) initDisruptionBudgetController() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "disruptionbudget-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "disruptionbudget-controller")
 	vca.disruptionBudgetController = disruptionbudget.NewDisruptionBudgetController(
 		vca.vmiInformer,
 		vca.pdbInformer,
@@ -545,7 +545,7 @@ func (vca *VirtControllerApp) initDisruptionBudgetController() {
 }
 
 func (vca *VirtControllerApp) initWorkloadUpdaterController() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "workload-update-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "workload-update-controller")
 	vca.workloadUpdateController = workloadupdater.NewWorkloadUpdateController(
 		vca.launcherImage,
 		vca.vmiInformer,
@@ -558,7 +558,7 @@ func (vca *VirtControllerApp) initWorkloadUpdaterController() {
 }
 
 func (vca *VirtControllerApp) initEvacuationController() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "disruptionbudget-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "disruptionbudget-controller")
 	vca.evacuationController = evacuation.NewEvacuationController(
 		vca.vmiInformer,
 		vca.migrationInformer,
@@ -571,7 +571,7 @@ func (vca *VirtControllerApp) initEvacuationController() {
 }
 
 func (vca *VirtControllerApp) initSnapshotController() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "snapshot-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "snapshot-controller")
 	vca.snapshotController = &snapshot.VMSnapshotController{
 		Client:                    vca.clientSet,
 		VMSnapshotInformer:        vca.vmSnapshotInformer,
@@ -591,7 +591,7 @@ func (vca *VirtControllerApp) initSnapshotController() {
 }
 
 func (vca *VirtControllerApp) initRestoreController() {
-	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "restore-controller")
+	recorder := vca.newRecorder(k8sv1.NamespaceAll, "restore-controller")
 	vca.restoreController = &snapshot.VMRestoreController{
 		Client:                    vca.clientSet,
 		VMRestoreInformer:         vca.vmRestoreInformer,
@@ -724,7 +724,7 @@ func (vca *VirtControllerApp) setupLeaderElector() (err error) {
 		clientSet.CoordinationV1(),
 		resourcelock.ResourceLockConfig{
 			Identity:      vca.host,
-			EventRecorder: vca.getNewRecorder(k8sv1.NamespaceAll, leaderelectionconfig.DefaultEndpointName),
+			EventRecorder: vca.newRecorder(k8sv1.NamespaceAll, leaderelectionconfig.DefaultEndpointName),
 		})
 
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The leader election process in virt-controller was affected by the rate limiter e2e tests. Therefore we've
decided to create a separate REST client for the leader election. That client won't be affected by external
rate limiter configuration from Kubevirt CR. 

**Which issue(s) this PR fixes** 
https://github.com/kubevirt/kubevirt/pull/6364

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
