### PR TITLE
Virtctl: cancel migrate

### DIFF
--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -82,6 +82,7 @@ func NewVirtctlCommand() *cobra.Command {
 		vm.NewStopCommand(clientConfig),
 		vm.NewRestartCommand(clientConfig),
 		vm.NewMigrateCommand(clientConfig),
+		vm.NewMigrateCancelCommand(clientConfig),
 		vm.NewGuestOsInfoCommand(clientConfig),
 		vm.NewUserListCommand(clientConfig),
 		vm.NewFSListCommand(clientConfig),

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -28,6 +28,7 @@ var _ = Describe("VirtualMachine", func() {
 	const vmName = "testvm"
 	var vmInterface *kubecli.MockVirtualMachineInterface
 	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
+	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
 	var ctrl *gomock.Controller
 
 	running := true
@@ -46,6 +47,7 @@ var _ = Describe("VirtualMachine", func() {
 		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
 		vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		migrationInterface = kubecli.NewMockVirtualMachineInstanceMigrationInterface(ctrl)
 	})
 
 	Context("With missing input parameters", func() {
@@ -63,6 +65,10 @@ var _ = Describe("VirtualMachine", func() {
 		})
 		It("should fail a migrate", func() {
 			cmd := tests.NewRepeatableVirtctlCommand("migrate")
+			Expect(cmd()).NotTo(BeNil())
+		})
+		It("should fail a migrate-cancel", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("migrate-cancel")
 			Expect(cmd()).NotTo(BeNil())
 		})
 	})
@@ -176,6 +182,51 @@ var _ = Describe("VirtualMachine", func() {
 			table.Entry("with default", &v1.MigrateOptions{}),
 			table.Entry("with dry-run option", &v1.MigrateOptions{DryRun: []string{k8smetav1.DryRunAll}}),
 		)
+	})
+
+	Context("with migrate-cancel VM cmd", func() {
+		vm := kubecli.NewMinimalVM(vmName)
+		migname := fmt.Sprintf("%s-%s", vm.Name, "migration") // "testvm-migration"
+		mig := kubecli.NewMinimalMigration(migname)
+		mig.Spec.VMIName = vm.Name // likely not required
+		labelselector := fmt.Sprintf("%s==%s", v1.MigrationSelectorLabel, vm.Name)
+		listoptions := k8smetav1.ListOptions{LabelSelector: labelselector}
+		cmd := tests.NewVirtctlCommand("migrate-cancel", vm.Name)
+		It("should cancel the vm migration", func() {
+			mig.Status.Phase = v1.MigrationRunning
+			migList := v1.VirtualMachineInstanceMigrationList{
+				Items: []v1.VirtualMachineInstanceMigration{
+					*mig,
+				},
+			}
+
+			kubecli.MockKubevirtClientInstance.EXPECT().
+				VirtualMachineInstanceMigration(k8smetav1.NamespaceDefault).
+				Return(migrationInterface).Times(2)
+
+			migrationInterface.EXPECT().List(&listoptions).Return(&migList, nil).Times(1)
+			migrationInterface.EXPECT().Delete(migname, &k8smetav1.DeleteOptions{}).Return(nil).Times(1)
+			Expect(cmd.Execute()).To(BeNil())
+		})
+		It("Should fail if no active migration is found", func() {
+			mig.Status.Phase = v1.MigrationSucceeded
+			migList := v1.VirtualMachineInstanceMigrationList{
+				Items: []v1.VirtualMachineInstanceMigration{
+					*mig,
+				},
+			}
+
+			kubecli.MockKubevirtClientInstance.EXPECT().
+				VirtualMachineInstanceMigration(k8smetav1.NamespaceDefault).
+				Return(migrationInterface).Times(1)
+
+			migrationInterface.EXPECT().List(&listoptions).Return(&migList, nil).Times(1)
+
+			res := cmd.Execute()
+			Expect(res).ToNot(BeNil())
+			errstr := fmt.Sprintf("Found no migration to cancel for %s", vm.Name)
+			Expect(res.Error()).To(ContainSubstring(errstr))
+		})
 	})
 
 	Context("with restart VM cmd", func() {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -230,6 +230,17 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		return vmi
 	}
 
+	cancelMigration := func(migration *v1.VirtualMachineInstanceMigration, vminame string, with_virtctl bool) {
+		if !with_virtctl {
+			By("Cancelling a Migration")
+			Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(migration.Name, &metav1.DeleteOptions{})).To(Succeed(), "Migration should be deleted successfully")
+		} else {
+			By("Cancelling a Migration with virtctl")
+			command := tests.NewRepeatableVirtctlCommand("migrate-cancel", "--namespace", migration.Namespace, vminame)
+			Expect(command()).To(Succeed(), "should successfully migrate-cancel a migration")
+		}
+	}
+
 	runAndCancelMigration := func(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, with_virtctl bool, timeout int) *v1.VirtualMachineInstanceMigration {
 		By("Starting a Migration")
 		Eventually(func() error {
@@ -255,14 +266,8 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 		}, timeout, 1*time.Second).Should(BeTrue())
 
-		if (!with_virtctl) {
-			By("Cancelling a Migration")
-			Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(migration.Name, &metav1.DeleteOptions{})).To(Succeed(), "Migration should be deleted successfully")
-		} else {
-			By("Cancelling a Migration with virtctl")
-			command := tests.NewRepeatableVirtctlCommand("migrate-cancel", "--namespace", migration.Namespace, vmi.Name)
-			Expect(command()).To(Succeed(), "should successfully migrate-cancel a migration")
-		}
+		cancelMigration(migration, vmi.Name, with_virtctl)
+
 		return migration
 	}
 
@@ -282,14 +287,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 		}, timeout, 1*time.Second).Should(BeTrue())
 
-		if (!with_virtctl) {
-			By("Cancelling a Migration")
-			Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(migration.Name, &metav1.DeleteOptions{})).To(Succeed(), "Migration should be deleted successfully")
-		} else {
-			By("Cancelling a Migration with virtctl")
-			command := tests.NewRepeatableVirtctlCommand("migrate-cancel", "--namespace", migration.Namespace, vmi.Name)
-			Expect(command()).To(Succeed(), "should successfully migrate-cancel a migration")
-		}
+		cancelMigration(migration, vmi.Name, with_virtctl)
 
 		return migration
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The command `migrate_cancel` was added to virtctl. It cancels an active VM migration.
Usage: `virtctl migrate_cancel vmname`
```
