### PR TITLE
virt-launcher, hostdev: Extract hot(un)plug from SR-IOV

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",
+        "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice/generic:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice/gpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice/legacy:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "addresspool.go",
         "hostdev.go",
+        "hotplug.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice",
     visibility = ["//visibility:public"],
@@ -14,6 +15,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )
 
@@ -23,6 +25,7 @@ go_test(
         "addresspool_test.go",
         "hostdev_test.go",
         "hostdevice_suite_test.go",
+        "hotplug_test.go",
     ],
     deps = [
         ":go_default_library",
@@ -32,5 +35,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug.go
@@ -1,0 +1,195 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package hostdevice
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+
+	"libvirt.org/go/libvirt"
+
+	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const (
+	MaxConcurrentHotPlugDevicesEvents = 32
+
+	affectLiveAndConfigLibvirtFlags = libvirt.DOMAIN_DEVICE_MODIFY_LIVE | libvirt.DOMAIN_DEVICE_MODIFY_CONFIG
+)
+
+type DeviceDetacher interface {
+	DetachDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
+}
+
+type EventRegistrar interface {
+	Register() error
+	Deregister() error
+	EventChannel() <-chan interface{}
+}
+
+func SafelyDetachHostDevices(hostDevices []api.HostDevice, eventDetach EventRegistrar, dom DeviceDetacher, timeout time.Duration) error {
+	if len(hostDevices) == 0 {
+		log.Log.Info("No host-devices to detach.")
+		return nil
+	}
+
+	if err := eventDetach.Register(); err != nil {
+		return fmt.Errorf("failed to detach host-devices: %v", err)
+	}
+	defer func() {
+		if err := eventDetach.Deregister(); err != nil {
+			log.Log.Reason(err).Errorf("failed to detach host-devices: %v", err)
+		}
+	}()
+
+	if err := detachHostDevices(dom, hostDevices); err != nil {
+		return err
+	}
+
+	return waitHostDevicesToDetach(eventDetach, hostDevices, timeout)
+}
+
+func FilterHostDevicesByAlias(domainSpec *api.DomainSpec, prefix string) []api.HostDevice {
+	var hostDevices []api.HostDevice
+
+	for _, hostDevice := range domainSpec.Devices.HostDevices {
+		if hostDevice.Alias != nil && strings.HasPrefix(hostDevice.Alias.GetName(), prefix) {
+			hostDevices = append(hostDevices, hostDevice)
+		}
+	}
+	return hostDevices
+}
+
+func detachHostDevices(dom DeviceDetacher, hostDevices []api.HostDevice) error {
+	for _, hostDev := range hostDevices {
+		devXML, err := xml.Marshal(hostDev)
+		if err != nil {
+			return fmt.Errorf("failed to encode (xml) hostdev %v, err: %v", hostDev, err)
+		}
+		err = dom.DetachDeviceFlags(string(devXML), affectLiveAndConfigLibvirtFlags)
+		if err != nil {
+			return fmt.Errorf("failed to detach hostdev %s, err: %v", devXML, err)
+		}
+		log.Log.Infof("Successfully hot-unplug hostdev: %s (%v)", hostDev.Alias.GetName(), hostDev.Source.Address)
+	}
+	return nil
+}
+
+func waitHostDevicesToDetach(eventDetach EventRegistrar, hostDevices []api.HostDevice, timeout time.Duration) error {
+	var detachedHostDevices []string
+	var desiredDetachCount = len(hostDevices)
+
+	for {
+		select {
+		case deviceAlias := <-eventDetach.EventChannel():
+			if dev := deviceLookup(hostDevices, deviceAlias.(string)); dev != nil {
+				detachedHostDevices = append(detachedHostDevices, dev.Alias.GetName())
+			}
+			if desiredDetachCount == len(detachedHostDevices) {
+				return nil
+			}
+		case <-time.After(timeout):
+
+			return fmt.Errorf(
+				"failed to wait for host-devices detach, timeout reached: %v/%v",
+				detachedHostDevices, hostDevicesNames(hostDevices))
+		}
+	}
+}
+
+func hostDevicesNames(hostDevices []api.HostDevice) []string {
+	var names []string
+	for _, dev := range hostDevices {
+		names = append(names, dev.Alias.GetName())
+	}
+	return names
+}
+
+func deviceLookup(hostDevices []api.HostDevice, deviceAlias string) *api.HostDevice {
+	deviceAlias = strings.TrimPrefix(deviceAlias, api.UserAliasPrefix)
+	for _, dev := range hostDevices {
+		if dev.Alias.GetName() == deviceAlias {
+			return &dev
+		}
+	}
+	return nil
+}
+
+type deviceAttacher interface {
+	AttachDeviceFlags(xmlData string, flags libvirt.DomainDeviceModifyFlags) error
+}
+
+func AttachHostDevices(dom deviceAttacher, hostDevices []api.HostDevice) error {
+	var errs []error
+	for _, hostDev := range hostDevices {
+		if err := attachHostDevice(dom, hostDev); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return buildAttachHostDevicesErrorMessage(errs)
+	}
+
+	return nil
+}
+
+func attachHostDevice(dom deviceAttacher, hostDev api.HostDevice) error {
+	devXML, err := xml.Marshal(hostDev)
+	if err != nil {
+		return fmt.Errorf("failed to encode (xml) host-device %v, err: %v", hostDev, err)
+	}
+	err = dom.AttachDeviceFlags(string(devXML), affectLiveAndConfigLibvirtFlags)
+	if err != nil {
+		return fmt.Errorf("failed to attach host-device %s, err: %v", devXML, err)
+	}
+	log.Log.Infof("Successfully hot-plug host-device: %s (%v)", hostDev.Alias.GetName(), hostDev.Source.Address)
+
+	return nil
+}
+
+func buildAttachHostDevicesErrorMessage(errors []error) error {
+	errorMessageBuilder := strings.Builder{}
+	for _, err := range errors {
+		errorMessageBuilder.WriteString(err.Error() + "\n")
+	}
+	return fmt.Errorf(errorMessageBuilder.String())
+}
+
+// DifferenceHostDevicesByAlias given two slices of host-devices, according to Alias.Name,
+// it returns a slice with host-devices that exists on the first slice and not exists on the second.
+func DifferenceHostDevicesByAlias(desiredHostDevices, actualHostDevices []api.HostDevice) []api.HostDevice {
+	actualHostDevicesByAlias := make(map[string]struct{}, len(actualHostDevices))
+	for _, hostDev := range actualHostDevices {
+		actualHostDevicesByAlias[hostDev.Alias.GetName()] = struct{}{}
+	}
+
+	var filteredSlice []api.HostDevice
+	for _, desiredHostDevice := range desiredHostDevices {
+		if _, exists := actualHostDevicesByAlias[desiredHostDevice.Alias.GetName()]; !exists {
+			filteredSlice = append(filteredSlice, desiredHostDevice)
+		}
+	}
+
+	return filteredSlice
+}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
@@ -1,0 +1,335 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package hostdevice_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"libvirt.org/go/libvirt"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
+)
+
+var _ = Describe("Hot(un)Plug HostDevice", func() {
+	Context("filter", func() {
+		It("filters 0 SRIOV devices, given non-SRIOV devices", func() {
+			var domainSpec api.DomainSpec
+
+			domainSpec.Devices.HostDevices = append(
+				domainSpec.Devices.HostDevices,
+				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov1")},
+				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov2")},
+			)
+			Expect(hostdevice.FilterHostDevicesByAlias(&domainSpec, aliasPrefix)).To(BeEmpty())
+		})
+
+		It("filters 2 SRIOV devices, given 2 SRIOV devices and 2 non-SRIOV devices", func() {
+			var domainSpec api.DomainSpec
+
+			hostDevice1 := api.HostDevice{Alias: api.NewUserDefinedAlias(aliasPrefix + "is-sriov1")}
+			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias(aliasPrefix + "is-sriov2")}
+			domainSpec.Devices.HostDevices = append(
+				domainSpec.Devices.HostDevices,
+				hostDevice1,
+				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov1")},
+				hostDevice2,
+				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov2")},
+			)
+			Expect(hostdevice.FilterHostDevicesByAlias(&domainSpec, aliasPrefix)).To(Equal([]api.HostDevice{hostDevice1, hostDevice2}))
+		})
+	})
+
+	Context("safe detachment", func() {
+		hostDevice := api.HostDevice{Alias: api.NewUserDefinedAlias(aliasPrefix + "net1")}
+
+		It("ignores an empty list of devices", func() {
+			domainSpec := newDomainSpec()
+
+			c := newCallbackerStub(false, false)
+			c.sendEvent("foo")
+			d := deviceDetacherStub{}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(Succeed())
+			Expect(len(c.EventChannel())).To(Equal(1))
+		})
+
+		It("fails to register a callback", func() {
+			domainSpec := newDomainSpec(hostDevice)
+
+			c := newCallbackerStub(true, false)
+			c.sendEvent("foo")
+			d := deviceDetacherStub{}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(HaveOccurred())
+			Expect(len(c.EventChannel())).To(Equal(1))
+		})
+
+		It("fails to detach device", func() {
+			domainSpec := newDomainSpec(hostDevice)
+
+			c := newCallbackerStub(false, false)
+			c.sendEvent("foo")
+			d := deviceDetacherStub{fail: true}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(HaveOccurred())
+			Expect(len(c.EventChannel())).To(Equal(1))
+		})
+
+		It("fails on timeout due to no detach event", func() {
+			domainSpec := newDomainSpec(hostDevice)
+
+			c := newCallbackerStub(false, false)
+			d := deviceDetacherStub{}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(HaveOccurred())
+		})
+
+		It("fails due to a missing event from a device", func() {
+			domainSpec := newDomainSpec(hostDevice)
+
+			c := newCallbackerStub(false, false)
+			c.sendEvent("unknown-device")
+			d := deviceDetacherStub{}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 10*time.Millisecond)).To(HaveOccurred())
+			Expect(len(c.EventChannel())).To(Equal(0))
+		})
+
+		// Failure to deregister the callback only emits a logging error.
+		It("succeeds to wait for a detached device and fails to deregister a callback", func() {
+			domainSpec := newDomainSpec(hostDevice)
+
+			c := newCallbackerStub(false, true)
+			c.sendEvent(api.UserAliasPrefix + hostDevice.Alias.GetName())
+			d := deviceDetacherStub{}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 10*time.Millisecond)).To(Succeed())
+		})
+
+		It("succeeds detaching 2 devices", func() {
+			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias(aliasPrefix + "net2")}
+			domainSpec := newDomainSpec(hostDevice, hostDevice2)
+
+			c := newCallbackerStub(false, false)
+			c.sendEvent(api.UserAliasPrefix + hostDevice.Alias.GetName())
+			c.sendEvent(api.UserAliasPrefix + hostDevice2.Alias.GetName())
+			d := deviceDetacherStub{}
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 10*time.Millisecond)).To(Succeed())
+		})
+	})
+
+	Context("attachment", func() {
+		hostDevice := api.HostDevice{Alias: api.NewUserDefinedAlias("net1")}
+
+		It("ignores nil list of devices", func() {
+			Expect(hostdevice.AttachHostDevices(deviceAttacherStub{}, nil)).Should(Succeed())
+		})
+
+		It("ignores an empty list of devices", func() {
+			Expect(hostdevice.AttachHostDevices(deviceAttacherStub{}, []api.HostDevice{})).Should(Succeed())
+		})
+
+		It("succeeds to attach device", func() {
+			Expect(hostdevice.AttachHostDevices(deviceAttacherStub{}, []api.HostDevice{hostDevice})).Should(Succeed())
+		})
+
+		It("succeeds to attach more than one device", func() {
+			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias("net2")}
+
+			Expect(hostdevice.AttachHostDevices(deviceAttacherStub{}, []api.HostDevice{hostDevice, hostDevice2})).Should(Succeed())
+		})
+
+		It("fails to attach device", func() {
+			obj := deviceAttacherStub{fail: true}
+			Expect(hostdevice.AttachHostDevices(obj, []api.HostDevice{hostDevice})).ShouldNot(Succeed())
+		})
+
+		It("error should contain at least the Alias of each device that failed to attach", func() {
+			obj := deviceAttacherStub{fail: true}
+			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias("net2")}
+			err := hostdevice.AttachHostDevices(obj, []api.HostDevice{hostDevice, hostDevice2})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(And(
+				ContainSubstring(hostDevice.Alias.GetName()),
+				ContainSubstring(hostDevice2.Alias.GetName())))
+		})
+	})
+
+	Context("difference", func() {
+		table.DescribeTable("should return the correct host-devices set comparing by host-devices's Alias.Name",
+			func(hostDevices, removeHostDevices, expectedHostDevices []api.HostDevice) {
+				Expect(hostdevice.DifferenceHostDevicesByAlias(hostDevices, removeHostDevices)).To(ConsistOf(expectedHostDevices))
+			},
+			table.Entry("empty set and zero elements to filter",
+				// slice A
+				[]api.HostDevice{},
+				// slice B
+				[]api.HostDevice{},
+				// expected
+				[]api.HostDevice{},
+			),
+			table.Entry("empty set and at least one element to filter",
+				// slice A
+				[]api.HostDevice{},
+				// slice B
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+				},
+				// expected
+				[]api.HostDevice{},
+			),
+			table.Entry("valid set and zero elements to filter",
+				// slice A
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+					{Alias: api.NewUserDefinedAlias("hostdev3")},
+				},
+				// slice B
+				[]api.HostDevice{},
+				// expected
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+					{Alias: api.NewUserDefinedAlias("hostdev3")},
+				},
+			),
+			table.Entry("valid set and at least one element to filter",
+				// slice A
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev4")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+					{Alias: api.NewUserDefinedAlias("hostdev3")},
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+				},
+				// slice B
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev4")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+				},
+				// expected
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+					{Alias: api.NewUserDefinedAlias("hostdev3")},
+				},
+			),
+
+			table.Entry("valid set and a set that includes all elements from the first set",
+				// slice A
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev4")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+				},
+				// slice B
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev4")},
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+					{Alias: api.NewUserDefinedAlias("hostdev3")},
+				},
+				// expected
+				[]api.HostDevice{},
+			),
+			table.Entry("valid set and larger set to to filter",
+				// slice A
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev4")},
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+				},
+				// slice B
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev4")},
+					{Alias: api.NewUserDefinedAlias("hostdev1")},
+					{Alias: api.NewUserDefinedAlias("hostdev7")},
+					{Alias: api.NewUserDefinedAlias("hostdev3")},
+				},
+				// expected
+				[]api.HostDevice{
+					{Alias: api.NewUserDefinedAlias("hostdev2")},
+				},
+			),
+		)
+	})
+})
+
+func newDomainSpec(hostDevices ...api.HostDevice) *api.DomainSpec {
+	domainSpec := &api.DomainSpec{}
+	domainSpec.Devices.HostDevices = append(domainSpec.Devices.HostDevices, hostDevices...)
+	return domainSpec
+}
+
+type deviceDetacherStub struct {
+	fail bool
+}
+
+func (d deviceDetacherStub) DetachDeviceFlags(data string, flags libvirt.DomainDeviceModifyFlags) error {
+	if d.fail {
+		return fmt.Errorf("detach device error")
+	}
+	return nil
+}
+
+type deviceAttacherStub struct {
+	fail bool
+}
+
+func (d deviceAttacherStub) AttachDeviceFlags(data string, flags libvirt.DomainDeviceModifyFlags) error {
+	if d.fail {
+		return fmt.Errorf("attach device error")
+	}
+	return nil
+}
+
+func newCallbackerStub(failRegister, failDeregister bool) *callbackerStub {
+	return &callbackerStub{
+		failRegister:   failRegister,
+		failDeregister: failDeregister,
+		eventChan:      make(chan interface{}, hostdevice.MaxConcurrentHotPlugDevicesEvents),
+	}
+}
+
+type callbackerStub struct {
+	failRegister   bool
+	failDeregister bool
+	eventChan      chan interface{}
+}
+
+func (c *callbackerStub) Register() error {
+	if c.failRegister {
+		return fmt.Errorf("register error")
+	}
+	return nil
+}
+
+func (c *callbackerStub) Deregister() error {
+	if c.failDeregister {
+		return fmt.Errorf("deregister error")
+	}
+	return nil
+}
+
+func (c *callbackerStub) EventChannel() <-chan interface{} {
+	return c.eventChan
+}
+
+func (c *callbackerStub) sendEvent(data string) {
+	c.eventChan <- data
+}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )
 
@@ -29,10 +28,10 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -20,15 +20,10 @@
 package sriov
 
 import (
-	"encoding/xml"
 	"fmt"
-	"strings"
 	"time"
 
-	"libvirt.org/go/libvirt"
-
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
@@ -36,10 +31,6 @@ import (
 
 const (
 	AliasPrefix = "sriov-"
-
-	MaxConcurrentHotPlugDevicesEvents = 32
-
-	affectLiveAndConfigLibvirtFlags = libvirt.DOMAIN_DEVICE_MODIFY_LIVE | libvirt.DOMAIN_DEVICE_MODIFY_CONFIG
 )
 
 func CreateHostDevices(vmi *v1.VirtualMachineInstance) ([]api.HostDevice, error) {
@@ -78,144 +69,9 @@ func createHostDevicesMetadata(ifaces []v1.Interface) []hostdevice.HostDeviceMet
 	return hostDevicesMetaData
 }
 
-type deviceDetacher interface {
-	DetachDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
-}
-
-type eventRegistrar interface {
-	Register() error
-	Deregister() error
-	EventChannel() <-chan interface{}
-}
-
-func SafelyDetachHostDevices(domainSpec *api.DomainSpec, eventDetach eventRegistrar, dom deviceDetacher, timeout time.Duration) error {
-	sriovDevices := FilterHostDevices(domainSpec)
-	if len(sriovDevices) == 0 {
-		log.Log.Info("No SR-IOV host-devices to detach.")
-		return nil
-	}
-
-	if err := eventDetach.Register(); err != nil {
-		return fmt.Errorf("failed to detach host-devices: %v", err)
-	}
-	defer func() {
-		if err := eventDetach.Deregister(); err != nil {
-			log.Log.Reason(err).Errorf("failed to detach host-devices: %v", err)
-		}
-	}()
-
-	if err := detachHostDevices(dom, sriovDevices); err != nil {
-		return err
-	}
-
-	return waitHostDevicesToDetach(eventDetach, sriovDevices, timeout)
-}
-
-func FilterHostDevices(domainSpec *api.DomainSpec) []api.HostDevice {
-	var hostDevices []api.HostDevice
-
-	for _, hostDevice := range domainSpec.Devices.HostDevices {
-		if hostDevice.Alias != nil && strings.HasPrefix(hostDevice.Alias.GetName(), AliasPrefix) {
-			hostDevices = append(hostDevices, hostDevice)
-		}
-	}
-	return hostDevices
-}
-
-func detachHostDevices(dom deviceDetacher, hostDevices []api.HostDevice) error {
-	for _, hostDev := range hostDevices {
-		devXML, err := xml.Marshal(hostDev)
-		if err != nil {
-			return fmt.Errorf("failed to encode (xml) hostdev %v, err: %v", hostDev, err)
-		}
-		err = dom.DetachDeviceFlags(string(devXML), affectLiveAndConfigLibvirtFlags)
-		if err != nil {
-			return fmt.Errorf("failed to detach hostdev %s, err: %v", devXML, err)
-		}
-		log.Log.Infof("Successfully hot-unplug hostdev: %s (%v)", hostDev.Alias.GetName(), hostDev.Source.Address)
-	}
-	return nil
-}
-
-func waitHostDevicesToDetach(eventDetach eventRegistrar, hostDevices []api.HostDevice, timeout time.Duration) error {
-	var detachedHostDevices []string
-	var desiredDetachCount = len(hostDevices)
-
-	for {
-		select {
-		case deviceAlias := <-eventDetach.EventChannel():
-			if dev := deviceLookup(hostDevices, deviceAlias.(string)); dev != nil {
-				detachedHostDevices = append(detachedHostDevices, dev.Alias.GetName())
-			}
-			if desiredDetachCount == len(detachedHostDevices) {
-				return nil
-			}
-		case <-time.After(timeout):
-
-			return fmt.Errorf(
-				"failed to wait for host-devices detach, timeout reached: %v/%v",
-				detachedHostDevices, hostDevicesNames(hostDevices))
-		}
-	}
-}
-
-func hostDevicesNames(hostDevices []api.HostDevice) []string {
-	var names []string
-	for _, dev := range hostDevices {
-		names = append(names, dev.Alias.GetName())
-	}
-	return names
-}
-
-func deviceLookup(hostDevices []api.HostDevice, deviceAlias string) *api.HostDevice {
-	deviceAlias = strings.TrimPrefix(deviceAlias, api.UserAliasPrefix)
-	for _, dev := range hostDevices {
-		if dev.Alias.GetName() == deviceAlias {
-			return &dev
-		}
-	}
-	return nil
-}
-
-type deviceAttacher interface {
-	AttachDeviceFlags(xmlData string, flags libvirt.DomainDeviceModifyFlags) error
-}
-
-func AttachHostDevices(dom deviceAttacher, hostDevices []api.HostDevice) error {
-	var errs []error
-	for _, hostDev := range hostDevices {
-		if err := attachHostDevice(dom, hostDev); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	if len(errs) > 0 {
-		return buildAttachHostDevicesErrorMessage(errs)
-	}
-
-	return nil
-}
-
-func attachHostDevice(dom deviceAttacher, hostDev api.HostDevice) error {
-	devXML, err := xml.Marshal(hostDev)
-	if err != nil {
-		return fmt.Errorf("failed to encode (xml) host-device %v, err: %v", hostDev, err)
-	}
-	err = dom.AttachDeviceFlags(string(devXML), affectLiveAndConfigLibvirtFlags)
-	if err != nil {
-		return fmt.Errorf("failed to attach host-device %s, err: %v", devXML, err)
-	}
-	log.Log.Infof("Successfully hot-plug host-device: %s (%v)", hostDev.Alias.GetName(), hostDev.Source.Address)
-
-	return nil
-}
-
-func buildAttachHostDevicesErrorMessage(errors []error) error {
-	errorMessageBuilder := strings.Builder{}
-	for _, err := range errors {
-		errorMessageBuilder.WriteString(err.Error() + "\n")
-	}
-	return fmt.Errorf(errorMessageBuilder.String())
+func SafelyDetachHostDevices(domainSpec *api.DomainSpec, eventDetach hostdevice.EventRegistrar, dom hostdevice.DeviceDetacher, timeout time.Duration) error {
+	sriovDevices := hostdevice.FilterHostDevicesByAlias(domainSpec, AliasPrefix)
+	return hostdevice.SafelyDetachHostDevices(sriovDevices, eventDetach, dom, timeout)
 }
 
 func GetHostDevicesToAttach(vmi *v1.VirtualMachineInstance, domainSpec *api.DomainSpec) ([]api.HostDevice, error) {
@@ -223,27 +79,9 @@ func GetHostDevicesToAttach(vmi *v1.VirtualMachineInstance, domainSpec *api.Doma
 	if err != nil {
 		return nil, err
 	}
-	currentAttachedSRIOVHostDevices := FilterHostDevices(domainSpec)
+	currentAttachedSRIOVHostDevices := hostdevice.FilterHostDevicesByAlias(domainSpec, AliasPrefix)
 
-	sriovHostDevicesToAttach := DifferenceHostDevicesByAlias(sriovDevices, currentAttachedSRIOVHostDevices)
+	sriovHostDevicesToAttach := hostdevice.DifferenceHostDevicesByAlias(sriovDevices, currentAttachedSRIOVHostDevices)
 
 	return sriovHostDevicesToAttach, nil
-}
-
-// DifferenceHostDevicesByAlias given two slices of host-devices, according to Alias.Name,
-// it returns a slice with host-devices that exists on the first slice and not exists on the second.
-func DifferenceHostDevicesByAlias(desiredHostDevices, actualHostDevices []api.HostDevice) []api.HostDevice {
-	actualHostDevicesByAlias := make(map[string]struct{}, len(actualHostDevices))
-	for _, hostDev := range actualHostDevices {
-		actualHostDevicesByAlias[hostDev.Alias.GetName()] = struct{}{}
-	}
-
-	var filteredSlice []api.HostDevice
-	for _, desiredHostDevice := range desiredHostDevices {
-		if _, exists := actualHostDevicesByAlias[desiredHostDevice.Alias.GetName()]; !exists {
-			filteredSlice = append(filteredSlice, desiredHostDevice)
-		}
-	}
-
-	return filteredSlice
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -23,8 +23,9 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
+
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"libvirt.org/go/libvirt"
@@ -182,34 +183,6 @@ var _ = Describe("SRIOV HostDevice", func() {
 		})
 	})
 
-	Context("filter", func() {
-		It("filters 0 SRIOV devices, given non-SRIOV devices", func() {
-			var domainSpec api.DomainSpec
-
-			domainSpec.Devices.HostDevices = append(
-				domainSpec.Devices.HostDevices,
-				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov1")},
-				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov2")},
-			)
-			Expect(sriov.FilterHostDevices(&domainSpec)).To(BeEmpty())
-		})
-
-		It("filters 2 SRIOV devices, given 2 SRIOV devices and 2 non-SRIOV devices", func() {
-			var domainSpec api.DomainSpec
-
-			hostDevice1 := api.HostDevice{Alias: api.NewUserDefinedAlias(sriov.AliasPrefix + "is-sriov1")}
-			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias(sriov.AliasPrefix + "is-sriov2")}
-			domainSpec.Devices.HostDevices = append(
-				domainSpec.Devices.HostDevices,
-				hostDevice1,
-				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov1")},
-				hostDevice2,
-				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov2")},
-			)
-			Expect(sriov.FilterHostDevices(&domainSpec)).To(Equal([]api.HostDevice{hostDevice1, hostDevice2}))
-		})
-	})
-
 	Context("safe detachment", func() {
 		hostDevice := api.HostDevice{Alias: api.NewUserDefinedAlias(sriov.AliasPrefix + "net1")}
 
@@ -282,140 +255,6 @@ var _ = Describe("SRIOV HostDevice", func() {
 			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 10*time.Millisecond)).To(Succeed())
 		})
 	})
-
-	Context("attachment", func() {
-		hostDevice := api.HostDevice{Alias: api.NewUserDefinedAlias("net1")}
-
-		It("ignores nil list of devices", func() {
-			Expect(sriov.AttachHostDevices(deviceAttacherStub{}, nil)).Should(Succeed())
-		})
-
-		It("ignores an empty list of devices", func() {
-			Expect(sriov.AttachHostDevices(deviceAttacherStub{}, []api.HostDevice{})).Should(Succeed())
-		})
-
-		It("succeeds to attach device", func() {
-			Expect(sriov.AttachHostDevices(deviceAttacherStub{}, []api.HostDevice{hostDevice})).Should(Succeed())
-		})
-
-		It("succeeds to attach more than one device", func() {
-			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias("net2")}
-
-			Expect(sriov.AttachHostDevices(deviceAttacherStub{}, []api.HostDevice{hostDevice, hostDevice2})).Should(Succeed())
-		})
-
-		It("fails to attach device", func() {
-			obj := deviceAttacherStub{fail: true}
-			Expect(sriov.AttachHostDevices(obj, []api.HostDevice{hostDevice})).ShouldNot(Succeed())
-		})
-
-		It("error should contain at least the Alias of each device that failed to attach", func() {
-			obj := deviceAttacherStub{fail: true}
-			hostDevice2 := api.HostDevice{Alias: api.NewUserDefinedAlias("net2")}
-			err := sriov.AttachHostDevices(obj, []api.HostDevice{hostDevice, hostDevice2})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(And(
-				ContainSubstring(hostDevice.Alias.GetName()),
-				ContainSubstring(hostDevice2.Alias.GetName())))
-		})
-	})
-
-	Context("difference", func() {
-		table.DescribeTable("should return the correct host-devices set comparing by host-devices's Alias.Name",
-			func(hostDevices, removeHostDevices, expectedHostDevices []api.HostDevice) {
-				Expect(sriov.DifferenceHostDevicesByAlias(hostDevices, removeHostDevices)).To(ConsistOf(expectedHostDevices))
-			},
-			table.Entry("empty set and zero elements to filter",
-				// slice A
-				[]api.HostDevice{},
-				// slice B
-				[]api.HostDevice{},
-				// expected
-				[]api.HostDevice{},
-			),
-			table.Entry("empty set and at least one element to filter",
-				// slice A
-				[]api.HostDevice{},
-				// slice B
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-				},
-				// expected
-				[]api.HostDevice{},
-			),
-			table.Entry("valid set and zero elements to filter",
-				// slice A
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-					{Alias: api.NewUserDefinedAlias("hostdev3")},
-				},
-				// slice B
-				[]api.HostDevice{},
-				// expected
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-					{Alias: api.NewUserDefinedAlias("hostdev3")},
-				},
-			),
-			table.Entry("valid set and at least one element to filter",
-				// slice A
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev4")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-					{Alias: api.NewUserDefinedAlias("hostdev3")},
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-				},
-				// slice B
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev4")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-				},
-				// expected
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-					{Alias: api.NewUserDefinedAlias("hostdev3")},
-				},
-			),
-
-			table.Entry("valid set and a set that includes all elements from the first set",
-				// slice A
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev4")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-				},
-				// slice B
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev4")},
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-					{Alias: api.NewUserDefinedAlias("hostdev3")},
-				},
-				// expected
-				[]api.HostDevice{},
-			),
-			table.Entry("valid set and larger set to to filter",
-				// slice A
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev4")},
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-				},
-				// slice B
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev4")},
-					{Alias: api.NewUserDefinedAlias("hostdev1")},
-					{Alias: api.NewUserDefinedAlias("hostdev7")},
-					{Alias: api.NewUserDefinedAlias("hostdev3")},
-				},
-				// expected
-				[]api.HostDevice{
-					{Alias: api.NewUserDefinedAlias("hostdev2")},
-				},
-			),
-		)
-	})
 })
 
 func newDomainSpec(hostDevices ...api.HostDevice) *api.DomainSpec {
@@ -458,22 +297,11 @@ func (d deviceDetacherStub) DetachDeviceFlags(data string, flags libvirt.DomainD
 	return nil
 }
 
-type deviceAttacherStub struct {
-	fail bool
-}
-
-func (d deviceAttacherStub) AttachDeviceFlags(data string, flags libvirt.DomainDeviceModifyFlags) error {
-	if d.fail {
-		return fmt.Errorf("attach device error")
-	}
-	return nil
-}
-
 func newCallbackerStub(failRegister, failDeregister bool) *callbackerStub {
 	return &callbackerStub{
 		failRegister:   failRegister,
 		failDeregister: failDeregister,
-		eventChan:      make(chan interface{}, sriov.MaxConcurrentHotPlugDevicesEvents),
+		eventChan:      make(chan interface{}, hostdevice.MaxConcurrentHotPlugDevicesEvents),
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"
 	domainerrors "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
@@ -100,7 +101,7 @@ func hotUnplugHostDevices(virConn cli.Connection, dom cli.VirDomain) error {
 		return err
 	}
 
-	eventChan := make(chan interface{}, sriov.MaxConcurrentHotPlugDevicesEvents)
+	eventChan := make(chan interface{}, hostdevice.MaxConcurrentHotPlugDevicesEvents)
 	var callback libvirt.DomainEventDeviceRemovedCallback = func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventDeviceRemoved) {
 		eventChan <- event.DevAlias
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -69,6 +69,7 @@ import (
 	agentpoller "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent-poller"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/legacy"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"
 	domainerrors "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
@@ -324,7 +325,7 @@ func (l *LibvirtDomainManager) hotPlugHostDevices(vmi *v1.VirtualMachineInstance
 		return err
 	}
 
-	if err := sriov.AttachHostDevices(domain, sriovHostDevices); err != nil {
+	if err := hostdevice.AttachHostDevices(domain, sriovHostDevices); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extract the hot(un)plug code from the SR-IOV package to allow its usage
by the other hostdevice types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
