### PR TITLE
Timeout Unschedulable Migration Target Pods

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -107,6 +107,15 @@ var _ = Describe("Migration watcher", func() {
 		})
 	}
 
+	shouldExpectPodDeletion := func() {
+		// Expect pod deletion
+		kubeClient.Fake.PrependReactor("delete", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
+			_, ok := action.(testing.DeleteAction)
+			Expect(ok).To(BeTrue())
+			return true, nil, nil
+		})
+	}
+
 	shouldExpectAttachmentPodCreation := func(uid types.UID, migrationUid types.UID) {
 		// Expect pod creation
 		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
@@ -137,6 +146,12 @@ var _ = Describe("Migration watcher", func() {
 			}
 
 			return true, pdb, nil
+		})
+	}
+
+	shouldExpectGenericMigrationUpdate := func() {
+		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).DoAndReturn(func(arg interface{}) (interface{}, interface{}) {
+			return arg, nil
 		})
 	}
 
@@ -586,6 +601,43 @@ var _ = Describe("Migration watcher", func() {
 			shouldExpectMigrationSchedulingState(migration)
 			controller.Execute()
 		})
+
+		table.DescribeTable("should handle pod stuck in unschedulable state", func(phase virtv1.VirtualMachineInstanceMigrationPhase, shouldTimeout bool, timeLapse int64) {
+			vmi := newVirtualMachine("testvmi", virtv1.Running)
+			migration := newMigration("testmigration", vmi.Name, phase)
+			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
+
+			pod.Status.Conditions = append(pod.Status.Conditions, k8sv1.PodCondition{
+				Type:   k8sv1.PodScheduled,
+				Status: k8sv1.ConditionFalse,
+				Reason: k8sv1.PodReasonUnschedulable,
+			})
+			now := now()
+			pod.CreationTimestamp = metav1.NewTime(now.Time.Add(time.Duration(-timeLapse) * time.Second))
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(pod)
+
+			if shouldTimeout {
+				shouldExpectPodDeletion()
+			}
+
+			if phase == virtv1.MigrationPending {
+				shouldExpectGenericMigrationUpdate()
+			}
+			controller.Execute()
+
+			if shouldTimeout {
+				testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+			}
+		},
+			table.Entry("in pending state", virtv1.MigrationPending, true, defaultUnschedulableTimeoutSeconds),
+			table.Entry("in scheduling state", virtv1.MigrationScheduling, true, defaultUnschedulableTimeoutSeconds),
+			table.Entry("in scheduled state", virtv1.MigrationScheduled, false, defaultUnschedulableTimeoutSeconds),
+			table.Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultUnschedulableTimeoutSeconds-1),
+			table.Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultUnschedulableTimeoutSeconds-1),
+		)
 	})
 	Context("Migration should immediately fail if", func() {
 

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -632,11 +632,43 @@ var _ = Describe("Migration watcher", func() {
 				testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			}
 		},
-			table.Entry("in pending state", virtv1.MigrationPending, true, defaultUnschedulableTimeoutSeconds),
-			table.Entry("in scheduling state", virtv1.MigrationScheduling, true, defaultUnschedulableTimeoutSeconds),
-			table.Entry("in scheduled state", virtv1.MigrationScheduled, false, defaultUnschedulableTimeoutSeconds),
-			table.Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultUnschedulableTimeoutSeconds-1),
-			table.Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultUnschedulableTimeoutSeconds-1),
+			table.Entry("in pending state", virtv1.MigrationPending, true, defaultUnschedulablePendingTimeoutSeconds),
+			table.Entry("in scheduling state", virtv1.MigrationScheduling, true, defaultUnschedulablePendingTimeoutSeconds),
+			table.Entry("in scheduled state", virtv1.MigrationScheduled, false, defaultUnschedulablePendingTimeoutSeconds),
+			table.Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultUnschedulablePendingTimeoutSeconds-1),
+			table.Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultUnschedulablePendingTimeoutSeconds-1),
+		)
+
+		table.DescribeTable("should handle pod stuck in pending phase for extended period of time", func(phase virtv1.VirtualMachineInstanceMigrationPhase, shouldTimeout bool, timeLapse int64) {
+			vmi := newVirtualMachine("testvmi", virtv1.Running)
+			migration := newMigration("testmigration", vmi.Name, phase)
+			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
+
+			now := now()
+			pod.CreationTimestamp = metav1.NewTime(now.Time.Add(time.Duration(-timeLapse) * time.Second))
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(pod)
+
+			if shouldTimeout {
+				shouldExpectPodDeletion()
+			}
+
+			if phase == virtv1.MigrationPending {
+				shouldExpectGenericMigrationUpdate()
+			}
+			controller.Execute()
+
+			if shouldTimeout {
+				testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+			}
+		},
+			table.Entry("in pending state", virtv1.MigrationPending, true, defaultCatchAllPendingTimeoutSeconds),
+			table.Entry("in scheduling state", virtv1.MigrationScheduling, true, defaultCatchAllPendingTimeoutSeconds),
+			table.Entry("in scheduled state", virtv1.MigrationScheduled, false, defaultCatchAllPendingTimeoutSeconds),
+			table.Entry("in pending state but timeout not hit", virtv1.MigrationPending, false, defaultCatchAllPendingTimeoutSeconds-1),
+			table.Entry("in scheduling state but timeout not hit", virtv1.MigrationScheduling, false, defaultCatchAllPendingTimeoutSeconds-1),
 		)
 	})
 	Context("Migration should immediately fail if", func() {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -637,6 +637,10 @@ const (
 	FuncTestForceLauncherMigrationFailureAnnotation string = "kubevirt.io/func-test-force-launcher-migration-failure"
 	// Used by functional tests to prevent virt launcher from finishing the target pod preparation.
 	FuncTestBlockLauncherPrepareMigrationTargetAnnotation string = "kubevirt.io/func-test-block-migration-target-preparation"
+
+	// Used by functional tests set custom image on migration target pod
+	FuncTestMigrationTargetImageOverrideAnnotation string = "kubevirt.io/func-test-migration-target-image-override"
+
 	// Used by functional tests to simulate virt-launcher crash looping
 	FuncTestLauncherFailFastAnnotation string = "kubevirt.io/func-test-virt-launcher-fail-fast"
 	// This label is used to match virtual machine instance IDs with pods.
@@ -749,6 +753,14 @@ const (
 
 	// MigrationTransportUnixAnnotation means that the VMI will be migrated using the unix URI
 	MigrationTransportUnixAnnotation string = "kubevirt.io/migrationTransportUnix"
+
+	// MigrationUnschedulablePodTimeoutSecondsAnnotation represents a custom timeout period used for unschedulable target pods
+	// This exists for functional testing
+	MigrationUnschedulablePodTimeoutSecondsAnnotation string = "kubevirt.io/migrationUnschedulablePodTimeoutSeconds"
+
+	// MigrationPendingPodTimeoutSecondsAnnotation represents a custom timeout period used for target pods stuck in pending for any reason
+	// This exists for functional testing
+	MigrationPendingPodTimeoutSecondsAnnotation string = "kubevirt.io/migrationPendingPodTimeoutSeconds"
 
 	// RealtimeLabel marks the node as capable of running realtime workloads
 	RealtimeLabel string = "kubevirt.io/realtime"

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -769,6 +769,59 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				Expect(isPaused).To(BeFalse(), "The VMI should be running, but it is not.")
 			})
 		})
+
+		Context("with an unschedualbe target pod", func() {
+			var nodes *k8sv1.NodeList
+			BeforeEach(func() {
+				tests.BeforeTestCleanup()
+				Eventually(func() []k8sv1.Node {
+					nodes = util.GetAllSchedulableNodes(virtClient)
+					return nodes.Items
+				}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be some compute node")
+			})
+
+			It("should automatically cancel unschedulable migration after a timeout period", func() {
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
+
+				// Add node affinity to ensure VMI affinity rules block target pod from being created
+				addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				// execute a migration that is expected to fail
+				By("Starting the Migration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+
+				By("Starting a Migration")
+				var err error
+				Eventually(func() error {
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
+					return err
+				}, 5, 1*time.Second).Should(Succeed(), "migration creation should succeed")
+
+				By("Migration should fail eventually due to pending target pod timeout")
+				Eventually(func() error {
+					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					if migration.Status.Phase != v1.MigrationFailed {
+						return fmt.Errorf("Waiting on migration with phase %s to reach phase Failed", migration.Status.Phase)
+					}
+					return nil
+				}, 400, 1*time.Second).Should(Succeed(), "migration creation should fail")
+
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			})
+		})
 		Context("with auto converge enabled", func() {
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()


### PR DESCRIPTION
This solves the issue where migrations can get stuck indefinitely when a migration target pod is unschedulable.

In the future, we may want to expand this logic to include any other situations we encounter where a migration can get stuck indefinitely as well.

```release-note
Pending migration target pods timeout after 5 minutes when unschedulable
```
