### PR TITLE
Solve flakiness for libguestfs tests

### DIFF
--- a/cmd/libguestfs/entrypoint.sh
+++ b/cmd/libguestfs/entrypoint.sh
@@ -4,4 +4,6 @@ DIR=/usr/local/lib/guestfs
 LIBGUEST_APPLIANCE=${DIR}/downloaded
 tar -Jxf ${LIBGUEST_APPLIANCE} -C ${DIR}
 
+touch ${DIR}/done
+
 /bin/bash

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -2,8 +2,6 @@ package storage
 
 import (
 	"context"
-
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -18,8 +16,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"
 )
-
-const APPLIANCE_FILES string = "README.fixed, initrd, kernel, root"
 
 type fakeAttacher struct {
 	done chan bool
@@ -91,17 +87,10 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 			return ready
 
 		}, 90*time.Second, 2*time.Second).Should(BeTrue())
-		// Verify that the appliance has been extracted before running any tests
-		// We check that all files are present and tar is not running
+		// Verify that the appliance has been extracted before running any tests by checking the done file
 		Eventually(func() bool {
-			output, _, err := execCommandLibguestfsPod(podName, []string{"ls", "-m", "/usr/local/lib/guestfs/appliance"})
-			Expect(err).ToNot(HaveOccurred())
-			if !strings.Contains(output, APPLIANCE_FILES) {
-				return false
-			}
-			output, _, err = execCommandLibguestfsPod(podName, []string{"ps", "-e", "-o", "comm="})
-			Expect(err).ToNot(HaveOccurred())
-			if strings.Contains(output, "tar") {
+			_, _, err := execCommandLibguestfsPod(podName, []string{"ls", "/usr/local/lib/guestfs/done"})
+			if err != nil {
 				return false
 			}
 			return true

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -47,9 +47,9 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		return tests.ExecuteCommandOnPodV2(virtClient, pod, "libguestfs", c)
 	}
 
-	createPVCFilesystem := func(name string) *corev1.PersistentVolumeClaim {
+	createPVCFilesystem := func(name string) {
 		quantity, _ := resource.ParseQuantity("500Mi")
-		return &corev1.PersistentVolumeClaim{
+		_, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Create(context.Background(), &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -59,7 +59,8 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 					},
 				},
 			},
-		}
+		}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
 	}
 
@@ -102,14 +103,6 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 
 	}
 
-	createGuestfsWithPVC := func(pvc *corev1.PersistentVolumeClaim) {
-		var err error
-		_, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Create(context.Background(), pvc, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		runGuestfsOnPVC(pvc.ObjectMeta.Name)
-
-	}
-
 	Context("Run libguestfs on PVCs", func() {
 		BeforeEach(func() {
 			var err error
@@ -128,8 +121,8 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 			f := createFakeAttacher()
 			defer f.closeChannel()
 			pvcClaim = "pvc-verify"
-			pvc := createPVCFilesystem(pvcClaim)
-			createGuestfsWithPVC(pvc)
+			createPVCFilesystem(pvcClaim)
+			runGuestfsOnPVC(pvcClaim)
 			output, _, err := execCommandLibguestfsPod("libguestfs-tools-"+pvcClaim, []string{"libguestfs-test-tool"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(ContainSubstring("===== TEST FINISHED OK ====="))
@@ -141,8 +134,8 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 			defer f.closeChannel()
 			pvcClaim = "pvc-fs"
 			podName := "libguestfs-tools-" + pvcClaim
-			pvc := createPVCFilesystem(pvcClaim)
-			createGuestfsWithPVC(pvc)
+			createPVCFilesystem(pvcClaim)
+			runGuestfsOnPVC(pvcClaim)
 			stdout, stderr, err := execCommandLibguestfsPod(podName, []string{"qemu-img", "create", "/disk/disk.img", "500M"})
 			Expect(stderr).To(Equal(""))
 			Expect(stdout).To(ContainSubstring("Formatting"))
@@ -158,8 +151,8 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 			f := createFakeAttacher()
 			defer f.closeChannel()
 			pvcClaim = "pvc-fail-to-run-twice"
-			pvc := createPVCFilesystem(pvcClaim)
-			createGuestfsWithPVC(pvc)
+			createPVCFilesystem(pvcClaim)
+			runGuestfsOnPVC(pvcClaim)
 			guestfsCmd := tests.NewVirtctlCommand("guestfs",
 				pvcClaim,
 				"--namespace", util.NamespaceTestDefault)
@@ -169,9 +162,11 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		It("[posneg:positive][test_id:6479]Should successfully run guestfs command on a block-based PVC", func() {
 			f := createFakeAttacher()
 			defer f.closeChannel()
-			pvcClaim = tests.BlockDiskForTest
+
+			pvcClaim = "pvc-block"
 			podName := "libguestfs-tools-" + pvcClaim
-			tests.CreateBlockVolumePvAndPvc("500Mi")
+			size, _ := resource.ParseQuantity("500Mi")
+			tests.CreateCephPVC(virtClient, pvcClaim, size)
 			runGuestfsOnPVC(pvcClaim)
 			stdout, stderr, err := execCommandLibguestfsPod(podName, []string{"guestfish", "-a", "/dev/vda", "run"})
 			Expect(stderr).To(Equal(""))


### PR DESCRIPTION
Solve flakiness for the libguestfs tests.

1) Use a dedicated block PVC for the test instead of the local block device. In the previous version, the test was using the [CreateBlockVolumePvAndPvc](https://github.com/kubevirt/kubevirt/blob/48c74adf169a6aac04b1c8900a4beb2e28207bd6/tests/utils.go#L2555) to create the block PVC and it was backed by [/mnt/local-storage/cirros-block-device](https://github.com/kubevirt/kubevirt/blob/48c74adf169a6aac04b1c8900a4beb2e28207bd6/tests/utils.go#L2598) this might create some conflicts as it can be scheduled only on node `node01`. Using ceph PVC can allow using a dedicated PVC for the test. 

2) Check container state if it is running instead of PodStatus == Running

3) Avoid ps to detect if the libguestfs appliance has been extracted (see Roman's [comment](https://github.com/kubevirt/kubevirt/pull/6739#issuecomment-963185457))
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
