### PR TITLE
virt-launcher, agent, Remove unnecessary interface merging

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -257,24 +257,6 @@ func MergeAgentStatusesWithDomainData(domInterfaces []api.Interface, interfaceSt
 		}
 	}
 
-	// If interface present in domain was not found in interfaceStatuses, add it
-	for mac, alias := range aliasByMac {
-		isCoveredByAgentData := false
-		for _, coveredAlias := range aliasesCoveredByAgent {
-			if alias == coveredAlias {
-				isCoveredByAgentData = true
-				break
-			}
-		}
-		if !isCoveredByAgentData {
-			interfaceStatuses = append(interfaceStatuses,
-				api.InterfaceStatus{
-					Mac:  mac,
-					Name: alias,
-				},
-			)
-		}
-	}
 	return interfaceStatuses
 }
 

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -201,11 +201,6 @@ var _ = Describe("Qemu agent poller", func() {
 					IPs:           []string{"1.2.3.4", "fe80::ff:1111:2222"},
 					InterfaceName: "eth5",
 				})
-			expectedStatuses = append(expectedStatuses,
-				api.InterfaceStatus{
-					Name: "net2",
-					Mac:  "02:11:11:b0:17:66",
-				})
 
 			Expect(interfaceStatuses).To(Equal(expectedStatuses))
 		})

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1746,23 +1746,6 @@ var _ = Describe("Manager", func() {
 				Expect(libvirtmanager.InterfacesStatus(fakeDomInterfaces)).To(BeNil())
 			})
 
-			It("should return merged list when interfaces exists on both the cache and argument", func() {
-				expectedResult := []api.InterfaceStatus{
-					{
-						Name: fakeInterfaces[0].Name,
-						Mac:  fakeInterfaces[0].Mac,
-					},
-					{
-						Name: fakeDomInterfaces[0].Alias.GetName(),
-						Mac:  fakeDomInterfaces[0].MAC.MAC,
-					},
-				}
-				agentStore.Store(agentpoller.GET_INTERFACES, fakeInterfaces)
-
-				interfaces := libvirtmanager.InterfacesStatus(fakeDomInterfaces)
-				Expect(interfaces).To(Equal(expectedResult))
-			})
-
 			It("should return merged list when interfaces exists on the cache only", func() {
 				expectedResult := []api.InterfaceStatus{
 					{


### PR DESCRIPTION
**What this PR does / why we need it:**

The code that adds the interfaces that exists on `domain.spec` but not on the guest agent report is not needed.
virt-handler iterates anyhow on the `domain.spec`, and will have access to those interfaces.

https://github.com/kubevirt/kubevirt/blob/f730efdd5c28220e94c5e61d79caec857aec7804/pkg/virt-handler/vm.go#L931

**Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):**

**Special notes for your reviewer:**

**Release note:**
```release-note
None
```
