### PR TITLE
Fix sig-storage flakiness: Use a smaller image for test

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -90,7 +90,7 @@ var _ = SIGDescribe("Storage", func() {
 			nfsIP := libnet.GetPodIpByFamily(nfsPod, ipFamily)
 			ExpectWithOffset(1, nfsIP).NotTo(BeEmpty())
 			os := string(cd.ContainerDiskAlpine)
-			tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
+			tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "1Gi", nfsIP, os)
 			return pvName
 		}
 


### PR DESCRIPTION
Tests enable all feature gates, so these tests enable the new
online resize. The disks get expanded to the largest size, causing
disk pressure that leaks into the next running test.

**What this PR does / why we need it**:
[Example of failure due to disk pressure](https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sig-storage/1457226507951804416/artifacts/k8s-reporter/1_pods.log).

The previous running test was "[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
