### PR TITLE
Fix sig-storage lane flakiness: Adjust output instead of disabling featuregate

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -618,10 +618,7 @@ var _ = SIGDescribe("Storage", func() {
 			}, 120)
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
-			It("[Serial][test_id:3138]should start vmi multiple times", func() {
-				// Expansion changes the blockdev output
-				tests.DisableFeatureGate(virtconfig.ExpandDisksGate)
-
+			It("[test_id:3138]should start vmi multiple times", func() {
 				vmi = tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 				tests.AddPVCDisk(vmi, "disk1", "virtio", tests.DiskCustomHostPath)
 
@@ -638,7 +635,7 @@ var _ = SIGDescribe("Storage", func() {
 
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 							&expect.BSnd{S: "blockdev --getsize64 /dev/vdb\n"},
-							&expect.BExp{R: "67108864"},
+							&expect.BExp{R: "1014686208"},
 						}, 200)).To(Succeed())
 					}
 


### PR DESCRIPTION
We don't wait until virt-handler sees the effects of the feature gate
change, so we often run the test with the feature gate -- adjust
the output, it also means we can run this test in parallel again so
it's a win in many regards.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
[Example failure](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6745/pull-kubevirt-e2e-k8s-1.21-sig-storage/1457380399587004416). The output for blockdev fits the scenario of it being expanded to the largest possible size.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
