### PR TITLE
Add release-note NONE to the changelog generation

### DIFF
--- a/hack/whatchanged.sh
+++ b/hack/whatchanged.sh
@@ -37,6 +37,7 @@ function main() {
     cd kubevirtci
     info=$(git log $PREVIOUS..$CURRENT --format="%h %s" | sed 's! (#!](https://github.com/kubevirt/kubevirtci/pull/!g')
     info=$(echo "$info" | sed 's/^/\[/')
+    info+='\n\n```release-note\nNONE\n```'
     decorated_info=$(echo -e "Bump kubevirtci\n\n${info}")
     echo "$decorated_info"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds a NONE release-note block to the changelog generation, thus removing the need for adding a tedious NONE release note every time kubevirtci gets bumped.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
