### PR TITLE
virt-handler, net: Drop virt-launcher pid usage in cache

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -528,7 +528,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			mockWatchdog.CreateFile(oldVMI)
 			// the domain is dead because the watchdog is expired
 			mockWatchdog.Expire(oldVMI)
-			controller.phase1NetworkSetupCache.Store(oldVMI.UID, 1)
+			controller.phase1NetworkSetupCache.Store(oldVMI.UID, 0)
 			vmiFeeder.Add(vmi)
 			domainFeeder.Add(domain)
 			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any()).Return(nil)
@@ -548,7 +548,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			mockWatchdog.CreateFile(vmi)
 
-			controller.phase1NetworkSetupCache.Store(vmi.UID, 1)
+			controller.phase1NetworkSetupCache.Store(vmi.UID, 0)
 			vmiFeeder.Add(vmi)
 			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any()).Return(nil)
 			client.EXPECT().Close()
@@ -576,7 +576,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			mockWatchdog.CreateFile(vmi)
 
-			controller.phase1NetworkSetupCache.Store(vmi.UID, 1)
+			controller.phase1NetworkSetupCache.Store(vmi.UID, 0)
 			vmiFeeder.Add(vmi)
 
 			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to avoid network setup on phase 1 to be executed more than
once, a cache check exists. This "cache" uses the VMI UID as the key and
the virt-launcher PID as the value.

There is no apparent reason to include the PID and validate it did not
changed over time. If the virt-launcher terminates, a full teardown is
expected to occur, including this cache cleanup for the specific VMI.

Therefore, this change removes the PID usage in the cache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a preliminary change to allow further refactoring to the network code base.
It is introduced in a dedicated PR to separate between logical and non-logical changes.

**Release note**:
```release-note
NONE
```
