### PR TITLE
Record VMI phase counts

### DIFF
--- a/tools/perfscale-audit/api/api.go
+++ b/tools/perfscale-audit/api/api.go
@@ -93,6 +93,10 @@ const (
 	ResultTypeResourceOperationCountFormat = "%s-%s-count"
 )
 
+const (
+	ResultTypePhaseCountFormat = "%s-phase-count"
+)
+
 type ThresholdResult struct {
 	ThresholdValue    float64 `json:"thresholdValue"`
 	ThresholdExceeded bool    `json:"thresholdExceeded"`

--- a/tools/perfscale-audit/metric-client/metric-client.go
+++ b/tools/perfscale-audit/metric-client/metric-client.go
@@ -36,14 +36,8 @@ import (
 )
 
 const (
-	vmiCreationTimePercentileQuery = `histogram_quantile(0.%d, rate(kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket{phase="Running"}[%ds]))`
-)
-
-// Counter - When using a Counter, use a range vector type so that we only get data
-//           from the current test period instead of the cumulative count.  Using an
-//           `offset` will covert to a range vector.
-const (
-	resourceRequestCountsByOperation = `sum by (verb, resource) (rest_client_requests_total{pod=~"virt-controller.*|virt-handler.*|virt-operator.*|virt-api.*"} offset %ds)`
+	vmiCreationTimePercentileQuery   = `histogram_quantile(0.%d, rate(kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket{phase="Running"}[%ds]))`
+	resourceRequestCountsByOperation = `increase(rest_client_requests_total{pod=~"virt-controller.*|virt-handler.*|virt-operator.*|virt-api.*"}[%ds])`
 )
 
 // Gauge - Using a Gauge doesn't require using an offset because it holds the accurate count


### PR DESCRIPTION
Signed-off-by: Ryan Hallisey <rhallisey@nvidia.com>

Record VMI phase counts in the audit tool's report so that we have more visibility into how the test went.

Convert `resourceRequestCountsByOperation` to a range vector by using `sum`.   `sum` with `offset` will get the counter's value during last `offset` of time.

Results from creating 21 VMIs:
```bash
{
  "Values": {
    "CREATE-events-count": {
      "value": 167
    },
    "DELETE-pods-count": {
      "value": 21
    },
    "GET-configmaps-count": {
      "value": 2
    },
    "GET-endpoints-count": {
      "value": 2038
    },
    "GET-nodes-count": {
      "value": 46
    },
    "LIST-cdiconfigs-count": {
      "value": 4
    },
    "LIST-cdis-count": {
      "value": 4
    },
    "LIST-clusterrolebindings-count": {
      "value": 9
    },
    "LIST-clusterroles-count": {
      "value": 9
    },
    "LIST-configmaps-count": {
      "value": 251
    },
    "LIST-controllerrevisions-count": {
      "value": 4
    },
    "LIST-customresourcedefinitions-count": {
      "value": 104
    },
    "LIST-daemonsets-count": {
      "value": 8
    },
    "LIST-datasources-count": {
      "value": 55
    },
    "LIST-datavolumes-count": {
      "value": 4
    },
    "LIST-deployments-count": {
      "value": 9
    },
    "LIST-jobs-count": {
      "value": 9
    },
    "LIST-kubevirts-count": {
      "value": 91
    },
    "LIST-limitranges-count": {
      "value": 52
    },
    "LIST-mutatingwebhookconfigurations-count": {
      "value": 9
    },
    "LIST-namespaces-count": {
      "value": 8
    },
    "LIST-nodes-count": {
      "value": 4
    },
    "LIST-persistentvolumeclaims-count": {
      "value": 4
    },
    "LIST-poddisruptionbudgets-count": {
      "value": 13
    },
    "LIST-pods-count": {
      "value": 17
    },
    "LIST-prometheusrules-count": {
      "value": 9
    },
    "LIST-rolebindings-count": {
      "value": 10
    },
    "LIST-roles-count": {
      "value": 9
    },
    "LIST-secrets-count": {
      "value": 8
    },
    "LIST-serviceaccounts-count": {
      "value": 8
    },
    "LIST-servicemonitors-count": {
      "value": 9
    },
    "LIST-services-count": {
      "value": 10
    },
    "LIST-storageclasses-count": {
      "value": 4
    },
    "LIST-validatingwebhookconfigurations-count": {
      "value": 9
    },
    "LIST-virtualmachineclusterflavors-count": {
      "value": 59
    },
    "LIST-virtualmachineflavors-count": {
      "value": 52
    },
    "LIST-virtualmachineinstancemigrations-count": {
      "value": 4
    },
    "LIST-virtualmachineinstancepresets-count": {
      "value": 52
    },
    "LIST-virtualmachineinstancereplicasets-count": {
      "value": 4
    },
    "LIST-virtualmachineinstances-count": {
      "value": 108
    },
    "LIST-virtualmachinerestores-count": {
      "value": 54
    },
    "LIST-virtualmachines-count": {
      "value": 4
    },
    "LIST-virtualmachinesnapshotcontents-count": {
      "value": 4
    },
    "LIST-virtualmachinesnapshots-count": {
      "value": 4
    },
    "PATCH-events-count": {
      "value": 181
    },
    "PATCH-nodes-count": {
      "value": 116
    },
    "PATCH-services-count": {
      "value": 18
    },
    "PATCH-virtualmachineinstances-count": {
      "value": 13
    },
    "UPDATE-endpoints-count": {
      "value": 1225
    },
    "UPDATE-virtualmachineinstances-count": {
      "value": 107
    },
    "running-phase-count": {
      "value": 12
    },
    "scheduling-phase-count": {
      "value": 9
    },
    "vmiCreationToRunningSecondsP50": {
      "value": 43
    },
    "vmiCreationToRunningSecondsP95": {
      "value": 49.3
    },
    "vmiCreationToRunningSecondsP99": {
      "value": 49.86
    }
  }
}
```

```release-note
NONE
```
