### PR TITLE
Only create 1MiB-aligned disk images

### DIFF
--- a/pkg/emptydisk/BUILD.bazel
+++ b/pkg/emptydisk/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )
 

--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -1,6 +1,7 @@
 package emptydisk
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -26,8 +27,11 @@ func (c *emptyDiskCreator) CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) 
 		if volume.EmptyDisk != nil {
 			// qemu-img takes the size in bytes or in Kibibytes/Mebibytes/...; lets take bytes
 			intSize := volume.EmptyDisk.Capacity.ToDec().ScaledValue(0)
-			// round down the size to the nearest 4KiB multiple
-			intSize = util.AlignImageSizeTo4k(intSize, logger.With("volume", volume.Name))
+			// round down the size to the nearest 1MiB multiple
+			intSize = util.AlignImageSizeTo1MiB(intSize, logger.With("volume", volume.Name))
+			if intSize == 0 {
+				return fmt.Errorf("the size for volume %s is too low", volume.Name)
+			}
 			// convert the size to string for qemu-img
 			size := strconv.FormatInt(intSize, 10)
 			file := filePathForVolumeName(c.emptyDiskBaseDir, volume.Name)

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -78,7 +78,10 @@ func ReplacePVCByHostDisk(vmi *v1.VirtualMachineInstance) error {
 				continue
 			}
 
-			replaceForHostDisk(volumeSource, volume.Name, pvcVolume)
+			err := replaceForHostDisk(volumeSource, volume.Name, pvcVolume)
+			if err != nil {
+				return err
+			}
 			// PersistenVolumeClaim is replaced by HostDisk
 			volumeSource.PersistentVolumeClaim = nil
 		}
@@ -87,7 +90,10 @@ func ReplacePVCByHostDisk(vmi *v1.VirtualMachineInstance) error {
 				continue
 			}
 
-			replaceForHostDisk(volumeSource, volume.Name, pvcVolume)
+			err := replaceForHostDisk(volumeSource, volume.Name, pvcVolume)
+			if err != nil {
+				return err
+			}
 			// PersistenVolumeClaim is replaced by HostDisk
 			volumeSource.DataVolume = nil
 		}
@@ -95,19 +101,25 @@ func ReplacePVCByHostDisk(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVolume map[string]v1.VolumeStatus) {
+func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVolume map[string]v1.VolumeStatus) error {
 	volumeStatus := pvcVolume[volumeName]
 	isShared := types.HasSharedAccessMode(volumeStatus.PersistentVolumeClaimInfo.AccessModes)
 	file := getPVCDiskImgPath(volumeName, "disk.img")
 	capacity := volumeStatus.PersistentVolumeClaimInfo.Capacity[k8sv1.ResourceStorage]
-	// The host-disk must be 4k-aligned. If the volume specifies a misaligned size, shrink it down to the nearest multiple of 4096
-	capacity.Set(util.AlignImageSizeTo4k(capacity.Value(), log.Log.V(2)))
+	// The host-disk must be 1MiB-aligned. If the volume specifies a misaligned size, shrink it down to the nearest multiple of 1MiB
+	size := util.AlignImageSizeTo1MiB(capacity.Value(), log.Log.V(2))
+	if size == 0 {
+		return fmt.Errorf("the size for volume %s is too low, must be at least 1MiB", volumeName)
+	}
+	capacity.Set(size)
 	volumeSource.HostDisk = &v1.HostDisk{
 		Path:     file,
 		Type:     v1.HostDiskExistsOrCreate,
 		Capacity: capacity,
 		Shared:   &isShared,
 	}
+
+	return nil
 }
 
 func shouldSkipVolumeSource(passthoughFSVolumes map[string]struct{}, hotplugVolumes map[string]bool, pvcVolume map[string]v1.VolumeStatus, volumeName string) bool {

--- a/pkg/host-disk/host-disk_test.go
+++ b/pkg/host-disk/host-disk_test.go
@@ -399,6 +399,9 @@ var _ = Describe("HostDisk", func() {
 					Name: volumeName,
 					PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
 						VolumeMode: &mode,
+						Capacity: map[k8sv1.ResourceName]resource.Quantity{
+							k8sv1.ResourceStorage: *resource.NewQuantity(1024*1024, resource.BinarySI),
+						},
 					},
 				},
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 )
 
 const (
@@ -149,4 +150,17 @@ func IsReadOnlyDisk(disk *v1.Disk) bool {
 	isReadOnlyCDRom := disk.CDRom != nil && (disk.CDRom.ReadOnly == nil || *disk.CDRom.ReadOnly == true)
 
 	return isReadOnlyCDRom
+}
+
+func AlignImageSizeTo4k(size int64, logger *log.FilteredLogger) int64 {
+	remainder := size % 4096
+	if remainder == 0 {
+		return size
+	} else {
+		newSize := size - remainder
+		if logger != nil {
+			logger.Warningf("new size is not 4k-aligned. Adjusting from %d down to %d.", size, newSize)
+		}
+		return newSize
+	}
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -651,7 +651,10 @@ func expandDiskImageOffline(imagePath string, size int64) error {
 	} else {
 		preallocateFlag = "--preallocation=off"
 	}
-	size = util2.AlignImageSizeTo4k(size, log.Log.With("image", imagePath))
+	size = util2.AlignImageSizeTo1MiB(size, log.Log.With("image", imagePath))
+	if size == 0 {
+		return fmt.Errorf("%s must be at least 1MiB", imagePath)
+	}
 	cmd := exec.Command("/usr/bin/qemu-img", "resize", preallocateFlag, imagePath, strconv.FormatInt(size, 10))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -676,7 +679,10 @@ func possibleGuestSize(disk api.Disk) (int64, bool) {
 		return 0, false
 	}
 	size := int64((1 - filesystemOverhead) * float64(preferredSize))
-	size = util2.AlignImageSizeTo4k(size, log.DefaultLogger())
+	size = util2.AlignImageSizeTo1MiB(size, log.DefaultLogger())
+	if size == 0 {
+		return 0, false
+	}
 	return size, true
 }
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -38,6 +38,8 @@ import (
 	"sync"
 	"time"
 
+	util2 "kubevirt.io/kubevirt/pkg/util"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/generic"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/gpu"
 
@@ -649,10 +651,11 @@ func expandDiskImageOffline(imagePath string, size int64) error {
 	} else {
 		preallocateFlag = "--preallocation=off"
 	}
+	size = util2.AlignImageSizeTo4k(size, log.Log.With("image", imagePath))
 	cmd := exec.Command("/usr/bin/qemu-img", "resize", preallocateFlag, imagePath, strconv.FormatInt(size, 10))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("Expanding image failed with error: %v, output: %s", err, out)
+		return fmt.Errorf("expanding image failed with error: %v, output: %s", err, out)
 	}
 	return nil
 }
@@ -672,7 +675,9 @@ func possibleGuestSize(disk api.Disk) (int64, bool) {
 		log.DefaultLogger().Reason(err).Error("Failed to parse filesystem overhead as float")
 		return 0, false
 	}
-	return int64((1 - filesystemOverhead) * float64(preferredSize)), true
+	size := int64((1 - filesystemOverhead) * float64(preferredSize))
+	size = util2.AlignImageSizeTo4k(size, log.DefaultLogger())
+	return size, true
 }
 
 func shouldExpandOffline(disk api.Disk) bool {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2298,7 +2298,7 @@ var _ = Describe("Manager helper functions", func() {
 		BeforeEach(func() {
 			fakePercentFloat = 0.7648
 			fakePercent := cdiv1beta1.Percent(fmt.Sprint(fakePercentFloat))
-			fakeCapacity := int64(123000)
+			fakeCapacity := int64(2345 * 3456) // We need (1-0.7648)*fakeCapacity to be > 1MiB and misaligned
 
 			properDisk = api.Disk{
 				FilesystemOverhead: &fakePercent,
@@ -2313,8 +2313,8 @@ var _ = Describe("Manager helper functions", func() {
 			Expect(capacity).ToNot(Equal(nil))
 
 			expectedSize := int64((1 - fakePercentFloat) * float64(*capacity))
-			// The size is expected to be 4k-aligned
-			expectedSize = expectedSize - expectedSize%4096
+			// The size is expected to be 1MiB-aligned
+			expectedSize = expectedSize - expectedSize%(1024*1024)
 
 			Expect(size).To(Equal(expectedSize))
 		})

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2313,6 +2313,8 @@ var _ = Describe("Manager helper functions", func() {
 			Expect(capacity).ToNot(Equal(nil))
 
 			expectedSize := int64((1 - fakePercentFloat) * float64(*capacity))
+			// The size is expected to be 4k-aligned
+			expectedSize = expectedSize - expectedSize%4096
 
 			Expect(size).To(Equal(expectedSize))
 		})

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -340,7 +340,7 @@ var _ = SIGDescribe("Storage", func() {
 				By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo blockdev --getsize64 /dev/vdc\n"},
-					&expect.BExp{R: "999997440"}, // 1G in bytes rounded down to nearest 4k boundary
+					&expect.BExp{R: "999292928"}, // 1G in bytes rounded down to nearest 1MiB boundary
 				}, 10)).To(Succeed())
 
 				By("Checking if we can write to /dev/vdc")
@@ -654,7 +654,7 @@ var _ = SIGDescribe("Storage", func() {
 
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 							&expect.BSnd{S: "blockdev --getsize64 /dev/vdb\n"},
-							&expect.BExp{R: "1014685696"},
+							&expect.BExp{R: "1013972992"},
 						}, 200)).To(Succeed())
 					}
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -329,7 +329,7 @@ var _ = SIGDescribe("Storage", func() {
 					Name: "emptydisk1",
 					VolumeSource: virtv1.VolumeSource{
 						EmptyDisk: &virtv1.EmptyDiskSource{
-							Capacity: resource.MustParse("2Gi"),
+							Capacity: resource.MustParse("1G"),
 						},
 					},
 				})
@@ -337,10 +337,10 @@ var _ = SIGDescribe("Storage", func() {
 
 				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
 
-				By("Checking that /dev/vdc has a capacity of 2Gi")
+				By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo blockdev --getsize64 /dev/vdc\n"},
-					&expect.BExp{R: "2147483648"}, // 2Gi in bytes
+					&expect.BExp{R: "999997440"}, // 1G in bytes rounded down to nearest 4k boundary
 				}, 10)).To(Succeed())
 
 				By("Checking if we can write to /dev/vdc")
@@ -654,7 +654,7 @@ var _ = SIGDescribe("Storage", func() {
 
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 							&expect.BSnd{S: "blockdev --getsize64 /dev/vdb\n"},
-							&expect.BExp{R: "1014686208"},
+							&expect.BExp{R: "1014685696"},
 						}, 200)).To(Succeed())
 					}
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2031,10 +2031,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			// PVC is mounted as tmpfs on kind, which does not support direct I/O.
 			// As such, it behaves as plugging in a hostDisk - check disks[6].
 			if tests.IsRunningOnKindInfra() {
-				// The chache mode is set to cacheWritethrough
+				// The cache mode is set to cacheWritethrough
 				Expect(string(disks[2].Driver.IO)).To(Equal(ioNone))
 			} else {
-				// The chache mode is set to cacheNone
+				// The cache mode is set to cacheNone
 				Expect(disks[2].Driver.IO).To(Equal(ioNative))
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Recent libvirt/qemu now refuse to start if any disk is not 1MiB-aligned.
This PR ensures disk image creation/resize will always produce 1MiB-aligned images by rounding the size down to the nearest 1MiB boundary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6712

**Special notes for your reviewer**:
2G (2000000000) happens to be 1k-aligned (!), so I used 1G in the test to ensure mis-alignment. (1k used to be fine, and might still be in some cases)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New and resized disks are now always 1MiB-aligned
```
