### PR TITLE
Update test (test_id:6981) - Check migration of VM with the default CPU instead of explicitly set 'host-model'

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2064,12 +2064,15 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			It("[test_id:6981]should migrate only to nodes supporting right cpu model", func() {
 				if !isHeterogeneousCluster() {
 					log.Log.Warning("all nodes have the same CPU model. Therefore the test is a happy-path since " +
-						"VMIs with host-model CPU can be migrated to every other node")
+						"VMIs with default CPU can be migrated to every other node")
 				}
 
-				By("Creating a VMI with host-model CPU mode")
+				By("Creating a VMI with default CPU mode")
 				vmi := cirrosVMIWithEvictionStrategy()
-				vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+
+				if cpu := vmi.Spec.Domain.CPU; cpu != nil && cpu.Model != v1.CPUModeHostModel {
+					log.Log.Warning("test is not expected to pass with CPU model other than host-model")
+				}
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)


### PR DESCRIPTION
Signed-off-by: Denys Shchedrivyi dshchedr@redhat.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
 Since the default CPU mode for VMs is "host-model" (recently merged #6721), let's update migration test accordingly: remove the explicit "host-model" setting and check migration with default cpu mode. It may help to catch the issue if someone changes the default CPU value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
