### PR TITLE
virt-handler, net: Simplify critical-error handling

### DIFF
--- a/pkg/network/errors/errors.go
+++ b/pkg/network/errors/errors.go
@@ -3,11 +3,16 @@ package errors
 import "fmt"
 
 type CriticalNetworkError struct {
-	Msg string
+	wrappedErr error
+	Msg        string
 }
 
 func (e CriticalNetworkError) Error() string { return e.Msg }
+func (e CriticalNetworkError) Unwrap() error { return e.wrappedErr }
 
 func CreateCriticalNetworkError(err error) *CriticalNetworkError {
-	return &CriticalNetworkError{Msg: fmt.Sprintf("Critical network error: %v", err)}
+	return &CriticalNetworkError{
+		wrappedErr: err,
+		Msg:        fmt.Sprintf("Critical network error: %v", err),
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Use error type instead of a boolean to detect critical errors in the
network setup flow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
