### PR TITLE
storage, Ignore a transient warning in order to reduce noise

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -167,7 +167,8 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+				warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
+				vmi = tests.RunVMIAndExpectLaunchIgnoreSelectedWarnings(vmi, 120, warningsIgnoreList)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -626,9 +626,10 @@ var _ = SIGDescribe("Storage", func() {
 				tests.AddPVCDisk(vmi, "disk1", "virtio", tests.DiskCustomHostPath)
 
 				num := 3
+				warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
 				By("Starting and stopping the VirtualMachineInstance number of times")
 				for i := 1; i <= num; i++ {
-					obj := tests.RunVMIAndExpectLaunch(vmi, 240)
+					obj := tests.RunVMIAndExpectLaunchIgnoreSelectedWarnings(vmi, 240, warningsIgnoreList)
 
 					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 					// after being restarted multiple times

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1580,6 +1580,17 @@ func RunVMIAndExpectLaunch(vmi *v1.VirtualMachineInstance, timeout int) *v1.Virt
 	return obj
 }
 
+func RunVMIAndExpectLaunchIgnoreSelectedWarnings(vmi *v1.VirtualMachineInstance, timeout int, warningsIgnoreList []string) *v1.VirtualMachineInstance {
+	obj := RunVMI(vmi, timeout)
+	By("Waiting until the VirtualMachineInstance will start")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wp := WarningsPolicy{FailOnWarnings: true, WarningsIgnoreList: warningsIgnoreList}
+	waitForVMIStart(ctx, obj, timeout, wp)
+	return obj
+}
+
 func RunVMIAndExpectLaunchWithDataVolume(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume, timeout int) *v1.VirtualMachineInstance {
 	obj := RunVMI(vmi, timeout)
 	By("Waiting until the DataVolume is ready")


### PR DESCRIPTION
**What this PR does / why we need it**:

The 2 tests that this PR updates were flaky,
one of the reason that cause it, is the transient warning
`unknown error encountered sending command Kill: rpc error: code = DeadlineExceeded desc = context deadline exceeded`
This PR suggests to ignore this warning, as this warning might happen when the machine is busy.
There is a built-in mechanism in kubevirt to retry once this warning occurs.

Note: those tests are still flaky even after this change, but it should clean some noise.

For example
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6745/pull-kubevirt-e2e-k8s-1.22-sig-storage/1457971688133103616

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
