### PR TITLE
[tests]: set the serial label for vmwatch test since it involves migration

### DIFF
--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -211,7 +211,7 @@ var _ = Describe("[rfe_id:3423][crit:high][arm64][vendor:cnv-qe@redhat.com][leve
 		util.PanicOnError(err)
 	})
 
-	It("[test_id:6870]Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
+	It("[Serial][test_id:6870]Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
 		By("Waiting for a VM to be created")
 		Eventually(func() bool {
 			_, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &v1.GetOptions{})


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Migration e2e tests run in serial manner. The serial label was missing in the vm watch tests.

**Release note**:
```release-note
NONE
```
