### PR TITLE
Update links in KubeVirt adopters doc

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,12 +6,12 @@
 | End-user| Civo | 2020 | [link](https://www.civo.com) | We are using KubeVirt as part of our stack to enable tenant cluster provisioning within Civo cloud. |
 | End-user | CoreWeave | 2020 | [link](https://www.coreweave.com) | A Kubernetes native cloud provider with focus on GPUs at scale. KubeVirt allows us to co-locate non-containerizable workloads such as Virtual Desktops next to compute intensive containers executing on bare metal. All orchestrated via the Kubernetes API leveraging the same network policies and persistent volumes for both VM and containerized workloads. |
 | End-user | NVIDIA | 2018 | [link](https://www.nvidia.com) | NVIDIA's latest computing platform is built on open-source projects like Kubernetes and KubeVirt to power products like [GeForce NOW](https://www.nvidia.com/en-us/geforce-now/) with more to come. |
-| Integration | minikube | 2020 | [link](https://minikube.sigs.k8s.io) | |
+| Integration | minikube | 2020 | [link](https://minikube.sigs.k8s.io/docs/tutorials/kubevirt/) | |
 | Integration | oVirt | | [link](https://www.ovirt.org/documentation/administration_guide/index.html#proc-adding-kubevirt-openshift-as-an-external-provider_external_providers) | |
-| Integration | okd | 2020 | [link](https://minikube.sigs.k8s.io) | |
+| Integration | OKD | 2020 | [link](https://docs.okd.io/latest/virt/about-virt.html) | |
 | Vendor | EQUINIX | | [link](https://metal.equinix.com/) | |
 | Vendor | H3C | 2019 | [link](https://www.h3c.com/en/Products_Technology/Enterprise_Products/Cloud_Computing/Cloud_Computing_Products/H3C_CloudOS/H3C_CloudOS_full-stack/) | We distribute KubeVirt as part of CloudOS to enable VM workloads on Kubernetes at customer sites. |
 | Vendor | KUBERMATIC | 2019 | [link](https://www.kubermatic.com/products/kubevirt/) | As a distributor we are running KubeVirt to enable VM workload on Kubermatic Virtualization. |
 | Vendor | PLATFORM9 | | [link](https://platform9.com/managed-kubevirt/) | Run Legacy and Cloud-Native Applications on Platform9 |
-| Vendor | Red Hat, Inc. | 2016 | [link](https://www.redhat.com) | As a distributor we are building OpenShift Virtualization on KubeVirt in order to enable VM workloads and -flows on Kubernetes. |
-| Vendor | SUSE | 2020 | [link](https://www.suse.com/) | SUSE believes KubeVirt is the best open source way to handle Virtual Machines on Kubernetes today. We offer this additional possibility to our customers by leveraging KubeVirt in our products. |
+| Vendor | Red Hat, Inc. | 2016 | [link](https://cloud.redhat.com/learn/topics/virtualization/) | As a distributor we are building OpenShift Virtualization on KubeVirt in order to enable VM workloads and -flows on Kubernetes. |
+| Vendor | SUSE | 2020 | [link](https://documentation.suse.com/sbp/all/html/SBP-KubeVirt-SLES15SP3/index.html) | SUSE believes KubeVirt is the best open source way to handle Virtual Machines on Kubernetes today. We offer this additional possibility to our customers by leveraging KubeVirt in our products. |


### PR DESCRIPTION
**What this PR does / why we need it**:

Update several links - from generic company/project links, to links describing kubevirt integration/usage details.
Also capitalize OKD as it's commonly referred as.

**Release note**:
```release-note
NONE
```
