### PR TITLE
Revert #6565: kubevirt's components managed-by label's value changed to virt-operator

### DIFF
--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -367,7 +367,7 @@ var _ = Describe("Apply Apps", func() {
 			managedBy, ok := deployment.Labels["app.kubernetes.io/managed-by"]
 
 			Expect(ok).To(BeTrue())
-			Expect(managedBy).To(Equal("virt-operator"))
+			Expect(managedBy).To(Equal("kubevirt-operator"))
 
 			version, ok := deployment.Annotations["kubevirt.io/install-strategy-version"]
 			Expect(ok).To(BeTrue())

--- a/pkg/virt-operator/resource/apply/reconcile_test.go
+++ b/pkg/virt-operator/resource/apply/reconcile_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Apply", func() {
 			managedBy, ok := deployment.Labels["app.kubernetes.io/managed-by"]
 
 			Expect(ok).To(BeTrue())
-			Expect(managedBy).To(Equal("virt-operator"))
+			Expect(managedBy).To(Equal("kubevirt-operator"))
 
 			version, ok := deployment.Annotations["kubevirt.io/install-strategy-version"]
 			Expect(ok).To(BeTrue())

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
@@ -729,7 +729,7 @@ const (
 	AppComponent = "kubevirt"
 	// This label will be set on all resources created by the operator
 	ManagedByLabel              = AppLabelPrefix + "/managed-by"
-	ManagedByLabelOperatorValue = "virt-operator"
+	ManagedByLabelOperatorValue = "kubevirt-operator"
 	// This annotation represents the kubevirt version for an install strategy configmap.
 	InstallStrategyVersionAnnotation = "kubevirt.io/install-strategy-version"
 	// This annotation represents the kubevirt registry used for an install strategy configmap.


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent PR (#6565) has changed the `app.kubernetes.io/managed-by` label value from `kubevirt-operator` to `virt-opertor`. This label is used as a label selector for most of the informers used by virt-operator, e.g. [here](https://github.com/kubevirt/kubevirt/blob/a7cddcc4fb5b332429978204984b1aab8ffbb720/pkg/controller/virtinformers.go#L690).
When performing an upgrade (as opposed to a clean install) to KubeVirt v0.47.0, this causes the OperatorCRD informer to drop all existing CRDs (still labeled with `kubevirt-informer`) and hence to fail to observe that they already exist --> conflict.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6763

**Release note**:

```release-note
Bugfix: revert #6565 which prevented upgrades to v0.47.
```
