### PR TITLE
alert if migration for VMI with host-model CPU is stuck since no node is suitable

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -121,6 +121,9 @@ const (
 	// ImagePullBackOffReason is set when an error has occured while pulling an image for a containerDisk VM volume,
 	// and that kubelet is backing off before retrying.
 	ImagePullBackOffReason = "ImagePullBackOff"
+	// NoSuitableNodesForHostModelMigration is set when a VMI with host-model CPU mode tries to migrate but no node
+	// is suitable for migration (since CPU model / required features are not supported)
+	NoSuitableNodesForHostModelMigration = "NoSuitableNodesForHostModelMigration"
 )
 
 const failedToRenderLaunchManifestErrFormat = "failed to render launch manifest: %v"
@@ -830,6 +833,10 @@ func isPodReady(pod *k8sv1.Pod) bool {
 	}
 
 	return pod.Status.Phase == k8sv1.PodRunning
+}
+
+func isPodPending(pod *k8sv1.Pod) bool {
+	return pod.Status.Phase == k8sv1.PodPending
 }
 
 func isPodDownOrGoingDown(pod *k8sv1.Pod) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If nodes on a cluster are updated, it is possible that features will be removed (e.g. TSX flag removed for Intel CPUs). It could be that a currently running VMI might have nowhere that it could be migrated. In this unfortunate case, it could actually be possible to block an update from proceeding (without rebooting all running VMs, possibly more than once).

This situation should result in an alert.

This alert is being fired at migration time if Migration is pending, VMI uses host-model and no other node is suitable to perform the migration.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
alert if migration for VMI with host-model CPU is stuck since no node is suitable
```
