### PR TITLE
Reduce sig-storage flakiness: Use a smaller image for NFS test

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -131,7 +131,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			ipProtocol := k8sv1.IPv4Protocol
 			os := string(cd.ContainerDiskAlpine)
-			size := "5Gi"
+			size := "1Gi"
 
 			AfterEach(func() {
 				tests.DeleteAlpineWithNonQEMUPermissions()


### PR DESCRIPTION
Tests enable all feature gates, so these tests enable the new
online resize. The disks get expanded to the largest size, which
is a bit slow with our NFS server and causes timeouts which show
as flakiness.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Essentially the same as #6745, but in one more case.
I missed that this is another 5Gi NFS image and assumed the previous test is causing the flakiness.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
