### PR TITLE
Add test to verify virt-operator release upgrade

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -24,6 +24,7 @@ PYTHON_CLIENT_OUT_DIR=$OUT_DIR/client-python
 ARCHITECTURE="${BUILD_ARCH:-$(uname -m)}"
 HOST_ARCHITECTURE="$(uname -m)"
 KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
+OPERATOR_MANIFEST_PATH=$MANIFESTS_OUT_DIR/release/kubevirt-operator.yaml
 
 function build_func_tests() {
     mkdir -p "${TESTS_OUT_DIR}/"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -51,7 +51,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
+    _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS} --manifests=${MANIFESTS_OUT_DIR} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
 }
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -51,7 +51,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS} --manifests=${MANIFESTS_OUT_DIR} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
+    _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
 }
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -47,6 +47,7 @@ var IPV4ConnectivityCheckAddress = ""
 var IPV6ConnectivityCheckAddress = ""
 var ConnectivityCheckDNS = ""
 var ArtifactsDir string
+var ManifestsDir string
 var ApplyDefaulte2eConfiguration bool
 
 var DeployTestingInfrastructureFlag = false
@@ -74,6 +75,7 @@ func init() {
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "quay.io/kubevirt", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
+	flag.StringVar(&ManifestsDir, "manifests", "_out/manifests", "Directory containing build output manifests")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presence of IPv6 address in the cluster pods.")
 	flag.StringVar(&IPV4ConnectivityCheckAddress, "conn-check-ipv4-address", "", "Address that is used for testing IPV4 connectivity to the outside world")

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -47,7 +47,7 @@ var IPV4ConnectivityCheckAddress = ""
 var IPV6ConnectivityCheckAddress = ""
 var ConnectivityCheckDNS = ""
 var ArtifactsDir string
-var ManifestsDir string
+var OperatorManifestPath string
 var ApplyDefaulte2eConfiguration bool
 
 var DeployTestingInfrastructureFlag = false
@@ -75,7 +75,7 @@ func init() {
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "quay.io/kubevirt", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
-	flag.StringVar(&ManifestsDir, "manifests", "_out/manifests", "Directory containing build output manifests")
+	flag.StringVar(&OperatorManifestPath, "operator-manifest-path", "_out/manifests/release/kubevirt-operator.yaml", "Set path to virt-operator manifest file")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presence of IPv6 address in the cluster pods.")
 	flag.StringVar(&IPV4ConnectivityCheckAddress, "conn-check-ipv4-address", "", "Address that is used for testing IPV4 connectivity to the outside world")

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -75,7 +75,7 @@ func init() {
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "quay.io/kubevirt", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
-	flag.StringVar(&OperatorManifestPath, "operator-manifest-path", "_out/manifests/release/kubevirt-operator.yaml", "Set path to virt-operator manifest file")
+	flag.StringVar(&OperatorManifestPath, "operator-manifest-path", "", "Set path to virt-operator manifest file")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presence of IPv6 address in the cluster pods.")
 	flag.StringVar(&IPV4ConnectivityCheckAddress, "conn-check-ipv4-address", "", "Address that is used for testing IPV4 connectivity to the outside world")

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1366,7 +1366,11 @@ spec:
 		// Ensuring VM/VMI is still operational after the update from previous release.
 		table.DescribeTable("[release-blocker][sig-compute][test_id:3145]from previous release to target tested release", func(updateOperator bool) {
 			if !tests.HasCDI() {
-				Skip("Skip Update test when CDI is not present")
+				Skip("Skip update test when CDI is not present")
+			}
+
+			if updateOperator && flags.OperatorManifestPath == "" {
+				Skip("Skip operator update test when operator manifest path isn't configured")
 			}
 
 			migratableVMIs := generateMigratableVMIs(2)

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1386,8 +1386,6 @@ spec:
 			curVersion := originalKv.Status.ObservedKubeVirtVersion
 			curRegistry := originalKv.Status.ObservedKubeVirtRegistry
 
-			curOperatorManifestPath := filepath.Join(flags.ManifestsDir, "release/kubevirt-operator.yaml")
-
 			allPodsAreReady(originalKv)
 			sanityCheckDeploymentsExist()
 
@@ -1403,7 +1401,7 @@ spec:
 
 			if updateOperator {
 				By("Deleting virt-operator installation")
-				deleteOperator(curOperatorManifestPath)
+				deleteOperator(flags.OperatorManifestPath)
 
 				By("Installing previous release of virt-operator")
 				manifestURL := tests.GetUpstreamReleaseAssetURL(previousImageTag, "kubevirt-operator.yaml")
@@ -1492,7 +1490,7 @@ spec:
 			// Update KubeVirt from the previous release to the testing target release.
 			if updateOperator {
 				By("Updating virt-operator installation")
-				installOperator(curOperatorManifestPath)
+				installOperator(flags.OperatorManifestPath)
 			} else {
 				By("Updating KubeVirt object With current tag")
 				patchKvVersionAndRegistry(kv.Name, curVersion, curRegistry)

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1364,7 +1364,7 @@ spec:
 		// running a VM/VMI using that previous release
 		// Updating KubeVirt to the target tested code
 		// Ensuring VM/VMI is still operational after the update from previous release.
-		table.DescribeTable("[release-blocker][sig-compute][test_id:3145]from previous release to target tested release", func(updateOperator bool) {
+		table.DescribeTable("[release-blocker][test_id:3145]from previous release to target tested release", func(updateOperator bool) {
 			if !tests.HasCDI() {
 				Skip("Skip update test when CDI is not present")
 			}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4935,6 +4935,28 @@ func getTagHint() string {
 
 }
 
+func GetUpstreamReleaseAssetURL(tag string, assetName string) string {
+	client := github.NewClient(nil)
+
+	var err error
+	var release *github.RepositoryRelease
+
+	Eventually(func() error {
+		release, _, err = client.Repositories.GetReleaseByTag(context.Background(), "kubevirt", "kubevirt", tag)
+
+		return err
+	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+	for _, asset := range release.Assets {
+		if asset.GetName() == assetName {
+			return asset.GetBrowserDownloadURL()
+		}
+	}
+
+	Fail(fmt.Sprintf("Asset %s not found in release %s of kubevirt upstream repo", assetName, tag))
+	return ""
+}
+
 func DetectLatestUpstreamOfficialTag() (string, error) {
 	client := github.NewClient(nil)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an important test case that simulates a KubeVirt upgrade scenario performed by upgrading the virt-operator itself.
This, in addition to the existing test that performed the upgrade by patching the KubeVirt CR with the desired release (while maintaining the virt-operator at its current version), covers the [two upgrade scenarios documented in the user guide](https://kubevirt.io/user-guide/operations/updating_and_deletion/#updating-kubevirt-control-plane).

The goal is to be able to catch virt-operator bugs the surface only when the operator itself is upgraded, e.g. #6763.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6785

**Special notes for your reviewer**:

I've tested this locally to verify that the scenario from #6763 is reproduced and fails the test - it does - the test fails after a reasonable timeout, and the virt-operator logs include the errors reported in #6763.
Here's how to reproduce:
1. Deploy any commit with the offending bug from #6565
```
git checkout 99a00e143 
make cluster-sync
```

2. Execute the test and force to upgrade from v0.46.1:
```
KUBEVIRT_E2E_FOCUS="by.updating.virt-operator" KUBEVIRT_FUNC_TEST_SUITE_ARGS="--ginkgo.v --previous-release-tag=v0.46.1" make functest
```

**Release note**:

```release-note
NONE
```
