### PR TITLE
Add a test for configuring maxDevices on virt-handler

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1315,6 +1315,56 @@ spec:
 		})
 	})
 
+	Describe("[test_id:6987]should apply component configuration", func() {
+
+		It("test VirtualMachineInstancesPerNode", func() {
+			newVirtualMachineInstancesPerNode := 10
+
+			By("Updating KubeVirt Object")
+			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(newVirtualMachineInstancesPerNode))
+			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
+
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Test that patch was applied to DaemonSet")
+			Eventually(func() string {
+				vc, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				containers := vc.Spec.Template.Spec.Containers
+				Expect(containers).ToNot(BeEmpty())
+
+				container := containers[0]
+
+				return strings.Join(container.Command, " ")
+			}, 60*time.Second, 5*time.Second).Should(ContainSubstring(fmt.Sprintf("--maxDevices %d", newVirtualMachineInstancesPerNode)))
+
+			By("Deleting patch from KubeVirt object")
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
+			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Test that patch was removed from DaemonSet")
+			Eventually(func() string {
+				vc, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				containers := vc.Spec.Template.Spec.Containers
+				Expect(containers).ToNot(BeEmpty())
+
+				container := containers[0]
+
+				return strings.Join(container.Command, " ")
+			}, 60*time.Second, 5*time.Second).ShouldNot(ContainSubstring(fmt.Sprintf("--maxDevices %d", newVirtualMachineInstancesPerNode)))
+		})
+	})
+
 	Describe("[test_id:4744]should apply component customization", func() {
 
 		It("[QUARANTINE]test applying and removing a patch", func() {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1323,7 +1323,7 @@ spec:
 			By("Updating KubeVirt Object")
 			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(newVirtualMachineInstancesPerNode))
+			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(&newVirtualMachineInstancesPerNode))
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
 
 			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds func test for configuring `VirtualMachingInstancesPerNode` (added in #6105).

This PR picks up the pending work from #6170 by @ashleyschuett (which is no longer involved in the project), and adds a tiny fix that addresses the last remaining [review comment](https://github.com/kubevirt/kubevirt/pull/6170#discussion_r681200235) (+rebase).

**Release note**:
```release-note
NONE
```
