### PR TITLE
tests, network: Add param to libvmi.InterfaceDeviceWithBridgeBinding

### DIFF
--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -23,6 +23,8 @@ import (
 	kvirtv1 "kubevirt.io/client-go/apis/core/v1"
 )
 
+const DefaultInterfaceName = "default"
+
 // WithInterface adds a Domain Device Interface.
 func WithInterface(iface kvirtv1.Interface) Option {
 	return func(vmi *kvirtv1.VirtualMachineInstance) {
@@ -50,10 +52,10 @@ func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interfa
 	}
 }
 
-// InterfaceDeviceWithBridgeBinding returns an Interface named "default" with bridge binding.
-func InterfaceDeviceWithBridgeBinding() kvirtv1.Interface {
+// InterfaceDeviceWithBridgeBinding returns an Interface with bridge binding.
+func InterfaceDeviceWithBridgeBinding(name string) kvirtv1.Interface {
 	return kvirtv1.Interface{
-		Name: "default",
+		Name: name,
 		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
 			Bridge: &kvirtv1.InterfaceBridge{},
 		},

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -92,7 +92,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 				BeforeEach(func() {
 					var err error
 
-					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding())
+					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName))
 					Expect(err).NotTo(HaveOccurred())
 
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -131,7 +131,7 @@ var _ = SIGDescribe("Services", func() {
 
 		createVMISpecWithBridgeInterface := func() *v1.VirtualMachineInstance {
 			return libvmi.NewCirros(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()))
 		}
 

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -103,6 +103,6 @@ func fedoraMasqueradeVMI() *v1.VirtualMachineInstance {
 
 func fedoraBridgeBindingVMI() *v1.VirtualMachineInstance {
 	return libvmi.NewFedora(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding()),
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR extends the function that creates network interfaces with bridge binding to receive a "name" parameter.
This PR will improve code readability of PR #6766

Signed-off-by: Orel Misan <omisan@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
