### PR TITLE
[test_id:5004]: Update migration configurations correctly

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -336,8 +336,10 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		}
 	}
 
-	setMigrationBandwidthLimitation := func(limitation resource.Quantity) {
-
+	setMigrationBandwidthLimitation := func(migrationBandwidth resource.Quantity) {
+		cfg := getCurrentKv()
+		cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
+		tests.UpdateKubeVirtConfigValueAndWait(cfg)
 	}
 
 	Describe("Starting a VirtualMachineInstance ", func() {
@@ -1509,11 +1511,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 			BeforeEach(func() {
 				pvName = "test-nfs" + rand.String(48)
-
-				cfg := getCurrentKv()
-				migrationBandwidth := resource.MustParse("40Mi")
-				cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
-				tests.UpdateKubeVirtConfigValueAndWait(cfg)
+				setMigrationBandwidthLimitation(resource.MustParse("40Mi"))
 			})
 
 			table.DescribeTable("should be migrated successfully, using guest agent on VM", func(mode v1.MigrationMode) {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1656,7 +1656,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				}
 			})
 
-			It("[test_id:5004]"+guestAgentMigrationTestName+"with postcopy", func() {
+			It("[QUARANTINE][test_id:5004]"+guestAgentMigrationTestName+"with postcopy", func() {
 				guestAgentMigrationTestFunc(v1.MigrationPostCopy)
 			})
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1585,7 +1585,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				setMigrationBandwidthLimitation(resource.MustParse("40Mi"))
 			})
 
-			It("[QUARANTINE][test_id:5004]"+guestAgentMigrationTestName+"with postcopy", func() {
+			It("[test_id:5004]"+guestAgentMigrationTestName+"with postcopy", func() {
 				guestAgentMigrationTestFunc(v1.MigrationPostCopy)
 			})
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -336,6 +336,10 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		}
 	}
 
+	setMigrationBandwidthLimitation := func(limitation resource.Quantity) {
+
+	}
+
 	Describe("Starting a VirtualMachineInstance ", func() {
 		Context("with a bridge network interface", func() {
 			It("[test_id:3226]should reject a migration of a vmi with a bridge interface", func() {
@@ -1254,11 +1258,6 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				By("create a new NFS PV and PVC")
 				os := string(cd.ContainerDiskFedoraTestTooling)
 				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
-
-				cfg := getCurrentKv()
-				migrationBandwidth := resource.MustParse("40Mi")
-				cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
-				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
 
 			AfterEach(func() {
@@ -1278,77 +1277,6 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					wffcPod = nil
 				}
 			})
-
-			table.DescribeTable("should be migrated successfully, using guest agent on VM", func(mode v1.MigrationMode) {
-				memoryRequestSize := resource.MustParse(fedoraVMSize)
-				if mode == v1.MigrationPostCopy {
-					config := getCurrentKv()
-					config.MigrationConfiguration.AllowPostCopy = pointer.BoolPtr(true)
-					config.MigrationConfiguration.CompletionTimeoutPerGiB = pointer.Int64Ptr(1)
-					tests.UpdateKubeVirtConfigValueAndWait(config)
-					memoryRequestSize = resource.MustParse("1Gi")
-				}
-
-				// Start the VirtualMachineInstance with the PVC attached
-				By("Creating the  VMI")
-				vmi = tests.NewRandomVMIWithPVC(pvName)
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequestSize
-				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
-
-				// add userdata for guest agent and service account mount
-				mountSvcAccCommands := fmt.Sprintf(`#!/bin/bash
-					mkdir /mnt/servacc
-					mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') /mnt/servacc
-				`, secretDiskSerial)
-				tests.AddUserData(vmi, "cloud-init", mountSvcAccCommands)
-
-				tests.AddServiceAccountDisk(vmi, "default")
-				disks := vmi.Spec.Domain.Devices.Disks
-				disks[len(disks)-1].Serial = secretDiskSerial
-
-				vmi = runVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
-
-				// Wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
-
-				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
-
-				if mode == v1.MigrationPostCopy {
-					By("Running stress test to allow transition to post-copy")
-					runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
-				}
-
-				// execute a migration, wait for finalized state
-				By("Starting the Migration for iteration")
-				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-
-				By("Checking VMI, confirm migration state")
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
-				confirmMigrationMode(vmi, mode)
-
-				By("Is agent connected after migration")
-				tests.WaitAgentConnected(virtClient, vmi)
-
-				By("Checking that the migrated VirtualMachineInstance console has expected output")
-				Expect(console.OnPrivilegedPrompt(vmi, 60)).To(BeTrue(), "Should stay logged in to the migrated VM")
-
-				By("Checking that the service account is mounted")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "cat /mnt/servacc/namespace\n"},
-					&expect.BExp{R: util.NamespaceTestDefault},
-				}, 30)).To(Succeed(), "Should be able to access the mounted service account file")
-
-				By("Deleting the VMI")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-
-				By("Waiting for VMI to disappear")
-				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-			},
-				table.Entry("[test_id:2653] with default migration configuration", v1.MigrationPreCopy),
-				table.Entry("[QUARANTINE][test_id:5004] with postcopy", v1.MigrationPostCopy),
-			)
 
 			It("[test_id:6975] should have guest agent functional after migration", func() {
 				By("Creating the  VMI")
@@ -1574,6 +1502,90 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		})
 
 		Context("migration postcopy", func() {
+
+			var (
+				pvName string
+			)
+
+			BeforeEach(func() {
+				pvName = "test-nfs" + rand.String(48)
+
+				cfg := getCurrentKv()
+				migrationBandwidth := resource.MustParse("40Mi")
+				cfg.MigrationConfiguration.BandwidthPerMigration = &migrationBandwidth
+				tests.UpdateKubeVirtConfigValueAndWait(cfg)
+			})
+
+			table.DescribeTable("should be migrated successfully, using guest agent on VM", func(mode v1.MigrationMode) {
+				memoryRequestSize := resource.MustParse(fedoraVMSize)
+				if mode == v1.MigrationPostCopy {
+					config := getCurrentKv()
+					config.MigrationConfiguration.AllowPostCopy = pointer.BoolPtr(true)
+					config.MigrationConfiguration.CompletionTimeoutPerGiB = pointer.Int64Ptr(1)
+					tests.UpdateKubeVirtConfigValueAndWait(config)
+					memoryRequestSize = resource.MustParse("1Gi")
+				}
+
+				By("Creating the  VMI")
+				vmi := tests.NewRandomVMIWithPVC(pvName)
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequestSize
+				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+
+				// add userdata for guest agent and service account mount
+				mountSvcAccCommands := fmt.Sprintf(`#!/bin/bash
+					mkdir /mnt/servacc
+					mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') /mnt/servacc
+				`, secretDiskSerial)
+				tests.AddUserData(vmi, "cloud-init", mountSvcAccCommands)
+
+				tests.AddServiceAccountDisk(vmi, "default")
+				disks := vmi.Spec.Domain.Devices.Disks
+				disks[len(disks)-1].Serial = secretDiskSerial
+
+				vmi = runVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+
+				// Wait for cloud init to finish and start the agent inside the vmi.
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+
+				if mode == v1.MigrationPostCopy {
+					By("Running stress test to allow transition to post-copy")
+					runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
+				}
+
+				// execute a migration, wait for finalized state
+				By("Starting the Migration for iteration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+
+				By("Checking VMI, confirm migration state")
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				confirmMigrationMode(vmi, mode)
+
+				By("Is agent connected after migration")
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Checking that the migrated VirtualMachineInstance console has expected output")
+				Expect(console.OnPrivilegedPrompt(vmi, 60)).To(BeTrue(), "Should stay logged in to the migrated VM")
+
+				By("Checking that the service account is mounted")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "cat /mnt/servacc/namespace\n"},
+					&expect.BExp{R: util.NamespaceTestDefault},
+				}, 30)).To(Succeed(), "Should be able to access the mounted service account file")
+
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+			},
+				table.Entry("[test_id:2653] with default migration configuration", v1.MigrationPreCopy),
+				table.Entry("[QUARANTINE][test_id:5004] with postcopy", v1.MigrationPostCopy),
+			)
+
 			It("[QUARANTINE][test_id:4747] should migrate using cluster level config for postcopy", func() {
 				config := getCurrentKv()
 				config.MigrationConfiguration.AllowPostCopy = pointer.BoolPtr(true)


### PR DESCRIPTION
Remove MigrationsConfiguration argument from test table. Instead only pass mode and update current config accordingly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
