### PR TITLE
[release-0.41] pdb: reconcile all old pdbs

### DIFF
--- a/pkg/util/pdbs/pdbs.go
+++ b/pkg/util/pdbs/pdbs.go
@@ -29,6 +29,15 @@ func PDBsForVMI(vmi *virtv1.VirtualMachineInstance, pdbInformer cache.SharedInde
 
 func IsPDBFromOldMigrationController(pdb *v1beta1.PodDisruptionBudget) bool {
 	// The pdb might be from an old migration-controller that used to create 2-pdbs per migration
-	_, isOld := pdb.ObjectMeta.Labels[virtv1.MigrationNameLabel]
-	return isOld && strings.HasPrefix(pdb.Name, "kubevirt-migration-pdb-")
+	_, migrationLabelExists := pdb.ObjectMeta.Labels[virtv1.MigrationNameLabel]
+	if migrationLabelExists && strings.HasPrefix(pdb.Name, "kubevirt-migration-pdb-") {
+		return true
+	}
+
+	owner := v1.GetControllerOf(pdb)
+	ownedByVMI := owner != nil && owner.Kind == virtv1.VirtualMachineInstanceGroupVersionKind.Kind
+	if ownedByVMI && !migrationLabelExists && pdb.Spec.MinAvailable.IntValue() == 2 {
+		return true
+	}
+	return false
 }

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 
@@ -2014,6 +2015,40 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 						return errors.IsNotFound(err)
 					}, 60*time.Second, 500*time.Millisecond).Should(BeTrue())
 				}
+			})
+
+			It("[sig-compute]should delete PDBs created by an old virt-controller", func() {
+				By("creating the VMI")
+				createdVMI, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				By("waiting for VMI")
+				tests.WaitForSuccessfulVMIStartWithTimeout(createdVMI, 60)
+
+				By("Adding a fake old virt-controller PDB")
+				two := intstr.FromInt(2)
+				pdb, err := virtClient.PolicyV1beta1().PodDisruptionBudgets(createdVMI.Namespace).Create(context.Background(), &v1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(createdVMI, v1.VirtualMachineInstanceGroupVersionKind),
+						},
+						GenerateName: "kubevirt-disruption-budget-",
+					},
+					Spec: v1beta1.PodDisruptionBudgetSpec{
+						MinAvailable: &two,
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								v1.CreatedByLabel: string(createdVMI.UID),
+							},
+						},
+					},
+				}, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("checking that the PDB disappeared")
+				Eventually(func() bool {
+					_, err := virtClient.PolicyV1beta1().PodDisruptionBudgets(tests.NamespaceTestDefault).Get(context.Background(), pdb.Name, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				}, 60*time.Second, 1*time.Second).Should(BeTrue())
 			})
 
 			It("[test_id:3244]should block the eviction api while a slow migration is in progress", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual cherry-pick of #6723

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
remove stale pdbs created by < 0.41.1 virt-controller
```
