### PR TITLE
Fix an outdated URL in docs/update-go-version.md

### DIFF
--- a/docs/update-go-version.md
+++ b/docs/update-go-version.md
@@ -53,7 +53,4 @@ In addition, [go rules for bazel](https://github.com/bazelbuild/rules_go) have t
     ```
 * Visit [Bazel's releases page](https://github.com/bazelbuild/rules_go/releases) and check whether the current Bazel version supports the new Go version.
   * If it is not supported, replace the `io_bazel_rules_go` definition with the one provided in Bazel's page.
-* Use [project-infra's uploader tool](https://github.com/kubevirt/project-infra/blob/master/plugins/cmd/uploader/README.md) to upload new dependencies to dependency mirror.
-
-
-  
+* Use [project-infra's uploader tool](https://github.com/kubevirt/project-infra/blob/main/robots/cmd/uploader/README.md) to upload new dependencies to dependency mirror.


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix an outdated URL in docs/update-go-version.md

**Special notes for your reviewer**:
The [project-infra's uploader has been moved to robots](https://github.com/kubevirt/project-infra/pull/1466)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
