### PR TITLE
Fix spelling container -> contains

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12288,7 +12288,7 @@
     ],
     "properties": {
      "image": {
-      "description": "Image that container initrd / kernel files.",
+      "description": "Image that contains initrd / kernel files.",
       "type": "string"
      },
      "imagePullPolicy": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -4548,7 +4548,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 kernel artifacts
                               properties:
                                 image:
-                                  description: Image that container initrd / kernel
+                                  description: Image that contains initrd / kernel
                                     files.
                                   type: string
                                 imagePullPolicy:
@@ -7507,7 +7507,7 @@ var CRDsValidation map[string]string = map[string]string{
                         kernel artifacts
                       properties:
                         image:
-                          description: Image that container initrd / kernel files.
+                          description: Image that contains initrd / kernel files.
                           type: string
                         imagePullPolicy:
                           description: 'Image pull policy. One of Always, Never, IfNotPresent.
@@ -9538,7 +9538,7 @@ var CRDsValidation map[string]string = map[string]string{
                         kernel artifacts
                       properties:
                         image:
-                          description: Image that container initrd / kernel files.
+                          description: Image that contains initrd / kernel files.
                           type: string
                         imagePullPolicy:
                           description: 'Image pull policy. One of Always, Never, IfNotPresent.
@@ -11381,7 +11381,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 kernel artifacts
                               properties:
                                 image:
-                                  description: Image that container initrd / kernel
+                                  description: Image that contains initrd / kernel
                                     files.
                                   type: string
                                 imagePullPolicy:
@@ -14958,7 +14958,7 @@ var CRDsValidation map[string]string = map[string]string{
                                             that containes kernel artifacts
                                           properties:
                                             image:
-                                              description: Image that container initrd
+                                              description: Image that contains initrd
                                                 / kernel files.
                                               type: string
                                             imagePullPolicy:

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -235,7 +235,7 @@ type EFI struct {
 
 // If set, the VM will be booted from the defined kernel / initrd.
 type KernelBootContainer struct {
-	// Image that container initrd / kernel files.
+	// Image that contains initrd / kernel files.
 	Image string `json:"image"`
 	// ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.
 	//+optional

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -128,7 +128,7 @@ func (EFI) SwaggerDoc() map[string]string {
 func (KernelBootContainer) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                "If set, the VM will be booted from the defined kernel / initrd.",
-		"image":           "Image that container initrd / kernel files.",
+		"image":           "Image that contains initrd / kernel files.",
 		"imagePullSecret": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.\n+optional",
 		"imagePullPolicy": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n+optional",
 		"kernelPath":      "The fully-qualified path to the kernel image in the host OS\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -16785,7 +16785,7 @@ func schema_kubevirtio_api_core_v1_KernelBootContainer(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Image that container initrd / kernel files.",
+							Description: "Image that contains initrd / kernel files.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/openapi_generated.go
@@ -21480,7 +21480,7 @@ func schema_client_go_apis_core_v1_KernelBootContainer(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Image that container initrd / kernel files.",
+							Description: "Image that contains initrd / kernel files.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
Fix a spelling error I spotted while browsing the API docs.
