### PR TITLE
Fix certificate rotation tests

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -309,7 +309,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 			By("checking that we can still start virtual machines and connect to the VMI")
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi = tests.RunVMI(vmi, 60)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 		})
 
@@ -325,7 +325,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			By("repeatedly starting VMIs until virt-api and virt-handler certificates are updated")
 			Eventually(func() (rotated bool) {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi = tests.RunVMI(vmi, 60)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

Test with id 4099 and 4100 are not waiting for VMI to come up. 
Therefore console connection is attempted sooner than it could succeed.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Connection timeout seems to be high(180sec) but I can see the connection to virt-handler is established just before the timeout and therefore failing the test. 

**Release note**:

```release-note
None
```
