### PR TITLE
Fix DV not being deleted in AfterEach()

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1207,7 +1207,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				quantity, err := resource.ParseQuantity("5Gi")
 				Expect(err).ToNot(HaveOccurred())
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-				dv := tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dv = tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				dv.Spec.PVC.Resources.Requests["storage"] = quantity
 				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
DV is not referring to outer scope variable in BeforeEach(), instead it creates a new DV bounded to BeforeEach() sope.

This is wrong since in the AfterEach() block the DV is checked to be nil, if it is nil it's being deleted. Since we don't ever
re-assign the dv variable it is never freed (since it's always nil).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
