### PR TITLE
[migrations]: add phase and VMI name to the VMIM CLI output

### DIFF
--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -287,13 +287,19 @@ func NewVirtualMachineInstanceMigrationCrd() (*extv1.CustomResourceDefinition, e
 			},
 		},
 	}
-	err := addFieldsToAllVersions(crd, &extv1.CustomResourceSubresources{
-		Status: &extv1.CustomResourceSubresourceStatus{},
-	})
+	err := addFieldsToAllVersions(crd,
+		[]extv1.CustomResourceColumnDefinition{
+			{Name: "Phase", Type: "string", JSONPath: ".status.phase",
+				Description: "The current phase of VM instance migration"},
+			{Name: "VMI", Type: "string", JSONPath: ".spec.vmiName",
+				Description: "The name of the VMI to perform the migration on"},
+		}, &extv1.CustomResourceSubresources{
+			Status: &extv1.CustomResourceSubresourceStatus{},
+		})
+
 	if err != nil {
 		return nil, err
 	}
-
 	if err = patchValidationForAllVersions(crd); err != nil {
 		return nil, err
 	}

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -300,6 +300,7 @@ func NewVirtualMachineInstanceMigrationCrd() (*extv1.CustomResourceDefinition, e
 	if err != nil {
 		return nil, err
 	}
+
 	if err = patchValidationForAllVersions(crd); err != nil {
 		return nil, err
 	}

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -2,6 +2,10 @@ package tests_test
 
 import (
 	"strings"
+	"time"
+
+	"kubevirt.io/kubevirt/tests/console"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -138,6 +142,67 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 
+	})
+
+	Describe("VM instance migration", func() {
+		var virtClient kubecli.KubevirtClient
+
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("'kubectl get vmim'", func() {
+			It("print the expected columns and their corresponding values", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+
+				By("Starting the VirtualMachineInstance")
+				vmi = tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, tests.MigrationWaitTime, false)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+				By("creating the migration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+
+				var migrationCreated *v1.VirtualMachineInstanceMigration
+				By("starting migration")
+				Eventually(func() error {
+					migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
+					return err
+				}, tests.MigrationWaitTime, 1*time.Second).Should(Succeed(), "migration creation should succeed")
+				migration = migrationCreated
+
+				tests.ExpectMigrationSuccess(virtClient, migration, tests.MigrationWaitTime)
+
+				k8sClient := tests.GetK8sCmdClient()
+				result, _, err := tests.RunCommand(k8sClient, "get", "vmim", migration.Name)
+				// due to issue of kubectl that sometimes doesn't show CRDs on the first try, retry the same command
+				if err != nil {
+					result, _, err = tests.RunCommand(k8sClient, "get", "vmim", migration.Name)
+				}
+
+				expectedHeader := []string{"NAME", "PHASE", "VMI"}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(result)).ToNot(Equal(0))
+				resultFields := strings.Fields(result)
+
+				By("Verify that only Header is not present")
+				Expect(len(resultFields)).Should(BeNumerically(">", len(expectedHeader)))
+
+				columnHeaders := resultFields[:len(expectedHeader)]
+				By("Verify the generated header is same as expected")
+				Expect(columnHeaders).To(Equal(expectedHeader))
+
+				By("Verify VMIM name")
+				Expect(resultFields[len(expectedHeader)]).To(Equal(migration.Name), "should match VMIM object name")
+				By("Verify VMIM phase")
+				Expect(resultFields[len(expectedHeader)+1]).To(Equal(string(v1.MigrationSucceeded)), "should have successful state")
+				By("Verify VMI name related to the VMIM")
+				Expect(resultFields[len(expectedHeader)+2]).To(Equal(vmi.Name), "should match the VMI name")
+			})
+		})
 	})
 
 })


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
In a large scale environment one may find a lots of VMIM resources. When it comes to CLI it is a tedious
task to manually determine the phase of each such resource and the VMI related to it.

Therefore we expose the VMI and PHASE columns

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2017802

**Special notes for your reviewer**:

**Release note**:
```release-note
Added PHASE and VMI columns for the 'kubectl get vmim' CLI output
```
