### PR TITLE
[release-0.44] Pre-pull custom kernel / initrd as an init container

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -220,6 +220,10 @@ func GenerateKernelBootContainer(vmi *v1.VirtualMachineInstance, imageIDs map[st
 	return generateKernelBootContainerHelper(vmi, imageIDs, podVolumeName, binVolumeName, false)
 }
 
+func GenerateKernelBootInitContainer(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, podVolumeName string, binVolumeName string) *kubev1.Container {
+	return generateKernelBootContainerHelper(vmi, imageIDs, podVolumeName, binVolumeName, true)
+}
+
 func generateKernelBootContainerHelper(vmi *v1.VirtualMachineInstance, imageIDs map[string]string, podVolumeName string, binVolumeName string, isInit bool) *kubev1.Container {
 	if !util.HasKernelBootContainerImage(vmi) {
 		return nil

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1351,6 +1351,11 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 
 		// this causes containerDisks to be pre-pulled before virt-launcher starts.
 		initContainers = append(initContainers, containerdisk.GenerateInitContainers(vmi, imageIDs, "container-disks", "virt-bin-share-dir")...)
+
+		kernelBootInitContainer := containerdisk.GenerateKernelBootInitContainer(vmi, imageIDs, "container-disks", "virt-bin-share-dir")
+		if kernelBootInitContainer != nil {
+			initContainers = append(initContainers, *kernelBootInitContainer)
+		}
 	}
 
 	// TODO use constants for podLabels

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2940,10 +2940,11 @@ var _ = Describe("Template", func() {
 				Expect(pod).ToNot(BeNil())
 
 				containers := pod.Spec.Containers
-				Expect(containers).Should(HaveLen(2))
+				initContainers := pod.Spec.InitContainers
 
+				Expect(hasContainerWithName(initContainers, "container-disk-binary")).To(BeTrue())
+				Expect(hasContainerWithName(initContainers, "kernel-boot")).To(BeTrue())
 				Expect(hasContainerWithName(containers, "kernel-boot")).To(BeTrue())
-				Expect(hasContainerWithName(pod.Spec.InitContainers, "container-disk-binary")).To(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/kubevirt/kubevirt/pull/6589

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
