### PR TITLE
[release-0.46] builder: Ensure that we always have nat tables for nftables

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -131,6 +131,16 @@ pkg_tar(
     visibility = ["//visibility:public"],
 )
 
+pkg_tar(
+    name = "nftables-tar",
+    srcs = [
+        ":ipv4-nat.nft",
+        ":ipv6-nat.nft",
+    ],
+    mode = "0644",
+    package_dir = "/etc/nftables",
+)
+
 container_image(
     name = "version-container",
     directory = "/",
@@ -141,10 +151,12 @@ container_image(
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             ":passwd-tar",
+            ":nftables-tar",
             "//rpm:handlerbase_aarch64",
         ],
         "//conditions:default": [
             ":passwd-tar",
+            ":nftables-tar",
             "//rpm:handlerbase_x86_64",
         ],
     }),

--- a/cmd/virt-handler/ipv4-nat.nft
+++ b/cmd/virt-handler/ipv4-nat.nft
@@ -1,0 +1,6 @@
+table nat {
+    chain prerouting     { type nat hook prerouting priority -100; }
+    chain input          { type nat hook input priority 100; }
+    chain output         { type nat hook output priority -100; }
+    chain postrouting    { type nat hook postrouting priority 100; }
+}

--- a/cmd/virt-handler/ipv6-nat.nft
+++ b/cmd/virt-handler/ipv6-nat.nft
@@ -1,0 +1,6 @@
+table ip6 nat {
+    chain prerouting     { type nat hook prerouting priority -100; }
+    chain input          { type nat hook input priority 100; }
+    chain output         { type nat hook output priority -100; }
+    chain postrouting    { type nat hook postrouting priority 100; }
+}


### PR DESCRIPTION
Backport of https://github.com/kubevirt/kubevirt/pull/6177/commits/95db6e82b10243e64cb9b39c69d3e6c8636d4f0f
cc @rmohr 
We'll need these files if we want to switch to nftables on 4.9

CentOS stream does not ship the ipv4-*.nft files like fedora. Therefore
shipping the tables directly in the codebase. This also avoids quit
fallbacks to iptables where nftables should be used but the files where
not present.

Signed-off-by: Roman Mohr <rmohr@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
