### PR TITLE
Remove now stable tests from quarantine

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -122,7 +122,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			return duration
 		}
 
-		It("[QUARANTINE]on the controller rate limiter should lead to delayed VMI starts", func() {
+		It("on the controller rate limiter should lead to delayed VMI starts", func() {
 			By("first getting the basetime for a replicaset")
 			replicaset := tests.NewRandomReplicaSetFromVMI(libvmi.NewCirros(libvmi.WithResourceMemory("1Mi")), int32(0))
 			replicaset, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -112,7 +112,7 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		})
 
 		// libguestfs-test-tool verifies the setup to run libguestfs-tools
-		It("[QUARANTINE]Should successfully run libguestfs-test-tool", func() {
+		It("Should successfully run libguestfs-test-tool", func() {
 			f := createFakeAttacher()
 			defer f.closeChannel()
 			pvcClaim = "pvc-verify"


### PR DESCRIPTION
Guestfs test by https://github.com/kubevirt/kubevirt/pull/6739
Controller rate limiter test fixed by https://github.com/kubevirt/kubevirt/pull/6726

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
