### PR TITLE
[virtctl] Initialize the Headers field for some auth plugins

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -151,6 +151,7 @@ func RequestFromConfig(config *rest.Config, resource, name, namespace, subresour
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    u,
+		Header: map[string][]string{},
 	}
 
 	return req, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Some auth plugins seem to trip over a hil header field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6607

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix a nil pointer in virtctl in combination with some external auth plugins
```
