### PR TITLE
Write virtctl errors to stderr

### DIFF
--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -114,7 +114,7 @@ func Execute() {
 	log.InitializeLogging(programName)
 	cmd := NewVirtctlCommand()
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(cmd.Root().OutOrStdout(), strings.TrimSpace(err.Error()))
+		fmt.Fprintln(cmd.Root().ErrOrStderr(), strings.TrimSpace(err.Error()))
 		os.Exit(1)
 	}
 }

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -57,7 +57,7 @@ func OptionsUsageTemplate() string {
 func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != n {
-			fmt.Printf("fatal: Number of input parameters is incorrect, %s accepts %d arg(s), received %d\n\n", nameOfCommand, n, len(args))
+			fmt.Fprintf(os.Stderr, "fatal: Number of input parameters is incorrect, %s accepts %d arg(s), received %d\n\n", nameOfCommand, n, len(args))
 			cmd.Help()
 			return errors.New("argument validation failed")
 		}


### PR DESCRIPTION
Signed-off-by: Orel Misan <omisan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
virtctl was writing errors to stdout so errors couldn't be differentiated from regular output
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl errors are written to stderr instead of stdout
```
