### PR TITLE
Fix kubevirtci download url

### DIFF
--- a/hack/sync-kubevirtci.sh
+++ b/hack/sync-kubevirtci.sh
@@ -40,7 +40,7 @@ fi
 if [[ "$download_cluster_up" == true ]]; then
     echo "downloading cluster-up"
     rm -rf cluster-up
-    curl -L https://github.com/kubevirt/kubevirtci/archive/${kubevirtci_git_hash}/kubevirtci.tar.gz | tar xz kubevirtci-${kubevirtci_git_hash}/cluster-up --strip-component 1
+    curl --fail -L https://github.com/kubevirt/kubevirtci/archive/refs/tags/${kubevirtci_git_hash}.tar.gz | tar xz kubevirtci-${kubevirtci_git_hash}/cluster-up --strip-component 1
 
     echo ${kubevirtci_git_hash} >${version_file}
     new_sha=$(getClusterUpShasum)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When fetching kubevirtci over the old url we get a 404, so we change the
url to the one we get from the tags page. Also we add fail flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
See https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-kubevirt/1464247383884828672

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
