### PR TITLE
virt-handler, net: Extract migration validation logic

### DIFF
--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "interface.go",
+        "network.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/pkg/network/vmispec",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/kubevirt.io/api/core/v1:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "interface_test.go",
+        "vmispec_suite_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package vmispec
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func FilterSRIOVInterfaces(ifaces []v1.Interface) []v1.Interface {
+	var sriovIfaces []v1.Interface
+	for _, iface := range ifaces {
+		if iface.SRIOV != nil {
+			sriovIfaces = append(sriovIfaces, iface)
+		}
+	}
+	return sriovIfaces
+}
+
+func IsPodNetworkWithMasqueradeBindingInterface(networks []v1.Network, ifaces []v1.Interface) bool {
+	if podNetwork := lookupPodNetwork(networks); podNetwork != nil {
+		if podInterface := lookupInterfaceByNetwork(ifaces, podNetwork); podInterface != nil {
+			return podInterface.Masquerade != nil
+		}
+	}
+	return true
+}
+
+func lookupInterfaceByNetwork(ifaces []v1.Interface, network *v1.Network) *v1.Interface {
+	for _, iface := range ifaces {
+		if iface.Name == network.Name {
+			iface := iface
+			return &iface
+		}
+	}
+	return nil
+}

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package vmispec_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+var _ = Describe("VMI network spec", func() {
+
+	Context("pod network", func() {
+		const podNet0 = "podnet0"
+
+		networks := []v1.Network{podNetwork(podNet0)}
+
+		It("does not exist", func() {
+			ifaces := []v1.Interface{interfaceWithBridgeBinding(podNet0)}
+			Expect(netvmispec.IsPodNetworkWithMasqueradeBindingInterface([]v1.Network{}, ifaces)).To(BeTrue())
+		})
+
+		It("is used by a masquerade interface", func() {
+			ifaces := []v1.Interface{interfaceWithMasqueradeBinding(podNet0)}
+			Expect(netvmispec.IsPodNetworkWithMasqueradeBindingInterface(networks, ifaces)).To(BeTrue())
+		})
+
+		It("used by a non-masquerade interface", func() {
+			ifaces := []v1.Interface{interfaceWithBridgeBinding(podNet0)}
+			Expect(netvmispec.IsPodNetworkWithMasqueradeBindingInterface(networks, ifaces)).To(BeFalse())
+		})
+	})
+
+	Context("SR-IOV", func() {
+		It("finds no SR-IOV interfaces in list", func() {
+			ifaces := []v1.Interface{
+				{
+					Name:                   "net0",
+					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+				},
+				{
+					Name:                   "net1",
+					InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+				},
+			}
+
+			Expect(netvmispec.FilterSRIOVInterfaces(ifaces)).To(BeEmpty())
+		})
+
+		It("finds two SR-IOV interfaces in list", func() {
+			sriov_net1 := v1.Interface{
+				Name:                   "sriov-net1",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
+			}
+			sriov_net2 := v1.Interface{
+				Name:                   "sriov-net2",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
+			}
+
+			ifaces := []v1.Interface{
+				{
+					Name:                   "masq-net0",
+					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+				},
+				sriov_net1,
+				sriov_net2,
+			}
+
+			Expect(netvmispec.FilterSRIOVInterfaces(ifaces)).To(Equal([]v1.Interface{sriov_net1, sriov_net2}))
+		})
+	})
+})
+
+func podNetwork(name string) v1.Network {
+	return v1.Network{
+		Name:          name,
+		NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+	}
+}
+func interfaceWithBridgeBinding(name string) v1.Interface {
+	return v1.Interface{
+		Name:                   name,
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+	}
+}
+
+func interfaceWithMasqueradeBinding(name string) v1.Interface {
+	return v1.Interface{
+		Name:                   name,
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
+	}
+}

--- a/pkg/network/vmispec/network.go
+++ b/pkg/network/vmispec/network.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package vmispec
+
+import v1 "kubevirt.io/api/core/v1"
+
+func lookupPodNetwork(networks []v1.Network) *v1.Network {
+	for _, network := range networks {
+		if network.Pod != nil {
+			net := network
+			return &net
+		}
+	}
+	return nil
+}

--- a/pkg/network/vmispec/vmispec_suite_test.go
+++ b/pkg/network/vmispec/vmispec_suite_test.go
@@ -1,0 +1,11 @@
+package vmispec_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVmiSpec(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/network/cache:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/network/setup:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -50,6 +50,7 @@ import (
 
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util"
 
 	"kubevirt.io/kubevirt/pkg/virt-handler/heartbeat"
@@ -2268,48 +2269,18 @@ func (d *VirtualMachineController) isPreMigrationTarget(vmi *v1.VirtualMachineIn
 }
 
 func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
-	err := validatePodNetworkInterfaceUsesMasqueradeBinding(vmi)
-	if err != nil {
-		return err
+	ifaces := vmi.Spec.Domain.Devices.Interfaces
+	if len(ifaces) == 0 {
+		return nil
 	}
 
-	err = d.validateSRIOVInterfacesForMigration(vmi)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validatePodNetworkInterfaceUsesMasqueradeBinding(vmi *v1.VirtualMachineInstance) error {
-	interfacesByName := map[string]v1.Interface{}
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		interfacesByName[iface.Name] = iface
-	}
-
-	vmiPodNetworkName := lookupVMIPodNetworkName(vmi.Spec.Networks)
-	if vmiPodNetworkName != "" && interfacesByName[vmiPodNetworkName].Masquerade == nil {
+	if !netvmispec.IsPodNetworkWithMasqueradeBindingInterface(vmi.Spec.Networks, ifaces) {
 		return fmt.Errorf("cannot migrate VMI which does not use masquerade to connect to the pod network")
 	}
 
-	return nil
-}
-
-func lookupVMIPodNetworkName(networks []v1.Network) string {
-	for _, network := range networks {
-		if network.Pod != nil {
-			return network.Name
-		}
-	}
-
-	return ""
-}
-
-func (d *VirtualMachineController) validateSRIOVInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.SRIOV != nil && !d.clusterConfig.SRIOVLiveMigrationEnabled() {
-			return fmt.Errorf("SRIOVLiveMigration feature-gate is closed, can't migrate VMI with SRIOV interfaces")
-		}
+	sriovLiveMigrationEnabled := d.clusterConfig.SRIOVLiveMigrationEnabled()
+	if len(netvmispec.FilterSRIOVInterfaces(ifaces)) > 0 && !sriovLiveMigrationEnabled {
+		return fmt.Errorf("SRIOVLiveMigration feature-gate is closed, can't migrate VMI with SRIOV interfaces")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Extract most of the network validation logic that is done on migration to
check if it is allowed to perform the operation.

The code is moved under the network package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
