### PR TITLE
[WIP] Remove StorageClassHostPath from config.go as it is confusing

### DIFF
--- a/tests/config.go
+++ b/tests/config.go
@@ -31,8 +31,6 @@ import (
 type KubeVirtTestsConfiguration struct {
 	// StorageClass to use to create local PVCs
 	StorageClassLocal string `json:"storageClassLocal"`
-	// StorageClass to use to create host-path PVCs
-	StorageClassHostPath string `json:"storageClassHostPath"`
 	// StorageClass to use to create block-volume PVCs
 	StorageClassBlockVolume string `json:"storageClassBlockVolume"`
 	// StorageClassHostPathSeparateDevice to use to create host-path PVCs that are on a separate device from the boot device

--- a/tests/conformance-config.json
+++ b/tests/conformance-config.json
@@ -1,6 +1,5 @@
 {
     "storageClassLocal":       "local",
-    "storageClassHostPath":    "host-path",
     "storageClassBlockVolume": "block-volume",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",

--- a/tests/default-config.json
+++ b/tests/default-config.json
@@ -1,6 +1,5 @@
 {
     "storageClassLocal":       "local",
-    "storageClassHostPath":    "host-path",
     "storageClassHostPathSeparateDevice":    "host-path-sd",
     "storageClassBlockVolume": "block-volume",
     "storageClassRhel":        "rhel",


### PR DESCRIPTION
The StorageClassHostPath is confusing as it immediately invokes
thoughts of the hostpath provisioner. However it has nothing to do
with the hostpath provisioner. It is just a storage class name
to use when creating some manual hostpath based PVs and PVCs.
The only test that really cares it is a hostpath is the hotplug test
because it is testing locating the right path if it is hostpath.
So we remove this field, and replace usage of it with the
standard storage class. In the hotplug case we confine the logic
of creating the SC/PV/PVC in the test.

Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
