### PR TITLE
Fix image upload with force-bind flag

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -445,7 +445,7 @@ func waitDvUploadScheduled(client kubecli.KubevirtClient, namespace, name string
 			return false, err
 		}
 
-		if dv.Status.Phase == cdiv1.WaitForFirstConsumer {
+		if dv.Status.Phase == cdiv1.WaitForFirstConsumer && !forceBind {
 			return false, fmt.Errorf("cannot upload to DataVolume in WaitForFirstConsumer state, make sure the PVC is Bound")
 		}
 		// TODO: can check Condition/Event here to provide user with some error messages

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -201,6 +201,9 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 
 	Context("Create upload volume with force-bind flag", func() {
 		DescribeTable("Should succeed", func(resource, targetName string, validateFunc func(string), deleteFunc func(string)) {
+			if !tests.HasBindingModeWaitForFirstConsumer() {
+				Skip("Skip no local wffc storage class available")
+			}
 			defer deleteFunc(targetName)
 
 			By("Upload image")
@@ -209,8 +212,9 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 				"--namespace", util.NamespaceTestDefault,
 				"--image-path", imagePath,
 				"--size", pvcSize,
+				"--storage-class", tests.Config.StorageClassLocal,
+				"--access-mode", "ReadWriteOnce",
 				"--force-bind",
-				"--block-volume",
 				"--insecure")
 
 			Expect(virtctlCmd()).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adapts the tests to run in environments without ceph. It fixes CI failures in cgroup v2 periodic job: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-cgroupsv2/1464383532250959872

Additionally the PR fixes `virtctl image-upload` command with `--force-bind` flag: previously the flag wan't checked for DataVolumes causing an error if the phase was `WaitForFirstConsumer` (while the flag description states that WaitForFirstConsumer logic is supposed to be ignored) .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
