### PR TITLE
Add full Podman support for `make` and `make test` instead of hard-coded docker

### DIFF
--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-source ../common.sh
+source $(dirname "$0")/../common.sh
 
 SCRIPT_DIR="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+source ../common.sh
+
 SCRIPT_DIR="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd
@@ -9,7 +11,7 @@ SCRIPT_DIR="$(
 # shellcheck source=hack/builder/version.sh
 . "${SCRIPT_DIR}/version.sh"
 
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+${KUBEVIRT_CRI} run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 for ARCH in ${ARCHITECTURES}; do
     case ${ARCH} in
@@ -26,7 +28,7 @@ for ARCH in ${ARCHITECTURES}; do
         bazel_arch=${ARCH}
         ;;
     esac
-    docker pull --platform="linux/${ARCH}" quay.io/centos/centos:stream8
-    docker build --platform="linux/${ARCH}" -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+    ${KUBEVIRT_CRI} pull --platform="linux/${ARCH}" quay.io/centos/centos:stream8
+    ${KUBEVIRT_CRI} build --platform="linux/${ARCH}" -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
     TMP_IMAGES="${TMP_IMAGES} quay.io/kubevirt/builder:${VERSION}-${ARCH}"
 done

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -3,6 +3,8 @@ set -ex
 
 source $(dirname "$0")/../common.sh
 
+fail_if_cri_bin_missing
+
 SCRIPT_DIR="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd

--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-source ../common.sh
+source $(dirname "$0")/../common.sh
 
 SCRIPT_DIR="$(
     cd "$(dirname "$BASH_SOURCE[0]")"

--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -3,6 +3,8 @@ set -ex
 
 source $(dirname "$0")/../common.sh
 
+fail_if_cri_bin_missing
+
 SCRIPT_DIR="$(
     cd "$(dirname "$BASH_SOURCE[0]")"
     pwd

--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+source ../common.sh
+
 SCRIPT_DIR="$(
     cd "$(dirname "$BASH_SOURCE[0]")"
     pwd
@@ -17,10 +19,10 @@ cleanup() {
 cleanup
 
 for ARCH in ${ARCHITECTURES}; do
-    docker push quay.io/kubevirt/builder:${VERSION}-${ARCH}
+    ${KUBEVIRT_CRI} push quay.io/kubevirt/builder:${VERSION}-${ARCH}
     TMP_IMAGES="${TMP_IMAGES} quay.io/kubevirt/builder:${VERSION}-${ARCH}"
 done
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-docker manifest create --amend quay.io/kubevirt/builder:${VERSION} ${TMP_IMAGES}
-docker manifest push quay.io/kubevirt/builder:${VERSION}
+${KUBEVIRT_CRI} manifest create --amend quay.io/kubevirt/builder:${VERSION} ${TMP_IMAGES}
+${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+determine_cri_bin() {
+    if [ "${KUBEVIRT_CRI}" = "podman" ]; then
+        echo podman
+    elif [ "${KUBEVIRT_CRI}" = "docker" ]; then
+        echo docker
+    else
+        if podman ps >/dev/null 2>&1; then
+            echo podman
+        elif docker ps >/dev/null 2>&1; then
+            echo docker
+        else
+            echo >&2 "no working container runtime found. Neither docker nor podman seems to work."
+            exit 1
+        fi
+    fi
+}
+
 if [ -f cluster-up/hack/common.sh ]; then
     source cluster-up/hack/common.sh
 fi
@@ -25,6 +42,7 @@ ARCHITECTURE="${BUILD_ARCH:-$(uname -m)}"
 HOST_ARCHITECTURE="$(uname -m)"
 KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 OPERATOR_MANIFEST_PATH=$MANIFESTS_OUT_DIR/release/kubevirt-operator.yaml
+export KUBEVIRT_CRI="$(determine_cri_bin)"
 
 function build_func_tests() {
     mkdir -p "${TESTS_OUT_DIR}/"
@@ -39,7 +57,7 @@ function build_func_tests_image() {
         ${TESTS_OUT_DIR}/
     rsync -ar ${KUBEVIRT_DIR}/manifests/ ${TESTS_OUT_DIR}/manifests
     cd ${TESTS_OUT_DIR}
-    docker build \
+    ${KUBEVIRT_CRI} build \
         -t ${docker_prefix}/${bin_name}:${docker_tag} \
         --label ${job_prefix} \
         --label ${bin_name} .

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -42,7 +42,7 @@ ARCHITECTURE="${BUILD_ARCH:-$(uname -m)}"
 HOST_ARCHITECTURE="$(uname -m)"
 KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 OPERATOR_MANIFEST_PATH=$MANIFESTS_OUT_DIR/release/kubevirt-operator.yaml
-export KUBEVIRT_CRI="$(determine_cri_bin)"
+KUBEVIRT_CRI="$(determine_cri_bin)"
 
 function build_func_tests() {
     mkdir -p "${TESTS_OUT_DIR}/"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -11,9 +11,15 @@ determine_cri_bin() {
         elif docker ps >/dev/null 2>&1; then
             echo docker
         else
-            echo >&2 "no working container runtime found. Neither docker nor podman seems to work."
-            exit 1
+            echo ""
         fi
+    fi
+}
+
+fail_if_cri_bin_missing() {
+    if [ -z "${KUBEVIRT_CRI}" ]; then
+        echo >&2 "no working container runtime found. Neither docker nor podman seems to work."
+        exit 1
     fi
 }
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -146,7 +146,8 @@ fi
 
 # Run the command
 test -t 1 && USE_TTY="-it"
-if ! $KUBEVIRT_CRI exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "KUBEVIRT_CRI=${KUBEVIRT_CRI} && $@"; then
+EXEC_ENV_VARS="--env KUBEVIRT_CRI=${KUBEVIRT_CRI}"
+if ! $KUBEVIRT_CRI exec $EXEC_ENV_VARS ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "$@"; then
     # Copy the build output out of the container, make sure that _out exactly matches the build result
     if [ "$SYNC_OUT" = "true" ]; then
         _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/out" ${OUT_DIR}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -5,6 +5,8 @@ set -e
 # Bootstrapping should be done inside the build container
 source $(dirname "$0")/common.sh
 
+fail_if_cri_bin_missing
+
 if [ "${KUBEVIRT_RUN_UNNESTED}" == "true" ]; then
     /bin/bash -c "$@"
     exit $?

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -10,20 +10,6 @@ if [ "${KUBEVIRT_RUN_UNNESTED}" == "true" ]; then
     exit $?
 fi
 
-# Select an available container runtime
-if [ -z ${KUBEVIRT_CRI} ]; then
-    if podman ps >/dev/null; then
-        KUBEVIRT_CRI=podman
-        echo "selecting podman as container runtime"
-    elif docker ps >/dev/null; then
-        KUBEVIRT_CRI=docker
-        echo "selecting docker as container runtime"
-    else
-        echo "no working container runtime found. Neither docker nor podman seems to work."
-        exit 1
-    fi
-fi
-
 KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2109081533-c2a4c43a6"
 
 SYNC_OUT=${SYNC_OUT:-true}
@@ -160,7 +146,7 @@ fi
 
 # Run the command
 test -t 1 && USE_TTY="-it"
-if ! $KUBEVIRT_CRI exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "$@"; then
+if ! $KUBEVIRT_CRI exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "KUBEVIRT_CRI=${KUBEVIRT_CRI} && $@"; then
     # Copy the build output out of the container, make sure that _out exactly matches the build result
     if [ "$SYNC_OUT" = "true" ]; then
         _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/out" ${OUT_DIR}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -5,12 +5,12 @@ set -e
 # Bootstrapping should be done inside the build container
 source $(dirname "$0")/common.sh
 
-fail_if_cri_bin_missing
-
 if [ "${KUBEVIRT_RUN_UNNESTED}" == "true" ]; then
     /bin/bash -c "$@"
     exit $?
 fi
+
+fail_if_cri_bin_missing
 
 KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2109081533-c2a4c43a6"
 

--- a/hack/func-tests-image.sh
+++ b/hack/func-tests-image.sh
@@ -12,5 +12,5 @@ if [ "${target}" = "build" ]; then
 fi
 
 if [ "${target}" = "push" ]; then
-    docker push ${docker_prefix}/tests:${docker_tag}
+    ${KUBEVIRT_CRI} push ${docker_prefix}/tests:${docker_tag}
 fi

--- a/hack/func-tests-image.sh
+++ b/hack/func-tests-image.sh
@@ -5,6 +5,7 @@ set -e
 source hack/common.sh
 source hack/config.sh
 
+fail_if_cri_bin_missing
 target=$1
 
 if [ "${target}" = "build" ]; then

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -16,6 +16,8 @@
 # Copyright 2020 Red Hat, Inc.
 #
 
+source ../common.sh
+
 readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
 
 function cleanup() {
@@ -29,7 +31,7 @@ function cleanup() {
 function lint() {
     local target_file="${1:?}"
 
-    docker run --rm --entrypoint=/bin/promtool \
+    ${KUBEVIRT_CRI} run --rm --entrypoint=/bin/promtool \
         -v "$target_file":/tmp/rules.verify:ro "$PROM_IMAGE" \
         check rules /tmp/rules.verify
 }
@@ -38,7 +40,7 @@ function unit_test() {
     local target_file="${1:?}"
     local tests_file="${2:?}"
 
-    docker run --rm --entrypoint=/bin/promtool \
+    ${KUBEVIRT_CRI} run --rm --entrypoint=/bin/promtool \
         -v "$tests_file":/tmp/rules.test:ro \
         -v "$target_file":/tmp/rules.verify:ro \
         "$PROM_IMAGE" \

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -18,6 +18,7 @@
 
 source $(dirname "$0")/../common.sh
 
+fail_if_cri_bin_missing
 readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
 
 function cleanup() {

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -16,7 +16,7 @@
 # Copyright 2020 Red Hat, Inc.
 #
 
-source ../common.sh
+source $(dirname "$0")/../common.sh
 
 readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source common.sh
+
 set -e
 
 if [ -z ${GPG_PRIVATE_KEY_FILE} ]; then
@@ -19,9 +21,9 @@ GIT_EMAIL=${GIT_EMAIL:-$(git config user.email)}
 echo "git user:  $GIT_USER"
 echo "git email: $GIT_EMAIL"
 
-docker pull quay.io/kubevirtci/release-tool:latest
+${KUBEVIRT_CRI} pull quay.io/kubevirtci/release-tool:latest
 
-echo "docker run -it --rm \
+echo "${KUBEVIRT_CRI} run -it --rm \
 -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
 -v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase \
 -v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token \
@@ -32,7 +34,7 @@ kubevirtci/release-tool:latest \
 --git-user \"${GIT_USER}\"
 \"$@\""
 
-docker run -it --rm \
+${KUBEVIRT_CRI} run -it --rm \
     -v ${GPG_PRIVATE_KEY_FILE}:/home/releaser/gpg-private \
     -v ${GPG_PASSPHRASE_FILE}:/home/releaser/gpg-passphrase \
     -v ${GITHUB_API_TOKEN_FILE}:/home/releaser/github-api-token \

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -4,6 +4,8 @@ source common.sh
 
 set -e
 
+fail_if_cri_bin_missing
+
 if [ -z ${GPG_PRIVATE_KEY_FILE} ]; then
     echo "GPG_PRIVATE_KEY_FILE env var must be set"
     exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses `determine_cri_bin()` function, which is now defined in `hack/common.sh` to dynamically discover right CRI to use if `KUBEVIRT_CRI` environment variable is not defined. Also, all hard-coded `docker` calls under `hack/` directory are now replaced with `${KUBEVIRT_CRI}`.

This allows Kubevirt developers to be able to develop either in Podman or in Docker to their choosing.

PR is tested to being able to perform `make` and `make test` in an environment without docker installed and without defining `KUBEVIRT_CRI` explicitly.

Note: `make cluster-up` and `make cluster-sync` are still not supported. In order to support Podman there as well further changes in CI are required (for example, https://github.com/kubevirt/kubevirtci/blob/main/cluster-provision/gocli/cmd/run.go uses docker explicitly, which is used in `quay.io/kubevirtci/k8s-1.XX`)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add full Podman support for `make` and `make test`
```
