### PR TITLE
tests, SR-IOV: Shorten tests SR-IOV NIC name

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -72,7 +72,7 @@ const (
 const (
 	sriovnet1           = "sriov"
 	sriovnet2           = "sriov2"
-	sriovnetLinkEnabled = "sriov-link-enabled"
+	sriovnetLinkEnabled = "sriov-linked"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We see errors on CI due to cloud-init fails to configure the SR-IOV network interface name on connectivity tests because its not valid [SearchCI](https://search.ci.kubevirt.io/?search=sriov-link-enabled%3A+Unexpected+error+while+running+command.&maxAge=336h&context=2&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job).
This PR rename the SR-IOV test network interfaces to valid one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Network interface name length can be up to 15 characters.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
