### PR TITLE
Add severity for outdated workload alert

### DIFF
--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -570,6 +570,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 				"summary":     "Some running VMIs are still active in outdated pods after KubeVirt control plane update has completed.",
 				"runbook_url": runbookUrlBasePath + "OutdatedVirtualMachineInstanceWorkloads",
 			},
+			Labels: map[string]string{
+				"severity": "warning",
+			},
 		})
 	}
 


### PR DESCRIPTION

Adds a severity (warning) to the alert that fires after workloads  are not updated over 24 hours. 

```release-note
NONE
```
