### PR TITLE
docs: Elaborate more on disk expansion usage and why-nots

### DIFF
--- a/docs/disk-expansion.md
+++ b/docs/disk-expansion.md
@@ -49,4 +49,5 @@ will be unlinked and garbage-collected by kubernetes once the import is done.
 They are not expected to continue to be used after the import is done.
 
 If you wish to track the current PVC size for a given `VirtualMachineInstance` without finding the
-matching PVC, you can inspect the `vmi.status.volumeStatus` `PersistentVolumeClaimInfo` field.
+matching PVC, you can inspect the `vmi.status.volumeStatus` `PersistentVolumeClaimInfo` field.  
+This field is kept up to date with the PVC spec request size and the PVC status capacity.

--- a/docs/disk-expansion.md
+++ b/docs/disk-expansion.md
@@ -1,5 +1,7 @@
 # Disk expansion
 
+## Enabling
+
 For some storage methods, Kubernetes may support expanding storage in-use (allowVolumeExpansion feature).
 KubeVirt can respond to it by making the additional storage available for the virtual machines.
 This feature is currently off by default, and requires enabling a feature gate.
@@ -17,3 +19,13 @@ spec:
 Enabling this feature does two things:
 - Notify the virtual machine about size changes
 - If the disk is a Filesystem PVC, the matching file is expanded to the remaining size (while reserving some space for file system overhead).
+
+## Usage
+
+To expand a disk, edit the matching PersistentVolumeClaim:
+
+`kubectl edit pvc my-disk-pvc`
+
+And increase the spec.resource.requests.storage to a larger size.
+A running VMI will be notified that the disk has been expanded.
+File systems remain unchanged - they need to be expanded to use the remaining data.

--- a/docs/disk-expansion.md
+++ b/docs/disk-expansion.md
@@ -29,3 +29,24 @@ To expand a disk, edit the matching PersistentVolumeClaim:
 And increase the spec.resource.requests.storage to a larger size.
 A running VMI will be notified that the disk has been expanded.
 File systems remain unchanged - they need to be expanded to use the remaining data.
+
+## Why do we not expand file systems?
+
+An operating system may do its own caching of disk writes, and to expand a file
+system we need to write to portions of the disk that are already in use. This
+may result in corrupt data, unless the operating system expects this kind of
+operation to happen.
+
+For this reason we do not increase the file system size automatically.
+
+## Why is the DataVolume size and the VirtualMachine size unchanged?
+
+The DataVolume and VirtualMachine specs are currently immutable and are not updated to match the
+growing PersistentVolumeClaim.
+
+Additionally, DataVolumes are predecessors to PVC populators (still in progress), and in the future,
+will be unlinked and garbage-collected by kubernetes once the import is done.  
+They are not expected to continue to be used after the import is done.
+
+If you wish to track the current PVC size for a given VirtualMachineInstance without finding the
+matching PVC, you can inspect the vmi.status.volumeStatus PersistentVolumeClaimInfo field.

--- a/docs/disk-expansion.md
+++ b/docs/disk-expansion.md
@@ -26,7 +26,7 @@ To expand a disk, edit the matching PersistentVolumeClaim:
 
 `kubectl edit pvc my-disk-pvc`
 
-And increase the spec.resource.requests.storage to a larger size.
+And increase the `spec.resource.requests.storage` to a larger size.
 A running VMI will be notified that the disk has been expanded.
 File systems remain unchanged - they need to be expanded to use the remaining data.
 
@@ -48,5 +48,5 @@ Additionally, DataVolumes are predecessors to PVC populators (still in progress)
 will be unlinked and garbage-collected by kubernetes once the import is done.  
 They are not expected to continue to be used after the import is done.
 
-If you wish to track the current PVC size for a given VirtualMachineInstance without finding the
-matching PVC, you can inspect the vmi.status.volumeStatus PersistentVolumeClaimInfo field.
+If you wish to track the current PVC size for a given `VirtualMachineInstance` without finding the
+matching PVC, you can inspect the `vmi.status.volumeStatus` `PersistentVolumeClaimInfo` field.

--- a/docs/disk-expansion.md
+++ b/docs/disk-expansion.md
@@ -27,7 +27,7 @@ To expand a disk, edit the matching PersistentVolumeClaim:
 `kubectl edit pvc my-disk-pvc`
 
 And increase the `spec.resource.requests.storage` to a larger size.
-A running VMI will be notified that the disk has been expanded.
+A running guest will then be notified of the capacity change using block layer commands (for example, a SCSI disk will be sent a "capacity data has changed" message).
 File systems remain unchanged - they need to be expanded to use the remaining data.
 
 ## Why do we not expand file systems?


### PR DESCRIPTION
It had occurred to me that many people may be wondering why looking at the DV size is more invalid than it was before, or the VM size request, so I should document what were the motivations for this decision.
While here document why file systems are not expanded (I hear it's possible in some scenarios with guestfs, though), which is another question I heard.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve documentation for disk expansion
```
