### PR TITLE
Add common labels into alert definitions

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -24,6 +24,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
               pod: "virt-controller-8546c99968-x9jgg"
               container: "virt-controller"
               namespace: ci
@@ -48,6 +50,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedMemory"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
               namespace: ci
               node: "node1"
               pod: "virt-controller-8546c99968-x9jgg"
@@ -84,6 +88,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 10m
         alertname: VirtControllerDown
         exp_alerts:
@@ -92,6 +98,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 10m
         alertname: VirtOperatorDown
         exp_alerts:
@@ -100,6 +108,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       # it must trigger when operators are not healthy
       - eval_time: 16m
         alertname: VirtAPIDown
@@ -109,6 +119,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 16m
         alertname: VirtControllerDown
         exp_alerts:
@@ -117,6 +129,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 16m
         alertname: VirtOperatorDown
         exp_alerts:
@@ -125,6 +139,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       # it must not trigger when operators are healthy
       - eval_time: 17m
         alertname: VirtAPIDown
@@ -162,6 +178,8 @@ tests:
               node: "node01"
               pod: "virt-handler-asdf"
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # Some virt controllers are not ready
   - interval: 1m
@@ -184,6 +202,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtControllersCount"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # All virt controllers are not ready
   - interval: 1m
@@ -204,6 +224,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # All virt operators are not ready
   - interval: 1m
@@ -224,6 +246,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
             exp_labels:
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # High REST errors
   - interval: 1m
@@ -255,6 +279,8 @@ tests:
             exp_labels:
               pod: "virt-controller-1"
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtControllerRESTErrorsBurst
         exp_alerts:
@@ -264,6 +290,8 @@ tests:
             exp_labels:
               pod: "virt-controller-1"
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtOperatorRESTErrorsHigh
         exp_alerts:
@@ -273,6 +301,8 @@ tests:
             exp_labels:
               pod: "virt-operator-1"
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtOperatorRESTErrorsBurst
         exp_alerts:
@@ -282,6 +312,8 @@ tests:
             exp_labels:
               pod: "virt-operator-1"
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtHandlerRESTErrorsHigh
         exp_alerts:
@@ -291,6 +323,8 @@ tests:
             exp_labels:
               pod: "virt-handler-1"
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtHandlerRESTErrorsBurst
         exp_alerts:
@@ -300,6 +334,8 @@ tests:
             exp_labels:
               pod: "virt-handler-1"
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtApiRESTErrorsHigh
         exp_alerts:
@@ -308,6 +344,8 @@ tests:
             exp_labels:
               pod: "virt-api-1"
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
       - eval_time: 5m
         alertname: VirtApiRESTErrorsBurst
         exp_alerts:
@@ -316,6 +354,8 @@ tests:
             exp_labels:
               pod: "virt-api-1"
               severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # Some nodes without KVM resources
   - interval: 1m
@@ -335,6 +375,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # All nodes without KVM resources
   - interval: 1m
@@ -354,6 +396,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # Two nodes with KVM resources
   - interval: 1m
@@ -386,6 +430,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
               container: "compute"
 
@@ -418,6 +464,8 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMCannotBeEvicted"
             exp_labels:
               severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
               name: "vm-evict-nonmigratable"
               namespace: "ns-test"
               node: "node1"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -9,10 +9,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const KUBEVIRT_PROMETHEUS_RULE_NAME = "prometheus-kubevirt-rules"
-const prometheusLabelKey = "prometheus.kubevirt.io"
-const prometheusLabelValue = "true"
-const runbookUrlBasePath = "https://kubevirt.io/monitoring/runbooks/"
+const (
+	KUBEVIRT_PROMETHEUS_RULE_NAME = "prometheus-kubevirt-rules"
+	prometheusLabelKey            = "prometheus.kubevirt.io"
+	prometheusLabelValue          = "true"
+	runbookUrlBasePath            = "https://kubevirt.io/monitoring/runbooks/"
+	severityAlertLabelKey         = "severity"
+	partOfAlertLabelKey           = "kubernetes_operator_part_of"
+	partOfAlertLabelValue         = "kubevirt"
+	componentAlertLabelKey        = "kubernetes_operator_component"
+	componentAlertLabelValue      = "kubevirt"
+)
 
 func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkipVerify bool) *v1.ServiceMonitor {
 	return &v1.ServiceMonitor{
@@ -98,7 +105,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtAPIDown",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -114,7 +121,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowVirtAPICount",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -131,7 +138,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowKVMNodesCount",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -155,7 +162,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowReadyVirtControllersCount",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -167,7 +174,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "NoReadyVirtController",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -179,7 +186,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtControllerDown",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -191,7 +198,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowVirtControllersCount",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -227,7 +234,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -239,7 +246,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -257,7 +264,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtOperatorDown",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -269,7 +276,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowVirtOperatorCount",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -305,7 +312,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -317,7 +324,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -341,7 +348,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowReadyVirtOperatorsCount",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -353,7 +360,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "NoReadyVirtOperator",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -365,7 +372,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "NoLeadingVirtOperator",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -384,7 +391,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtHandlerDaemonSetRolloutFailing",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -420,7 +427,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -432,7 +439,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -467,7 +474,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"summary": getRestCallsFailedWarning(5, "virt-api", "hour"),
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -478,7 +485,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"summary": getRestCallsFailedWarning(80, "virt-api", "5 minutes"),
 						},
 						Labels: map[string]string{
-							"severity": "critical",
+							severityAlertLabelKey: "critical",
 						},
 					},
 					{
@@ -495,7 +502,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubevirtVmHighMemoryUsage",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -511,7 +518,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "OrphanedVirtualMachineImages",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -524,7 +531,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VMCannotBeEvicted",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -537,7 +544,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedMemory",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 					{
@@ -552,7 +559,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedCPU",
 						},
 						Labels: map[string]string{
-							"severity": "warning",
+							severityAlertLabelKey: "warning",
 						},
 					},
 				},
@@ -571,9 +578,19 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 				"runbook_url": runbookUrlBasePath + "OutdatedVirtualMachineInstanceWorkloads",
 			},
 			Labels: map[string]string{
-				"severity": "warning",
+				severityAlertLabelKey: "warning",
 			},
 		})
+	}
+
+	for _, group := range ruleSpec.Groups {
+		for _, rule := range group.Rules {
+			if rule.Alert == "" {
+				continue
+			}
+			rule.Labels[partOfAlertLabelKey] = partOfAlertLabelValue
+			rule.Labels[componentAlertLabelKey] = componentAlertLabelValue
+		}
 	}
 
 	return ruleSpec


### PR DESCRIPTION
We want to be able to list all kubevirt alerts so we added labels to
differentiate them.

Signed-off-by: assafad <aadmi@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added common labels into alert definitions
```
