### PR TITLE
tests suite reporter: Dump vfio devices mode

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1004,6 +1004,7 @@ func (r *KubernetesReporter) executeNodeCommands(virtCli kubecli.KubevirtClient,
 		{command: networkPrefix + "nft list ruleset", fileNameSuffix: "nftlist"},
 
 		{command: hostPrefix + "/usr/bin/" + networkPrefix + "/usr/sbin/iptables --list -v", fileNameSuffix: "iptables"},
+		{command: "ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}
 
 	r.executeContainerCommands(virtCli, logsdir, &pod, "virt-handler", cmds)
@@ -1019,6 +1020,7 @@ func (r *KubernetesReporter) executeVirtLauncherCommands(virtCli kubecli.Kubevir
 		{command: "bridge fdb", fileNameSuffix: "brfdb"},
 		{command: "lspci", fileNameSuffix: "lspci"},
 		{command: "env", fileNameSuffix: "env"},
+		{command: "ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}
 
 	r.executeContainerCommands(virtCli, logsdir, &pod, "compute", cmds)


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With this PR test suite reporter will dump cluster nodes and virt-launcher pods `/dev/vfio/` content status from failing tests
and save them at `artifacts/network/nodes` and `artifacts/network/pods` respectively.

Having those logs will help debugging failing tests due to VM's that fail to start because missing permissions to `/dev/vfio/vfio`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR changes will help with working on #6771

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
