### PR TITLE
Fix pseudo version generation for kubevirt.io/api

### DIFF
--- a/hack/publish-staging.sh
+++ b/hack/publish-staging.sh
@@ -65,7 +65,7 @@ function get_pseudo_tag() {
     NAME=$1
     API_REF_DIR=/tmp/${NAME}
     pushd ${API_REF_DIR} >/dev/null
-    echo "v0.0.0-$(date -u +%Y%M%d%H%M%S)-$(git rev-parse --short=12 HEAD)"
+    echo "v0.0.0-$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")-$(git rev-parse --short=12 HEAD)"
     popd >/dev/null
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Generate the pseudo version for kubevirt.io/api which is used in kubevirt.io/client-go the correct way to avoid `go mod` errors due to a wrong timestamp in the pseudo version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
