### PR TITLE
Adjust file names to use parallelnode

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -22,7 +22,7 @@ package tests_test
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -53,14 +53,14 @@ func TestTests(t *testing.T) {
 	flags.NormalizeFlags()
 	tests.CalculateNamespaces()
 	maxFails := getMaxFailsFromEnv()
-	artifactsPath := path.Join(flags.ArtifactsDir, "k8s-reporter")
-	junitOutput := path.Join(flags.ArtifactsDir, "junit.functest.xml")
+	artifactsPath := filepath.Join(flags.ArtifactsDir, "k8s-reporter")
+	junitOutput := filepath.Join(flags.ArtifactsDir, "junit.functest.xml")
 	if qe_reporters.JunitOutput != "" {
 		junitOutput = qe_reporters.JunitOutput
 	}
 	if config.GinkgoConfig.ParallelTotal > 1 {
-		artifactsPath = path.Join(artifactsPath, strconv.Itoa(config.GinkgoConfig.ParallelNode))
-		junitOutput = path.Join(flags.ArtifactsDir, fmt.Sprintf("partial.junit.functest.%d.xml", config.GinkgoConfig.ParallelNode))
+		artifactsPath = filepath.Join(artifactsPath, strconv.Itoa(config.GinkgoConfig.ParallelNode))
+		junitOutput = filepath.Join(flags.ArtifactsDir, fmt.Sprintf("partial.junit.functest.%d.xml", config.GinkgoConfig.ParallelNode))
 	}
 
 	outputEnricherReporter := reporter.NewCapturedOutputEnricher(
@@ -73,6 +73,9 @@ func TestTests(t *testing.T) {
 		k8sReporter,
 	}
 	if qe_reporters.Polarion.Run {
+		if config.GinkgoConfig.ParallelTotal > 1 {
+			qe_reporters.Polarion.Filename = filepath.Join(flags.ArtifactsDir, fmt.Sprintf("partial.polarion.functest.%d.xml", config.GinkgoConfig.ParallelNode))
+		}
 		reporters = append(reporters, &qe_reporters.Polarion)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The filenames need to be separate for the test processes that are
started so they don't overwrite each other. This needs to be done for
both the junit result files and the polarion result files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
