### PR TITLE
Add release-note NONE to bump rpm-deps script

### DIFF
--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -301,3 +301,5 @@ if [ -z "${SINGLE_ARCH}" ] || [ "${SINGLE_ARCH}" == "aarch64" ]; then
     rm ${SANDBOX_DIR} -rf
     kubevirt::bootstrap::regenerate aarch64
 fi
+
+echo '```release-note\nNONE\n```'


### PR DESCRIPTION
**Special notes for your reviewer**:
Somewhat blind change. May not work as expected.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
