### PR TITLE
[Bug fix]: Unscheduable host-model VMI alert is not triggered 

### DIFF
--- a/tests/migration.go
+++ b/tests/migration.go
@@ -50,15 +50,21 @@ func expectMigrationSuccessWithOffset(offset int, virtClient kubecli.KubevirtCli
 
 func RunMigrationAndExpectCompletion(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) string {
 	By("Starting a Migration")
+	migration = RunMigration(virtClient, migration, timeout)
+
+	return ExpectMigrationSuccess(virtClient, migration, timeout)
+}
+
+func RunMigration(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) *v1.VirtualMachineInstanceMigration {
+	By("Starting a Migration")
 	var err error
 	var migrationCreated *v1.VirtualMachineInstanceMigration
 	Eventually(func() error {
 		migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
 		return err
 	}, timeout, 1*time.Second).Should(Succeed(), "migration creation should succeed")
-	migration = migrationCreated
 
-	return ExpectMigrationSuccess(virtClient, migration, timeout)
+	return migrationCreated
 }
 
 func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, migrationUID string) *v1.VirtualMachineInstance {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"sync"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	virthandler "kubevirt.io/kubevirt/pkg/virt-handler"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -2300,6 +2302,101 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				Expect(isModelSupportedOnNode(newNode, hostModel)).To(BeTrue(), "original host model should be supported on new node")
 				expectFeatureToBeSupportedOnNode(newNode, requiredFeatures)
 			})
+
+			Context("[Serial]Should trigger event", func() {
+
+				var originalNodeLabels map[string]string
+				var originalNodeAnnotations map[string]string
+				var vmi *v1.VirtualMachineInstance
+				var node *k8sv1.Node
+
+				copyMap := func(originalMap map[string]string) map[string]string {
+					newMap := make(map[string]string, len(originalMap))
+
+					for key, value := range originalMap {
+						newMap[key] = value
+					}
+
+					return newMap
+				}
+
+				BeforeEach(func() {
+					By("Creating a VMI with default CPU mode")
+					vmi = cirrosVMIWithEvictionStrategy()
+					vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+
+					By("Starting the VirtualMachineInstance")
+					vmi = runVMIAndExpectLaunch(vmi, 240)
+
+					By("Saving the original node's state")
+					node, err = virtClient.CoreV1().Nodes().Get(context.Background(), vmi.Status.NodeName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					originalNodeLabels = copyMap(node.Labels)
+					originalNodeAnnotations = copyMap(node.Annotations)
+
+					node = disableNodeLabeller(node, virtClient)
+				})
+
+				AfterEach(func() {
+					By("Restore node to its original state")
+					node.Labels = originalNodeLabels
+					node.Annotations = originalNodeAnnotations
+					node, err = virtClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Eventually(func() map[string]string {
+						node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+
+						return node.Labels
+					}, 10*time.Second, 1*time.Second).Should(Equal(originalNodeLabels), "Node should have fake host model")
+					Expect(node.Annotations).To(Equal(originalNodeAnnotations))
+				})
+
+				It("when no node is suited for host model", func() {
+					By("Changing node labels to support fake host model")
+					// Remove all supported host models
+					for key, _ := range node.Labels {
+						if strings.HasPrefix(key, v1.HostModelCPULabel) {
+							delete(node.Labels, key)
+						}
+					}
+					node.Labels[v1.HostModelCPULabel+"fake-model"] = "true"
+
+					node, err = virtClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Eventually(func() bool {
+						node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+
+						labelValue, ok := node.Labels[v1.HostModelCPULabel+"fake-model"]
+						return ok && labelValue == "true"
+					}, 10*time.Second, 1*time.Second).Should(BeTrue(), "Node should have fake host model")
+
+					By("Starting the migration")
+					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+					_ = tests.RunMigration(virtClient, migration, tests.MigrationWaitTime)
+
+					By("Expecting for an alert to be triggered")
+					Eventually(func() []k8sv1.Event {
+						//var hostModelEvents []k8sv1.Event
+
+						events, err := virtClient.CoreV1().Events(vmi.Namespace).List(
+							context.Background(),
+							metav1.ListOptions{
+								FieldSelector: fmt.Sprintf("type=%s,reason=%s", k8sv1.EventTypeWarning, watch.NoSuitableNodesForHostModelMigration),
+							},
+						)
+						Expect(err).ToNot(HaveOccurred())
+
+						return events.Items
+					}, 30*time.Second, 1*time.Second).Should(HaveLen(1), "Exactly one alert is expected")
+				})
+
+			})
+
 		})
 
 		Context("with migration policies", func() {
@@ -3139,4 +3236,21 @@ func temporaryTLSConfig() *tls.Config {
 			return &cert, nil
 		},
 	}
+}
+
+func disableNodeLabeller(node *k8sv1.Node, virtClient kubecli.KubevirtClient) *k8sv1.Node {
+	var err error
+
+	node.Annotations[v1.LabellerSkipNodeAnnotation] = "true"
+
+	node, err = virtClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	Eventually(func() bool {
+		node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+		value, ok := node.Annotations[v1.LabellerSkipNodeAnnotation]
+		return ok && value == "true"
+	}, 30*time.Second, time.Second).Should(BeTrue())
+
+	return node
 }

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2354,7 +2354,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					Expect(node.Annotations).To(Equal(originalNodeAnnotations))
 				})
 
-				It("when no node is suited for host model", func() {
+				It("[test_id:7505]when no node is suited for host model", func() {
 					By("Changing node labels to support fake host model")
 					// Remove all supported host models
 					for key, _ := range node.Labels {
@@ -2381,8 +2381,6 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 					By("Expecting for an alert to be triggered")
 					Eventually(func() []k8sv1.Event {
-						//var hostModelEvents []k8sv1.Event
-
 						events, err := virtClient.CoreV1().Events(vmi.Namespace).List(
 							context.Background(),
 							metav1.ListOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:
This is PR to fix a bug this PR: https://github.com/kubevirt/kubevirt/pull/6773. 

This PR fixes a bug that caused alert for unschedulable host-model VMIs to trigger.
Two bugs are now fixed:
- In `alertIfHostModelIsUnschedulable()` function, which scans all nodes to check whether one or more nodes support the VMI host model and cpu required features, the source node is now skipped. If the source node is not skipped, it is always found to be suitable, obviously.
- In `isNodeSuitableForHostModelMigration()` function, iterate on Pod's `NodeSelector`, not `Labels`.

In addition, the PR includes several improvements:
- Introduces unit and functional test
- Moves logic to `handlePendingPodTimeout()` which already deals with unschedulable migration target pods
- Refactoring and other small improvements

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: Unscheduable host-model VMI alert is now properly triggered
```
