### PR TITLE
network: Extract netns execution and use it in the setup

### DIFF
--- a/pkg/network/netns/BUILD.bazel
+++ b/pkg/network/netns/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["netns.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network/netns",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/containernetworking/plugins/pkg/ns:go_default_library"],
+)

--- a/pkg/network/netns/netns.go
+++ b/pkg/network/netns/netns.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package netns
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+)
+
+type NetNS struct {
+	nspath string
+}
+
+func New(pid int) NetNS {
+	return NetNS{nspath: fmt.Sprintf("/proc/%d/ns/net", pid)}
+}
+
+func (n NetNS) Do(f func() error) error {
+	netns, err := ns.GetNS(n.nspath)
+	if err != nil {
+		return fmt.Errorf("failed to fetch network namespace object: %v", err)
+	}
+
+	return netns.Do(func(_ ns.NetNS) error {
+		return f()
+	})
+}

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/network/driver:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/network/infraconfigurators:go_default_library",
+        "//pkg/network/netns:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-handler/isolation/BUILD.bazel
+++ b/pkg/virt-handler/isolation/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//vendor/github.com/containernetworking/plugins/pkg/ns:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/mitchellh/go-ps:go_default_library",
         "//vendor/github.com/moby/sys/mountinfo:go_default_library",

--- a/pkg/virt-handler/isolation/detector_test.go
+++ b/pkg/virt-handler/isolation/detector_test.go
@@ -141,12 +141,6 @@ var _ = Describe("Isolation Detector", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.MountRoot()).To(Equal(fmt.Sprintf("/proc/%d/root", os.Getpid())))
 		})
-
-		It("Should detect the Network namespace of the test suite", func() {
-			result, err := NewSocketBasedIsolationDetector(tmpDir, cgroupParser).Allowlist([]string{"devices"}).Detect(vm)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.NetNamespace()).To(Equal(fmt.Sprintf("/proc/%d/ns/net", os.Getpid())))
-		})
 	})
 })
 

--- a/pkg/virt-handler/isolation/generated_mock_isolation.go
+++ b/pkg/virt-handler/isolation/generated_mock_isolation.go
@@ -99,16 +99,6 @@ func (_mr *_MockIsolationResultRecorder) NetNamespace() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NetNamespace")
 }
 
-func (_m *MockIsolationResult) DoNetNS(_param0 func() error) error {
-	ret := _m.ctrl.Call(_m, "DoNetNS", _param0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockIsolationResultRecorder) DoNetNS(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoNetNS", arg0)
-}
-
 func (_m *MockIsolationResult) Mounts(_param0 mountinfo.FilterFunc) ([]*mountinfo.Info, error) {
 	ret := _m.ctrl.Call(_m, "Mounts", _param0)
 	ret0, _ := ret[0].([]*mountinfo.Info)

--- a/pkg/virt-handler/isolation/generated_mock_isolation.go
+++ b/pkg/virt-handler/isolation/generated_mock_isolation.go
@@ -89,16 +89,6 @@ func (_mr *_MockIsolationResultRecorder) MountNamespace() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountNamespace")
 }
 
-func (_m *MockIsolationResult) NetNamespace() string {
-	ret := _m.ctrl.Call(_m, "NetNamespace")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-func (_mr *_MockIsolationResultRecorder) NetNamespace() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NetNamespace")
-}
-
 func (_m *MockIsolationResult) Mounts(_param0 mountinfo.FilterFunc) ([]*mountinfo.Info, error) {
 	ret := _m.ctrl.Call(_m, "Mounts", _param0)
 	ret0, _ := ret[0].([]*mountinfo.Info)

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -52,8 +52,6 @@ type IsolationResult interface {
 	MountRoot() string
 	// full path to the mount namespace
 	MountNamespace() string
-	// full path to the network namespace
-	NetNamespace() string
 	// mounts for the process
 	Mounts(mount.FilterFunc) ([]*mount.Info, error)
 }
@@ -120,10 +118,6 @@ func (r *RealIsolationResult) IsBlockDevice(path string) (bool, error) {
 		return false, fmt.Errorf("found %v, but it's not a block device", path)
 	}
 	return true, nil
-}
-
-func (r *RealIsolationResult) NetNamespace() string {
-	return fmt.Sprintf("/proc/%d/ns/net", r.pid)
 }
 
 func (r *RealIsolationResult) MountRoot() string {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -81,7 +81,7 @@ import (
 )
 
 type netconf interface {
-	Setup(vmi *v1.VirtualMachineInstance, launcherPid int, doNetNS func(func() error) error, preSetup func() error) error
+	Setup(vmi *v1.VirtualMachineInstance, launcherPid int, preSetup func() error) error
 	Teardown(vmi *v1.VirtualMachineInstance) error
 	SetupCompleted(vmi *v1.VirtualMachineInstance) bool
 }
@@ -495,7 +495,7 @@ func (d *VirtualMachineController) setupNetwork(vmi *v1.VirtualMachineInstance) 
 	rootMount := isolationRes.MountRoot()
 	requiresDeviceClaim := virtutil.IsNonRootVMI(vmi) && virtutil.WantVirtioNetDevice(vmi)
 
-	return d.netConf.Setup(vmi, isolationRes.Pid(), isolationRes.DoNetNS, func() error {
+	return d.netConf.Setup(vmi, isolationRes.Pid(), func() error {
 		if requiresDeviceClaim {
 			if err := d.claimDeviceOwnership(rootMount, "vhost-net"); err != nil {
 				return neterrors.CreateCriticalNetworkError(fmt.Errorf("failed to set up vhost-net device, %s", err))

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3031,7 +3031,7 @@ type netConfStub struct {
 	SetupError error
 }
 
-func (nc *netConfStub) Setup(vmi *v1.VirtualMachineInstance, launcherPid int, doNetNS func(func() error) error, preSetup func() error) error {
+func (nc *netConfStub) Setup(vmi *v1.VirtualMachineInstance, launcherPid int, preSetup func() error) error {
 	if nc.SetupError != nil {
 		return nc.SetupError
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The network namespace processing is extracted from the isolation
structure to its own package.

In order to support tests, the `NetConf` object can be created using
a custom `netns` factory. This is transparent to the production calls,
by providing a default factory.

No unit tests are written for the wrapping `netns` package as no logic
is exercised. It just forwards calls to the underlying `ns` external package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #6781 , please review here only the last commit in the chain.~~

**Release note**:
```release-note
NONE
```
