### PR TITLE
net, netstat: Remove pod network iface name normalization

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -66,16 +66,6 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 		return nil
 	}
 
-	// This is needed to be backwards compatible with vmi's which have status interfaces
-	// with the name not being set
-	if len(domain.Spec.Devices.Interfaces) == 0 && len(vmi.Status.Interfaces) == 1 && vmi.Status.Interfaces[0].Name == "" {
-		for _, network := range vmi.Spec.Networks {
-			if network.NetworkSource.Pod != nil {
-				vmi.Status.Interfaces[0].Name = network.Name
-			}
-		}
-	}
-
 	if len(vmi.Status.Interfaces) == 0 {
 		// Set Pod Interface
 		interfaces := make([]v1.VirtualMachineInstanceNetworkInterface, 0)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8637,9 +8637,8 @@ var CRDsValidation map[string]string = map[string]string{
                 description: Hardware address of a Virtual Machine interface
                 type: string
               name:
-                description: 'Name of the interface, corresponds to name of the network
-                  assigned to the interface TODO: remove omitempty, when api breaking
-                  changes are allowed'
+                description: Name of the interface, corresponds to name of the network
+                  assigned to the interface
                 type: string
             type: object
           type: array

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -501,7 +501,6 @@ type VirtualMachineInstanceNetworkInterface struct {
 	// Hardware address of a Virtual Machine interface
 	MAC string `json:"mac,omitempty"`
 	// Name of the interface, corresponds to name of the network assigned to the interface
-	// TODO: remove omitempty, when api breaking changes are allowed
 	Name string `json:"name,omitempty"`
 	// List of all IP addresses of a Virtual Machine interface
 	IPs []string `json:"ipAddresses,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Back in https://github.com/kubevirt/kubevirt/pull/1595 (from 2018), a
normalization has been added to populate the pod network iface name in
case it was missing, for compatibility reasons.

Since, another restriction was added: Only when the domain is not
reporting this iface as part of it.

As the normalization is performed now for more than 3 years and such old
virt-launchers are not expected to be supported by current
virt-handlers, this should be safer to remove.

The comment on the API, about making the iface name mandatory is also
removed, as this is known to be a valid option. Ifaces detected in the
guest by the guest-agent, with no ability to link them to an existing
network in the VMI spec will miss the name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #6781 , please review here only the last commit in the chain.~~

**Release note**:
```release-note
NONE
```
