### PR TITLE
Istio: Fix ssh traffic forwarding to VMIs with Istio proxy

### DIFF
--- a/pkg/network/infraconfigurators/masquerade_test.go
+++ b/pkg/network/infraconfigurators/masquerade_test.go
@@ -419,7 +419,10 @@ func mockNFTablesFrontend(handler *netdriver.MockNetworkHandler, proto iptables.
 			handler.EXPECT().NftablesAppendRule(proto, "nat", chain, "tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(skipPorts, ", ")), nftIPString, "saddr", GetLoopbackAdrress(proto), "counter", "return").Return(nil)
 		}
 	}
-
+	if isIstioAware(vmiAnnotations) {
+		handler.EXPECT().NftablesAppendRule(proto, "nat", "KUBEVIRT_PREINBOUND",
+			"tcp", "dport", strconv.Itoa(istio.SshPort), "counter", "dnat", "to", vmIP)
+	}
 	if len(portList) > 0 {
 		mockNFTablesBackendSpecificPorts(handler, proto, nftIPString, vmIP, gwIP, portList)
 	} else {

--- a/pkg/network/istio/ports.go
+++ b/pkg/network/istio/ports.go
@@ -29,6 +29,7 @@ const (
 	EnvoyMergedPrometheusTelemetryPort = 15020
 	EnvoyHealthCheckPort               = 15021
 	EnvoyPrometheusTelemetryPort       = 15090
+	SshPort                            = 22
 )
 
 func ReservedPorts() []string {
@@ -40,5 +41,11 @@ func ReservedPorts() []string {
 		fmt.Sprint(EnvoyMergedPrometheusTelemetryPort),
 		fmt.Sprint(EnvoyHealthCheckPort),
 		fmt.Sprint(EnvoyPrometheusTelemetryPort),
+	}
+}
+
+func NonProxiedPorts() []int {
+	return []int{
+		SshPort,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Istio by default excludes port 22 from proxying. The reason for this
exclusion is for use cases where istio proxies run on VMs, to prevent
loosing connectivity to nodes in case of misconfiguration of the proxies.

In our use case however, we're forwarding to the VM network namespace
only traffic that was proxied. Therefore, port 22 is missed as it's not
proxied.

Current implementation of this port 22 exclusion in Istio u/s doesn't
give us other option than add an exception for this port to make sure that
traffic to port 22 is forwarded to the VM.

Note: This means that traffic to 22 is not being proxied, but the same behaviour
would be with regular pods.

This is the line of code in Istio u/s that adds the port 22 exclusion:
https://github.com/istio/istio/blob/f907fd498846a877fab3c1013ffdb6cd83bec28a/tools/istio-iptables/pkg/capture/run.go#L172

The only way around ATM would be adding an anotation that explicitly
defines list of ports to proxy, but that's not a viable option
for use case where we forward all ports.

We may revert this when https://issues.redhat.com/browse/OSSM-782
is resolved.
    
Second commit adds e2e test for SSH connectivity.
    
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix issue with ssh being unreachable on VMIs with Istio proxy
```
