### PR TITLE
support k8s server existing uri path

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -147,7 +147,7 @@ func RequestFromConfig(config *rest.Config, resource, name, namespace, subresour
 		return nil, fmt.Errorf("Unsupported Protocol %s", u.Scheme)
 	}
 
-	u.Path = fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/%s/%s/%s/%s", v1.ApiStorageVersion, namespace, resource, name, subresource)
+	u.Path = u.Path+fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/%s/%s/%s/%s", v1.ApiStorageVersion, namespace, resource, name, subresource)
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    u,


### PR DESCRIPTION
Signed-off-by: Jiri Broulik <jiribroulik@gmail.com>

```release-note
support existing URI path in kubeconfig and append kubevirt to allow api gateways to route the request appropriately
```
