### PR TITLE
netstat: Drop dependencies between status report iterations and simplify the data collection from the pod

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -75,14 +75,12 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 				return err
 			}
 
-			if podIface != nil {
-				ifc := v1.VirtualMachineInstanceNetworkInterface{
-					Name: network.Name,
-					IP:   podIface.PodIP,
-					IPs:  podIface.PodIPs,
-				}
-				interfaces = append(interfaces, ifc)
+			ifc := v1.VirtualMachineInstanceNetworkInterface{
+				Name: network.Name,
+				IP:   podIface.PodIP,
+				IPs:  podIface.PodIPs,
 			}
+			interfaces = append(interfaces, ifc)
 		}
 		vmi.Status.Interfaces = interfaces
 	}

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -370,7 +370,7 @@ func (i interfaceCacheFactoryStatusStub) CacheDHCPConfigForPid(pid string) cache
 type podInterfaceCacheStoreStatusStub struct{ failRemove bool }
 
 func (p podInterfaceCacheStoreStatusStub) Read(iface string) (*cache.PodCacheInterface, error) {
-	return nil, nil
+	return &cache.PodCacheInterface{Iface: &v1.Interface{Name: "net-name"}}, nil
 }
 
 func (p podInterfaceCacheStoreStatusStub) Write(iface string, cacheInterface *cache.PodCacheInterface) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

The VMI interfaces status has been "leaking" between update iterations, dragging along data which has the potential to be outdated.
Therefore, the interfaces status is now overridden on each update with last known data from the pod. Further processing will override some of the properties with data from the domain and guest-agent (if available).

This change also includes some small simplifications of the code, regarding the expected data arriving from the pod interface cache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #6781 , only the last 3 commits are relevant to this PR.~~

**Release note**:
```release-note
NONE
```
