### PR TITLE
Add sig-monitoring lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -57,6 +57,9 @@ elif [[ $TARGET =~ sig-compute ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
 elif [[ $TARGET =~ sig-operator ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-operator/}
+elif [[ $TARGET =~ sig-monitoring ]]; then
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-monitoring/}
+    export KUBEVIRT_DEPLOY_PROMETHEUS=true
 else
   export KUBEVIRT_PROVIDER=${TARGET}
 fi
@@ -362,6 +365,8 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
   elif [[ $TARGET =~ sig-compute ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-compute\\]"
     export KUBEVIRT_E2E_SKIP="GPU|MediatedDevices"
+  elif [[ $TARGET =~ sig-monitoring ]]; then
+      export KUBEVIRT_E2E_FOCUS="\\[sig-monitoring\\]"
   elif [[ $TARGET =~ sig-operator ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-operator\\]"
   elif [[ $TARGET =~ sriov.* ]]; then

--- a/hack/check-unassigned-tests.sh
+++ b/hack/check-unassigned-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 main() {
-    skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]"
+    skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
     result=$(FUNC_TEST_ARGS="-dryRun -skip=${skip}" make functest)
     total_tests=$(echo "${result}" | grep "Ran[[:space:]].*of" | awk '{print $2}')
     if [ "${total_tests}" != "0" ]; then

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -223,6 +223,7 @@ go_test(
         "//tests/libnet:go_default_library",
         "//tests/libreplicaset:go_default_library",
         "//tests/libvmi:go_default_library",
+        "//tests/monitoring:go_default_library",
         "//tests/network:go_default_library",
         "//tests/numa:go_default_library",
         "//tests/performance:go_default_library",

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "monitoring.go",
+        "prometheus_utils.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tests/monitoring",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/flags:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/api/prometheus/v1:go_default_library",
+        "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -1,0 +1,140 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"kubevirt.io/kubevirt/tests"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/tests/flags"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+const (
+	virtOperatorDeploymentName = "virt-operator"
+)
+
+var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
+
+	var err error
+	var virtClient kubecli.KubevirtClient
+	var scales map[string]*autoscalingv1.Scale
+
+	backupScale := func(operatorName string) {
+		Eventually(func() error {
+			virtOperatorCurrentScale, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).GetScale(context.TODO(), operatorName, metav1.GetOptions{})
+			if err == nil {
+				scales[operatorName] = virtOperatorCurrentScale
+			}
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+	}
+
+	revertScale := func(operatorName string) {
+		revert := scales[operatorName].DeepCopy()
+		revert.ResourceVersion = ""
+		Eventually(func() error {
+			_, err = virtClient.
+				AppsV1().
+				Deployments(flags.KubeVirtInstallNamespace).
+				UpdateScale(context.TODO(), operatorName, revert, metav1.UpdateOptions{})
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+	}
+
+	updateScale := func(operatorName string, replicas int32) {
+		scale := scales[operatorName].DeepCopy()
+		scale.Spec.Replicas = replicas
+		Eventually(func() error {
+			_, err = virtClient.
+				AppsV1().
+				Deployments(flags.KubeVirtInstallNamespace).
+				UpdateScale(context.TODO(), operatorName, scale, metav1.UpdateOptions{})
+			return err
+		}, 30*time.Second, 1*time.Second).Should(BeNil())
+	}
+
+	verifyAlertExist := func(alertName string) {
+		Eventually(func() error {
+			alerts, err := getAlerts(virtClient)
+			if err != nil {
+				return err
+			}
+			for _, alert := range alerts {
+				if string(alert.Labels["alertname"]) == alertName {
+					return nil
+				}
+			}
+			return fmt.Errorf("alert doesn't exist: %v", alertName)
+		}, 120*time.Second, 1*time.Second).Should(BeNil())
+
+	}
+
+	waitUntilThereIsNoAlert := func() {
+		Eventually(func() error {
+			alerts, err := getAlerts(virtClient)
+			if err != nil {
+				return err
+			}
+			if len(alerts) == 0 {
+				return nil
+			}
+			return fmt.Errorf("some alerts exist: %v", alerts)
+		}, 120*time.Second, 1*time.Second).Should(BeNil())
+
+	}
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(virtClient).ToNot(BeNil())
+
+		tests.SkipIfPrometheusRuleIsNotEnabled(virtClient)
+		tests.BeforeTestCleanup()
+	})
+
+	Context("Up metrics", func() {
+		BeforeEach(func() {
+			scales = make(map[string]*autoscalingv1.Scale, 1)
+			backupScale(virtOperatorDeploymentName)
+		})
+
+		AfterEach(func() {
+			revertScale(virtOperatorDeploymentName)
+			waitUntilThereIsNoAlert()
+		})
+
+		It("VirtOperatorDown should be triggered when virt-operator is down", func() {
+			By("By scaling virt-operator to zero")
+			updateScale(virtOperatorDeploymentName, int32(0))
+			verifyAlertExist("VirtOperatorDown")
+		})
+	})
+})

--- a/tests/monitoring/prometheus_utils.go
+++ b/tests/monitoring/prometheus_utils.go
@@ -1,0 +1,182 @@
+package monitoring
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+type AlertRequestResult struct {
+	Alerts prometheusv1.AlertsResult `json:"data"`
+	Status string                    `json:"status"`
+}
+
+func getAlerts(cli kubecli.KubevirtClient) ([]prometheusv1.Alert, error) {
+	bodyBytes := DoPrometheusHTTPRequest(cli, "/alerts")
+
+	var result AlertRequestResult
+	err := json.Unmarshal(bodyBytes, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Status != "success" {
+		return nil, fmt.Errorf("api request failed. result: %v", result)
+	}
+
+	return result.Alerts.Alerts, nil
+}
+
+func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte {
+
+	monitoringNs := getMonitoringNs(cli)
+	token := getAuthorizationToken(cli, monitoringNs)
+
+	var result []byte
+	var err error
+	if tests.IsOpenShift() {
+		url := getPrometheusURLForOpenShift()
+		resp := doHttpRequest(url, endpoint, token)
+		defer resp.Body.Close()
+		result, err = ioutil.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		sourcePort := 4321 + rand.Intn(6000)
+		targetPort := 9090
+		Eventually(func() error {
+			_, cmd, err := tests.CreateCommandWithNS(monitoringNs, tests.GetK8sCmdClient(),
+				"port-forward", "service/prometheus-k8s", fmt.Sprintf("%d:%d", sourcePort, targetPort))
+			if err != nil {
+				return err
+			}
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				return err
+			}
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			waitForPortForwardCmd(stdout, sourcePort, targetPort)
+			defer killPortForwardCommand(cmd)
+
+			url := fmt.Sprintf("http://localhost:%d", sourcePort)
+			resp := doHttpRequest(url, endpoint, token)
+			defer resp.Body.Close()
+			result, err = ioutil.ReadAll(resp.Body)
+			return err
+		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
+	}
+	return result
+}
+
+func getPrometheusURLForOpenShift() string {
+	var host string
+
+	Eventually(func() error {
+		var stderr string
+		var err error
+		host, stderr, err = tests.RunCommand(tests.GetK8sCmdClient(), "-n", "openshift-monitoring", "get", "route", "prometheus-k8s", "--template", "{{.spec.host}}")
+		if err != nil {
+			return fmt.Errorf("error while getting route. err:'%v', stderr:'%v'", err, stderr)
+		}
+		return nil
+	}, 10*time.Second, time.Second).Should(BeTrue())
+
+	return fmt.Sprintf("https://%s", host)
+}
+
+func doHttpRequest(url string, endpoint string, token string) *http.Response {
+	var resp *http.Response
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	Eventually(func() bool {
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/%s", url, endpoint), nil)
+		if err != nil {
+			return false
+		}
+		req.Header.Add("Authorization", "Bearer "+token)
+		resp, err = client.Do(req)
+		if err != nil {
+			return false
+		}
+		if resp.StatusCode != http.StatusOK {
+			return false
+		}
+		return true
+	}, 10*time.Second, 1*time.Second).Should(BeTrue())
+
+	return resp
+}
+
+func getAuthorizationToken(cli kubecli.KubevirtClient, monitoringNs string) string {
+	var token string
+	Eventually(func() bool {
+		var secretName string
+		sa, err := cli.CoreV1().ServiceAccounts(monitoringNs).Get(context.TODO(), "prometheus-k8s", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		for _, secret := range sa.Secrets {
+			if strings.HasPrefix(secret.Name, "prometheus-k8s-token") {
+				secretName = secret.Name
+			}
+		}
+		secret, err := cli.CoreV1().Secrets(monitoringNs).Get(context.TODO(), secretName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		if _, ok := secret.Data["token"]; !ok {
+			return false
+		}
+		token = string(secret.Data["token"])
+		return true
+	}, 10*time.Second, time.Second).Should(BeTrue())
+	return token
+}
+
+func getMonitoringNs(cli kubecli.KubevirtClient) string {
+	if tests.IsOpenShift() {
+		return "openshift-monitoring"
+	}
+
+	return "monitoring"
+}
+
+func waitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
+	Eventually(func() string {
+		tmp := make([]byte, 1024)
+		_, err := stdout.Read(tmp)
+		Expect(err).NotTo(HaveOccurred())
+
+		return string(tmp)
+	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Forwarding from 127.0.0.1:%d -> %d", src, dst)))
+}
+
+func killPortForwardCommand(portForwardCmd *exec.Cmd) error {
+	if portForwardCmd == nil {
+		return nil
+	}
+
+	portForwardCmd.Process.Kill()
+	_, err := portForwardCmd.Process.Wait()
+	return err
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
+	_ "kubevirt.io/kubevirt/tests/monitoring"
 	_ "kubevirt.io/kubevirt/tests/network"
 	_ "kubevirt.io/kubevirt/tests/numa"
 	_ "kubevirt.io/kubevirt/tests/performance"

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3555,6 +3555,18 @@ func SkipIfUseFlannel(virtClient kubecli.KubevirtClient) {
 	}
 }
 
+func SkipIfPrometheusRuleIsNotEnabled(virtClient kubecli.KubevirtClient) {
+	ext, err := extclient.NewForConfig(virtClient.Config())
+	util2.PanicOnError(err)
+
+	_, err = ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "prometheusrules.monitoring.coreos.com", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		Skip("Skip monitoring tests when PrometheusRule CRD is not available in the cluster")
+	} else if err != nil {
+		util2.PanicOnError(err)
+	}
+}
+
 func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
 	var cpus int64
 


### PR DESCRIPTION
We have many metrics&alerts but we don't have tests which run with real Prometheus. This PR adds a new lane and a test case as an example. We will add more tests for alerts in time. 

Corresponding change in project-infra: https://github.com/kubevirt/project-infra/pull/1790


Signed-off-by: Erkan Erol <eerol@redhat.com>

**Release note**:
```release-note
Add a new lane for monitoring tests
```
