### PR TITLE
DNM? debug: implement a way to override arbitrary files in virt-launcher

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15635,6 +15635,13 @@
        "type": "string"
       }
      },
+     "overrideVirtLauncherFiles": {
+      "description": "Map of path-\u003eURL of files to override in virt-launcher before starting libvirtd",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
      "pvcTolerateLessSpaceUpToPercent": {
       "type": "integer",
       "format": "int32"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -220,6 +220,12 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      overrideVirtLauncherFiles:
+                        additionalProperties:
+                          type: string
+                        description: Map of path->URL of files to override in virt-launcher
+                          before starting libvirtd
+                        type: object
                       pvcTolerateLessSpaceUpToPercent:
                         type: integer
                       useEmulation:
@@ -2836,6 +2842,12 @@ spec:
                       nodeSelectors:
                         additionalProperties:
                           type: string
+                        type: object
+                      overrideVirtLauncherFiles:
+                        additionalProperties:
+                          type: string
+                        description: Map of path->URL of files to override in virt-launcher
+                          before starting libvirtd
                         type: object
                       pvcTolerateLessSpaceUpToPercent:
                         type: integer

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -320,3 +320,8 @@ func (c *ClusterConfig) GetObsoleteCPUModels() map[string]bool {
 func (c *ClusterConfig) GetClusterCPUArch() string {
 	return c.cpuArch
 }
+
+//GetVirtLauncherOverrides returns the file->URL map of files to override in virt-launcher
+func (c *ClusterConfig) GetVirtLauncherOverrides() map[string]string {
+	return c.GetConfig().DeveloperConfiguration.OverrideVirtLauncherFiles
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -439,6 +439,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		return nil, err
 	}
 
+	overrides := t.clusterConfig.GetVirtLauncherOverrides()
+
 	var command []string
 	if tempPod {
 		logger := log.DefaultLogger()
@@ -465,6 +467,14 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if customDebugFilters, exists := vmi.Annotations[v1.CustomLibvirtLogFiltersAnnotation]; exists {
 			log.Log.Object(vmi).Infof("Applying custom debug filters for vmi %s: %s", vmi.Name, customDebugFilters)
 			command = append(command, "--libvirt-log-filters", customDebugFilters)
+		}
+		if overrides != nil && len(overrides) != 0 {
+			flag := ""
+			for file, url := range overrides {
+				flag += file + "=" + url + ","
+			}
+			flag = flag[:len(flag)-1]
+			command = append(command, "--override-files", flag)
 		}
 	}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -700,6 +700,12 @@ var CRDsValidation map[string]string = map[string]string{
                   additionalProperties:
                     type: string
                   type: object
+                overrideVirtLauncherFiles:
+                  additionalProperties:
+                    type: string
+                  description: Map of path->URL of files to override in virt-launcher
+                    before starting libvirtd
+                  type: object
                 pvcTolerateLessSpaceUpToPercent:
                   type: integer
                 useEmulation:

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -743,6 +743,13 @@ func (in *DeveloperConfiguration) DeepCopyInto(out *DeveloperConfiguration) {
 		*out = new(LogVerbosity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.OverrideVirtLauncherFiles != nil {
+		in, out := &in.OverrideVirtLauncherFiles, &out.OverrideVirtLauncherFiles
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2235,6 +2235,8 @@ type DeveloperConfiguration struct {
 	MinimumClusterTSCFrequency *int64            `json:"minimumClusterTSCFrequency,omitempty"`
 	DiskVerification           *DiskVerification `json:"diskVerification,omitempty"`
 	LogVerbosity               *LogVerbosity     `json:"logVerbosity,omitempty"`
+	// Map of path->URL of files to override in virt-launcher before starting libvirtd
+	OverrideVirtLauncherFiles map[string]string `json:"overrideVirtLauncherFiles,omitempty"`
 }
 
 // LogVerbosity sets log verbosity level of  various components

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -698,6 +698,7 @@ func (DeveloperConfiguration) SwaggerDoc() map[string]string {
 		"":                           "DeveloperConfiguration holds developer options",
 		"useEmulation":               "UseEmulation can be set to true to allow fallback to software emulation\nin case hardware-assisted emulation is not available.",
 		"minimumClusterTSCFrequency": "Allow overriding the automatically determined minimum TSC frequency of the cluster\nand fixate the minimum to this frequency.",
+		"overrideVirtLauncherFiles":  "Map of path->URL of files to override in virt-launcher before starting libvirtd",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -15599,6 +15599,21 @@ func schema_kubevirtio_api_core_v1_DeveloperConfiguration(ref common.ReferenceCa
 							Ref: ref("kubevirt.io/api/core/v1.LogVerbosity"),
 						},
 					},
+					"overrideVirtLauncherFiles": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Map of path->URL of files to override in virt-launcher before starting libvirtd",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
I've been using this hack for a while to debug programs running in virt-launcher.
It allows for making arbitrary changes to the virt-launcher filesystem without having to rebuild or redeploy kubevirt.

This PR is not really intended to be merged, but rather cherry-picked into dev environments to help with debugging.
I will close it in a few days unless there is a lot of interest for something like this actually being merged.

For example, I currently have this in my kubevirt CR to debug vTPM:
```
spec:
  configuration:
    developerConfiguration:
      overrideVirtLauncherFiles:
        /usr/bin/swtpm: http://192.168.0.11/swtpm
        /usr/bin/swtpm_setup: http://192.168.0.11/swtpm_setup
        /usr/lib64/libswtpm_libtpms.so.0: http://192.168.0.11/libswtpm_libtpms.so.0
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
