### PR TITLE
Fix some typos in API comments

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11219,7 +11219,7 @@
     }
    },
    "v1.ClientPassthroughDevices": {
-    "description": "Represent a subset of client devices that can be accessed by VMI. At the moment only, USB devices using Usbredir's library and tooling. Another fit would be a smartcard with libcacard.\n\nThe struct is currently empty as there is no imediate request for user-facing APIs. This structure simply turns on USB redirection of UsbClientPassthroughMaxNumberOf devices.",
+    "description": "Represent a subset of client devices that can be accessed by VMI. At the moment only, USB devices using Usbredir's library and tooling. Another fit would be a smartcard with libcacard.\n\nThe struct is currently empty as there is no immediate request for user-facing APIs. This structure simply turns on USB redirection of UsbClientPassthroughMaxNumberOf devices.",
     "type": "object"
    },
    "v1.Clock": {
@@ -13195,7 +13195,7 @@
     }
    },
    "v1.Port": {
-    "description": "Port repesents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
+    "description": "Port represents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
     "type": "object",
     "required": [
      "port"

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -4209,7 +4209,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: List of ports to be forwarded to the
                                   virtual machine.
                                 items:
-                                  description: Port repesents a port to expose from
+                                  description: Port represents a port to expose from
                                     the virtual machine. Default protocol TCP. The
                                     port field is mandatory
                                   properties:
@@ -7201,7 +7201,7 @@ var CRDsValidation map[string]string = map[string]string{
                         description: List of ports to be forwarded to the virtual
                           machine.
                         items:
-                          description: Port repesents a port to expose from the virtual
+                          description: Port represents a port to expose from the virtual
                             machine. Default protocol TCP. The port field is mandatory
                           properties:
                             name:
@@ -9237,7 +9237,7 @@ var CRDsValidation map[string]string = map[string]string{
                         description: List of ports to be forwarded to the virtual
                           machine.
                         items:
-                          description: Port repesents a port to expose from the virtual
+                          description: Port represents a port to expose from the virtual
                             machine. Default protocol TCP. The port field is mandatory
                           properties:
                             name:
@@ -11057,7 +11057,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: List of ports to be forwarded to the
                                   virtual machine.
                                 items:
-                                  description: Port repesents a port to expose from
+                                  description: Port represents a port to expose from
                                     the virtual machine. Default protocol TCP. The
                                     port field is mandatory
                                   properties:
@@ -14331,7 +14331,7 @@ var CRDsValidation map[string]string = map[string]string{
                                         description: List of ports to be forwarded
                                           to the virtual machine.
                                         items:
-                                          description: Port repesents a port to expose
+                                          description: Port represents a port to expose
                                             from the virtual machine. Default protocol
                                             TCP. The port field is mandatory
                                           properties:
@@ -17948,9 +17948,10 @@ var CRDsValidation map[string]string = map[string]string{
                                             description: List of ports to be forwarded
                                               to the virtual machine.
                                             items:
-                                              description: Port repesents a port to
-                                                expose from the virtual machine. Default
-                                                protocol TCP. The port field is mandatory
+                                              description: Port represents a port
+                                                to expose from the virtual machine.
+                                                Default protocol TCP. The port field
+                                                is mandatory
                                               properties:
                                                 name:
                                                   description: If specified, this

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -454,7 +454,7 @@ type Devices struct {
 // moment only, USB devices using Usbredir's library and tooling. Another fit
 // would be a smartcard with libcacard.
 //
-// The struct is currently empty as there is no imediate request for
+// The struct is currently empty as there is no immediate request for
 // user-facing APIs. This structure simply turns on USB redirection of
 // UsbClientPassthroughMaxNumberOf devices.
 type ClientPassthroughDevices struct {
@@ -1168,7 +1168,7 @@ type InterfaceSRIOV struct{}
 
 type InterfaceMacvtap struct{}
 
-// Port repesents a port to expose from the virtual machine.
+// Port represents a port to expose from the virtual machine.
 // Default protocol TCP.
 // The port field is mandatory
 type Port struct {

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -249,7 +249,7 @@ func (Devices) SwaggerDoc() map[string]string {
 
 func (ClientPassthroughDevices) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "Represent a subset of client devices that can be accessed by VMI. At the\nmoment only, USB devices using Usbredir's library and tooling. Another fit\nwould be a smartcard with libcacard.\n\nThe struct is currently empty as there is no imediate request for\nuser-facing APIs. This structure simply turns on USB redirection of\nUsbClientPassthroughMaxNumberOf devices.",
+		"": "Represent a subset of client devices that can be accessed by VMI. At the\nmoment only, USB devices using Usbredir's library and tooling. Another fit\nwould be a smartcard with libcacard.\n\nThe struct is currently empty as there is no immediate request for\nuser-facing APIs. This structure simply turns on USB redirection of\nUsbClientPassthroughMaxNumberOf devices.",
 	}
 }
 
@@ -656,7 +656,7 @@ func (InterfaceMacvtap) SwaggerDoc() map[string]string {
 
 func (Port) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":         "Port repesents a port to expose from the virtual machine.\nDefault protocol TCP.\nThe port field is mandatory",
+		"":         "Port represents a port to expose from the virtual machine.\nDefault protocol TCP.\nThe port field is mandatory",
 		"name":     "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.\n+optional",
 		"protocol": "Protocol for port. Must be UDP or TCP.\nDefaults to \"TCP\".\n+optional",
 		"port":     "Number of port to expose for the virtual machine.\nThis must be a valid port number, 0 < x < 65536.",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -14367,7 +14367,7 @@ func schema_kubevirtio_api_core_v1_ClientPassthroughDevices(ref common.Reference
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Represent a subset of client devices that can be accessed by VMI. At the moment only, USB devices using Usbredir's library and tooling. Another fit would be a smartcard with libcacard.\n\nThe struct is currently empty as there is no imediate request for user-facing APIs. This structure simply turns on USB redirection of UsbClientPassthroughMaxNumberOf devices.",
+				Description: "Represent a subset of client devices that can be accessed by VMI. At the moment only, USB devices using Usbredir's library and tooling. Another fit would be a smartcard with libcacard.\n\nThe struct is currently empty as there is no immediate request for user-facing APIs. This structure simply turns on USB redirection of UsbClientPassthroughMaxNumberOf devices.",
 				Type:        []string{"object"},
 			},
 		},
@@ -18273,7 +18273,7 @@ func schema_kubevirtio_api_core_v1_Port(ref common.ReferenceCallback) common.Ope
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Port repesents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
+				Description: "Port represents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes 2 small typos in the API comments. Why is it needed? If you use this APIs to generate some swagger, and swagger clients and use some codespell to check the spelling, there are 2 spelling errors in the generated client code files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
