### PR TITLE
Remove disabling TLS option from Migration Policies

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15676,9 +15676,6 @@
       "type": "integer",
       "format": "int64"
      },
-     "disableTLS": {
-      "type": "boolean"
-     },
      "selectors": {
       "$ref": "#/definitions/v1alpha1.Selectors"
      }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -2425,8 +2425,6 @@ var CRDsValidation map[string]string = map[string]string{
         completionTimeoutPerGiB:
           format: int64
           type: integer
-        disableTLS:
-          type: boolean
         selectors:
           properties:
             namespaceSelector:

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/deepcopy_generated.go
@@ -114,11 +114,6 @@ func (in *MigrationPolicySpec) DeepCopyInto(out *MigrationPolicySpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.DisableTLS != nil {
-		in, out := &in.DisableTLS, &out.DisableTLS
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
@@ -52,8 +52,6 @@ type MigrationPolicySpec struct {
 	CompletionTimeoutPerGiB *int64 `json:"completionTimeoutPerGiB,omitempty"`
 	//+optional
 	AllowPostCopy *bool `json:"allowPostCopy,omitempty"`
-	//+optional
-	DisableTLS *bool `json:"disableTLS,omitempty"`
 }
 
 type Selectors struct {
@@ -99,10 +97,6 @@ func (m *MigrationPolicy) GetMigrationConfByPolicy(clusterMigrationConfiguration
 	if policySpec.AllowPostCopy != nil {
 		changed = true
 		*clusterMigrationConfigurations.AllowPostCopy = *policySpec.AllowPostCopy
-	}
-	if policySpec.DisableTLS != nil {
-		changed = true
-		*clusterMigrationConfigurations.DisableTLS = *policySpec.DisableTLS
 	}
 
 	return changed, nil

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types_swagger_generated.go
@@ -15,7 +15,6 @@ func (MigrationPolicySpec) SwaggerDoc() map[string]string {
 		"bandwidthPerMigration":   "+optional",
 		"completionTimeoutPerGiB": "+optional",
 		"allowPostCopy":           "+optional",
-		"disableTLS":              "+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22116,12 +22116,6 @@ func schema_kubevirtio_api_migrations_v1alpha1_MigrationPolicySpec(ref common.Re
 							Format: "",
 						},
 					},
-					"disableTLS": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
 				},
 				Required: []string{"selectors"},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
The option to disable TLS in Migration Policies (https://github.com/kubevirt/kubevirt/pull/6399) is part of Migration Policies since it's also part of MigrationConfigurations in KubevirtCR.

This option was added to KubevirtCR since disabling TLS was supposed to provide a performance boost. After testing, it seems that disabling TLS does not provide any such boost, therefore disabling has no benefit and makes cluster less secure.

For these reasons it needs to be removed from MigrationPolicy CRD.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove disabling TLS configuration from Live Migration Policies
```
