### PR TITLE
Refactor VM-controller: extract logic to functions

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -306,11 +306,7 @@ func (c *VMController) execute(key string) error {
 		return err
 	}
 
-	if syncErr != nil {
-		return syncErr
-	}
-
-	return nil
+	return syncErr
 }
 
 func (c *VMController) listDataVolumesForVM(vm *virtv1.VirtualMachine) ([]*cdiv1.DataVolume, error) {
@@ -1921,126 +1917,130 @@ func (c *VMController) processFailureCondition(vm *virtv1.VirtualMachine, vmi *v
 	return
 }
 
-func (c *VMController) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
-	clearChangeRequest := false
+func (c *VMController) isTrimFirstChangeRequestNeeded(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) (clearChangeRequest bool) {
+	if len(vm.Status.StateChangeRequests) == 0 {
+		return false
+	}
 
-	if len(vm.Status.StateChangeRequests) != 0 {
-		// Only consider one stateChangeRequest at a time. The second and subsequent change
-		// requests have not been acted upon by this controller yet!
-		stateChange := vm.Status.StateChangeRequests[0]
-		switch stateChange.Action {
-		case virtv1.StopRequest:
-			if vmi == nil {
-				// because either the VM or VMI informers can trigger processing here
-				// double check the state of the cluster before taking action
-				_, err := c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Get(vm.GetName(), &v1.GetOptions{})
-				if err != nil && errors.IsNotFound(err) {
-					// If there's no VMI, then the VMI was stopped, and the stopRequest can be cleared
-					log.Log.Object(vm).V(4).Infof("No VMI. Clearing stop request")
-					clearChangeRequest = true
-				}
-			} else {
-				if stateChange.UID == nil {
-					// It never makes sense to have a request to stop a VMI that doesn't
-					// have a UUID associated with it. This shouldn't be possible -- but if
-					// it occurs, clear the stopRequest because it can't be acted upon
-					log.Log.Object(vm).Errorf("Stop Request has no UID.")
-					clearChangeRequest = true
-				} else if *stateChange.UID != vmi.UID {
-					// If there is a VMI, but the UID doesn't match, then it
-					// must have been previously stopped, so the stopRequest can be cleared
-					log.Log.Object(vm).V(4).Infof("VMI's UID doesn't match. clearing stop request")
-					clearChangeRequest = true
-				}
+	// Only consider one stateChangeRequest at a time. The second and subsequent change
+	// requests have not been acted upon by this controller yet!
+	stateChange := vm.Status.StateChangeRequests[0]
+	switch stateChange.Action {
+	case virtv1.StopRequest:
+		if vmi == nil {
+			// because either the VM or VMI informers can trigger processing here
+			// double check the state of the cluster before taking action
+			_, err := c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Get(vm.GetName(), &v1.GetOptions{})
+			if err != nil && errors.IsNotFound(err) {
+				// If there's no VMI, then the VMI was stopped, and the stopRequest can be cleared
+				log.Log.Object(vm).V(4).Infof("No VMI. Clearing stop request")
+				return true
 			}
-		case virtv1.StartRequest:
-			// If the current VMI is running, then it has been started.
-			if vmi != nil {
-				log.Log.Object(vm).V(4).Infof("VMI exists. clearing start request")
-				clearChangeRequest = true
+		} else {
+			if stateChange.UID == nil {
+				// It never makes sense to have a request to stop a VMI that doesn't
+				// have a UUID associated with it. This shouldn't be possible -- but if
+				// it occurs, clear the stopRequest because it can't be acted upon
+				log.Log.Object(vm).Errorf("Stop Request has no UID.")
+				return true
+			} else if *stateChange.UID != vmi.UID {
+				// If there is a VMI, but the UID doesn't match, then it
+				// must have been previously stopped, so the stopRequest can be cleared
+				log.Log.Object(vm).V(4).Infof("VMI's UID doesn't match. clearing stop request")
+				return true
 			}
+		}
+	case virtv1.StartRequest:
+		// If the current VMI is running, then it has been started.
+		if vmi != nil {
+			log.Log.Object(vm).V(4).Infof("VMI exists. clearing start request")
+			return true
 		}
 	}
 
-	return clearChangeRequest
+	return false
 }
 
 func (c *VMController) trimDoneVolumeRequests(vm *virtv1.VirtualMachine) {
-	if len(vm.Status.VolumeRequests) > 0 {
-		volumeMap := make(map[string]virtv1.Volume)
-		diskMap := make(map[string]virtv1.Disk)
-
-		for _, volume := range vm.Spec.Template.Spec.Volumes {
-			volumeMap[volume.Name] = volume
-		}
-		for _, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
-			diskMap[disk.Name] = disk
-		}
-
-		tmpVolRequests := vm.Status.VolumeRequests[:0]
-		for _, request := range vm.Status.VolumeRequests {
-
-			var added bool
-			var volName string
-
-			removeRequest := false
-
-			if request.AddVolumeOptions != nil {
-				volName = request.AddVolumeOptions.Name
-				added = true
-			} else if request.RemoveVolumeOptions != nil {
-				volName = request.RemoveVolumeOptions.Name
-				added = false
-			}
-
-			_, volExists := volumeMap[volName]
-			_, diskExists := diskMap[volName]
-
-			if added && volExists && diskExists {
-				removeRequest = true
-			} else if !added && !volExists && !diskExists {
-				removeRequest = true
-			}
-
-			if !removeRequest {
-				tmpVolRequests = append(tmpVolRequests, request)
-			}
-		}
-		vm.Status.VolumeRequests = tmpVolRequests
+	if len(vm.Status.VolumeRequests) == 0 {
+		return
 	}
+
+	volumeMap := make(map[string]virtv1.Volume)
+	diskMap := make(map[string]virtv1.Disk)
+
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		volumeMap[volume.Name] = volume
+	}
+	for _, disk := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+		diskMap[disk.Name] = disk
+	}
+
+	tmpVolRequests := vm.Status.VolumeRequests[:0]
+	for _, request := range vm.Status.VolumeRequests {
+
+		var added bool
+		var volName string
+
+		removeRequest := false
+
+		if request.AddVolumeOptions != nil {
+			volName = request.AddVolumeOptions.Name
+			added = true
+		} else if request.RemoveVolumeOptions != nil {
+			volName = request.RemoveVolumeOptions.Name
+			added = false
+		}
+
+		_, volExists := volumeMap[volName]
+		_, diskExists := diskMap[volName]
+
+		if added && volExists && diskExists {
+			removeRequest = true
+		} else if !added && !volExists && !diskExists {
+			removeRequest = true
+		}
+
+		if !removeRequest {
+			tmpVolRequests = append(tmpVolRequests, request)
+		}
+	}
+	vm.Status.VolumeRequests = tmpVolRequests
 }
 
 func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, key string, dataVolumes []*cdiv1.DataVolume) (syncError, error) {
 	var syncErr syncError
 
-	// Scale up or down, if all expected creates and deletes were report by the listener
-	if c.needsSync(key) && vm.ObjectMeta.DeletionTimestamp == nil {
-		runStrategy, err := vm.RunStrategy()
-		if err != nil {
-			return nil, err
-		}
-
-		dataVolumesReady, err := c.handleDataVolumes(vm, dataVolumes)
-		if err != nil {
-			syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}
-		} else if dataVolumesReady || runStrategy == virtv1.RunStrategyHalted {
-			syncErr = c.startStop(vm, vmi)
-		} else {
-			log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready. %d datavolumes found", len(dataVolumes))
-		}
-
-		// Must check needsSync again here because a VMI can be created or
-		// deleted in the startStop function which impacts how we process
-		// hotplugged volumes
-		if c.needsSync(key) && syncErr == nil {
-
-			err = c.handleVolumeRequests(vm, vmi)
-			if err != nil {
-				syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), HotPlugVolumeErrorReason}
-			}
-		}
-		virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
+	if !c.needsSync(key) || vm.ObjectMeta.DeletionTimestamp != nil {
+		return nil, nil
 	}
+
+	// Scale up or down, if all expected creates and deletes were report by the listener
+	runStrategy, err := vm.RunStrategy()
+	if err != nil {
+		return nil, err
+	}
+
+	dataVolumesReady, err := c.handleDataVolumes(vm, dataVolumes)
+	if err != nil {
+		syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while creating DataVolumes: %v", err), FailedCreateReason}
+	} else if dataVolumesReady || runStrategy == virtv1.RunStrategyHalted {
+		syncErr = c.startStop(vm, vmi)
+	} else {
+		log.Log.Object(vm).V(3).Infof("Waiting on DataVolumes to be ready. %d datavolumes found", len(dataVolumes))
+	}
+
+	// Must check needsSync again here because a VMI can be created or
+	// deleted in the startStop function which impacts how we process
+	// hotplugged volumes
+	if c.needsSync(key) && syncErr == nil {
+
+		err = c.handleVolumeRequests(vm, vmi)
+		if err != nil {
+			syncErr = &syncErrorImpl{fmt.Errorf("Error encountered while handling volume hotplug requests: %v", err), HotPlugVolumeErrorReason}
+		}
+	}
+	virtControllerVMWorkQueueTracer.StepTrace(key, "sync", trace.Field{Key: "VM Name", Value: vm.Name})
 
 	return syncErr, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors VM controller by extracting some logic from main functions (like `updateStatus()`) to helper functions where it makes sense. This should cause the code to be easier to read and understand.

**Special notes for your reviewer**:
No behavior is changed - code is only moved around to helper functions.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
