### PR TITLE
Add NUMA information to config driver devices metadata

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13397,6 +13397,10 @@
       "description": "Name of the GPU device as exposed by a device plugin",
       "type": "string"
      },
+     "tag": {
+      "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
+      "type": "string"
+     },
      "virtualGPUOptions": {
       "$ref": "#/definitions/v1.VGPUOptions"
      }
@@ -13483,6 +13487,10 @@
       "type": "string"
      },
      "name": {
+      "type": "string"
+     },
+     "tag": {
+      "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
       "type": "string"
      }
     }

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -59,6 +59,7 @@ const (
 	DataSourceNoCloud     DataSourceType     = "noCloud"
 	DataSourceConfigDrive DataSourceType     = "configDrive"
 	NICMetadataType       DeviceMetadataType = "nic"
+	HostDevMetadataType   DeviceMetadataType = "hostdev"
 )
 
 // CloudInitData is a data source independent struct that

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -93,12 +93,14 @@ type ConfigDriveMetadata struct {
 }
 
 type DeviceData struct {
-	Type    DeviceMetadataType `json:"type"`
-	Bus     string             `json:"bus"`
-	Address string             `json:"address"`
-	MAC     string             `json:"mac,omitempty"`
-	Serial  string             `json:"serial,omitempty"`
-	Tags    []string           `json:"tags"`
+	Type     	DeviceMetadataType `json:"type"`
+	Bus      	string             `json:"bus"`
+	Address 	string             `json:"address"`
+	MAC      	string             `json:"mac,omitempty"`
+	Serial   	string             `json:"serial,omitempty"`
+	NumaNode 	uint32             `json:"numaNode,omitempty"`
+	AlignedCPUs     []uint32           `json:"alignedCPUs,omitempty"`
+	Tags     	[]string           `json:"tags"`
 }
 
 // IsValidCloudInitData checks if the given CloudInitData object is valid in the sense that GenerateLocalData can be called with it.

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -93,14 +93,14 @@ type ConfigDriveMetadata struct {
 }
 
 type DeviceData struct {
-	Type     	DeviceMetadataType `json:"type"`
-	Bus      	string             `json:"bus"`
-	Address 	string             `json:"address"`
-	MAC      	string             `json:"mac,omitempty"`
-	Serial   	string             `json:"serial,omitempty"`
-	NumaNode 	uint32             `json:"numaNode,omitempty"`
-	AlignedCPUs     []uint32           `json:"alignedCPUs,omitempty"`
-	Tags     	[]string           `json:"tags"`
+	Type        DeviceMetadataType `json:"type"`
+	Bus         string             `json:"bus"`
+	Address     string             `json:"address"`
+	MAC         string             `json:"mac,omitempty"`
+	Serial      string             `json:"serial,omitempty"`
+	NumaNode    uint32             `json:"numaNode,omitempty"`
+	AlignedCPUs []uint32           `json:"alignedCPUs,omitempty"`
+	Tags        []string           `json:"tags"`
 }
 
 // IsValidCloudInitData checks if the given CloudInitData object is valid in the sense that GenerateLocalData can be called with it.

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -150,7 +150,10 @@ var _ = Describe("CloudInit", func() {
       "bus": "pci",
       "address": "0000:65:10:0",
       "numaNode": 1,
-      "alignedCPUs": [0, 1],
+      "alignedCPUs": [
+        0,
+        1
+      ],
       "tags": [
         "testtag1"
       ]
@@ -181,6 +184,9 @@ var _ = Describe("CloudInit", func() {
 				}
 				buf, err := json.MarshalIndent(metadataStruct, "", "  ")
 				Expect(err).To(BeNil())
+				fmt.Println("expected: ", string(buf))
+				fmt.Println("exmapleJsob: ", exampleJSONParsed)
+
 				Expect(string(buf)).To(Equal(exampleJSONParsed))
 			})
 			It("should match the generated nocloud metadata", func() {

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -162,13 +162,13 @@ var _ = Describe("CloudInit", func() {
 }`
 				devices := []DeviceData{
 					{
-						Type:     HostDevMetadataType,
-						Bus:      "pci",
-						Address:  "0000:65:10:0",
-						MAC:      "",
-						NumaNode: uint32(1),
+						Type:        HostDevMetadataType,
+						Bus:         "pci",
+						Address:     "0000:65:10:0",
+						MAC:         "",
+						NumaNode:    uint32(1),
 						AlignedCPUs: []uint32{0, 1},
-						Tags:     []string{"testtag1"},
+						Tags:        []string{"testtag1"},
 					},
 				}
 

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -139,6 +139,50 @@ var _ = Describe("CloudInit", func() {
 				Expect(err).To(BeNil())
 				Expect(string(buf)).To(Equal(exampleJSONParsed))
 			})
+			It("should match the generated configdrive metadata for hostdev with numaNode", func() {
+				exampleJSONParsed := `{
+  "instance_id": "fake.fake-namespace",
+  "local_hostname": "fake",
+  "uuid": "5d307ca9-b3ef-428c-8861-06e72d69f223",
+  "devices": [
+    {
+      "type": "hostdev",
+      "bus": "pci",
+      "address": "0000:65:10:0",
+      "numaNode": 1,
+      "alignedCPUs": [0, 1],
+      "tags": [
+        "testtag1"
+      ]
+    }
+  ],
+  "public_keys": {
+    "0": "somekey"
+  }
+}`
+				devices := []DeviceData{
+					{
+						Type:     HostDevMetadataType,
+						Bus:      "pci",
+						Address:  "0000:65:10:0",
+						MAC:      "",
+						NumaNode: uint32(1),
+						AlignedCPUs: []uint32{0, 1},
+						Tags:     []string{"testtag1"},
+					},
+				}
+
+				metadataStruct := ConfigDriveMetadata{
+					InstanceID:    "fake.fake-namespace",
+					LocalHostname: "fake",
+					UUID:          "5d307ca9-b3ef-428c-8861-06e72d69f223",
+					Devices:       &devices,
+					PublicSSHKeys: map[string]string{"0": "somekey"},
+				}
+				buf, err := json.MarshalIndent(metadataStruct, "", "  ")
+				Expect(err).To(BeNil())
+				Expect(string(buf)).To(Equal(exampleJSONParsed))
+			})
 			It("should match the generated nocloud metadata", func() {
 				exampleJSONParsed := `{
   "instance-id": "fake.fake-namespace",

--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util/hardware",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util/hardware",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//pkg/util:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
     ],
 )
 

--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["hw_utils.go"],
     importpath = "kubevirt.io/kubevirt/pkg/util/hardware",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/api/core/v1:go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//pkg/util:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -113,7 +113,6 @@ func ParsePciAddress(pciAddress string) ([]string, error) {
 	return res[1:], nil
 }
 
-
 func GetDeviceNumaNode(pciAddress string) (*uint32, error) {
 	pciBasePath := "/sys/bus/pci/devices"
 	numaNodePath := filepath.Join(pciBasePath, pciAddress, "numa_node")

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/network/cache:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -4227,6 +4227,11 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: Name of the GPU device as exposed by
                                   a device plugin
                                 type: string
+                              tag:
+                                description: If specified, the virtual network interface
+                                  address and its tag will be provided to the guest
+                                  via config drive
+                                type: string
                               virtualGPUOptions:
                                 properties:
                                   display:
@@ -4264,6 +4269,11 @@ var CRDsValidation map[string]string = map[string]string{
                                   host device exposed by a device plugin
                                 type: string
                               name:
+                                type: string
+                              tag:
+                                description: If specified, the virtual network interface
+                                  address and its tag will be provided to the guest
+                                  via config drive
                                 type: string
                             required:
                             - deviceName
@@ -7250,6 +7260,10 @@ var CRDsValidation map[string]string = map[string]string{
                         description: Name of the GPU device as exposed by a device
                           plugin
                         type: string
+                      tag:
+                        description: If specified, the virtual network interface address
+                          and its tag will be provided to the guest via config drive
+                        type: string
                       virtualGPUOptions:
                         properties:
                           display:
@@ -7286,6 +7300,10 @@ var CRDsValidation map[string]string = map[string]string{
                           exposed by a device plugin
                         type: string
                       name:
+                        type: string
+                      tag:
+                        description: If specified, the virtual network interface address
+                          and its tag will be provided to the guest via config drive
                         type: string
                     required:
                     - deviceName
@@ -9334,6 +9352,10 @@ var CRDsValidation map[string]string = map[string]string{
                         description: Name of the GPU device as exposed by a device
                           plugin
                         type: string
+                      tag:
+                        description: If specified, the virtual network interface address
+                          and its tag will be provided to the guest via config drive
+                        type: string
                       virtualGPUOptions:
                         properties:
                           display:
@@ -9370,6 +9392,10 @@ var CRDsValidation map[string]string = map[string]string{
                           exposed by a device plugin
                         type: string
                       name:
+                        type: string
+                      tag:
+                        description: If specified, the virtual network interface address
+                          and its tag will be provided to the guest via config drive
                         type: string
                     required:
                     - deviceName
@@ -11157,6 +11183,11 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: Name of the GPU device as exposed by
                                   a device plugin
                                 type: string
+                              tag:
+                                description: If specified, the virtual network interface
+                                  address and its tag will be provided to the guest
+                                  via config drive
+                                type: string
                               virtualGPUOptions:
                                 properties:
                                   display:
@@ -11194,6 +11225,11 @@ var CRDsValidation map[string]string = map[string]string{
                                   host device exposed by a device plugin
                                 type: string
                               name:
+                                type: string
+                              tag:
+                                description: If specified, the virtual network interface
+                                  address and its tag will be provided to the guest
+                                  via config drive
                                 type: string
                             required:
                             - deviceName
@@ -18050,6 +18086,12 @@ var CRDsValidation map[string]string = map[string]string{
                                             description: Name of the GPU device as
                                               exposed by a device plugin
                                             type: string
+                                          tag:
+                                            description: If specified, the virtual
+                                              network interface address and its tag
+                                              will be provided to the guest via config
+                                              drive
+                                            type: string
                                           virtualGPUOptions:
                                             properties:
                                               display:
@@ -18092,6 +18134,12 @@ var CRDsValidation map[string]string = map[string]string{
                                               device plugin
                                             type: string
                                           name:
+                                            type: string
+                                          tag:
+                                            description: If specified, the virtual
+                                              network interface address and its tag
+                                              will be provided to the guest via config
+                                              drive
                                             type: string
                                         required:
                                         - deviceName

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -14464,6 +14464,11 @@ var CRDsValidation map[string]string = map[string]string{
                                         description: Name of the GPU device as exposed
                                           by a device plugin
                                         type: string
+                                      tag:
+                                        description: If specified, the virtual network
+                                          interface address and its tag will be provided
+                                          to the guest via config drive
+                                        type: string
                                       virtualGPUOptions:
                                         properties:
                                           display:
@@ -14504,6 +14509,11 @@ var CRDsValidation map[string]string = map[string]string{
                                           of the host device exposed by a device plugin
                                         type: string
                                       name:
+                                        type: string
+                                      tag:
+                                        description: If specified, the virtual network
+                                          interface address and its tag will be provided
+                                          to the guest via config drive
                                         type: string
                                     required:
                                     - deviceName

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -506,6 +506,9 @@ type GPU struct {
 	Name              string       `json:"name"`
 	DeviceName        string       `json:"deviceName"`
 	VirtualGPUOptions *VGPUOptions `json:"virtualGPUOptions,omitempty"`
+	// If specified, the virtual network interface address and its tag will be provided to the guest via config drive
+	// +optional
+	Tag string `json:"tag,omitempty"`
 }
 
 type VGPUOptions struct {
@@ -527,6 +530,9 @@ type HostDevice struct {
 	Name string `json:"name"`
 	// DeviceName is the resource name of the host device exposed by a device plugin
 	DeviceName string `json:"deviceName"`
+	// If specified, the virtual network interface address and its tag will be provided to the guest via config drive
+	// +optional
+	Tag string `json:"tag,omitempty"`
 }
 
 type Disk struct {

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -284,6 +284,7 @@ func (FilesystemVirtiofs) SwaggerDoc() map[string]string {
 func (GPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name": "Name of the GPU device as exposed by a device plugin",
+		"tag":  "If specified, the virtual network interface address and its tag will be provided to the guest via config drive\n+optional",
 	}
 }
 
@@ -301,6 +302,7 @@ func (VGPUDisplayOptions) SwaggerDoc() map[string]string {
 func (HostDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"deviceName": "DeviceName is the resource name of the host device exposed by a device plugin",
+		"tag":        "If specified, the virtual network interface address and its tag will be provided to the guest via config drive\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -16197,6 +16197,13 @@ func schema_kubevirtio_api_core_v1_GPU(ref common.ReferenceCallback) common.Open
 							Ref: ref("kubevirt.io/api/core/v1.VGPUOptions"),
 						},
 					},
+					"tag": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name", "deviceName"},
 			},
@@ -16379,6 +16386,13 @@ func schema_kubevirtio_api_core_v1_HostDevice(ref common.ReferenceCallback) comm
 					"deviceName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DeviceName is the resource name of the host device exposed by a device plugin",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"tag": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/cloud-init:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/vmispec:go_default_library",
+        "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -253,6 +253,11 @@ const (
 	waitVolumeRequestProcessError = "waiting on all VolumeRequests to be processed"
 )
 
+const (
+	cgroupV1cpusetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+	cgroupV2cpusetPath = "/sys/fs/cgroup/cpuset.cpus.effective"
+)
+
 type ProcessFunc func(event *k8sv1.Event) (done bool)
 
 type ObjectEventWatcher struct {
@@ -1700,6 +1705,32 @@ func getPodsByLabel(label, labelType, namespace string) (*k8sv1.PodList, error) 
 	}
 
 	return pods, nil
+}
+
+func GetPodCPUSet(pod *k8sv1.Pod) (output string, err error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return
+	}
+	output, err = ExecuteCommandOnPod(
+		virtClient,
+		pod,
+		"compute",
+		[]string{"cat", cgroupV2cpusetPath},
+	)
+
+	if err == nil {
+		return
+	}
+
+	output, err = ExecuteCommandOnPod(
+		virtClient,
+		pod,
+		"compute",
+		[]string{"cat", cgroupV1cpusetPath},
+	)
+
+	return
 }
 
 func GetRunningPodByLabel(label string, labelType string, namespace string, node string) (*k8sv1.Pod, error) {

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -420,7 +420,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(xml.Unmarshal([]byte(domXml), domSpec)).To(Succeed())
 				nic := domSpec.Devices.Interfaces[0]
 				address := nic.Address
-				pciAddrStr := fmt.Sprintf("%s:%s:%s:%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
+				pciAddrStr := fmt.Sprintf("%s:%s:%s.%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
 				deviceData := []cloudinit.DeviceData{
 					{
 						Type:    cloudinit.NICMetadataType,

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2249,32 +2249,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		Context("[Serial]with cpu pinning enabled", func() {
-			const (
-				cgroupV1cpusetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
-				cgroupV2cpusetPath = "/sys/fs/cgroup/cpuset.cpus.effective"
-			)
-
-			getPodCPUSet := func(pod *kubev1.Pod) (output string, err error) {
-				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
-					pod,
-					"compute",
-					[]string{"cat", cgroupV2cpusetPath},
-				)
-
-				if err == nil {
-					return
-				}
-
-				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
-					pod,
-					"compute",
-					[]string{"cat", cgroupV1cpusetPath},
-				)
-
-				return
-			}
 
 			It("[test_id:1684]should set the cpumanager label to false when it's not running", func() {
 
@@ -2343,7 +2317,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
 
-				output, err := getPodCPUSet(readyPod)
+				output, err := tests.GetPodCPUSet(readyPod)
 				log.Log.Infof("%v", output)
 				Expect(err).ToNot(HaveOccurred())
 				output = strings.TrimSuffix(output, "\n")
@@ -2458,7 +2432,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
 
-				output, err := getPodCPUSet(readyPod)
+				output, err := tests.GetPodCPUSet(readyPod)
 				log.Log.Infof("%v", output)
 				Expect(err).ToNot(HaveOccurred())
 				output = strings.TrimSuffix(output, "\n")


### PR DESCRIPTION
**What this PR does / why we need it**:
So far KubeVirt didn't assign any NUMA node reference of the assigned PCI devices. This made it very hard for the guest OS users to find out the affinity of the device. I.E which vCPUs are mapped to pCPU that are aligned to the Numa node the device is in.
This is especially needed in case the vCPUs are mapped to pCPUs from various numa nodes. 
This PR will attempt to provide a list of the aligned vCPU (in case the VMI has requested dedicatedCPUPlacement) or the NUMA node number (in case the VMI has requested NUMA mapping)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6667

**Release note**:
```release-note
Numa information of an assigned device will be presented in the devices metadata
```
