### PR TITLE
Update openshift mirror URL to working one

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -12,6 +12,6 @@ RUN mkdir -p "$BIN_DIR" && chmod -R 777 "$BIN_DIR"
 
 # download oc binary
 RUN cd "$BIN_DIR" && \
-    curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/linux/oc.tar.gz | tar -C . -xzf -  && \
+    curl https://mirror2.openshift.com/pub/openshift-v4/clients/oc/4.4/linux/oc.tar.gz | tar -C . -xzf -  && \
     chmod +x oc && \
     ln -s oc kubectl


### PR DESCRIPTION
**What this PR does / why we need it**:
mirror.openshift.com is retired, let's avoid referencing it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
