### PR TITLE
netstat: Update VMI interface status report unit tests

### DIFF
--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -244,37 +244,6 @@ var _ = Describe("netstat", func() {
 		}), "the pod IP/s should be reported in the status")
 	})
 
-	It("should add a new interface based on the domain spec", func() {
-		const (
-			existingNetworkName = "primary"
-			existingMAC         = "C0:01:BE:E7:15:G0:0D"
-
-			newNetworkName = "secondary"
-			newDomainMAC   = "22:22:22:22:22:22"
-		)
-
-		vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-			{
-				MAC:  existingMAC,
-				Name: existingNetworkName,
-			},
-		}
-
-		domain := &api.Domain{
-			Spec: api.DomainSpec{Devices: api.Devices{Interfaces: []api.Interface{
-				newDomainSpecIface(existingNetworkName, existingMAC),
-				newDomainSpecIface(newNetworkName, newDomainMAC),
-			}}},
-		}
-
-		netStat.UpdateStatus(vmi, domain)
-
-		Expect(vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(existingNetworkName, nil, existingMAC, "", netvmispec.InfoSourceDomain),
-			newVMIStatusIface(newNetworkName, nil, newDomainMAC, "", netvmispec.InfoSourceDomain),
-		}), "the new interface should be reported in the status")
-	})
-
 	It("should report SR-IOV interface with MAC and network name, based on VMI spec and guest-agent data", func() {
 		const (
 			networkName    = "sriov-network"

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -275,42 +275,6 @@ var _ = Describe("netstat", func() {
 		}), "the new interface should be reported in the status")
 	})
 
-	It("should replace a non-named interface with new data (with name) from the domain", func() {
-		const (
-			networkName  = "primary"
-			existingIPv4 = "1.1.1.1"
-			existingMAC  = "C0:01:BE:E7:15:G0:0D"
-			newDomainMAC = "22:22:22:22:22:22"
-		)
-
-		vmi.Spec.Networks = []v1.Network{
-			{
-				Name:          "other_name",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
-			},
-			{
-				Name:          networkName,
-				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-			},
-		}
-
-		vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-			{IP: existingIPv4, MAC: existingMAC},
-		}
-
-		domain := &api.Domain{
-			Spec: api.DomainSpec{Devices: api.Devices{Interfaces: []api.Interface{
-				newDomainSpecIface(networkName, newDomainMAC),
-			}}},
-		}
-
-		netStat.UpdateStatus(vmi, domain)
-
-		Expect(vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(networkName, nil, newDomainMAC, "", netvmispec.InfoSourceDomain),
-		}), "the new interface should be reported in the status")
-	})
-
 	It("should report SR-IOV interface with MAC and network name, based on VMI spec and guest-agent data", func() {
 		const (
 			networkName    = "sriov-network"

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -43,6 +43,24 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, nil)).To(Succeed())
 	})
 
+	It("volatile cache is updated based on non-volotile cache", func() {
+		const (
+			primaryNetworkName = "primary"
+			primaryPodIPv4     = "1.1.1.1"
+		)
+
+		setup.addNetworkInterface(
+			newVMISpecIfaceWithBridgeBinding(primaryNetworkName),
+			newVMISpecPodNetwork(primaryNetworkName),
+			newDomainSpecIface(primaryNetworkName, ""),
+			primaryPodIPv4,
+		)
+
+		setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)
+
+		Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
+	})
+
 	Context("with volatile cache", func() {
 		const (
 			primaryNetworkName = "primary"


### PR DESCRIPTION
**What this PR does / why we need it**:

The existing unit tests which cover the VMI interface status report is missing some realistic overall scenarios about the existing data available.

This change unifies and tries to place some rules on what is the expected data provided to the report processing.

The current netstat unit tests have been updated to reflect the
following expected behavior:
- When regular interfaces are added, this is the expected state/input:
  - VMI spec interfaces and networks should be in sync with 1:1 relation.
  - Domain spec is expect to reflect the VMI spec, i.e. having the same
    interfaces.
  - The filesystem cache should reflect the same interfaces as the VMI
    spec.
  - The volatile cache is optional, reflecting the same interface.
  - The Guest Agent data is optional.

- When SR-IOV interfaces are added, this is the expected state/input:
  - VMI spec interfaces and networks should be in sync with 1:1 relation.
  - The Guest Agent data is optional.
  Notes: Caches do not exist and the domain spec interfaces do not
  include the SR-IOV interfaces. These are under the hostdevice section.

Miscellaneous scenarios are also covered to reflect what happens when such cases occur. However, these are not expected to occur in a normal system operation. Future production changes may treat these scenarios explicitly to avoid undefined and nontrivial behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #6926~~
~~Only the last 6 commits are to be reviewed as part of this PR.~~

**Release note**:
```release-note
NONE
```
