### PR TITLE
services, ip-family-policy: valid default for multiple IP families

### DIFF
--- a/pkg/virtctl/expose/BUILD.bazel
+++ b/pkg/virtctl/expose/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//tests:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -139,7 +139,7 @@ func (o *Command) RunE(args []string) error {
 		return err
 	}
 
-	ipFamilyPolicy, err := convertIPFamilyPolicy(strIPFamilyPolicy)
+	ipFamilyPolicy, err := convertIPFamilyPolicy(strIPFamilyPolicy, ipFamilies)
 	if err != nil {
 		return err
 	}
@@ -291,9 +291,12 @@ func convertIPFamily(strIPFamily string) ([]v1.IPFamily, error) {
 	}
 }
 
-func convertIPFamilyPolicy(strIPFamilyPolicy string) (v1.IPFamilyPolicyType, error) {
+func convertIPFamilyPolicy(strIPFamilyPolicy string, ipFamilies []v1.IPFamily) (v1.IPFamilyPolicyType, error) {
 	switch strings.ToLower(strIPFamilyPolicy) {
 	case "":
+		if len(ipFamilies) > 1 {
+			return v1.IPFamilyPolicyPreferDualStack, nil
+		}
 		return "", nil
 	case "singlestack":
 		return v1.IPFamilyPolicySingleStack, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The default `IPFamilyPolicyType` value for a service is `SingleStack`.
When multiple `IPFamily`s are provided, on k8s-1.23, this value is not
valid. As such, an appropriate backwards-compatible value is provided
on those scenarios.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the `virtctl` exposed services `IPFamilyPolicyType` default to `IPFamilyPolicyPreferDualStack`
when multiple `IPFamily` are requested.
```
