### PR TITLE
tests: Use fedora-with-test-tooling based on Fedora 35

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -191,7 +191,6 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//containerimages:alpine-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-custom-container-disk-demo:$(container_tag)": "//containerimages:cirros-custom-container-disk-image",
-        "$(container_prefix)/$(image_prefix)microlivecd-container-disk-demo:$(container_tag)": "//containerimages:microlivecd-container-disk-image",
         "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
         # Kernel boot container
         "$(container_prefix)/$(image_prefix)alpine-ext-kernel-boot-demo:$(container_tag)": "//containerimages:alpine-ext-kernel-boot-demo-container",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,33 +122,6 @@ http_file(
 )
 
 http_file(
-    name = "microlivecd_image",
-    sha256 = "ae449ae8c0f73b1a7e2c394bc5385e7ab01d8fc000f5b074bc8b2aaabf931eac",
-    urls = [
-        "https://github.com/jean-edouard/microlivecd/releases/download/0.1/microlivecd_amd64.iso",
-        "https://storage.googleapis.com/builddeps/ae449ae8c0f73b1a7e2c394bc5385e7ab01d8fc000f5b074bc8b2aaabf931eac",
-    ],
-)
-
-http_file(
-    name = "microlivecd_image_ppc64el",
-    sha256 = "eae431d68b9dc5fab422f4b90d4204cbc28c39518780c4822970a4bef42f7c7f",
-    urls = [
-        "https://github.com/jean-edouard/microlivecd/releases/download/0.1/microlivecd_ppc64el.iso",
-        "https://storage.googleapis.com/builddeps/eae431d68b9dc5fab422f4b90d4204cbc28c39518780c4822970a4bef42f7c7f",
-    ],
-)
-
-http_file(
-    name = "microlivecd_image_aarch64",
-    sha256 = "2d9a7790fa6347251aacd997384b30962bc60dfe4eb9f0c2bd76b42f54d04b8d",
-    urls = [
-        "https://github.com/jean-edouard/microlivecd/releases/download/0.2/microlivecd_arm64.iso",
-        "https://storage.googleapis.com/builddeps/2d9a7790fa6347251aacd997384b30962bc60dfe4eb9f0c2bd76b42f54d04b8d",
-    ],
-)
-
-http_file(
     name = "virtio_win_image",
     sha256 = "7bf7f53e30c69a360f89abb3d2cc19cc978f533766b1b2270c2d8344edf9b3ef",
     urls = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -330,9 +330,9 @@ container_pull(
 # TODO build fedora_with_test_tooling for multi-arch
 container_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:c986d7c2e1fd330ed8a7b9bce75de3f81d8dc191ece36850ac060efe247670e2",
-    registry = "ghcr.io",
-    repository = "vasiliy-ul/fedora-with-test-tooling",
+    digest = "sha256:da6c118dbd9ac643713c1737cbaa43dcc7386b269b4beb0984413168f3a5f2d3",
+    registry = "quay.io",
+    repository = "kubevirtci/fedora-with-test-tooling",
 )
 
 container_pull(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -357,9 +357,9 @@ container_pull(
 # TODO build fedora_with_test_tooling for multi-arch
 container_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:14193941e1fe74f2189536263c71479abbd296dc93b75e8a7f97f0b31e78b71e",
-    registry = "quay.io",
-    repository = "kubevirtci/fedora-with-test-tooling",
+    digest = "sha256:c986d7c2e1fd330ed8a7b9bce75de3f81d8dc191ece36850ac060efe247670e2",
+    registry = "ghcr.io",
+    repository = "vasiliy-ul/fedora-with-test-tooling",
 )
 
 container_pull(

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -66,27 +66,6 @@ container_image(
 )
 
 pkg_tar(
-    name = "microlivecd-image-tar",
-    srcs = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": ["@microlivecd_image_aarch64//file"],
-        "//conditions:default": ["@microlivecd_image//file"],
-    }),
-    mode = "440",
-    owner = "107.107",
-    package_dir = "/disk",
-)
-
-container_image(
-    name = "microlivecd-container-disk-image",
-    architecture = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
-        "//conditions:default": "amd64",
-    }),
-    tars = [":microlivecd-image-tar"],
-    visibility = ["//visibility:public"],
-)
-
-pkg_tar(
     name = "virtio-image-tar",
     srcs = ["@virtio_win_image//file"],
     mode = "440",

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -26,5 +26,5 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/microlivecd-container-disk-demo:devel
+      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -146,7 +146,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 	// Do not login, if we already logged in
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: fmt.Sprintf(`(\[fedora@(localhost|%s) ~\]\$ |\[root@(localhost|%s) fedora\]\# )`, vmi.Name, vmi.Name)},
+		&expect.BExp{R: fmt.Sprintf(`(\[fedora@(localhost|fedora|%s) ~\]\$ |\[root@(localhost|fedora|%s) fedora\]\# )`, vmi.Name, vmi.Name)},
 	})
 	_, err = expecter.ExpectBatch(b, 5*time.Second)
 	if err == nil {
@@ -160,7 +160,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 			&expect.Case{
 				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
 				// and in case the VM's did not get hostname form DHCP server try the default hostname
-				R:  regexp.MustCompile(fmt.Sprintf(`(localhost|%s) login: `, vmi.Name)),
+				R:  regexp.MustCompile(fmt.Sprintf(`(localhost|fedora|%s) login: `, vmi.Name)),
 				S:  "fedora\n",
 				T:  expect.Next(),
 				Rt: 10,
@@ -177,7 +177,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 				Rt: 10,
 			},
 			&expect.Case{
-				R: regexp.MustCompile(fmt.Sprintf(`\[fedora@(localhost|%s) ~\]\$ `, vmi.Name)),
+				R: regexp.MustCompile(fmt.Sprintf(`\[fedora@(localhost|fedora|%s) ~\]\$ `, vmi.Name)),
 				T: expect.OK(),
 			},
 		}},

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -32,7 +32,6 @@ const (
 	ContainerDiskCirros               ContainerDisk = "cirros"
 	ContainerDiskAlpine               ContainerDisk = "alpine"
 	ContainerDiskFedoraTestTooling    ContainerDisk = "fedora-with-test-tooling"
-	ContainerDiskMicroLiveCD          ContainerDisk = "microlivecd"
 	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
 	ContainerDiskEmpty                ContainerDisk = "empty"
 	ContainerDiskFedoraRealtime       ContainerDisk = "fedora-realtime"
@@ -55,7 +54,7 @@ func DataVolumeImportUrlFromRegistryForContainerDisk(registry string, name Conta
 
 func ContainerDiskFromRegistryFor(registry string, name ContainerDisk) string {
 	switch name {
-	case ContainerDiskCirros, ContainerDiskAlpine, ContainerDiskMicroLiveCD, ContainerDiskCirrosCustomLocation:
+	case ContainerDiskCirros, ContainerDiskAlpine, ContainerDiskCirrosCustomLocation:
 		return fmt.Sprintf("%s/%s-container-disk-demo:%s", registry, name, flags.KubeVirtUtilityVersionTag)
 	case ContainerDiskVirtio:
 		return fmt.Sprintf("%s/virtio-container-disk:%s", registry, flags.KubeVirtUtilityVersionTag)

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -37,6 +37,10 @@ const (
 	ContainerDiskFedoraRealtime       ContainerDisk = "fedora-realtime"
 )
 
+const (
+	FedoraVolumeSize = "6Gi"
+)
+
 // ContainerDiskFor takes the name of an image and returns the full
 // registry diks image path.
 // Use the ContainerDisk* constants as input values.

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -88,6 +88,7 @@ import (
 
 const (
 	fedoraVMSize         = "256M"
+	fedoraVolumeSize     = "6Gi"
 	secretDiskSerial     = "D23YZ9W6WA5DJ487"
 	stressDefaultVMSize  = "100"
 	stressLargeVMSize    = "400"
@@ -1506,7 +1507,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var wffcPod *k8sv1.Pod
 
 			BeforeEach(func() {
-				quantity, err := resource.ParseQuantity("5Gi")
+				quantity, err := resource.ParseQuantity(fedoraVolumeSize)
 				Expect(err).ToNot(HaveOccurred())
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 				dv = tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
@@ -1554,7 +1555,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// create a new PV and PVC (PVs can't be reused)
 				By("create a new NFS PV and PVC")
 				os := string(cd.ContainerDiskFedoraTestTooling)
-				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
+				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, fedoraVolumeSize, nfsIP, os)
 			})
 
 			AfterEach(func() {
@@ -1924,7 +1925,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 				memoryRequestSize = resource.MustParse("1Gi")
 
-				quantity, err := resource.ParseQuantity("5Gi")
+				quantity, err := resource.ParseQuantity(fedoraVolumeSize)
 				Expect(err).ToNot(HaveOccurred())
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 				dv := tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -88,7 +88,6 @@ import (
 
 const (
 	fedoraVMSize         = "256M"
-	fedoraVolumeSize     = "6Gi"
 	secretDiskSerial     = "D23YZ9W6WA5DJ487"
 	stressDefaultVMSize  = "100"
 	stressLargeVMSize    = "400"
@@ -1507,7 +1506,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var wffcPod *k8sv1.Pod
 
 			BeforeEach(func() {
-				quantity, err := resource.ParseQuantity(fedoraVolumeSize)
+				quantity, err := resource.ParseQuantity(cd.FedoraVolumeSize)
 				Expect(err).ToNot(HaveOccurred())
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 				dv = tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
@@ -1555,7 +1554,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// create a new PV and PVC (PVs can't be reused)
 				By("create a new NFS PV and PVC")
 				os := string(cd.ContainerDiskFedoraTestTooling)
-				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, fedoraVolumeSize, nfsIP, os)
+				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, cd.FedoraVolumeSize, nfsIP, os)
 			})
 
 			AfterEach(func() {
@@ -1925,7 +1924,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 				memoryRequestSize = resource.MustParse("1Gi")
 
-				quantity, err := resource.ParseQuantity(fedoraVolumeSize)
+				quantity, err := resource.ParseQuantity(cd.FedoraVolumeSize)
 				Expect(err).ToNot(HaveOccurred())
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 				dv := tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
@@ -1973,7 +1972,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// create a new PV and PVC (PVs can't be reused)
 				By("create a new NFS PV and PVC")
 				os := string(cd.ContainerDiskFedoraTestTooling)
-				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "5Gi", nfsIP, os)
+				tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, cd.FedoraVolumeSize, nfsIP, os)
 			})
 
 			AfterEach(func() {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -942,7 +942,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		}
 		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
 			dataVolume := tests.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-			dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("5Gi")
+			dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
 			dataVolume = dvChange(dataVolume)
 			preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
 
@@ -966,7 +966,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=100 2> /dev/null\n"},
+				&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: syncName},
 				&expect.BExp{R: console.PromptExpression},
@@ -986,7 +986,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			By("Deleting large file and trimming disk")
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				// Write a small file so that we'll have an increase in image size if trim is unsupported.
-				&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=20 2> /dev/null\n"},
+				&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: syncName},
 				&expect.BExp{R: console.PromptExpression},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2305,7 +2305,7 @@ func NewRandomVMIWithEFIBootloader() *v1.VirtualMachineInstance {
 }
 
 func NewRandomVMIWithSecureBoot() *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskMicroLiveCD))
+	vmi := NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
 
 	// EFI needs more memory than other images
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1378,7 +1378,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in vmi status")
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedVmi.Status.GuestOSInfo.Name).To(Equal("Fedora"))
+				Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
 			})
 
 			It("[test_id:4627]should return the whole data when agent is present", func() {

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -101,11 +101,10 @@ const (
 )
 
 const (
-	imageAlpine      = "alpine-container-disk-demo"
-	imageCirros      = "cirros-container-disk-demo"
-	imageFedora      = "fedora-with-test-tooling-container-disk"
-	imageMicroLiveCD = "microlivecd-container-disk-demo"
-	imageKernelBoot  = "alpine-ext-kernel-boot-demo"
+	imageAlpine     = "alpine-container-disk-demo"
+	imageCirros     = "cirros-container-disk-demo"
+	imageFedora     = "fedora-with-test-tooling-container-disk"
+	imageKernelBoot = "alpine-ext-kernel-boot-demo"
 )
 const windowsFirmware = "5d307ca9-b3ef-428c-8861-06e72d69f223"
 const defaultInterfaceName = "default"
@@ -430,7 +429,7 @@ func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 func GetVMISecureBoot() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiSecureBoot)
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageMicroLiveCD, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageFedora, DockerTag), busVirtio)
 
 	_true := true
 	vmi.Spec.Domain.Features = &v1.Features{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR introduces fedora-with-test-tooling image based on Fedora 35 (https://github.com/kubevirt/kubevirtci/pull/713). The new version supports UEFI boot (required for https://github.com/kubevirt/kubevirt/pull/6166).

Also the new image replaces microlivecd in secure boot tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Major differences in Fedora 35:

- `bash` and `libreadline` in Fedora 35 come with `bracketed-paste` mode enabled by default. This results in extra escape sequences in the console output. The mode is now explicitly disabled in `/etc/profile.d/disable-bracketed-paste.sh` for all login shells (see https://github.com/kubevirt/kubevirtci/pull/713)
- Different hosts resolution modules priority in `/etc/nsswitch.conf`:
  Fedora 32: `hosts:      files dns myhostname`
  Fedora 35: `hosts:      files myhostname resolve [!UNAVAIL=return] dns`
  Here the fact that `myhostname` precedes `resolve` and `dns` modules prevents `hostname -f` from returning a `FQDN` (it just returns the short name reported by `myhostname`): https://bugzilla.redhat.com/show_bug.cgi?id=2038634

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
