### PR TITLE
[migrations]: generate event when target pod enters unschedulable phase

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -933,6 +933,12 @@ func (c *MigrationController) handlePendingPodTimeout(migration *virtv1.VirtualM
 
 	if isPodPendingUnschedulable(pod) {
 		c.alertIfHostModelIsUnschedulable(vmi, pod)
+		c.recorder.Eventf(
+			migration,
+			k8sv1.EventTypeWarning,
+			MigrationTargetPodUnschedulable,
+			"Migration target pod for VMI [%s/%s] is currently unschedulable.", vmi.Namespace, vmi.Name)
+		log.Log.Object(migration).Warningf("Migration target pod for VMI [%s/%s] is currently unschedulable.", vmi.Namespace, vmi.Name)
 		if secondsSpentPending >= unschedulableTimeout {
 			return c.deleteTimedOutTargetPod(migration, vmi, pod, "unschedulable pod timeout period exceeded")
 		} else {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -671,6 +671,10 @@ var _ = Describe("Migration watcher", func() {
 			}
 			controller.Execute()
 
+			if phase != virtv1.MigrationScheduled {
+				testutils.ExpectEvent(recorder, MigrationTargetPodUnschedulable)
+			}
+
 			if shouldTimeout {
 				testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			}
@@ -1437,6 +1441,7 @@ var _ = Describe("Migration watcher", func() {
 			shouldExpectPodDeletion()
 			controller.Execute()
 			testutils.ExpectEvent(recorder, NoSuitableNodesForHostModelMigration)
+			testutils.ExpectEvent(recorder, MigrationTargetPodUnschedulable)
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 		})
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -110,6 +110,8 @@ const (
 	FailedMigrationReason = "FailedMigration"
 	// SuccessfulAbortMigrationReason is added when an attempt to abort migration completes successfully
 	SuccessfulAbortMigrationReason = "SuccessfulAbortMigration"
+	// MigrationTargetPodUnschedulable is added a migration target pod enters Unschedulable phase
+	MigrationTargetPodUnschedulable = "migrationTargetPodUnschedulable"
 	// FailedAbortMigrationReason is added when an attempt to abort migration fails
 	FailedAbortMigrationReason = "FailedAbortMigration"
 	// MissingAttachmentPodReason is set when we have a hotplugged volume, but the attachment pod is missing


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2017802

**Special notes for your reviewer**:

**Release note**:
```release-note
generate event when target pod enters unschedulable phase
```
