### PR TITLE
network, fqdn: Fix subdomain flow

### DIFF
--- a/pkg/network/dhcp/bridge_test.go
+++ b/pkg/network/dhcp/bridge_test.go
@@ -20,6 +20,7 @@ import (
 const (
 	ifaceName   = "eth0"
 	launcherPID = "self"
+	subdomain   = "subdomain"
 )
 
 var _ = Describe("Bridge DHCP configurator", func() {
@@ -67,6 +68,7 @@ var _ = Describe("Bridge DHCP configurator", func() {
 				vmiSpecIfaces:    []v1.Interface{iface},
 				vmiSpecIface:     &iface,
 				handler:          mockHandler,
+				subdomain:        subdomain,
 			}
 
 			mtu := 1410
@@ -82,6 +84,7 @@ var _ = Describe("Bridge DHCP configurator", func() {
 			advertisingIPAddr, _ := netlink.ParseAddr(fakeBridgeIP)
 			expectedConfig.AdvertisingIPAddr = advertisingIPAddr.IP
 			expectedConfig.Mtu = 1410
+			expectedConfig.Subdomain = subdomain
 			Expect(*config).To(Equal(expectedConfig))
 		})
 		It("Should succeed with no ipam", func() {
@@ -91,6 +94,7 @@ var _ = Describe("Bridge DHCP configurator", func() {
 				cacheFactory:     cacheFactory,
 				launcherPID:      launcherPID,
 				podInterfaceName: ifaceName,
+				subdomain:        subdomain,
 			}
 			config, err := generator.Generate()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/network/dhcp/masquerade.go
+++ b/pkg/network/dhcp/masquerade.go
@@ -45,6 +45,7 @@ func (d *MasqueradeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 	}
 
 	dhcpConfig.Name = podNicLink.Attrs().Name
+	dhcpConfig.Subdomain = d.subdomain
 	dhcpConfig.Mtu = uint16(podNicLink.Attrs().MTU)
 
 	ipv4Gateway, ipv4, err := virtnetlink.GenerateMasqueradeGatewayAndVmIPAddrs(d.vmiSpecNetwork, iptables.ProtocolIPv4)
@@ -68,7 +69,6 @@ func (d *MasqueradeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 		}
 		dhcpConfig.IPv6 = *ipv6
 		dhcpConfig.AdvertisingIPv6Addr = ipv6Gateway.IP.To16()
-		dhcpConfig.Subdomain = d.subdomain
 	}
 
 	return dhcpConfig, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

The subdomain was set in the DHCP config under the condition IPv6 enabled.
It is wrong, because the subdomain is not related to IPv6, and need to be
populated even if IPv6 is disabled, so in case it is specified,
the missing search domain will be added as part of IPv4 DHCP server
(which currently used by default, and always exists for masquerade interfaces).

Additional change:

Add missing subdomain unit test.
In case IPAM is enabled on bridge interface,
the subdomain should be propagated by
the bridge generator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Fixes a problem of https://github.com/kubevirt/kubevirt/pull/6508
In case IPv6 is disable in the cluster, DHCP won't add the missing domain for masquerade interfaces.

**Release note**:
```release-note
None
```
