### PR TITLE
k8s 1.23 storage lane fix

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -70,6 +70,7 @@ var restoreAnnotationsToDelete = []string{
 	"pv.kubernetes.io",
 	"volume.beta.kubernetes.io",
 	"cdi.kubevirt.io",
+	"volume.kubernetes.io",
 }
 
 func restorePVCName(vmRestore *snapshotv1.VirtualMachineRestore, name string) string {


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

New annotation added to PVCs in 1.23.  Has to be removed when creating restore PVC def.

See failure run here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6947/pull-kubevirt-e2e-k8s-1.23-sig-storage/1470770667963027456

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
