### PR TITLE
Add Zvi maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,7 @@ aliases:
       - jean-edouard
       - mhenriks
       - enp0s3
+      - zcahana
   emeritus_approvers:
       - cynepco3hahue
       - slintes


### PR DESCRIPTION
Zvi has been committing quality code and code reviews for quite some time now across the kubevirt/kubevirt repo. I'd like to sponsor him as an approver.

Per out guidelines [here](https://github.com/kubevirt/community/blob/main/membership_policy.md#approver) We need one more approver to sponsor Zvi in addition to myself.

```release-note
NONE
```
