### PR TITLE
Quarantine test_id:4744 due to flakiness

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1318,7 +1318,7 @@ spec:
 
 	Describe("[test_id:4744]should apply component customization", func() {
 
-		It("test applying and removing a patch", func() {
+		It("[QUARANTINE]test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"
 			annotationPatchKey := "applied-patch"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Test has had more than 20% failures in the last two days.

Source: https://search.ci.kubevirt.io/?search=test_id%3A4744&maxAge=48h&context=1&type=junit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Recent failures:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6933/pull-kubevirt-e2e-k8s-1.20-operator/1471742758426251264
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6933/pull-kubevirt-e2e-k8s-1.21-operator/1471742758359142400
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6933/pull-kubevirt-e2e-k8s-1.20-operator-nonroot/1471742758514331648
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6933/pull-kubevirt-e2e-k8s-1.20-operator/1471687274012872704
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6821/pull-kubevirt-e2e-k8s-1.20-operator/1471657074956963840
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6933/pull-kubevirt-e2e-k8s-1.20-operator/1471581572770566144
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6821/pull-kubevirt-e2e-k8s-1.20-operator/1471566474010169344

Flakefinder shows that check-tests-for-flakes reported failures here:
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2021-12-16-168h.html#row39

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @acardace
Mind taking a look? Maybe you know what this is about?
/cc @fgimenez 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
