### PR TITLE
netstat: Simplify pod interface volatile cache

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -254,10 +254,6 @@ func (p *PodInterfaceByVMIAndName) Store(vmiUID types.UID, interfaceName string,
 	p.syncMap.Store(p.key(vmiUID, interfaceName), podCacheInterface)
 }
 
-func (p *PodInterfaceByVMIAndName) Size() int {
-	return syncMapLen(&p.syncMap)
-}
-
 func (*PodInterfaceByVMIAndName) cast(result interface{}) *cache.PodCacheInterface {
 	podCacheInterface, ok := result.(*cache.PodCacheInterface)
 	if !ok {
@@ -268,13 +264,4 @@ func (*PodInterfaceByVMIAndName) cast(result interface{}) *cache.PodCacheInterfa
 
 func (*PodInterfaceByVMIAndName) key(vmiUID types.UID, interfaceName string) string {
 	return fmt.Sprintf("%s/%s", vmiUID, interfaceName)
-}
-
-func syncMapLen(m *sync.Map) int {
-	mapLen := 0
-	m.Range(func(k, v interface{}) bool {
-		mapLen += 1
-		return true
-	})
-	return mapLen
 }

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -50,7 +50,7 @@ func NewNetStat(ifaceCacheFactory cache.InterfaceCacheFactory) *NetStat {
 
 func (c *NetStat) Teardown(vmi *v1.VirtualMachineInstance) {
 	c.podInterfaceVolatileCache.Range(func(key, value interface{}) bool {
-		if strings.Contains(key.(string), string(vmi.UID)) {
+		if strings.HasPrefix(key.(string), string(vmi.UID)) {
 			c.podInterfaceVolatileCache.Delete(key)
 		}
 		return true


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplify the existing code that implements the cache behind the pod interface, by removing several wrappers and optimizing some parts of the logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #6781~~
~~Only the last 3 commits are relevant to review in this context.~~

**Release note**:
```release-note
NONE
```
