### PR TITLE
Improve kubevirt update test

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -40,6 +40,8 @@ var KubeVirtGoCliPath = ""
 var KubeVirtInstallNamespace string
 var PreviousReleaseTag = ""
 var PreviousReleaseRegistry = ""
+var PreviousUtilityRegistry = ""
+var PreviousUtilityTag = ""
 var ConfigFile = ""
 var SkipShasumCheck bool
 var SkipDualStackTests bool
@@ -73,6 +75,8 @@ func init() {
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
 	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "quay.io/kubevirt", "Set registry of the release to test updating from")
+	flag.StringVar(&PreviousUtilityRegistry, "previous-utility-container-registry", "", "Set registry of the utility containers to test updating from")
+	flag.StringVar(&PreviousUtilityTag, "previous-utility-container-tag", "", "Set tag of the utility containers to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
 	flag.StringVar(&OperatorManifestPath, "operator-manifest-path", "", "Set path to virt-operator manifest file")
@@ -95,4 +99,13 @@ func NormalizeFlags() {
 	if KubeVirtUtilityRepoPrefix == "" {
 		KubeVirtUtilityRepoPrefix = KubeVirtRepoPrefix
 	}
+
+	if PreviousUtilityRegistry == "" {
+		PreviousUtilityRegistry = PreviousReleaseRegistry
+	}
+
+	if PreviousUtilityTag == "" {
+		PreviousUtilityTag = PreviousReleaseTag
+	}
+
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -901,7 +901,7 @@ spec:
 			}
 		}
 
-		generatePreviousVersionVmYamls = func(previousImageRegistry string, previousImageTag string) {
+		generatePreviousVersionVmYamls = func(previousUtilityRegistry string, previousUtilityTag string) {
 			ext, err := extclient.NewForConfig(virtClient.Config())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -972,7 +972,7 @@ spec:
 
             echo 'printed from cloud-init userdata'
         name: cloudinitdisk
-`, version, version, version, i, version, i, previousImageRegistry, cd.ContainerDiskCirros, previousImageTag)
+`, version, version, version, i, version, i, previousUtilityRegistry, cd.ContainerDiskCirros, previousUtilityTag)
 
 				yamlFile := filepath.Join(workDir, fmt.Sprintf("vm-%s.yaml", version))
 				err = ioutil.WriteFile(yamlFile, []byte(vmYaml), 0644)
@@ -1408,9 +1408,18 @@ spec:
 			if previousImageTag == "" {
 				previousImageTag, err = tests.DetectLatestUpstreamOfficialTag()
 				Expect(err).ToNot(HaveOccurred())
-				By(fmt.Sprintf("By Using detected tag %s", previousImageTag))
+				By(fmt.Sprintf("By Using detected tag %s for previous kubevirt", previousImageTag))
 			} else {
-				By(fmt.Sprintf("By Using user defined tag %s", previousImageTag))
+				By(fmt.Sprintf("By Using user defined tag %s for previous kubevirt", previousImageTag))
+			}
+
+			previousUtilityTag := flags.PreviousUtilityTag
+			previousUtilityRegistry := flags.PreviousUtilityRegistry
+			if previousUtilityTag == "" {
+				previousUtilityTag = previousImageTag
+				By(fmt.Sprintf("By Using detected tag %s for previous utility containers", previousUtilityTag))
+			} else {
+				By(fmt.Sprintf("By Using user defined tag %s for previous utility containers", previousUtilityTag))
 			}
 
 			curVersion := originalKv.Status.ObservedKubeVirtVersion
@@ -1481,7 +1490,7 @@ spec:
 			// needs to be a VM created for every api. This is how we will ensure
 			// our api remains upgradable and supportable from previous release.
 
-			generatePreviousVersionVmYamls(previousImageRegistry, previousImageTag)
+			generatePreviousVersionVmYamls(previousUtilityRegistry, previousUtilityTag)
 			generatePreviousVersionVmsnapshotYamls()
 			for _, vmYaml := range vmYamls {
 				By(fmt.Sprintf("Creating VM with %s api", vmYaml.vmName))

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -663,8 +663,13 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		// save the operator sha
 		_, _, _, _, version := parseOperatorImage()
-		Expect(strings.HasPrefix(version, "@")).To(BeTrue())
-		originalOperatorVersion = strings.TrimPrefix(version, "@")
+		if !flags.SkipShasumCheck {
+			Expect(strings.HasPrefix(version, "@")).To(BeTrue())
+			originalOperatorVersion = strings.TrimPrefix(version, "@")
+		} else {
+			Expect(strings.HasPrefix(version, ":")).To(BeTrue())
+			originalOperatorVersion = strings.TrimPrefix(version, ":")
+		}
 
 		if tests.HasDataVolumeCRD() {
 			cdiList, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
@@ -1394,7 +1399,9 @@ spec:
 
 			migratableVMIs := generateMigratableVMIs(2)
 			launcherSha := getVirtLauncherSha()
-			Expect(launcherSha).ToNot(Equal(""))
+			if !flags.SkipShasumCheck {
+				Expect(launcherSha).ToNot(Equal(""))
+			}
 
 			previousImageTag := flags.PreviousReleaseTag
 			previousImageRegistry := flags.PreviousReleaseRegistry


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Improve current test code for kubevirt release update test:
- allow to specify previous utility container registry and tag: it is possible that the utility containers for previous test release are in different repo from flags.PreviousReleaseRegistry, and have different tagging rules
- fix minor test issues about shasum when kubevirt infrastructure pod uses tags only (KUBEVIRT_ONLY_USE_TAGS enabled and -skip-shasums-check used in test flags)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE
```
