### PR TITLE
[Prometheus]: Remove ComponentExceedsRequestedCPU alert

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -6,32 +6,6 @@ group_eval_order:
   - kubevirt.rules
 #information about this format can be found in: https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/
 tests:
-  # Pod is using more CPU than expected
-  - interval: 1m
-    input_series:
-      - series: 'node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="ci",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
-        values: '2+0x10'
-      - series: 'kube_pod_container_resource_requests{namespace="ci",container="virt-controller",resource="cpu",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
-        values: '0+0x6'
-
-    alert_rule_test:
-      - eval_time: 5m
-        alertname: KubeVirtComponentExceedsRequestedCPU
-        exp_alerts:
-          - exp_annotations:
-              description: "Container virt-controller in pod virt-controller-8546c99968-x9jgg cpu usage exceeds the CPU requested"
-              summary: "The container is using more CPU than what is defined in the containers resource requests"
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU"
-            exp_labels:
-              severity: "warning"
-              kubernetes_operator_part_of: "kubevirt"
-              kubernetes_operator_component: "kubevirt"
-              pod: "virt-controller-8546c99968-x9jgg"
-              container: "virt-controller"
-              namespace: ci
-              node: node1
-              resource: cpu
-
   # Pod is using more memory than expected
   - interval: 1m
     input_series:

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -544,21 +544,6 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							severityAlertLabelKey: "warning",
 						},
 					},
-					{
-						Alert: "KubeVirtComponentExceedsRequestedCPU",
-						Expr: intstr.FromString(
-							fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="cpu"}) - on(pod) group_left(node) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="%s"}) < 0`, ns, ns),
-						),
-						For: "5m",
-						Annotations: map[string]string{
-							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} cpu usage exceeds the CPU requested",
-							"summary":     "The container is using more CPU than what is defined in the containers resource requests",
-							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedCPU",
-						},
-						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes `KubeVirtComponentExceedsRequestedCPU` alert.

The [runbook for this alert](https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU.html) says: `If this alert consistently fires this could mean that the node’s CPU resources are not being optimally used and could be overloaded`. This is a mistake.

In Kubernetes, it's completely normal to use more vCPU than whatever defined in `request` section. Not only that - in order to avoid wasted CPU time, the CPU "leftovers" will be distributed between containers proportionately to their CPU request amount.

Example: let's imagine that two containers are running on a node. Container A requests 0.5 CPUs, container B requests 0.3 CPUs, and the node has 1 CPU (for the simplicity of the example). In this situation it isn't wise to waste the remaining 20% CPU time that is left unused. Instead every container would get the remained 20% proportionate to the requested amount of its CPU usage.

Therefore, an alert is not needed to be triggered on such cases which are absolutely normal and expected.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
