### PR TITLE
pdb: silence 'PodDisruptionBudgetAtLimit' alert for migratable VMIs

### DIFF
--- a/pkg/util/pdbs/pdbs.go
+++ b/pkg/util/pdbs/pdbs.go
@@ -10,6 +10,10 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 )
 
+const (
+	OpenShiftPDBAtLimitAlert = "alerts.openshift.io/PodDisruptionBudgetAtLimit"
+)
+
 func PDBsForVMI(vmi *virtv1.VirtualMachineInstance, pdbInformer cache.SharedIndexInformer) ([]*v1beta1.PodDisruptionBudget, error) {
 	pbds, err := pdbInformer.GetIndexer().ByIndex(cache.NamespaceIndex, vmi.Namespace)
 	if err != nil {

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/monitoring/vmistats:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/cluster:go_default_library",
         "//pkg/util/lookup:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/pdbs:go_default_library",

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -151,6 +151,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
@@ -42,6 +43,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
+	discoveryFake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/tools/record"
 
 	io_prometheus_client "github.com/prometheus/client_model/go"
@@ -178,6 +180,11 @@ var _ = Describe("Application", func() {
 		app.nodeInformer = nodeInformer
 
 		app.readyChan = make(chan bool)
+
+		discoveryClient := &discoveryFake.FakeDiscovery{
+			Fake: &fake.NewSimpleClientset().Fake,
+		}
+		virtClient.EXPECT().DiscoveryClient().Return(discoveryClient).AnyTimes()
 
 		By("Invoking callback")
 		go app.onStartedLeading()(ctx)

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/util/cluster:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/pdbs:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -149,8 +149,9 @@ var _ = Describe("Migration watcher", func() {
 			Expect(ok).To(BeTrue())
 			Expect(patch.GetPatchType()).To(Equal(types.StrategicMergePatchType))
 
-			expectedPatch := fmt.Sprintf(`{"spec":{"minAvailable": 2},"metadata":{"labels":{"%s": "%s"}}}`, virtv1.MigrationNameLabel, vmim.Name)
-			Expect(string(patch.GetPatch())).To(Equal(expectedPatch))
+			expectedPatch := fmt.Sprintf(`{"spec":{"minAvailable": 2},"metadata":{"labels":{"%s": "%s"`, virtv1.MigrationNameLabel, vmim.Name)
+			hasPrefix := strings.HasPrefix(string(patch.GetPatch()), expectedPatch)
+			Expect(hasPrefix).To(BeTrue())
 
 			pdb := newPDB(patch.GetName(), vmi, 2)
 			pdb.Labels = map[string]string{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -193,6 +193,7 @@ go_test(
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/dns:go_default_library",
+        "//pkg/util/pdbs:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",


### PR DESCRIPTION
Silence the alert only when running on OpenShift (upstream k8s does not
have this alert).

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This patch will be effective only when https://github.com/openshift/cluster-kube-controller-manager-operator/pull/583 is merged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
silence PodDisruptionBudgetAtLimit for migratable VMIs when running on OpenShift
```
