### PR TITLE
[release-0.44] Ensure cdi-http-import-server is running as root

### DIFF
--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -32,6 +32,8 @@ spec:
         kubevirt.io: cdi-http-import-server
     spec:
       serviceAccountName: kubevirt-testing
+      securityContext:
+        runAsUser: 0
       containers:
         - name: cdi-http-import-server
           image: {{.DockerPrefix}}/cdi-http-import-server:{{.DockerTag}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Server needs to run as root to be able to access
configuration.
Some platforms defaults container uid if its not set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
