### PR TITLE
network, fqdn: Fix adding subdomain search entry flow

### DIFF
--- a/pkg/network/dns/resolveconf.go
+++ b/pkg/network/dns/resolveconf.go
@@ -73,6 +73,12 @@ func ParseSearchDomains(content string) ([]string, error) {
 	return searchDomains, nil
 }
 
+//GetLongestServiceDomainName returns the longest service search domain entry
+func GetLongestServiceDomainName(searchDomains []string) string {
+	serviceDomains := GetServiceDomainList(searchDomains)
+	return GetDomainName(serviceDomains)
+}
+
 //GetDomainName returns the longest search domain entry, which is the most exact equivalent to a domain
 func GetDomainName(searchDomains []string) string {
 	selected := ""
@@ -82,6 +88,19 @@ func GetDomainName(searchDomains []string) string {
 		}
 	}
 	return selected
+}
+
+//GetServiceDomainList returns a list of search domains which are a service entry
+func GetServiceDomainList(searchDomains []string) []string {
+	const k8sServiceInfix = ".svc."
+
+	serviceDomains := []string{}
+	for _, d := range searchDomains {
+		if strings.Contains(d, k8sServiceInfix) {
+			serviceDomains = append(serviceDomains, d)
+		}
+	}
+	return serviceDomains
 }
 
 //DomainNameWithSubdomain returns the DNS domain according subdomain.
@@ -96,8 +115,8 @@ func DomainNameWithSubdomain(searchDomains []string, subdomain string) string {
 		return ""
 	}
 
-	domainName := GetDomainName(searchDomains)
-	if !strings.Contains(domainName, subdomain) {
+	domainName := GetLongestServiceDomainName(searchDomains)
+	if domainName != "" && !strings.HasPrefix(domainName, subdomain+".") {
 		return subdomain + "." + domainName
 	}
 

--- a/pkg/network/dns/resolveconf_test.go
+++ b/pkg/network/dns/resolveconf_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Resolveconf", func() {
 	})
 
 	Context("subdomain", func() {
-		It("should be added to the longest domain", func() {
+		It("should be added to the longest service domain", func() {
 			searchDomains := []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}
 
 			const subdomain = "subdomain"
@@ -109,7 +109,7 @@ var _ = Describe("Resolveconf", func() {
 			Expect(domain).To(Equal(""))
 		})
 
-		It("should be added even if the longest existing domain isn't the first", func() {
+		It("should be added even if the longest existing service domain isn't the first", func() {
 			searchDomains := []string{"svc.cluster.local", "cluster.local", "default.svc.cluster.local"}
 
 			const subdomain = "subdomain"
@@ -117,8 +117,25 @@ var _ = Describe("Resolveconf", func() {
 			Expect(domain).To(Equal(subdomain + "." + searchDomains[2]))
 		})
 
-		It("should not be added if the longest existing domain already has it", func() {
+		It("should not be added if the longest existing service domain already has it", func() {
 			searchDomains := []string{"svc.cluster.local", "cluster.local", "subdomain.default.svc.cluster.local"}
+
+			const subdomain = "subdomain"
+			domain := DomainNameWithSubdomain(searchDomains, subdomain)
+			Expect(domain).To(Equal(""))
+		})
+
+		It("should be added to the right entry if the longest entry is not a service entry", func() {
+			searchDomains := []string{"default.svc.cluster.local", "svc.cluster.local",
+				"cluster.local", "this.is.a.very.very.very.long.entry"}
+
+			const subdomain = "subdomain"
+			domain := DomainNameWithSubdomain(searchDomains, subdomain)
+			Expect(domain).To(Equal(subdomain + "." + searchDomains[0]))
+		})
+
+		It("should not be added if there is no service entry", func() {
+			searchDomains := []string{"example.com"}
 
 			const subdomain = "subdomain"
 			domain := DomainNameWithSubdomain(searchDomains, subdomain)


### PR DESCRIPTION
**What this PR does / why we need it**:

The default virt-launcher `dnsPolicy` is `ClusterFirst`
(unless changed via the VMI spec).
It means that k8s default search domains will be added as the first ones,
and in case the nodes have more entries, they will be appended
to the pod's search list. [1]

The current logic of adding the missing subdomain entry,
is to find the longest entry, and to add the subdomain to this entry.

In case the longest entry will be a node entry instead of the
entries that k8s added itself, the logic would fail to find
and add the subdomain to the right service domain entry.

The fix is to find the longest svc entry instead of the absolute longest entry,
which indicates it is a k8s added service entry, and to prepend this entry
with the subdomain if needed.

We search for `.svc.` because it means it is a service added by k8s itself.
Only the longest service entry is the one that we should add subdomain to,
so it will be of the form `subdomain.namespace.svc.cluster.local`
(where cluster.local is the cluster domain).
See [2] for additional info.

In case no service entry was found a subdomain won't be added.
One example is if `dnsPolicy` is `None` and no service domain included manually.

Note:
The fix affects DHCP option 119 (domain search list).
The expected unchanged behavior is that option 15 still uses the longest entry
from the domain search list.

[1] https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
[2] https://kubernetes.io/docs/tasks/debug-application-cluster/debug-service/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
