### PR TITLE
Pass through docker prefix and tag for vms-generator

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -37,6 +37,8 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
+	vmsgeneratorutils "kubevirt.io/kubevirt/tools/vms-generator/utils"
+
 	_ "kubevirt.io/kubevirt/tests/launchsecurity"
 	_ "kubevirt.io/kubevirt/tests/monitoring"
 	_ "kubevirt.io/kubevirt/tests/network"
@@ -75,6 +77,9 @@ func TestTests(t *testing.T) {
 	if qe_reporters.Polarion.Run {
 		reporters = append(reporters, &qe_reporters.Polarion)
 	}
+
+	vmsgeneratorutils.DockerPrefix = flags.KubeVirtUtilityRepoPrefix
+	vmsgeneratorutils.DockerTag = flags.KubeVirtVersionTag
 
 	RunSpecsWithDefaultAndCustomReporters(t, "Tests Suite", reporters)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR addresses problems when running kubevirt e2e tests while using `KUBEVIRT_PROVIDER=external`. In that case a registry:5000 is normally not available, so the vm-generator needs to get passed the source registry from which to pull the utility images that we use for the tests. 

In oder to work for other image registries pointed at by
`--utility-container-prefix` and `--container-tag` when testing
we need to pass through that test flag to the vms-generator
which is used in the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @akalenyu @iholder-redhat 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
