### PR TITLE
Auto delete prom-spec-dumper after verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ prom-rules-verify: build-prom-spec-dumper
 	./hack/prom-rule-ci/verify-rules.sh \
 		"${current-dir}/${rule-spec-dumper-executable}" \
 		"${current-dir}/hack/prom-rule-ci/prom-rules-tests.yaml"
+	rm ${rule-spec-dumper-executable}
 
 olm-push:
 	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} CSV_VERSION=${CSV_VERSION} QUAY_USERNAME=${QUAY_USERNAME} \


### PR DESCRIPTION
**What this PR does / why we need it**:
`prom-rule-dumper` binary is being built and run when performing `make prom-rules-verify` to verify (or "unit test") Prometheus rules. This is also being run by `pull-kubevirt-prom-rules-verify` lane.

Currently when performing a verification the executable is not being deleted. This is unintended as it can be added to one of the commits by mistake (as happened [here](https://github.com/kubevirt/kubevirt/pull/6956#issuecomment-999048809)). Now this binary is being automatically removed after verification.

The other alternative to deal with this is to add it to `.gitignore`. While possible I don't think it's a better approach since Prometheus rule verification is being done fairly rarely so the binary will be unneeded for most of the times. Also, building this binary is very very quick, so no extra overhead if we delete it everytime.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
