### PR TITLE
Update OrphanedVirtualMachineImages alert name

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -169,11 +169,11 @@ tests:
 
     alert_rule_test:
       - eval_time: 60m
-        alertname: OrphanedVirtualMachineImages
+        alertname: OrphanedVirtualMachineInstances
         exp_alerts:
           - exp_annotations:
               summary: "No virt-handler pod detected on node node01 with running vmis for more than an hour"
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineImages"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
               pod: "virt-handler-asdf"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -510,12 +510,12 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:   intstr.FromString("count by(node)(node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} ) * on (node) group_left(pod) (1*(kube_pod_container_status_ready{pod=~'virt-handler-.*'} + on (pod) group_left(node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-handler-.*'} ))) or on (node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} )"),
 					},
 					{
-						Alert: "OrphanedVirtualMachineImages",
+						Alert: "OrphanedVirtualMachineInstances",
 						Expr:  intstr.FromString("(kubevirt_num_virt_handlers_by_node_running_virt_launcher) == 0"),
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary":     "No virt-handler pod detected on node {{ $labels.node }} with running vmis for more than an hour",
-							"runbook_url": runbookUrlBasePath + "OrphanedVirtualMachineImages",
+							"runbook_url": runbookUrlBasePath + "OrphanedVirtualMachineInstances",
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",


### PR DESCRIPTION
Updated OrphanedVirtualMachineImages alert name to OrphanedVirtualMachineInstances.

Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The alert name is incorrect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Alert OrphanedVirtualMachineImages name was changed to OrphanedVirtualMachineInstances.
```
