### PR TITLE
Fix ignored domain events in virt-handler and migration abort test

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2638,14 +2638,14 @@ func (d *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 func (d *VirtualMachineController) addFunc(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err == nil {
-		d.vmiExpectations.LowerExpectations(key, 1, 0)
+		d.vmiExpectations.CreationObserved(key)
 		d.Queue.Add(key)
 	}
 }
 func (d *VirtualMachineController) deleteFunc(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err == nil {
-		d.vmiExpectations.LowerExpectations(key, 1, 0)
+		d.vmiExpectations.ControllerExpectationsInterface.DeletionObserved(key)
 		d.Queue.Add(key)
 	}
 }
@@ -2660,10 +2660,7 @@ func (d *VirtualMachineController) updateFunc(_, new interface{}) {
 func (d *VirtualMachineController) addDomainFunc(obj interface{}) {
 	domain := obj.(*api.Domain)
 	log.Log.Object(domain).Infof("Domain is in state %s reason %s", domain.Status.Status, domain.Status.Reason)
-	key, err := controller.KeyFunc(obj)
-	if err == nil {
-		d.Queue.Add(key)
-	}
+	d.addFunc(obj)
 }
 func (d *VirtualMachineController) deleteDomainFunc(obj interface{}) {
 	domain, ok := obj.(*api.Domain)
@@ -2680,10 +2677,7 @@ func (d *VirtualMachineController) deleteDomainFunc(obj interface{}) {
 		}
 	}
 	log.Log.Object(domain).Info("Domain deleted")
-	key, err := controller.KeyFunc(obj)
-	if err == nil {
-		d.Queue.Add(key)
-	}
+	d.deleteFunc(obj)
 }
 func (d *VirtualMachineController) updateDomainFunc(old, new interface{}) {
 	newDomain := new.(*api.Domain)
@@ -2696,10 +2690,7 @@ func (d *VirtualMachineController) updateDomainFunc(old, new interface{}) {
 		log.Log.Object(newDomain).Info("Domain is marked for deletion")
 	}
 
-	key, err := controller.KeyFunc(new)
-	if err == nil {
-		d.Queue.Add(key)
-	}
+	d.updateFunc(old, new)
 }
 
 func (d *VirtualMachineController) finalizeMigration(vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -355,7 +355,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 	now := metav1.Now()
 	if abortStatus != "" {
 		metaAbortStatus := domainSpec.Metadata.KubeVirt.Migration.AbortStatus
-		if metaAbortStatus == string(abortStatus) && metaAbortStatus == string(v1.MigrationAbortInProgress) {
+		if metaAbortStatus == string(abortStatus) && metaAbortStatus == string(v1.MigrationAbortInProgress) || metaAbortStatus == string(v1.MigrationAbortSucceeded) {
 			return domainerrors.MigrationAbortInProgressError
 		}
 		domainSpec.Metadata.KubeVirt.Migration.AbortStatus = string(abortStatus)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The first commit addresses the issue wit domain events: previously the callbacks used by the domain informer were not adjusting the VMI expectations when queueing objects. As a result some of the events were ignored by virt-handler. That was causing issues with timely updates of VMI status fields (e.g. the secondary NIC address info reported by Guest Agent was not reflected). Also LowerExpectations was called incorrectly in deleteFunc. Switched to using {Creation,Deletion}Observed helpers.

The second commit fixes the migration abort tests. Sometimes the `MigrationAbortInProgress` status was set *after* `MigrationAbortSuceeded`. The additional check should prevent that scenario and fix flaky test:

> Tests Suite: [Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration Starting a VirtualMachineInstance live migration cancelation should be able to cancel a migration [sig-storage][test_id:2226] with ContainerDisk

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Hit the issues while working on https://github.com/kubevirt/kubevirt/pull/6958. Some tests were very flaky.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
