### PR TITLE
New annotation to customize libvirt log filters + gradually increase libvirt logs according to virt-launcher logVerbosity

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -359,7 +359,7 @@ func main() {
 	qemuAgentFSFreezeStatusInterval := pflag.Duration("qemu-fsfreeze-status-interval", 5*time.Second, "Interval between consecutive qemu agent calls for fsfreeze status command")
 	keepAfterFailure := pflag.Bool("keep-after-failure", false, "virt-launcher will be kept alive after failure for debugging if set to true")
 	simulateCrash := pflag.Bool("simulate-crash", false, "Causes virt-launcher to immediately crash. This is used by functional tests to simulate crash loop scenarios.")
-	customDebugFilters := pflag.String("log-filters", "", "Set custom log filters for libvirt")
+	libvirtLogFilters := pflag.String("libvirt-log-filters", "", "Set custom log filters for libvirt")
 
 	// set new default verbosity, was set to 0 by glog
 	goflag.Set("v", "2")
@@ -416,7 +416,7 @@ func main() {
 	stopChan := make(chan struct{})
 
 	l := util.NewLibvirtWrapper(*runWithNonRoot)
-	err = l.SetupLibvirt(customDebugFilters)
+	err = l.SetupLibvirt(libvirtLogFilters)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -359,6 +359,7 @@ func main() {
 	qemuAgentFSFreezeStatusInterval := pflag.Duration("qemu-fsfreeze-status-interval", 5*time.Second, "Interval between consecutive qemu agent calls for fsfreeze status command")
 	keepAfterFailure := pflag.Bool("keep-after-failure", false, "virt-launcher will be kept alive after failure for debugging if set to true")
 	simulateCrash := pflag.Bool("simulate-crash", false, "Causes virt-launcher to immediately crash. This is used by functional tests to simulate crash loop scenarios.")
+	customDebugFilters := pflag.String("log-filters", "", "Set custom log filters for libvirt")
 
 	// set new default verbosity, was set to 0 by glog
 	goflag.Set("v", "2")
@@ -415,7 +416,7 @@ func main() {
 	stopChan := make(chan struct{})
 
 	l := util.NewLibvirtWrapper(*runWithNonRoot)
-	err = l.SetupLibvirt()
+	err = l.SetupLibvirt(customDebugFilters)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1191,6 +1191,13 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		verbosityStr := fmt.Sprint(virtLauncherLogVerbosity)
 		if isSet {
 			verbosityStr = verbosity
+
+			verbosityInt, err := strconv.Atoi(verbosity)
+			if err != nil {
+				return nil, fmt.Errorf("verbosity %s cannot cast to int: %v", verbosity, err)
+			}
+
+			virtLauncherLogVerbosity = uint(verbosityInt)
 		}
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY, Value: verbosityStr})
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1058,6 +1058,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if nonRoot {
 			command = append(command, "--run-as-nonroot")
 		}
+		if customDebugFilters, exists := vmi.Annotations[v1.CustomLibvirtLogFiltersAnnotation]; exists {
+			log.Log.Object(vmi).Infof("Applying custom debug filters for vmi %s: %s", vmi.Name, customDebugFilters)
+			command = append(command, "--log-filters", customDebugFilters)
+		}
 	}
 
 	allowEmulation := t.clusterConfig.AllowEmulation()

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1060,7 +1060,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		}
 		if customDebugFilters, exists := vmi.Annotations[v1.CustomLibvirtLogFiltersAnnotation]; exists {
 			log.Log.Object(vmi).Infof("Applying custom debug filters for vmi %s: %s", vmi.Name, customDebugFilters)
-			command = append(command, "--log-filters", customDebugFilters)
+			command = append(command, "--libvirt-log-filters", customDebugFilters)
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -41,7 +42,9 @@ go_test(
         "//vendor/github.com/go-kit/kit/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/hooks:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
+        "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -512,7 +512,8 @@ func (l LibvirtWrapper) SetupLibvirt(customLogFilters *string) (err error) {
 		defer util.CloseIOAndCheckErr(libvirdDConf, &err)
 
 		// see https://libvirt.org/kbase/debuglogs.html for details
-		const defaultLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
+		const defaultLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device " +
+			"3:rpc 3:access 3:qemu.qemu_monitor_json 3:conf.domain_addr 3:util.threadjob 3:cpu.cpu 3:qemu.qemu_monitor 1:*"
 
 		var actualLogFilters string
 		if customLogFilters != nil && *customLogFilters != "" {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -809,6 +809,11 @@ const (
 	// This exists for functional testing
 	MigrationPendingPodTimeoutSecondsAnnotation string = "kubevirt.io/migrationPendingPodTimeoutSeconds"
 
+	// CustomLibvirtLogFiltersAnnotation can be used to customized libvirt log filters. Example value could be
+	// "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*".
+	// For more info: https://libvirt.org/kbase/debuglogs.html
+	CustomLibvirtLogFiltersAnnotation string = "kubevirt.io/libvirt-log-filters"
+
 	// RealtimeLabel marks the node as capable of running realtime workloads
 	RealtimeLabel string = "kubevirt.io/realtime"
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -223,7 +223,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			var err error
 			vmi := tests.NewRandomVMI()
 			vmi.Labels = map[string]string{
-				"debugLogs": "true",
+				"logVerbosity": "10",
 			}
 
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -88,6 +88,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 	var allowEmulation *bool
 
+	const fakeLibvirtLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
+
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
@@ -219,12 +221,11 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				Should(ContainSubstring(`"subcomponent":"libvirt"`))
 		})
 
-		It("[test_id:3197]should log libvirtd debug logs when enabled", func() {
+		table.DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {
 			var err error
 			vmi := tests.NewRandomVMI()
-			vmi.Labels = map[string]string{
-				"logVerbosity": "10",
-			}
+			vmi.Labels = vmiLabels
+			vmi.Annotations = vmiAnnotations
 
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil(), "Create VMI successfully")
@@ -233,13 +234,32 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
 
+			const totalTestTime = 2 * time.Second
+			const checkIntervalTime = 500 * time.Millisecond
+			const logEntryToSearch = "QEMU_MONITOR_SEND_MSG"
+			const subcomponent = `"subcomponent":"libvirt"`
+
 			// There are plenty of strings we can use to identify the debug logs.
 			// Here we use something we deeply care about when in debug mode.
-			Eventually(logs,
-				2*time.Second,
-				500*time.Millisecond).
-				Should(And(ContainSubstring("QEMU_MONITOR_SEND_MSG"), ContainSubstring(`"subcomponent":"libvirt"`)))
-		})
+			if expectDebugLogs {
+				Eventually(logs,
+					totalTestTime,
+					checkIntervalTime).
+					Should(And(ContainSubstring(logEntryToSearch), ContainSubstring(subcomponent)))
+			} else {
+				Consistently(logs,
+					totalTestTime,
+					checkIntervalTime).
+					ShouldNot(And(ContainSubstring(logEntryToSearch), ContainSubstring(subcomponent)))
+			}
+
+		},
+			table.Entry("[test_id:3197]enabled when debugLogs label defined", map[string]string{"debugLogs": "true"}, nil, true),
+			table.Entry("enabled when customLogFilters defined", nil, map[string]string{v1.CustomLibvirtLogFiltersAnnotation: fakeLibvirtLogFilters}, true),
+			table.Entry("enabled when log verbosity is high", map[string]string{"logVerbosity": "10"}, nil, true),
+			table.Entry("disabled when log verbosity is low", map[string]string{"logVerbosity": "2"}, nil, false),
+			table.Entry("disabled when log verbosity, debug logs and customLogFilters are not defined", nil, nil, false),
+		)
 
 		It("[test_id:1623]should reject POST if validation webhook deems the spec invalid", func() {
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR serves two purposes:
1) Adds a possibility to override Kubevirt's default libvirt log filters though VMI annotations. This may be helpful for both debugging, developing and production. To override defaults filters one needs to add an annotation where the key is `kubevirt.io/libvirt-log-filters` and the value is a string representing libvirt filters.

Example:
```yaml
kind: VirtualMachineInstance
metadata:
  name: my-vmi
  annotations:
    kubevirt.io/libvirt-log-filters: "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
```

2) <del>Massively reduces log length where libvirt debug logs are turned on (environment variable `LIBVIRT_DEBUG_LOGS` is defined and equals to 1) alongside virt-launcher log verbosity (defined in KubevirtCR's developerConfiguration).</del>
Currently, virt-launcher verbosity level 5 and above causes all of libvirt logs to be fired. Instead, this PR gradually increase libvirt verbosity according to virt-launcher verbosity. Now level 5 filters out a lot of categories, level 6 includes `qemu.qemu_monitor_json` and `conf.domain_addr categories`, level 7 includes `qemu.qemu_monitor_json` 
 and `conf.domain_addr` and level 8 includes `util.threadjob` and `cpu.cpu`.

----------------------------------

Below you can see a table for the filters I've added alongside their impact. This was measure in the following way; I've created a VMI with a custom filter `log-filters: "1:XYZ 4:*"` where `XYZ` is a certain filter. I've created the VMI, waited for 10 seconds, collected virt-launcher log, then removed the VMI. Then I've filtered out all line that do not have `"subcomponent":"libvirt"` in the log so I only count libvirt log entries. Here are the results:

| Filter category      | number of log lines | log link     |
| :----:        |    :----:   |          :----: |
| qemu.qemu_monitor      | 2805       | [log](https://zerobin.net/?2b8439f437602cb8#cKZVG2WMLRFG+kkcUqDnhr4NbEqKb0OjzFN4QsRS4c8=)   |
| util.threadjob   | 119        | [log](https://zerobin.net/?8bf7942c2c1e7200#2Ej/XUa8HlTRBRj+IsiDZ7ypJiIb5KcHVP3m1WPh6Fg=)      |
| qemu.qemu_monitor_json   | 899        | [log](https://zerobin.net/?d4867ee336768563#YDaRW4JZwn2QnCIXrfxC5IHJSHYg58Aq6hYnVDC/NLM=) |
| conf.domain_addr   | 288        | [log](https://zerobin.net/?4497dc04a70d8a6c#j2g1fvpZ8kzHA0dLU3mHl2ei7y0eR2rH0vgMO4DYmec=)   |
| cpu.cpu  | 1911        | [log](https://zerobin.net/?35b8dcbce220a42b#qfNzIvtFApKSRZA6oGNym/ZAIT95hu/SC5HimRyGIJw=) |

Here's the before/after results for default filters and after adding all of the above:
| Description  | number of log lines | log link     |
| :----:        |    :----:   |          :----: |
| With currently defined filters  | 5925       | [log](https://zerobin.net/?d3517a91ac1c3896#u6yUGasXfK536Kwy/hcMs8EpJAI+1Mtx0XFkM24gCOk=)   |
| With all filters defined above   | 818        | [log](https://zerobin.net/?f0df7ac529c6774a#brUQIkbNjEz/YhLC+JgfhXo6LYTv+gaES/mnXis6UDc=)      |

As you can see from provided logs, most of the categories above include noise for the vast majority of the use cases. If these categories do matter - it is possible to re-add them to VMIs with the annotation explained above.

_**IMPORTANT NOTE: All filters are added with level 3, meaning that debug and info logs will be filtered while warning and errors logs will be recorded. Take a look [here](https://libvirt.org/logging.html) for more info.**_

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds a possibility to override default libvirt log filters though VMI annotations
```
