### PR TITLE
[Bugfix]: Avoid setting block migration for volumes used by read-only disks

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -138,3 +138,9 @@ func HasKernelBootContainerImage(vmi *v1.VirtualMachineInstance) bool {
 func HasHugePages(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.Memory != nil && vmi.Spec.Domain.Memory.Hugepages != nil
 }
+
+func IsReadOnlyDisk(disk *v1.Disk) bool {
+	isReadOnlyCDRom := disk.CDRom != nil && (disk.CDRom.ReadOnly == nil || *disk.CDRom.ReadOnly == true)
+
+	return isReadOnlyCDRom
+}

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -103,6 +103,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2166,6 +2166,19 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 				return true, fmt.Errorf("cannot migrate VMI with non-shared HostDisk")
 			}
 		} else {
+			isVolumeUsedByReadOnlyDisk := false
+			for _, disk := range vmi.Spec.Domain.Devices.Disks {
+				if virtutil.IsReadOnlyDisk(&disk) && disk.Name == volume.Name {
+					isVolumeUsedByReadOnlyDisk = true
+					break
+				}
+			}
+
+			if isVolumeUsedByReadOnlyDisk {
+				continue
+			}
+
+			log.Log.Object(vmi).Infof("migration is block migration because of %s volume", volume.Name)
 			blockMigrate = true
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
There is no need to migrate read-only disks. Therefore, setting the migration as Block Migration should be avoided for volumes that are used by read-only disks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2035677

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Avoid setting block migration for volumes used by read-only disks
```
