### PR TITLE
Adjust some storage tests to respect different environment

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -460,6 +460,9 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
 					realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
 				}
+				if realRegistryPort == "" {
+					Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
+				}
 
 				fakeRegistryName := "fakeregistry"
 				fakeRegistryWithPort := fakeRegistryName

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -274,6 +274,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 				namespace, util.NamespaceTestDefault,
 				"--archive-path", archivePath,
 				size, pvcSize,
+				"--force-bind",
 				insecure)
 
 			Expect(virtctlCmd()).To(Succeed())

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -103,6 +103,8 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 		var vmi *v1.VirtualMachineInstance
 		t := true
 		vm.Spec.Running = &t
+		var gracePeriod int64 = 10
+		vm.Spec.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
 		vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(func() bool {


### PR DESCRIPTION
- `should correctly handle eventually consistent DataVolumes`
Unless we specify a local registry (: separator), docker urls will continue to be parsed
as docker.io/${REPO}. This makes this test flow fail on an environment where we supply an external registry,
such as quay.io/kubevirt.
- `virtctl image-upload archive tests`
As these are not storage class specific, we need to force bind on env's
where the storage is WaitForFirstConsumer.
- Graceful termination in restore tests
  We are stopping the VM right after calling sync() syscall, which does not guarantee finish upon return:
  `The writing, although scheduled, is not necessarily complete upon return from sync().`
  Need to be a little more cautious here because otherwise we end up with messed fs:
  ```bash
  $ df -h
  Filesystem                Size      Used Available Use% Mounted on
  /dev                    492.1M         0    492.1M   0% /dev
  /dev/vda1               611.0M    607.0M         0 100% /
  tmpfs                   496.2M         0    496.2M   0% /dev/shm
  tmpfs                   496.2M     56.0K    496.2M   0% /run
  $ sudo du -h -d1 /
  683.0K  /sbin
  du: /test: Input/output error
  12.0K   /lost+found
  0       /dev
  ```

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
