### PR TITLE
set scsi as default disk bus on Arm64

### DIFF
--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "amd64.go",
         "arm64.go",
         "hyperv.go",
         "utils.go",

--- a/pkg/virt-api/webhooks/amd64.go
+++ b/pkg/virt-api/webhooks/amd64.go
@@ -1,0 +1,52 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021
+ *
+ */
+
+/*
+ * arm64 utilities are in the webhooks package because they are used both
+ * by validation and mutation webhooks.
+ */
+package webhooks
+
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
+
+// setDefaultDisksBus set default Disks Bus
+func setAmd64DefaultDisksBus(vmi *v1.VirtualMachineInstance) {
+	// Setting SATA as the default bus since it is typically supported out of the box by
+	// guest operating systems (we support only q35 and therefore IDE is not supported)
+	// TODO: consider making this OS-specific (VIRTIO for linux, SATA for others)
+	bus := v1.DiskBusSATA
+
+	for i := range vmi.Spec.Domain.Devices.Disks {
+		disk := &vmi.Spec.Domain.Devices.Disks[i].DiskDevice
+
+		if disk.Disk != nil && disk.Disk.Bus == "" {
+			disk.Disk.Bus = bus
+		}
+		if disk.CDRom != nil && disk.CDRom.Bus == "" {
+			disk.CDRom.Bus = bus
+		}
+		if disk.LUN != nil && disk.LUN.Bus == "" {
+			disk.LUN.Bus = bus
+		}
+	}
+}
+
+// SetVirtualMachineInstanceAmd64Defaults is mutating function for mutating-webhook
+func SetVirtualMachineInstanceAmd64Defaults(vmi *v1.VirtualMachineInstance) {
+	setAmd64DefaultDisksBus(vmi)
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -108,15 +108,12 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 			log.Log.V(2).Infof("Failed to set HyperV dependencies: %s", err)
 		}
 
-		// Do some specific setting for Arm64 Arch. It should put before SetObjectDefaults_VirtualMachineInstance
+		// Do some CPU arch specific setting.
 		if webhooks.IsARM64() {
 			log.Log.V(4).Info("Apply Arm64 specific setting")
-			err = webhooks.SetVirtualMachineInstanceArm64Defaults(newVMI)
-			if err != nil {
-				// if SetVirtualMachineInstanceArm64Defaults fails, it's due to a validation error, which will get caught in the validation webhook after mutation finishes.
-				log.Log.V(2).Infof("Failed to setting for Arm64: %s", err)
-			}
+			webhooks.SetVirtualMachineInstanceArm64Defaults(newVMI)
 		} else {
+			webhooks.SetVirtualMachineInstanceAmd64Defaults(newVMI)
 			mutator.setDefaultCPUModel(newVMI)
 		}
 		if newVMI.IsRealtimeEnabled() {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -200,29 +200,28 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal(memoryLimit))
 	})
 
-	It("should apply defaults on VMI create", func() {
+	DescribeTable("should apply defaults on VMI create", func(arch string, cpuModel string) {
 		// no limits wanted on this test, to not copy the limit to requests
+		defer func() {
+			webhooks.Arch = rt.GOARCH
+		}()
+		webhooks.Arch = arch
 		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
-		if webhooks.IsPPC64() {
-			Expect(vmiSpec.Domain.Machine.Type).To(Equal("pseries"))
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))
-		} else if webhooks.IsARM64() {
-			Expect(vmiSpec.Domain.Machine.Type).To(Equal("virt"))
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.CPUModeHostPassthrough))
-		} else {
-			Expect(vmiSpec.Domain.Machine.Type).To(Equal("q35"))
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel))
-		}
-
-		Expect(v1.DefaultCPUModel).To(Equal(v1.CPUModeHostModel))
+		Expect(vmiSpec.Domain.CPU.Model).To(Equal(cpuModel))
 		Expect(vmiSpec.Domain.Resources.Requests.Cpu().IsZero()).To(BeTrue())
-		// no default for requested memory when no memory is specified
 		Expect(vmiSpec.Domain.Resources.Requests.Memory().Value()).To(Equal(int64(0)))
-	})
+	},
+		Entry("on amd64", "amd64", v1.DefaultCPUModel),
+		Entry("on arm64", "arm64", v1.CPUModeHostPassthrough),
+		Entry("on ppc64le", "ppc64le", v1.DefaultCPUModel),
+	)
 
-	It("should apply configurable defaults on VMI create", func() {
-		// no limits wanted on this test, to not copy the limit to requests
+	DescribeTable("should apply configurable defaults on VMI create", func(arch string, cpuModel string) {
+		defer func() {
+			webhooks.Arch = rt.GOARCH
+		}()
+		webhooks.Arch = arch
 		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
@@ -235,10 +234,15 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		})
 
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
-		Expect(vmiSpec.Domain.CPU.Model).To(Equal(cpuModelFromConfig))
+		Expect(vmiSpec.Domain.CPU.Model).To(Equal(cpuModel))
 		Expect(vmiSpec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
 		Expect(*vmiSpec.Domain.Resources.Requests.Cpu()).To(Equal(cpuReq))
-	})
+	},
+		Entry("on amd64", "amd64", cpuModelFromConfig),
+		// Currently only Host-Passthrough is supported on Arm64, so you can only
+		// modify the CPU Model in a VMI yaml file, rather than in cluster config
+		Entry("on arm64", "arm64", v1.CPUModeHostPassthrough),
+	)
 
 	DescribeTable("it should", func(given []v1.Volume, expected []v1.Volume) {
 		vmi.Spec.Volumes = given
@@ -794,16 +798,80 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	// Check following convert for ARM64
 	// 1. should convert CPU model to host-passthrough
 	// 2. should convert default bootloader to UEFI non secureboot
-	It("should convert cpu model, AutoattachGraphicsDevice and UEFI boot on ARM64", func() {
-		// turn on arm validation/mutation
-		webhooks.Arch = "arm64"
+	It("should convert cpu model and UEFI boot on ARM64", func() {
 		defer func() {
 			webhooks.Arch = rt.GOARCH
 		}()
+		// turn on arm validation/mutation
+		webhooks.Arch = "arm64"
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(*(vmiSpec.Domain.Firmware.Bootloader.EFI.SecureBoot)).To(BeFalse())
 		Expect(vmiSpec.Domain.CPU.Model).To(Equal("host-passthrough"))
 	})
+
+	DescribeTable("should convert disk bus to virtio or scsi on ARM64", func(given v1.Disk, diskType string, expectedBus v1.DiskBus) {
+		defer func() {
+			webhooks.Arch = rt.GOARCH
+		}()
+		// turn on arm validation/mutation
+		webhooks.Arch = "arm64"
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "a",
+			VolumeSource: v1.VolumeSource{
+				ContainerDisk: &v1.ContainerDiskSource{
+					Image: "test:latest",
+				},
+			},
+		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, given)
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
+
+		getDiskDeviceBus := func(device string) v1.DiskBus {
+			switch device {
+			case "Disk":
+				return vmiSpec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus
+			case "CDRom":
+				return vmiSpec.Domain.Devices.Disks[0].DiskDevice.CDRom.Bus
+			case "LUN":
+				return vmiSpec.Domain.Devices.Disks[0].DiskDevice.LUN.Bus
+			default:
+				return ""
+			}
+		}
+
+		Expect(getDiskDeviceBus(diskType), expectedBus)
+	},
+		Entry("Disk device",
+			v1.Disk{
+				Name: "a",
+			}, "Disk", v1.DiskBusVirtio),
+
+		Entry("Disk device with virtio bus",
+			v1.Disk{
+				Name: "a",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{
+						Bus: "scsi",
+					},
+				},
+			}, "Disk", v1.DiskBusSCSI),
+
+		Entry("CDRom device",
+			v1.Disk{
+				Name: "a",
+				DiskDevice: v1.DiskDevice{
+					CDRom: &v1.CDRomTarget{},
+				},
+			}, "CDRom", v1.DiskBusVirtio),
+
+		Entry("LUN device",
+			v1.Disk{
+				Name: "a",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{},
+				},
+			}, "LUN", v1.DiskBusVirtio),
+	)
 
 	var (
 		vmxFeature = v1.CPUFeature{

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/ephemeral-disk/fake:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -41,6 +41,7 @@ import (
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	"kubevirt.io/kubevirt/pkg/ephemeral-disk/fake"
@@ -960,6 +961,8 @@ var _ = Describe("Converter", func() {
   <memory unit="b">8388608</memory>
   <os>
     <type arch="aarch64" machine="virt">hvm</type>
+    <loader readonly="yes" secure="no" type="pflash"></loader>
+    <nvram>/tmp/mynamespace_testvmi</nvram>
   </os>
   <sysinfo type="smbios">
     <system>
@@ -1008,26 +1011,26 @@ var _ = Describe("Converter", func() {
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
-      <target bus="sata" dev="sda" tray="closed"></target>
+      <target bus="virtio" dev="vdc" tray="closed"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/cdrom_tray_open/disk.img"></source>
-      <target bus="sata" dev="sdb" tray="open"></target>
+      <target bus="virtio" dev="vdd" tray="open"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
-    <disk device="disk" type="file">
+    <disk device="disk" type="file" model="virtio-non-transitional">
       <source file="/var/run/kubevirt-private/vmi-disks/should_default_to_disk/disk.img"></source>
-      <target bus="sata" dev="sdc"></target>
+      <target bus="virtio" dev="vde"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-should_default_to_disk"></alias>
     </disk>
-    <disk device="disk" type="file">
+    <disk device="disk" type="file" model="virtio-non-transitional">
       <source file="/var/run/libvirt/kubevirt-ephemeral-disk/ephemeral_pvc/disk.qcow2"></source>
-      <target bus="sata" dev="sdd"></target>
+      <target bus="virtio" dev="vdf"></target>
       <driver cache="none" error_policy="stop" name="qemu" type="qcow2" iothread="1" discard="unmap"></driver>
       <alias name="ua-ephemeral_pvc"></alias>
       <backingStore type="file">
@@ -1035,47 +1038,47 @@ var _ = Describe("Converter", func() {
         <source file="/var/run/kubevirt-private/vmi-disks/ephemeral_pvc/disk.img"></source>
       </backingStore>
     </disk>
-    <disk device="disk" type="file">
+    <disk device="disk" type="file" model="virtio-non-transitional">
       <source file="/var/run/kubevirt-private/secret-disks/secret_test.iso"></source>
-      <target bus="sata" dev="sde"></target>
+      <target bus="virtio" dev="vdg"></target>
       <serial>D23YZ9W6WA5DJ487</serial>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-secret_test"></alias>
     </disk>
-    <disk device="disk" type="file">
+    <disk device="disk" type="file" model="virtio-non-transitional">
       <source file="/var/run/kubevirt-private/config-map-disks/configmap_test.iso"></source>
-      <target bus="sata" dev="sdf"></target>
+      <target bus="virtio" dev="vdh"></target>
       <serial>CVLY623300HK240D</serial>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-configmap_test"></alias>
     </disk>
-    <disk device="disk" type="block">
+    <disk device="disk" type="block" model="virtio-non-transitional">
       <source dev="/dev/pvc_block_test" name="pvc_block_test"></source>
-      <target bus="sata" dev="sdg"></target>
+      <target bus="virtio" dev="vdi"></target>
       <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
-    <disk device="disk" type="block">
+    <disk device="disk" type="block" model="virtio-non-transitional">
       <source dev="/dev/dv_block_test" name="dv_block_test"></source>
-      <target bus="sata" dev="sdh"></target>
+      <target bus="virtio" dev="vdj"></target>
       <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-dv_block_test"></alias>
     </disk>
-    <disk device="disk" type="file">
+    <disk device="disk" type="file" model="virtio-non-transitional">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
-      <target bus="sata" dev="sdi"></target>
+      <target bus="virtio" dev="vdk"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep.iso"></source>
-      <target bus="sata" dev="sdj" tray="closed"></target>
+      <target bus="virtio" dev="vdl" tray="closed"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-sysprep"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep_secret.iso"></source>
-      <target bus="sata" dev="sdk" tray="closed"></target>
+      <target bus="virtio" dev="vdm" tray="closed"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-sysprep_secret"></alias>
     </disk>
@@ -1139,7 +1142,7 @@ var _ = Describe("Converter", func() {
     </kvm>
     <pvspinlock state="off"></pvspinlock>
   </features>
-  <cpu mode="host-model">
+  <cpu mode="host-passthrough">
     <topology sockets="1" cores="1" threads="1"></topology>
   </cpu>
   <vcpu placement="static">1</vcpu>
@@ -1406,6 +1409,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			c.Architecture = arch
+			vmiArchMutate(arch, vmi, c)
 			Expect(vmiToDomainXML(vmi, c)).To(Equal(domain))
 		},
 			Entry("for amd64", "amd64", convertedDomain),
@@ -1417,6 +1421,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			c.Architecture = arch
+			vmiArchMutate(arch, vmi, c)
 			c.MemBalloonStatsPeriod = period
 			Expect(vmiToDomainXML(vmi, c)).To(Equal(domain))
 		},
@@ -1433,6 +1438,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.AutoattachMemBalloon = False()
 			c.Architecture = arch
+			vmiArchMutate(arch, vmi, c)
 			Expect(vmiToDomainXML(vmi, c)).To(Equal(domain))
 		},
 			Entry("when Autoattach memballoon device is false for amd64", "amd64", convertedDomainWithFalseAutoattach),
@@ -1450,6 +1456,7 @@ var _ = Describe("Converter", func() {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 				c.Architecture = "amd64"
+				vmiArchMutate("amd64", vmi, c)
 				spec := vmiToDomain(vmi, c).Spec.DeepCopy()
 				Expect(PlacePCIDevicesOnRootComplex(spec)).To(Succeed())
 				data, err := xml.MarshalIndent(spec, "", "  ")
@@ -3429,4 +3436,20 @@ func True() *bool {
 func False() *bool {
 	b := false
 	return &b
+}
+
+// As the arch specific default disk is set in the mutating webhook, so in some tests,
+// it needs to run the mutate function before verifying converter
+func vmiArchMutate(arch string, vmi *v1.VirtualMachineInstance, c *ConverterContext) {
+	if arch == "arm64" {
+		webhooks.SetVirtualMachineInstanceArm64Defaults(vmi)
+		// bootloader has been initialized in webhooks.SetVirtualMachineInstanceArm64Defaults,
+		// c.EFIConfiguration.SecureLoader is needed in the converter.Convert_v1_VirtualMachineInstance_To_api_Domain.
+		c.EFIConfiguration = &EFIConfiguration{
+			SecureLoader: false,
+		}
+
+	} else {
+		webhooks.SetVirtualMachineInstanceAmd64Defaults(vmi)
+	}
 }

--- a/staging/src/kubevirt.io/api/core/v1/defaults.go
+++ b/staging/src/kubevirt.io/api/core/v1/defaults.go
@@ -125,25 +125,9 @@ func SetDefaults_VirtualMachineInstance(obj *VirtualMachineInstance) {
 }
 
 func setDefaults_Disk(obj *VirtualMachineInstance) {
-	// Setting SATA as the default bus since it is typically supported out of the box by
-	// guest operating systems (we support only q35 and therefore IDE is not supported)
-	// TODO: consider making this OS-specific (VIRTIO for linux, SATA for others)
-	bus := DiskBusSATA
-
 	for i := range obj.Spec.Domain.Devices.Disks {
 		disk := &obj.Spec.Domain.Devices.Disks[i].DiskDevice
-
 		SetDefaults_DiskDevice(disk)
-
-		if disk.Disk != nil && disk.Disk.Bus == "" {
-			disk.Disk.Bus = bus
-		}
-		if disk.CDRom != nil && disk.CDRom.Bus == "" {
-			disk.CDRom.Bus = bus
-		}
-		if disk.LUN != nil && disk.LUN.Bus == "" {
-			disk.LUN.Bus = bus
-		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As SATA is not supported by qemu-kvm in virt-launcher of Arm64, set scsi as default bus for disk.
Fix vmi-mutator_test errors

**Release note**:
```release-note
none
```
@rmohr 
Currently, there are three place to do CPU arch specific modification, 
1. in the `virt-api webhooks`, set DefaultCPUModel, DefaultBootloader and DefaultDisksBus
2. in the `virt-config/configuration.go`, set DefaultOVMFPath, DefaultEmulatedMachines and DefaultMachineType
3. in the `virt-launcher/virtwrap/converter/converter.go`, set `AutoattachGraphicsDevice`, `OS.SMBios` and ` domain.Spec.Devices.Controllers`

Is it better to manage them in one place? What your opinion?
