### PR TITLE
Handle IPv4 validation with leading zeros on go 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-aggregator v0.20.2
 	k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f
-	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	kubevirt.io/api v0.0.0-00010101000000-000000000000
 	kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -1706,8 +1706,9 @@ k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 h1:0T5IaWHO3sJTEmCP6mUlBvMukxPKUQWqiI/YuiBNMiQ=
 k8s.io/utils v0.0.0-20210111153108-fddb29f9d009/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b h1:wxEMGetGMur3J1xuGLQY7GEQYg9bZxKn3tKo5k/eYcs=
+k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 kubevirt.io/containerized-data-importer v1.41.0 h1:iGsYrf/L/x2gh/6VRMxpllWp8vImY8t7ORh73bJABhY=
 kubevirt.io/containerized-data-importer v1.41.0/go.mod h1:3bxLyI6jF+dz5PfHkORGCp5qnf+p0ZmSTj/pdu2QXAE=
 kubevirt.io/containerized-data-importer-api v1.41.0 h1:VdEwYP36N+4asMnTBSadVH4SF7OVPvvraEQMtOd7Vlk=

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/clone:go_default_library",
     ],
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/kubevirt/pkg/hooks"
@@ -296,7 +297,7 @@ func validateDHCPExtraOptions(field *k8sfield.Path, iface v1.Interface) (causes 
 func validateDHCPNTPServersAreValidIPv4Addresses(field *k8sfield.Path, iface v1.Interface, idx int) (causes []metav1.StatusCause) {
 	if iface.DHCPOptions != nil {
 		for index, ip := range iface.DHCPOptions.NTPServers {
-			if net.ParseIP(ip).To4() == nil {
+			if netutils.ParseIPSloppy(ip).To4() == nil {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: "NTP servers must be a list of valid IPv4 addresses.",
@@ -1602,7 +1603,7 @@ func validatePodDNSConfig(dnsConfig *k8sv1.PodDNSConfig, dnsPolicy *k8sv1.DNSPol
 			})
 		}
 		for _, ns := range dnsConfig.Nameservers {
-			if ip := net.ParseIP(ns); ip == nil {
+			if ip := netutils.ParseIPSloppy(ns); ip == nil {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: fmt.Sprintf("must be valid IP address: %s", ns),

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/LICENSE
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/PATENTS
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/net/BUILD.bazel
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/net/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "ip.go",
+        "parse.go",
+    ],
+    importmap = "kubevirt.io/kubevirt/vendor/k8s.io/utils/internal/third_party/forked/golang/net",
+    importpath = "k8s.io/utils/internal/third_party/forked/golang/net",
+    visibility = ["//vendor/k8s.io/utils:__subpackages__"],
+)

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/net/ip.go
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/net/ip.go
@@ -1,0 +1,236 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// IP address manipulations
+//
+// IPv4 addresses are 4 bytes; IPv6 addresses are 16 bytes.
+// An IPv4 address can be converted to an IPv6 address by
+// adding a canonical prefix (10 zeros, 2 0xFFs).
+// This library accepts either size of byte slice but always
+// returns 16-byte addresses.
+
+package net
+
+///////////////////////////////////////////////////////////////////////////////
+// NOTE: This file was forked because we need to maintain backwards-compatible
+// IP parsing logic, which was changed in a correct but incompatible way in
+// go-1.17.
+//
+// See https://issue.k8s.io/100895
+///////////////////////////////////////////////////////////////////////////////
+
+import (
+	stdnet "net"
+)
+
+//
+// Lean on the standard net lib as much as possible.
+//
+
+type IP = stdnet.IP
+type IPNet = stdnet.IPNet
+type ParseError = stdnet.ParseError
+
+const IPv4len = stdnet.IPv4len
+const IPv6len = stdnet.IPv6len
+
+var CIDRMask = stdnet.CIDRMask
+var IPv4 = stdnet.IPv4
+
+// Parse IPv4 address (d.d.d.d).
+func parseIPv4(s string) IP {
+	var p [IPv4len]byte
+	for i := 0; i < IPv4len; i++ {
+		if len(s) == 0 {
+			// Missing octets.
+			return nil
+		}
+		if i > 0 {
+			if s[0] != '.' {
+				return nil
+			}
+			s = s[1:]
+		}
+		n, c, ok := dtoi(s)
+		if !ok || n > 0xFF {
+			return nil
+		}
+		//
+		// NOTE: This correct check was added for go-1.17, but is a
+		// backwards-incompatible change for kubernetes users, who might have
+		// stored data which uses these leading zeroes already.
+		//
+		// See https://issue.k8s.io/100895
+		//
+		//if c > 1 && s[0] == '0' {
+		//	// Reject non-zero components with leading zeroes.
+		//	return nil
+		//}
+		s = s[c:]
+		p[i] = byte(n)
+	}
+	if len(s) != 0 {
+		return nil
+	}
+	return IPv4(p[0], p[1], p[2], p[3])
+}
+
+// parseIPv6 parses s as a literal IPv6 address described in RFC 4291
+// and RFC 5952.
+func parseIPv6(s string) (ip IP) {
+	ip = make(IP, IPv6len)
+	ellipsis := -1 // position of ellipsis in ip
+
+	// Might have leading ellipsis
+	if len(s) >= 2 && s[0] == ':' && s[1] == ':' {
+		ellipsis = 0
+		s = s[2:]
+		// Might be only ellipsis
+		if len(s) == 0 {
+			return ip
+		}
+	}
+
+	// Loop, parsing hex numbers followed by colon.
+	i := 0
+	for i < IPv6len {
+		// Hex number.
+		n, c, ok := xtoi(s)
+		if !ok || n > 0xFFFF {
+			return nil
+		}
+
+		// If followed by dot, might be in trailing IPv4.
+		if c < len(s) && s[c] == '.' {
+			if ellipsis < 0 && i != IPv6len-IPv4len {
+				// Not the right place.
+				return nil
+			}
+			if i+IPv4len > IPv6len {
+				// Not enough room.
+				return nil
+			}
+			ip4 := parseIPv4(s)
+			if ip4 == nil {
+				return nil
+			}
+			ip[i] = ip4[12]
+			ip[i+1] = ip4[13]
+			ip[i+2] = ip4[14]
+			ip[i+3] = ip4[15]
+			s = ""
+			i += IPv4len
+			break
+		}
+
+		// Save this 16-bit chunk.
+		ip[i] = byte(n >> 8)
+		ip[i+1] = byte(n)
+		i += 2
+
+		// Stop at end of string.
+		s = s[c:]
+		if len(s) == 0 {
+			break
+		}
+
+		// Otherwise must be followed by colon and more.
+		if s[0] != ':' || len(s) == 1 {
+			return nil
+		}
+		s = s[1:]
+
+		// Look for ellipsis.
+		if s[0] == ':' {
+			if ellipsis >= 0 { // already have one
+				return nil
+			}
+			ellipsis = i
+			s = s[1:]
+			if len(s) == 0 { // can be at end
+				break
+			}
+		}
+	}
+
+	// Must have used entire string.
+	if len(s) != 0 {
+		return nil
+	}
+
+	// If didn't parse enough, expand ellipsis.
+	if i < IPv6len {
+		if ellipsis < 0 {
+			return nil
+		}
+		n := IPv6len - i
+		for j := i - 1; j >= ellipsis; j-- {
+			ip[j+n] = ip[j]
+		}
+		for j := ellipsis + n - 1; j >= ellipsis; j-- {
+			ip[j] = 0
+		}
+	} else if ellipsis >= 0 {
+		// Ellipsis must represent at least one 0 group.
+		return nil
+	}
+	return ip
+}
+
+// ParseIP parses s as an IP address, returning the result.
+// The string s can be in IPv4 dotted decimal ("192.0.2.1"), IPv6
+// ("2001:db8::68"), or IPv4-mapped IPv6 ("::ffff:192.0.2.1") form.
+// If s is not a valid textual representation of an IP address,
+// ParseIP returns nil.
+func ParseIP(s string) IP {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.':
+			return parseIPv4(s)
+		case ':':
+			return parseIPv6(s)
+		}
+	}
+	return nil
+}
+
+// ParseCIDR parses s as a CIDR notation IP address and prefix length,
+// like "192.0.2.0/24" or "2001:db8::/32", as defined in
+// RFC 4632 and RFC 4291.
+//
+// It returns the IP address and the network implied by the IP and
+// prefix length.
+// For example, ParseCIDR("192.0.2.1/24") returns the IP address
+// 192.0.2.1 and the network 192.0.2.0/24.
+func ParseCIDR(s string) (IP, *IPNet, error) {
+	i := indexByteString(s, '/')
+	if i < 0 {
+		return nil, nil, &ParseError{Type: "CIDR address", Text: s}
+	}
+	addr, mask := s[:i], s[i+1:]
+	iplen := IPv4len
+	ip := parseIPv4(addr)
+	if ip == nil {
+		iplen = IPv6len
+		ip = parseIPv6(addr)
+	}
+	n, i, ok := dtoi(mask)
+	if ip == nil || !ok || i != len(mask) || n < 0 || n > 8*iplen {
+		return nil, nil, &ParseError{Type: "CIDR address", Text: s}
+	}
+	m := CIDRMask(n, 8*iplen)
+	return ip, &IPNet{IP: ip.Mask(m), Mask: m}, nil
+}
+
+// This is copied from go/src/internal/bytealg, which includes versions
+// optimized for various platforms.  Those optimizations are elided here so we
+// don't have to maintain them.
+func indexByteString(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/vendor/k8s.io/utils/internal/third_party/forked/golang/net/parse.go
+++ b/vendor/k8s.io/utils/internal/third_party/forked/golang/net/parse.go
@@ -1,0 +1,59 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Simple file i/o and string manipulation, to avoid
+// depending on strconv and bufio and strings.
+
+package net
+
+///////////////////////////////////////////////////////////////////////////////
+// NOTE: This file was forked because it is used by other code that needed to
+// be forked, not because it is used on its own.
+///////////////////////////////////////////////////////////////////////////////
+
+// Bigger than we need, not too big to worry about overflow
+const big = 0xFFFFFF
+
+// Decimal to integer.
+// Returns number, characters consumed, success.
+func dtoi(s string) (n int, i int, ok bool) {
+	n = 0
+	for i = 0; i < len(s) && '0' <= s[i] && s[i] <= '9'; i++ {
+		n = n*10 + int(s[i]-'0')
+		if n >= big {
+			return big, i, false
+		}
+	}
+	if i == 0 {
+		return 0, 0, false
+	}
+	return n, i, true
+}
+
+// Hexadecimal to integer.
+// Returns number, characters consumed, success.
+func xtoi(s string) (n int, i int, ok bool) {
+	n = 0
+	for i = 0; i < len(s); i++ {
+		if '0' <= s[i] && s[i] <= '9' {
+			n *= 16
+			n += int(s[i] - '0')
+		} else if 'a' <= s[i] && s[i] <= 'f' {
+			n *= 16
+			n += int(s[i]-'a') + 10
+		} else if 'A' <= s[i] && s[i] <= 'F' {
+			n *= 16
+			n += int(s[i]-'A') + 10
+		} else {
+			break
+		}
+		if n >= big {
+			return 0, i, false
+		}
+	}
+	if i == 0 {
+		return 0, i, false
+	}
+	return n, i, true
+}

--- a/vendor/k8s.io/utils/net/BUILD.bazel
+++ b/vendor/k8s.io/utils/net/BUILD.bazel
@@ -5,9 +5,11 @@ go_library(
     srcs = [
         "ipnet.go",
         "net.go",
+        "parse.go",
         "port.go",
     ],
     importmap = "kubevirt.io/kubevirt/vendor/k8s.io/utils/net",
     importpath = "k8s.io/utils/net",
     visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/utils/internal/third_party/forked/golang/net:go_default_library"],
 )

--- a/vendor/k8s.io/utils/net/ipnet.go
+++ b/vendor/k8s.io/utils/net/ipnet.go
@@ -30,7 +30,7 @@ func ParseIPNets(specs ...string) (IPNetSet, error) {
 	ipnetset := make(IPNetSet)
 	for _, spec := range specs {
 		spec = strings.TrimSpace(spec)
-		_, ipnet, err := net.ParseCIDR(spec)
+		_, ipnet, err := ParseCIDRSloppy(spec)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ type IPSet map[string]net.IP
 func ParseIPSet(items ...string) (IPSet, error) {
 	ipset := make(IPSet)
 	for _, item := range items {
-		ip := net.ParseIP(strings.TrimSpace(item))
+		ip := ParseIPSloppy(strings.TrimSpace(item))
 		if ip == nil {
 			return nil, fmt.Errorf("error parsing IP %q", item)
 		}

--- a/vendor/k8s.io/utils/net/net.go
+++ b/vendor/k8s.io/utils/net/net.go
@@ -30,7 +30,7 @@ import (
 func ParseCIDRs(cidrsString []string) ([]*net.IPNet, error) {
 	cidrs := make([]*net.IPNet, 0, len(cidrsString))
 	for _, cidrString := range cidrsString {
-		_, cidr, err := net.ParseCIDR(cidrString)
+		_, cidr, err := ParseCIDRSloppy(cidrString)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse cidr value:%q with error:%v", cidrString, err)
 		}
@@ -71,7 +71,7 @@ func IsDualStackIPs(ips []net.IP) (bool, error) {
 func IsDualStackIPStrings(ips []string) (bool, error) {
 	parsedIPs := make([]net.IP, 0, len(ips))
 	for _, ip := range ips {
-		parsedIP := net.ParseIP(ip)
+		parsedIP := ParseIPSloppy(ip)
 		parsedIPs = append(parsedIPs, parsedIP)
 	}
 	return IsDualStackIPs(parsedIPs)
@@ -120,14 +120,14 @@ func IsIPv6(netIP net.IP) bool {
 
 // IsIPv6String returns if ip is IPv6.
 func IsIPv6String(ip string) bool {
-	netIP := net.ParseIP(ip)
+	netIP := ParseIPSloppy(ip)
 	return IsIPv6(netIP)
 }
 
 // IsIPv6CIDRString returns if cidr is IPv6.
 // This assumes cidr is a valid CIDR.
 func IsIPv6CIDRString(cidr string) bool {
-	ip, _, _ := net.ParseCIDR(cidr)
+	ip, _, _ := ParseCIDRSloppy(cidr)
 	return IsIPv6(ip)
 }
 
@@ -144,7 +144,7 @@ func IsIPv4(netIP net.IP) bool {
 
 // IsIPv4String returns if ip is IPv4.
 func IsIPv4String(ip string) bool {
-	netIP := net.ParseIP(ip)
+	netIP := ParseIPSloppy(ip)
 	return IsIPv4(netIP)
 }
 
@@ -157,7 +157,7 @@ func IsIPv4CIDR(cidr *net.IPNet) bool {
 // IsIPv4CIDRString returns if cidr is IPv4.
 // This assumes cidr is a valid CIDR.
 func IsIPv4CIDRString(cidr string) bool {
-	ip, _, _ := net.ParseCIDR(cidr)
+	ip, _, _ := ParseCIDRSloppy(cidr)
 	return IsIPv4(ip)
 }
 

--- a/vendor/k8s.io/utils/net/parse.go
+++ b/vendor/k8s.io/utils/net/parse.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	forkednet "k8s.io/utils/internal/third_party/forked/golang/net"
+)
+
+// ParseIPSloppy is identical to Go's standard net.ParseIP, except that it allows
+// leading '0' characters on numbers.  Go used to allow this and then changed
+// the behavior in 1.17.  We're choosing to keep it for compat with potential
+// stored values.
+var ParseIPSloppy = forkednet.ParseIP
+
+// ParseCIDRSloppy is identical to Go's standard net.ParseCIDR, except that it allows
+// leading '0' characters on numbers.  Go used to allow this and then changed
+// the behavior in 1.17.  We're choosing to keep it for compat with potential
+// stored values.
+var ParseCIDRSloppy = forkednet.ParseCIDR

--- a/vendor/k8s.io/utils/net/port.go
+++ b/vendor/k8s.io/utils/net/port.go
@@ -71,7 +71,7 @@ func NewLocalPort(desc, ip string, ipFamily IPFamily, port int, protocol Protoco
 		return nil, fmt.Errorf("Invalid IP family %s", ipFamily)
 	}
 	if ip != "" {
-		parsedIP := net.ParseIP(ip)
+		parsedIP := ParseIPSloppy(ip)
 		if parsedIP == nil {
 			return nil, fmt.Errorf("invalid ip address %s", ip)
 		}

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -46,86 +46,200 @@ func AllPtrFieldsNil(obj interface{}) bool {
 	return true
 }
 
-// Int32Ptr returns a pointer to an int32
-func Int32Ptr(i int32) *int32 {
+// Int returns a pointer to an int
+func Int(i int) *int {
 	return &i
 }
 
-// Int32PtrDerefOr dereference the int32 ptr and returns it if not nil,
-// else returns def.
-func Int32PtrDerefOr(ptr *int32, def int32) int32 {
+var IntPtr = Int // for back-compat
+
+// IntDeref dereferences the int ptr and returns it if not nil, or else
+// returns def.
+func IntDeref(ptr *int, def int) int {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// Int64Ptr returns a pointer to an int64
-func Int64Ptr(i int64) *int64 {
+var IntPtrDerefOr = IntDeref // for back-compat
+
+// Int32 returns a pointer to an int32.
+func Int32(i int32) *int32 {
 	return &i
 }
 
-// Int64PtrDerefOr dereference the int64 ptr and returns it if not nil,
-// else returns def.
-func Int64PtrDerefOr(ptr *int64, def int64) int64 {
+var Int32Ptr = Int32 // for back-compat
+
+// Int32Deref dereferences the int32 ptr and returns it if not nil, or else
+// returns def.
+func Int32Deref(ptr *int32, def int32) int32 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// BoolPtr returns a pointer to a bool
-func BoolPtr(b bool) *bool {
+var Int32PtrDerefOr = Int32Deref // for back-compat
+
+// Int32Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Int32Equal(a, b *int32) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Int64 returns a pointer to an int64.
+func Int64(i int64) *int64 {
+	return &i
+}
+
+var Int64Ptr = Int64 // for back-compat
+
+// Int64Deref dereferences the int64 ptr and returns it if not nil, or else
+// returns def.
+func Int64Deref(ptr *int64, def int64) int64 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+var Int64PtrDerefOr = Int64Deref // for back-compat
+
+// Int64Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Int64Equal(a, b *int64) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Bool returns a pointer to a bool.
+func Bool(b bool) *bool {
 	return &b
 }
 
-// BoolPtrDerefOr dereference the bool ptr and returns it if not nil,
-// else returns def.
-func BoolPtrDerefOr(ptr *bool, def bool) bool {
+var BoolPtr = Bool // for back-compat
+
+// BoolDeref dereferences the bool ptr and returns it if not nil, or else
+// returns def.
+func BoolDeref(ptr *bool, def bool) bool {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// StringPtr returns a pointer to the passed string.
-func StringPtr(s string) *string {
+var BoolPtrDerefOr = BoolDeref // for back-compat
+
+// BoolEqual returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func BoolEqual(a, b *bool) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// String returns a pointer to a string.
+func String(s string) *string {
 	return &s
 }
 
-// StringPtrDerefOr dereference the string ptr and returns it if not nil,
-// else returns def.
-func StringPtrDerefOr(ptr *string, def string) string {
+var StringPtr = String // for back-compat
+
+// StringDeref dereferences the string ptr and returns it if not nil, or else
+// returns def.
+func StringDeref(ptr *string, def string) string {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// Float32Ptr returns a pointer to the passed float32.
-func Float32Ptr(i float32) *float32 {
+var StringPtrDerefOr = StringDeref // for back-compat
+
+// StringEqual returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func StringEqual(a, b *string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Float32 returns a pointer to the a float32.
+func Float32(i float32) *float32 {
 	return &i
 }
 
-// Float32PtrDerefOr dereference the float32 ptr and returns it if not nil,
-// else returns def.
-func Float32PtrDerefOr(ptr *float32, def float32) float32 {
+var Float32Ptr = Float32
+
+// Float32Deref dereferences the float32 ptr and returns it if not nil, or else
+// returns def.
+func Float32Deref(ptr *float32, def float32) float32 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
 }
 
-// Float64Ptr returns a pointer to the passed float64.
-func Float64Ptr(i float64) *float64 {
+var Float32PtrDerefOr = Float32Deref // for back-compat
+
+// Float32Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Float32Equal(a, b *float32) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// Float64 returns a pointer to the a float64.
+func Float64(i float64) *float64 {
 	return &i
 }
 
-// Float64PtrDerefOr dereference the float64 ptr and returns it if not nil,
-// else returns def.
-func Float64PtrDerefOr(ptr *float64, def float64) float64 {
+var Float64Ptr = Float64
+
+// Float64Deref dereferences the float64 ptr and returns it if not nil, or else
+// returns def.
+func Float64Deref(ptr *float64, def float64) float64 {
 	if ptr != nil {
 		return *ptr
 	}
 	return def
+}
+
+var Float64PtrDerefOr = Float64Deref // for back-compat
+
+// Float64Equal returns true if both arguments are nil or both arguments
+// dereference to the same value.
+func Float64Equal(a, b *float64) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
 }

--- a/vendor/k8s.io/utils/trace/trace.go
+++ b/vendor/k8s.io/utils/trace/trace.go
@@ -56,7 +56,7 @@ func writeTraceItemSummary(b *bytes.Buffer, msg string, totalTime time.Duration,
 		b.WriteString(" ")
 	}
 
-	b.WriteString(fmt.Sprintf("%vms (%v)", durationToMilliseconds(totalTime), startTime.Format("15:04:00.000")))
+	b.WriteString(fmt.Sprintf("%vms (%v)", durationToMilliseconds(totalTime), startTime.Format("15:04:05.000")))
 }
 
 func durationToMilliseconds(timeDuration time.Duration) int64 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -944,10 +944,11 @@ k8s.io/kube-openapi/pkg/builder
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util
 k8s.io/kube-openapi/pkg/util/proto
-# k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
+# k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 ## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
+k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/trace


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since go version 1.17, net.ParseIP() and net.ParseCIDR() functions rejects leading zeros in the dot-decimal notation of IPv4 addresses.
In order to upgrade Kubevirt's go version to 1.17 and to maintain backwards compatibility - we need to use ParseIPSloppy() and ParseCIDRSloppy() functions from k8s.io/utils.
The affected fields in the VMI spec are:
- dnsConfig.nameservers (k8s.io.api.core.v1.PodDNSConfig)
- domain.devices.interfaces.dhcpOptions.ntpServers (v1.DHCPOptions)

These fields will always be parsed as decimal IPv4 addresses (leading zeros are ignored):
For example: 192.168.010.1 => 192.168.10.1

This PR:
1. Lets the above fields to be validated successfully on go 1.17.
2. Adds E2E test cases to make sure the above fields are backward compatible.

For additional details please see issue #6498.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This change was tested locally on go 1.17 - the above fields are passing validation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
