### PR TITLE
[reporter]: do not list /dev/vfio if it doesn't exist

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1063,7 +1063,7 @@ func (r *KubernetesReporter) executeNodeCommands(virtCli kubecli.KubevirtClient,
 		{command: networkPrefix + "nft list ruleset", fileNameSuffix: "nftlist"},
 
 		{command: hostPrefix + "/usr/bin/" + networkPrefix + "/usr/sbin/iptables --list -v", fileNameSuffix: "iptables"},
-		{command: "ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
+		{command: "[ -e /dev/vfio ] && ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}
 
 	r.executeContainerCommands(virtCli, logsdir, &pod, "virt-handler", cmds)
@@ -1079,7 +1079,7 @@ func (r *KubernetesReporter) executeVirtLauncherCommands(virtCli kubecli.Kubevir
 		{command: "bridge fdb", fileNameSuffix: "brfdb"},
 		{command: "lspci", fileNameSuffix: "lspci"},
 		{command: "env", fileNameSuffix: "env"},
-		{command: "ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
+		{command: "[ -e /dev/vfio ] && ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}
 
 	r.executeContainerCommands(virtCli, logsdir, &pod, "compute", cmds)


### PR DESCRIPTION

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
there are cases when the /dev/vfio doesn't exist on
virt-launcher pod fs, which causes some noisy logs in the junit report

therefore we check if the directory exists. In case it won't there won't
be vfio-devices file in the k8s-reporter artifacts.


**Which issue(s) this PR fixes** 
https://search.ci.kubevirt.io/?search=cannot+access+%27%2Fdev%2Fvfio%27%3A+No+such+file+or+directory&maxAge=336h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job


**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
