### PR TITLE
virtctl expose: more legible error message

### DIFF
--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -200,7 +200,7 @@ func (o *Command) RunE(args []string) error {
 	}
 
 	if len(serviceSelector) == 0 {
-		return fmt.Errorf("missing label information for %s: %s", vmType, vmName)
+		return fmt.Errorf("cannot expose %s without any label: %s", vmType, vmName)
 	}
 
 	if port == 0 && len(ports) == 0 {


### PR DESCRIPTION
One cannot expose a VM that has no label. I had to read the code to
understand that that was my problem having read "missing label
information for vm: foo". I hope that the suggested text is more legible
and more in line with other error texts in this module.

```release-note
NONE
```
