### PR TITLE
Improve functests usage of storage (part 3)

### DIFF
--- a/tests/config.go
+++ b/tests/config.go
@@ -31,14 +31,10 @@ import (
 type KubeVirtTestsConfiguration struct {
 	// StorageClass to use to create local PVCs
 	StorageClassLocal string `json:"storageClassLocal"`
-	// StorageClassHostPathSeparateDevice to use to create host-path PVCs that are on a separate device from the boot device
-	StorageClassHostPathSeparateDevice string `json:"storageClassHostPathSeparateDevice"`
 	// StorageClass to use to create rhel PVCs
 	StorageClassRhel string `json:"storageClassRhel"`
 	// StorageClass to use to create windows PVCs
 	StorageClassWindows string `json:"storageClassWindows"`
-	// Flag if true the storageclasses are managed, false otherwise
-	ManageStorageClasses bool `json:"manageStorageClasses"`
 	// StorageClass supporting RWX Filesystem
 	StorageRWXFileSystem string `json:"storageRWXFileSystem"`
 	// StorageClass supporting RWX Block

--- a/tests/config.go
+++ b/tests/config.go
@@ -31,8 +31,6 @@ import (
 type KubeVirtTestsConfiguration struct {
 	// StorageClass to use to create local PVCs
 	StorageClassLocal string `json:"storageClassLocal"`
-	// StorageClass to use to create host-path PVCs
-	StorageClassHostPath string `json:"storageClassHostPath"`
 	// StorageClassHostPathSeparateDevice to use to create host-path PVCs that are on a separate device from the boot device
 	StorageClassHostPathSeparateDevice string `json:"storageClassHostPathSeparateDevice"`
 	// StorageClass to use to create rhel PVCs

--- a/tests/config.go
+++ b/tests/config.go
@@ -29,8 +29,6 @@ import (
 
 // KubeVirtTestsConfiguration contains the configuration for KubeVirt tests
 type KubeVirtTestsConfiguration struct {
-	// StorageClass to use to create local PVCs
-	StorageClassLocal string `json:"storageClassLocal"`
 	// StorageClass to use to create rhel PVCs
 	StorageClassRhel string `json:"storageClassRhel"`
 	// StorageClass to use to create windows PVCs

--- a/tests/conformance-config.json
+++ b/tests/conformance-config.json
@@ -1,6 +1,5 @@
 {
     "storageClassLocal":       "local",
-    "storageClassHostPath":    "host-path",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",
     "manageStorageClasses":    false,

--- a/tests/conformance-config.json
+++ b/tests/conformance-config.json
@@ -1,5 +1,4 @@
 {
-    "storageClassLocal":       "local",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",
     "storageRWOFileSystem":    "local"

--- a/tests/conformance-config.json
+++ b/tests/conformance-config.json
@@ -2,7 +2,6 @@
     "storageClassLocal":       "local",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",
-    "manageStorageClasses":    false,
     "storageRWOFileSystem":    "local"
 }
 

--- a/tests/default-ceph-config.json
+++ b/tests/default-ceph-config.json
@@ -1,6 +1,5 @@
 {
     "storageClassLocal":       "rook-ceph-block",
-    "storageClassHostPath":    "host-path",
     "storageClassHostPathSeparateDevice":    "host-path-sd",
     "storageClassRhel":        "rook-ceph-block",
     "storageClassWindows":     "rook-ceph-block",

--- a/tests/default-ceph-config.json
+++ b/tests/default-ceph-config.json
@@ -1,5 +1,4 @@
 {
-    "storageClassLocal":       "rook-ceph-block",
     "storageClassRhel":        "rook-ceph-block",
     "storageClassWindows":     "rook-ceph-block",
     "storageRWXBlock":         "rook-ceph-block",

--- a/tests/default-ceph-config.json
+++ b/tests/default-ceph-config.json
@@ -2,7 +2,7 @@
     "storageClassRhel":        "rook-ceph-block",
     "storageClassWindows":     "rook-ceph-block",
     "storageRWXBlock":         "rook-ceph-block",
-    "storageRWOFileSystem":    "rook-ceph-block",
+    "storageRWOFileSystem":    "local",
     "storageRWOBlock":         "rook-ceph-block",
     "storageSnapshot":         "rook-ceph-block"
 }

--- a/tests/default-ceph-config.json
+++ b/tests/default-ceph-config.json
@@ -1,9 +1,7 @@
 {
     "storageClassLocal":       "rook-ceph-block",
-    "storageClassHostPathSeparateDevice":    "host-path-sd",
     "storageClassRhel":        "rook-ceph-block",
     "storageClassWindows":     "rook-ceph-block",
-    "manageStorageClasses":    true,
     "storageRWXBlock":         "rook-ceph-block",
     "storageRWOFileSystem":    "rook-ceph-block",
     "storageRWOBlock":         "rook-ceph-block",

--- a/tests/default-config.json
+++ b/tests/default-config.json
@@ -1,9 +1,7 @@
 {
     "storageClassLocal":       "local",
-    "storageClassHostPathSeparateDevice":    "host-path-sd",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",
-    "manageStorageClasses":    true,
     "storageRWOFileSystem":    "local"
 }
 

--- a/tests/default-config.json
+++ b/tests/default-config.json
@@ -1,6 +1,5 @@
 {
     "storageClassLocal":       "local",
-    "storageClassHostPath":    "host-path",
     "storageClassHostPathSeparateDevice":    "host-path-sd",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",

--- a/tests/default-config.json
+++ b/tests/default-config.json
@@ -1,5 +1,4 @@
 {
-    "storageClassLocal":       "local",
     "storageClassRhel":        "rhel",
     "storageClassWindows":     "windows",
     "storageRWOFileSystem":    "local"

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2177,20 +2177,13 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				if !tests.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
-				sc, exists := tests.GetRWXBlockStorageClass()
-				if !exists {
-					Skip("Skip migration test when RWX block storage is not present")
-				}
 
 				quantity, err := resource.ParseQuantity("5Gi")
 				Expect(err).ToNot(HaveOccurred())
 
-				volMode := k8sv1.PersistentVolumeBlock
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-				dv := tests.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
-				dv.Spec.PVC.StorageClassName = &sc
+				dv := tests.NewRandomBlockDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				dv.Spec.PVC.Resources.Requests["storage"] = quantity
-				dv.Spec.PVC.VolumeMode = &volMode
 
 				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -231,7 +231,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Expect(err).To(BeNil())
 
 				// This will only work on storage with binding mode WaitForFirstConsumer,
-				if tests.HasBindingModeWaitForFirstConsumer() {
+				if tests.IsStorageClassBindingModeWaitForFirstConsumer(tests.Config.StorageRWOFileSystem) {
 					Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
 				num := 2
@@ -290,7 +290,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				// This will only work on storage with binding mode WaitForFirstConsumer,
-				if tests.HasBindingModeWaitForFirstConsumer() {
+				if tests.IsStorageClassBindingModeWaitForFirstConsumer(tests.Config.StorageRWOFileSystem) {
 					Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
 				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -728,6 +728,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				}
 				var err error
 				dv := tests.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+				tests.SetDataVolumeForceBindAnnotation(dv)
 				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
@@ -777,7 +778,8 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				createdVirtualMachine = vm
 
-				// wait for clone to complete
+				// start vm and check dv clone succeeded
+				createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
 				targetDVName := vm.Spec.DataVolumeTemplates[0].Name
 				Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
 			}
@@ -846,8 +848,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				createVmSuccess()
 
-				// start/stop vm
-				createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
+				// stop vm
 				createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
 			},
 				table.Entry("[test_id:3193]with explicit role", explicitCloneRole, false, false),

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1132,7 +1132,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		})
 
 		It("should attach a hostpath based volume to running VM", func() {
-			dv := tests.NewRandomBlankDataVolume(util.NamespaceTestDefault, tests.Config.StorageClassHostPathSeparateDevice, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
+			dv := tests.NewRandomBlankDataVolume(util.NamespaceTestDefault, tests.StorageClassHostPathSeparateDevice, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
 

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -208,8 +208,8 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 
 	Context("Create upload volume with force-bind flag", func() {
 		DescribeTable("Should succeed", func(resource, targetName string, validateFunc func(string), deleteFunc func(string)) {
-			storageClass, exists := tests.GetStorageClassWithBindingModeWaitForFirstConsumer()
-			if !exists {
+			storageClass, exists := tests.GetRWOFileSystemStorageClass()
+			if !exists || !tests.IsStorageClassBindingModeWaitForFirstConsumer(storageClass) {
 				Skip("Skip no wffc storage class available")
 			}
 			defer deleteFunc(targetName)

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -208,8 +208,9 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 
 	Context("Create upload volume with force-bind flag", func() {
 		DescribeTable("Should succeed", func(resource, targetName string, validateFunc func(string), deleteFunc func(string)) {
-			if !tests.HasBindingModeWaitForFirstConsumer() {
-				Skip("Skip no local wffc storage class available")
+			storageClass, exists := tests.GetStorageClassWithBindingModeWaitForFirstConsumer()
+			if !exists {
+				Skip("Skip no wffc storage class available")
 			}
 			defer deleteFunc(targetName)
 
@@ -219,7 +220,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 				namespace, util.NamespaceTestDefault,
 				"--image-path", imagePath,
 				size, pvcSize,
-				"--storage-class", tests.Config.StorageClassLocal,
+				"--storage-class", storageClass,
 				"--access-mode", "ReadWriteOnce",
 				"--force-bind",
 				insecure)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -453,7 +453,7 @@ var _ = SIGDescribe("Storage", func() {
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				By("Waiting until the DataVolume is ready")
-				if tests.HasBindingModeWaitForFirstConsumer() {
+				if tests.IsStorageClassBindingModeWaitForFirstConsumer(tests.Config.StorageRWOFileSystem) {
 					Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3847,7 +3847,10 @@ func CreateNFSPvAndPvc(name string, namespace string, size string, nfsTargetIP s
 func newNFSPV(name string, namespace string, size string, nfsTargetIP string, os string) *k8sv1.PersistentVolume {
 	quantity := resource.MustParse(size)
 
-	storageClass := "local"
+	storageClass, exists := GetRWOFileSystemStorageClass()
+	if !exists {
+		Skip("Skip test when Filesystem storage is not present")
+	}
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 
 	nfsTargetIP = ip.NormalizeIPAddress(nfsTargetIP)
@@ -3881,7 +3884,10 @@ func newNFSPVC(name string, namespace string, size string, os string) *k8sv1.Per
 	quantity, err := resource.ParseQuantity(size)
 	util2.PanicOnError(err)
 
-	storageClass := "local"
+	storageClass, exists := GetRWOFileSystemStorageClass()
+	if !exists {
+		Skip("Skip test when Filesystem storage is not present")
+	}
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 
 	return &k8sv1.PersistentVolumeClaim{
@@ -4282,6 +4288,15 @@ func VolumeExpansionAllowed(sc string) bool {
 		*storageClass.AllowVolumeExpansion
 }
 
+func SetDataVolumeForceBindAnnotation(dv *cdiv1.DataVolume) {
+	annotations := dv.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["cdi.kubevirt.io/storage.bind.immediate.requested"] = "true"
+	dv.SetAnnotations(annotations)
+}
+
 func IsStorageClassBindingModeWaitForFirstConsumer(sc string) bool {
 	virtClient, err := kubecli.GetKubevirtClient()
 	Expect(err).ToNot(HaveOccurred())
@@ -4291,28 +4306,6 @@ func IsStorageClassBindingModeWaitForFirstConsumer(sc string) bool {
 	}
 	return storageClass.VolumeBindingMode != nil &&
 		*storageClass.VolumeBindingMode == wffc
-}
-
-func GetStorageClassWithBindingModeWaitForFirstConsumer() (string, bool) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	Expect(err).ToNot(HaveOccurred())
-
-	storageClassList, err := virtClient.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
-	Expect(err).ToNot(HaveOccurred())
-
-	wffcStorageClass := ""
-	for _, storageClass := range storageClassList.Items {
-		isWFFC := storageClass.VolumeBindingMode != nil && *storageClass.VolumeBindingMode == wffc
-		if !isWFFC {
-			continue
-		}
-		if storageClass.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
-			return storageClass.Name, true
-		}
-		wffcStorageClass = storageClass.Name
-	}
-
-	return wffcStorageClass, wffcStorageClass != ""
 }
 
 func GetSnapshotStorageClass() (string, bool) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -253,6 +253,10 @@ const (
 	cgroupV2cpusetPath = "/sys/fs/cgroup/cpuset.cpus.effective"
 )
 
+const StorageClassHostPathSeparateDevice = "host-path-sd"
+
+var wffc = storagev1.VolumeBindingWaitForFirstConsumer
+
 type ProcessFunc func(event *k8sv1.Event) (done bool)
 
 type ObjectEventWatcher struct {
@@ -490,9 +494,6 @@ func WaitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) 
 func SynchronizedAfterTestSuiteCleanup() {
 	RestoreKubeVirtResource()
 
-	if Config.ManageStorageClasses {
-		DeleteStorageClass(Config.StorageClassHostPathSeparateDevice)
-	}
 	CleanNodes()
 }
 
@@ -672,11 +673,6 @@ func SynchronizedBeforeTestSetup() []byte {
 	if flags.DeployTestingInfrastructureFlag {
 		WipeTestingInfrastructure()
 		DeployTestingInfrastructure()
-	}
-
-	if Config.ManageStorageClasses {
-		wffc := storagev1.VolumeBindingWaitForFirstConsumer
-		CreateStorageClass(Config.StorageClassHostPathSeparateDevice, &wffc)
 	}
 
 	EnsureKVMPresent()
@@ -1065,14 +1061,17 @@ func DeleteAllSeparateDeviceHostPathPvs() {
 	pvList, err := virtClient.CoreV1().PersistentVolumes().List(context.Background(), metav1.ListOptions{})
 	util2.PanicOnError(err)
 	for _, pv := range pvList.Items {
-		if pv.Spec.StorageClassName == Config.StorageClassHostPathSeparateDevice {
+		if pv.Spec.StorageClassName == StorageClassHostPathSeparateDevice {
 			// ignore error we want to attempt to delete them all.
 			virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
 		}
 	}
+
+	DeleteStorageClass(StorageClassHostPathSeparateDevice)
 }
 
 func CreateAllSeparateDeviceHostPathPvs(osName string) {
+	CreateStorageClass(StorageClassHostPathSeparateDevice, &wffc)
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 	Eventually(func() int {
@@ -1109,7 +1108,7 @@ func createSeparateDeviceHostPathPv(osName, nodeName string) {
 					Path: "/tmp/hostImages/mount_hp/test",
 				},
 			},
-			StorageClassName: Config.StorageClassHostPathSeparateDevice,
+			StorageClassName: StorageClassHostPathSeparateDevice,
 			NodeAffinity: &k8sv1.VolumeNodeAffinity{
 				Required: &k8sv1.NodeSelector{
 					NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
@@ -4293,7 +4292,7 @@ func HasBindingModeWaitForFirstConsumer() bool {
 		return false
 	}
 	return storageClass.VolumeBindingMode != nil &&
-		*storageClass.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer
+		*storageClass.VolumeBindingMode == wffc
 }
 
 func GetSnapshotStorageClass() (string, bool) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -491,8 +491,7 @@ func SynchronizedAfterTestSuiteCleanup() {
 	RestoreKubeVirtResource()
 
 	if Config.ManageStorageClasses {
-		deleteStorageClass(Config.StorageClassHostPath)
-		deleteStorageClass(Config.StorageClassHostPathSeparateDevice)
+		DeleteStorageClass(Config.StorageClassHostPathSeparateDevice)
 	}
 	CleanNodes()
 }
@@ -676,10 +675,8 @@ func SynchronizedBeforeTestSetup() []byte {
 	}
 
 	if Config.ManageStorageClasses {
-		immediateBinding := storagev1.VolumeBindingImmediate
 		wffc := storagev1.VolumeBindingWaitForFirstConsumer
-		createStorageClass(Config.StorageClassHostPath, &immediateBinding)
-		createStorageClass(Config.StorageClassHostPathSeparateDevice, &wffc)
+		CreateStorageClass(Config.StorageClassHostPathSeparateDevice, &wffc)
 	}
 
 	EnsureKVMPresent()
@@ -820,7 +817,7 @@ func RestoreKubeVirtResource() {
 	}
 }
 
-func createStorageClass(name string, bindingMode *storagev1.VolumeBindingMode) {
+func CreateStorageClass(name string, bindingMode *storagev1.VolumeBindingMode) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
@@ -840,7 +837,7 @@ func createStorageClass(name string, bindingMode *storagev1.VolumeBindingMode) {
 	}
 }
 
-func deleteStorageClass(name string) {
+func DeleteStorageClass(name string) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
@@ -989,7 +986,8 @@ func CreateSecret(name string, data map[string]string) {
 }
 
 func CreateHostPathPVC(os, size string) {
-	CreatePVC(os, size, Config.StorageClassHostPath, false)
+	sc := "manual"
+	CreatePVC(os, size, sc, false)
 }
 
 func CreatePVC(os, size, storageClass string, recycledPV bool) *k8sv1.PersistentVolumeClaim {
@@ -1136,11 +1134,16 @@ func createSeparateDeviceHostPathPv(osName, nodeName string) {
 	}
 }
 
-func CreateHostPathPv(osName string, hostPath string) string {
-	return CreateHostPathPvWithSize(osName, hostPath, "1Gi")
+func CreateHostPathPv(osName, hostPath string) string {
+	return createHostPathPvWithSize(osName, hostPath, "1Gi")
 }
 
-func CreateHostPathPvWithSize(osName string, hostPath string, size string) string {
+func createHostPathPvWithSize(osName, hostPath, size string) string {
+	sc := "manual"
+	return CreateHostPathPvWithSizeAndStorageClass(osName, hostPath, size, sc)
+}
+
+func CreateHostPathPvWithSizeAndStorageClass(osName, hostPath, size, sc string) string {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
@@ -1170,7 +1173,7 @@ func CreateHostPathPvWithSize(osName string, hostPath string, size string) strin
 					Type: &hostPathType,
 				},
 			},
-			StorageClassName: Config.StorageClassHostPath,
+			StorageClassName: sc,
 			NodeAffinity: &k8sv1.VolumeNodeAffinity{
 				Required: &k8sv1.NodeSelector{
 					NodeSelectorTerms: []k8sv1.NodeSelectorTerm{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a PR to continue the work in PR #6936 and PR #7010 the first commit is all the code in those PRs since it rely on those changes.
This PR removes the configuration of hostpath storage class since it is confusing and not needed specifically.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
