### PR TITLE
[Go version update guide]: Remove bullet on project-infra's mirror uploader tool

### DIFF
--- a/docs/update-go-version.md
+++ b/docs/update-go-version.md
@@ -53,7 +53,3 @@ In addition, [go rules for bazel](https://github.com/bazelbuild/rules_go) have t
     ```
 * Visit [Bazel's releases page](https://github.com/bazelbuild/rules_go/releases) and check whether the current Bazel version supports the new Go version.
   * If it is not supported, replace the `io_bazel_rules_go` definition with the one provided in Bazel's page.
-* Use [project-infra's uploader tool](https://github.com/kubevirt/project-infra/blob/main/robots/cmd/uploader/README.md) to upload new dependencies to dependency mirror.
-
-
-  


### PR DESCRIPTION
**What this PR does / why we need it**:
According to [this comment](https://github.com/kubevirt/kubevirt/pull/6974#discussion_r776757967) the dependency mirroring is done by our bot after the PR gets merged. Therefore it needs to be removed from the go update guide that says it's needed to be updated manually.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
