### PR TITLE
Fix small typo: topologyToTopology() to capabilitiesToTopology()

### DIFF
--- a/pkg/virt-handler/options.go
+++ b/pkg/virt-handler/options.go
@@ -18,7 +18,7 @@ func virtualMachineOptions(
 	options := &cmdv1.VirtualMachineOptions{
 		MemBalloonStatsPeriod: period,
 		PreallocatedVolumes:   preallocatedVolumes,
-		Topology:              topologyToTopology(capabilities),
+		Topology:              capabilitiesToTopology(capabilities),
 		DisksInfo:             disksInfoToDisksInfo(disksInfo),
 		ExpandDisksEnabled:    expandDisksEnabled,
 	}
@@ -34,7 +34,7 @@ func virtualMachineOptions(
 	return options
 }
 
-func topologyToTopology(capabilities *api.Capabilities) *cmdv1.Topology {
+func capabilitiesToTopology(capabilities *api.Capabilities) *cmdv1.Topology {
 	topology := &cmdv1.Topology{}
 	if capabilities == nil {
 		return topology


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix small typo: topologyToTopology() to capabilitiesToTopology()

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
