### PR TITLE
[virtctl] Warning message for client and server versions not aligned

### DIFF
--- a/cmd/virt-chroot/main.go
+++ b/cmd/virt-chroot/main.go
@@ -106,7 +106,7 @@ func main() {
 
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
+			cmd.Printf(cmd.UsageString())
 		},
 	}
 
@@ -169,7 +169,7 @@ func main() {
 		Short: "run selinux operations in specific namespaces",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
+			cmd.Printf(cmd.UsageString())
 		},
 	}
 

--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )
 

--- a/pkg/virtctl/version/BUILD.bazel
+++ b/pkg/virtctl/version/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//staging/src/kubevirt.io/client-go/version:def.bzl", "version_x_defs")
 
 go_library(
     name = "go_default_library",
@@ -9,7 +10,27 @@ go_library(
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
+        "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "version_suite_test.go",
+        "version_test.go",
+    ],
+    x_defs = version_x_defs(),
+    deps = [
+        ":go_default_library",
+        "//pkg/virtctl:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//staging/src/kubevirt.io/client-go/version:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -2,6 +2,9 @@ package version
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/blang/semver"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -11,10 +14,15 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
-var clientOnly bool
+var (
+	cmd        *cobra.Command
+	clientOnly bool
+)
+
+const versionsNotAlignedWarnMessage = "You are using a client virtctl version that is different from the KubeVirt version running in the cluster\nClient Version: %s\nServer Version: %s\n"
 
 func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd = &cobra.Command{
 		Use:     "version",
 		Short:   "Print the client and server version information.",
 		Example: usage(),
@@ -40,7 +48,7 @@ type Version struct {
 }
 
 func (v *Version) Run() error {
-	fmt.Printf("Client Version: %s\n", fmt.Sprintf("%#v", version.Get()))
+	cmd.Printf("Client Version: %s\n", fmt.Sprintf("%#v", version.Get()))
 
 	if !clientOnly {
 		virCli, err := kubecli.GetKubevirtClientFromClientConfig(v.clientConfig)
@@ -53,8 +61,41 @@ func (v *Version) Run() error {
 			return err
 		}
 
-		fmt.Printf("Server Version: %s\n", fmt.Sprintf("%#v", *serverInfo))
+		cmd.Printf("Server Version: %s\n", fmt.Sprintf("%#v", *serverInfo))
 	}
 
 	return nil
+}
+
+func CheckClientServerVersion(clientConfig *clientcmd.ClientConfig) {
+	clientVersion := version.Get()
+	virCli, err := kubecli.GetKubevirtClientFromClientConfig(*clientConfig)
+	if err != nil {
+		cmd.Println(err)
+		return
+	}
+
+	serverVersion, err := virCli.ServerVersion().Get()
+	if err != nil {
+		cmd.Println(err)
+		return
+	}
+
+	clientGitVersion := strings.TrimPrefix(clientVersion.GitVersion, "v")
+	serverGitVersion := strings.TrimPrefix(serverVersion.GitVersion, "v")
+	client, err := semver.Make(clientGitVersion)
+	if err != nil {
+		cmd.Println(err)
+		return
+	}
+
+	server, err := semver.Make(serverGitVersion)
+	if err != nil {
+		cmd.Println(err)
+		return
+	}
+
+	if client.Major != server.Major || client.Minor != server.Minor {
+		cmd.Printf(versionsNotAlignedWarnMessage, clientVersion, *serverVersion)
+	}
 }

--- a/pkg/virtctl/version/version_suite_test.go
+++ b/pkg/virtctl/version/version_suite_test.go
@@ -1,0 +1,11 @@
+package version_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVersion(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/version/version_test.go
+++ b/pkg/virtctl/version/version_test.go
@@ -1,0 +1,54 @@
+package version_test
+
+import (
+	"bytes"
+	"fmt"
+	goruntime "runtime"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/kubecli"
+	virt_version "kubevirt.io/client-go/version"
+	"kubevirt.io/kubevirt/pkg/virtctl"
+	"kubevirt.io/kubevirt/pkg/virtctl/version"
+)
+
+var _ = Describe("Version", func() {
+
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
+		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+		serverVersionInterface := kubecli.NewMockServerVersionInterface(ctrl)
+		kubecli.MockKubevirtClientInstance.EXPECT().ServerVersion().Return(serverVersionInterface).AnyTimes()
+		serverVersionInterface.EXPECT().Get().Return(&virt_version.Info{
+			GitVersion:   "v0.46.1",
+			GitCommit:    "fda30004223b51f9e604276419a2b376652cb5ad",
+			GitTreeState: "clear",
+			BuildDate:    time.Now().Format("%Y-%m-%dT%H:%M:%SZ"),
+			GoVersion:    goruntime.Version(),
+			Compiler:     goruntime.Compiler,
+			Platform:     fmt.Sprintf("%s/%s", goruntime.GOOS, goruntime.GOARCH),
+		}, nil,
+		).AnyTimes()
+	})
+
+	Context("should print a message if server and client virtctl versions are different", func() {
+		It("in version command", func() {
+			var buf bytes.Buffer
+			cmd, clientConfig := virtctl.NewVirtctlCommand()
+			cmd.SetOut(&buf)
+			version.CheckClientServerVersion(&clientConfig)
+			//Print out the captured output to show the test output also in the console
+			fmt.Printf(buf.String())
+			Expect(buf.String()).To(ContainSubstring("You are using a client virtctl version that is different from the KubeVirt version running in the cluster"),
+				"Warning message was not shown or has been changed")
+		})
+
+	})
+})

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -73,6 +73,7 @@ import (
 	v1alpha18 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1"
 	versioned2 "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned"
 	versioned3 "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned"
+	version "kubevirt.io/client-go/version"
 )
 
 // Mock of KubevirtClient interface
@@ -226,9 +227,9 @@ func (_mr *_MockKubevirtClientRecorder) MigrationPolicy() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MigrationPolicy")
 }
 
-func (_m *MockKubevirtClient) ServerVersion() *ServerVersion {
+func (_m *MockKubevirtClient) ServerVersion() ServerVersionInterface {
 	ret := _m.ctrl.Call(_m, "ServerVersion")
-	ret0, _ := ret[0].(*ServerVersion)
+	ret0, _ := ret[0].(ServerVersionInterface)
 	return ret0
 }
 
@@ -1780,4 +1781,36 @@ func (_m *MockKubeVirtInterface) PatchStatus(name string, pt types.PatchType, da
 
 func (_mr *_MockKubeVirtInterfaceRecorder) PatchStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PatchStatus", arg0, arg1, arg2, arg3)
+}
+
+// Mock of ServerVersionInterface interface
+type MockServerVersionInterface struct {
+	ctrl     *gomock.Controller
+	recorder *_MockServerVersionInterfaceRecorder
+}
+
+// Recorder for MockServerVersionInterface (not exported)
+type _MockServerVersionInterfaceRecorder struct {
+	mock *MockServerVersionInterface
+}
+
+func NewMockServerVersionInterface(ctrl *gomock.Controller) *MockServerVersionInterface {
+	mock := &MockServerVersionInterface{ctrl: ctrl}
+	mock.recorder = &_MockServerVersionInterfaceRecorder{mock}
+	return mock
+}
+
+func (_m *MockServerVersionInterface) EXPECT() *_MockServerVersionInterfaceRecorder {
+	return _m.recorder
+}
+
+func (_m *MockServerVersionInterface) Get() (*version.Info, error) {
+	ret := _m.ctrl.Call(_m, "Get")
+	ret0, _ := ret[0].(*version.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockServerVersionInterfaceRecorder) Get() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get")
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -30,6 +30,8 @@ import (
 	"net"
 	"time"
 
+	"kubevirt.io/client-go/version"
+
 	migrationsv1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1"
 
 	secv1 "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
@@ -69,7 +71,7 @@ type KubevirtClient interface {
 	VirtualMachineFlavor(namespace string) flavorv1alpha1.VirtualMachineFlavorInterface
 	VirtualMachineClusterFlavor() flavorv1alpha1.VirtualMachineClusterFlavorInterface
 	MigrationPolicy() migrationsv1.MigrationPolicyInterface
-	ServerVersion() *ServerVersion
+	ServerVersion() ServerVersionInterface
 	ClusterProfiler() *ClusterProfiler
 	GuestfsVersion() *GuestfsVersion
 	RestClient() *rest.RESTClient
@@ -279,4 +281,8 @@ type KubeVirtInterface interface {
 	Patch(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions, subresources ...string) (result *v1.KubeVirt, err error)
 	UpdateStatus(*v1.KubeVirt) (*v1.KubeVirt, error)
 	PatchStatus(name string, pt types.PatchType, data []byte, patchOptions *metav1.PatchOptions) (result *v1.KubeVirt, err error)
+}
+
+type ServerVersionInterface interface {
+	Get() (*version.Info, error)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/version.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/version.go
@@ -38,7 +38,7 @@ const (
 	ApiGroupName = "/apis/" + v1.SubresourceGroupName
 )
 
-func (k *kubevirt) ServerVersion() *ServerVersion {
+func (k *kubevirt) ServerVersion() ServerVersionInterface {
 	return &ServerVersion{
 		restClient: k.restClient,
 		resource:   "version",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3164,7 +3164,7 @@ func NewVirtctlCommand(args ...string) *cobra.Command {
 	if kubeconfig != nil && kubeconfig.String() != "" {
 		commandline = append(commandline, "--kubeconfig", kubeconfig.String())
 	}
-	cmd := virtctl.NewVirtctlCommand()
+	cmd, _ := virtctl.NewVirtctlCommand()
 	cmd.SetArgs(append(commandline, args...))
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a `virtctl` command returns an error we check if the server and client versions are aligned: if not, show a warning message suggesting, implicitly, that a possible cause could be this difference.
This message shows also the `ClientVerison` and `ServerVersion` to highlight the difference.
The check is based on the equality of the `Major` and `Minor` values, excluding the `Patch` one.
In this way, if client and server versions differ only from the `Patch` value they are considered as aligned.

The equality check it's based on 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add an warning message if the client and server virtctl versions are not aligned
```
