### PR TITLE
[release-0.44] virt-handler: use /proc instead of virt-chroot to stat virt-launcher files

### DIFF
--- a/pkg/virt-handler/isolation/validation.go
+++ b/pkg/virt-handler/isolation/validation.go
@@ -3,8 +3,9 @@ package isolation
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
-	"strconv"
+	"path/filepath"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
@@ -41,16 +42,11 @@ func GetImageInfo(imagePath string, context IsolationResult, config *v1.DiskVeri
 	return info, err
 }
 
-func GetFileSize(imagePath string, context IsolationResult, config *v1.DiskVerification) (int, error) {
-	memoryLimit := fmt.Sprintf("%d", config.MemoryLimit.Value())
-
-	// #nosec g204 no risk to use MountNamespace()  argument as it returns a fixed string of "/proc/<pid>/ns/mnt"
-	out, err := virt_chroot.ExecChroot(
-		"--user", "qemu", "--memory", memoryLimit, "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
-		"/usr/bin/stat", "--printf=%s", imagePath,
-	).Output()
-	if err == nil {
-		return strconv.Atoi(string(out))
+func GetFileSize(imagePath string, context IsolationResult) (int64, error) {
+	path := filepath.Join(context.MountRoot(), imagePath)
+	info, err := os.Stat(path)
+	if err != nil {
+		return -1, err
 	}
-	return -1, err
+	return info.Size(), nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -854,19 +854,19 @@ func IsoGuestVolumePath(vmi *v1.VirtualMachineInstance, volume *v1.Volume) (stri
 
 	basepath := "/var/run"
 	if volume.CloudInitNoCloud != nil {
-		volPath = path.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "noCloud.iso")
+		volPath = filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "noCloud.iso")
 	} else if volume.CloudInitConfigDrive != nil {
-		volPath = path.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "configdrive.iso")
+		volPath = filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "configdrive.iso")
 	} else if volume.ConfigMap != nil {
-		volPath = path.Join(basepath, "kubevirt-private", path.Base(config.ConfigMapDisksDir), volume.Name+".iso")
+		volPath = filepath.Join(basepath, "kubevirt-private", path.Base(config.ConfigMapDisksDir), volume.Name+".iso")
 	} else if volume.DownwardAPI != nil {
-		volPath = path.Join(basepath, "kubevirt-private", path.Base(config.DownwardAPIDisksDir), volume.Name+".iso")
+		volPath = filepath.Join(basepath, "kubevirt-private", path.Base(config.DownwardAPIDisksDir), volume.Name+".iso")
 	} else if volume.Secret != nil {
-		volPath = path.Join(basepath, "kubevirt-private", path.Base(config.SecretDisksDir), volume.Name+".iso")
+		volPath = filepath.Join(basepath, "kubevirt-private", path.Base(config.SecretDisksDir), volume.Name+".iso")
 	} else if volume.ServiceAccount != nil {
-		volPath = path.Join(basepath, "kubevirt-private", path.Base(config.ServiceAccountDiskDir), config.ServiceAccountDiskName)
+		volPath = filepath.Join(basepath, "kubevirt-private", path.Base(config.ServiceAccountDiskDir), config.ServiceAccountDiskName)
 	} else if volume.Sysprep != nil {
-		volPath = path.Join(basepath, "kubevirt-private", path.Base(config.SysprepDisksDir), volume.Name+".iso")
+		volPath = filepath.Join(basepath, "kubevirt-private", path.Base(config.SysprepDisksDir), volume.Name+".iso")
 	} else {
 		return "", false
 	}
@@ -901,7 +901,7 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 			log.DefaultLogger().V(2).Warningf("failed to detect VMI %s", vmi.Name)
 			continue
 		}
-		size, err := isolation.GetFileSize(volPath, res, d.clusterConfig.GetDiskVerification())
+		size, err := isolation.GetFileSize(volPath, res)
 		if err != nil {
 			log.DefaultLogger().V(2).Warningf("failed to determine file size for volume %s", volPath)
 			continue
@@ -909,7 +909,7 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 
 		for i, _ := range vmi.Status.VolumeStatus {
 			if vmi.Status.VolumeStatus[i].Name == volume.Name {
-				vmi.Status.VolumeStatus[i].Size = int64(size)
+				vmi.Status.VolumeStatus[i].Size = size
 				continue
 			}
 		}
@@ -2888,7 +2888,7 @@ func (d *VirtualMachineController) claimKVMDeviceOwnership(vmi *v1.VirtualMachin
 		return err
 	}
 
-	kvmPath := path.Join(isolation.MountRoot(), "dev", "kvm")
+	kvmPath := filepath.Join(isolation.MountRoot(), "dev", "kvm")
 
 	softwareEmulation, err := util.UseSoftwareEmulationForDevice(kvmPath, d.clusterConfig.IsUseEmulation())
 	if err != nil || softwareEmulation {


### PR DESCRIPTION
and fix mis-uses of path instead of filepath

This is a manual cherry-pick of #6696 

```release-note
NONE
```
