### PR TITLE
[virt-api]: replace UPDATE client method with PATCH in pod eviction admitter

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -53,7 +55,7 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 
 	if !vmi.IsMarkedForEviction() && vmi.Status.NodeName == launcher.Spec.NodeName {
 		dryRun := ar.Request.DryRun != nil && *ar.Request.DryRun == true
-		err := admitter.markVMI(ar, vmi, dryRun)
+		err := admitter.markVMI(ar, vmi.Name, vmi.Status.NodeName, dryRun)
 		if err != nil {
 			// As with the previous case, it is up to the user to issue a retry.
 			return denied(fmt.Sprintf("kubevirt failed marking the vmi for eviction: %s", err.Error()))
@@ -65,12 +67,19 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 	return validating_webhooks.NewPassingAdmissionResponse()
 }
 
-func (admitter *PodEvictionAdmitter) markVMI(ar *admissionv1.AdmissionReview, vmi *virtv1.VirtualMachineInstance, dryRun bool) (err error) {
-	vmiCopy := vmi.DeepCopy()
-	vmiCopy.Status.EvacuationNodeName = vmi.Status.NodeName
+func (admitter *PodEvictionAdmitter) markVMI(ar *admissionv1.AdmissionReview, vmiName, nodeName string, dryRun bool) (err error) {
+	data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
+
 	if !dryRun {
-		_, err = admitter.VirtClient.VirtualMachineInstance(ar.Request.Namespace).Update(vmiCopy)
+		_, err = admitter.
+			VirtClient.
+			VirtualMachineInstance(ar.Request.Namespace).
+			Patch(vmiName,
+				types.JSONPatchType,
+				[]byte(data),
+				&metav1.PatchOptions{})
 	}
+
 	return err
 }
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
recently the e2e test id 3242 related to pod eviction become
flaky. The reason was a failure in updating the VMI object because
it was too old.

Therefore we use the patch method instead, since we want to do
only a partial update and not override the whole resource.


**Which issue(s) this PR fixes** 
[[test_id:3242] flakiness](https://search.ci.kubevirt.io/?search=test_id%3A3242&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

**Special notes for your reviewer**:
As mentioned [here](https://github.com/kubevirt/kubevirt/pull/4012#discussion_r498246689), another improvement is required in the pod eviction admitter area, related to usage of client side cache
rather than direct API calls, I've decided to defer it to a follow up PR because of the amount of changes
it will require (most of them in unit tests)

**Release note**:
```release-note
NONE
```
