### PR TITLE
[cluster-profiler]: fix for flaky test - do not dump data from a pod that is under deletion

### DIFF
--- a/pkg/virt-api/rest/profiler.go
+++ b/pkg/virt-api/rest/profiler.go
@@ -135,6 +135,8 @@ func podIsReadyComponent(pod *k8sv1.Pod) bool {
 		return false
 	} else if pod.Status.Phase != k8sv1.PodRunning {
 		return false
+	} else if pod.DeletionTimestamp != nil {
+		return false
 	} else {
 		for _, cond := range pod.Status.Conditions {
 			if cond.Type == k8sv1.PodReady && cond.Status == k8sv1.ConditionTrue {


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
This is a fix for a [flaky](https://github.com/kubevirt/kubevirt/blob/ca59262fb8f4b301a4535f675294388717d5dbca/tests/infra_test.go#L1569) e2e test related to cluster profiler.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#6787 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
