### PR TITLE
tests: drop redudant UsrBinBash constant

### DIFF
--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -89,7 +89,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 			virtClient,
 			pod,
 			"compute",
-			[]string{tests.UsrBinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+			[]string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
@@ -102,7 +102,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 			virtClient,
 			pod,
 			"compute",
-			[]string{tests.UsrBinBash, "-c", "grep 'locked memory' /proc/$(ps -u qemu -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
+			[]string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -u qemu -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		limits := strings.Split(strings.TrimSpace(psOutput), " ")
@@ -131,7 +131,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 			virtClient,
 			pod,
 			"compute",
-			[]string{tests.UsrBinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+			[]string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
@@ -143,7 +143,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 			virtClient,
 			pod,
 			"compute",
-			[]string{tests.UsrBinBash, "-c", "ps -cT -u qemu  |grep -i cpu |awk '{print $3\" \" $8}'"},
+			[]string{tests.BinBash, "-c", "ps -cT -u qemu  |grep -i cpu |awk '{print $3\" \" $8}'"},
 		)
 		Expect(err).ToNot(HaveOccurred())
 		slice = strings.Split(strings.TrimSpace(psOutput), "\n")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -427,7 +427,7 @@ var _ = SIGDescribe("Storage", func() {
 					virtClient,
 					pod,
 					"compute",
-					[]string{tests.UsrBinBash, "-c", virtioFsFileTestCmd},
+					[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
@@ -494,7 +494,7 @@ var _ = SIGDescribe("Storage", func() {
 					virtClient,
 					pod,
 					"compute",
-					[]string{tests.UsrBinBash, "-c", virtioFsFileTestCmd},
+					[]string{tests.BinBash, "-c", virtioFsFileTestCmd},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
@@ -909,12 +909,12 @@ var _ = SIGDescribe("Storage", func() {
 					diskPath = filepath.Join(mountDir, diskImgName)
 					srcDir := filepath.Join(tmpDir, "src")
 					cmd := "mkdir -p " + mountDir + " && mkdir -p " + srcDir + " && chcon -t container_file_t " + srcDir + " && mount --bind " + srcDir + " " + mountDir + " && while true; do sleep 1; done"
-					pod = tests.RenderHostPathPod("host-path-preparator", tmpDir, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationBidirectional, []string{tests.UsrBinBash, "-c"}, []string{cmd})
+					pod = tests.RenderHostPathPod("host-path-preparator", tmpDir, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationBidirectional, []string{tests.BinBash, "-c"}, []string{cmd})
 					pod.Spec.Containers[0].Lifecycle = &k8sv1.Lifecycle{
 						PreStop: &k8sv1.Handler{
 							Exec: &k8sv1.ExecAction{
 								Command: []string{
-									tests.UsrBinBash, "-c",
+									tests.BinBash, "-c",
 									fmt.Sprintf("rm -f %s && umount %s", diskPath, mountDir),
 								},
 							},
@@ -938,7 +938,7 @@ var _ = SIGDescribe("Storage", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Determining the size of the mounted directory")
-					diskSizeStr, _, err := tests.ExecuteCommandOnPodV2(virtClient, pod, pod.Spec.Containers[0].Name, []string{tests.UsrBinBash, "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
+					diskSizeStr, _, err := tests.ExecuteCommandOnPodV2(virtClient, pod, pod.Spec.Containers[0].Name, []string{tests.BinBash, "-c", fmt.Sprintf("df %s | tail -n 1 | awk '{print $4}'", mountDir)})
 					Expect(err).ToNot(HaveOccurred())
 					diskSize, err = strconv.Atoi(strings.TrimSpace(diskSizeStr))
 					diskSize = diskSize * 1000 // byte to kilobyte

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -138,7 +138,6 @@ const (
 	CommandPipeFailedFmt         = "command pipe failed: %v"
 	EchoLastReturnValue          = "echo $?\n"
 	BashHelloScript              = "#!/bin/bash\necho 'hello'\n"
-	UsrBinBash                   = "/usr/bin/bash"
 )
 
 var Config *KubeVirtTestsConfiguration


### PR DESCRIPTION
On any reasonable system, /usr/bin/bash and /bin/bash are one and the same. Using both confuses the user to think that the differentiation matters.

```release-note
NONE
```
