### PR TITLE
network, netstat: Simplify status update

### DIFF
--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -253,9 +253,9 @@ var _ = Describe("netstat", func() {
 		}), "the pod IP/s should be reported in the status")
 	})
 
-	// The reporting of the SR-IOV interface is based on a false source.
+	// The reporting of the SR-IOV interface when no guest-agent exists is missing.
 	// See https://github.com/kubevirt/kubevirt/issues/7050 for more information.
-	It("should report SR-IOV interface when guest-agent is inactive and no other interface exists", func() {
+	It("should not report SR-IOV interface when guest-agent is inactive and no other interface exists", func() {
 		const (
 			networkName = "sriov-network"
 			ifaceMAC    = "C0:01:BE:E7:15:G0:0D"
@@ -271,9 +271,7 @@ var _ = Describe("netstat", func() {
 
 		setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)
 
-		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusIface(networkName, nil, "", "", ""),
-		}), "the SR-IOV interface should be reported in the status, associated to the network")
+		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{}), "the SR-IOV interface should not be reported in the status.")
 	})
 
 	// The reporting of the SR-IOV interface when no guest-agent exists is missing.

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -49,14 +49,39 @@ func IsPodNetworkWithMasqueradeBindingInterface(networks []v1.Network, ifaces []
 }
 
 func LookupInterfaceStatusByMac(interfaces []v1.VirtualMachineInstanceNetworkInterface, macAddress string) *v1.VirtualMachineInstanceNetworkInterface {
-	for _, iface := range interfaces {
-		if iface.MAC == macAddress {
-			iface := iface
-			return &iface
+	for index := range interfaces {
+		if interfaces[index].MAC == macAddress {
+			return &interfaces[index]
 		}
 	}
-
 	return nil
+}
+
+func LookupInterfaceStatusByName(interfaces []v1.VirtualMachineInstanceNetworkInterface, name string) *v1.VirtualMachineInstanceNetworkInterface {
+	for index := range interfaces {
+		if interfaces[index].Name == name {
+			return &interfaces[index]
+		}
+	}
+	return nil
+}
+
+func IndexInterfaceSpecByName(interfaces []v1.Interface) map[string]v1.Interface {
+	ifacesByName := map[string]v1.Interface{}
+	for _, ifaceSpec := range interfaces {
+		ifacesByName[ifaceSpec.Name] = ifaceSpec
+	}
+	return ifacesByName
+}
+
+func IndexInterfaceSpecByMac(interfaces []v1.Interface) map[string]v1.Interface {
+	ifacesByMac := map[string]v1.Interface{}
+	for _, ifaceSpec := range interfaces {
+		if mac := ifaceSpec.MacAddress; mac != "" {
+			ifacesByMac[mac] = ifaceSpec
+		}
+	}
+	return ifacesByMac
 }
 
 func lookupInterfaceByNetwork(ifaces []v1.Interface, network *v1.Network) *v1.Interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

This change aims to simplify the status update logic for network
interface.

It follows the expected logic where:
- The interface status is populated with IP data from the configuration
cache (written to during the network setup).
- Afterwards, it gets updated by the data collected from the domain
configuration.
- Lastly, it gets updated by the (optional) guest-agent data.

With the new logic in place, the SR-IOV reporting is partially fixed to
not report interfaces when the guest-agent is missing.
A full fix should come in a following change that resolves
https://github.com/kubevirt/kubevirt/issues/7050


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #6951 , only the last commit is to be reviewed.~~

Although the changes have been introduced gradually while developing, the end result seem too different from the original code. Therefore, it is recommended to go over both version of the code and see it indeed does the needed. The diff tooling will most likely not help.

Please also warn about missing coverage in unit tests if you notice any.

**Release note**:
```release-note
NONE
```
