### PR TITLE
Fix kubevirt_vm_container_free_memory_bytes

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -440,7 +440,7 @@ tests:
   # Memory utilization less than 20MB close to limit
   - interval: 1m
     input_series:
-      - series: 'kube_pod_container_resource_limits_memory_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'kube_pod_container_resource_limits{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
         values: "47185920 48234496 48234496 49283072"
@@ -463,7 +463,7 @@ tests:
   # Memory utilization more than 20MB close to limit
   - interval: 30s
     input_series:
-      - series: 'kube_pod_container_resource_limits_memory_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'kube_pod_container_resource_limits{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
         values: "19922944 18874368 18874368 17825792"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -486,12 +486,12 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 					},
 					{
-						Record: "kubevirt_vm_container_free_memory_bytes",
-						Expr:   intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_limits_memory_bytes{pod=~'virt-launcher-.*', container='compute'} - on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
-					},
-					{
 						Record: "kubevirt_vmi_memory_used_bytes",
 						Expr:   intstr.FromString("kubevirt_vmi_memory_available_bytes-kubevirt_vmi_memory_usable_bytes"),
+					},
+					{
+						Record: "kubevirt_vm_container_free_memory_bytes",
+						Expr:   intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_limits{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
 					},
 					{
 						Alert: "KubevirtVmHighMemoryUsage",


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updated kubevirt_vm_container_free_memory_bytes recording,
since kube_pod_container_resource_limits_memory_bytes metric was deprecated
in favor of kube_pod_container_resource_limits.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6486

**Special notes for your reviewer**:
If there is no memory limit set to the VM, the recording rule kubevirt_vm_container_free_memory_bytes, will not return any result for the VM.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated recording rule "kubevirt_vm_container_free_memory_bytes" 
```
