### PR TITLE
network, mac update test: Add assertion of the expected status

### DIFF
--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -133,6 +133,14 @@ var _ = SIGDescribe("Infosource", func() {
 				return dummyInterfaceExists(vmi)
 			}, 120*time.Second, 2*time.Second).Should(Equal(true))
 
+			networkInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceMac)
+			Expect(networkInterface).NotTo(BeNil(), "interface not found")
+			Expect(networkInterface.IP).To(BeEmpty())
+
+			guestInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceNewMac)
+			Expect(guestInterface).NotTo(BeNil(), "interface not found")
+			Expect(guestInterface.IP).NotTo(BeEmpty())
+
 			for i := range vmi.Status.Interfaces {
 				vmi.Status.Interfaces[i].IP = ""
 				vmi.Status.Interfaces[i].IPs = nil


### PR DESCRIPTION
**What this PR does / why we need it**:

The test that updates mac, was missing an assertion
that the IP should not be reported for the interface
that is derived from the domain spec.

Add also an assert that the interface with the new mac do have ip.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
