### PR TITLE
Trigger audit from inside the performance test

### DIFF
--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -82,17 +82,4 @@ fi
 
 additional_test_args="${additional_test_args} --skipPackage test/performance"
 
-start_timestamp=$(date -u +%Y-%m-%dT%TZ)
-sleep 30
 perftest ${additional_test_args} ${FUNC_TEST_ARGS}
-sleep 60
-stop_timestamp=$(date -u +%Y-%m-%dT%TZ)
-cat <<EOF >${ARTIFACTS}/perfscale-audit-cfg.json
-{
-	"prometheusURL": "http://127.0.0.1:${PROMETHEUS_PORT}",
-	"startTime": "$start_timestamp",
-	"endTime": "$stop_timestamp"
-}
-EOF
-
-perfaudit

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -18,6 +18,8 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/util:go_default_library",
+        "//tools/perfscale-audit/api:go_default_library",
+        "//tools/perfscale-audit/metric-client:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",


### PR DESCRIPTION
I noticed after the func test runs, the namespace used by the density test gets cleaned up.  That could be why we're seeing inconsistent results for the density test.  So instead of calling the audit tool after the func test runs, call it from inside the func test.   Calling from inside the func tests makes sense for future tests too since we'll want to call perf audit `afterEach` test.
```
------------------------------
• [SLOW TEST:89.300 seconds]
[sig-performance][Serial] Control Plane Performance Density Testing
tests/performance/framework.go:57
  Density test
  tests/performance/density.go:68
    [small] create a batch of 20 VMIs
    tests/performance/density.go:72
      should sucessfully create all VMIS
      tests/performance/density.go:73
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
S [SKIPPING] in Spec Setup (BeforeEach) [0.000 seconds]
[sig-performance][Serial] CPU latency tests for measuring realtime VMs performance
tests/performance/framework.go:57
  running cyclictest and collecting results directly from VM [BeforeEach]
  tests/performance/realtime.go:83

  Realtime performance tests are not enabled

  tests/performance/framework.go:72
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Waiting for namespace kubevirt-test-default1 to be removed, this can take a while ...
Waiting for namespace kubevirt-test-alternative1 to be removed, this can take a while ...
Waiting for namespace kubevirt-test-operator1 to be removed, this can take a while ...
```

We'll see if this yields more consistent results in the periodic job.  Here are the result from a local run:
```
{
  "Values": {
    "CREATE-events-count": {
      "value": 78.61666666666667
    },
    "CREATE-pods-count": {
      "value": 19.283333333333335
    },
    "GET-endpoints-count": {
      "value": 145.36095688012753
    },
    "GET-nodes-count": {
      "value": 126.08333333333334
    },
    "LIST-clusterrolebindings-count": {
      "value": 1.4833333333333334
    },
    "LIST-customresourcedefinitions-count": {
      "value": 2.966666666666667
    },
    "LIST-daemonsets-count": {
      "value": 2.966666666666667
    },
    "LIST-deployments-count": {
      "value": 1.4833333333333334
    },
    "LIST-jobs-count": {
      "value": 1.4833333333333334
    },
    "LIST-kubevirts-count": {
      "value": 1.4833333333333334
    },
    "LIST-limitranges-count": {
      "value": 1.4833333333333334
    },
    "LIST-poddisruptionbudgets-count": {
      "value": 1.4833333333333334
    },
    "LIST-rolebindings-count": {
      "value": 1.4833333333333334
    },
    "LIST-roles-count": {
      "value": 1.4833333333333334
    },                                                                                                                                                                                                                                         
    "LIST-virtualmachineclusterflavors-count": {
      "value": 2.966666666666667
    },
    "LIST-virtualmachineflavors-count": {
      "value": 1.4833333333333334
    },
    "LIST-virtualmachineinstances-count": {
      "value": 1.4833333333333334
    },
    "PATCH-pods-count": {
      "value": 32.63333333333333
    },
    "PATCH-virtualmachineinstances-count": {
      "value": 29.666666666666668
    },
    "UPDATE-endpoints-count": {
      "value": 89
    },
    "UPDATE-virtualmachineinstances-count": {
      "value": 204.7
    },
    "running-phase-count": {
      "value": 20
    },
    "vmiCreationToRunningSecondsP50": {
      "value": 31
    },
    "vmiCreationToRunningSecondsP95": {
      "value": 40.000000000000036
    },
    "vmiCreationToRunningSecondsP99": {
      "value": 47.99999999999999
    }
  }
}
```

Signed-off-by: Ryan Hallisey <rhallisey@nvidia.com>

```release-note
NONE
```
