### PR TITLE
[sig-scale] add script and configuration files to automate the execution of performance test in our CI/CD system

### DIFF
--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 IBM, Inc.
+#
+
+set -ex
+
+kubectl() { KUBEVIRTCI_VERBOSE=false cluster-up/kubectl.sh "$@"; }
+
+_prometheus_port_forward_pid=""
+trap "clean_up" EXIT SIGINT SIGTERM SIGQUIT
+clean_up() {
+  kill -9 $_prometheus_port_forward_pid 2> /dev/null
+  make cluster-clean
+}
+
+echo "Nodes are ready:"
+kubectl get nodes
+
+echo "Cluster sync: push docker images and deploy kubevirt"
+make cluster-sync
+
+# OpenShift is running important containers under default namespace
+namespaces=(kubevirt default)
+if [[ $NAMESPACE != "kubevirt" ]]; then
+  namespaces+=($NAMESPACE)
+fi
+
+timeout=300
+sample=30
+
+for i in ${namespaces[@]}; do
+  # Wait until kubevirt pods are running or completed
+  current_time=0
+  while [ -n "$(kubectl get pods -n $i --no-headers | grep -v -E 'Running|Completed')" ]; do
+    echo "Waiting for kubevirt pods to enter the Running/Completed state ..."
+    kubectl get pods -n $i --no-headers | >&2 grep -v -E 'Running|Completed' || true
+    sleep $sample
+
+    current_time=$((current_time + sample))
+    if [ $current_time -gt $timeout ]; then
+      echo "Dump kubevirt state:"
+      make dump
+      exit 1
+    fi
+  done
+
+  # Make sure all containers are ready
+  current_time=0
+  while [ -n "$(kubectl get pods -n $i --field-selector=status.phase==Running -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false)" ]; do
+    echo "Waiting for KubeVirt containers to become ready ..."
+    kubectl get pods -n $i --field-selector=status.phase==Running -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false || true
+    sleep $sample
+
+    current_time=$((current_time + sample))
+    if [ $current_time -gt $timeout ]; then
+      echo "Dump kubevirt state:"
+      make dump
+      exit 1
+    fi
+  done
+  kubectl get pods -n $i
+done
+
+# build perfscale tools
+make bazel-build
+
+export DOCKER_PREFIX="${DOCKER_PREFIX:-registry:5000/kubevirt}"
+export DOCKER_TAG="${DOCKER_TAG:-devel}"
+export PERFAUDIT="${PERFAUDIT:-true}"
+export PROMETHEUS_PORT=${PROMETHEUS_PORT:-30007}
+
+# expose prometheus in an external kubernetes cluster
+if [[ (${PERFAUDIT} == "true" || ${PERFAUDIT} == "True") && ${KUBEVIRT_PROVIDER} == "external" ]]; then
+  kubectl -n monitoring port-forward service/prometheus-stack-kube-prom-prometheus ${PROMETHEUS_PORT} &> /dev/null &
+  _prometheus_port_forward_pid=$1
+fi
+
+# Run performance tests
+./hack/perfscale-tests.sh

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -76,7 +76,7 @@ metadata:
   name: ${namespace:?}
 EOF
 
-if [[ "$KUBEVIRT_PROVIDER" =~ kind.* ]]; then
+if [[ "$KUBEVIRT_PROVIDER" =~ kind.* || "$KUBEVIRT_PROVIDER" = "external" ]]; then
     # Don't install CDI and loopback devices it's crashing with dind because loopback devices are shared with the host
     export KUBEVIRT_DEPLOY_CDI=false
 fi

--- a/hack/perfscale-tests.sh
+++ b/hack/perfscale-tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 IBM, Inc.
+
+set -e
+
+_docker_prefix="quay.io/kubevirt/"
+_perfscale_workload="tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml"
+_perfscale_workload_warmup="tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-warmup.yaml"
+
+export DOCKER_PREFIX=${DOCKER_PREFIX-${_docker_prefix}}
+export DOCKER_TAG=${DOCKER_TAG:-"latest"}
+export PROMETHEUS_PORT=${PROMETHEUS_PORT:-30007}
+export PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1}
+export PERFSCALE_WORKLOAD=${PERFSCALE_WORKLOAD-${_perfscale_workload}}
+
+echo 'Preparing directory for artifacts'
+export ARTIFACTS=_out/artifacts/perfscale
+export AUDIT_CONFIG=${ARTIFACTS}/perfscale-audit-cfg.json
+export AUDIT_RESULTS=${ARTIFACTS}/perfscale-audit-results.json
+rm -rf $ARTIFACTS
+mkdir -p $ARTIFACTS
+
+function perftest() {
+    _out/cmd/perfscale-load-generator/perfscale-load-generator \
+          -container-prefix ${DOCKER_PREFIX} \
+          -container-tag ${DOCKER_TAG} \
+          -v 6 \
+          -workload ${PERFSCALE_WORKLOAD}
+}
+
+function perfaudit() {
+    start_timestamp=$1
+    stop_timestamp=$2
+    cat <<EOF >${ARTIFACTS}/perfscale-audit-cfg.json
+{
+	"prometheusURL": "${PROMETHEUS_URL}:${PROMETHEUS_PORT}",
+	"startTime": "$start_timestamp",
+	"endTime": "$stop_timestamp"
+}
+EOF
+    _out/cmd/perfscale-audit/perfscale-audit \
+        --config-file=${AUDIT_CONFIG} \
+        --results-file=${AUDIT_RESULTS}
+}
+
+# as workaround to collect all pod events, we first need to warmup the kubevirt cluster creating a VMI
+# more info in https://github.com/kubevirt/kubevirt/issues/7083
+if [[ ${PERFAUDIT} == "true" || ${PERFAUDIT} == "True" ]]; then
+    _perfscale_workload_tmp=${PERFSCALE_WORKLOAD}
+    export PERFSCALE_WORKLOAD=$_perfscale_workload_warmup
+    # run small test to warm up the system and be able to collect metrics
+    perftest ${additional_test_args} ${FUNC_TEST_ARGS}
+    # wait 30 before running the test to let prometheus scrape metrics
+    echo "Sleeping 30 to let prometheus scrape all metrics"
+    sleep 30
+    export PERFSCALE_WORKLOAD=$_perfscale_workload_tmp
+fi
+
+start_timestamp=$(date -u +%Y-%m-%dT%TZ)
+# run the test
+perftest ${additional_test_args} ${FUNC_TEST_ARGS}
+
+# run audit tool to dump metrics
+if [[ ${PERFAUDIT} == "true" || ${PERFAUDIT} == "True" ]]; then
+    # wait 180s after finished the test. More info in https://github.com/kubevirt/kubevirt/issues/7083
+    stop=$(date -u +%Y-%m-%dT%TZ)
+    echo "Sleeping 180s to let prometheus scrape all metrics"
+    sleep 180s
+    stop_timestamp=$(date -u +%Y-%m-%dT%TZ)
+    perfaudit $start_timestamp $stop_timestamp
+fi

--- a/hack/perfscale-tests.sh
+++ b/hack/perfscale-tests.sh
@@ -22,11 +22,11 @@ _docker_prefix="quay.io/kubevirt/"
 _perfscale_workload="tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml"
 _perfscale_workload_warmup="tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-warmup.yaml"
 
-export DOCKER_PREFIX=${DOCKER_PREFIX-${_docker_prefix}}
+export DOCKER_PREFIX=${DOCKER_PREFIX:-${_docker_prefix}}
 export DOCKER_TAG=${DOCKER_TAG:-"latest"}
 export PROMETHEUS_PORT=${PROMETHEUS_PORT:-30007}
 export PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1}
-export PERFSCALE_WORKLOAD=${PERFSCALE_WORKLOAD-${_perfscale_workload}}
+export PERFSCALE_WORKLOAD=${PERFSCALE_WORKLOAD:-${_perfscale_workload}}
 
 echo 'Preparing directory for artifacts'
 export ARTIFACTS=_out/artifacts/perfscale
@@ -37,10 +37,10 @@ mkdir -p $ARTIFACTS
 
 function perftest() {
     _out/cmd/perfscale-load-generator/perfscale-load-generator \
-          -container-prefix ${DOCKER_PREFIX} \
-          -container-tag ${DOCKER_TAG} \
-          -v 6 \
-          -workload ${PERFSCALE_WORKLOAD}
+        -container-prefix ${DOCKER_PREFIX} \
+        -container-tag ${DOCKER_TAG} \
+        -v 6 \
+        -workload ${PERFSCALE_WORKLOAD}
 }
 
 function perfaudit() {
@@ -58,7 +58,7 @@ EOF
         --results-file=${AUDIT_RESULTS}
 }
 
-# as workaround to collect all pod events, we first need to warmup the kubevirt cluster creating a VMI
+# as workaround to collect all pod events, we first need to warmup the kubevirt cluster creating a VMI to prevent Prometheus zero metrics problem
 # more info in https://github.com/kubevirt/kubevirt/issues/7083
 if [[ ${PERFAUDIT} == "true" || ${PERFAUDIT} == "True" ]]; then
     _perfscale_workload_tmp=${PERFSCALE_WORKLOAD}

--- a/tools/perfscale-load-generator/README.md
+++ b/tools/perfscale-load-generator/README.md
@@ -57,7 +57,7 @@ workloads:
         inputVars:
           // containerPrefix defines the repository prefix for all images
           // if the value is empty (i.e., "") the default value defined in the cmd flag will be used
-          containerPrefix: registry:5000/kubevirt/
+          containerPrefix: registry:5000/kubevirt
           // containerImg defines the VMI image in the 
           containerImg: cirros-container-disk-demo
           // containerTag defines the image tag
@@ -76,4 +76,4 @@ workloads:
 - Each workload iteration might sleep X times before each iteration to avoid being affected by a previous execution
 
 ## Comments
-Note that the containerPrefix can also be defined via command line to make it easier to run the workload in different environments. For example, when creating a cluster using the kubevirtci, the containerPrefix = `registry:5000/kubevirt/`, but then creating the cluster using kubespray the containerPrefix = `localhost:5000/kubevirt/`.
+Note that the containerPrefix can also be defined via command line to make it easier to run the workload in different environments. For example, when creating a cluster using the kubevirtci, the containerPrefix = `registry:5000/kubevirt`, but then creating the cluster using kubespray the containerPrefix = `localhost:5000/kubevirt`.

--- a/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-scale.yaml
+++ b/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-scale.yaml
@@ -2,7 +2,7 @@ globalConfig:
     qps: 0
     burst: 0
 workloads:
-  - name: kubevirt-density-400
+  - name: kubevirt-density-200
     iterationCount: 1
     iterationInterval: 0
     iterationCreationWait: true
@@ -12,7 +12,26 @@ workloads:
     maxWaitTimeout: 1h
     qps: 20
     burst: 20
-    waitWhenFinished: 15m
+    waitWhenFinished: 10m
+    objects:          
+      - templateFile: templates/vmi-ephemeral.yaml
+        replicas: 200
+        inputVars:
+          containerPrefix: ""
+          containerImg: cirros-container-disk-demo
+          containerTag: ""
+          namespace: kubevirt-density
+  - name: kubevirt-density-400
+    iterationCount: 1
+    iterationInterval: 0
+    iterationCreationWait: true
+    iterationCleanup: true
+    iterationDeletionWait: true
+    namespacedIterations: false
+    maxWaitTimeout: 1h
+    qps: 20
+    burst: 20
+    waitWhenFinished: 10m
     objects:          
       - templateFile: templates/vmi-ephemeral.yaml
         replicas: 400
@@ -27,25 +46,6 @@ workloads:
     iterationCreationWait: true
     iterationCleanup: true
     iterationDeletionWait: true
-    namespacedIterations: false
-    maxWaitTimeout: 1h
-    qps: 20
-    burst: 20
-    waitWhenFinished: 15m
-    objects:          
-      - templateFile: templates/vmi-ephemeral.yaml
-        replicas: 600
-        inputVars:
-          containerPrefix: ""
-          containerImg: cirros-container-disk-demo
-          containerTag: ""
-          namespace: kubevirt-density
-  - name: kubevirt-density-800
-    iterationCount: 1
-    iterationInterval: 0
-    iterationCreationWait: true
-    iterationCleanup: true
-    iterationDeletionWait: true
     namespacedIterations: false    
     maxWaitTimeout: 1h
     qps: 20
@@ -53,7 +53,7 @@ workloads:
     waitWhenFinished: 30s
     objects:          
       - templateFile: templates/vmi-ephemeral.yaml
-        replicas: 800
+        replicas: 600
         inputVars:
           containerPrefix: ""
           containerImg: cirros-container-disk-demo

--- a/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-scale.yaml
+++ b/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-scale.yaml
@@ -1,0 +1,61 @@
+globalConfig:
+    qps: 0
+    burst: 0
+workloads:
+  - name: kubevirt-density-400
+    iterationCount: 1
+    iterationInterval: 0
+    iterationCreationWait: true
+    iterationCleanup: true
+    iterationDeletionWait: true
+    namespacedIterations: false    
+    maxWaitTimeout: 1h
+    qps: 20
+    burst: 20
+    waitWhenFinished: 15m
+    objects:          
+      - templateFile: templates/vmi-ephemeral.yaml
+        replicas: 400
+        inputVars:
+          containerPrefix: ""
+          containerImg: cirros-container-disk-demo
+          containerTag: ""
+          namespace: kubevirt-density
+  - name: kubevirt-density-600
+    iterationCount: 1
+    iterationInterval: 0
+    iterationCreationWait: true
+    iterationCleanup: true
+    iterationDeletionWait: true
+    namespacedIterations: false
+    maxWaitTimeout: 1h
+    qps: 20
+    burst: 20
+    waitWhenFinished: 15m
+    objects:          
+      - templateFile: templates/vmi-ephemeral.yaml
+        replicas: 600
+        inputVars:
+          containerPrefix: ""
+          containerImg: cirros-container-disk-demo
+          containerTag: ""
+          namespace: kubevirt-density
+  - name: kubevirt-density-800
+    iterationCount: 1
+    iterationInterval: 0
+    iterationCreationWait: true
+    iterationCleanup: true
+    iterationDeletionWait: true
+    namespacedIterations: false    
+    maxWaitTimeout: 1h
+    qps: 20
+    burst: 20
+    waitWhenFinished: 30s
+    objects:          
+      - templateFile: templates/vmi-ephemeral.yaml
+        replicas: 800
+        inputVars:
+          containerPrefix: ""
+          containerImg: cirros-container-disk-demo
+          containerTag: ""
+          namespace: kubevirt-density

--- a/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-warmup.yaml
+++ b/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density-warmup.yaml
@@ -2,7 +2,7 @@ globalConfig:
     qps: 0
     burst: 0
 workloads:
-  - name: kubevirt-density-100
+  - name: kubevirt-density-1
     iterationCount: 1
     iterationInterval: 0
     iterationCreationWait: true
@@ -16,7 +16,6 @@ workloads:
     objects:          
       - templateFile: templates/vmi-ephemeral.yaml
         replicas: 1
-          #replicas: 100
         inputVars:
           containerPrefix: ""
           containerImg: cirros-container-disk-demo

--- a/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml
+++ b/tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml
@@ -15,8 +15,7 @@ workloads:
     waitWhenFinished: 30s
     objects:          
       - templateFile: templates/vmi-ephemeral.yaml
-        replicas: 1
-          #replicas: 100
+        replicas: 100
         inputVars:
           containerPrefix: ""
           containerImg: cirros-container-disk-demo

--- a/tools/perfscale-load-generator/examples/workload/kubevirt-density/templates/vmi-ephemeral.yaml
+++ b/tools/perfscale-load-generator/examples/workload/kubevirt-density/templates/vmi-ephemeral.yaml
@@ -29,7 +29,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: {{.containerPrefix}}{{.containerImg}}:{{.containerTag}}
+      image: {{.containerPrefix}}/{{.containerImg}}:{{.containerTag}}
       imagePullPolicy: IfNotPresent
     name: disk0
   - cloudInitNoCloud:

--- a/tools/perfscale-load-generator/flags/flags.go
+++ b/tools/perfscale-load-generator/flags/flags.go
@@ -42,7 +42,7 @@ func init() {
 	flag.StringVar(&Kubemaster, "master", "", "kubernetes master url")
 	flag.IntVar(&Verbosity, "v", 2, "log level for V logs")
 	flag.StringVar(&WorkloadConfigFile, "workload", "tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml", "path to the file containing the worload configuration")
-	flag.StringVar(&ContainerPrefix, "container-prefix", "registry:5000/kubevirt/", "Set the repository prefix for all images")
+	flag.StringVar(&ContainerPrefix, "container-prefix", "registry:5000/kubevirt", "Set the repository prefix for all images")
 	flag.StringVar(&ContainerTag, "container-tag", "devel", "Set the image tag or digest to use")
 
 	if Kubeconfig == "" {


### PR DESCRIPTION
Add configuration to run density scaling performance testing by varying the number of VMIs creation from 400, 600, up tp 800.

This configuration will be used for the Medium-scale performance test that will run daily on the performance cluster on our CI/CD system. This test is part of the planned performance tests being introduced to monitor performance regressions.

This PR is related to #6309

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>

/cc @fgimenez @rmohr @davidvossel @rthallisey 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
