### PR TITLE
Add KubevirtVmHighMemoryUsageBasedOnRequests alert

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -473,6 +473,42 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts: []
 
+  # Memory utilization is more than 20MB close to requested memory
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+        values: "67108864 67108864 67108864 67108864"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "47185920 48234496 48234496 49283072"
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KubevirtVmHighMemoryUsageBasedOnRequests
+        exp_alerts:
+          - exp_annotations:
+              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to requested memory"
+              summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsageBasedOnRequests"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              pod: "virt-launcher-testvm-123"
+              container: "compute"
+
+  # Memory utilization more than 20MB close to requested memory
+  - interval: 30s
+    input_series:
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+        values: "67108864 67108864 67108864 67108864"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "19922944 18874368 18874368 17825792"
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KubevirtVmHighMemoryUsageBasedOnRequests
+        exp_alerts: []
+
   # VM eviction strategy is set but vm is not migratable
   - interval: 1m
     input_series:

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -507,6 +507,23 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 					},
 					{
+						Record: "kubevirt_vm_container_free_memory_bytes_based_on_requests",
+						Expr:   intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
+					},
+					{
+						Alert: "KubevirtVmHighMemoryUsageBasedOnRequests",
+						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_requests < 20971520"),
+						For:   "1m",
+						Annotations: map[string]string{
+							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} free memory is less than 20 MB and it is close to requested memory",
+							"summary":     "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime.",
+							"runbook_url": runbookUrlBasePath + "KubevirtVmHighMemoryUsageBasedOnRequests",
+						},
+						Labels: map[string]string{
+							severityAlertLabelKey: "warning",
+						},
+					},
+					{
 						Record: "kubevirt_num_virt_handlers_by_node_running_virt_launcher",
 						Expr:   intstr.FromString("count by(node)(node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} ) * on (node) group_left(pod) (1*(kube_pod_container_status_ready{pod=~'virt-handler-.*'} + on (pod) group_left(node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-handler-.*'} ))) or on (node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} )"),
 					},


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Added kubevirt_vm_container_free_memory_bytes_based_on_requests
recording rule and KubevirtVmHighMemoryUsageBasedOnRequests
alert for alerting if the memory used is close to the
requested memory of the container running the VM.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added KubevirtVmHighMemoryUsageBasedOnRequests alert that notifies if the container that is running the VM is close to its requested memory, since it means that it might be in danger of eviction or termination.
```
