### PR TITLE
Fix CRD removal race condition

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2617,6 +2617,10 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 			kvTestData.shouldExpectDeletions()
+
+			// Due to finalizers being added to CRDs during deletion
+			kvTestData.extClient.Fake.PrependReactor("patch", "customresourcedefinitions", kvTestData.crdPatchFunc())
+
 			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()
@@ -2654,6 +2658,9 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 			kvTestData.shouldExpectDeletions()
+
+			// Due to finalizers being added to CRDs during deletion
+			kvTestData.extClient.Fake.PrependReactor("patch", "customresourcedefinitions", kvTestData.crdPatchFunc())
 			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kvTestData.controller.Execute()

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "certificates_test.go",
         "core_test.go",
         "crds_test.go",
+        "delete_test.go",
         "install_strategy_suite_test.go",
         "patches_test.go",
         "pdb_test.go",

--- a/pkg/virt-operator/resource/apply/delete_test.go
+++ b/pkg/virt-operator/resource/apply/delete_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Deletion", func() {
 
 			needDeletion := crdFilterNeedDeletion(crds)
 
-			Expect(len(needDeletion)).To(Equal(1))
+			Expect(needDeletion).To(HaveLen(1))
 			Expect(needDeletion[0].Name).To(Equal("needs-deletion"))
 		})
 

--- a/pkg/virt-operator/resource/apply/delete_test.go
+++ b/pkg/virt-operator/resource/apply/delete_test.go
@@ -1,0 +1,185 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package apply
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("Deletion", func() {
+
+	Context("CRD deletion", func() {
+		It("Filter needs deletion", func() {
+			crds := []*extv1.CustomResourceDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "does-not-deletion1",
+						DeletionTimestamp: now(),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "needs-deletion",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "does-not-deletion2",
+						DeletionTimestamp: now(),
+					},
+				},
+			}
+
+			needDeletion := crdFilterNeedDeletion(crds)
+
+			Expect(len(needDeletion)).To(Equal(1))
+			Expect(needDeletion[0].Name).To(Equal("needs-deletion"))
+		})
+
+		It("Filter needs finalizer", func() {
+			crds := []*extv1.CustomResourceDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "does-not-need-finalizer-1",
+						DeletionTimestamp: now(),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "needs-finalizer",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "does-not-need-finalizer-2",
+						Finalizers: []string{v1.VirtOperatorComponentFinalizer},
+					},
+				},
+			}
+
+			needAdded := crdFilterNeedFinalizerAdded(crds)
+
+			Expect(len(needAdded)).To(Equal(1))
+			Expect(needAdded[0].Name).To(Equal("needs-finalizer"))
+		})
+
+		It("Filter needs finalizer removed", func() {
+			crds := []*extv1.CustomResourceDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "1",
+						Finalizers:        []string{v1.VirtOperatorComponentFinalizer},
+						DeletionTimestamp: now(),
+					},
+					Status: extv1.CustomResourceDefinitionStatus{
+						Conditions: []extv1.CustomResourceDefinitionCondition{
+							instanceRemovedCondition(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "2",
+						Finalizers:        []string{v1.VirtOperatorComponentFinalizer},
+						DeletionTimestamp: now(),
+					},
+					Status: extv1.CustomResourceDefinitionStatus{
+
+						Conditions: []extv1.CustomResourceDefinitionCondition{
+							instanceRemovedCondition(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "3",
+						Finalizers:        []string{v1.VirtOperatorComponentFinalizer},
+						DeletionTimestamp: now(),
+					},
+					Status: extv1.CustomResourceDefinitionStatus{
+						Conditions: []extv1.CustomResourceDefinitionCondition{
+							instanceRemovedCondition(),
+						},
+					},
+				},
+			}
+
+			needRemoved := crdFilterNeedFinalizerRemoved(crds)
+			Expect(len(needRemoved)).To(Equal(3))
+		})
+
+		It("Should block finalizer removal until all CRD CRs are removed", func() {
+			crds := []*extv1.CustomResourceDefinition{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "1",
+						Finalizers:        []string{v1.VirtOperatorComponentFinalizer},
+						DeletionTimestamp: now(),
+					},
+					Status: extv1.CustomResourceDefinitionStatus{
+						Conditions: []extv1.CustomResourceDefinitionCondition{
+							instanceRemovedCondition(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "2",
+						Finalizers:        []string{v1.VirtOperatorComponentFinalizer},
+						DeletionTimestamp: now(),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "3",
+						Finalizers:        []string{v1.VirtOperatorComponentFinalizer},
+						DeletionTimestamp: now(),
+					},
+					Status: extv1.CustomResourceDefinitionStatus{
+						Conditions: []extv1.CustomResourceDefinitionCondition{
+							instanceRemovedCondition(),
+						},
+					},
+				},
+			}
+
+			needRemoved := crdFilterNeedFinalizerRemoved(crds)
+			Expect(len(needRemoved)).To(Equal(0))
+		})
+	})
+})
+
+func instanceRemovedCondition() extv1.CustomResourceDefinitionCondition {
+	return extv1.CustomResourceDefinitionCondition{
+		Type:   extv1.Terminating,
+		Status: extv1.ConditionFalse,
+		Reason: "InstanceDeletionCompleted",
+	}
+}
+
+func now() *metav1.Time {
+	now := metav1.Now()
+	return &now
+}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -760,6 +760,9 @@ const (
 	// This label indicates the object is a part of the install strategy retrieval process.
 	InstallStrategyLabel = "kubevirt.io/install-strategy"
 
+	// Set by virt-operator to coordinate component deletion
+	VirtOperatorComponentFinalizer string = "kubevirt.io/virtOperatorFinalizer"
+
 	// Set by VMI controller to ensure VMIs are processed during deletion
 	VirtualMachineInstanceFinalizer string = "foregroundDeleteVirtualMachine"
 	// Set By VM controller on VMIs to ensure VMIs are processed by VM controller during deletion

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1744,6 +1744,11 @@ spec:
 			allPodsAreReady(originalKv)
 			sanityCheckDeploymentsExist()
 
+			// This ensures that we can remove kubevirt while workloads are running
+			By("Starting some vmis")
+			vmis := generateMigratableVMIs(2)
+			startAllVMIs(vmis)
+
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false)
 


### PR DESCRIPTION
related to: https://bugzilla.redhat.com/show_bug.cgi?id=2035324 

# What's happening

To understand what's occurring I need to point out a few things about how the system works.

1. We register mutation/validation webhooks our CRDs which are served by virt-api
2. Update/Patch to our KubeVirt APIs fail when virt-api is unavailable due to these webhook registrations
3. virt-api will fail to initialize if not all CRDs are registered due to not being able to sync informer cache.

What we have going on in this BZ is that during teardown, virt-api re-initialized (most likely due to CDI apis being removed), and was unable to come back online due to some of our CRDs no longer being registered. Since virt-api hosts the webhooks for all our CRDs, any remaining KubeVirt CRs in the cluster that require the removal of finalizers will fail because we can't call Patch/Update without webhooks being online.

The result is a deadlock of sorts. We can't remove objects with finalizers because we can't call Update/Patch on those objects. And we can't call update/patch because virt-api is down, and virt-api is down because some KubeVirt APIs have already been removed which prevents the informer cache from syncing.

virt-controller is subject to this same issue. If some CRDs are not registered anymore, virt-controller will fail to initialize in that situation.


# Logs show sequence of events

virt-api re-initializes because DataSource object from CDI is removed.

```2022-01-11T11:15:52.647206472Z {"component":"virt-api","level":"info","msg":"Reinitialize virt-api, cdi DataSource api has been removed","pos":"api.go:985","timestamp":"2022-01-11T11:15:52.647130Z"}```

virt-api is stuck trying to come back online but can't sync informers

```
022-01-11T11:53:19.372804960Z E0111 11:53:19.372752       1 reflector.go:138] pkg/controller/virtinformers.go:305: Failed to watch *v1alpha1.VirtualMachineRestore: failed to list *v1alpha1.VirtualMachineRestore: the server could not find the requested resource (get virtualmachinerestores.snapshot.kubevirt.io)
2022-01-11T11:53:34.820951778Z E0111 11:53:34.820897       1 reflector.go:138] pkg/controller/virtinformers.go:305: Failed to watch *v1.VirtualMachineInstancePreset: failed to list *v1.VirtualMachineInstancePreset: the server could not find the requested resource (get virtualmachineinstancepresets.kubevirt.io)
```

virt-controller can't patch VMI object because virt-api isn't initialized.

```
2022-01-11T11:53:52.792661238Z {"component":"virt-controller","level":"info","msg":"reenqueuing VirtualMachineInstance kubevirt-hyperconverged/fedora-responsible-boar","pos":"vmi.go:272","reason":"patching of vmi conditions and activePods failed: Internal error occurred: failed calling webhook \"virtualmachineinstances-mutator.kubevirt.io\": failed to call webhook: Post \"https://virt-api.kubevirt-hyperconverged.svc:443/virtualmachineinstances-mutate?timeout=10s\": no endpoints available for service \"virt-api\"","timestamp":"2022-01-11T11:53:52.792516Z"}
```

# The Fix

We need to change the deletion order from this...

- Delete all CRDs
- Delete Webhook registrations

to this...
- Add finalizers to all CRDs
- Delete All CRDs (finalizer prevents them from being completely removed)
- Remove All CRD finalizers after waiting for all CRDs to report CRs are removed
- Delete webhook registrations

When  a CRD is marked for deletion, no new creations can occur while CRs for that CRD are being removed. By freezing the ability to create new objects when tearing down our API, we can do a controlled deletion of all CRs and only delete the CRDs once all CRs are removed.

Essentially, we're not allowing CRDs to disappear until every CR associated with the KubeVirt API is gone. That allows our control plane to properly tear down CRs without hitting issues with API's being unavailable.

```release-note
Fixes issue associated with blocked uninstalls when VMIs exist during removal
```
