### PR TITLE
Fix initialization of the device plugin with different vendor/product id but same resource name

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -147,10 +147,9 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]Contro
 					supportedPCIDeviceMap[strings.ToLower(pciDev.PCIVendorSelector)] = pciDev.ResourceName
 				}
 			}
-			pciHostDevices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
-			for pciID, pciDevices := range pciHostDevices {
-				pciResourceName := supportedPCIDeviceMap[pciID]
-				log.Log.V(4).Infof("Discovered PCI device on the node, ID: %s, resourceName: %s", pciID, pciResourceName)
+			pciHostDevicesPerResourceName := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
+			for pciResourceName, pciDevices := range pciHostDevicesPerResourceName {
+				log.Log.V(4).Infof("Discovered PCIs %d devices on the node for the resource: %s", len(pciDevices), pciResourceName)
 				// add a device plugin only for new devices
 				if _, isRunning := c.devicePlugins[pciResourceName]; !isRunning {
 					devicePluginsToRun[pciResourceName] = ControlledDevice{

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -387,7 +387,7 @@ func discoverPermittedHostPCIDevices(supportedPCIDeviceMap map[string]string) ma
 			log.DefaultLogger().Reason(err).Errorf("failed get vendor:device ID for device: %s", info.Name())
 			return nil
 		}
-		if _, supported := supportedPCIDeviceMap[pciID]; supported {
+		if resourceName, supported := supportedPCIDeviceMap[pciID]; supported {
 			// check device driver
 			driver, err := Handler.GetDeviceDriver(pciBasePath, info.Name())
 			if err != nil || driver != "vfio-pci" {
@@ -405,7 +405,7 @@ func discoverPermittedHostPCIDevices(supportedPCIDeviceMap map[string]string) ma
 			pcidev.iommuGroup = iommuGroup
 			pcidev.driver = driver
 			pcidev.numaNode = Handler.GetDeviceNumaNode(pciBasePath, info.Name())
-			pciDevicesMap[pciID] = append(pciDevicesMap[pciID], pcidev)
+			pciDevicesMap[resourceName] = append(pciDevicesMap[resourceName], pcidev)
 		}
 		return nil
 	})

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -71,8 +71,7 @@ type PCIDevicePlugin struct {
 }
 
 func NewPCIDevicePlugin(pciDevices []*PCIDevice, resourceName string) *PCIDevicePlugin {
-	deviceIDStr := strings.Replace(pciDevices[0].pciID, ":", "-", -1)
-	serverSock := SocketPath(deviceIDStr)
+	serverSock := SocketPath(strings.Replace(resourceName, "/", "-", -1))
 	iommuToPCIMap := make(map[string]string)
 
 	initHandler()

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -89,12 +89,12 @@ pciHostDevices:
 		// It's assumed here that it will find a PCI device at 0000:00:00.0
 		devices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
 		Expect(len(devices)).To(Equal(1))
-		Expect(len(devices[fakeID])).To(Equal(1))
-		Expect(devices[fakeID][0].pciID).To(Equal(fakeID))
-		Expect(devices[fakeID][0].driver).To(Equal(fakeDriver))
-		Expect(devices[fakeID][0].pciAddress).To(Equal(fakeAddress))
-		Expect(devices[fakeID][0].iommuGroup).To(Equal(fakeIommuGroup))
-		Expect(devices[fakeID][0].numaNode).To(Equal(fakeNumaNode))
+		Expect(len(devices[fakeName])).To(Equal(1))
+		Expect(devices[fakeName][0].pciID).To(Equal(fakeID))
+		Expect(devices[fakeName][0].driver).To(Equal(fakeDriver))
+		Expect(devices[fakeName][0].pciAddress).To(Equal(fakeAddress))
+		Expect(devices[fakeName][0].iommuGroup).To(Equal(fakeIommuGroup))
+		Expect(devices[fakeName][0].numaNode).To(Equal(fakeNumaNode))
 	})
 
 	It("Should validate DPI devices", func() {
@@ -109,7 +109,7 @@ pciHostDevices:
 		// discoverPermittedHostPCIDevices() will walk real PCI devices wherever the tests are running
 		// It's assumed here that it will find a PCI device at 0000:00:00.0
 		pciDevices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
-		devs := constructDPIdevices(pciDevices[fakeID], iommuToPCIMap)
+		devs := constructDPIdevices(pciDevices[fakeName], iommuToPCIMap)
 		Expect(devs[0].ID).To(Equal(fakeIommuGroup))
 		Expect(devs[0].Topology.Nodes[0].ID).To(Equal(int64(fakeNumaNode)))
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix the initialization of the PCI device list for the device plugin with the same resource name.
The current code has a bug that doesn't correct initialize the PCI devices with different vendor/product id before the device plugin is started ([here](https://github.com/kubevirt/kubevirt/blob/314b515473a3720dce35f5477c6dbfdc7d544e5c/pkg/virt-handler/device-manager/device_controller.go#L151-L160)). The variable `isRunning` is always false as we haven't started the device plugin yet and if we have multiple devices with the same resource name we are overwriting the previous value and pass a single device. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/7012

**Special notes for your reviewer**:
This PR requires https://github.com/kubevirt/kubevirtci/pull/734
The second commit changes the socket name. Previously, we were using the vendor and product id of the first device. With this PR we change it and use the resource name

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
