### PR TITLE
docs: Fix a broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Please have a look at our [membership guidelines](https://github.com/kubevirt/co
   * [Documentation - The Go Programming Language](https://golang.org/doc/)
   * [Getting Started - The Go Programming Language](https://golang.org/doc/install)
 * Patterns
-  * [Introducing Operators: Putting Operational Knowledge into Software](https://coreos.com/blog/introducing-operators.html)
+  * [Introducing Operators: Putting Operational Knowledge into Software](https://web.archive.org/web/20210210032403/https://coreos.com/blog/introducing-operators.html)
   * [Microservices](https://martinfowler.com/articles/microservices.html) nice
     content by Martin Fowler
 * Testing


### PR DESCRIPTION
Signed-off-by: Mor Cohen <mocohen@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is a broken link in `CONTRIBUTING.md` file under `Additional Topics` section:
[Introducing Operators: Putting Operational Knowledge into Software](https://coreos.com/blog/introducing-operators.html) which redirects to https://cloud.redhat.com/blog and not to the article.
I found a snapshot of the article on archive.org so I updated the link. 
 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
