### PR TITLE
tests, utils: coalesce datavolume creation functions

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2021,10 +2021,6 @@ func NewRandomDataVolumeWithRegistryImport(imageUrl, namespace string, accessMod
 	return NewRandomDataVolumeWithRegistryImportInStorageClass(imageUrl, namespace, sc, accessMode, k8sv1.PersistentVolumeFilesystem)
 }
 
-func NewRandomBlankDataVolume(namespace, storageClass, size string, accessMode k8sv1.PersistentVolumeAccessMode, volumeMode k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
-	return newRandomBlankDataVolume(namespace, storageClass, size, accessMode, volumeMode)
-}
-
 func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, accessMode k8sv1.PersistentVolumeAccessMode, volMode k8sv1.PersistentVolumeMode) (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
@@ -2112,7 +2108,7 @@ func NewRandomDataVolumeWithRegistryImportInStorageClass(imageUrl, namespace, st
 	return newDataVolume(namespace, storageClass, size, accessMode, volumeMode, dataVolumeSource)
 }
 
-func newRandomBlankDataVolume(namespace, storageClass, size string, accessMode k8sv1.PersistentVolumeAccessMode, volumeMode k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
+func NewRandomBlankDataVolume(namespace, storageClass, size string, accessMode k8sv1.PersistentVolumeAccessMode, volumeMode k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
 	dataVolumeSource := cdiv1.DataVolumeSource{
 		Blank: &cdiv1.DataVolumeBlankImage{},
 	}


### PR DESCRIPTION
Move DataVolume creation into a single auxiliary function. This makes it clearer to the reader to tell the difference between `NewRandomDataVolumeWithRegistryImportInStorageClass` and `NewRandomBlankDataVolume` (the difference is only the dv source).

This PR drops a needlessly-public constant `TestDataVolumeName` as it becomes an internal implementation detail of a single helper function.

```release-note
NONE
```
