### PR TITLE
virt-launcher, hostdevice: Pass only hostdevices to the filter

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug.go
@@ -69,15 +69,15 @@ func SafelyDetachHostDevices(hostDevices []api.HostDevice, eventDetach EventRegi
 	return waitHostDevicesToDetach(eventDetach, hostDevices, timeout)
 }
 
-func FilterHostDevicesByAlias(domainSpec *api.DomainSpec, prefix string) []api.HostDevice {
-	var hostDevices []api.HostDevice
+func FilterHostDevicesByAlias(hostDevices []api.HostDevice, prefix string) []api.HostDevice {
+	var filteredHostDevices []api.HostDevice
 
-	for _, hostDevice := range domainSpec.Devices.HostDevices {
+	for _, hostDevice := range hostDevices {
 		if hostDevice.Alias != nil && strings.HasPrefix(hostDevice.Alias.GetName(), prefix) {
-			hostDevices = append(hostDevices, hostDevice)
+			filteredHostDevices = append(filteredHostDevices, hostDevice)
 		}
 	}
-	return hostDevices
+	return filteredHostDevices
 }
 
 func detachHostDevices(dom DeviceDetacher, hostDevices []api.HostDevice) error {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov1")},
 				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov2")},
 			)
-			Expect(hostdevice.FilterHostDevicesByAlias(&domainSpec, aliasPrefix)).To(BeEmpty())
+			Expect(hostdevice.FilterHostDevicesByAlias(domainSpec.Devices.HostDevices, aliasPrefix)).To(BeEmpty())
 		})
 
 		It("filters 2 SRIOV devices, given 2 SRIOV devices and 2 non-SRIOV devices", func() {
@@ -58,7 +58,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 				hostDevice2,
 				api.HostDevice{Alias: api.NewUserDefinedAlias("non-sriov2")},
 			)
-			Expect(hostdevice.FilterHostDevicesByAlias(&domainSpec, aliasPrefix)).To(Equal([]api.HostDevice{hostDevice1, hostDevice2}))
+			Expect(hostdevice.FilterHostDevicesByAlias(domainSpec.Devices.HostDevices, aliasPrefix)).To(Equal([]api.HostDevice{hostDevice1, hostDevice2}))
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -70,7 +70,7 @@ func createHostDevicesMetadata(ifaces []v1.Interface) []hostdevice.HostDeviceMet
 }
 
 func SafelyDetachHostDevices(domainSpec *api.DomainSpec, eventDetach hostdevice.EventRegistrar, dom hostdevice.DeviceDetacher, timeout time.Duration) error {
-	sriovDevices := hostdevice.FilterHostDevicesByAlias(domainSpec, AliasPrefix)
+	sriovDevices := hostdevice.FilterHostDevicesByAlias(domainSpec.Devices.HostDevices, AliasPrefix)
 	return hostdevice.SafelyDetachHostDevices(sriovDevices, eventDetach, dom, timeout)
 }
 
@@ -79,7 +79,7 @@ func GetHostDevicesToAttach(vmi *v1.VirtualMachineInstance, domainSpec *api.Doma
 	if err != nil {
 		return nil, err
 	}
-	currentAttachedSRIOVHostDevices := hostdevice.FilterHostDevicesByAlias(domainSpec, AliasPrefix)
+	currentAttachedSRIOVHostDevices := hostdevice.FilterHostDevicesByAlias(domainSpec.Devices.HostDevices, AliasPrefix)
 
 	sriovHostDevicesToAttach := hostdevice.DifferenceHostDevicesByAlias(sriovDevices, currentAttachedSRIOVHostDevices)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Limit the argument passed to the filter to the hostdevices list.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
