### PR TITLE
[Bug fix] VMI with kernel boot stuck on "Terminating" status if more disks are defined

### DIFF
--- a/pkg/virt-handler/container-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/container-disk/generated_mock_mount.go
@@ -55,16 +55,6 @@ func (_mr *_MockMounterRecorder) MountAndVerify(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountAndVerify", arg0)
 }
 
-func (_m *MockMounter) MountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bool) error {
-	ret := _m.ctrl.Call(_m, "MountKernelArtifacts", vmi, verify)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockMounterRecorder) MountKernelArtifacts(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountKernelArtifacts", arg0, arg1)
-}
-
 func (_m *MockMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 	ret := _m.ctrl.Call(_m, "Unmount", vmi)
 	ret0, _ := ret[0].(error)
@@ -73,14 +63,4 @@ func (_m *MockMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 
 func (_mr *_MockMounterRecorder) Unmount(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0)
-}
-
-func (_m *MockMounter) UnmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "UnmountKernelArtifacts", vmi)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockMounterRecorder) UnmountKernelArtifacts(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountKernelArtifacts", arg0)
 }

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -149,7 +149,15 @@ func (m *mounter) getMountTargetRecord(vmi *v1.VirtualMachineInstance) (*vmiMoun
 	return nil, nil
 }
 
+func (m *mounter) addMountTargetRecord(vmi *v1.VirtualMachineInstance, record *vmiMountTargetRecord) error {
+	return m.setAddMountTargetRecordHelper(vmi, record, true)
+}
+
 func (m *mounter) setMountTargetRecord(vmi *v1.VirtualMachineInstance, record *vmiMountTargetRecord) error {
+	return m.setAddMountTargetRecordHelper(vmi, record, false)
+}
+
+func (m *mounter) setAddMountTargetRecordHelper(vmi *v1.VirtualMachineInstance, record *vmiMountTargetRecord, addPreviousRules bool) error {
 	if string(vmi.UID) == "" {
 		return fmt.Errorf("unable to set container disk mounted directories for vmi without uid")
 	}
@@ -167,6 +175,10 @@ func (m *mounter) setMountTargetRecord(vmi *v1.VirtualMachineInstance, record *v
 	if ok && fileExists && reflect.DeepEqual(existingRecord, record) {
 		// already done
 		return nil
+	}
+
+	if addPreviousRules {
+		record.MountTargetEntries = append(record.MountTargetEntries, existingRecord.MountTargetEntries...)
 	}
 
 	bytes, err := json.Marshal(record)

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -177,7 +177,7 @@ func (m *mounter) setAddMountTargetRecordHelper(vmi *v1.VirtualMachineInstance, 
 		return nil
 	}
 
-	if addPreviousRules {
+	if addPreviousRules && existingRecord != nil && len(existingRecord.MountTargetEntries) > 0 {
 		record.MountTargetEntries = append(record.MountTargetEntries, existingRecord.MountTargetEntries...)
 	}
 
@@ -389,7 +389,8 @@ func (m *mounter) ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitial
 	return true, nil
 }
 
-// Mount artifacts defined by KernelBootName in VMI
+// MountKernelArtifacts mounts artifacts defined by KernelBootName in VMI.
+// This function is assumed to run after MountAndVerify.
 func (m *mounter) MountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bool) error {
 	const kernelBootName = containerdisk.KernelBootName
 
@@ -420,7 +421,7 @@ func (m *mounter) MountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 		}},
 	}
 
-	err = m.setMountTargetRecord(vmi, &record)
+	err = m.addMountTargetRecord(vmi, &record)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -543,7 +543,7 @@ func (m *mounter) UnmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
 			log.Log.Object(vmi).Reason(err).Error("unable to unmount kernel artifacts")
 		}
 
-		err = os.Remove(targetDir)
+		err = os.RemoveAll(targetDir)
 		if err != nil {
 			log.DefaultLogger().Object(vmi).Infof("cannot delete dir %s. err: %v", targetDir, err)
 		}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1810,9 +1810,6 @@ func (d *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstan
 	d.migrationProxy.StopSourceListener(vmiId)
 
 	// Unmount container disks and clean up remaining files
-	if err := d.containerDiskMounter.UnmountKernelArtifacts(vmi); err != nil {
-		return err
-	}
 	if err := d.containerDiskMounter.Unmount(vmi); err != nil {
 		return err
 	}
@@ -2393,10 +2390,6 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 		return err
 	}
 
-	if err := d.containerDiskMounter.MountKernelArtifacts(vmi, false); err != nil {
-		return fmt.Errorf("failed to mount kernel artifacts: %v", err)
-	}
-
 	// Mount hotplug disks
 	if attachmentPodUID := vmi.Status.MigrationState.TargetAttachmentPodUID; attachmentPodUID != types.UID("") {
 		if err := d.hotplugVolumeMounter.MountFromPod(vmi, attachmentPodUID); err != nil {
@@ -2483,10 +2476,6 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		disksInfo, err = d.containerDiskMounter.MountAndVerify(vmi)
 		if err != nil {
 			return err
-		}
-
-		if err := d.containerDiskMounter.MountKernelArtifacts(vmi, true); err != nil {
-			return fmt.Errorf("failed to mount kernel artifacts: %v", err)
 		}
 
 		// Try to mount hotplug volume if there is any during startup.

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -20,8 +20,19 @@
 package tests_test
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	"kubevirt.io/kubevirt/tests/util"
 
@@ -33,9 +44,9 @@ import (
 var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 
 	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
-		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
 		tests.BeforeTestCleanup()
@@ -47,6 +58,46 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(obj)
+		})
+
+		It("ensure successful boot and deletion when VMI has a disk defined", func() {
+			By("Creating VMI with disk and kernel boot")
+			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+			utils.AddKernelBootToVMI(vmi)
+
+			Expect(vmi.Spec.Volumes).ToNot(BeEmpty())
+			Expect(vmi.Spec.Domain.Devices.Disks).ToNot(BeEmpty())
+
+			By("Ensuring VMI can boot")
+			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Fetching virt-launcher pod")
+			virtLauncherPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+
+			By("Ensuring VMI is deleted")
+			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &v1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() (isVmiDeleted bool) {
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &v1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return true
+				}
+				Expect(err).ToNot(HaveOccurred())
+				return false
+			}, 60*time.Second, 3*time.Second).Should(BeTrue(), "VMI Should be successfully deleted")
+
+			By("Ensuring virt-launcher is deleted")
+			Eventually(func() (isVmiDeleted bool) {
+				_, err = virtClient.CoreV1().Pods(virtLauncherPod.Namespace).Get(context.Background(), virtLauncherPod.Name, v1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return true
+				}
+				Expect(err).ToNot(HaveOccurred())
+				return false
+			}, 60*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("virt-launcher pod (%s) Should be successfully deleted", virtLauncherPod.Name))
 		})
 	})
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -620,16 +620,19 @@ func GetVMIWindows() *v1.VirtualMachineInstance {
 
 func GetVMIKernelBoot() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiKernelBoot)
+	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
+	AddKernelBootToVMI(vmi)
+	return vmi
+}
+
+func AddKernelBootToVMI(vmi *v1.VirtualMachineInstance) {
 	image := fmt.Sprintf(strFmt, DockerPrefix, imageKernelBoot, DockerTag)
-	KernelArgs := "console=ttyS0"
-	kernelPath := "/boot/vmlinuz-virt"
-	initrdPath := "/boot/initramfs-virt"
+	const KernelArgs = "console=ttyS0"
+	const kernelPath = "/boot/vmlinuz-virt"
+	const initrdPath = "/boot/initramfs-virt"
 
 	addKernelBootContainer(&vmi.Spec, image, KernelArgs, kernelPath, initrdPath)
-
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
-	return vmi
 }
 
 func getBaseVM(name string, labels map[string]string) *v1.VirtualMachine {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when trying to delete a VMI that is defined with disks + external kernel boot, the VM/VMI is deleted but the virt-launcher pod is stuck on "Terminating" status.

This bug is caused since `MountKernelArtifacts()` function uses `setMountTargetRecord()` which overrides the previous mount records. Therefore these mounts aren't being unmounted causing the Pod to stuck. This PR adds a `addMountTargetRecord()` function which appends records to the existing ones, which is used now when mounting kernel artifacts.

In addition, for better robustness, now the functions to mount/unmount kernel artifacts are unexported ("private") and are used only by the main mount/unmount functions.

A new functional test is introduced to make sure this bug does not repeat itself.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2039976

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bug fix] VMI with kernel boot stuck on "Terminating" status if more disks are defined
```
