### PR TITLE
[release-0.41] Manual backport of 'tests: fix skipping of HostDisk tests'

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -657,15 +657,18 @@ var _ = SIGDescribe("Storage", func() {
 
 		Context("[rfe_id:2298][crit:medium][vendor:cnv-qe@redhat.com][level:component] With HostDisk and PVC initialization", func() {
 
+			BeforeEach(func() {
+				if !tests.HasFeature(virtconfig.HostDiskGate) {
+					Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
+				}
+			})
+
 			Context("With a HostDisk defined", func() {
 
 				var hostDiskDir string
 				var nodeName string
 
 				BeforeEach(func() {
-					if !tests.HasFeature(virtconfig.HostDiskGate) {
-						Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
-					}
 					hostDiskDir = tests.RandTmpDir()
 					nodeName = ""
 				})


### PR DESCRIPTION
Extend the scope of the check for the HostDisk feature gate to more
tests.

Signed-off-by: Denis Ollier <dollierp@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
