### PR TITLE
sig/network OWNERS file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -64,3 +64,5 @@ aliases:
       - phoracek
       - qinqon
       - rhrazdil
+  network-approvers:
+      - AlonaKaplan

--- a/pkg/network/OWNERS
+++ b/pkg/network/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - network-reviewers
+approvers:
+  - network-approvers
+labels:
+  - sig/network

--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -1,2 +1,4 @@
 reviewers:
   - network-reviewers
+labels:
+  - sig/network

--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -1,4 +1,6 @@
 reviewers:
   - network-reviewers
+approvers:
+  - network-approvers
 labels:
   - sig/network


### PR DESCRIPTION
**What this PR does / why we need it**:

Update existing OWNERS file for the sig/network and add one for the pkg/network folder.

They now allow auto-labeling with `sig/network` and explicitly specify the sig/network maintainer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```