### PR TITLE
network, setup: tiny cleanup

### DIFF
--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -74,9 +74,8 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain) ([]podNIC, erro
 	return nics, nil
 }
 
-func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(pid int) error {
-	launcherPID := &pid
-	nics, err := n.getPhase1NICs(launcherPID)
+func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int) error {
+	nics, err := n.getPhase1NICs(&launcherPID)
 	if err != nil {
 		return err
 	}

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -49,13 +49,9 @@ func NewVMNetworkConfigurator(vmi *v1.VirtualMachineInstance, cacheFactory cache
 }
 
 func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int) ([]podNIC, error) {
-	nics := []podNIC{}
+	var nics []podNIC
 
-	if len(v.vmi.Spec.Domain.Devices.Interfaces) == 0 {
-		return nics, nil
-	}
-
-	for i, _ := range v.vmi.Spec.Networks {
+	for i := range v.vmi.Spec.Networks {
 		nic, err := newPhase1PodNIC(v.vmi, &v.vmi.Spec.Networks[i], v.handler, v.cacheFactory, launcherPID)
 		if err != nil {
 			return nil, err
@@ -63,17 +59,12 @@ func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int) ([]podNIC, error)
 		nics = append(nics, *nic)
 	}
 	return nics, nil
-
 }
 
 func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain) ([]podNIC, error) {
-	nics := []podNIC{}
+	var nics []podNIC
 
-	if len(v.vmi.Spec.Domain.Devices.Interfaces) == 0 {
-		return nics, nil
-	}
-
-	for i, _ := range v.vmi.Spec.Networks {
+	for i := range v.vmi.Spec.Networks {
 		nic, err := newPhase2PodNIC(v.vmi, &v.vmi.Spec.Networks[i], v.handler, v.cacheFactory, domain)
 		if err != nil {
 			return nil, err
@@ -81,7 +72,6 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain) ([]podNIC, erro
 		nics = append(nics, *nic)
 	}
 	return nics, nil
-
 }
 
 func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(pid int) error {

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -13,21 +13,17 @@ func TestNetwork(t *testing.T) {
 	testutils.KubeVirtTestSuiteSetup(t)
 }
 
-func newVMI(namespace, name string) *v1.VirtualMachineInstance {
+func newVMIBridgeInterface(namespace string, name string) *v1.VirtualMachineInstance {
 	vmi := api2.NewMinimalVMIWithNS(namespace, name)
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	return vmi
-}
-
-func newVMIBridgeInterface(namespace string, name string) *v1.VirtualMachineInstance {
-	vmi := newVMI(namespace, name)
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
 }
 
 func newVMIMasqueradeInterface(namespace, name, masqueradeCidr, masqueradeIpv6Cidr string) *v1.VirtualMachineInstance {
-	vmi := newVMI(namespace, name)
+	vmi := api2.NewMinimalVMIWithNS(namespace, name)
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}}
 	network := vmi.Spec.Networks[0]
 	network.Pod.VMNetworkCIDR = masqueradeCidr

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+	api2 "kubevirt.io/client-go/api"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/infraconfigurators"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -99,7 +100,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				}}))
 			})
 			It("should accept empty network list", func() {
-				vmi := newVMI("testnamespace", "testVmName")
+				vmi := api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, interfaceCacheFactory)
 				launcherPID := 0
 				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -33,6 +33,7 @@ import (
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/network/errors"
 	"kubevirt.io/kubevirt/pkg/network/infraconfigurators"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -97,7 +98,7 @@ func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, handler netd
 		return nil, fmt.Errorf("Network not implemented")
 	}
 
-	correspondingNetworkIface := findInterfaceByNetworkName(vmi, network)
+	correspondingNetworkIface := vmispec.LookupInterfaceByNetwork(vmi.Spec.Domain.Devices.Interfaces, network)
 	if correspondingNetworkIface == nil {
 		return nil, fmt.Errorf("no iface matching with network %s", network.Name)
 	}
@@ -370,15 +371,6 @@ func composePodInterfaceName(vmi *v1.VirtualMachineInstance, network *v1.Network
 		return fmt.Sprintf("net%d", multusIndex), nil
 	}
 	return primaryPodInterfaceName, nil
-}
-
-func findInterfaceByNetworkName(vmi *v1.VirtualMachineInstance, network *v1.Network) *v1.Interface {
-	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Name == network.Name {
-			return &vmi.Spec.Domain.Devices.Interfaces[i]
-		}
-	}
-	return nil
 }
 
 func findMultusIndex(vmi *v1.VirtualMachineInstance, networkToFind *v1.Network) int {

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	v1 "kubevirt.io/api/core/v1"
+	api2 "kubevirt.io/client-go/api"
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/dhcp"
@@ -170,7 +171,8 @@ var _ = Describe("podNIC", func() {
 		)
 		BeforeEach(func() {
 
-			vmi = newVMI("testnamespace", "testVmName")
+			vmi = api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
 				Name: "default",
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -41,7 +41,7 @@ func FilterSRIOVInterfaces(ifaces []v1.Interface) []v1.Interface {
 
 func IsPodNetworkWithMasqueradeBindingInterface(networks []v1.Network, ifaces []v1.Interface) bool {
 	if podNetwork := lookupPodNetwork(networks); podNetwork != nil {
-		if podInterface := lookupInterfaceByNetwork(ifaces, podNetwork); podInterface != nil {
+		if podInterface := LookupInterfaceByNetwork(ifaces, podNetwork); podInterface != nil {
 			return podInterface.Masquerade != nil
 		}
 	}
@@ -84,7 +84,7 @@ func IndexInterfaceSpecByMac(interfaces []v1.Interface) map[string]v1.Interface 
 	return ifacesByMac
 }
 
-func lookupInterfaceByNetwork(ifaces []v1.Interface, network *v1.Network) *v1.Interface {
+func LookupInterfaceByNetwork(ifaces []v1.Interface, network *v1.Network) *v1.Interface {
 	for _, iface := range ifaces {
 		if iface.Name == network.Name {
 			iface := iface


### PR DESCRIPTION
**What this PR does / why we need it**:

Some tiny cleanup:
- Drop the redundant interface count check
- Use LookupInterfaceByNetwork at podnic
- Drop redundant variable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
