### PR TITLE
[release-0.44]Pass through docker prefix and tag for vms-generator

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -37,6 +37,8 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
+	vmsgeneratorutils "kubevirt.io/kubevirt/tools/vms-generator/utils"
+
 	_ "kubevirt.io/kubevirt/tests/network"
 	_ "kubevirt.io/kubevirt/tests/numa"
 	_ "kubevirt.io/kubevirt/tests/performance"
@@ -65,6 +67,10 @@ func TestTests(t *testing.T) {
 	if qe_reporters.Polarion.Run {
 		reporters = append(reporters, &qe_reporters.Polarion)
 	}
+
+	vmsgeneratorutils.DockerPrefix = flags.KubeVirtUtilityRepoPrefix
+	vmsgeneratorutils.DockerTag = flags.KubeVirtVersionTag
+
 	RunSpecsWithDefaultAndCustomReporters(t, "Tests Suite", reporters)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses problems when running kubevirt e2e tests while using KUBEVIRT_PROVIDER=external. In that case a registry:5000 is normally not available, so the vm-generator needs to get passed the source registry from which to pull the utility images that we use for the tests.

In oder to work for other image registries pointed at by
--utility-container-prefix and --container-tag when testing
we need to pass through that test flag to the vms-generator
which is used in the tests.

**Which issue(s) this PR fixes**(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
/cc @dhiller 