### PR TITLE
Fix hotplugs volumesnapshot was not created in vmsnapshot

### DIFF
--- a/pkg/virt-controller/watch/snapshot/source.go
+++ b/pkg/virt-controller/watch/snapshot/source.go
@@ -296,19 +296,7 @@ func (s *vmSnapshotSource) Unfreeze() error {
 }
 
 func (s *vmSnapshotSource) PersistentVolumeClaims() (map[string]string, error) {
-	vm := s.vm
-	online, err := s.Online()
-	if err != nil {
-		return map[string]string{}, err
-	}
-
-	if online {
-		vm, err = s.getVMRevision()
-		if err != nil {
-			return map[string]string{}, err
-		}
-	}
-	return getPVCsFromVolumes(vm.Spec.Template.Spec.Volumes), nil
+	return getPVCsFromVolumes(s.vm.Spec.Template.Spec.Volumes), nil
 }
 
 func (s *vmSnapshotSource) pvcNames() sets.String {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -437,7 +437,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}
 			})
 
-			doRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool) {
+			doRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, expectedRestores int) {
 				By("creating 'message with initial value")
 				Expect(libnet.WithIPv6(login)(vmi)).To(Succeed())
 
@@ -546,7 +546,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				restore = waitRestoreComplete(restore, vm)
-				Expect(restore.Status.Restores).To(HaveLen(1))
+				Expect(restore.Status.Restores).To(HaveLen(expectedRestores))
 
 				vm = tests.StartVirtualMachine(vm)
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
@@ -623,7 +623,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
 
-				doRestore("", console.LoginToCirros, false)
+				doRestore("", console.LoginToCirros, false, 1)
 				Expect(restore.Status.DeletedDataVolumes).To(HaveLen(1))
 				Expect(restore.Status.DeletedDataVolumes).To(ContainElement(originalDVName))
 
@@ -655,7 +655,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 
-				doRestore("", console.LoginToCirros, false)
+				doRestore("", console.LoginToCirros, false, 1)
 
 				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
 
@@ -712,7 +712,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 
-				doRestore("", console.LoginToCirros, false)
+				doRestore("", console.LoginToCirros, false, 1)
 
 				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
 				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), originalPVCName, metav1.GetOptions{})
@@ -780,7 +780,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 
-				doRestore("/dev/vdc", console.LoginToCirros, false)
+				doRestore("/dev/vdc", console.LoginToCirros, false, 1)
 
 				Expect(restore.Status.DeletedDataVolumes).To(HaveLen(1))
 				Expect(restore.Status.DeletedDataVolumes).To(ContainElement(dvName))
@@ -891,7 +891,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 				))
 
-				doRestore("", console.LoginToCirros, true)
+				doRestore("", console.LoginToCirros, true, 1)
 
 			})
 
@@ -944,7 +944,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
 				tests.WaitAgentConnected(virtClient, vmi)
 
-				doRestore("/dev/vdc", console.LoginToFedora, true)
+				doRestore("/dev/vdc", console.LoginToFedora, true, 1)
 
 			})
 
@@ -959,7 +959,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
 
-				doRestore("", console.LoginToFedora, true)
+				doRestore("", console.LoginToFedora, true, 1)
 				Expect(restore.Status.DeletedDataVolumes).To(HaveLen(1))
 				Expect(restore.Status.DeletedDataVolumes).To(ContainElement(originalDVName))
 
@@ -1029,7 +1029,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				By("Add temporary hotplug disk")
 				tempVolName := tests.AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, true)
 
-				doRestore("", console.LoginToFedora, true)
+				doRestore("", console.LoginToFedora, true, 2)
 
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The hotplugs were included in the vmsnapshotcontent
but volumesnapshot wasnt created for them since the
volumes list was taken from the vm revision and
not from the current vm volumes.
Added the vmsnapshot hotplugs test of snapshot
and restore a check for the volumebackup and volumesnapshot
and number of restores.

Fixed: BZ#2042908

Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
