### PR TITLE
Run replica set tests in parallel

### DIFF
--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -48,7 +48,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachineInstanceReplicaSet", func() {
+var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachineInstanceReplicaSet", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION


**What this PR does / why we need it**:

An individual test creates at max 6 cirros VMs with 128Mb each. This is
still less than a single fedora instance requests, and we allow running
fedora based tests in parallel already.

On my machine the 16 tests need roughly 100s compared to 250s+ before.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
