### PR TITLE
Reduce the cleanup time before/after each test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/cleanup:go_default_library",
+        "//tests/framework/client:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libvmi:go_default_library",

--- a/tests/framework/client/BUILD.bazel
+++ b/tests/framework/client/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["client.go"],
+    importpath = "kubevirt.io/kubevirt/tests/framework/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+    ],
+)

--- a/tests/framework/client/client.go
+++ b/tests/framework/client/client.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"k8s.io/client-go/util/flowcontrol"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+func TestClientWithHighRateLimits() (kubecli.KubevirtClient, error) {
+	config, err := kubecli.GetKubevirtClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(40, 80)
+	return kubecli.GetKubevirtClientFromRESTConfig(config)
+}

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -82,11 +82,13 @@ func CreateErrorDisk(nodeName string) (address string, device string) {
 func CreateSCSIDisk(nodeName string, opts []string) (address string, device string) {
 	args := []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/sbin/modprobe", "scsi_debug"}
 	args = append(args, opts...)
-	_, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
+	stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
+	fmt.Println(stdout)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create faulty disk")
 
 	args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/bin/lsscsi"}
-	stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
+	stdout, err = ExecuteCommandInVirtHandlerPod(nodeName, args)
+	fmt.Println(stdout)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to find out address of  SCSI disk")
 
 	// Example output


### PR DESCRIPTION
**What this PR does / why we need it**:

Use for namespace cleanup a rest client with a higher rate limit and
operator on both namespaces which need to be cleaned in parallel.

Reduce to cleanup time from 5-6 seconds to 1-2 seconds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Still wip to see if unexpected consequences arise form the increased limit.

**Release note**:

```release-note
NONE
```
