### PR TITLE
Remove leftover label applied to a node

### DIFF
--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -87,6 +89,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 		var desiredMdevTypeName string = "nvidia-222"
 		var expectedInstancesNum int = 16
 		var config v1.KubeVirtConfiguration
+		var mdevTestLabel = "mdevTestLabel1"
 
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
@@ -197,7 +200,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			config.MediatedDevicesConfiguration.NodeMediatedDeviceTypes = []v1.NodeMediatedDeviceTypesConfig{
 				{
 					NodeSelector: map[string]string{
-						"mdevTestLabel1": "true",
+						cleanup.TestLabelForNamespace(util.NamespaceTestDefault): mdevTestLabel,
 					},
 					MediatedDevicesTypes: []string{
 						"nvidia-223",
@@ -211,7 +214,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			By("Adding a mdevTestLabel1 that should trigger mdev config change")
 			// There should be only one node in this lane
 			singleNode := util.GetAllSchedulableNodes(virtClient).Items[0]
-			tests.AddLabelToNode(singleNode.Name, "mdevTestLabel1", "true")
+			tests.AddLabelToNode(singleNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), mdevTestLabel)
 
 			By("Creating a Fedora VMI")
 			vmi = tests.NewRandomFedoraVMIWithGuestAgent()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -31,10 +31,12 @@ import (
 	"sync"
 
 	"kubevirt.io/api/migrations/v1alpha1"
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
+
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch"
-	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
-	"kubevirt.io/kubevirt/tests/framework/cleanup"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	virthandler "kubevirt.io/kubevirt/pkg/virt-handler"
@@ -3105,13 +3107,13 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := cirrosVMIWithEvictionStrategy()
-					vmi.Spec.NodeSelector = map[string]string{"tests.kubevirt.io": "target"}
+					vmi.Spec.NodeSelector = map[string]string{cleanup.TestLabelForNamespace(util.NamespaceTestDefault): "target"}
 					vmis = append(vmis, vmi)
 				}
 
 				By("selecting a node as the source")
 				sourceNode := util.GetAllSchedulableNodes(virtClient).Items[0]
-				tests.AddLabelToNode(sourceNode.Name, "tests.kubevirt.io", "target")
+				tests.AddLabelToNode(sourceNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), "target")
 
 				By("starting four VMIs on that node")
 				for _, vmi := range vmis {
@@ -3126,7 +3128,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("selecting a node as the target")
 				targetNode := util.GetAllSchedulableNodes(virtClient).Items[1]
-				tests.AddLabelToNode(targetNode.Name, "tests.kubevirt.io", "target")
+				tests.AddLabelToNode(targetNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), "target")
 
 				By("tainting the source node as non-schedulabele")
 				tests.Taint(sourceNode.Name, tests.GetNodeDrainKey(), k8sv1.TaintEffectNoSchedule)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -567,7 +567,7 @@ func CleanNodes() {
 		new.Spec.Taints = taints
 
 		for k := range node.Labels {
-			if strings.HasPrefix(k, "tests.kubevirt.io") {
+			if strings.HasPrefix(k, cleanup.KubeVirtTestLabelPrefix) {
 				found = true
 				delete(new.Labels, k)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Rename the prefix label (`mdevTestLabel1`) applied to a node during test `MediatedDevices - with mediated devices configuration - Should override default mdev configuration on a specific node`.
Using the standard prefix `tests.kubevirt.io` makes the cleanup function remove it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
