### PR TITLE
tests, network: Create VMI/s using libvmi (in vmi_networking)

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -89,3 +89,16 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts = append(cirrosOpts, opts...)
 	return New(RandName(DefaultVmiName), cirrosOpts...)
 }
+
+// NewAlpine instantiates a new Alpine based VMI configuration
+func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	alpineOpts := []Option{
+		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
+		WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n", true),
+		WithResourceMemory("128Mi"),
+		WithRng(),
+		WithTerminationGracePeriod(DefaultTestGracePeriod),
+	}
+	alpineOpts = append(alpineOpts, opts...)
+	return New(RandName(DefaultVmiName), alpineOpts...)
+}

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -62,6 +62,16 @@ func InterfaceDeviceWithBridgeBinding(name string) kvirtv1.Interface {
 	}
 }
 
+// InterfaceDeviceWithSlirpBinding returns an Interface with SLIRP binding.
+func InterfaceDeviceWithSlirpBinding(name string) kvirtv1.Interface {
+	return kvirtv1.Interface{
+		Name: name,
+		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
+			Slirp: &kvirtv1.InterfaceSlirp{},
+		},
+	}
+}
+
 // InterfaceDeviceWithSRIOVBinding returns an Interface with SRIOV binding.
 func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
 	return kvirtv1.Interface{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2859,21 +2859,6 @@ func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 }
 
-func NewRandomVMIWithe1000NetworkInterface() *v1.VirtualMachineInstance {
-	// Use alpine because cirros dhcp client starts prematurely before link is ready
-	vmi := NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-	AddExplicitPodNetworkInterface(vmi)
-	vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
-	return vmi
-}
-
-func NewRandomVMIWithCustomMacAddress() *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-	AddExplicitPodNetworkInterface(vmi)
-	vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
-	return vmi
-}
-
 // Block until the specified VirtualMachineInstance reached either Failed or Running states
 func WaitForVMIStartOrFailed(obj runtime.Object, seconds int, wp WarningsPolicy) (nodeName string) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating Alpine/Cirros based VMI/s, use `libvmi` package.

Using `libvmi` provides transparency to what is created, avoiding needless helpers which hide unneeded details.
The lack of transparency when creating VMI/s causes callers to override values which such helpers add.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
*Code Cleanup*

**Release note**:
```release-note
NONE
```
