### PR TITLE
Add field to kubevirtCR to set Prometheus ServiceMonitor object's namespace

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13988,6 +13988,10 @@
       "description": "Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.",
       "type": "string"
      },
+     "serviceMonitorNamespace": {
+      "description": "The namespace the service monitor will be deployed\n When ServiceMonitorNamespace is set, then we'll install the service monitor object in that namespace\notherwise we will use the monitoring namespace.",
+      "type": "string"
+     },
      "uninstallStrategy": {
       "description": "Specifies if kubevirt can be deleted if workloads are still present. This is mainly a precaution to avoid accidental data loss",
       "type": "string"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1518,6 +1518,11 @@ spec:
                   components. Useful if KubeVirt is included as part of a product.
                   If ProductVersion is not specified, KubeVirt's version will be used.
                 type: string
+              serviceMonitorNamespace:
+                description: The namespace the service monitor will be deployed  When
+                  ServiceMonitorNamespace is set, then we'll install the service monitor
+                  object in that namespace otherwise we will use the monitoring namespace.
+                type: string
               uninstallStrategy:
                 description: Specifies if kubevirt can be deleted if workloads are
                   still present. This is mainly a precaution to avoid accidental data
@@ -4125,6 +4130,11 @@ spec:
                 description: Designate the apps.kubevirt.io/version label for KubeVirt
                   components. Useful if KubeVirt is included as part of a product.
                   If ProductVersion is not specified, KubeVirt's version will be used.
+                type: string
+              serviceMonitorNamespace:
+                description: The namespace the service monitor will be deployed  When
+                  ServiceMonitorNamespace is set, then we'll install the service monitor
+                  object in that namespace otherwise we will use the monitoring namespace.
                 type: string
               uninstallStrategy:
                 description: Specifies if kubevirt can be deleted if workloads are

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1172,8 +1172,8 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 
 	all = append(all, apiDeployment, apiDeploymentPdb, controller, controllerPdb, handler)
 
-	all = append(all, rbac.GetAllServiceMonitor(NAMESPACE, config.GetMonitorNamespaces()[0], config.GetMonitorServiceAccount())...)
-	all = append(all, components.NewServiceMonitorCR(NAMESPACE, config.GetMonitorNamespaces()[0], true))
+	all = append(all, rbac.GetAllServiceMonitor(NAMESPACE, config.GetPotentialMonitorNamespaces()[0], config.GetMonitorServiceAccountName())...)
+	all = append(all, components.NewServiceMonitorCR(NAMESPACE, config.GetPotentialMonitorNamespaces()[0], true))
 
 	// ca certificate
 	caSecret := components.NewCACertSecret(NAMESPACE)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1925,6 +1925,11 @@ var CRDsValidation map[string]string = map[string]string{
             Useful if KubeVirt is included as part of a product. If ProductVersion
             is not specified, KubeVirt's version will be used.
           type: string
+        serviceMonitorNamespace:
+          description: The namespace the service monitor will be deployed  When ServiceMonitorNamespace
+            is set, then we'll install the service monitor object in that namespace
+            otherwise we will use the monitoring namespace.
+          type: string
         uninstallStrategy:
           description: Specifies if kubevirt can be deleted if workloads are still
             present. This is mainly a precaution to avoid accidental data loss

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -433,7 +433,11 @@ func (c *KubeVirtDeploymentConfig) GetMigrationNetwork() *string {
 	}
 }
 
-func (c *KubeVirtDeploymentConfig) GetMonitorNamespaces() []string {
+/*
+if the monitoring namespace field is defiend in kubevirtCR than return it
+otherwise we return common monitoring namespaces.
+*/
+func (c *KubeVirtDeploymentConfig) GetPotentialMonitorNamespaces() []string {
 	p := c.AdditionalProperties[AdditionalPropertiesMonitorNamespace]
 	if p == "" {
 		return DefaultMonitorNamespaces
@@ -446,7 +450,7 @@ func (c *KubeVirtDeploymentConfig) GetServiceMonitorNamespace() string {
 	return svcMonitorNs
 }
 
-func (c *KubeVirtDeploymentConfig) GetMonitorServiceAccount() string {
+func (c *KubeVirtDeploymentConfig) GetMonitorServiceAccountName() string {
 	p := c.AdditionalProperties[AdditionalPropertiesMonitorServiceAccount]
 	if p == "" {
 		return DefaultMonitorAccount

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -60,6 +60,9 @@ const (
 	AdditionalPropertiesMonitorNamespace = "MonitorNamespace"
 
 	// lookup key in AdditionalProperties
+	AdditionalPropertiesServiceMonitorNamespace = "ServiceMonitorNamespace"
+
+	// lookup key in AdditionalProperties
 	AdditionalPropertiesMonitorServiceAccount = "MonitorAccount"
 
 	// lookup key in AdditionalProperties
@@ -436,6 +439,11 @@ func (c *KubeVirtDeploymentConfig) GetMonitorNamespaces() []string {
 		return DefaultMonitorNamespaces
 	}
 	return []string{p}
+}
+
+func (c *KubeVirtDeploymentConfig) GetServiceMonitorNamespace() string {
+	svcMonitorNs := c.AdditionalProperties[AdditionalPropertiesServiceMonitorNamespace]
+	return svcMonitorNs
 }
 
 func (c *KubeVirtDeploymentConfig) GetMonitorServiceAccount() string {

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -191,8 +191,8 @@ var _ = Describe("Operator Config", func() {
 			Expect(parsedConfig.GetImagePrefix()).To(Equal("somePrefix"))
 			Expect(parsedConfig.GetKubeVirtVersion()).To(Equal("devel"))
 			Expect(parsedConfig.GetImagePullPolicy()).To(Equal(k8sv1.PullIfNotPresent))
-			Expect(parsedConfig.GetMonitorNamespaces()).To(ConsistOf("non-default-monitor-namespace"))
-			Expect(parsedConfig.GetMonitorServiceAccount()).To(Equal("non-default-prometheus-k8s"))
+			Expect(parsedConfig.GetPotentialMonitorNamespaces()).To(ConsistOf("non-default-monitor-namespace"))
+			Expect(parsedConfig.GetMonitorServiceAccountName()).To(Equal("non-default-prometheus-k8s"))
 		})
 	})
 
@@ -202,8 +202,8 @@ var _ = Describe("Operator Config", func() {
 			os.Setenv(TargetDeploymentConfig, json)
 			parsedConfig, err := GetConfigFromEnv()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(parsedConfig.GetMonitorNamespaces()).To(ConsistOf("openshift-monitoring", "monitoring"))
-			Expect(parsedConfig.GetMonitorServiceAccount()).To(Equal("prometheus-k8s"))
+			Expect(parsedConfig.GetPotentialMonitorNamespaces()).To(ConsistOf("openshift-monitoring", "monitoring"))
+			Expect(parsedConfig.GetMonitorServiceAccountName()).To(Equal("prometheus-k8s"))
 		})
 	})
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1632,6 +1632,11 @@ type KubeVirtSpec struct {
 	// Defaults to openshift-monitor
 	MonitorNamespace string `json:"monitorNamespace,omitempty"`
 
+	// The namespace the service monitor will be deployed
+	//  When ServiceMonitorNamespace is set, then we'll install the service monitor object in that namespace
+	// otherwise we will use the monitoring namespace.
+	ServiceMonitorNamespace string `json:"serviceMonitorNamespace,omitempty"`
+
 	// The name of the Prometheus service account that needs read-access to KubeVirt endpoints
 	// Defaults to prometheus-k8s
 	MonitorAccount string `json:"monitorAccount,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -424,19 +424,20 @@ func (KubeVirtWorkloadUpdateStrategy) SwaggerDoc() map[string]string {
 
 func (KubeVirtSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"imageTag":               "The image tag to use for the continer images installed.\nDefaults to the same tag as the operator's container image.",
-		"imageRegistry":          "The image registry to pull the container images from\nDefaults to the same registry the operator's container image is pulled from.",
-		"imagePullPolicy":        "The ImagePullPolicy to use.",
-		"monitorNamespace":       "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
-		"monitorAccount":         "The name of the Prometheus service account that needs read-access to KubeVirt endpoints\nDefaults to prometheus-k8s",
-		"workloadUpdateStrategy": "WorkloadUpdateStrategy defines at the cluster level how to handle\nautomated workload updates",
-		"uninstallStrategy":      "Specifies if kubevirt can be deleted if workloads are still present.\nThis is mainly a precaution to avoid accidental data loss",
-		"productVersion":         "Designate the apps.kubevirt.io/version label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductVersion is not specified, KubeVirt's version will be used.",
-		"productName":            "Designate the apps.kubevirt.io/part-of label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductName is not specified, the part-of label will be omitted.",
-		"productComponent":       "Designate the apps.kubevirt.io/component label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductComponent is not specified, the component label default value is kubevirt.",
-		"configuration":          "holds kubevirt configurations.\nsame as the virt-configMap",
-		"infra":                  "selectors and tolerations that should apply to KubeVirt infrastructure components\n+optional",
-		"workloads":              "selectors and tolerations that should apply to KubeVirt workloads\n+optional",
+		"imageTag":                "The image tag to use for the continer images installed.\nDefaults to the same tag as the operator's container image.",
+		"imageRegistry":           "The image registry to pull the container images from\nDefaults to the same registry the operator's container image is pulled from.",
+		"imagePullPolicy":         "The ImagePullPolicy to use.",
+		"monitorNamespace":        "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
+		"serviceMonitorNamespace": "The namespace the service monitor will be deployed\n When ServiceMonitorNamespace is set, then we'll install the service monitor object in that namespace\notherwise we will use the monitoring namespace.",
+		"monitorAccount":          "The name of the Prometheus service account that needs read-access to KubeVirt endpoints\nDefaults to prometheus-k8s",
+		"workloadUpdateStrategy":  "WorkloadUpdateStrategy defines at the cluster level how to handle\nautomated workload updates",
+		"uninstallStrategy":       "Specifies if kubevirt can be deleted if workloads are still present.\nThis is mainly a precaution to avoid accidental data loss",
+		"productVersion":          "Designate the apps.kubevirt.io/version label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductVersion is not specified, KubeVirt's version will be used.",
+		"productName":             "Designate the apps.kubevirt.io/part-of label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductName is not specified, the part-of label will be omitted.",
+		"productComponent":        "Designate the apps.kubevirt.io/component label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductComponent is not specified, the component label default value is kubevirt.",
+		"configuration":           "holds kubevirt configurations.\nsame as the virt-configMap",
+		"infra":                   "selectors and tolerations that should apply to KubeVirt infrastructure components\n+optional",
+		"workloads":               "selectors and tolerations that should apply to KubeVirt workloads\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17417,6 +17417,13 @@ func schema_kubevirtio_api_core_v1_KubeVirtSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"serviceMonitorNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The namespace the service monitor will be deployed\n When ServiceMonitorNamespace is set, then we'll install the service monitor object in that namespace\notherwise we will use the monitoring namespace.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"monitorAccount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the Prometheus service account that needs read-access to KubeVirt endpoints Defaults to prometheus-k8s",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
I added field to kubevirtCR to set Prometheus ServiceMonitor object's namespace.
I added logic to remove the old monitoring components, fixed some bugs regarding the removal of old components.
I added unit test to verify that old objects are being deleted .
And refactored related functions names and if statement for better clarity.

I will update the user guide to consider the new field if that PR will be merged .


**What this PR does / why we need it**:
Currently we always deploy our ServiceMonitor object in Prometheus installation namespace this is not necessary.
Some projects with KubeVirt might want to deploy it in different namespace.

For instance in OpenShift-CNV Prometheus ServiceMonitor objects should be deployed in `openshift-cnv` 
namespace (kubevirt installation namespace) , it is better to move it to our namespace because  keeping
components in our namespace makes management easier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
The operator should remove unused rolebinding ,role, serviceAccount and servicemonitor objects from **Their Namespace**
, with the current logic we remove object(Not necessarily the right object) from our Namespace  and this is a bug.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add field to kubevirtCR to set Prometheus ServiceMonitor object's namespace
```
