### PR TITLE
Reorder teardown of clone test to avoid dangling VM

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -749,6 +749,11 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			})
 
 			AfterEach(func() {
+				if createdVirtualMachine != nil {
+					err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				}
+
 				if cloneRole != nil {
 					err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -756,11 +761,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				if cloneRoleBinding != nil {
 					err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				if createdVirtualMachine != nil {
-					err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
 			})


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We first strip down the SA from its permissions, and only then issue a Delete() of the VM.
This results in a dangling VM because any Update() (remove finalizer, for example) will fail
on admission hook (don't have the right permission any longer).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
