### PR TITLE
Add Framework to support common operations used by functional tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -221,6 +221,7 @@ go_test(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/framework/storage:go_default_library",
         "//tests/launchsecurity:go_default_library",

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"fmt"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -37,7 +39,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	pool "kubevirt.io/api/pool"
 	"kubevirt.io/api/snapshot/v1alpha1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -161,6 +162,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client
+	f := framework.NewDefaultFramework("access")
 
 	doSarRequest := func(group string, resource string, subresource string, namespace string, role string, verb string, expected bool) {
 		roleToUser := map[string]string{
@@ -196,14 +198,11 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	}
 
 	BeforeEach(func() {
+		var err error
 		k8sClient = tests.GetK8sCmdClient()
 		tests.SkipIfNoCmd(k8sClient)
-		virtClient, err := kubecli.GetKubevirtClient()
+		authClient, err = authClientV1.NewForConfig(f.KubevirtClient.Config())
 		Expect(err).ToNot(HaveOccurred())
-		authClient, err = authClientV1.NewForConfig(virtClient.Config())
-		Expect(err).ToNot(HaveOccurred())
-
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("With default kubevirt service accounts", func() {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,7 +35,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -43,7 +44,7 @@ import (
 
 var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", func() {
 
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("config")
 
 	var CheckIsoVolumeSizes = func(vmi *v1.VirtualMachineInstance) {
 		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -60,7 +61,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			}
 			if len(path) > 0 {
 				cmdCheck := []string{"stat", "--printf='%s'", path}
-				out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+				out, err := tests.ExecuteCommandOnPod(f.KubevirtClient, pod, "compute", cmdCheck)
 				Expect(err).NotTo(HaveOccurred())
 				size, err := strconv.Atoi(strings.Trim(out, "'"))
 				Expect(err).NotTo(HaveOccurred())
@@ -68,15 +69,6 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			}
 		}
 	}
-
-	BeforeEach(func() {
-		var err error
-
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
 
 	Context("With a ConfigMap defined", func() {
 
@@ -114,7 +106,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				By("Checking if ConfigMap has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				podOutput, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -208,7 +200,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				By("Checking if Secret has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				podOutput, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -280,7 +272,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			By("Checking if ServiceAccount has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 			namespace, err := tests.ExecuteCommandOnPod(
-				virtClient,
+				f.KubevirtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"cat",
@@ -292,7 +284,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			Expect(namespace).To(Equal(util.NamespaceTestDefault))
 
 			token, err := tests.ExecuteCommandOnPod(
-				virtClient,
+				f.KubevirtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"tail", "-c", "20",
@@ -382,7 +374,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				By("Checking if ConfigMap has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				podOutputCfgMap, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -411,7 +403,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 
 				By("Checking if Secret has also been attached to the same pod")
 				podOutputSecret, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -493,7 +485,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				By("Checking if Secret has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				podOutput1, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -504,7 +496,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutput1).To(Equal(expectedPrivateKey), "Expected pod output of private key to match genereated one.")
 
 				podOutput2, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
@@ -560,7 +552,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			By("Checking if DownwardAPI has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 			podOutput, err := tests.ExecuteCommandOnPod(
-				virtClient,
+				f.KubevirtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
 				[]string{"grep", testLabelKey,

--- a/tests/framework/framework/BUILD.bazel
+++ b/tests/framework/framework/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["framework.go"],
+    importpath = "kubevirt.io/kubevirt/tests/framework/framework",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)

--- a/tests/framework/framework/framework.go
+++ b/tests/framework/framework/framework.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file was originally copied from https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/framework.go
+
+package framework
+
+import (
+	"fmt"
+	"math/rand"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/util"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"k8s.io/client-go/rest"
+
+	. "github.com/onsi/ginkgo"
+)
+
+// Framework supports common operations used by e2e tests; it will keep a client & clean the cluster for you.
+type Framework struct {
+	BaseName string
+
+	UniqueName string
+
+	clientConfig   *rest.Config
+	KubevirtClient kubecli.KubevirtClient
+	// afterEaches is a map of name to function to be called after each test.  These are not
+	// cleared.  The call order is randomized so that no dependencies can grow between
+	// the various afterEaches
+	afterEaches map[string]AfterEachActionFunc
+}
+
+// AfterEachActionFunc is a function that can be called after each test
+type AfterEachActionFunc func(f *Framework, failed bool)
+
+// NewDefaultFramework makes a new framework and sets up a BeforeEach/AfterEach for
+// you (you can write additional before/after each functions).
+func NewDefaultFramework(baseName string) *Framework {
+	return NewFramework(baseName, nil, nil)
+}
+
+// NewFramework creates a test framework.
+func NewFramework(baseName string, client kubecli.KubevirtClient, config *rest.Config) *Framework {
+	f := &Framework{
+		BaseName:       baseName,
+		KubevirtClient: client,
+		clientConfig:   config,
+	}
+	BeforeEach(f.BeforeEach)
+	AfterEach(f.AfterEach)
+
+	return f
+}
+
+// BeforeEach gets a client and clean the cluster.
+func (f *Framework) BeforeEach() {
+	if f.KubevirtClient == nil {
+		By("Creating a kubevirt client")
+		client, err := kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+		f.KubevirtClient = client
+		config, err := kubecli.GetKubevirtClientConfig()
+		util.PanicOnError(err)
+		f.clientConfig = config
+	}
+	f.UniqueName = fmt.Sprintf("%s-%08x", f.BaseName, rand.Int31())
+	tests.BeforeTestCleanup()
+}
+
+// AddAfterEach is a way to add a function to be called after every test.  The execution order is intentionally random
+// to avoid growing dependencies.  If you register the same name twice, it is a coding error and will panic.
+func (f *Framework) AddAfterEach(name string, fn AfterEachActionFunc) {
+	if _, ok := f.afterEaches[name]; ok {
+		panic(fmt.Sprintf("%q is already registered", name))
+	}
+
+	if f.afterEaches == nil {
+		f.afterEaches = map[string]AfterEachActionFunc{}
+	}
+	f.afterEaches[name] = fn
+}
+
+// AfterEach deletes the namespace, after reading its events.
+func (f *Framework) AfterEach() {
+	// This should not happen. Given KubevirtClient is a public field a test must have updated it!
+	// Error out early before any API calls during cleanup.
+	if f.KubevirtClient == nil {
+		Fail("The framework KubevirtClient must not be nil at this point")
+	}
+
+	// run all aftereach functions in random order to ensure no dependencies grow
+	for _, afterEachFn := range f.afterEaches {
+		afterEachFn(f, CurrentGinkgoTestDescription().Failed)
+	}
+}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -35,6 +35,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -81,16 +83,13 @@ import (
 
 var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	var (
-		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset
 		err              error
 	)
+	f := framework.NewDefaultFramework("infra")
 	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
 		if aggregatorClient == nil {
-			config, err := kubecli.GetConfig()
+			config, err := kubecli.GetKubevirtClientConfig()
 			if err != nil {
 				panic(err)
 			}
@@ -100,10 +99,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("changes to the kubernetes client", func() {
-
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
 
 		scheduledToRunning := func(vmis []v1.VirtualMachineInstance) time.Duration {
 			var duration time.Duration
@@ -125,15 +120,15 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		It("on the controller rate limiter should lead to delayed VMI starts", func() {
 			By("first getting the basetime for a replicaset")
 			replicaset := tests.NewRandomReplicaSetFromVMI(libvmi.NewCirros(libvmi.WithResourceMemory("1Mi")), int32(0))
-			replicaset, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)
+			replicaset, err = f.KubevirtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)
 			Expect(err).ToNot(HaveOccurred())
 			start := time.Now()
-			libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)
+			libreplicaset.DoScaleWithScaleSubresource(f.KubevirtClient, replicaset.Name, 10)
 			fastDuration := time.Now().Sub(start)
-			libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 0)
+			libreplicaset.DoScaleWithScaleSubresource(f.KubevirtClient, replicaset.Name, 0)
 
 			By("reducing the throughput on controller")
-			originalKubeVirt := util.GetCurrentKv(virtClient)
+			originalKubeVirt := util.GetCurrentKv(f.KubevirtClient)
 			originalKubeVirt.Spec.Configuration.ControllerConfiguration = &v1.ReloadableComponentConfiguration{
 				RestClient: &v1.RESTClientConfiguration{
 					RateLimiter: &v1.RateLimiter{
@@ -147,32 +142,32 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
 			By("starting a replicaset with reduced throughput")
 			start = time.Now()
-			libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)
+			libreplicaset.DoScaleWithScaleSubresource(f.KubevirtClient, replicaset.Name, 10)
 			slowDuration := time.Now().Sub(start)
 			Expect(slowDuration.Seconds()).To(BeNumerically(">", 2*fastDuration.Seconds()))
 		})
 
 		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", func() {
 			By("first getting the basetime for a replicaset")
-			targetNode := util.GetAllSchedulableNodes(virtClient).Items[0]
+			targetNode := util.GetAllSchedulableNodes(f.KubevirtClient).Items[0]
 			vmi := libvmi.NewCirros(
 				libvmi.WithResourceMemory("1Mi"),
 				libvmi.WithNodeSelectorFor(&targetNode),
 			)
 			replicaset := tests.NewRandomReplicaSetFromVMI(vmi, 0)
-			replicaset, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)
+			replicaset, err = f.KubevirtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)
 			Expect(err).ToNot(HaveOccurred())
-			libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)
+			libreplicaset.DoScaleWithScaleSubresource(f.KubevirtClient, replicaset.Name, 10)
 			Eventually(matcher.AllVMIs(replicaset.Namespace), 90*time.Second, 1*time.Second).Should(matcher.BeInPhase(v1.Running))
 			vmis, err := matcher.AllVMIs(replicaset.Namespace)()
 			Expect(err).ToNot(HaveOccurred())
 			fastDuration := scheduledToRunning(vmis)
 
-			libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 0)
+			libreplicaset.DoScaleWithScaleSubresource(f.KubevirtClient, replicaset.Name, 0)
 			Eventually(matcher.AllVMIs(replicaset.Namespace), 90*time.Second, 1*time.Second).Should(matcher.BeGone())
 
 			By("reducing the throughput on handler")
-			originalKubeVirt := util.GetCurrentKv(virtClient)
+			originalKubeVirt := util.GetCurrentKv(f.KubevirtClient)
 			originalKubeVirt.Spec.Configuration.HandlerConfiguration = &v1.ReloadableComponentConfiguration{
 				RestClient: &v1.RESTClientConfiguration{
 					RateLimiter: &v1.RateLimiter{
@@ -186,7 +181,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
 
 			By("starting a replicaset with reduced throughput")
-			libreplicaset.DoScaleWithScaleSubresource(virtClient, replicaset.Name, 10)
+			libreplicaset.DoScaleWithScaleSubresource(f.KubevirtClient, replicaset.Name, 10)
 			Eventually(matcher.AllVMIs(replicaset.Namespace), 180*time.Second, 1*time.Second).Should(matcher.BeInPhase(v1.Running))
 			vmis, err = matcher.AllVMIs(replicaset.Namespace)()
 			Expect(err).ToNot(HaveOccurred())
@@ -206,7 +201,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			Expect(err).ToNot(HaveOccurred())
 			timestamp := getTimeFromMetrics(metrics)
 
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() int {
 				metrics, err = getDownwardMetrics(vmi)
@@ -225,7 +220,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			}
 
 			for _, name := range ourCRDs {
-				ext, err := extclient.NewForConfig(virtClient.Config())
+				ext, err := extclient.NewForConfig(f.KubevirtClient.Config())
 				Expect(err).ToNot(HaveOccurred())
 
 				crd, err := ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
@@ -242,10 +237,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
 
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		It("[test_id:4099] should be rotated when a new CA is created", func() {
 			By("checking that the config-map gets the new CA bundle attached")
 			Eventually(func() int {
@@ -255,14 +246,14 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 			By("destroying the certificate")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+				secret, err := f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				secret.Data = map[string][]byte{
 					"tls.crt": []byte(""),
 					"tls.key": []byte(""),
 				}
 
-				_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+				_, err = f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
 				return err
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -283,7 +274,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 			By("checking that the ca bundle gets propagated to the validating webhook")
 			Eventually(func() bool {
-				webhook, err := virtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), components.VirtAPIValidatingWebhookName, metav1.GetOptions{})
+				webhook, err := f.KubevirtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), components.VirtAPIValidatingWebhookName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if len(webhook.Webhooks) > 0 {
 					return tests.ContainsCrt(webhook.Webhooks[0].ClientConfig.CABundle, newCA)
@@ -292,7 +283,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			}, 10*time.Second, 1*time.Second).Should(BeTrue())
 			By("checking that the ca bundle gets propagated to the mutating webhook")
 			Eventually(func() bool {
-				webhook, err := virtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), components.VirtAPIMutatingWebhookName, metav1.GetOptions{})
+				webhook, err := f.KubevirtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), components.VirtAPIMutatingWebhookName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if len(webhook.Webhooks) > 0 {
 					return tests.ContainsCrt(webhook.Webhooks[0].ClientConfig.CABundle, newCA)
@@ -319,7 +310,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("destroying the CA certificate")
-			err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Delete(context.Background(), components.KubeVirtCASecretName, metav1.DeleteOptions{})
+			err = f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Delete(context.Background(), components.KubeVirtCASecretName, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("repeatedly starting VMIs until virt-api and virt-handler certificates are updated")
@@ -327,7 +318,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+				err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				newAPICert, _, err := tests.GetPodsCertIfSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
 				Expect(err).ToNot(HaveOccurred())
@@ -340,7 +331,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		table.DescribeTable("should be rotated when deleted for ", func(secretName string) {
 			By("destroying the certificate")
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
+				secret, err := f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -348,7 +339,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					"tls.crt": []byte(""),
 					"tls.key": []byte(""),
 				}
-				_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+				_, err = f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
 
 				return err
 			})
@@ -370,7 +361,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	// start a VMI, wait for it to run and return the node it runs on
 	startVMI := func(vmi *v1.VirtualMachineInstance) string {
 		By("Starting a new VirtualMachineInstance")
-		obj, err := virtClient.
+		obj, err := f.KubevirtClient.
 			RestClient().
 			Post().
 			Resource("virtualmachineinstances").
@@ -397,7 +388,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				if selectedNodeName != "" {
 					By("removing the taint from the tainted node")
 					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
+						selectedNode, err := f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
 						if err != nil {
 							return err
 						}
@@ -413,7 +404,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 						nodeCopy.ResourceVersion = ""
 						nodeCopy.Spec.Taints = taints
 
-						_, err = virtClient.CoreV1().Nodes().Update(context.Background(), nodeCopy, metav1.UpdateOptions{})
+						_, err = f.KubevirtClient.CoreV1().Nodes().Update(context.Background(), nodeCopy, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ShouldNot(HaveOccurred())
@@ -423,12 +414,12 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			It("[test_id:4134] kubevirt components on that node should not evict", func() {
 
 				By("finding all kubevirt pods")
-				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+				pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
 				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
 
 				By("finding all schedulable nodes")
-				schedulableNodesList := util.GetAllSchedulableNodes(virtClient)
+				schedulableNodesList := util.GetAllSchedulableNodes(f.KubevirtClient)
 				schedulableNodes := map[string]*k8sv1.Node{}
 				for _, node := range schedulableNodesList.Items {
 					schedulableNodes[node.Name] = node.DeepCopy()
@@ -458,7 +449,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 
 				By("setting up a watch for terminated pods")
-				lw, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Watch(context.Background(), metav1.ListOptions{})
+				lw, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Watch(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				// in the test env, we also deploy non core-kubevirt apps
 				kvCoreApps := map[string]string{
@@ -493,7 +484,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 				By("tainting the selected node")
 				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
+					selectedNode, err := f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -505,7 +496,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 						Effect: k8sv1.TaintEffectNoExecute,
 					})
 
-					_, err = virtClient.CoreV1().Nodes().Update(context.Background(), selectedNodeCopy, metav1.UpdateOptions{})
+					_, err = f.KubevirtClient.CoreV1().Nodes().Update(context.Background(), selectedNodeCopy, metav1.UpdateOptions{})
 					return err
 				})
 				Expect(err).ShouldNot(HaveOccurred())
@@ -525,7 +516,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		*/
 
 		tests.BeforeAll(func() {
-			onOCP, err := clusterutil.IsOnOpenShift(virtClient)
+			onOCP, err := clusterutil.IsOnOpenShift(f.KubevirtClient)
 			Expect(err).ToNot(HaveOccurred(), "failed to detect cluster type")
 
 			if !onOCP {
@@ -548,7 +539,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			startVMI(vmi)
 
 			By("finding virt-operator pod")
-			ops, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
+			ops, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
 			Expect(err).ToNot(HaveOccurred(), "failed to list virt-operators")
 			Expect(ops.Size).ToNot(Equal(0), "no virt-operators found")
 			op := ops.Items[0]
@@ -557,7 +548,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			var ep *k8sv1.Endpoints
 			By("finding Prometheus endpoint")
 			Eventually(func() bool {
-				ep, err = virtClient.CoreV1().Endpoints("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
+				ep, err = f.KubevirtClient.CoreV1().Endpoints("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "failed to retrieve Prometheus endpoint")
 
 				if len(ep.Subsets) == 0 || len(ep.Subsets[0].Addresses) == 0 {
@@ -578,7 +569,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 			// We need a token from a service account that can view all namespaces in the cluster
 			By("extracting virt-operator sa token")
-			token, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+			token, _, err := tests.ExecuteCommandOnPodV2(f.KubevirtClient,
 				&op,
 				"virt-operator",
 				[]string{
@@ -589,7 +580,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			Expect(token).ToNot(BeEmpty(), "virt-operator sa token returned empty")
 
 			By("querying Prometheus API endpoint for a VMI exported metric")
-			stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+			stdout, _, err := tests.ExecuteCommandOnPodV2(f.KubevirtClient,
 				&op,
 				"virt-operator",
 				[]string{
@@ -643,7 +634,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		// returns metrics from the node the VMI(s) runs on
 		getKubevirtVMMetrics := func(ip string) string {
 			metricsURL := prepareMetricsURL(ip, 8443)
-			stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+			stdout, _, err := tests.ExecuteCommandOnPodV2(f.KubevirtClient,
 				pod,
 				"virt-handler",
 				[]string{
@@ -715,11 +706,10 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		}
 
 		tests.BeforeAll(func() {
-			tests.BeforeTestCleanup()
 
 			By("Finding the virt-controller prometheus endpoint")
-			virtControllerLeaderPodName := getLeader()
-			leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), virtControllerLeaderPodName, metav1.GetOptions{})
+			virtControllerLeaderPodName := getLeader(f.KubevirtClient)
+			leaderPod, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), virtControllerLeaderPodName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Should find the virt-controller pod")
 
 			for _, ip := range leaderPod.Status.PodIPs {
@@ -737,7 +727,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			prepareVMIForTests(nodeName)
 
 			By("Finding the virt-handler prometheus endpoint")
-			pod, err = kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
+			pod, err = kubecli.NewVirtHandlerClient(f.KubevirtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
 			Expect(err).ToNot(HaveOccurred(), "Should find the virt-handler pod")
 			for _, ip := range pod.Status.PodIPs {
 				handlerMetricIPs = append(handlerMetricIPs, ip.IP)
@@ -745,7 +735,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 
 		PIt("[test_id:4136][flaky] should find one leading virt-controller and two ready", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+			endpoint, err := f.KubevirtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			foundMetrics := map[string]int{
 				"ready":   0,
@@ -757,7 +747,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					continue
 				}
 				stdout, _, err := tests.ExecuteCommandOnPodV2(
-					virtClient,
+					f.KubevirtClient,
 					pod,
 					"virt-handler",
 					[]string{
@@ -784,7 +774,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 
 		It("[test_id:4137]should find one leading virt-operator and two ready", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+			endpoint, err := f.KubevirtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			foundMetrics := map[string]int{
 				"ready":   0,
@@ -796,7 +786,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					continue
 				}
 				stdout, _, err := tests.ExecuteCommandOnPodV2(
-					virtClient,
+					f.KubevirtClient,
 					pod,
 					"virt-handler",
 					[]string{
@@ -823,11 +813,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 
 		It("[test_id:4138]should be exposed and registered on the metrics endpoint", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+			endpoint, err := f.KubevirtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			l, err := labels.Parse("prometheus.kubevirt.io=true")
 			Expect(err).ToNot(HaveOccurred())
-			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
+			pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(endpoint.Subsets).To(HaveLen(1))
 
@@ -849,10 +839,10 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			}
 		})
 		It("[test_id:4139]should return Prometheus metrics", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+			endpoint, err := f.KubevirtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			for _, ep := range endpoint.Subsets[0].Addresses {
-				stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+				stdout, _, err := tests.ExecuteCommandOnPodV2(f.KubevirtClient,
 					pod,
 					"virt-handler",
 					[]string{
@@ -868,7 +858,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should throttle the Prometheus metrics access", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -916,7 +906,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -934,7 +924,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -974,7 +964,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -1002,7 +992,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -1041,7 +1031,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -1062,7 +1052,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(controllerMetricIPs, family)
@@ -1082,7 +1072,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		table.DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -1107,7 +1097,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
 		table.DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
 			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
+				libnet.SkipWhenNotDualStackCluster(f.KubevirtClient)
 			}
 
 			ip := getSupportedIP(handlerMetricIPs, family)
@@ -1135,33 +1125,30 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("Start a VirtualMachineInstance", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
 
 		Context("when the controller pod is not running and an election happens", func() {
 			It("[test_id:4642]should succeed afterwards", func() {
-				newLeaderPod := getNewLeaderPod(virtClient)
+				newLeaderPod := getNewLeaderPod(f.KubevirtClient)
 				Expect(newLeaderPod).NotTo(BeNil())
 
 				// TODO: It can be race condition when newly deployed pod receive leadership, in this case we will need
 				// to reduce Deployment replica before destroying the pod and to restore it after the test
 				By("Destroying the leading controller pod")
 				Eventually(func() string {
-					leaderPodName := getLeader()
+					leaderPodName := getLeader(f.KubevirtClient)
 
-					Expect(virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), leaderPodName, metav1.DeleteOptions{})).To(BeNil())
+					Expect(f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Delete(context.Background(), leaderPodName, metav1.DeleteOptions{})).To(BeNil())
 
 					Eventually(getLeader, 30*time.Second, 5*time.Second).ShouldNot(Equal(leaderPodName))
 
-					leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), getLeader(), metav1.GetOptions{})
+					leaderPod, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), getLeader(f.KubevirtClient), metav1.GetOptions{})
 					Expect(err).To(BeNil())
 
 					return leaderPod.Name
 				}, 90*time.Second, 5*time.Second).Should(Equal(newLeaderPod.Name))
 
 				Expect(func() k8sv1.ConditionStatus {
-					leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), newLeaderPod.Name, metav1.GetOptions{})
+					leaderPod, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), newLeaderPod.Name, metav1.GetOptions{})
 					Expect(err).To(BeNil())
 
 					for _, condition := range leaderPod.Status.Conditions {
@@ -1175,7 +1162,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				vmi := tests.NewRandomVMI()
 
 				By("Starting a new VirtualMachineInstance")
-				obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
+				obj, err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
 				Expect(err).To(BeNil())
 				tests.WaitForSuccessfulVMIStart(obj)
 			}, 150)
@@ -1193,7 +1180,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		}
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			nodesWithKVM = tests.GetNodesWithKVM()
 			if len(nodesWithKVM) == 0 {
 				Skip("Skip testing with node-labeller, because there are no nodes with kvm")
@@ -1224,7 +1210,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				payloadBytes, err := json.Marshal(p)
 				Expect(err).ToNot(HaveOccurred())
 
-				_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+				_, err = f.KubevirtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
@@ -1253,7 +1239,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					payloadBytes, err := json.Marshal(p)
 					Expect(err).ToNot(HaveOccurred())
 
-					_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+					_, err = f.KubevirtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
 				kvConfig := v1.KubeVirtConfiguration{ObsoleteCPUModels: map[string]bool{}}
@@ -1350,7 +1336,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			var originalKubeVirt *v1.KubeVirt
 
 			BeforeEach(func() {
-				originalKubeVirt = util.GetCurrentKv(virtClient)
+				originalKubeVirt = util.GetCurrentKv(f.KubevirtClient)
 			})
 
 			AfterEach(func() {
@@ -1374,7 +1360,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+				node, err = f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				found := false
 				for key := range node.Labels {
@@ -1388,7 +1374,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			})
 
 			It("[test_id:6250] should update node with new cpu model vendor label", func() {
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				nodes, err := f.KubevirtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, node := range nodes.Items {
 					for key := range node.Labels {
@@ -1411,7 +1397,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				kvConfig.MinCPUModel = minCPU
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+				node, err = f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(numberOfLabelsBeforeUpdate).ToNot(Equal(len(node.Labels)), "Node should have different number of labels")
@@ -1432,7 +1418,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				kvConfig.ObsoleteCPUModels = obsoleteModels
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+				node, err = f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				found := false
 				label := ""
@@ -1453,13 +1439,12 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			var originalKubeVirt *v1.KubeVirt
 
 			BeforeEach(func() {
-				tests.BeforeTestCleanup()
-				originalKubeVirt = util.GetCurrentKv(virtClient)
+				originalKubeVirt = util.GetCurrentKv(f.KubevirtClient)
 
 			})
 
 			AfterEach(func() {
-				originalNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+				originalNode, err := f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				node := originalNode.DeepCopy()
@@ -1480,12 +1465,12 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 				data := []byte(fmt.Sprintf("[ %s, %s ]", patchTestLabels, patchLabels))
 
-				_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodesWithKVM[0].Name, types.JSONPatchType, data, metav1.PatchOptions{})
+				_, err = f.KubevirtClient.CoreV1().Nodes().Patch(context.Background(), nodesWithKVM[0].Name, types.JSONPatchType, data, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("[test_id:6253] should remove old labeller labels and annotations", func() {
-				originalNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+				originalNode, err := f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				node := originalNode.DeepCopy()
@@ -1517,14 +1502,14 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 				data := []byte(fmt.Sprintf("[ %s, %s, %s, %s ]", patchTestLabels, patchLabels, patchTestAnnotations, patchAnnotations))
 
-				_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodesWithKVM[0].Name, types.JSONPatchType, data, metav1.PatchOptions{})
+				_, err = f.KubevirtClient.CoreV1().Nodes().Patch(context.Background(), nodesWithKVM[0].Name, types.JSONPatchType, data, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
 				kvConfig.ObsoleteCPUModels = map[string]bool{"486": true}
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
 				time.Sleep(time.Second * 10)
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+				node, err = f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				foundSpecialLabel := false
@@ -1549,43 +1534,36 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("cluster profiler for pprof data aggregation", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		Context("when ClusterProfiler feature gate", func() {
 			It("is disabled it should prevent subresource access", func() {
 				tests.DisableFeatureGate("ClusterProfiler")
 
-				err := virtClient.ClusterProfiler().Start()
+				err := f.KubevirtClient.ClusterProfiler().Start()
 				Expect(err).ToNot(BeNil())
 
-				err = virtClient.ClusterProfiler().Stop()
+				err = f.KubevirtClient.ClusterProfiler().Stop()
 				Expect(err).ToNot(BeNil())
 
-				_, err = virtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
+				_, err = f.KubevirtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
 				Expect(err).ToNot(BeNil())
 			})
 			It("[QUARANTINE] is enabled it should allow subresource access", func() {
 				tests.EnableFeatureGate("ClusterProfiler")
 
-				err := virtClient.ClusterProfiler().Start()
+				err := f.KubevirtClient.ClusterProfiler().Start()
 				Expect(err).To(BeNil())
 
-				err = virtClient.ClusterProfiler().Stop()
+				err = f.KubevirtClient.ClusterProfiler().Stop()
 				Expect(err).To(BeNil())
 
-				_, err = virtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
+				_, err = f.KubevirtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
 				Expect(err).To(BeNil())
 			})
 		})
 	})
 })
 
-func getLeader() string {
-	virtClient, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
-
+func getLeader(virtClient kubecli.KubevirtClient) string {
 	controllerEndpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), leaderelectionconfig.DefaultEndpointName, metav1.GetOptions{})
 	util.PanicOnError(err)
 
@@ -1604,7 +1582,7 @@ func getNewLeaderPod(virtClient kubecli.KubevirtClient) *k8sv1.Pod {
 	controllerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(),
 		metav1.ListOptions{LabelSelector: labelSelector.String(), FieldSelector: fieldSelector.String()})
 	util.PanicOnError(err)
-	leaderPodName := getLeader()
+	leaderPodName := getLeader(virtClient)
 	for _, pod := range controllerPods.Items {
 		if pod.Name != leaderPodName {
 			return &pod

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -85,10 +85,7 @@ func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualM
 	return vmi
 }
 
-func setOrClearDedicatedMigrationNetwork(nad string, set bool) *v1.KubeVirt {
-	virtClient, err := kubecli.GetKubevirtClient()
-	Expect(err).ToNot(HaveOccurred())
-
+func setOrClearDedicatedMigrationNetwork(virtClient kubecli.KubevirtClient, nad string, set bool) *v1.KubeVirt {
 	kv := util.GetCurrentKv(virtClient)
 
 	// Saving the list of virt-handler pods prior to changing migration settings, see comment below.
@@ -137,12 +134,12 @@ func setOrClearDedicatedMigrationNetwork(nad string, set bool) *v1.KubeVirt {
 	return res
 }
 
-func SetDedicatedMigrationNetwork(nad string) *v1.KubeVirt {
-	return setOrClearDedicatedMigrationNetwork(nad, true)
+func SetDedicatedMigrationNetwork(virtClient kubecli.KubevirtClient, nad string) *v1.KubeVirt {
+	return setOrClearDedicatedMigrationNetwork(virtClient, nad, true)
 }
 
-func ClearDedicatedMigrationNetwork() *v1.KubeVirt {
-	return setOrClearDedicatedMigrationNetwork("", false)
+func ClearDedicatedMigrationNetwork(virtClient kubecli.KubevirtClient) *v1.KubeVirt {
+	return setOrClearDedicatedMigrationNetwork(virtClient, "", false)
 }
 
 func GenerateMigrationCNINetworkAttachmentDefinition() *k8snetworkplumbingwgv1.NetworkAttachmentDefinition {

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/flags:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/prometheus/client_golang/api/prometheus/v1:go_default_library",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnet/service:go_default_library",
         "//tests/libvmi:go_default_library",

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -4,19 +4,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 var _ = SIGDescribe("Dual stack cluster network configuration", func() {
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
-	})
+	f := framework.NewDefaultFramework("network/dual stack cluster")
 
 	Context("when dual stack cluster configuration is enabled", func() {
 		Specify("the cluster must be dual stack", func() {
@@ -24,7 +19,7 @@ var _ = SIGDescribe("Dual stack cluster network configuration", func() {
 				Skip("user requested the dual stack check on the live cluster to be skipped")
 			}
 
-			isClusterDualStack, err := libnet.IsClusterDualStack(virtClient)
+			isClusterDualStack, err := libnet.IsClusterDualStack(f.KubevirtClient)
 			Expect(err).NotTo(HaveOccurred(), "must be able to infer the dual stack configuration from the live cluster")
 			Expect(isClusterDualStack).To(BeTrue(), "the live cluster should be in dual stack mode")
 		})

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -27,18 +29,10 @@ import (
 )
 
 var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
-	var (
-		virtClient      kubecli.KubevirtClient
-		serverVMILabels map[string]string
-	)
+	var serverVMILabels map[string]string
+	f := framework.NewDefaultFramework("network/networkpolicy")
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred(), "should succeed retrieving the kubevirt client")
-
-		tests.SkipIfUseFlannel(virtClient)
+		tests.SkipIfUseFlannel(f.KubevirtClient)
 		skipNetworkPolicyRunningOnKindInfra()
 
 		serverVMILabels = map[string]string{"type": "test"}
@@ -49,7 +43,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			var err error
-			serverVMI, err = createServerVmi(virtClient, util.NamespaceTestDefault, serverVMILabels)
+			serverVMI, err = createServerVmi(f.KubevirtClient, util.NamespaceTestDefault, serverVMILabels)
 			Expect(err).ToNot(HaveOccurred())
 			assertIPsNotEmptyForVMI(serverVMI)
 		})
@@ -61,7 +55,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				var err error
 				// deny-by-default networkpolicy will deny all the traffic to the vms in the namespace
 				policy = createNetworkPolicy(serverVMI.Namespace, "deny-by-default", metav1.LabelSelector{}, []networkv1.NetworkPolicyIngressRule{})
-				clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+				clientVMI, err = createClientVmi(util.NamespaceTestDefault, f.KubevirtClient)
 				Expect(err).ToNot(HaveOccurred())
 				assertIPsNotEmptyForVMI(clientVMI)
 			})
@@ -113,7 +107,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 
 				BeforeEach(func() {
 					var err error
-					clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+					clientVMI, err = createClientVmi(util.NamespaceTestDefault, f.KubevirtClient)
 					Expect(err).ToNot(HaveOccurred())
 					assertIPsNotEmptyForVMI(clientVMI)
 				})
@@ -128,7 +122,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 
 				BeforeEach(func() {
 					var err error
-					clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, virtClient)
+					clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, f.KubevirtClient)
 					Expect(err).ToNot(HaveOccurred())
 					assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 				})
@@ -169,7 +163,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 
 				BeforeEach(func() {
 					var err error
-					clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, virtClient)
+					clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, f.KubevirtClient)
 					Expect(err).ToNot(HaveOccurred())
 					assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 				})
@@ -183,7 +177,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 			When("client vmi is on default namespace", func() {
 				BeforeEach(func() {
 					var err error
-					clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+					clientVMI, err = createClientVmi(util.NamespaceTestDefault, f.KubevirtClient)
 					Expect(err).ToNot(HaveOccurred())
 					assertIPsNotEmptyForVMI(clientVMI)
 				})
@@ -198,7 +192,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 
 					BeforeEach(func() {
 						var err error
-						clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, virtClient)
+						clientVMIAlternativeNamespace, err = createClientVmi(tests.NamespaceTestAlternative, f.KubevirtClient)
 						Expect(err).ToNot(HaveOccurred())
 						assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 					})
@@ -230,7 +224,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				)
 
 				var err error
-				clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+				clientVMI, err = createClientVmi(util.NamespaceTestDefault, f.KubevirtClient)
 				Expect(err).ToNot(HaveOccurred())
 				assertIPsNotEmptyForVMI(clientVMI)
 			})
@@ -259,7 +253,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				)
 
 				var err error
-				clientVMI, err = createClientVmi(util.NamespaceTestDefault, virtClient)
+				clientVMI, err = createClientVmi(util.NamespaceTestDefault, f.KubevirtClient)
 				Expect(err).ToNot(HaveOccurred())
 				assertIPsNotEmptyForVMI(clientVMI)
 			})

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -25,6 +25,8 @@ import (
 	"os/exec"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -40,17 +42,8 @@ import (
 )
 
 var _ = SIGDescribe("Port-forward", func() {
-	var (
-		err        error
-		virtClient kubecli.KubevirtClient
-	)
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
+	var err error
+	f := framework.NewDefaultFramework("network/port forward")
 
 	Context("VMI With masquerade binding", func() {
 		const localPort = 1500
@@ -62,7 +55,7 @@ var _ = SIGDescribe("Port-forward", func() {
 		)
 
 		JustBeforeEach(func() {
-			vmi = createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
+			vmi = createCirrosVMIWithPortsAndBlockUntilReady(f.KubevirtClient, vmiDeclaredPorts)
 			tests.StartHTTPServer(vmi, vmiHttpServerPort)
 
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)

--- a/tests/numa/BUILD.bazel
+++ b/tests/numa/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/util:go_default_library",
         "//tools/perfscale-audit/api:go_default_library",
         "//tools/perfscale-audit/metric-client:go_default_library",

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -44,17 +46,13 @@ import (
 
 var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
 	var (
-		err        error
-		virtClient kubecli.KubevirtClient
-		startTime  time.Time
-		endTime    time.Time
+		startTime time.Time
+		endTime   time.Time
 	)
+	f := framework.NewDefaultFramework("performance/density")
 	BeforeEach(func() {
 		startTime = time.Now()
 		skipIfNoPerformanceTests()
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 	})
 
 	AfterEach(func() {
@@ -71,10 +69,10 @@ var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
 		Context(fmt.Sprintf("[small] create a batch of %d VMIs", vmCount), func() {
 			It("should sucessfully create all VMIS", func() {
 				By("Creating a batch of VMIs")
-				createBatchVMIWithRateControl(virtClient, vmCount)
+				createBatchVMIWithRateControl(f.KubevirtClient, vmCount)
 
 				By("Waiting a batch of VMIs")
-				waitRunningVMI(virtClient, vmCount, vmBatchStartupLimit)
+				waitRunningVMI(f.KubevirtClient, vmCount, vmBatchStartupLimit)
 			})
 		})
 	})

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -36,20 +38,14 @@ import (
 
 var _ = Describe("[sig-compute]PortForward", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("portforward")
 
 	var (
 		LaunchVMI func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
 	)
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		LaunchVMI = tests.VMILauncherIgnoreWarnings(virtClient)
+		LaunchVMI = tests.VMILauncherIgnoreWarnings(f.KubevirtClient)
 	})
 
 	It("should successfully open connection to guest", func() {
@@ -64,7 +60,7 @@ var _ = Describe("[sig-compute]PortForward", func() {
 			err    error
 		)
 		Eventually(func() error {
-			tunnel, err = virtClient.VirtualMachineInstance(vmi.Namespace).PortForward(vmi.Name, 22, "tcp")
+			tunnel, err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).PortForward(vmi.Name, 22, "tcp")
 			if err != nil {
 				return err
 			}

--- a/tests/realtime/BUILD.bazel
+++ b/tests/realtime/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -4,29 +4,22 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	"kubevirt.io/kubevirt/tests/util"
 
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
 var _ = PDescribe("Ensure stable functionality", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
+	f := framework.NewDefaultFramework("stability")
 
 	Measure("by repeately starting vmis many times without issues", func(b Benchmarker) {
 		b.Time("from_start_to_ready", func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil(), "Create VMI successfully")
 			tests.WaitForSuccessfulVMIStart(vmi)
 		})

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/framework/storage:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
@@ -43,35 +45,28 @@ import (
 var _ = Describe("[sig-compute]Subresource Api", func() {
 
 	var err error
-	var virtCli kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("subresource api")
 
 	manual := v1.RunStrategyManual
 	restartOnError := v1.RunStrategyRerunOnFailure
-
-	BeforeEach(func() {
-		virtCli, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization", func() {
 		var resource string
 		BeforeEach(func() {
 			vm := tests.NewRandomVMWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			resource = vm.Name
-			vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+			vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("with correct permissions", func() {
 			It("[test_id:3170]should be allowed to access subresource endpoint", func() {
-				testClientJob(virtCli, true, resource)
+				testClientJob(f.KubevirtClient, true, resource)
 			}, 15)
 		})
 		Context("Without permissions", func() {
 			It("[test_id:3171]should not be able to access subresource endpoint", func() {
-				testClientJob(virtCli, false, resource)
+				testClientJob(f.KubevirtClient, false, resource)
 			}, 15)
 		})
 	})
@@ -81,12 +76,12 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 		Context("with authenticated user", func() {
 			It("[test_id:3172]should be allowed to access subresource version endpoint", func() {
-				testClientJob(virtCli, true, resource)
+				testClientJob(f.KubevirtClient, true, resource)
 			})
 		})
 		Context("Without permissions", func() {
 			It("[test_id:3173]should be able to access subresource version endpoint", func() {
-				testClientJob(virtCli, false, resource)
+				testClientJob(f.KubevirtClient, false, resource)
 			})
 		})
 	})
@@ -95,19 +90,19 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 		Context("with a restart endpoint", func() {
 			It("[test_id:1304] should restart a VM", func() {
 				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
 				tests.StartVirtualMachine(vm)
-				vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+				err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 					if err != nil || vmi.UID == newVMI.UID {
 						return v1.VmPhaseUnset
 					}
@@ -117,10 +112,10 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 			It("[test_id:1305][posneg:negative] should return an error when VM is not running", func() {
 				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+				err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -128,7 +123,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vmi := tests.NewRandomVMI()
 				tests.RunVMIAndExpectLaunch(vmi, 60)
 
-				err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
+				err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -140,11 +135,11 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vm.Spec.Running = nil
 
 				By("Creating VM")
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Trying to start VM via Restart subresource")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+				err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -154,31 +149,31 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vm.Spec.Running = nil
 
 				By("Creating VM")
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Starting VM via Start subresource")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Start(vm.Name, &v1.StartOptions{Paused: false})
+				err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Start(vm.Name, &v1.StartOptions{Paused: false})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to start")
 				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 					if err != nil {
 						return v1.VmPhaseUnset
 					}
 					return newVMI.Status.Phase
 				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
 
-				vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Restarting VM")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+				err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 					if err != nil || vmi.UID == newVMI.UID {
 						return v1.VmPhaseUnset
 					}
@@ -194,27 +189,27 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vm.Spec.Running = nil
 
 				By("Creating VM")
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to start")
 				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 					if err != nil {
 						return v1.VmPhaseUnset
 					}
 					return newVMI.Status.Phase
 				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
 
-				vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Restarting VM")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+				err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 					if err != nil || vmi.UID == newVMI.UID {
 						return v1.VmPhaseUnset
 					}
@@ -227,7 +222,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources", func() {
 		It("[test_id:3177]should be aggregated into the apiserver openapi spec", func() {
 			Eventually(func() string {
-				spec, err := virtCli.RestClient().Get().AbsPath("/openapi/v2").DoRaw(context.Background())
+				spec, err := f.KubevirtClient.RestClient().Get().AbsPath("/openapi/v2").DoRaw(context.Background())
 				Expect(err).ToNot(HaveOccurred())
 				return string(spec)
 				// The first item in the SubresourceGroupVersions array is the preferred version
@@ -244,10 +239,10 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "#!/bin/bash\necho 'hello'\n")
 				vm = tests.NewRandomVirtualMachine(vmi, true)
-				vm, err = virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() bool {
-					vmi, err = virtCli.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					if errors.IsNotFound(err) {
 						return false
 					}
@@ -259,14 +254,14 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 			It("[test_id:7476]Freeze without guest agent", func() {
 				expectedErr := "Internal error occurred"
-				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
+				err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(expectedErr))
 			})
 
 			It("[test_id:7477]Unfreeze without guest agent", func() {
 				expectedErr := "Internal error occurred"
-				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
+				err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(expectedErr))
 			})
@@ -280,10 +275,10 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Namespace = util.NamespaceTestDefault
 				vm = tests.NewRandomVirtualMachine(vmi, true)
-				vm, err = virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				vm, err = f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() bool {
-					vmi, err = virtCli.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					if errors.IsNotFound(err) {
 						return false
 					}
@@ -291,12 +286,12 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 					return vmi.Status.Phase == v1.Running
 				}, 180*time.Second, time.Second).Should(BeTrue())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtCli, vmi)
+				tests.WaitAgentConnected(f.KubevirtClient, vmi)
 			})
 
 			waitVMIFSFreezeStatus := func(expectedStatus string) {
 				Eventually(func() bool {
-					updatedVMI, err := virtCli.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					updatedVMI, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return updatedVMI.Status.FSFreezeStatus == expectedStatus
 				}, 30*time.Second, 2*time.Second).Should(BeTrue())
@@ -304,13 +299,13 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 			It("[test_id:7479]Freeze Unfreeze should succeed", func() {
 				By("Freezing VMI")
-				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
+				err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				waitVMIFSFreezeStatus("frozen")
 
 				By("Unfreezing VMI")
-				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
+				err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
 				Expect(err).ToNot(HaveOccurred())
 
 				waitVMIFSFreezeStatus("")
@@ -319,7 +314,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			It("[test_id:7480]Multi Freeze Unfreeze calls should succeed", func() {
 				for i := 0; i < 5; i++ {
 					By("Freezing VMI")
-					err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
+					err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 					Expect(err).ToNot(HaveOccurred())
 
 					waitVMIFSFreezeStatus("frozen")
@@ -327,7 +322,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 				By("Unfreezing VMI")
 				for i := 0; i < 5; i++ {
-					err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
+					err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
 					Expect(err).ToNot(HaveOccurred())
 
 					waitVMIFSFreezeStatus("")
@@ -337,7 +332,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			It("Freeze without Unfreeze should trigger unfreeze after timeout", func() {
 				By("Freezing VMI")
 				unfreezeTimeout := 10 * time.Second
-				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, unfreezeTimeout)
+				err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, unfreezeTimeout)
 				Expect(err).ToNot(HaveOccurred())
 
 				waitVMIFSFreezeStatus("frozen")

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -23,30 +23,19 @@ import (
 	"fmt"
 	"runtime"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"kubevirt.io/kubevirt/tests/util"
-
-	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/tests"
 )
 
 var _ = Describe("[sig-compute]Version", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
+	f := framework.NewDefaultFramework("version")
 
 	Describe("Check that version parameters where loaded by ldflags in build time", func() {
 		It("[test_id:555]Should return a good version information struct", func() {
-			info, err := virtClient.ServerVersion().Get()
+			info, err := f.KubevirtClient.ServerVersion().Get()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(info.Compiler).To(Equal(runtime.Compiler))
 			Expect(info.Platform).To(Equal(fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)))

--- a/tests/virtoperatorbasic/BUILD.bazel
+++ b/tests/virtoperatorbasic/BUILD.bazel
@@ -6,10 +6,9 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/virtoperatorbasic",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//tests:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -29,6 +29,8 @@ import (
 	"time"
 	"unicode"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -49,7 +51,6 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	kubevirt_hooks_v1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -69,7 +70,7 @@ type VMICreationFuncWithEFI func() *v1.VirtualMachineInstance
 var _ = Describe("[sig-compute]Configurations", func() {
 
 	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vmi configuration")
 
 	const (
 		cgroupV1MemoryUsagePath = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
@@ -78,7 +79,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 	getPodMemoryUsage := func(pod *kubev1.Pod) (output string, err error) {
 		output, err = tests.ExecuteCommandOnPod(
-			virtClient,
+			f.KubevirtClient,
 			pod,
 			"compute",
 			[]string{"cat", cgroupV2MemoryUsagePath},
@@ -89,7 +90,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		}
 
 		output, err = tests.ExecuteCommandOnPod(
-			virtClient,
+			f.KubevirtClient,
 			pod,
 			"compute",
 			[]string{"cat", cgroupV1MemoryUsagePath},
@@ -97,13 +98,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		return
 	}
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
 
 	Context("with all devices on the root PCI bus", func() {
 		It("[test_id:4623]should start run the guest as usual", func() {
@@ -150,7 +144,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
 			Eventually(func() kubev1.PodQOSClass {
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.IsFinal()).To(BeFalse())
 				if vmi.Status.QOSClass == nil {
@@ -179,7 +173,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
 			Eventually(func() kubev1.PodQOSClass {
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.IsFinal()).To(BeFalse())
 				if vmi.Status.QOSClass == nil {
@@ -205,7 +199,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
 			Eventually(func() kubev1.PodQOSClass {
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.IsFinal()).To(BeFalse())
 				if vmi.Status.QOSClass == nil {
@@ -214,7 +208,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				return *vmi.Status.QOSClass
 			}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSGuaranteed))
 
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmi.Spec.Domain.Resources.Requests.Cpu().Cmp(*vmi.Spec.Domain.Resources.Limits.Cpu())).To(BeZero())
 			Expect(vmi.Spec.Domain.Resources.Requests.Memory().Cmp(*vmi.Spec.Domain.Resources.Limits.Memory())).To(BeZero())
@@ -228,7 +222,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			tests.BeforeAll(func() {
-				availableNumberOfCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+				availableNumberOfCPUs = tests.GetHighestCPUNumberAmongNodes(f.KubevirtClient)
 			})
 
 			BeforeEach(func() {
@@ -249,7 +243,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -290,11 +284,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				expectedMemoryXMLStr := fmt.Sprintf("unit='KiB'>%d", expectedMemoryInKiB)
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(domXml).To(ContainSubstring(expectedMemoryXMLStr))
 			})
@@ -311,7 +305,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -335,7 +329,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -361,7 +355,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -388,7 +382,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -413,17 +407,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Devices.BlockMultiQueue = &_true
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(domXml).To(ContainSubstring("queues='3'"))
 			})
 
 			It("[test_id:1665]should map cores to virtio net queues", func() {
-				if tests.ShouldAllowEmulation(virtClient) {
+				if tests.ShouldAllowEmulation(f.KubevirtClient) {
 					Skip("Software emulation should not be enabled for this test to run")
 				}
 
@@ -440,11 +434,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(domXml).To(ContainSubstring("driver name='vhost' queues='3'"))
 				// make sure that there are not block queues configured
@@ -461,11 +455,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(domXml).ToNot(ContainSubstring("queues='"))
 			})
@@ -476,14 +470,14 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi := tests.NewRandomVMI()
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
 				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", func() {
 			BeforeEach(func() {
-				kv := util.GetCurrentKv(virtClient)
+				kv := util.GetCurrentKv(f.KubevirtClient)
 
 				config := kv.Spec.Configuration
 				config.DeveloperConfiguration.MemoryOvercommit = 200
@@ -519,7 +513,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(vmi.Spec.Domain.Devices.Interfaces[0].BootOrder).To(BeNil())
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Expecting no bootable NIC")
@@ -546,7 +540,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].BootOrder = &bootOrder
 
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Expecting a bootable NIC")
@@ -557,19 +551,19 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		table.DescribeTable("[rfe_id:2262][crit:medium][vendor:cnv-qe@redhat.com][level:component]with EFI bootloader method", func(vmiNew VMICreationFuncWithEFI, loginTo console.LoginToFunction, msg string, fileName string) {
 			vmi := vmiNew()
 			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			wp := tests.WarningsPolicy{FailOnWarnings: false}
 			tests.WaitForVMIStartOrFailed(vmi, 180, wp)
-			vmiMeta, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			vmiMeta, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 			switch vmiMeta.Status.Phase {
 			case v1.Failed:
 				// This Error is expected to be handled
 				By("Getting virt-launcher logs")
-				logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
+				logs := func() string { return getVirtLauncherLogs(f.KubevirtClient, vmi) }
 				Eventually(logs,
 					30*time.Second,
 					500*time.Millisecond).
@@ -577,7 +571,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			default:
 				tests.WaitUntilVMIReady(vmi, loginTo)
 				By(msg)
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(domXml).To(MatchRegexp(fileName))
 			}
@@ -594,7 +588,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					Guest: &guestMemory,
 				}
 
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -614,7 +608,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Resources.Limits = kubev1.ResourceList{
 					kubev1.ResourceMemory: resource.MustParse("256Mi"),
 				}
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -641,7 +635,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					Cores:   6,
 				}
 
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -670,7 +664,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					Guest: &guestMemory,
 				}
 
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -705,18 +699,18 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("128M")
 				vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
 
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 			})
 
 			It("[test_id:730]Check OverCommit VM Created and Started", func() {
-				overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+				overcommitVmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(overcommitVmi)
 			})
 			It("[test_id:731]Check OverCommit status on VMI", func() {
-				overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+				overcommitVmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(overcommitVmi.Spec.Domain.Resources.OvercommitGuestOverhead).To(BeTrue())
 			})
@@ -743,7 +737,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -766,7 +760,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -783,7 +777,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			It("[test_id:3118]should start the VMI without usb controller", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 
 				tests.WaitForSuccessfulVMIStart(vmi)
@@ -810,7 +804,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(HaveOccurred(), "should not start vmi")
 			})
 
@@ -824,7 +818,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(HaveOccurred(), "should not start vmi")
 			})
 
@@ -838,7 +832,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -862,7 +856,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "should start vmi")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -895,7 +889,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 						},
 					},
 				}
-				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+				_, err := f.KubevirtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Starting a VirtualMachineInstance")
@@ -907,8 +901,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 							kubev1.ResourceMemory: resource.MustParse("64M"),
 						},
 					}
-					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-					virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 					return err
 				}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.memory '64M' is greater than spec.domain.resources.limits.memory '32Mi'"))
 			})
@@ -932,7 +926,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 						},
 					},
 				}
-				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+				_, err := f.KubevirtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Starting a VirtualMachineInstance")
@@ -945,8 +939,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 							kubev1.ResourceMemory: resource.MustParse("512M"),
 						},
 					}
-					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-					virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 					return err
 				}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.cpu '800m' is greater than spec.domain.resources.limits.cpu '500m'"))
 			})
@@ -974,7 +968,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 						},
 					},
 				}
-				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+				_, err := f.KubevirtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
@@ -989,10 +983,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Creating a VMI")
 				Eventually(func() bool {
-					createdVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					createdVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).ToNot(HaveOccurred(), "should create vmi")
 
-					err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(createdVMI.Name, &metav1.DeleteOptions{})
+					err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(createdVMI.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred(), "should delete vmi")
 
 					return reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega), int64(64)) &&
@@ -1009,7 +1003,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			verifyHugepagesConsumption := func() bool {
 				// TODO: we need to check hugepages state via node allocated resources, but currently it has the issue
 				// https://github.com/kubernetes/kubernetes/issues/64691
-				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
+				pods, err := f.KubevirtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(1))
 
@@ -1018,7 +1012,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				// Get a hugepages statistics from virt-launcher pod
 				output, err := tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					&pods.Items[0],
 					pods.Items[0].Spec.Containers[0].Name,
 					[]string{"cat", fmt.Sprintf("%s/nr_hugepages", hugepagesDir)},
@@ -1029,7 +1023,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					&pods.Items[0],
 					pods.Items[0].Spec.Containers[0].Name,
 					[]string{"cat", fmt.Sprintf("%s/free_hugepages", hugepagesDir)},
@@ -1040,7 +1034,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
+					f.KubevirtClient,
 					&pods.Items[0],
 					pods.Items[0].Spec.Containers[0].Name,
 					[]string{"cat", fmt.Sprintf("%s/resv_hugepages", hugepagesDir)},
@@ -1077,7 +1071,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					log.DefaultLogger().Object(hugepagesVmi).Infof("Fall back to use hugepages source file. Libvirt in the 1.16 provider version doesn't support memfd as memory backend")
 				}
 
-				nodeWithHugepages := tests.GetNodeWithHugepages(virtClient, hugepageType)
+				nodeWithHugepages := tests.GetNodeWithHugepages(f.KubevirtClient, hugepageType)
 				if nodeWithHugepages == nil {
 					Skip(fmt.Sprintf("No node with hugepages %s capacity", hugepageType))
 				}
@@ -1106,7 +1100,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VM")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(hugepagesVmi)
 
@@ -1120,7 +1114,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			Context("with unsupported page size", func() {
 				It("[test_id:1673]should failed to schedule the pod", func() {
-					nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+					nodes, err := f.KubevirtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					hugepageType2Mi := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + "2Mi")
@@ -1137,12 +1131,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					}
 
 					By("Starting a VM")
-					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
+					_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
 					Expect(err).ToNot(HaveOccurred())
 
 					var vmiCondition v1.VirtualMachineInstanceCondition
 					Eventually(func() bool {
-						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(hugepagesVmi.Name, &metav1.GetOptions{})
+						vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(hugepagesVmi.Name, &metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 
 						if len(vmi.Status.Conditions) > 0 {
@@ -1172,7 +1166,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				rngVmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 
 				By("Starting a VirtualMachineInstance")
-				rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
+				rngVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(rngVmi)
 
@@ -1188,7 +1182,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			It("[test_id:1675]should not have the virtio rng device when not present", func() {
 				By("Starting a VirtualMachineInstance")
-				rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
+				rngVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(rngVmi)
 
@@ -1211,7 +1205,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				agentVMI := tests.NewRandomFedoraVMIWithGuestAgent()
 
 				By("Starting a VirtualMachineInstance")
-				agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+				agentVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 				tests.WaitForSuccessfulVMIStart(agentVMI)
 
@@ -1220,7 +1214,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("VMI has the guest agent connected condition")
 				Eventually(func() []v1.VirtualMachineInstanceCondition {
-					freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 					return freshVMI.Status.Conditions
 				}, 240*time.Second, 2).Should(
@@ -1237,17 +1231,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				agentVMI = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				By("Starting a VirtualMachineInstance")
-				agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+				agentVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 				tests.WaitForSuccessfulVMIStart(agentVMI)
 
 				getOptions := metav1.GetOptions{}
 				var freshVMI *v1.VirtualMachineInstance
 
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+				freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
+				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, freshVMI)
 				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
 
 				Expect(domXML).To(ContainSubstring("<channel type='unix'>"), "Should contain at least one channel")
@@ -1259,7 +1253,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 
-				freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+				freshVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 				Expect(freshVMI.Status.Conditions).To(
 					ContainElement(
@@ -1285,7 +1279,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("VMI has the guest agent connected condition")
 				Eventually(func() []v1.VirtualMachineInstanceCondition {
-					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					freshVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 					return freshVMI.Status.Conditions
 				}, 240*time.Second, 2).ShouldNot(
@@ -1298,7 +1292,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			Context("[Serial]with cluster config changes", func() {
 				BeforeEach(func() {
-					kv := util.GetCurrentKv(virtClient)
+					kv := util.GetCurrentKv(f.KubevirtClient)
 
 					config := kv.Spec.Configuration
 					config.SupportedGuestAgentVersions = []string{"X.*"}
@@ -1308,16 +1302,16 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				It("[test_id:5267]VMI condition should signal unsupported agent presence", func() {
 					agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-shutdown")
 					By("Starting a VirtualMachineInstance")
-					agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+					agentVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
 					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 					tests.WaitForSuccessfulVMIStart(agentVMI)
 
 					getOptions := metav1.GetOptions{}
-					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					freshVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 
 					Eventually(func() []v1.VirtualMachineInstanceCondition {
-						freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 						return freshVMI.Status.Conditions
 					}, 240*time.Second, 2).Should(
@@ -1332,17 +1326,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
 					agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-exec,guest-set-password")
 					By("Starting a VirtualMachineInstance")
-					agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+					agentVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
 					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 					tests.WaitForSuccessfulVMIStart(agentVMI)
 
 					getOptions := metav1.GetOptions{}
-					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					freshVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 
 					By("VMI has the guest agent connected condition")
 					Eventually(func() []v1.VirtualMachineInstanceCondition {
-						freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 						return freshVMI.Status.Conditions
 					}, 240*time.Second, 2).Should(
@@ -1353,7 +1347,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 						"Should have agent connected condition")
 
 					By("fetching the VMI after agent has connected")
-					freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 					Expect(freshVMI.Status.Conditions).ToNot(
 						ContainElement(
@@ -1373,7 +1367,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
-					updatedVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					updatedVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
 					if err != nil {
 						return false
 					}
@@ -1389,7 +1383,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
-					guestInfo, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
+					guestInfo, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
 					if err != nil {
 						// invalid request, retry
 						return false
@@ -1419,7 +1413,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Expecting the Guest VM information")
 				Eventually(func() string {
-					_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
+					_, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
 					if err != nil {
 						return err.Error()
 					}
@@ -1434,7 +1428,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
-					userList, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).UserList(agentVMI.Name)
+					userList, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).UserList(agentVMI.Name)
 					if err != nil {
 						// invalid request, retry
 						return false
@@ -1451,7 +1445,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
-					fsList, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).FilesystemList(agentVMI.Name)
+					fsList, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).FilesystemList(agentVMI.Name)
 					if err != nil {
 						// invalid request, retry
 						return false
@@ -1476,17 +1470,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				snVmi.Spec.Domain.Firmware = &v1.Firmware{Serial: "4b2f5496-f3a3-460b-a375-168223f68845"}
 
 				By("Starting a VirtualMachineInstance")
-				snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
+				snVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(snVmi)
 
 				getOptions := metav1.GetOptions{}
 				var freshVMI *v1.VirtualMachineInstance
 
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
+				freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
+				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, freshVMI)
 				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
 
 				Expect(domXML).To(ContainSubstring("<entry name='serial'>4b2f5496-f3a3-460b-a375-168223f68845</entry>"), "Should have serial-number present")
@@ -1494,17 +1488,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			It("[test_id:3122]should not have serial-number set when not present", func() {
 				By("Starting a VirtualMachineInstance")
-				snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
+				snVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(snVmi)
 
 				getOptions := metav1.GetOptions{}
 				var freshVMI *v1.VirtualMachineInstance
 
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
+				freshVMI, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
+				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, freshVMI)
 				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
 
 				Expect(domXML).ToNot(ContainSubstring("<entry name='serial'>"), "Should have serial-number present")
@@ -1526,7 +1520,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking the TSC frequency on the VMI")
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Status.TopologyHints).ToNot(BeNil())
 				Expect(vmi.Status.TopologyHints.TSCFrequency).ToNot(BeNil())
@@ -1569,7 +1563,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Creating a VMI with timezone set")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for successful start of VMI")
@@ -1606,7 +1600,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: diskName,
 				})
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(HaveOccurred())
 				const expectedErrMessage = "denied the request: spec.domain.devices.disks[0].Name '" + diskName + "' not found."
 				Expect(err.Error()).To(ContainSubstring(expectedErrMessage))
@@ -1620,7 +1614,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 						CloudInitNoCloud: &v1.CloudInitNoCloudSource{UserData: " "},
 					},
 				})
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(HaveOccurred())
 				const expectedErrMessage = "denied the request: spec.domain.volumes[0].name '" + volumeName + "' not found."
 				Expect(err.Error()).To(ContainSubstring(expectedErrMessage))
@@ -1644,7 +1638,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			It("should apply runtimeClassName to pod when set", func() {
 				By("Configuring a default runtime class")
-				config := util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
+				config := util.GetCurrentKv(f.KubevirtClient).Spec.Configuration.DeepCopy()
 				config.DefaultRuntimeClass = runtimeClassName
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
 
@@ -1661,7 +1655,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			It("should not apply runtimeClassName to pod when not set", func() {
 				By("Creating a VMI")
 				var vmi = tests.NewRandomVMI()
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Waiting for successful start of VMI")
@@ -1701,7 +1695,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		// Collect capabilities once for all tests
 		tests.BeforeAll(func() {
-			nodes = util.GetAllSchedulableNodes(virtClient)
+			nodes = util.GetAllSchedulableNodes(f.KubevirtClient)
 			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 		})
 
@@ -1719,7 +1713,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				niceName := parseCPUNiceName(supportedCPUs[0])
 
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(cpuVmi)
 
@@ -1741,7 +1735,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(cpuVmi)
 
@@ -1764,7 +1758,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model not defined", func() {
 			It("[test_id:1680]should report CPU model from libvirt capabilities", func() {
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(cpuVmi)
 
@@ -1796,7 +1790,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(cpuVmi)
 
@@ -1808,7 +1802,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", func() {
 		BeforeEach(func() {
-			kv := util.GetCurrentKv(virtClient)
+			kv := util.GetCurrentKv(f.KubevirtClient)
 
 			config := kv.Spec.Configuration
 			config.EmulatedMachines = []string{"q35*", "pc-q35*", "pc*"}
@@ -1847,7 +1841,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[Serial][test_id:3126]should set machine type from kubevirt-config", func() {
-			kv := util.GetCurrentKv(virtClient)
+			kv := util.GetCurrentKv(f.KubevirtClient)
 
 			config := kv.Spec.Configuration
 			config.MachineType = "pc"
@@ -1897,7 +1891,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[Serial][test_id:3129]should set CPU request from kubevirt-config", func() {
-			kv := util.GetCurrentKv(virtClient)
+			kv := util.GetCurrentKv(f.KubevirtClient)
 
 			config := kv.Spec.Configuration
 			configureCPURequest := resource.MustParse("800m")
@@ -1924,14 +1918,14 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			// create a new PV and PVC (PVs can't be reused)
 			dataVolume = tests.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 		}, 60)
 
 		AfterEach(func() {
-			err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+			err = f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -2056,7 +2050,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			By("creating a block volume")
 			dataVolume := tests.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
@@ -2093,7 +2087,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			By("creating a block volume")
 			dataVolume := tests.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
@@ -2133,10 +2127,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			tmpHostDiskDir := tests.RandTmpDir()
 			tmpHostDiskPath := filepath.Join(tmpHostDiskDir, fmt.Sprintf("disk-%s.img", uuid.NewRandom().String()))
 			job := tests.CreateHostDiskImage(tmpHostDiskPath)
-			job, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), job, metav1.CreateOptions{})
+			job, err = f.KubevirtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), job, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			getStatus := func() k8sv1.PodPhase {
-				pod, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), job.Name, metav1.GetOptions{})
+				pod, err := f.KubevirtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), job.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if pod.Spec.NodeName != "" && nodeName == "" {
 					nodeName = pod.Spec.NodeName
@@ -2199,7 +2193,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		}
 
 		It("[test_id:1682]should have all the device nodes", func() {
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -2218,7 +2212,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			By("checking disk1 Pci address")
 			vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = "0000:00:10.0"
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 
@@ -2232,12 +2226,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = wrongPciAddress
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			var vmiCondition v1.VirtualMachineInstanceCondition
 			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				if len(vmi.Status.Conditions) > 0 {
@@ -2260,7 +2254,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		isNodeHasCPUManagerLabel := func(nodeName string) bool {
 			Expect(nodeName).ToNot(BeEmpty())
 
-			nodeObject, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+			nodeObject, err := f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			nodeHaveCpuManagerLabel := false
 			nodeLabels := nodeObject.GetLabels()
@@ -2276,7 +2270,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		BeforeEach(func() {
 			checks.SkipTestIfNoCPUManager()
-			nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			nodes, err = f.KubevirtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			if len(nodes.Items) == 1 {
 				Skip("Skip cpu pinning test that requires multiple nodes when only one node is present.")
@@ -2288,19 +2282,19 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			It("[test_id:1684]should set the cpumanager label to false when it's not running", func() {
 
 				By("adding a cpumanger=true label to a node")
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
+				nodes, err := f.KubevirtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
 				Expect(err).ToNot(HaveOccurred())
 				if len(nodes.Items) == 0 {
 					Skip("Skip CPU manager test on clusters where CPU manager is running on all worker/compute nodes")
 				}
 
 				node := &nodes.Items[0]
-				node, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, v1.CPUManager)), metav1.PatchOptions{})
+				node, err = f.KubevirtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, v1.CPUManager)), metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("setting the cpumanager label back to false")
 				Eventually(func() string {
-					n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+					n, err := f.KubevirtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return n.Labels[v1.CPUManager]
 				}, 3*time.Minute, 2*time.Second).Should(Equal("false"))
@@ -2325,12 +2319,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				node := tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Checking that the VMI QOS is guaranteed")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Status.QOSClass).ToNot(BeNil())
 				Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
@@ -2371,7 +2365,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 15)).To(Succeed())
 
 				By("Check values in domain XML")
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, cpuVmi)
+				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, cpuVmi)
 				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
 				Expect(domXML).To(ContainSubstring("<hint-dedicated state='on'/>"), "should container the hint-dedicated feature")
 			})
@@ -2392,12 +2386,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				node := tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Checking that the VMI QOS is guaranteed")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Status.QOSClass).ToNot(BeNil())
 				Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
@@ -2440,12 +2434,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				node := tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Checking that the VMI QOS is guaranteed")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Status.QOSClass).ToNot(BeNil())
 				Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
@@ -2495,7 +2489,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 
 				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -2507,7 +2501,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
 
 				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuVmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				node := tests.WaitForSuccessfulVMIStart(cpuVmi)
 				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
@@ -2532,7 +2526,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("3")
 
 				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
 			})
 			It("[test_id:1689]should fail the vmi creation if cpu is not an integer", func() {
@@ -2544,7 +2538,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("300m")
 
 				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
 			})
 			It("[test_id:1690]should fail the vmi creation if Guaranteed QOS cannot be set", func() {
@@ -2559,7 +2553,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
 			})
 			It("[test_id:830]should start a vm with no cpu pinning after a vm with cpu pinning on same node", func() {
@@ -2574,13 +2568,13 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Vmi.Spec.NodeSelector = map[string]string{v1.CPUManager: "true"}
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
 				node := tests.WaitForSuccessfulVMIStart(cpuVmi)
 				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
 
 				By("Starting a VirtualMachineInstance without dedicated cpus")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(Vmi)
+				_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(Vmi)
 				Expect(err).ToNot(HaveOccurred())
 				node = tests.WaitForSuccessfulVMIStart(cpuVmi)
 				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
@@ -2594,7 +2588,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			BeforeEach(func() {
 
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := util.GetAllSchedulableNodes(f.KubevirtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some nodes")
 				node = nodes.Items[1].Name
 
@@ -2626,7 +2620,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			It("[test_id:829]should start a vm with no cpu pinning after a vm with cpu pinning on same node", func() {
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")
-				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
+				cpuvmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
 				Expect(err).ToNot(HaveOccurred())
 				node1 := tests.WaitForSuccessfulVMIStart(cpuvmi)
 				Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
@@ -2636,7 +2630,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(libnet.WithIPv6(console.LoginToFedora)(cpuvmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance without dedicated cpus")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				node2 := tests.WaitForSuccessfulVMIStart(vmi)
 				Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
@@ -2649,7 +2643,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", func() {
 
 				By("Starting a VirtualMachineInstance without dedicated cpus")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				node2 := tests.WaitForSuccessfulVMIStart(vmi)
 				Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
@@ -2659,7 +2653,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")
-				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
+				cpuvmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
 				Expect(err).ToNot(HaveOccurred())
 				node1 := tests.WaitForSuccessfulVMIStart(cpuvmi)
 				Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
@@ -2680,12 +2674,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			}
 
 			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("Check values on domain XML")
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
 
@@ -2710,7 +2704,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[test_id:2751]test default SMBios", func() {
-			kv := util.GetCurrentKv(virtClient)
+			kv := util.GetCurrentKv(f.KubevirtClient)
 
 			config := kv.Spec.Configuration
 			// Clear SMBios values if already set in kubevirt-config, for testing default values.
@@ -2719,12 +2713,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(config)
 
 			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("Check values in domain XML")
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<entry name='family'>KubeVirt</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='product'>None</entry>"))
@@ -2746,7 +2740,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[test_id:2752]test custom SMBios values", func() {
-			kv := util.GetCurrentKv(virtClient)
+			kv := util.GetCurrentKv(f.KubevirtClient)
 			config := kv.Spec.Configuration
 			// Set a custom test SMBios
 			test_smbios := &v1.SMBiosConfiguration{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
@@ -2754,11 +2748,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(config)
 
 			By("Starting a VirtualMachineInstance")
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<entry name='family'>test</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='product'>test</entry>"))
@@ -2794,7 +2788,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			tests.AddEphemeralCdrom(vmi, "cdrom-0", bus, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			By(fmt.Sprintf("Starting a VMI with a %s CD-ROM", bus))
-			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			_, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			if errMsg == "" {
 				Expect(err).ToNot(HaveOccurred())
 			} else {
@@ -2878,12 +2872,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			} else {
 				assignDisksToSlots(startIndex, vmi)
 			}
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
 			Expect(len(vmi.Spec.Domain.Devices.Disks)).Should(BeNumerically("==", numOfDevices))
 
-			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+			err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		},
 			table.Entry("[test_id:5269]across all available PCI root bus slots", 2, numOfSlotsToTest, false),
@@ -2908,12 +2902,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			}
 
 			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("Check values in domain XML")
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(f.KubevirtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<hidden state='on'/>"))
 
@@ -2931,7 +2925,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		It("[test_id:5272]test cpuid default", func() {
 			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"strings"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/api/core/v1"
@@ -31,7 +33,6 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -40,15 +41,10 @@ import (
 
 var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vmi headless")
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 	})
 
@@ -128,7 +124,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 			It("[test_id:738][posneg:negative]should not connect to VNC", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
-				_, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
+				_, err := f.KubevirtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
 
 				Expect(err.Error()).To(Equal("No graphics devices are present."), "vnc should not connect on headless VM")
 			})

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -22,6 +22,8 @@ package tests_test
 import (
 	"context"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,7 +31,6 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -37,18 +38,15 @@ import (
 
 var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]IgnitionData", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vmi ignition")
 
 	var LaunchVMI func(*v1.VirtualMachineInstance)
 
 	tests.BeforeAll(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
 
 		LaunchVMI = func(vmi *v1.VirtualMachineInstance) {
 			By("Starting a VirtualMachineInstance")
-			obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
+			obj, err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
 			Expect(err).To(BeNil())
 
 			By("Waiting the VirtualMachineInstance start")
@@ -59,7 +57,6 @@ var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][leve
 	})
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
 		if !tests.HasExperimentalIgnitionSupport() {
 			Skip("ExperimentalIgnitionSupport feature gate is not enabled in kubevirt-config")
 		}

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -22,6 +22,8 @@ package tests_test
 import (
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,26 +32,18 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 )
 
 var _ = Describe("[sig-compute]Health Monitoring", func() {
 
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
-	})
+	f := framework.NewDefaultFramework("vmi monitoring")
 
 	Describe("A VirtualMachineInstance with a watchdog device", func() {
 		It("[test_id:4641]should be shut down when the watchdog expires", func() {
 			vmi := tests.NewRandomVMIWithWatchdog()
-			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			obj, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil())
 			tests.WaitForSuccessfulVMIStart(obj)
 
@@ -69,7 +63,7 @@ var _ = Describe("[sig-compute]Health Monitoring", func() {
 
 			By("Checking that the VirtualMachineInstance has Failed status")
 			Eventually(func() v1.VirtualMachineInstancePhase {
-				startedVMI, err := virtClient.VirtualMachineInstance(namespace).Get(name, &metav1.GetOptions{})
+				startedVMI, err := f.KubevirtClient.VirtualMachineInstance(namespace).Get(name, &metav1.GetOptions{})
 
 				Expect(err).ToNot(HaveOccurred())
 				return startedVMI.Status.Phase

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -23,6 +23,8 @@ import (
 	"encoding/xml"
 	"fmt"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,19 +42,12 @@ import (
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Sound", func() {
 
 	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vmi sound")
 	var vmi *v1.VirtualMachineInstance
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
 
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with default sound support", func() {
 		BeforeEach(func() {
-			vmi, err = createSoundVMI(virtClient, "test-model-empty")
+			vmi, err = createSoundVMI(f.KubevirtClient, "test-model-empty")
 			Expect(err).To(BeNil())
 			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 		})
@@ -64,33 +59,33 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ich9 sound support", func() {
 		BeforeEach(func() {
-			vmi, err = createSoundVMI(virtClient, "ich9")
+			vmi, err = createSoundVMI(f.KubevirtClient, "ich9")
 			Expect(err).To(BeNil())
 			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 		})
 
 		It("should create ich9 sound device on ich9 model ", func() {
-			checkXMLSoundCard(virtClient, vmi, "ich9")
+			checkXMLSoundCard(f.KubevirtClient, vmi, "ich9")
 			checkAudioDevice(vmi, "ich9")
 		})
 	})
 
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ac97 sound support", func() {
 		BeforeEach(func() {
-			vmi, err = createSoundVMI(virtClient, "ac97")
+			vmi, err = createSoundVMI(f.KubevirtClient, "ac97")
 			Expect(err).To(BeNil())
 			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
 		})
 
 		It("should create ac97 sound device on ac97 model", func() {
-			checkXMLSoundCard(virtClient, vmi, "ac97")
+			checkXMLSoundCard(f.KubevirtClient, vmi, "ac97")
 			checkAudioDevice(vmi, "ac97")
 		})
 	})
 
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with unsupported sound support", func() {
 		It("should fail to create VMI with unsupported sound device", func() {
-			vmi, err = createSoundVMI(virtClient, "ich7")
+			vmi, err = createSoundVMI(f.KubevirtClient, "ich7")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -27,28 +27,23 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 )
 
 var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vmi defaults")
 
 	var vmi *v1.VirtualMachineInstance
 
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-	})
-
 	Context("Disk defaults", func() {
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			// create VMI with missing disk target
 			vmi = tests.NewRandomVMI()
 			vmi.Spec = v1.VirtualMachineInstanceSpec{
@@ -79,10 +74,10 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 		It("[test_id:4115]Should be applied to VMIs", func() {
 			// create the VMI first
-			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+			newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			// check defaults
@@ -97,11 +92,10 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 		var kvConfiguration v1.KubeVirtConfiguration
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			// create VMI with missing disk target
 			vmi = tests.NewRandomVMI()
 
-			kv := util.GetCurrentKv(virtClient)
+			kv := util.GetCurrentKv(f.KubevirtClient)
 			kvConfiguration = kv.Spec.Configuration
 		})
 
@@ -111,7 +105,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 		It("[test_id:4556]Should be present in domain", func() {
 			By("Creating a virtual machine")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for successful start")
@@ -145,7 +139,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(*kvConfigurationCopy)
 
 			By("Creating a virtual machine")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for successful start")
@@ -185,9 +179,9 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 		It("[test_id:4559]Should not be present in domain ", func() {
 			By("Creating a virtual machine with autoAttachmemballoon set to false")
-			f := false
-			vmi.Spec.Domain.Devices.AutoattachMemBalloon = &f
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			_f := false
+			vmi.Spec.Domain.Devices.AutoattachMemBalloon = &_f
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for successful start")

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
@@ -48,7 +50,7 @@ import (
 
 var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIPreset", func() {
 	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vmi preset")
 
 	var vmi *v1.VirtualMachineInstance
 	var memoryPreset *v1.VirtualMachineInstancePreset
@@ -64,10 +66,6 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	cores := 7
 
 	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 		vmi.Labels = map[string]string{flavorKey: memoryFlavor}
 
@@ -100,7 +98,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			// Preset with missing selector should fail CRD validation
 			jsonString := fmt.Sprintf("{\"kind\":\"VirtualMachineInstancePreset\",\"apiVersion\":\"%s\",\"metadata\":{\"generateName\":\"test-memory-\",\"creationTimestamp\":null},\"spec\":{}}", v1.StorageGroupVersion.String())
 
-			result := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body([]byte(jsonString)).SetHeader("Content-Type", "application/json").Do(context.Background())
+			result := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body([]byte(jsonString)).SetHeader("Content-Type", "application/json").Do(context.Background())
 
 			// Verify validation failed.
 			statusCode := 0
@@ -124,7 +122,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					CDRom: &v1.CDRomTarget{},
 				},
 			})
-			result := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background())
+			result := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background())
 			// Verify validation failed.
 			statusCode := 0
 			result.StatusCode(&statusCode)
@@ -142,7 +140,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Context("Preset Matching", func() {
 		It("[test_id:1597]Should be accepted on POST", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 			Expect(err).To(BeNil())
 		})
 
@@ -150,10 +148,10 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			// This test requires an explicit name or the resources won't conflict
 			presetName := "test-preset"
 			memoryPreset.Name = presetName
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
-			b, err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).DoRaw(context.Background())
+			b, err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).DoRaw(context.Background())
 			Expect(err).To(HaveOccurred())
 			status := k8smetav1.Status{}
 			err = json.Unmarshal(b, &status)
@@ -161,7 +159,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		It("[test_id:1599]Should return 404 if VMIPreset does not exist", func() {
-			b, err := virtClient.RestClient().Get().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name("wrong").DoRaw(context.Background())
+			b, err := f.KubevirtClient.RestClient().Get().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name("wrong").DoRaw(context.Background())
 			Expect(err).To(HaveOccurred())
 			status := k8smetav1.Status{}
 			err = json.Unmarshal(b, &status)
@@ -170,16 +168,16 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		It("[test_id:1600]Should reject presets that conflict with VirtualMachineInstance settings", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
-			newPreset, err := getPreset(virtClient, memoryPrefix)
+			newPreset, err := getPreset(f.KubevirtClient, memoryPrefix)
 			Expect(err).ToNot(HaveOccurred())
 
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -193,19 +191,19 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		It("[test_id:1601]Should accept presets that don't conflict with VirtualMachineInstance settings", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
-			newPreset, err := getPreset(virtClient, cpuPrefix)
+			newPreset, err := getPreset(f.KubevirtClient, cpuPrefix)
 			Expect(err).ToNot(HaveOccurred())
 
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			vmi.Labels = map[string]string{flavorKey: cpuFlavor}
 
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -221,18 +219,18 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		It("[test_id:1602]Should ignore VMIs that don't match", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
-			newPreset, err := getPreset(virtClient, memoryPrefix)
+			newPreset, err := getPreset(f.KubevirtClient, memoryPrefix)
 			Expect(err).ToNot(HaveOccurred())
 
 			// reset the label so it will not match
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMIStart(vmi)
@@ -247,17 +245,17 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:1603]Should not be applied to existing VMIs", func() {
 			// create the VirtualMachineInstance first
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
-			err = virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+			err = f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
-			newPreset, err := getPreset(virtClient, memoryPrefix)
+			newPreset, err := getPreset(f.KubevirtClient, memoryPrefix)
 			Expect(err).ToNot(HaveOccurred())
 
 			// check the annotations
@@ -270,13 +268,13 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Context("Exclusions", func() {
 		It("[test_id:1604]Should not apply presets to VirtualMachineInstance's with the exclusion marking", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
-			newPreset, err := getPreset(virtClient, cpuPrefix)
+			newPreset, err := getPreset(f.KubevirtClient, cpuPrefix)
 			Expect(err).ToNot(HaveOccurred())
 
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
@@ -284,7 +282,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			exclusionMarking := "virtualmachineinstancepresets.admission.kubevirt.io/exclude"
 			vmi.Annotations = map[string]string{exclusionMarking: "true"}
 
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			newVMI, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -322,10 +320,10 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		It("[test_id:1605]should denied to start the VMI", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(conflictPreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(conflictPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+			err = f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
@@ -333,7 +331,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			vmi.Labels = map[string]string{flavorKey: memoryFlavor, conflictKey: conflictFlavor}
 			By("creating the VirtualMachineInstance")
-			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			_, err = f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -364,7 +362,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:644][rfe_id:609] should override presets", func() {
 			By("Creating preset with 64M")
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(overridePreset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(overridePreset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
@@ -375,7 +373,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			vmi.Labels = map[string]string{overrideKey: overrideFlavor}
 			vmi.Spec.Domain.Resources.Requests["memory"] = vmiMemory
 
-			newVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			newVmi, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying VMI")
@@ -391,7 +389,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(newVmi.Spec.Domain.Resources.Requests["memory"]).To(Equal(vmiMemory))
 
 			By("Checking event list")
-			evList, err := virtClient.CoreV1().Events(util.NamespaceTestDefault).List(context.Background(), k8smetav1.ListOptions{})
+			evList, err := f.KubevirtClient.CoreV1().Events(util.NamespaceTestDefault).List(context.Background(), k8smetav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			for _, event := range evList.Items {
 				if event.InvolvedObject.GetObjectKind() == newVmi.GetObjectKind() &&
@@ -425,19 +423,19 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:617][rfe_id:609] should create and delete preset", func() {
 			By("Creating preset")
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background()).Error()
+			err := f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that preset was created")
-			newPreset, err := getPreset(virtClient, presetNamePrefix)
+			newPreset, err := getPreset(f.KubevirtClient, presetNamePrefix)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Deleting preset")
-			err = virtClient.RestClient().Delete().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name(newPreset.GetName()).Do(context.Background()).Error()
+			err = f.KubevirtClient.RestClient().Delete().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name(newPreset.GetName()).Do(context.Background()).Error()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking preset was deleted")
-			waitForPresetDeletion(virtClient, newPreset.GetName())
+			waitForPresetDeletion(f.KubevirtClient, newPreset.GetName())
 		})
 	})
 
@@ -484,18 +482,18 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:726] Should match multiple VMs via MatchExpression", func() {
 			By("Creating preset with MatchExpression")
-			_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
+			_, err := f.KubevirtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
 			By("Creating first VirtualMachineInstance")
-			newVmi7, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
+			newVmi7, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Creating second VirtualMachineInstance")
-			newVmi10, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
+			newVmi10, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that preset matched bot VMs")
@@ -546,18 +544,18 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		It("[test_id:672] Should match multiple VMs via MatchLabel", func() {
 			By("Creating preset with MatchExpression")
-			_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
+			_, err := f.KubevirtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Give virt-api's cache time to sync before proceeding
 			time.Sleep(3 * time.Second)
 
 			By("Creating first VirtualMachineInstance")
-			newVmi7, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
+			newVmi7, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Creating second VirtualMachineInstance")
-			newVmi10, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
+			newVmi10, err := f.KubevirtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that preset matched the first VMI")

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -29,6 +29,8 @@ import (
 	"os"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	"github.com/mitchellh/go-vnc"
 
 	"kubevirt.io/kubevirt/tests/util"
@@ -49,17 +51,13 @@ import (
 var _ = Describe("[Serial][rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VNC", func() {
 
 	var err error
-	var virtClient kubecli.KubevirtClient
+	f := framework.NewDefaultFramework("vnc test")
 	var vmi *v1.VirtualMachineInstance
 
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		tests.BeforeAll(func() {
-			virtClient, err = kubecli.GetKubevirtClient()
-			util.PanicOnError(err)
-
-			tests.BeforeTestCleanup()
 			vmi = tests.NewRandomVMI()
-			Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()).To(Succeed())
+			Expect(f.KubevirtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()).To(Succeed())
 			tests.WaitForSuccessfulVMIStart(vmi)
 		})
 
@@ -76,7 +74,7 @@ var _ = Describe("[Serial][rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.
 
 				go func() {
 					defer GinkgoRecover()
-					vnc, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
+					vnc, err := f.KubevirtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
 					if err != nil {
 						k8ResChan <- err
 						return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr add a Framework that supports common operations used by e2e tests; it will keep a client & clean the cluster for you. It is not necessary anymore to clean the cluster on `BeforeEach` of all tests if you use the framework because it cleans it for you. It contains a call to `tests.BeforeTestCleanup()` on its `BeforeEach()`. It also initializes a virtClient that can be used everywhere: in this way you have not to retrieve the virtClient because it creates one for you, you can simply use it.
Looking at the tests files there where different cases where`tests.BeforeTestCleanup()` was defined inside `BeforeEach()` of the outer `Describe` block and also in the inner ones(`Context, It, Describe`..). Since `BeforeEach()` is executed for each specs it causes a multiple calls to `tests.BeforeTestCleanup()` function.
In other cases, it was not defined in any of the `BeforeEach()` causing a possible dependency between tests.
Defining a new framework inside the outer `Describe` block has the following advantages:
1. Make sure that each test will run in a cleaned cluster
2. Provides to you a virtClient that can be used without the necessity of retrieving ones
3. Gives the possibility to write a `BeforeEach()` that is specific for that set of tests

Since it cleans the cluster before each test this ensures that every test runs in the same cluster conditions.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Framework to support common operations used by functional tests
```
