### PR TITLE
Garbage collect finalized Migration objects

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1936,6 +1936,53 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
+			It("old finalized migrations should get garbage collected", func() {
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+
+				// this annotation causes virt launcher to immediately fail a migration
+				vmi.Annotations = map[string]string{v1.FuncTestForceLauncherMigrationFailureAnnotation: ""}
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				for i := 0; i < 10; i++ {
+					// execute a migration, wait for finalized state
+					By("Starting the Migration")
+					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+					migration.Name = fmt.Sprintf("%s-iter-%d", vmi.Name, i)
+					migrationUID := runMigrationAndExpectFailure(migration, 180)
+
+					// check VMI, confirm migration state
+					confirmVMIPostMigrationFailed(vmi, migrationUID)
+
+					Eventually(func() error {
+						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						pod, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), vmi.Status.MigrationState.TargetPod, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						if pod.Status.Phase == k8sv1.PodFailed || pod.Status.Phase == k8sv1.PodSucceeded {
+							return nil
+						}
+
+						return fmt.Errorf("still waiting on target pod to complete, current phase is %s", pod.Status.Phase)
+					}, 10*time.Second, time.Second).Should(Succeed(), "Target pod should exit quickly after migration fails.")
+				}
+
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).List(&metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				Expect(migrations.Items).To(HaveLen(5))
+
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			})
+
 			It("[test_id:6979]Target pod should exit after failed migration", func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")


### PR DESCRIPTION
related to https://bugzilla.redhat.com/show_bug.cgi?id=2021992

With the addition of the `workload updates` api, VMIs will automatically get migrated after a kubevirt update in order to run on the latest virt-launcher pod.

This automation is eventually consistent, and will continually attempt to migrate VMIs until all "migratable" VMIs are running on new virt-launcher pods. In the even that a VMI continually fails to live migrate, the number of Migration objects will grow indefinitely as the system continually tries to move the VMI. 

To avoid allowing the finalized migrations for a VMI grow indefinitely, this PR garbage collects all but the most recent 5 migration objects. This means we continue to have a buffer of migration objects which we can use to debug issues, while not having an indefinitely large list of migration objects weight down the system.

```release-note
Garbage collect finalized migration objects only leaving the most recent 5 objects 
```
