### PR TITLE
monitor: Don't send SIGTERM to the current process group

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -466,10 +466,14 @@ func main() {
 	}
 
 	finalShutdownCallback := func(pid int) {
-		err := domainManager.KillVMI(vmi)
-		if err != nil {
-			log.Log.Reason(err).Errorf("Unable to stop qemu with libvirt, falling back to SIGTERM")
-			syscall.Kill(pid, syscall.SIGTERM)
+		if err := domainManager.KillVMI(vmi); err != nil {
+			log.Log.Reason(err).Errorf("Unable to stop qemu with libvirt")
+			if pid != 0 {
+				log.Log.Warning("Falling back to SIGTERM")
+				if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+					log.Log.Reason(err).Errorf("Unable to kill PID %d", pid)
+				}
+			}
 		}
 	}
 

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -156,6 +156,7 @@ func (mon *monitor) refresh() {
 		syscall.Kill(1, syscall.SIGCHLD)
 		mon.pid = 0
 		mon.isDone = true
+		return
 	}
 
 	if expired {


### PR DESCRIPTION
The shutdown callback can get pid == 0 if the monitored process is zombie and the grace period has expired:

https://github.com/kubevirt/kubevirt/blob/c793106e6eefeee585fc8f22c89ee7bb78427e2b/pkg/virt-launcher/monitor.go#L154-L164

During test run, sending SIGTERM to PID 0 (i.e. to the current process group) will interrupt the execution with an error:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6958/pull-kubevirt-unit-test/1488030763378020352

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This should fix the problem with monitor tests:
```
Received interrupt.  Emitting contents of GinkgoWriter...
230
---------------------------------------------------------
231
{"component":"","level":"info","msg":"Found PID for 7fcd88f2-37cc-4bc4-bc4f-71d044c8dc49: 33","pos":"monitor.go:139","timestamp":"2022-01-26T22:13:27.357014Z"}
232
{"component":"","level":"info","msg":"Monitoring loop: rate 1s start timeout 1s","pos":"monitor.go:177","timestamp":"2022-01-26T22:13:27.357224Z"}
233
{"component":"","level":"info","msg":"Grace Period expired, shutting down.","pos":"monitor.go:162","timestamp":"2022-01-26T22:13:58.357930Z"}
234
{"component":"","level":"info","msg":"Process 7fcd88f2-37cc-4bc4-bc4f-71d044c8dc49 and pid 33 is a zombie, sending SIGCHLD to pid 1 to reap process","pos":"monitor.go:155","timestamp":"2022-01-26T22:13:59.360425Z"}
235
{"component":"","level":"info","msg":"Grace Period expired, shutting down.","pos":"monitor.go:162","timestamp":"2022-01-26T22:13:59.360503Z"}
236
237
JUnit report was created: /tmp/cache/bazel/18316b1300bb8985bc913139d5cc6323/sandbox/linux-sandbox/4130/execroot/kubevirt/bazel-out/k8-fastbuild/testlogs/pkg/virt-launcher/go_default_test/test.xml
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6684

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
