### PR TITLE
fix flaky tests ID 4747

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1748,15 +1748,9 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			})
 
 			It("[QUARANTINE][test_id:4747] should migrate using cluster level config for postcopy", func() {
-				config := getCurrentKv()
-				config.MigrationConfiguration.AllowPostCopy = pointer.BoolPtr(true)
-				config.MigrationConfiguration.CompletionTimeoutPerGiB = pointer.Int64Ptr(1)
-				bandwidth := resource.MustParse("256Mi")
-				config.MigrationConfiguration.BandwidthPerMigration = &bandwidth
-				tests.UpdateKubeVirtConfigValueAndWait(config)
-
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequestSize
+				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix tests ID 4747
remove redundant configuration of kubevirt CR
update vm specification

Failure logs:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6425/pull-kubevirt-e2e-k8s-1.21-sig-compute/1443322259866390528
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6182/pull-kubevirt-e2e-k8s-1.19-sig-compute/1443032079519453184
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6329/pull-kubevirt-e2e-k8s-1.20-sig-compute/1442391933665153024
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.21-sig-compute/1441523049454112768
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-compute/1443299699560812544
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-compute/1442575001399070720

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
