### PR TITLE
Support single stack IPv6

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -55,7 +55,7 @@ function functest() {
 	    -conn-check-dns=${conn_check_dns} \
 	    -migration-network-nic=${migration_network_nic} \
 	    ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
-    if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|k8s-sriov.* ]]; then
+    if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|(k8s-sriov)|(ipv6).* ]]; then
         echo "Will skip test asserting the cluster is in dual-stack mode."
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -223,15 +223,26 @@ func (_mr *_MockNetworkHandlerRecorder) HasNatIptables(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasNatIptables", arg0)
 }
 
-func (_m *MockNetworkHandler) IsIpv6Enabled(interfaceName string) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsIpv6Enabled", interfaceName)
+func (_m *MockNetworkHandler) HasIPv4GlobalUnicastAddress(interfaceName string) (bool, error) {
+	ret := _m.ctrl.Call(_m, "HasIPv4GlobalUnicastAddress", interfaceName)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled", arg0)
+func (_mr *_MockNetworkHandlerRecorder) HasIPv4GlobalUnicastAddress(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasIPv4GlobalUnicastAddress", arg0)
+}
+
+func (_m *MockNetworkHandler) HasIPv6GlobalUnicastAddress(interfaceName string) (bool, error) {
+	ret := _m.ctrl.Call(_m, "HasIPv6GlobalUnicastAddress", interfaceName)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockNetworkHandlerRecorder) HasIPv6GlobalUnicastAddress(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasIPv6GlobalUnicastAddress", arg0)
 }
 
 func (_m *MockNetworkHandler) IsIpv4Primary() (bool, error) {

--- a/tests/console/BUILD.bazel
+++ b/tests/console/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -867,9 +867,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 
 		table.DescribeTable("should throttle the Prometheus metrics access", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -915,9 +913,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -933,9 +929,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -973,9 +967,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1001,9 +993,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1040,9 +1030,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1061,9 +1049,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(controllerMetricIPs, family)
 
@@ -1081,9 +1067,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		table.DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1106,9 +1090,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
 		table.DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
-			if family == k8sv1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
-			}
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cloudinit.go",
-        "cluster.go",
         "dns.go",
         "expose_util.go",
         "ipaddress.go",
@@ -24,6 +23,7 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/cleanup:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/libnet/cluster/BUILD.bazel
+++ b/tests/libnet/cluster/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cluster.go"],
+    importpath = "kubevirt.io/kubevirt/tests/libnet/cluster",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/flags:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
+)

--- a/tests/libnet/ipaddress.go
+++ b/tests/libnet/ipaddress.go
@@ -1,6 +1,9 @@
 package libnet
 
 import (
+	"fmt"
+	"net"
+
 	k8sv1 "k8s.io/api/core/v1"
 	netutils "k8s.io/utils/net"
 
@@ -33,4 +36,20 @@ func getFamily(ip string) k8sv1.IPFamily {
 		return k8sv1.IPv6Protocol
 	}
 	return k8sv1.IPv4Protocol
+}
+
+func GetLoopbackAddress(family k8sv1.IPFamily) string {
+	if family == k8sv1.IPv4Protocol {
+		return "127.0.0.1"
+
+	}
+	return net.IPv6loopback.String()
+}
+
+func GetLoopbackAddressForUrl(family k8sv1.IPFamily) string {
+	address := GetLoopbackAddress(family)
+	if family == k8sv1.IPv6Protocol {
+		address = fmt.Sprintf("[%s]", address)
+	}
+	return address
 }

--- a/tests/libnet/ipv6.go
+++ b/tests/libnet/ipv6.go
@@ -26,12 +26,12 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
 		panic(err)
 	}
 
-	isClusterDualStack, err := IsClusterDualStack(virtClient)
+	clusterSupportsIpv6, err := ClusterSupportsIpv6(virtClient)
 	if err != nil {
 		return err
 	}
 
-	if !isClusterDualStack ||
+	if !clusterSupportsIpv6 ||
 		(vmi.Spec.Domain.Devices.Interfaces == nil || len(vmi.Spec.Domain.Devices.Interfaces) == 0 || vmi.Spec.Domain.Devices.Interfaces[0].InterfaceBindingMethod.Masquerade == nil) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface != nil && !*vmi.Spec.Domain.Devices.AutoattachPodInterface) ||
 		(!hasEth0Iface() || hasGlobalIPv6()) {

--- a/tests/libnet/ipv6.go
+++ b/tests/libnet/ipv6.go
@@ -3,6 +3,8 @@ package libnet
 import (
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -26,7 +28,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
 		panic(err)
 	}
 
-	clusterSupportsIpv6, err := ClusterSupportsIpv6(virtClient)
+	clusterSupportsIpv6, err := cluster.SupportsIpv6(virtClient)
 	if err != nil {
 		return err
 	}

--- a/tests/libnet/skips.go
+++ b/tests/libnet/skips.go
@@ -5,11 +5,13 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
+
 	"kubevirt.io/client-go/kubecli"
 )
 
 func SkipWhenNotDualStackCluster(virtClient kubecli.KubevirtClient) {
-	isClusterDualStack, err := IsClusterDualStack(virtClient)
+	isClusterDualStack, err := cluster.DualStack(virtClient)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
 	if !isClusterDualStack {
 		Skip("This test requires a dual stack network config.")
@@ -17,7 +19,7 @@ func SkipWhenNotDualStackCluster(virtClient kubecli.KubevirtClient) {
 }
 
 func SkipWhenClusterNotSupportIpv4(virtClient kubecli.KubevirtClient) {
-	clusterSupportsIpv4, err := ClusterSupportsIpv4(virtClient)
+	clusterSupportsIpv4, err := cluster.SupportsIpv4(virtClient)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv4")
 	if !clusterSupportsIpv4 {
 		Skip("This test requires an ipv4 network config.")
@@ -25,7 +27,7 @@ func SkipWhenClusterNotSupportIpv4(virtClient kubecli.KubevirtClient) {
 }
 
 func SkipWhenClusterNotSupportIpv6(virtClient kubecli.KubevirtClient) {
-	clusterSupportsIpv6, err := ClusterSupportsIpv6(virtClient)
+	clusterSupportsIpv6, err := cluster.SupportsIpv6(virtClient)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv6")
 	if !clusterSupportsIpv6 {
 		Skip("This test requires an ipv6 network config.")

--- a/tests/libnet/skips.go
+++ b/tests/libnet/skips.go
@@ -3,6 +3,7 @@ package libnet
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
 )
@@ -12,5 +13,29 @@ func SkipWhenNotDualStackCluster(virtClient kubecli.KubevirtClient) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
 	if !isClusterDualStack {
 		Skip("This test requires a dual stack network config.")
+	}
+}
+
+func SkipWhenClusterNotSupportIpv4(virtClient kubecli.KubevirtClient) {
+	clusterSupportsIpv4, err := ClusterSupportsIpv4(virtClient)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv4")
+	if !clusterSupportsIpv4 {
+		Skip("This test requires an ipv4 network config.")
+	}
+}
+
+func SkipWhenClusterNotSupportIpv6(virtClient kubecli.KubevirtClient) {
+	clusterSupportsIpv6, err := ClusterSupportsIpv6(virtClient)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv6")
+	if !clusterSupportsIpv6 {
+		Skip("This test requires an ipv6 network config.")
+	}
+}
+
+func SkipWhenClusterNotSupportIpFamily(virtClient kubecli.KubevirtClient, ipFamily k8sv1.IPFamily) {
+	if ipFamily == k8sv1.IPv4Protocol {
+		SkipWhenClusterNotSupportIpv4(virtClient)
+	} else {
+		SkipWhenClusterNotSupportIpv6(virtClient)
 	}
 }

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/libnet:go_default_library",
+        "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/service:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/util:go_default_library",

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -4,9 +4,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
+
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 var _ = SIGDescribe("Dual stack cluster network configuration", func() {
@@ -24,7 +25,7 @@ var _ = SIGDescribe("Dual stack cluster network configuration", func() {
 				Skip("user requested the dual stack check on the live cluster to be skipped")
 			}
 
-			isClusterDualStack, err := libnet.IsClusterDualStack(virtClient)
+			isClusterDualStack, err := cluster.DualStack(virtClient)
 			Expect(err).NotTo(HaveOccurred(), "must be able to infer the dual stack configuration from the live cluster")
 			Expect(isClusterDualStack).To(BeTrue(), "the live cluster should be in dual stack mode")
 		})

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libnet/cluster"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -325,7 +326,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					case k8sv1.IPFamilyPolicySingleStack:
 						return 1
 					case k8sv1.IPFamilyPolicyPreferDualStack:
-						isClusterDualStack, err := libnet.IsClusterDualStack(virtClient)
+						isClusterDualStack, err := cluster.DualStack(virtClient)
 						ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
 						if isClusterDualStack {
 							return 2

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -90,6 +90,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					}
 				)
 				BeforeEach(func() {
+					libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 					var err error
 
 					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName))

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -69,8 +69,8 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		guestAgentPingProbe := createGuestAgentPingProbe(period, initialSeconds)
 
 		table.DescribeTable("should succeed", func(readinessProbe *v1.Probe, ipFamily corev1.IPFamily, isExecProbe bool, disableEnableCycle bool) {
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
 			if ipFamily == corev1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
 				By("Create a support pod which will reply to kubelet's probes ...")
 				probeBackendPod, supportPodCleanupFunc := buildProbeBackendPodSpec(readinessProbe)
 				defer func() {
@@ -163,9 +163,8 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		httpProbe := createHTTPProbe(period, initialSeconds, port)
 
 		table.DescribeTable("should not fail the VMI", func(livenessProbe *v1.Probe, ipFamily corev1.IPFamily, isExecProbe bool) {
-
+			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
 			if ipFamily == corev1.IPv6Protocol {
-				libnet.SkipWhenNotDualStackCluster(virtClient)
 
 				By("Create a support pod which will reply to kubelet's probes ...")
 				probeBackendPod, supportPodCleanupFunc := buildProbeBackendPodSpec(livenessProbe)

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -149,6 +149,7 @@ var _ = SIGDescribe("Services", func() {
 		}
 
 		BeforeEach(func() {
+			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 			subdomain := "vmi"
 			hostname := "inbound"
 
@@ -273,9 +274,8 @@ var _ = SIGDescribe("Services", func() {
 			table.DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
 				By("setting up resources to expose the VMI via a service", func() {
+					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
 					if ipFamily == k8sv1.IPv6Protocol {
-						libnet.SkipWhenNotDualStackCluster(virtClient)
-
 						serviceName = serviceName + "v6"
 						service = netservice.BuildIPv6Spec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
 					} else {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	k8sv1 "k8s.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/tests/framework/checks"
 
 	expect "github.com/google/goexpect"
@@ -101,7 +103,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 			By("Getting back the VMI IP")
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			vmiIP := vmi.Status.Interfaces[0].IP
+			vmiIP := libnet.GetVmiPrimaryIpByFamily(vmi, k8sv1.IPv4Protocol)
 
 			By("Running job to send a request to the server")
 			return virtClient.BatchV1().Jobs(util.NamespaceTestDefault).Create(
@@ -115,6 +117,8 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 
 			virtClient, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
+
+			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 
 			By("Create NetworkAttachmentDefinition")
 			nad := generateIstioCNINetworkAttachmentDefinition()
@@ -219,7 +223,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					By("Getting the VMI IP")
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
-					vmiIP := vmi.Status.Interfaces[0].IP
+					vmiIP := libnet.GetVmiPrimaryIpByFamily(vmi, k8sv1.IPv4Protocol)
 
 					Expect(
 						checkSSHConnection(bastionVMI, "fedora", vmiIP),
@@ -234,7 +238,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					By("Getting the VMI IP")
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
-					vmiIP := vmi.Status.Interfaces[0].IP
+					vmiIP := libnet.GetVmiPrimaryIpByFamily(vmi, k8sv1.IPv4Protocol)
 
 					Expect(
 						checkSSHConnection(bastionVMI, "fedora", vmiIP),

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -57,6 +57,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 	Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
 		Context("when virt-handler is responsive", func() {
 			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				bridgeVMI := vmi
 				// Remove the masquerade interface to use the default bridge one
 				bridgeVMI.Spec.Domain.Devices.Interfaces = nil
@@ -93,6 +94,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 			})
 
 			It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				bridgeVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				// Remove the masquerade interface to use the default bridge one
 				bridgeVMI.Spec.Domain.Devices.Interfaces = nil

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 var _ = SIGDescribe("Slirp Networking", func() {
@@ -74,6 +75,8 @@ var _ = SIGDescribe("Slirp Networking", func() {
 
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
+
+		libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 
 		kv := util.GetCurrentKv(virtClient)
 		currentConfiguration = kv.Spec.Configuration

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -55,6 +55,9 @@ var _ = SIGDescribe("Subdomain", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
 
+		// Should be skipped as long as masquerade binding doesn't have dhcpv6 + ra (issue- https://github.com/kubevirt/kubevirt/issues/7184)
+		libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -253,9 +253,7 @@ var _ = SIGDescribe("Storage", func() {
 					}
 				})
 				table.DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily, imageOwnedByQEMU bool) {
-					if family == k8sv1.IPv6Protocol {
-						libnet.SkipWhenNotDualStackCluster(virtClient)
-					}
+					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
 					var nodeName string
 					// Start the VirtualMachineInstance with the PVC attached
@@ -550,9 +548,8 @@ var _ = SIGDescribe("Storage", func() {
 
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
 				table.DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily) {
-					if family == k8sv1.IPv6Protocol {
-						libnet.SkipWhenNotDualStackCluster(virtClient)
-					}
+					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {
 						nfsPod = storageframework.InitNFS(tests.HostPathAlpine, "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add masquerade VMs support to single stack IPv6.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Follow ups**
* Using alpine instead of cirros - more details in `tests, single stack ipv6: increase login timeout to cirros` commit message.
* Add support to VM port forwarding over IPv6 - https://github.com/kubevirt/kubevirt/issues/7276.

This is a part of #6732.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add masquerade VMs support to single stack IPv6.
```
