### PR TITLE
[builder]: embed the asciidoctor utility into the builder container

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -35,11 +35,15 @@ RUN dnf install -y dnf-plugins-core && \
         redhat-rpm-config \
         jq \
         wget \
+        rubygems \
         diffutils && \
     dnf -y clean all
 
 # Avoids the need to install sssd-client by disabling lookups
 COPY nsswitch.conf /etc/nsswitch.conf
+
+# Necessary for generation of HTML-formatted API docs (.adoc)
+RUN gem install asciidoctor
 
 # Necessary for Bazel to find Python inside the container
 #

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2112231627-152540e23"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2202010936-905b3aae5"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/gen-swagger-doc/build.gradle
+++ b/hack/gen-swagger-doc/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 
     dependencies {
         classpath "io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.3"
-        classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.6"
     }
 }
 
@@ -23,15 +22,3 @@ convertSwagger2markup {
     ]
 }
 
-apply plugin: 'org.asciidoctor.convert'
-
-asciidoctor {
-  sourceDir = file('./')
-  sources {
-    // paths.adoc is being renamed to operations.adoc by gen-swagger-docs.sh.
-    // Keeping it here in case somebody run: gradle convertSwagger2markup asciidoctor
-    include 'definitions.adoc', 'overview.adoc', 'paths.adoc',  'security.adoc', 'operations.adoc'
-  }
-  outputDir = file('./')
-  attributes 'toc' : 'right'
-}

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -84,7 +84,16 @@ if [ "$OUTPUT_FORMAT" = "html" ]; then
         "$WORKDIR/overview.adoc"
 
     # Generate *.html files from *.adoc
-    gradle -b $GRADLE_BUILD_FILE asciidoctor --info
+    rm -rf "$WORKDIR/html5" && mkdir -p "$WORKDIR/html5"
+    adoc_files=("definitions.adoc" "overview.adoc" "security.adoc" "operations.adoc")
+    for html_file in ${adoc_files[@]}; do
+        asciidoctor \
+            --failure-level INFO \
+            --attribute toc=right \
+            --destination-dir $WORKDIR/html5 \
+            $PWD/$WORKDIR/$html_file
+    done
+
     rm -rf "$WORKDIR/html5/content" && mkdir "$WORKDIR/html5/content" && mv -f "$WORKDIR/html5/"*.html "$WORKDIR/html5/content"
     mv -f "$WORKDIR/html5/content/overview.html" "$WORKDIR/html5/content/index.html"
 elif [ "$OUTPUT_FORMAT" = "markdown" ]; then


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
In the current situation the asciidcotor tool is being used from inside
gradle, as a plugin. The repo of the plugin will go down soon.
Therefore we do the transition to call this tool directly from the builder
container. This will also reduce the dependency in a third party repo.


**Special notes for your reviewer**:
- I will hold the PR since these changes require a new builder to be published.
- The other Gradle plugin can also be probably used locally from inside the container,
I've decided to defer the work to a follow up PR.


**Release note**:
```release-note
NONE
```
