### PR TITLE
tests: Relocate migration network test

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -43,7 +43,6 @@ elif [[ $TARGET =~ sig-network ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-network/}
   export KUBEVIRT_DEPLOY_ISTIO=true
   export KUBEVIRT_DEPLOY_CDI=false
-  export KUBEVIRT_NUM_SECONDARY_NICS=1
   if [[ $TARGET =~ k8s-1\.1.* ]]; then
     export KUBEVIRT_DEPLOY_ISTIO=false
   fi
@@ -56,6 +55,8 @@ elif [[ $TARGET =~ sig-compute-realtime ]]; then
   export KUBEVIRT_REALTIME_SCHEDULER=true
 elif [[ $TARGET =~ sig-compute-migrations ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-migrations/}
+  export KUBEVIRT_WITH_CNAO=true
+  export KUBEVIRT_NUM_SECONDARY_NICS=1
 elif [[ $TARGET =~ sig-compute ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
 elif [[ $TARGET =~ sig-operator ]]; then

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3818,6 +3818,53 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("[Serial]with a dedicated migration network", func() {
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating the Network Attachment Definition")
+			nad := tests.GenerateMigrationCNINetworkAttachmentDefinition()
+			_, err = virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(flags.KubeVirtInstallNamespace).Create(context.TODO(), nad, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create the Network Attachment Definition")
+
+			By("Setting it as the migration network in the KubeVirt CR")
+			tests.SetDedicatedMigrationNetwork(nad.Name)
+		})
+		AfterEach(func() {
+			By("Clearing the migration network in the KubeVirt CR")
+			tests.ClearDedicatedMigrationNetwork()
+
+			By("Deleting the Network Attachment Definition")
+			nad := tests.GenerateMigrationCNINetworkAttachmentDefinition()
+			err = virtClient.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(flags.KubeVirtInstallNamespace).Delete(context.TODO(), nad.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to delete the Network Attachment Definition")
+		})
+		It("Should migrate over that network", func() {
+			vmi := libvmi.NewCirros(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Starting the migration")
+			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+
+			By("Checking if the migration happened, and over the right network")
+			vmi = tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+			Expect(vmi.Status.MigrationState.TargetNodeAddress).To(HavePrefix("172.21.42."), "The migration did not appear to go over the dedicated migration network")
+
+			// delete VMI
+			By("Deleting the VMI")
+			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed(), "Failed to delete the VMI")
+
+			By("Waiting for VMI to disappear")
+			tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+		})
+	})
 })
 
 func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the migration network test from the network tests to the migration
tests.

The migration network option is maintained and focus on the compute area
and less in the network domain. In other words, it does not test network
components, but the migration ability to use a secondary network.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
