### PR TITLE
tests: Quarantine the migration network test

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -914,7 +914,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			)
 		})
 
-		Context("[Serial]with a dedicated migration network", func() {
+		Context("[Serial][QUARANTINE]with a dedicated migration network", func() {
 			BeforeEach(func() {
 				virtClient, err = kubecli.GetKubevirtClient()
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

The test is unstable and failing multiple times in the last two weeks.

The search can be found [here](https://search.ci.kubevirt.io/?search=with+a+dedicated+migration+network&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job&wrap=on).
Attached is also the [current report](https://github.com/kubevirt/kubevirt/files/7985088/ci-migration-network-is-flaky-last14d.pdf).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

