### PR TITLE
[release-0.49] make sure to watch/trigger reconcile for DataVolumes not owned by VM

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -32,7 +32,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -343,26 +342,56 @@ func (f *kubeInformerFactory) Namespace() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "namespaces", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(
 			lw,
-			&corev1.Namespace{},
+			&k8sv1.Namespace{},
 			f.defaultResync,
 			cache.Indexers{
 				"namespace_name": func(obj interface{}) ([]string, error) {
-					return []string{obj.(*corev1.Namespace).GetName()}, nil
+					return []string{obj.(*k8sv1.Namespace).GetName()}, nil
 				},
 			},
 		)
 	})
 }
 
+func GetVMIInformerIndexers() cache.Indexers {
+	return cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		"node": func(obj interface{}) (strings []string, e error) {
+			return []string{obj.(*kubev1.VirtualMachineInstance).Status.NodeName}, nil
+		},
+		"dv": func(obj interface{}) ([]string, error) {
+			vmi, ok := obj.(*kubev1.VirtualMachineInstance)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+			var dvs []string
+			for _, vol := range vmi.Spec.Volumes {
+				if vol.DataVolume != nil {
+					dvs = append(dvs, fmt.Sprintf("%s/%s", vmi.Namespace, vol.DataVolume.Name))
+				}
+			}
+			return dvs, nil
+		},
+		"pvc": func(obj interface{}) ([]string, error) {
+			vmi, ok := obj.(*kubev1.VirtualMachineInstance)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+			var pvcs []string
+			for _, vol := range vmi.Spec.Volumes {
+				if vol.PersistentVolumeClaim != nil {
+					pvcs = append(pvcs, fmt.Sprintf("%s/%s", vmi.Namespace, vol.PersistentVolumeClaim.ClaimName))
+				}
+			}
+			return pvcs, nil
+		},
+	}
+}
+
 func (f *kubeInformerFactory) VMI() cache.SharedIndexInformer {
 	return f.getInformer("vmiInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.restClient, "virtualmachineinstances", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineInstance{}, f.defaultResync, cache.Indexers{
-			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-			"node": func(obj interface{}) (strings []string, e error) {
-				return []string{obj.(*kubev1.VirtualMachineInstance).Status.NodeName}, nil
-			},
-		})
+		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineInstance{}, f.defaultResync, GetVMIInformerIndexers())
 	})
 }
 
@@ -448,77 +477,121 @@ func (f *kubeInformerFactory) KubeVirtNode() cache.SharedIndexInformer {
 	})
 }
 
+func GetVirtualMachineInformerIndexers() cache.Indexers {
+	return cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		"dv": func(obj interface{}) ([]string, error) {
+			vm, ok := obj.(*kubev1.VirtualMachine)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+			var dvs []string
+			for _, vol := range vm.Spec.Template.Spec.Volumes {
+				if vol.DataVolume != nil {
+					dvs = append(dvs, fmt.Sprintf("%s/%s", vm.Namespace, vol.DataVolume.Name))
+				}
+			}
+			return dvs, nil
+		},
+		"pvc": func(obj interface{}) ([]string, error) {
+			vm, ok := obj.(*kubev1.VirtualMachine)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+			var pvcs []string
+			for _, vol := range vm.Spec.Template.Spec.Volumes {
+				if vol.PersistentVolumeClaim != nil {
+					pvcs = append(pvcs, fmt.Sprintf("%s/%s", vm.Namespace, vol.PersistentVolumeClaim.ClaimName))
+				}
+			}
+			return pvcs, nil
+		},
+	}
+}
+
 func (f *kubeInformerFactory) VirtualMachine() cache.SharedIndexInformer {
 	return f.getInformer("vmInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.restClient, "virtualmachines", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachine{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachine{}, f.defaultResync, GetVirtualMachineInformerIndexers())
 	})
+}
+
+func GetVirtualMachineSnapshotInformerIndexers() cache.Indexers {
+	return cache.Indexers{
+		"vm": func(obj interface{}) ([]string, error) {
+			vms, ok := obj.(*snapshotv1.VirtualMachineSnapshot)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			if vms.Spec.Source.APIGroup != nil &&
+				*vms.Spec.Source.APIGroup == core.GroupName &&
+				vms.Spec.Source.Kind == "VirtualMachine" {
+				return []string{fmt.Sprintf("%s/%s", vms.Namespace, vms.Spec.Source.Name)}, nil
+			}
+
+			return nil, nil
+		},
+	}
 }
 
 func (f *kubeInformerFactory) VirtualMachineSnapshot() cache.SharedIndexInformer {
 	return f.getInformer("vmSnapshotInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().SnapshotV1alpha1().RESTClient(), "virtualmachinesnapshots", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &snapshotv1.VirtualMachineSnapshot{}, f.defaultResync, cache.Indexers{
-			"vm": func(obj interface{}) ([]string, error) {
-				vms, ok := obj.(*snapshotv1.VirtualMachineSnapshot)
-				if !ok {
-					return nil, unexpectedObjectError
-				}
-
-				if vms.Spec.Source.APIGroup != nil &&
-					*vms.Spec.Source.APIGroup == core.GroupName &&
-					vms.Spec.Source.Kind == "VirtualMachine" {
-					return []string{fmt.Sprintf("%s/%s", vms.Namespace, vms.Spec.Source.Name)}, nil
-				}
-
-				return nil, nil
-			},
-		})
+		return cache.NewSharedIndexInformer(lw, &snapshotv1.VirtualMachineSnapshot{}, f.defaultResync, GetVirtualMachineSnapshotInformerIndexers())
 	})
+}
+
+func GetVirtualMachineSnapshotContentInformerIndexers() cache.Indexers {
+	return cache.Indexers{
+		"volumeSnapshot": func(obj interface{}) ([]string, error) {
+			vmsc, ok := obj.(*snapshotv1.VirtualMachineSnapshotContent)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+			var volumeSnapshots []string
+			for _, v := range vmsc.Spec.VolumeBackups {
+				if v.VolumeSnapshotName != nil {
+					k := fmt.Sprintf("%s/%s", vmsc.Namespace, *v.VolumeSnapshotName)
+					volumeSnapshots = append(volumeSnapshots, k)
+				}
+			}
+			return volumeSnapshots, nil
+		},
+	}
 }
 
 func (f *kubeInformerFactory) VirtualMachineSnapshotContent() cache.SharedIndexInformer {
 	return f.getInformer("vmSnapshotContentInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().SnapshotV1alpha1().RESTClient(), "virtualmachinesnapshotcontents", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &snapshotv1.VirtualMachineSnapshotContent{}, f.defaultResync, cache.Indexers{
-			"volumeSnapshot": func(obj interface{}) ([]string, error) {
-				vmsc, ok := obj.(*snapshotv1.VirtualMachineSnapshotContent)
-				if !ok {
-					return nil, unexpectedObjectError
-				}
-				var volumeSnapshots []string
-				for _, v := range vmsc.Spec.VolumeBackups {
-					if v.VolumeSnapshotName != nil {
-						k := fmt.Sprintf("%s/%s", vmsc.Namespace, *v.VolumeSnapshotName)
-						volumeSnapshots = append(volumeSnapshots, k)
-					}
-				}
-				return volumeSnapshots, nil
-			},
-		})
+		return cache.NewSharedIndexInformer(lw, &snapshotv1.VirtualMachineSnapshotContent{}, f.defaultResync, GetVirtualMachineSnapshotContentInformerIndexers())
 	})
+}
+
+func GetVirtualMachineRestoreInformerIndexers() cache.Indexers {
+	return cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		"vm": func(obj interface{}) ([]string, error) {
+			vmr, ok := obj.(*snapshotv1.VirtualMachineRestore)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			if vmr.Spec.Target.APIGroup != nil &&
+				*vmr.Spec.Target.APIGroup == core.GroupName &&
+				vmr.Spec.Target.Kind == "VirtualMachine" {
+				return []string{fmt.Sprintf("%s/%s", vmr.Namespace, vmr.Spec.Target.Name)}, nil
+			}
+
+			return nil, nil
+		},
+	}
 }
 
 func (f *kubeInformerFactory) VirtualMachineRestore() cache.SharedIndexInformer {
 	return f.getInformer("vmRestoreInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.GeneratedKubeVirtClient().SnapshotV1alpha1().RESTClient(), "virtualmachinerestores", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &snapshotv1.VirtualMachineRestore{}, f.defaultResync, cache.Indexers{
-			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-			"vm": func(obj interface{}) ([]string, error) {
-				vmr, ok := obj.(*snapshotv1.VirtualMachineRestore)
-				if !ok {
-					return nil, unexpectedObjectError
-				}
-
-				if vmr.Spec.Target.APIGroup != nil &&
-					*vmr.Spec.Target.APIGroup == core.GroupName &&
-					vmr.Spec.Target.Kind == "VirtualMachine" {
-					return []string{fmt.Sprintf("%s/%s", vmr.Namespace, vmr.Spec.Target.Name)}, nil
-				}
-
-				return nil, nil
-			},
-		})
+		return cache.NewSharedIndexInformer(lw, &snapshotv1.VirtualMachineRestore{}, f.defaultResync, GetVirtualMachineRestoreInformerIndexers())
 	})
 }
 
@@ -637,26 +710,30 @@ func (f *kubeInformerFactory) LimitRanges() cache.SharedIndexInformer {
 	})
 }
 
+func GetControllerRevisionInformerIndexers() cache.Indexers {
+	return cache.Indexers{
+		"vm": func(obj interface{}) ([]string, error) {
+			cr, ok := obj.(*appsv1.ControllerRevision)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			for _, ref := range cr.OwnerReferences {
+				if ref.Kind == "VirtualMachine" {
+					return []string{string(ref.UID)}, nil
+				}
+			}
+
+			return nil, nil
+		},
+	}
+}
+
 func (f *kubeInformerFactory) ControllerRevision() cache.SharedIndexInformer {
 	return f.getInformer("controllerRevisionInformer", func() cache.SharedIndexInformer {
 		restClient := f.clientSet.AppsV1().RESTClient()
 		lw := cache.NewListWatchFromClient(restClient, "controllerrevisions", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &appsv1.ControllerRevision{}, f.defaultResync, cache.Indexers{
-			"vm": func(obj interface{}) ([]string, error) {
-				cr, ok := obj.(*appsv1.ControllerRevision)
-				if !ok {
-					return nil, unexpectedObjectError
-				}
-
-				for _, ref := range cr.OwnerReferences {
-					if ref.Kind == "VirtualMachine" {
-						return []string{string(ref.UID)}, nil
-					}
-				}
-
-				return nil, nil
-			},
-		})
+		return cache.NewSharedIndexInformer(lw, &appsv1.ControllerRevision{}, f.defaultResync, GetControllerRevisionInformerIndexers())
 	})
 }
 
@@ -882,7 +959,7 @@ func (f *kubeInformerFactory) Secrets() cache.SharedIndexInformer {
 
 		restClient := f.clientSet.CoreV1().RESTClient()
 		lw := NewListWatchFromClient(restClient, "secrets", f.kubevirtNamespace, fields.Everything(), labelSelector)
-		return cache.NewSharedIndexInformer(lw, &corev1.Secret{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		return cache.NewSharedIndexInformer(lw, &k8sv1.Secret{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-controller/watch/snapshot/BUILD.bazel
+++ b/pkg/virt-controller/watch/snapshot/BUILD.bazel
@@ -48,9 +48,9 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/controller:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util/status:go_default_library",
-        "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -7,8 +7,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/api/core"
-
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,6 +25,7 @@ import (
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/util/status"
 )
@@ -229,17 +228,7 @@ var _ = Describe("Restore controlleer", func() {
 			virtClient := kubecli.NewMockKubevirtClient(ctrl)
 			vmInterface = kubecli.NewMockVirtualMachineInterface(ctrl)
 
-			vmRestoreInformer, vmRestoreSource = testutils.NewFakeInformerWithIndexersFor(&snapshotv1.VirtualMachineRestore{}, cache.Indexers{
-				"vm": func(obj interface{}) ([]string, error) {
-					vmr := obj.(*snapshotv1.VirtualMachineRestore)
-					if vmr.Spec.Target.APIGroup != nil &&
-						*vmr.Spec.Target.APIGroup == core.GroupName &&
-						vmr.Spec.Target.Kind == "VirtualMachine" {
-						return []string{vmr.Namespace + "/" + vmr.Spec.Target.Name}, nil
-					}
-					return nil, nil
-				},
-			})
+			vmRestoreInformer, vmRestoreSource = testutils.NewFakeInformerWithIndexersFor(&snapshotv1.VirtualMachineRestore{}, virtcontroller.GetVirtualMachineRestoreInformerIndexers())
 			vmSnapshotInformer, vmSnapshotSource = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
 			vmSnapshotContentInformer, vmSnapshotContentSource = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1404,23 +1404,22 @@ func (c *VMController) addDataVolume(obj interface{}) {
 		return
 	}
 	controllerRef := v1.GetControllerOf(dataVolume)
-	if controllerRef == nil {
-		return
+	if controllerRef != nil {
+		log.Log.Object(dataVolume).Info("Looking for DataVolume Ref")
+		vm := c.resolveControllerRef(dataVolume.Namespace, controllerRef)
+		if vm != nil {
+			vmKey, err := controller.KeyFunc(vm)
+			if err != nil {
+				log.Log.Object(dataVolume).Errorf("Cannot parse key of VM: %s for DataVolume: %s", vm.Name, dataVolume.Name)
+			} else {
+				log.Log.Object(dataVolume).Infof("DataVolume created because %s was added.", dataVolume.Name)
+				c.dataVolumeExpectations.CreationObserved(vmKey)
+			}
+		} else {
+			log.Log.Object(dataVolume).Errorf("Cant find the matching VM for DataVolume: %s", dataVolume.Name)
+		}
 	}
-	log.Log.Object(dataVolume).Info("Looking for DataVolume Ref")
-	vm := c.resolveControllerRef(dataVolume.Namespace, controllerRef)
-	if vm == nil {
-		log.Log.Object(dataVolume).Errorf("Cant find the matching VM for DataVolume: %s", dataVolume.Name)
-		return
-	}
-	vmKey, err := controller.KeyFunc(vm)
-	if err != nil {
-		log.Log.Object(dataVolume).Errorf("Cannot parse key of VM: %s for DataVolume: %s", vm.Name, dataVolume.Name)
-		return
-	}
-	log.Log.Object(dataVolume).Infof("DataVolume created because %s was added.", dataVolume.Name)
-	c.dataVolumeExpectations.CreationObserved(vmKey)
-	c.enqueueVm(vm)
+	c.queueVMsForDataVolume(dataVolume)
 }
 func (c *VMController) updateDataVolume(old, cur interface{}) {
 	curDataVolume := cur.(*cdiv1.DataVolume)
@@ -1433,7 +1432,7 @@ func (c *VMController) updateDataVolume(old, cur interface{}) {
 	}
 	labelChanged := !equality.Semantic.DeepEqual(curDataVolume.Labels, oldDataVolume.Labels)
 	if curDataVolume.DeletionTimestamp != nil {
-		// having a DataVOlume marked for deletion is enough
+		// having a DataVolume marked for deletion is enough
 		// to count as a deletion expectation
 		c.deleteDataVolume(curDataVolume)
 		if labelChanged {
@@ -1452,15 +1451,7 @@ func (c *VMController) updateDataVolume(old, cur interface{}) {
 			c.enqueueVm(vm)
 		}
 	}
-	if curControllerRef == nil {
-		return
-	}
-	vm := c.resolveControllerRef(curDataVolume.Namespace, curControllerRef)
-	if vm == nil {
-		return
-	}
-	log.Log.V(4).Object(curDataVolume).Infof("DataVolume updated")
-	c.enqueueVm(vm)
+	c.queueVMsForDataVolume(curDataVolume)
 }
 
 func (c *VMController) deleteDataVolume(obj interface{}) {
@@ -1481,21 +1472,46 @@ func (c *VMController) deleteDataVolume(obj interface{}) {
 			return
 		}
 	}
-	controllerRef := v1.GetControllerOf(dataVolume)
-	if controllerRef == nil {
-		// No controller should care about orphans being deleted.
-		return
+	if controllerRef := v1.GetControllerOf(dataVolume); controllerRef != nil {
+		if vm := c.resolveControllerRef(dataVolume.Namespace, controllerRef); vm != nil {
+			if vmKey, err := controller.KeyFunc(vm); err == nil {
+				c.dataVolumeExpectations.DeletionObserved(vmKey, controller.DataVolumeKey(dataVolume))
+			}
+		}
 	}
-	vm := c.resolveControllerRef(dataVolume.Namespace, controllerRef)
-	if vm == nil {
-		return
+	c.queueVMsForDataVolume(dataVolume)
+}
+
+func (c *VMController) queueVMsForDataVolume(dataVolume *cdiv1.DataVolume) {
+	var vmOwner string
+	if controllerRef := v1.GetControllerOf(dataVolume); controllerRef != nil {
+		if vm := c.resolveControllerRef(dataVolume.Namespace, controllerRef); vm != nil {
+			vmOwner = vm.Name
+			log.Log.V(4).Object(dataVolume).Infof("DataVolume updated for vm %s", vm.Name)
+			c.enqueueVm(vm)
+		}
 	}
-	vmKey, err := controller.KeyFunc(vm)
+	// handle DataVolumes not owned by the VM but referenced in the spec
+	// TODO come back when DV/PVC name may differ
+	k, err := controller.KeyFunc(dataVolume)
 	if err != nil {
+		log.Log.Object(dataVolume).Errorf("Cannot parse key of DataVolume: %s", dataVolume.Name)
 		return
 	}
-	c.dataVolumeExpectations.DeletionObserved(vmKey, controller.DataVolumeKey(dataVolume))
-	c.enqueueVm(vm)
+	for _, indexName := range []string{"dv", "pvc"} {
+		objs, err := c.vmInformer.GetIndexer().ByIndex(indexName, k)
+		if err != nil {
+			log.Log.Object(dataVolume).Errorf("Cannot get index %s of DataVolume: %s", indexName, dataVolume.Name)
+			return
+		}
+		for _, obj := range objs {
+			vm := obj.(*virtv1.VirtualMachine)
+			if vm.Name != vmOwner {
+				log.Log.V(4).Object(dataVolume).Infof("DataVolume updated for vm %s", vm.Name)
+				c.enqueueVm(vm)
+			}
+		}
+	}
 }
 
 func (c *VMController) addVirtualMachine(obj interface{}) {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -24,10 +24,9 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	"kubevirt.io/client-go/api"
-
 	virtv1 "kubevirt.io/api/core/v1"
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
+	"kubevirt.io/client-go/api"
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
@@ -84,8 +83,8 @@ var _ = Describe("VirtualMachine", func() {
 			generatedInterface := fake.NewSimpleClientset()
 
 			dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
-			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
-			vmInformer, vmSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+			vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, virtcontroller.GetVMIInformerIndexers())
+			vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, virtcontroller.GetVirtualMachineInformerIndexers())
 			pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			crInformer, _ = testutils.NewFakeInformerWithIndexersFor(&appsv1.ControllerRevision{}, cache.Indexers{
 				"vm": func(obj interface{}) ([]string, error) {
@@ -633,6 +632,44 @@ var _ = Describe("VirtualMachine", func() {
 			existingDataVolume.Status.Phase = cdiv1.Succeeded
 			addVirtualMachine(vm)
 			dataVolumeFeeder.Add(existingDataVolume)
+			// expect creation called
+			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))
+			}).Return(vmi, nil)
+			// expect update status is called
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*virtv1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*virtv1.VirtualMachine).Status.Ready).To(BeFalse())
+			}).Return(nil, nil)
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+		})
+
+		It("should start VMI once DataVolumes (not templates) are complete", func() {
+
+			vm, vmi := DefaultVirtualMachine(true)
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+				Name: "test1",
+				VolumeSource: virtv1.VolumeSource{
+					DataVolume: &virtv1.DataVolumeSource{
+						Name: "dv1",
+					},
+				},
+			})
+			dvt := &virtv1.DataVolumeTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dv1",
+				},
+			}
+
+			existingDataVolume, _ := createDataVolumeManifest(virtClient, dvt, vm)
+
+			existingDataVolume.OwnerReferences = nil
+			existingDataVolume.Namespace = "default"
+			existingDataVolume.Status.Phase = cdiv1.Succeeded
+			addVirtualMachine(vm)
+			dataVolumeFeeder.Add(existingDataVolume)
+
 			// expect creation called
 			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(arg interface{}) {
 				Expect(arg.(*virtv1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("testvmi"))

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1140,10 +1140,21 @@ func (c *VMIController) updatePVC(old, cur interface{}) {
 		return
 	}
 
-	vmis, err := c.listVMIsMatchingPVC(curPVC.Namespace, curPVC.Name)
-	if err != nil {
-		log.Log.V(4).Object(curPVC).Errorf("Error encountered during pvc update: %v", err)
-		return
+	var err error
+	var vmis []*virtv1.VirtualMachineInstance
+	controllerRef := v1.GetControllerOf(curPVC)
+	if controllerRef != nil && controllerRef.Kind == "DataVolume" {
+		vmis, err = c.listVMIsMatchingDV(curPVC.Namespace, controllerRef.Name)
+		if err != nil {
+			log.Log.V(4).Object(curPVC).Errorf("Error encountered getting VMIs for DataVolume: %v", err)
+			return
+		}
+	} else {
+		vmis, err = c.listVMIsMatchingPVC(curPVC.Namespace, curPVC.Name)
+		if err != nil {
+			log.Log.V(4).Object(curPVC).Errorf("Error encountered getting VMIs for PVC: %v", err)
+			return
+		}
 	}
 	for _, vmi := range vmis {
 		log.Log.V(4).Object(curPVC).Infof("PVC updated for vmi %s", vmi.Name)
@@ -1158,7 +1169,7 @@ func (c *VMIController) addDataVolume(obj interface{}) {
 		return
 	}
 
-	vmis, err := c.listVMIsMatchingPVC(dataVolume.Namespace, dataVolume.Name)
+	vmis, err := c.listVMIsMatchingDV(dataVolume.Namespace, dataVolume.Name)
 	if err != nil {
 		return
 	}
@@ -1189,7 +1200,7 @@ func (c *VMIController) updateDataVolume(old, cur interface{}) {
 		return
 	}
 
-	vmis, err := c.listVMIsMatchingPVC(curDataVolume.Namespace, curDataVolume.Name)
+	vmis, err := c.listVMIsMatchingDV(curDataVolume.Namespace, curDataVolume.Name)
 	if err != nil {
 		log.Log.V(4).Object(curDataVolume).Errorf("Error encountered during datavolume update: %v", err)
 		return
@@ -1217,7 +1228,7 @@ func (c *VMIController) deleteDataVolume(obj interface{}) {
 			return
 		}
 	}
-	vmis, err := c.listVMIsMatchingPVC(dataVolume.Namespace, dataVolume.Name)
+	vmis, err := c.listVMIsMatchingDV(dataVolume.Namespace, dataVolume.Name)
 	if err != nil {
 		return
 	}
@@ -1416,21 +1427,33 @@ func (c *VMIController) resolveControllerRef(namespace string, controllerRef *v1
 	return vmi.(*virtv1.VirtualMachineInstance)
 }
 
+func (c *VMIController) listVMIsMatchingDV(namespace string, dvName string) ([]*virtv1.VirtualMachineInstance, error) {
+	// TODO - refactor if/when dv/pvc do not have the same name
+	vmis, err := c.listVMIsMatchingPVC(namespace, dvName)
+	if err != nil {
+		return nil, err
+	}
+	objs, err := c.vmiInformer.GetIndexer().ByIndex("dv", namespace+"/"+dvName)
+	if err != nil {
+		return nil, err
+	}
+	for _, obj := range objs {
+		vmi := obj.(*virtv1.VirtualMachineInstance)
+		vmis = append(vmis, vmi.DeepCopy())
+	}
+	return vmis, nil
+}
+
 // takes a PVC name and namespace and returns all VMIs from the VMI cache which use this PVC
 func (c *VMIController) listVMIsMatchingPVC(namespace string, pvcName string) ([]*virtv1.VirtualMachineInstance, error) {
-	objs, err := c.vmiInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	objs, err := c.vmiInformer.GetIndexer().ByIndex("pvc", namespace+"/"+pvcName)
 	if err != nil {
 		return nil, err
 	}
 	vmis := []*virtv1.VirtualMachineInstance{}
 	for _, obj := range objs {
 		vmi := obj.(*virtv1.VirtualMachineInstance)
-		for _, volume := range vmi.Spec.Volumes {
-			if volume.VolumeSource.DataVolume != nil && volume.VolumeSource.DataVolume.Name == pvcName ||
-				volume.VolumeSource.PersistentVolumeClaim != nil && volume.VolumeSource.PersistentVolumeClaim.ClaimName == pvcName {
-				vmis = append(vmis, vmi)
-			}
-		}
+		vmis = append(vmis, vmi.DeepCopy())
 	}
 	return vmis, nil
 }

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -45,18 +45,15 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	"kubevirt.io/client-go/api"
-
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-
-	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
-
 	virtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/api"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 )
 
 var _ = Describe("VirtualMachineInstance watcher", func() {
@@ -205,8 +202,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 
-		vmiInformer, vmiSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
-		vmInformer, vmSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+		vmiInformer, vmiSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachineInstance{}, kvcontroller.GetVMIInformerIndexers())
+		vmInformer, vmSource = testutils.NewFakeInformerWithIndexersFor(&virtv1.VirtualMachine{}, kvcontroller.GetVirtualMachineInformerIndexers())
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		recorder = record.NewFakeRecorder(100)

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -306,11 +306,18 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			})
 
 			It("should accurately report DataVolume provisioning", func() {
-				if tests.IsStorageClassBindingModeWaitForFirstConsumer(tests.Config.StorageRWOFileSystem) {
-					Skip("need immediate binding")
+				sc, exists := tests.GetSnapshotStorageClass()
+				if !exists {
+					Skip("no snapshot storage class configured")
 				}
 
-				dataVolume := tests.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume := tests.NewRandomDataVolumeWithRegistryImportInStorageClass(
+					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
+					util.NamespaceTestDefault,
+					sc,
+					k8sv1.ReadWriteOnce,
+					k8sv1.PersistentVolumeFilesystem,
+				)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 				vm := tests.NewRandomVirtualMachine(vmi, false)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/7104

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

https://bugzilla.redhat.com/show_bug.cgi?id=2010908

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
