### PR TITLE
stability_test: simplify

### DIFF
--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -2,33 +2,22 @@ package tests_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/tests/util"
-
-	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
+// Replace PDescribe with FDescribe in order to measure if your changes made
+// VMI startup any worse
 var _ = PDescribe("Ensure stable functionality", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
-
 	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
 		tests.BeforeTestCleanup()
 	})
 
 	Measure("by repeately starting vmis many times without issues", func(b Benchmarker) {
 		b.Time("from_start_to_ready", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
+			tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), 30)
 		})
 	}, 15)
 })


### PR DESCRIPTION
Reusage of existing helper functions makes this file awfully shorter and
clearer.

```release-note
NONE
```
