### PR TITLE
Simplify controller test

### DIFF
--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -13,7 +13,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[sig-compute]Controller devices", func() {
@@ -27,11 +27,9 @@ var _ = Describe("[sig-compute]Controller devices", func() {
 
 	Context("with ephemeral disk", func() {
 		table.DescribeTable("a scsi controller", func(enabled bool) {
-			randomVMI := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			randomVMI.Spec.Domain.Devices.DisableHotplug = !enabled
-			vmi, apiErr := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(randomVMI)
-			Expect(apiErr).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
+			vmi := libvmi.NewCirros()
+			vmi.Spec.Domain.Devices.DisableHotplug = !enabled
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			domSpec := &api.DomainSpec{}

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/tests/util"
@@ -25,8 +24,9 @@ var _ = Describe("[sig-compute]Controller devices", func() {
 		util.PanicOnError(err)
 	})
 
-	Context("with ephemeral disk", func() {
-		table.DescribeTable("a scsi controller", func(enabled bool) {
+	Context("VMI with hotplug disabled", func() {
+		It("should not have an scsi controller", func() {
+			enabled := true
 			vmi := libvmi.NewCirros()
 			vmi.Spec.Domain.Devices.DisableHotplug = !enabled
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
@@ -43,9 +43,6 @@ var _ = Describe("[sig-compute]Controller devices", func() {
 				}
 			}
 			Expect(found).To(Equal(enabled))
-		},
-			table.Entry("should appear if enabled", true),
-			table.Entry("should NOT appear if disabled", false),
-		)
+		})
 	})
 })


### PR DESCRIPTION
Simplify vmi_controller_test by reusing helper functions and dropping a non-required test.

The purpose of vmi.Spec.Domain.Devices.DisableHotplug is to let the VM
owner to express that they do not want hot-pluggability nor the
additional scsi controller that comes with it. There may be a rare VM
owner who cares, so this test is fine.

However, no one cares how hot plug is implemented. No test should fail
if we ever reimplement it without a scsi controller. A kubevirt
functional tests should not look at the libvirt layer unless there is a
very good reason to do so. Our typical user wants to ensure that hotplug
works and does not require seing a scsi controller there.

Am I correct, @awels, or do I miss something ?

```release-note
NONE
```
