### PR TITLE
Add thresholds for some requests counts and phase transitions

### DIFF
--- a/tools/perfscale-audit/api/api.go
+++ b/tools/perfscale-audit/api/api.go
@@ -52,7 +52,9 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 }
 
 type InputThreshold struct {
-	Value float64 `json:"value"`
+	Value  float64    `json:"value"`
+	Metric ResultType `json:"metric,omitempty"`
+	Ratio  float64    `json:"ratio,omitempty"`
 }
 
 type InputConfig struct {
@@ -88,6 +90,12 @@ func (i *InputConfig) GetDuration() time.Duration {
 type ResultType string
 
 const (
+	// rest_client_requests_total
+	ResultTypePatchVMICount   ResultType = "PATCH-virtualmachineinstances-count"
+	ResultTypeUpdateVMICount  ResultType = "UPDATE-virtualmachineinstances-count"
+	ResultTypeCreatePodsCount ResultType = "CREATE-pods-count"
+
+	// kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket
 	ResultTypeVMICreationToRunningP99 ResultType = "vmiCreationToRunningSecondsP99"
 	ResultTypeVMICreationToRunningP95 ResultType = "vmiCreationToRunningSecondsP95"
 	ResultTypeVMICreationToRunningP50 ResultType = "vmiCreationToRunningSecondsP50"
@@ -102,8 +110,10 @@ const (
 )
 
 type ThresholdResult struct {
-	ThresholdValue    float64 `json:"thresholdValue"`
-	ThresholdExceeded bool    `json:"thresholdExceeded"`
+	ThresholdValue    float64    `json:"thresholdValue"`
+	ThresholdMetric   ResultType `json:"thresholdMetric,omitempty"`
+	ThresholdRatio    float64    `json:"thresholdRatio,omitempty"`
+	ThresholdExceeded bool       `json:"thresholdExceeded"`
 }
 
 type ResultValue struct {


### PR DESCRIPTION
Signed-off-by: Ryan Hallisey <rhallisey@nvidia.com>

Add `ratio` and `metric` to the `InputThresold` config.  This will make the audit tool check if the `metric` is within the expected `ratio` of another metric.  For example, we expect there to be less than 2x the number of `PATCH-virtualmachineinstances-count` than the number of `CREATE-pods-count`.

The 100 VMI density test is configured with the following thresholds:
```
{
	"prometheusURL": "http://127.0.0.1:9090",
	"startTime": "$start",
	"endTime": "$end"
	"thresholdExpectations": {
		"PATCH-virtualmachineinstances-count": {
			"ratio": 2,
			"metric": "CREATE-pods-count"
		},
		"UPDATE-virtualmachineinstances-count": {
			"ratio": 10,
			"metric": "CREATE-pods-count"
		},
		"vmiCreationToRunningSecondsP95": {
			"value": 60
		},
		"vmiCreationToRunningSecondsP50": {
			"value": 45
		}
	}
}
```
Example result:
```
{
  "Values": {
    "CREATE-events-count": {
      "value": 46.666666666666664
    },
    "CREATE-pods-count": {
      "value": 12.222222222222223
    },            
.
.
.     
    "LIST-virtualmachinesnapshots-count": {
      "value": 1.1111111111111112
    },
    "PATCH-events-count": {                                                                                                                                                                                                                        "value": 3.3333333333333335
    },
    "PATCH-nodes-count": {
      "value": 2.2222222222222223
    },
    "PATCH-pods-count": {
      "value": 14.444444444444446
    },
    "PATCH-virtualmachineinstances-count": {
      "value": 14.444444444444445,
      "thresholdResult": {
        "thresholdValue": 24.444444444444446,
        "thresholdMetric": "CREATE-pods-count",                                                                                                                                                                                                     
        "thresholdRatio": 1.1818181818181817,                                                                                                                                                                                                       
        "thresholdExceeded": false
      }
    },
    "UPDATE-endpoints-count": {
      "value": 298.8888888888889
    },
    "UPDATE-virtualmachineinstances-count": {
      "value": 113.33333333333333,
      "thresholdResult": {
        "thresholdValue": 122.22222222222223,
        "thresholdMetric": "CREATE-pods-count",
        "thresholdRatio": 9.272727272727272,
        "thresholdExceeded": false
      }
    },
    "running-phase-count": {
      "value": 10
    },
    "vmiCreationToRunningSecondsP50": {
      "value": 21.666666666666668,
      "thresholdResult": {
        "thresholdValue": 45,
        "thresholdExceeded": false
      }
    },
    "vmiCreationToRunningSecondsP95": {
      "value": 29.166666666666664,
      "thresholdResult": {
        "thresholdValue": 60,
        "thresholdExceeded": false
      }
    },
    "vmiCreationToRunningSecondsP99": {
      "value": 29.833333333333332
    }
  }
}
```


**Release note**:
```release-note
NONE
```
