### PR TITLE
console_test: more simplification

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -181,32 +181,6 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
 			})
-
-			It("[test_id:1594]should fail waiting for the expecter", func() {
-				vmi := libvmi.NewAlpine()
-				vmi.Spec.Affinity = &k8sv1.Affinity{
-					NodeAffinity: &k8sv1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
-							NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
-								{
-									MatchExpressions: []k8sv1.NodeSelectorRequirement{
-										{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{"notexist"}},
-									},
-								},
-							},
-						},
-					},
-				}
-
-				By("Creating a new VirtualMachineInstance")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Expecting the VirtualMachineInstance console")
-				_, _, err = console.NewExpecter(virtClient, vmi, 30*time.Second)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
-			})
 		})
 
 		Context("without a serial console", func() {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -51,7 +51,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 		tests.BeforeTestCleanup()
 	})
 
-	ExpectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {
+	expectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {
 		By("Checking that the console output equals to expected one")
 		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
@@ -59,7 +59,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 		}, 120)).To(Succeed())
 	}
 
-	OpenConsole := func(vmi *v1.VirtualMachineInstance) (expect.Expecter, <-chan error) {
+	openConsole := func(vmi *v1.VirtualMachineInstance) (expect.Expecter, <-chan error) {
 		By("Expecting the VirtualMachineInstance console")
 		expecter, errChan, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				It("[test_id:1588]should return that we are running cirros", func() {
 					vmi := libvmi.NewCirros()
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
-					ExpectConsoleOutput(
+					expectConsoleOutput(
 						vmi,
 						"login as 'cirros' user",
 					)
@@ -84,7 +84,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				It("[sig-compute][test_id:1589]should return that we are running fedora", func() {
 					vmi := libvmi.NewFedora()
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
-					ExpectConsoleOutput(
+					expectConsoleOutput(
 						vmi,
 						"Welcome to",
 					)
@@ -107,7 +107,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				table.DescribeTable("should return that we are running alpine", func(createVMI vmiBuilder) {
 					vmi := createVMI()
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
-					ExpectConsoleOutput(vmi, "login")
+					expectConsoleOutput(vmi, "login")
 				},
 					table.Entry("[test_id:4637][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithAlpineFileDisk),
 					table.Entry("[test_id:4638][storage-req]with Block Disk", newVirtualMachineInstanceWithAlpineBlockDisk),
@@ -119,7 +119,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				for i := 0; i < 5; i++ {
-					ExpectConsoleOutput(vmi, "login")
+					expectConsoleOutput(vmi, "login")
 				}
 			})
 
@@ -128,7 +128,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("opening 1st console connection")
-				expecter, errChan := OpenConsole(vmi)
+				expecter, errChan := openConsole(vmi)
 				defer expecter.Close()
 
 				By("expecting error on 1st console connection")
@@ -144,7 +144,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				}()
 
 				By("opening 2nd console connection")
-				ExpectConsoleOutput(vmi, "login")
+				expectConsoleOutput(vmi, "login")
 			}, 220)
 
 			It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", func() {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -153,6 +153,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 
+				By("and connecting to it very quickly. Hopefully the VM is not yet up")
 				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -59,13 +59,6 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 		}, 120)).To(Succeed())
 	}
 
-	openConsole := func(vmi *v1.VirtualMachineInstance) (expect.Expecter, <-chan error) {
-		By("Expecting the VirtualMachineInstance console")
-		expecter, errChan, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		return expecter, errChan
-	}
-
 	Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		Context("with a serial console", func() {
 			Context("with a cirros image", func() {
@@ -128,7 +121,9 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("opening 1st console connection")
-				expecter, errChan := openConsole(vmi)
+				expecter, errChan, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+
 				defer expecter.Close()
 
 				By("expecting error on 1st console connection")


### PR DESCRIPTION
Following PR #7114, here are few more simplifications of console_test.go, which make the code easier to read and quicker to run.

```release-note
NONE
```
