### PR TITLE
[tests] Remove Job Delete Deprecation warnings

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1820,7 +1820,9 @@ func cleanNamespaces() {
 		util2.PanicOnError(err)
 
 		//Remove all Jobs
-		util2.PanicOnError(virtCli.BatchV1().RESTClient().Delete().Namespace(namespace).Resource("jobs").Do(context.Background()).Error())
+		jobDeleteStrategy := metav1.DeletePropagationOrphan
+		jobDeleteOptions := metav1.DeleteOptions{PropagationPolicy: &jobDeleteStrategy}
+		util2.PanicOnError(virtCli.BatchV1().RESTClient().Delete().Namespace(namespace).Resource("jobs").Body(&jobDeleteOptions).Do(context.Background()).Error())
 		//Remove all HPA
 		util2.PanicOnError(virtCli.AutoscalingV1().RESTClient().Delete().Namespace(namespace).Resource("horizontalpodautoscalers").Do(context.Background()).Error())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Get rid of deprecation warnings when we clean up jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
