### PR TITLE
Add Test Client and Framework for e2e tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -216,6 +216,7 @@ go_test(
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/cleanup:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/launchsecurity:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/framework/client/BUILD.bazel
+++ b/tests/framework/client/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "coreClient.go",
+        "migrationPolicyClient.go",
+        "migrationpolicy.go",
+        "namespace.go",
+        "node.go",
+        "persistentvolume.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tests/framework/client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)

--- a/tests/framework/client/client.go
+++ b/tests/framework/client/client.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"sync"
+
+	migrationsv1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1"
+
+	"kubevirt.io/kubevirt/tests/util"
+
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+// TestClient is a wrapped kubevirt client that exposes all client functionality
+// and can be used as a normal client. It provides a mechanism that track
+// non-namespaced resources created or updated during e2e tests and functions to rollback them at the end of the execution.
+type TestClient struct {
+	kubecli.KubevirtClient
+}
+
+type CleanableResource interface {
+	Clean()
+}
+
+var (
+	coreOnce                  sync.Once
+	testCoreV1Client          *TestCoreV1Client
+	migrationOnce             sync.Once
+	testMigrationPolicyClient *TestMigrationPolicyClient
+	resourcesToClean          []CleanableResource
+)
+
+func GetKubevirtClient() (kubecli.KubevirtClient, error) {
+	client, err := kubecli.GetKubevirtClient()
+	testClient := TestClient{
+		client,
+	}
+	return &testClient, err
+}
+
+func (c *TestClient) CoreV1() corev1.CoreV1Interface {
+	config, err := kubecli.GetKubevirtClientConfig()
+	util.PanicOnError(err)
+	coreOnce.Do(func() {
+		testCoreV1Client = CoreNewForConfig(config)
+	})
+	return testCoreV1Client
+}
+
+func (c *TestClient) MigrationPolicy() migrationsv1.MigrationPolicyInterface {
+	config, err := kubecli.GetKubevirtClientConfig()
+	util.PanicOnError(err)
+	migrationOnce.Do(func() {
+		testMigrationPolicyClient = MigrationPolicyNewForConfig(config)
+	})
+
+	return testMigrationPolicyClient.MigrationPolicies()
+}
+
+func (c *TestClient) Clean() {
+	for resourceIndex, _ := range resourcesToClean {
+		resourcesToClean[resourceIndex].Clean()
+	}
+}

--- a/tests/framework/client/coreClient.go
+++ b/tests/framework/client/coreClient.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"sync"
+
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+// TestCoreV1Client is used to interact with features provided by the  group.
+type TestCoreV1Client struct {
+	corev1.CoreV1Client
+}
+
+var (
+	namespaceOnce             sync.Once
+	namespaceInterface        corev1.NamespaceInterface
+	nodeOnce                  sync.Once
+	nodeInterface             corev1.NodeInterface
+	persistentVolumeOnce      sync.Once
+	persistentVolumeInterface corev1.PersistentVolumeInterface
+)
+
+func (c *TestCoreV1Client) Namespaces() corev1.NamespaceInterface {
+	namespaceOnce.Do(func() {
+		namespaceInterface = newNamespaces(c)
+		resourcesToClean = append(resourcesToClean, namespaceInterface.(CleanableResource))
+	})
+	return namespaceInterface
+}
+
+func (c *TestCoreV1Client) Nodes() corev1.NodeInterface {
+	nodeOnce.Do(func() {
+		nodeInterface = newNodes(c)
+		resourcesToClean = append(resourcesToClean, nodeInterface.(CleanableResource))
+	})
+	return nodeInterface
+}
+
+func (c *TestCoreV1Client) PersistentVolumes() corev1.PersistentVolumeInterface {
+	persistentVolumeOnce.Do(func() {
+		persistentVolumeInterface = newPersistentVolumes(c)
+		resourcesToClean = append(resourcesToClean, persistentVolumeInterface.(CleanableResource))
+	})
+	return persistentVolumeInterface
+}
+
+// CoreNewForConfig creates a new CoreV1Client for the given RESTClient.
+func CoreNewForConfig(c *rest.Config) *TestCoreV1Client {
+	coreClient := corev1.NewForConfigOrDie(c)
+	return &TestCoreV1Client{*coreClient}
+}

--- a/tests/framework/client/migrationPolicyClient.go
+++ b/tests/framework/client/migrationPolicyClient.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"sync"
+
+	"k8s.io/client-go/rest"
+
+	migrationsv1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1"
+)
+
+type TestMigrationPolicyClient struct {
+	migrationsv1.MigrationsV1alpha1Client
+}
+
+var (
+	migrationPolicyOnce      sync.Once
+	migrationPolicyInterface migrationsv1.MigrationPolicyInterface
+)
+
+func (c *TestMigrationPolicyClient) MigrationPolicies() migrationsv1.MigrationPolicyInterface {
+	migrationPolicyOnce.Do(func() {
+		migrationPolicyInterface = newMigrationPolicies(c)
+		resourcesToClean = append(resourcesToClean, migrationPolicyInterface.(CleanableResource))
+	})
+	return migrationPolicyInterface
+}
+
+// MigrationPolicyNewForConfig creates a new MigrationPolicy for the given RESTClient.
+func MigrationPolicyNewForConfig(c *rest.Config) *TestMigrationPolicyClient {
+	migrationPolicyClient := migrationsv1.NewForConfigOrDie(c)
+	return &TestMigrationPolicyClient{*migrationPolicyClient}
+}

--- a/tests/framework/client/migrationpolicy.go
+++ b/tests/framework/client/migrationpolicy.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	migrationsv1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1"
+
+	v1alpha1 "kubevirt.io/api/migrations/v1alpha1"
+)
+
+var createdMigrationPolicies = make(map[string]context.Context, 0)
+
+// migrationPolicies implements MigrationPolicyInterface
+type migrationPolicies struct {
+	migrationsv1.MigrationPolicyInterface
+}
+
+// newMigrationPolicies returns a MigrationPolicies
+func newMigrationPolicies(c *TestMigrationPolicyClient) *migrationPolicies {
+	return &migrationPolicies{
+		c.MigrationsV1alpha1Client.MigrationPolicies(),
+	}
+}
+
+func (c *migrationPolicies) Clean() {
+	for name, ctx := range createdMigrationPolicies {
+		err := c.Delete(ctx, name, v1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			panic(err)
+		}
+	}
+}
+
+func (c *migrationPolicies) Create(ctx context.Context, migrationPolicy *v1alpha1.MigrationPolicy, opts v1.CreateOptions) (result *v1alpha1.MigrationPolicy, err error) {
+	created, err := c.MigrationPolicyInterface.Create(ctx, migrationPolicy, opts)
+	if err == nil && opts.DryRun == nil {
+		createdMigrationPolicies[created.Name] = ctx
+	}
+
+	return created, err
+}
+
+func (c *migrationPolicies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+	err := c.MigrationPolicyInterface.Delete(ctx, name, opts)
+	if _, exist := createdMigrationPolicies[name]; exist && err == nil && opts.DryRun == nil {
+		delete(createdMigrationPolicies, name)
+	}
+
+	return err
+}

--- a/tests/framework/client/namespace.go
+++ b/tests/framework/client/namespace.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var createdNamespaces = make(map[string]context.Context, 0)
+
+// namespaces implements NamespaceInterface
+type namespaces struct {
+	v12.NamespaceInterface
+}
+
+// newNamespaces returns a Namespaces
+func newNamespaces(c *TestCoreV1Client) *namespaces {
+	return &namespaces{
+		c.CoreV1Client.Namespaces(),
+	}
+}
+
+func (c *namespaces) Clean() {
+	for name, ctx := range createdNamespaces {
+		err := c.NamespaceInterface.Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			panic(err)
+		}
+	}
+}
+
+func (c *namespaces) Create(ctx context.Context, namespace *v1.Namespace, opts metav1.CreateOptions) (result *v1.Namespace, err error) {
+	created, err := c.NamespaceInterface.Create(ctx, namespace, opts)
+	if err == nil && opts.DryRun == nil {
+		createdNamespaces[created.Name] = ctx
+	}
+
+	return created, err
+}
+
+func (c *namespaces) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	err := c.NamespaceInterface.Delete(ctx, name, opts)
+	if _, exist := createdNamespaces[name]; exist && err == nil && opts.DryRun == nil {
+		delete(createdNamespaces, name)
+	}
+
+	return err
+}

--- a/tests/framework/client/node.go
+++ b/tests/framework/client/node.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var createdNodes = make(map[string]nodeInfo, 0)
+var nodeSpecMap = make(map[string]nodeSpec, 0)
+
+type nodeSpec struct {
+	labels        map[string]string
+	unschedulable bool
+	taints        []v1.Taint
+}
+
+type nodeInfo struct {
+	name string
+	ctx  context.Context
+}
+
+// nodes implements NodesInterface
+type nodes struct {
+	v12.NodeInterface
+}
+
+// newNodes returns a Nodes
+func newNodes(c *TestCoreV1Client) *nodes {
+	return &nodes{
+		c.CoreV1Client.Nodes(),
+	}
+}
+
+func (c *nodes) Clean() {
+	for _, node := range createdNodes {
+		err := c.NodeInterface.Delete(node.ctx, node.name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			panic(err)
+		}
+	}
+
+	for name, nodeSpec := range nodeSpecMap {
+		currentNode, err := c.NodeInterface.Get(context.Background(), name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		if reflect.DeepEqual(currentNode.Labels, nodeSpec.labels) &&
+			currentNode.Spec.Unschedulable == nodeSpec.unschedulable &&
+			reflect.DeepEqual(currentNode.Spec.Taints, nodeSpec.taints) {
+			return
+		}
+
+		oldNode, err := json.Marshal(currentNode)
+		Expect(err).ToNot(HaveOccurred())
+		newNode := currentNode.DeepCopy()
+
+		newNode.Spec.Taints = nodeSpec.taints
+		newNode.Labels = nodeSpec.labels
+		newNode.Spec.Unschedulable = nodeSpec.unschedulable
+		newJson, err := json.Marshal(newNode)
+		Expect(err).ToNot(HaveOccurred())
+
+		patch, err := strategicpatch.CreateTwoWayMergePatch(oldNode, newJson, currentNode)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = c.NodeInterface.Patch(context.Background(), currentNode.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func (c *nodes) Create(ctx context.Context, node *v1.Node, opts metav1.CreateOptions) (result *v1.Node, err error) {
+	created, err := c.NodeInterface.Create(ctx, node, opts)
+	if err == nil && opts.DryRun == nil {
+		createdNodes[node.Name] = nodeInfo{created.Name, ctx}
+	}
+
+	return created, err
+}
+
+func (c *nodes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	err := c.NodeInterface.Delete(ctx, name, opts)
+	if _, exist := createdNodes[name]; exist && err == nil && opts.DryRun == nil {
+		delete(createdNodes, name)
+	}
+
+	return err
+}
+
+func (c *nodes) Update(ctx context.Context, node *v1.Node, opts metav1.UpdateOptions) (result *v1.Node, err error) {
+	if opts.DryRun == nil {
+		c.saveNodeSpecs(ctx, node.Name)
+	}
+
+	return c.NodeInterface.Update(ctx, node, opts)
+}
+
+func (c *nodes) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Node, err error) {
+	if opts.DryRun == nil {
+		c.saveNodeSpecs(ctx, name)
+	}
+
+	return c.NodeInterface.Patch(ctx, name, pt, data, opts, subresources...)
+}
+
+func (c *nodes) saveNodeSpecs(ctx context.Context, name string) {
+	if _, exist := createdNodes[name]; exist {
+		//node will be deleted
+		return
+	}
+
+	if _, exist := nodeSpecMap[name]; exist {
+		//node information has already been saved
+		return
+	}
+
+	//save the information before the first update
+	currentNode, err := c.NodeInterface.Get(ctx, name, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	nodeSpecMap[currentNode.Name] = nodeSpec{
+		labels:        currentNode.Labels,
+		unschedulable: currentNode.Spec.Unschedulable,
+		taints:        currentNode.Spec.Taints,
+	}
+}

--- a/tests/framework/client/persistentvolume.go
+++ b/tests/framework/client/persistentvolume.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var createdPVs = make(map[string]context.Context, 0)
+
+// persistentVolumes implements PersistentVolumeInterface
+type persistentVolumes struct {
+	v12.PersistentVolumeInterface
+}
+
+// newPersistentVolumes returns a PersistentVolumes
+func newPersistentVolumes(c *TestCoreV1Client) *persistentVolumes {
+	return &persistentVolumes{
+		c.CoreV1Client.PersistentVolumes(),
+	}
+}
+
+func (c *persistentVolumes) Clean() {
+	for name, ctx := range createdPVs {
+		err := c.Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			panic(err)
+		}
+	}
+}
+
+func (c *persistentVolumes) Create(ctx context.Context, persistentVolume *v1.PersistentVolume, opts metav1.CreateOptions) (result *v1.PersistentVolume, err error) {
+	created, err := c.PersistentVolumeInterface.Create(ctx, persistentVolume, opts)
+	if err == nil && opts.DryRun == nil {
+		createdPVs[created.Name] = ctx
+	}
+
+	return created, err
+}
+
+func (c *persistentVolumes) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	err := c.PersistentVolumeInterface.Delete(ctx, name, opts)
+	if _, exist := createdPVs[name]; exist && err == nil && opts.DryRun == nil {
+		delete(createdPVs, name)
+	}
+
+	return err
+}

--- a/tests/framework/framework/BUILD.bazel
+++ b/tests/framework/framework/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["framework.go"],
+    importpath = "kubevirt.io/kubevirt/tests/framework/framework",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/framework/client:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)

--- a/tests/framework/framework/framework.go
+++ b/tests/framework/framework/framework.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file was originally copied from https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/framework.go
+
+package framework
+
+import (
+	"fmt"
+	"math/rand"
+
+	testclient "kubevirt.io/kubevirt/tests/framework/client"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/util"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"k8s.io/client-go/rest"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// Framework supports common operations used by e2e tests; it will keep a client & clean the cluster for you.
+type Framework struct {
+	BaseName string
+
+	UniqueName string
+
+	clientConfig   *rest.Config
+	KubevirtClient kubecli.KubevirtClient
+	// afterEaches is a map of name to function to be called after each test.  These are not
+	// cleared.  The call order is randomized so that no dependencies can grow between
+	// the various afterEaches
+	afterEaches map[string]AfterEachActionFunc
+}
+
+// AfterEachActionFunc is a function that can be called after each test
+type AfterEachActionFunc func(f *Framework, failed bool)
+
+// NewDefaultFramework makes a new framework and sets up a BeforeEach/AfterEach for
+// you (you can write additional before/after each functions).
+func NewDefaultFramework(baseName string) *Framework {
+	return NewFramework(baseName, nil, nil)
+}
+
+// NewFramework creates a test framework.
+func NewFramework(baseName string, client kubecli.KubevirtClient, config *rest.Config) *Framework {
+	f := &Framework{
+		BaseName:       baseName,
+		KubevirtClient: client,
+		clientConfig:   config,
+	}
+	BeforeEach(f.BeforeEach)
+	AfterEach(f.AfterEach)
+
+	return f
+}
+
+// BeforeEach gets a client and clean the cluster.
+func (f *Framework) BeforeEach() {
+	if f.KubevirtClient == nil {
+		By("Creating a kubevirt client")
+		client, err := testclient.GetKubevirtClient()
+		util.PanicOnError(err)
+		f.KubevirtClient = client
+		config, err := kubecli.GetKubevirtClientConfig()
+		util.PanicOnError(err)
+		f.clientConfig = config
+	}
+	f.UniqueName = fmt.Sprintf("%s-%08x", f.BaseName, rand.Int31())
+	tests.BeforeTestCleanup()
+}
+
+// AddAfterEach is a way to add a function to be called after every test.  The execution order is intentionally random
+// to avoid growing dependencies.  If you register the same name twice, it is a coding error and will panic.
+func (f *Framework) AddAfterEach(name string, fn AfterEachActionFunc) {
+	if _, ok := f.afterEaches[name]; ok {
+		panic(fmt.Sprintf("%q is already registered", name))
+	}
+
+	if f.afterEaches == nil {
+		f.afterEaches = map[string]AfterEachActionFunc{}
+	}
+	f.afterEaches[name] = fn
+}
+
+// AfterEach deletes the namespace, after reading its events.
+func (f *Framework) AfterEach() {
+	// This should not happen. Given KubevirtClient is a public field a test must have updated it!
+	// Error out early before any API calls during cleanup.
+	if f.KubevirtClient == nil {
+		Fail("The framework KubevirtClient must not be nil at this point")
+	}
+	f.KubevirtClient.(testclient.CleanableResource).Clean()
+
+	// run all aftereach functions in random order to ensure no dependencies grow
+	for _, afterEachFn := range f.afterEaches {
+		afterEachFn(f, CurrentSpecReport().Failed())
+	}
+}

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -185,15 +185,11 @@ func CreateFaultyDisk(nodeName, deviceName string) {
 	executeDeviceMapperOnNode(nodeName, args)
 }
 
-func CreatePVandPVCwithFaultyDisk(nodeName, devicePath, namespace string) (*corev1.PersistentVolume, *corev1.PersistentVolumeClaim, error) {
-	return CreatePVandPVCwithSCSIDisk(nodeName, devicePath, namespace, "faulty-disks", "ioerrorpvc", "ioerrorpvc")
+func CreatePVandPVCwithFaultyDisk(virtClient kubecli.KubevirtClient, nodeName, devicePath, namespace string) (*corev1.PersistentVolume, *corev1.PersistentVolumeClaim, error) {
+	return CreatePVandPVCwithSCSIDisk(virtClient, nodeName, devicePath, namespace, "faulty-disks", "ioerrorpvc", "ioerrorpvc")
 }
 
-func CreatePVandPVCwithSCSIDisk(nodeName, devicePath, namespace, storageClass, pvName, pvcName string) (*corev1.PersistentVolume, *corev1.PersistentVolumeClaim, error) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	if err != nil {
-		return nil, nil, err
-	}
+func CreatePVandPVCwithSCSIDisk(virtClient kubecli.KubevirtClient, nodeName, devicePath, namespace, storageClass, pvName, pvcName string) (*corev1.PersistentVolume, *corev1.PersistentVolumeClaim, error) {
 
 	size := resource.MustParse("1Gi")
 	volumeMode := corev1.PersistentVolumeBlock
@@ -230,7 +226,7 @@ func CreatePVandPVCwithSCSIDisk(nodeName, devicePath, namespace, storageClass, p
 			},
 		},
 	}
-	pv, err = virtClient.CoreV1().PersistentVolumes().Create(context.Background(), pv, metav1.CreateOptions{})
+	pv, err := virtClient.CoreV1().PersistentVolumes().Create(context.Background(), pv, metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -122,10 +122,7 @@ func GetNodeDrainKey() string {
 	return virtconfig.NodeDrainTaintDefaultKey
 }
 
-func addLabelAnnotationHelper(nodeName, key, value string, isLabel bool) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
-
+func addLabelAnnotationHelper(virtCli kubecli.KubevirtClient, nodeName, key, value string, isLabel bool) {
 	origNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -141,17 +138,15 @@ func addLabelAnnotationHelper(nodeName, key, value string, isLabel bool) {
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func AddLabelToNode(nodeName, key, value string) {
-	addLabelAnnotationHelper(nodeName, key, value, true)
+func AddLabelToNode(virtCli kubecli.KubevirtClient, nodeName, key, value string) {
+	addLabelAnnotationHelper(virtCli, nodeName, key, value, true)
 }
 
-func AddAnnotationToNode(nodeName, key, value string) {
-	addLabelAnnotationHelper(nodeName, key, value, false)
+func AddAnnotationToNode(virtCli kubecli.KubevirtClient, nodeName, key, value string) {
+	addLabelAnnotationHelper(virtCli, nodeName, key, value, false)
 }
 
-func RemoveLabelFromNode(nodeName string, key string) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
+func RemoveLabelFromNode(virtCli kubecli.KubevirtClient, nodeName string, key string) {
 	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -174,9 +169,7 @@ func RemoveLabelFromNode(nodeName string, key string) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func Taint(nodeName string, key string, effect k8sv1.TaintEffect) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
+func Taint(virtCli kubecli.KubevirtClient, nodeName string, key string, effect k8sv1.TaintEffect) {
 	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -215,7 +215,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			By("Adding a mdevTestLabel1 that should trigger mdev config change")
 			// There should be only one node in this lane
 			singleNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
-			libnode.AddLabelToNode(singleNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), mdevTestLabel)
+			libnode.AddLabelToNode(virtClient, singleNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), mdevTestLabel)
 
 			By("Creating a Fedora VMI")
 			vmi = tests.NewRandomFedoraVMIWithGuestAgent()

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -34,6 +34,8 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/testsuite"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	util2 "kubevirt.io/kubevirt/tests/util"
@@ -100,7 +102,6 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 	var err error
 	var workDir string
 
-	var virtClient kubecli.KubevirtClient
 	var aggregatorClient *aggregatorclient.Clientset
 	var k8sClient string
 	var vmYamls map[string]*vmYamlDefinition
@@ -150,10 +151,9 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		verifyVMIsEvicted                      func([]*v1.VirtualMachineInstance)
 		fetchVirtHandlerCommand                func() string
 	)
+	f := framework.NewDefaultFramework("operator")
 
 	tests.DeprecatedBeforeAll(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util2.PanicOnError(err)
 		config, err := kubecli.GetKubevirtClientConfig()
 		util2.PanicOnError(err)
 		aggregatorClient = aggregatorclient.NewForConfigOrDie(config)
@@ -188,17 +188,17 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		createKv = func(newKv *v1.KubeVirt) {
 			Eventually(func() error {
-				_, err = virtClient.KubeVirt(newKv.Namespace).Create(newKv)
+				_, err = f.KubevirtClient.KubeVirt(newKv.Namespace).Create(newKv)
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
 
 		createCdi = func() {
-			_, err = virtClient.CdiClient().CdiV1beta1().CDIs().Create(context.Background(), copyOriginalCDI(), metav1.CreateOptions{})
+			_, err = f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Create(context.Background(), copyOriginalCDI(), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				cdi, err := virtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
+				cdi, err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
 				if err != nil {
 					return false
 				} else if cdi.Status.Phase != sdkapi.PhaseDeployed {
@@ -211,7 +211,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		sanityCheckDeploymentsExistWithNS = func(namespace string) {
 			Eventually(func() error {
 				for _, deployment := range []string{"virt-api", "virt-controller"} {
-					_, err := virtClient.AppsV1().Deployments(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
+					_, err := f.KubevirtClient.AppsV1().Deployments(namespace).Get(context.Background(), deployment, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -228,7 +228,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			Eventually(func() int {
 				deploymentCount := 2
 				for _, deployment := range []string{"virt-api", "virt-controller"} {
-					_, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
+					_, err := f.KubevirtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
 					if err != nil && errors.IsNotFound(err) {
 						deploymentCount--
 					}
@@ -239,7 +239,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		allPodsAreTerminated = func(kv *v1.KubeVirt) {
 			Eventually(func() error {
-				pods, err := virtClient.CoreV1().Pods(kv.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io"})
+				pods, err := f.KubevirtClient.CoreV1().Pods(kv.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io"})
 				if err != nil {
 					return err
 				}
@@ -261,7 +261,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		allPodsAreReady = func(kv *v1.KubeVirt) {
 			Eventually(func() error {
 
-				curKv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				curKv, err := f.KubevirtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -271,7 +271,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 				podsReadyAndOwned := 0
 
-				pods, err := virtClient.CoreV1().Pods(curKv.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io"})
+				pods, err := f.KubevirtClient.CoreV1().Pods(curKv.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io"})
 				if err != nil {
 					return err
 				}
@@ -313,7 +313,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		waitForUpdateCondition = func(kv *v1.KubeVirt) {
 			Eventually(func() error {
-				kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err := f.KubevirtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -341,7 +341,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		waitForKvWithTimeout = func(newKv *v1.KubeVirt, timeoutSeconds int) {
 			Eventually(func() error {
-				kv, err := virtClient.KubeVirt(newKv.Namespace).Get(newKv.Name, &metav1.GetOptions{})
+				kv, err := f.KubevirtClient.KubeVirt(newKv.Namespace).Get(newKv.Name, &metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -398,7 +398,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 				"]")
 
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -407,7 +407,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		patchKvVersionAndRegistry = func(name string, version string, registry string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/imageTag", "value": "%s"},{ "op": "replace", "path": "/spec/imageRegistry", "value": "%s"}]`, version, registry))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -416,7 +416,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		patchKvVersion = func(name string, version string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "add", "path": "/spec/imageTag", "value": "%s"}]`, version))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -430,7 +430,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -444,7 +444,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
-			_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+			_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(errMsg))
 
@@ -495,7 +495,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -512,7 +512,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/certificateRotateStrategy", "value": %s}]`, "replace", string(certConfigData)))
 			By(fmt.Sprintf("sending JSON patch: '%s'", string(data)))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
+				_, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data, &metav1.PatchOptions{})
 
 				return err
 			}, 10*time.Second, 1*time.Second).Should(HaveOccurred())
@@ -521,7 +521,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		parseDaemonset = func(name string) (imagePrefix string) {
 			var err error
-			daemonSet, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
+			daemonSet, err := f.KubevirtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			image := daemonSet.Spec.Template.Spec.Containers[0].Image
 			imageRegEx := regexp.MustCompile(fmt.Sprintf("%s%s%s", `^(.*)/(.*)`, name, `([@:].*)?$`))
@@ -545,7 +545,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		parseDeployment = func(name string) (deployment *v12.Deployment, image, registry, imagePrefix, version string) {
 			var err error
-			deployment, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
+			deployment, err = f.KubevirtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			image = deployment.Spec.Template.Spec.Containers[0].Image
 			registry, imagePrefix, version = parseImage(name, image)
@@ -594,7 +594,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 				op := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/template", "value": %s }]`, string(newTemplate))
 
-				_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), "virt-operator", types.JSONPatchType, []byte(op), metav1.PatchOptions{})
+				_, err = f.KubevirtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), "virt-operator", types.JSONPatchType, []byte(op), metav1.PatchOptions{})
 
 				return err
 			}, 15*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -608,7 +608,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for KubeVirt CRD to be created")
-			ext, err := extclient.NewForConfig(virtClient.Config())
+			ext, err := extclient.NewForConfig(f.KubevirtClient.Config())
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() error {
@@ -635,7 +635,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		deleteAllKvAndWait = func(ignoreOriginal bool) {
 			Eventually(func() error {
 
-				kvs := util2.GetKvList(virtClient)
+				kvs := util2.GetKvList(f.KubevirtClient)
 
 				deleteCount := 0
 				for _, kv := range kvs {
@@ -647,7 +647,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 					if kv.DeletionTimestamp == nil {
 
 						By("deleting the kv object")
-						err := virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+						err := f.KubevirtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
 						if err != nil {
 							return err
 						}
@@ -673,12 +673,12 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			}
 
 			for _, name := range []string{"virt-operator", "virt-api", "virt-controller"} {
-				deployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
+				deployment, err := f.KubevirtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(usesSha(deployment.Spec.Template.Spec.Containers[0].Image)).To(BeTrue(), fmt.Sprintf("%s should use sha", name))
 			}
 
-			handler, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+			handler, err := f.KubevirtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(usesSha(handler.Spec.Template.Spec.Containers[0].Image)).To(BeTrue(), "virt-handler should use sha")
 		}
@@ -686,7 +686,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		// make sure virt deployments use shasums before we start
 		ensureShasums()
 
-		originalKv = util2.GetCurrentKv(virtClient)
+		originalKv = util2.GetCurrentKv(f.KubevirtClient)
 
 		// save the operator sha
 		_, _, _, _, version := parseOperatorImage()
@@ -699,7 +699,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		}
 
 		if libstorage.HasDataVolumeCRD() {
-			cdiList, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
+			cdiList, err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cdiList.Items).To(HaveLen(1))
 
@@ -760,7 +760,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		startAllVMIs = func(vmis []*v1.VirtualMachineInstance) {
 			for _, vmi := range vmis {
-				vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil(), "Create VMI successfully")
 				tests.WaitForSuccessfulVMIStart(vmi)
 			}
@@ -768,7 +768,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 		deleteAllVMIs = func(vmis []*v1.VirtualMachineInstance) {
 			for _, vmi := range vmis {
-				err := virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+				err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).To(BeNil(), "Delete VMI successfully")
 			}
 		}
@@ -777,7 +777,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 			Eventually(func() error {
 				for _, vmi := range vmis {
-					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					if err == nil && !vmi.IsFinal() {
 						return fmt.Errorf("waiting for vmi %s/%s to shutdown as part of update", vmi.Namespace, vmi.Name)
 					} else if !errors.IsNotFound(err) {
@@ -793,7 +793,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 			Eventually(func() error {
 				for _, vmi := range vmis {
-					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -839,7 +839,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			// the results
 			Eventually(func() error {
 				By("Verifying only a single successful migration took place for each vmi")
-				migrationList, err := virtClient.VirtualMachineInstanceMigration(util2.NamespaceTestDefault).List(&metav1.ListOptions{})
+				migrationList, err := f.KubevirtClient.VirtualMachineInstanceMigration(util2.NamespaceTestDefault).List(&metav1.ListOptions{})
 				Expect(err).To(BeNil(), "retrieving migrations")
 				for _, vmi := range vmis {
 					count := 0
@@ -866,7 +866,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		}
 
 		generatePreviousVersionVmsnapshotYamls = func() {
-			ext, err := extclient.NewForConfig(virtClient.Config())
+			ext, err := extclient.NewForConfig(f.KubevirtClient.Config())
 			Expect(err).ToNot(HaveOccurred())
 
 			crd, err := ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachinesnapshots.snapshot.kubevirt.io", metav1.GetOptions{})
@@ -928,7 +928,7 @@ spec:
 		}
 
 		generatePreviousVersionVmYamls = func(previousUtilityRegistry string, previousUtilityTag string) {
-			ext, err := extclient.NewForConfig(virtClient.Config())
+			ext, err := extclient.NewForConfig(f.KubevirtClient.Config())
 			Expect(err).ToNot(HaveOccurred())
 
 			crd, err := ext.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachines.kubevirt.io", metav1.GetOptions{})
@@ -1015,7 +1015,7 @@ spec:
 		}
 
 		fetchVirtHandlerCommand = func() string {
-			virtHandler, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+			virtHandler, err := f.KubevirtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			containers := virtHandler.Spec.Template.Spec.Containers
@@ -1027,7 +1027,9 @@ spec:
 	})
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
+		config, err := kubecli.GetKubevirtClientConfig()
+		util2.PanicOnError(err)
+		aggregatorClient = aggregatorclient.NewForConfigOrDie(config)
 
 		workDir = GinkgoT().TempDir()
 
@@ -1039,7 +1041,7 @@ spec:
 	AfterEach(func() {
 		deleteAllKvAndWait(true)
 
-		kvs := util2.GetKvList(virtClient)
+		kvs := util2.GetKvList(f.KubevirtClient)
 		if len(kvs) == 0 {
 			By("Re-creating the original KV to stabilize")
 			createKv(copyOriginalKv())
@@ -1063,7 +1065,7 @@ spec:
 			// ensure we wait for cdi to finish deleting before restoring it
 			// in the event that cdi has the deletionTimestamp set.
 			Eventually(func() bool {
-				cdi, err := virtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
+				cdi, err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
 				if err != nil && errors.IsNotFound(err) {
 					// cdi isn't deleting and doesn't exist.
 					return true
@@ -1081,11 +1083,11 @@ spec:
 			}, 240*time.Second, 1*time.Second).Should(BeTrue())
 
 			if cdiExists {
-				cdi, err := virtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
+				cdi, err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if !equality.Semantic.DeepEqual(cdi.Spec, originalCDI.Spec) {
 					cdi.Spec = originalCDI.Spec
-					_, err := virtClient.CdiClient().CdiV1beta1().CDIs().Update(context.Background(), cdi, metav1.UpdateOptions{})
+					_, err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Update(context.Background(), cdi, metav1.UpdateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
 			} else if !cdiExists {
@@ -1099,12 +1101,12 @@ spec:
 		// ensure that the state is fully restored after destructive tests
 		verifyOperatorWebhookCertificate()
 
-		_, err = virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "disks-images-provider", metav1.GetOptions{})
+		_, err = f.KubevirtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "disks-images-provider", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred(), "")
 	})
 
 	It("[test_id:1746]should have created and available condition", func() {
-		kv := util2.GetCurrentKv(virtClient)
+		kv := util2.GetCurrentKv(f.KubevirtClient)
 
 		By("verifying that created and available condition is present")
 		waitForKv(kv)
@@ -1138,13 +1140,13 @@ spec:
 			}, 120*time.Second, 5*time.Second).Should(BeTrue(), "waiting for deployment to revert to original state")
 
 			Eventually(func() int64 {
-				currentKV := util2.GetCurrentKv(virtClient)
+				currentKV := util2.GetCurrentKv(f.KubevirtClient)
 				return apply.GetExpectedGeneration(resource, currentKV.Status.Generations)
 			}, 60*time.Second, 5*time.Second).Should(Equal(generation), "reverted deployment generation should be set on KV resource")
 
 			By("Test that the expected generation is unchanged")
 			Consistently(func() int64 {
-				currentKV := util2.GetCurrentKv(virtClient)
+				currentKV := util2.GetCurrentKv(f.KubevirtClient)
 				return apply.GetExpectedGeneration(resource, currentKV.Status.Generations)
 			}, 30*time.Second, 5*time.Second).Should(Equal(generation))
 		},
@@ -1153,7 +1155,7 @@ spec:
 
 				func() {
 
-					vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+					vc, err := f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					vc.Spec.Template.Spec.Containers[0].Env = []k8sv1.EnvVar{
@@ -1164,7 +1166,7 @@ spec:
 					}
 
 					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						vc, err = virtClient.AppsV1().Deployments(originalKv.Namespace).Update(context.Background(), vc, metav1.UpdateOptions{})
+						vc, err = f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Update(context.Background(), vc, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1172,13 +1174,13 @@ spec:
 				},
 
 				func() runtime.Object {
-					vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+					vc, err := f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return vc
 				},
 
 				func() bool {
-					vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+					vc, err := f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					for _, env := range vc.Spec.Template.Spec.Containers[0].Env {
@@ -1192,13 +1194,13 @@ spec:
 
 			Entry("[test_id:6255] customresourcedefinitions",
 				func() {
-					vmcrd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
+					vmcrd, err := f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					vmcrd.Spec.Names.ShortNames = append(vmcrd.Spec.Names.ShortNames, shortNameAdded)
 
 					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						vmcrd, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), vmcrd, metav1.UpdateOptions{})
+						vmcrd, err = f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), vmcrd, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1206,13 +1208,13 @@ spec:
 				},
 
 				func() runtime.Object {
-					vmcrd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
+					vmcrd, err := f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return vmcrd
 				},
 
 				func() bool {
-					vmcrd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
+					vmcrd, err := f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					for _, sn := range vmcrd.Spec.Names.ShortNames {
@@ -1225,7 +1227,7 @@ spec:
 				}),
 			Entry("[test_id:6256] poddisruptionbudgets",
 				func() {
-					pdb, err := virtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
+					pdb, err := f.KubevirtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					pdb.Spec.Selector.MatchLabels = map[string]string{
@@ -1233,7 +1235,7 @@ spec:
 					}
 
 					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						pdb, err = virtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Update(context.Background(), pdb, metav1.UpdateOptions{})
+						pdb, err = f.KubevirtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Update(context.Background(), pdb, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1242,22 +1244,22 @@ spec:
 
 				func() runtime.Object {
 					// No virt-controller PDB on single-replica deployments
-					checks.SkipIfSingleReplica(virtClient)
+					checks.SkipIfSingleReplica(f.KubevirtClient)
 
-					pdb, err := virtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
+					pdb, err := f.KubevirtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return pdb
 				},
 
 				func() bool {
-					pdb, err := virtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
+					pdb, err := f.KubevirtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					return pdb.Spec.Selector.MatchLabels["kubevirt.io"] != "dne"
 				}),
 			Entry("[test_id:6308] daemonsets",
 				func() {
-					vc, err := virtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
+					vc, err := f.KubevirtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					vc.Spec.Template.Spec.Containers[0].Env = append(vc.Spec.Template.Spec.Containers[0].Env, k8sv1.EnvVar{
@@ -1266,7 +1268,7 @@ spec:
 					})
 
 					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						vc, err = virtClient.AppsV1().DaemonSets(originalKv.Namespace).Update(context.Background(), vc, metav1.UpdateOptions{})
+						vc, err = f.KubevirtClient.AppsV1().DaemonSets(originalKv.Namespace).Update(context.Background(), vc, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -1282,7 +1284,7 @@ spec:
 					// wait for virt-handler readiness
 					Eventually(func() bool {
 						var err error
-						ds, err = virtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
+						ds, err = f.KubevirtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 						return ds.Status.DesiredNumberScheduled == ds.Status.NumberReady && ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntValue() == 1
 					}, 60*time.Second, 1*time.Second).Should(BeTrue(), "waiting for daemonSet to be ready")
@@ -1290,7 +1292,7 @@ spec:
 				},
 
 				func() bool {
-					vc, err := virtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
+					vc, err := f.KubevirtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					for _, env := range vc.Spec.Template.Spec.Containers[0].Env {
@@ -1304,20 +1306,20 @@ spec:
 		)
 
 		It("[test_id:6309] checking updating service is reverted to original state", func() {
-			service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
+			service, err := f.KubevirtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			originalPort := service.Spec.Ports[0].Port
 			service.Spec.Ports[0].Port = 123
 
 			By("Update service with undesired port")
-			service, err = virtClient.CoreV1().Services(originalKv.Namespace).Update(context.Background(), service, metav1.UpdateOptions{})
+			service, err = f.KubevirtClient.CoreV1().Services(originalKv.Namespace).Update(context.Background(), service, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Ports[0].Port).To(Equal(int32(123)))
 
 			By("Test that the port is revered to the original")
 			Eventually(func() bool {
-				service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
+				service, err := f.KubevirtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return service.Spec.Ports[0].Port == originalPort
@@ -1325,7 +1327,7 @@ spec:
 
 			By("Test that the revert of the service stays consistent")
 			Consistently(func() int32 {
-				service, err = virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
+				service, err = f.KubevirtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return service.Spec.Ports[0].Port
@@ -1342,14 +1344,14 @@ spec:
 
 			By("starting a VM")
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("getting virt-launcher")
 			uid := vmi.GetObjectMeta().GetUID()
 			labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
-			pods, err := virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+			pods, err := f.KubevirtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 			Expect(err).ToNot(HaveOccurred(), "Should list pods")
 			Expect(pods.Items).To(HaveLen(1))
 			Expect(usesSha(pods.Items[0].Spec.Containers[0].Image)).To(BeTrue(), "launcher pod should use shasum")
@@ -1364,23 +1366,23 @@ spec:
 			maxDevicesCommandArgument := fmt.Sprintf("--maxDevices %d", newVirtualMachineInstancesPerNode)
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kv.Spec.Configuration.VirtualMachineInstancesPerNode).ToNot(Equal(&newVirtualMachineInstancesPerNode))
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = &newVirtualMachineInstancesPerNode
 
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			kv, err = f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Test that patch was applied to DaemonSet")
 			Eventually(fetchVirtHandlerCommand, 60*time.Second, 5*time.Second).Should(ContainSubstring(maxDevicesCommandArgument))
 
 			By("Deleting patch from KubeVirt object")
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(originalKv.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
-			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
+			kv, err = f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Test that patch was removed from DaemonSet")
@@ -1395,7 +1397,7 @@ spec:
 			annotationPatchKey := "applied-patch"
 
 			By("Updating KubeVirt Object")
-			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err := f.KubevirtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{
 				Patches: []v1.CustomizeComponentsPatch{
@@ -1408,39 +1410,39 @@ spec:
 				},
 			}
 
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = f.KubevirtClient.KubeVirt(originalKv.Namespace).Update(kv)
 			Expect(err).ToNot(HaveOccurred())
 			generation := kv.GetGeneration()
 
 			By("Test that patch was applied to deployment")
 			Eventually(func() string {
-				vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
+				vc, err := f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return vc.Spec.Template.ObjectMeta.Annotations[annotationPatchKey]
 			}, 60*time.Second, 5*time.Second).Should(Equal(annotationPatchValue))
 
 			Consistently(func() string {
-				vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
+				vc, err := f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return vc.Spec.Template.ObjectMeta.Annotations[annotationPatchKey]
 			}, 30*time.Second, 5*time.Second).Should(Equal(annotationPatchValue))
 
 			By("Deleting patch from KubeVirt object")
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+			kv, err = f.KubevirtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check that KubeVirt CR generation does not get updated when applying patch")
 			Expect(kv.GetGeneration()).To(Equal(generation))
 
 			kv.Spec.CustomizeComponents = v1.CustomizeComponents{}
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(kv)
+			kv, err = f.KubevirtClient.KubeVirt(originalKv.Namespace).Update(kv)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Test that patch was removed from deployment")
 			Eventually(func() string {
-				vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
+				vc, err := f.KubevirtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				return vc.Spec.Template.ObjectMeta.Annotations[annotationPatchKey]
@@ -1597,7 +1599,7 @@ spec:
 				By(fmt.Sprintf("Waiting for VM with %s api to become ready", vmYaml.apiVersion))
 
 				Eventually(func() bool {
-					virtualMachine, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					virtualMachine, err := f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					if virtualMachine.Status.Ready {
 						return true
@@ -1637,7 +1639,7 @@ spec:
 					// We are using our internal client here on purpose to ensure we can interact
 					// with previously created objects that may have been created using a different
 					// api version from the latest one our client uses.
-					virtualMachine, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					virtualMachine, err := f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					if !virtualMachine.Status.Ready {
 						return false
@@ -1653,7 +1655,7 @@ spec:
 				By(fmt.Sprintf("Ensure vm %s vmsnapshots exist and ready ", vmYaml.vmName))
 				for _, snapshot := range vmYaml.vmSnapshots {
 					Eventually(func() bool {
-						vmSnapshot, err := virtClient.VirtualMachineSnapshot(util2.NamespaceTestDefault).Get(context.Background(), snapshot.vmSnapshotName, metav1.GetOptions{})
+						vmSnapshot, err := f.KubevirtClient.VirtualMachineSnapshot(util2.NamespaceTestDefault).Get(context.Background(), snapshot.vmSnapshotName, metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 						if !(vmSnapshot.Status != nil && vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse) {
 							return false
@@ -1673,7 +1675,7 @@ spec:
 				// completes while we wait for the kubernetes apiserver to detect our
 				// subresource api server is online and ready to serve requests.
 				Eventually(func() error {
-					vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					vmi, err := f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					if err := console.LoginToCirros(vmi); err != nil {
 						return err
@@ -1689,7 +1691,7 @@ spec:
 
 				By("Waiting for VMI to stop")
 				Eventually(func() bool {
-					_, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					_, err := f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					if err != nil && errors.IsNotFound(err) {
 						return true
 					} else if err != nil {
@@ -1704,7 +1706,7 @@ spec:
 
 				By("Ensuring we can Modify the VM Spec")
 				Eventually(func() error {
-					vm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					vm, err := f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
@@ -1716,22 +1718,22 @@ spec:
 					Expect(err).ToNot(HaveOccurred())
 
 					ops := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations", "value": %s }]`, string(annotationBytes))
-					_, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte(ops), &metav1.PatchOptions{})
+					_, err = f.KubevirtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte(ops), &metav1.PatchOptions{})
 					return err
 				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				// change run stategy to halted to be able to restore the vm
 				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					vm, err := f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					if err != nil {
 						return false
 					}
 					vm.Spec.RunStrategy = &runStrategyHalted
-					_, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Update(vm)
+					_, err = f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Update(vm)
 					if err != nil {
 						return false
 					}
-					updatedVM, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					updatedVM, err := f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return updatedVM.Spec.Running == nil && updatedVM.Spec.RunStrategy != nil && *updatedVM.Spec.RunStrategy == runStrategyHalted
 				}, 30*time.Second, 3*time.Second).Should(BeTrue())
@@ -1741,7 +1743,7 @@ spec:
 					_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(func() bool {
-						r, err := virtClient.VirtualMachineRestore(util2.NamespaceTestDefault).Get(context.Background(), snapshot.restoreName, metav1.GetOptions{})
+						r, err := f.KubevirtClient.VirtualMachineRestore(util2.NamespaceTestDefault).Get(context.Background(), snapshot.restoreName, metav1.GetOptions{})
 						if err != nil {
 							return false
 						}
@@ -1755,7 +1757,7 @@ spec:
 
 				By("Waiting for VM to be removed")
 				Eventually(func() bool {
-					_, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					_, err := f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					if err != nil && errors.IsNotFound(err) {
 						return true
 					}
@@ -1769,7 +1771,7 @@ spec:
 			if len(migratableVMIs) > 0 {
 				By("Verifying that a once migrated VMI after an update can be migrated again")
 				vmi := migratableVMIs[0]
-				migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(tests.NewRandomMigration(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
+				migration, err := f.KubevirtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(tests.NewRandomMigration(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
 			}
@@ -1806,14 +1808,14 @@ spec:
 			sanityCheckDeploymentsDeleted()
 
 			By("ensuring that namespaces can be successfully created and deleted")
-			_, err := virtClient.CoreV1().Namespaces().Create(context.Background(), &k8sv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testsuite.NamespaceTestOperator}}, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CoreV1().Namespaces().Create(context.Background(), &k8sv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testsuite.NamespaceTestOperator}}, metav1.CreateOptions{})
 			if err != nil && !errors.IsAlreadyExists(err) {
 				Expect(err).ToNot(HaveOccurred())
 			}
-			err = virtClient.CoreV1().Namespaces().Delete(context.Background(), testsuite.NamespaceTestOperator, metav1.DeleteOptions{})
+			err = f.KubevirtClient.CoreV1().Namespaces().Delete(context.Background(), testsuite.NamespaceTestOperator, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
-				_, err := virtClient.CoreV1().Namespaces().Get(context.Background(), testsuite.NamespaceTestOperator, metav1.GetOptions{})
+				_, err := f.KubevirtClient.CoreV1().Namespaces().Get(context.Background(), testsuite.NamespaceTestOperator, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}, 60*time.Second, 1*time.Second).Should(BeTrue())
 
@@ -1836,18 +1838,18 @@ spec:
 				sanityCheckDeploymentsExist()
 
 				By("setting the right uninstall strategy")
-				kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+				kv, err := f.KubevirtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
-				_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
+				_, err = f.KubevirtClient.KubeVirt(kv.Namespace).Update(kv)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("creating a simple VMI")
-				_, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros)))
+				_, err = f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros)))
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Deleting KubeVirt object")
-				err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+				err = f.KubevirtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("there are still Virtual Machine Instances present"))
 			})
@@ -1928,7 +1930,7 @@ spec:
 
 			By("Verifying VMs are working")
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
 			Expect(err).ShouldNot(HaveOccurred(), "Create VMI successfully")
 			tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -1942,7 +1944,7 @@ spec:
 			}
 
 			By("Deleting VM")
-			err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+			err = f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 			Expect(err).ShouldNot(HaveOccurred(), "Delete VMI successfully")
 
 			By("Restore Operator using original imagePrefix ")
@@ -2079,7 +2081,7 @@ spec:
 			createKv(newKv)
 			By("Waiting for duplicate KubeVirt object to fail")
 			Eventually(func() error {
-				kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(newKv.Name, &metav1.GetOptions{})
+				kv, err := f.KubevirtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(newKv.Name, &metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -2104,14 +2106,14 @@ spec:
 		})
 
 		It("[test_id:4612]should create non-namespaces resources without owner references", func() {
-			crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+			crd, err := f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
 		})
 
 		It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", func() {
 			By("getting existing resource to reference")
-			cm, err := virtClient.CoreV1().ConfigMaps(originalKv.Namespace).Get(context.Background(), "kubevirt-ca", metav1.GetOptions{})
+			cm, err := f.KubevirtClient.CoreV1().ConfigMaps(originalKv.Namespace).Get(context.Background(), "kubevirt-ca", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			ownerRef := []metav1.OwnerReference{
 				*metav1.NewControllerRef(&k8sv1.ConfigMap{
@@ -2123,15 +2125,15 @@ spec:
 			}
 
 			By("adding an owner reference")
-			origCRD, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+			origCRD, err := f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			crd := origCRD.DeepCopy()
 			crd.OwnerReferences = ownerRef
 			patch := patchCRD(origCRD, crd)
-			_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
+			_, err = f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			By("verifying that the owner reference is there")
-			origCRD, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+			origCRD, err = f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(origCRD.OwnerReferences).ToNot(BeEmpty())
 
@@ -2139,12 +2141,12 @@ spec:
 			crd = origCRD.DeepCopy()
 			crd.Annotations[v1.InstallStrategyVersionAnnotation] = "outdated"
 			patch = patchCRD(origCRD, crd)
-			_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
+			_, err = f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting until the owner reference disappears again")
 			Eventually(func() []metav1.OwnerReference {
-				crd, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+				crd, err = f.KubevirtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return crd.OwnerReferences
 			}, 20*time.Second, 1*time.Second).Should(BeEmpty())
@@ -2166,7 +2168,7 @@ spec:
 			for _, deployment := range []string{"virt-api", "virt-controller"} {
 				By(fmt.Sprintf("Ensuring that the %s deployment is updated", deployment))
 				Eventually(func() bool {
-					dep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
+					dep, err := f.KubevirtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return dep.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dep.ObjectMeta.Labels[v1.AppPartOfLabel] == productName && dep.ObjectMeta.Labels[v1.AppComponentLabel] == productComponent
 				}, 240*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Expected labels to be updated for %s deployment", deployment))
@@ -2174,7 +2176,7 @@ spec:
 
 			By("Ensuring that the virt-handler daemonset is updated")
 			Eventually(func() bool {
-				dms, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+				dms, err := f.KubevirtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return dms.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dms.ObjectMeta.Labels[v1.AppPartOfLabel] == productName && dms.ObjectMeta.Labels[v1.AppComponentLabel] == productComponent
 			}, 240*time.Second, 1*time.Second).Should(BeTrue(), "Expected labels to be updated for virt-handler daemonset")
@@ -2196,7 +2198,7 @@ spec:
 				var expectedSCCs, sccs []string
 
 				By("Checking if kubevirt SCCs have been created")
-				secClient := virtClient.SecClient()
+				secClient := f.KubevirtClient.SecClient()
 				operatorSCCs := components.GetAllSCC(flags.KubeVirtInstallNamespace)
 				for _, scc := range operatorSCCs {
 					expectedSCCs = append(expectedSCCs, scc.GetName())
@@ -2213,7 +2215,7 @@ spec:
 				l, err := labels.Parse("kubevirt.io=virt-handler")
 				Expect(err).ToNot(HaveOccurred())
 
-				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
+				pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
 				Expect(err).ToNot(HaveOccurred(), "Should get virt-handler")
 				Expect(pods.Items).ToNot(BeEmpty())
 				Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
@@ -2222,13 +2224,13 @@ spec:
 
 				By("Checking if virt-launcher is assigned to kubevirt-controller SCC")
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-				vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				uid := vmi.GetObjectMeta().GetUID()
 				labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
-				pods, err = virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+				pods, err = f.KubevirtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 				Expect(err).ToNot(HaveOccurred(), "Should get virt-launcher")
 				Expect(pods.Items).To(HaveLen(1))
 				Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
@@ -2245,13 +2247,13 @@ spec:
 		AfterEach(func() {
 
 			if vm != nil {
-				_, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				_, err := f.KubevirtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				if err != nil && !errors.IsNotFound(err) {
 					Expect(err).ToNot(HaveOccurred())
 				}
 
 				if vm != nil && vm.DeletionTimestamp == nil {
-					err = virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+					err = f.KubevirtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
 					Expect(err).ToNot(HaveOccurred())
 				}
 				vm = nil
@@ -2272,7 +2274,7 @@ spec:
 			// Delete CDI object
 			By("Deleting CDI install")
 			Eventually(func() error {
-				cdi, err := virtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
+				cdi, err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
 				if err != nil && errors.IsNotFound(err) {
 					// cdi is deleted
 					return nil
@@ -2281,7 +2283,7 @@ spec:
 				}
 
 				if cdi.DeletionTimestamp == nil {
-					err := virtClient.CdiClient().CdiV1beta1().CDIs().Delete(context.Background(), originalCDI.Name, metav1.DeleteOptions{})
+					err := f.KubevirtClient.CdiClient().CdiV1beta1().CDIs().Delete(context.Background(), originalCDI.Name, metav1.DeleteOptions{})
 					if err != nil {
 						return err
 					}
@@ -2297,7 +2299,7 @@ spec:
 			// Verify posting a VM with DataVolumeTemplate fails when DataVolumes
 			// feature gate is disabled
 			By("Expecting Error to Occur when posting VM with DataVolume")
-			_, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
+			_, err = f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
 			Expect(err).To(HaveOccurred())
 
 			// Enable DataVolumes by reinstalling CDI
@@ -2309,7 +2311,7 @@ spec:
 
 			// Verify we can post a VM with DataVolumeTemplates successfully
 			By("Expecting Error to not occur when posting VM with DataVolume")
-			vm, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
+			vm, err = f.KubevirtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Expecting VM to start successfully")
@@ -2326,7 +2328,7 @@ spec:
 		})
 
 		It("[test_id:3154]Should not create RBAC Role or RoleBinding for ServiceMonitor", func() {
-			rbacClient := virtClient.RbacV1()
+			rbacClient := f.KubevirtClient.RbacV1()
 
 			By("Checking that Role for ServiceMonitor doesn't exist")
 			roleName := "kubevirt-service-monitor"
@@ -2350,7 +2352,7 @@ spec:
 		})
 
 		It("[test_id:4614]Checks if the kubevirt PrometheusRule cr exists and verify it's spec", func() {
-			monv1 := virtClient.PrometheusClient().MonitoringV1()
+			monv1 := f.KubevirtClient.PrometheusClient().MonitoringV1()
 			prometheusRule, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 			hasWorkloadUpdates := false
@@ -2371,7 +2373,7 @@ spec:
 		})
 
 		It("[test_id:4615]Checks that we do not deploy a PrometheusRule cr when not needed", func() {
-			monv1 := virtClient.PrometheusClient().MonitoringV1()
+			monv1 := f.KubevirtClient.PrometheusClient().MonitoringV1()
 			_, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
 		})
@@ -2386,7 +2388,7 @@ spec:
 		})
 
 		It("[test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints", func() {
-			coreClient := virtClient.CoreV1()
+			coreClient := f.KubevirtClient.CoreV1()
 
 			// we don't know when the prometheus toolchain will pick up our config, so we retry plenty of times
 			// before to give up. TODO: there is a smarter way to wait?
@@ -2420,7 +2422,7 @@ spec:
 
 		It("[test_id:4616]Should patch our namespace labels with openshift.io/cluster-monitoring=true", func() {
 			By("Inspecting the labels on our namespace")
-			namespace, err := virtClient.CoreV1().Namespaces().Get(context.Background(), flags.KubeVirtInstallNamespace, metav1.GetOptions{})
+			namespace, err := f.KubevirtClient.CoreV1().Namespaces().Get(context.Background(), flags.KubeVirtInstallNamespace, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			monitoringLabel, exists := namespace.ObjectMeta.Labels["openshift.io/cluster-monitoring"]
 			Expect(exists).To(BeTrue())
@@ -2431,18 +2433,18 @@ spec:
 	It("[test_id:4617]should adopt previously unmanaged entities by updating its metadata", func() {
 		By("removing registration metadata")
 		patchData := []byte(fmt.Sprint(`[{ "op": "replace", "path": "/metadata/labels", "value": {} }]`))
-		_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Patch(context.Background(), components.VirtApiCertSecretName, types.JSONPatchType, patchData, metav1.PatchOptions{})
+		_, err = f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Patch(context.Background(), components.VirtApiCertSecretName, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		_, err = aggregatorClient.ApiregistrationV1().APIServices().Patch(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		_, err = virtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Patch(context.Background(), components.VirtAPIValidatingWebhookName, types.JSONPatchType, patchData, metav1.PatchOptions{})
+		_, err = f.KubevirtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Patch(context.Background(), components.VirtAPIValidatingWebhookName, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		_, err = virtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Patch(context.Background(), components.VirtAPIMutatingWebhookName, types.JSONPatchType, patchData, metav1.PatchOptions{})
+		_, err = f.KubevirtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Patch(context.Background(), components.VirtAPIMutatingWebhookName, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("checking that it gets added again")
 		Eventually(func() map[string]string {
-			secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.VirtApiCertSecretName, metav1.GetOptions{})
+			secret, err := f.KubevirtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.VirtApiCertSecretName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return secret.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
@@ -2452,12 +2454,12 @@ spec:
 			return apiService.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 		Eventually(func() map[string]string {
-			validatingWebhook, err := virtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), components.VirtAPIValidatingWebhookName, metav1.GetOptions{})
+			validatingWebhook, err := f.KubevirtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), components.VirtAPIValidatingWebhookName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return validatingWebhook.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 		Eventually(func() map[string]string {
-			mutatingWebhook, err := virtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), components.VirtAPIMutatingWebhookName, metav1.GetOptions{})
+			mutatingWebhook, err := f.KubevirtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), components.VirtAPIMutatingWebhookName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return mutatingWebhook.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
@@ -2479,7 +2481,7 @@ spec:
 
 			Eventually(func() bool {
 				for _, name := range []string{"virt-controller", "virt-api"} {
-					deployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
+					deployment, err := f.KubevirtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					if deployment.Spec.Template.Spec.NodeSelector == nil || deployment.Spec.Template.Spec.NodeSelector[labelKey] != labelValue {
 						return false
@@ -2502,7 +2504,7 @@ spec:
 			patchKvWorkloads(&workloads, false, "")
 
 			Eventually(func() bool {
-				daemonset, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+				daemonset, err := f.KubevirtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if daemonset.Spec.Template.Spec.NodeSelector == nil || daemonset.Spec.Template.Spec.NodeSelector[labelKey] != labelValue {
 					return false
@@ -2546,7 +2548,7 @@ spec:
 		It("[test_id:8235]should check if kubevirt components have linux node selector", func() {
 			By("Listing only kubevirt components")
 
-			kv := util2.GetCurrentKv(virtClient)
+			kv := util2.GetCurrentKv(f.KubevirtClient)
 			productComponent := kv.Spec.ProductComponent
 			if productComponent == "" {
 				productComponent = "kubevirt"
@@ -2558,7 +2560,7 @@ spec:
 				panic(err)
 			}
 
-			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{
+			pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: labels.NewSelector().Add(
 					*labelReq,
 				).String(),
@@ -2593,7 +2595,7 @@ spec:
 				By(fmt.Sprintf("Expecting %d replicas of virt-api and virt-controller", replicas))
 				Eventually(func() bool {
 					for _, name := range []string{"virt-api", "virt-controller"} {
-						pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
+						pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
 						Expect(err).ToNot(HaveOccurred())
 						if len(pods.Items) != int(replicas) {
 							return false
@@ -2606,7 +2608,7 @@ spec:
 					By(fmt.Sprintf("Expecting PDBs to disppear"))
 					Eventually(func() bool {
 						for _, name := range []string{"virt-api", "virt-controller"} {
-							_, err := virtClient.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).Get(context.Background(), name+"-pdb", metav1.GetOptions{})
+							_, err := f.KubevirtClient.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).Get(context.Background(), name+"-pdb", metav1.GetOptions{})
 							if err == nil {
 								return false
 							}
@@ -2617,7 +2619,7 @@ spec:
 					By(fmt.Sprintf("Expecting minAvailable to become %d on the PDBs", replicas-1))
 					Eventually(func() bool {
 						for _, name := range []string{"virt-api", "virt-controller"} {
-							pdb, err := virtClient.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).Get(context.Background(), name+"-pdb", metav1.GetOptions{})
+							pdb, err := f.KubevirtClient.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).Get(context.Background(), name+"-pdb", metav1.GetOptions{})
 							Expect(err).ToNot(HaveOccurred())
 							if pdb.Spec.MinAvailable.IntValue() != int(replicas-1) {
 								return false
@@ -2634,12 +2636,12 @@ spec:
 			kv := copyOriginalKv()
 
 			By("deleting the kv CR")
-			virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+			f.KubevirtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
 
 			By("waiting for virt-api and virt-controller to be gone")
 			Eventually(func() bool {
 				for _, name := range []string{"virt-api", "virt-controller"} {
-					pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
+					pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
 					Expect(err).ToNot(HaveOccurred())
 					if len(pods.Items) != 0 {
 						return false
@@ -2654,12 +2656,12 @@ spec:
 			}
 			var one uint8 = 1
 			kv.Spec.Infra.Replicas = &one
-			kv, err = virtClient.KubeVirt(kv.Namespace).Create(kv)
+			kv, err = f.KubevirtClient.KubeVirt(kv.Namespace).Create(kv)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the kv CR to get a finalizer")
 			Eventually(func() bool {
-				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv, err = f.KubevirtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return len(kv.Finalizers) > 0
 			}, 120*time.Second, 4*time.Second).Should(BeTrue())
@@ -2667,7 +2669,7 @@ spec:
 			By("ensuring the CR generation is stable")
 			Expect(err).ToNot(HaveOccurred())
 			Consistently(func() int64 {
-				kv2, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
+				kv2, err := f.KubevirtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return kv2.GetGeneration()
 			}, 30*time.Second, 2*time.Second).Should(Equal(kv.GetGeneration()))
@@ -2682,7 +2684,7 @@ spec:
 			}
 			Eventually(func() bool {
 				for _, name := range []string{"virt-api", "virt-controller"} {
-					pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
+					pods, err := f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
 					Expect(err).ToNot(HaveOccurred())
 					if len(pods.Items) != expectedReplicas {
 						return false
@@ -2747,7 +2749,7 @@ spec:
 
 		AfterEach(func() {
 			// cleanup the obsolete configMap
-			_ = virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Delete(ctx, "kubevirt-config", metav1.DeleteOptions{})
+			_ = f.KubevirtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Delete(ctx, "kubevirt-config", metav1.DeleteOptions{})
 
 			// make sure virt-operators are up before leaving
 			Eventually(ThisDeploymentWith(flags.KubeVirtInstallNamespace, components.VirtOperatorName), 180*time.Second, 1*time.Second).Should(HaveReadyReplicasNumerically(">", 0))
@@ -2764,15 +2766,15 @@ spec:
 				},
 			}
 
-			_, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Create(ctx, cm, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Create(ctx, cm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, virtOpLabelSelector)
+			err = f.KubevirtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, virtOpLabelSelector)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(ThisDeploymentWith(flags.KubeVirtInstallNamespace, components.VirtOperatorName), 180*time.Second, 1*time.Second).Should(HaveReadyReplicasNumerically("==", 0))
 
 			Eventually(func() int {
-				events, err := virtClient.CoreV1().Events(flags.KubeVirtInstallNamespace).List(
+				events, err := f.KubevirtClient.CoreV1().Events(flags.KubeVirtInstallNamespace).List(
 					context.Background(),
 					metav1.ListOptions{
 						FieldSelector: "involvedObject.kind=ConfigMap,involvedObject.name=kubevirt-config,type=Warning,reason=ObsoleteConfigMapExists",

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/framework:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/framework/storage:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("[Serial]K8s IO events", func() {
 
 		nodeName = tests.NodeNameWithHandler()
 		tests.CreateFaultyDisk(nodeName, deviceName)
-		pv, pvc, err = tests.CreatePVandPVCwithFaultyDisk(nodeName, "/dev/mapper/"+deviceName, util.NamespaceTestDefault)
+		pv, pvc, err = tests.CreatePVandPVCwithFaultyDisk(virtClient, nodeName, "/dev/mapper/"+deviceName, util.NamespaceTestDefault)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for faulty disk")
 	})
 	AfterEach(func() {

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -28,6 +28,8 @@ import (
 
 	"kubevirt.io/kubevirt/tests/framework/checks"
 
+	"kubevirt.io/kubevirt/tests/framework/framework"
+
 	"kubevirt.io/client-go/log"
 
 	expect "github.com/google/goexpect"
@@ -43,7 +45,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -77,15 +78,7 @@ type addVolumeFunction func(name, namespace, volumeName, claimName string, bus v
 type removeVolumeFunction func(name, namespace, volumeName string, dryRun bool)
 
 var _ = SIGDescribe("Hotplug", func() {
-	var err error
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
+	f := framework.NewDefaultFramework("storage/hotplug")
 
 	getDryRunOption := func(dryRun bool) []string {
 		if dryRun {
@@ -102,13 +95,13 @@ var _ = SIGDescribe("Hotplug", func() {
 	createVirtualMachine := func(running bool, template *v1.VirtualMachineInstance) *v1.VirtualMachine {
 		By("Creating VirtualMachine")
 		vm := tests.NewRandomVirtualMachine(template, running)
-		newVM, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+		newVM, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 		Expect(err).ToNot(HaveOccurred())
 		return newVM
 	}
 
 	deleteVirtualMachine := func(vm *v1.VirtualMachine) error {
-		return virtClient.VirtualMachine(util.NamespaceTestDefault).Delete(vm.Name, &metav1.DeleteOptions{})
+		return f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Delete(vm.Name, &metav1.DeleteOptions{})
 	}
 
 	getAddVolumeOptions := func(volumeName string, bus v1.DiskBus, volumeSource *v1.HotplugVolumeSource, dryRun bool) *v1.AddVolumeOptions {
@@ -128,7 +121,7 @@ var _ = SIGDescribe("Hotplug", func() {
 	}
 	addVolumeVMIWithSource := func(name, namespace string, volumeOptions *v1.AddVolumeOptions) {
 		Eventually(func() error {
-			return virtClient.VirtualMachineInstance(namespace).AddVolume(name, volumeOptions)
+			return f.KubevirtClient.VirtualMachineInstance(namespace).AddVolume(name, volumeOptions)
 		}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
@@ -150,7 +143,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 	addVolumeVMWithSource := func(name, namespace string, volumeOptions *v1.AddVolumeOptions) {
 		Eventually(func() error {
-			return virtClient.VirtualMachine(namespace).AddVolume(name, volumeOptions)
+			return f.KubevirtClient.VirtualMachine(namespace).AddVolume(name, volumeOptions)
 		}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
@@ -184,7 +177,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 	removeVolumeVMI := func(name, namespace, volumeName string, dryRun bool) {
 		Eventually(func() error {
-			return virtClient.VirtualMachineInstance(namespace).RemoveVolume(name, &v1.RemoveVolumeOptions{
+			return f.KubevirtClient.VirtualMachineInstance(namespace).RemoveVolume(name, &v1.RemoveVolumeOptions{
 				Name:   volumeName,
 				DryRun: getDryRunOption(dryRun),
 			})
@@ -193,7 +186,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 	removeVolumeVM := func(name, namespace, volumeName string, dryRun bool) {
 		Eventually(func() error {
-			return virtClient.VirtualMachine(namespace).RemoveVolume(name, &v1.RemoveVolumeOptions{
+			return f.KubevirtClient.VirtualMachine(namespace).RemoveVolume(name, &v1.RemoveVolumeOptions{
 				Name:   volumeName,
 				DryRun: getDryRunOption(dryRun),
 			})
@@ -218,7 +211,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			nameMap[volumeName] = true
 		}
 		Eventually(func() error {
-			updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			updatedVM, err := f.KubevirtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -248,7 +241,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			nameMap[volumeName] = true
 		}
 		Eventually(func() error {
-			updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			updatedVMI, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -278,7 +271,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			volumeNamesMap[volumeName] = struct{}{}
 		}
 		Consistently(func() error {
-			currentVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			currentVMI, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -374,7 +367,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 		labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
 
-		pods, err := virtClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+		pods, err := f.KubevirtClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 		Expect(err).ToNot(HaveOccurred(), "Should list pods")
 
 		var virtlauncher *corev1.Pod
@@ -386,7 +379,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		}
 		Expect(virtlauncher).ToNot(BeNil(), "Should find running virtlauncher pod")
 		Eventually(func() bool {
-			podList, err := virtClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
+			podList, err := f.KubevirtClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				return false
 			}
@@ -408,7 +401,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			nameMap[volumeName] = true
 		}
 		res := make([]string, 0)
-		updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+		updatedVMI, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		for _, volumeStatus := range updatedVMI.Status.VolumeStatus {
 			if _, ok := nameMap[volumeStatus.Name]; ok && volumeStatus.HotplugVolume != nil {
@@ -423,7 +416,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		template := libvmi.NewCirros()
 		vm := createVirtualMachine(true, template)
 		Eventually(func() bool {
-			vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+			vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return vm.Status.Ready
 		}, 300*time.Second, 1*time.Second).Should(BeTrue())
@@ -431,7 +424,7 @@ var _ = SIGDescribe("Hotplug", func() {
 	}
 
 	checkNoProvisionerStorageClassPVs := func(storageClassName string) {
-		sc, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), storageClassName, metav1.GetOptions{})
+		sc, err := f.KubevirtClient.StorageV1().StorageClasses().Get(context.Background(), storageClassName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		if sc.Provisioner != "" && sc.Provisioner != "kubernetes.io/no-provisioner" {
@@ -439,7 +432,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		}
 
 		// Verify we have at least 3 available file system PVs
-		pvList, err := virtClient.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+		pvList, err := f.KubevirtClient.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		count := 0
 		for _, pv := range pvList.Items {
@@ -466,7 +459,7 @@ var _ = SIGDescribe("Hotplug", func() {
 	}
 
 	verifySingleAttachmentPod := func(vmi *v1.VirtualMachineInstance) {
-		podList, err := virtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
+		podList, err := f.KubevirtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		attachmentPodCount := 0
 		for _, pod := range podList.Items {
@@ -491,7 +484,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		}
 		By("Creating DataVolume")
 		dvBlock := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", accessMode, volumeMode)
-		_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dvBlock.Namespace).Create(context.Background(), dvBlock, metav1.CreateOptions{})
+		_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dvBlock.Namespace).Create(context.Background(), dvBlock, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 		Eventually(ThisDV(dvBlock), 240).Should(HaveSucceeded())
 		return dvBlock
@@ -517,7 +510,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume1, "madeup", v1.DiskBusSCSI, false)
 			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume2, "madeup", v1.DiskBusSCSI, false)
 			By("Verifying the volumes have been added to the template spec")
-			tests.VerifyVolumeAndDiskVMAdded(virtClient, vm, testNewVolume1, testNewVolume2)
+			tests.VerifyVolumeAndDiskVMAdded(f.KubevirtClient, vm, testNewVolume1, testNewVolume2)
 			By("Removing new volumes from VM")
 			removeVolumeFunc(vm.Name, vm.Namespace, testNewVolume1, false)
 			removeVolumeFunc(vm.Name, vm.Namespace, testNewVolume2, false)
@@ -548,13 +541,13 @@ var _ = SIGDescribe("Hotplug", func() {
 
 		DescribeTable("Should be able to add and use WFFC local storage", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction) {
 			checks.SkipIfNonRoot("root owned disk.img")
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 			dvNames := make([]string, 0)
 			for i := 0; i < 3; i++ {
 				dv := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
+				_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				dvNames = append(dvNames, dv.Name)
 			}
@@ -564,9 +557,9 @@ var _ = SIGDescribe("Hotplug", func() {
 				addVolumeFunc(vm.Name, vm.Namespace, dvNames[i], dvNames[i], v1.DiskBusSCSI, false)
 			}
 
-			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, dvNames...)
+			tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, dvNames...)
 			verifyVolumeStatus(vmi, v1.VolumeReady, dvNames...)
 			getVmiConsoleAndLogin(vmi)
 			verifyHotplugAttachedAndUseable(vmi, dvNames)
@@ -592,7 +585,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			)
 
 			findCPUManagerWorkerNode := func() string {
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+				nodes, err := f.KubevirtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 					LabelSelector: "node-role.kubernetes.io/worker",
 				})
 				Expect(err).ToNot(HaveOccurred())
@@ -623,7 +616,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				}
 				vm = createVirtualMachine(true, template)
 				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return vm.Status.Ready
 				}, 300*time.Second, 1*time.Second).Should(BeTrue())
@@ -632,7 +625,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			DescribeTable("should add/remove volume", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode corev1.PersistentVolumeMode, vmiOnly, waitToStart bool) {
 				dv := createDataVolumeAndWaitForImport(sc, volumeMode)
 
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				if waitToStart {
 					tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
@@ -641,11 +634,11 @@ var _ = SIGDescribe("Hotplug", func() {
 				addVolumeFunc(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false)
 				By(verifyingVolumeDiskInVM)
 				if !vmiOnly {
-					tests.VerifyVolumeAndDiskVMAdded(virtClient, vm, "testvolume")
+					tests.VerifyVolumeAndDiskVMAdded(f.KubevirtClient, vm, "testvolume")
 				}
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "testvolume")
 				verifyVolumeStatus(vmi, v1.VolumeReady, "testvolume")
 				getVmiConsoleAndLogin(vmi)
 				targets := verifyHotplugAttachedAndUseable(vmi, []string{"testvolume"})
@@ -668,7 +661,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			)
 
 			DescribeTable("Should be able to add and remove multiple volumes", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode corev1.PersistentVolumeMode, vmiOnly bool) {
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				getVmiConsoleAndLogin(vmi)
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
@@ -683,11 +676,11 @@ var _ = SIGDescribe("Hotplug", func() {
 				}
 				By(verifyingVolumeDiskInVM)
 				if !vmiOnly {
-					tests.VerifyVolumeAndDiskVMAdded(virtClient, vm, testVolumes...)
+					tests.VerifyVolumeAndDiskVMAdded(f.KubevirtClient, vm, testVolumes...)
 				}
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, testVolumes...)
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, testVolumes...)
 				verifyVolumeStatus(vmi, v1.VolumeReady, testVolumes...)
 				targets := verifyHotplugAttachedAndUseable(vmi, testVolumes)
 				verifySingleAttachmentPod(vmi)
@@ -709,7 +702,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			)
 
 			DescribeTable("Should be able to add and remove and re-add multiple volumes", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode corev1.PersistentVolumeMode, vmiOnly bool) {
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 				testVolumes := make([]string, 0)
@@ -728,29 +721,29 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				By(verifyingVolumeDiskInVM)
 				if !vmiOnly {
-					tests.VerifyVolumeAndDiskVMAdded(virtClient, vm, testVolumes[:len(testVolumes)-1]...)
+					tests.VerifyVolumeAndDiskVMAdded(f.KubevirtClient, vm, testVolumes[:len(testVolumes)-1]...)
 				}
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, testVolumes[:len(testVolumes)-1]...)
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, testVolumes[:len(testVolumes)-1]...)
 				waitForAttachmentPodToRun(vmi)
 				verifyVolumeStatus(vmi, v1.VolumeReady, testVolumes[:len(testVolumes)-1]...)
 				verifySingleAttachmentPod(vmi)
 				By("removing volume sdc, with dv" + dvNames[2])
 				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return vmi.Status.VolumeStatus[4].Target
 				}, 40*time.Second, 2*time.Second).Should(Equal("sdc"))
 				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return vmi.Status.VolumeStatus[5].Target
 				}, 40*time.Second, 2*time.Second).Should(Equal("sdd"))
 
 				removeVolumeFunc(vm.Name, vm.Namespace, testVolumes[2], false)
 				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return vmi.Status.VolumeStatus[4].Target
 				}, 40*time.Second, 2*time.Second).Should(Equal("sdd"))
@@ -758,7 +751,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				By("Adding remaining volume, it should end up in the spot that was just cleared")
 				addVolumeFunc(vm.Name, vm.Namespace, testVolumes[4], dvNames[4], v1.DiskBusSCSI, false)
 				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					for _, volumeStatus := range vmi.Status.VolumeStatus {
 						if volumeStatus.Name == testVolumes[4] {
@@ -770,7 +763,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				By("Adding intermediate volume, it should end up at the end")
 				addVolumeFunc(vm.Name, vm.Namespace, testVolumes[2], dvNames[2], v1.DiskBusSCSI, false)
 				Eventually(func() string {
-					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					for _, volumeStatus := range vmi.Status.VolumeStatus {
 						if volumeStatus.Name == testVolumes[2] {
@@ -797,17 +790,17 @@ var _ = SIGDescribe("Hotplug", func() {
 			It("should permanently add hotplug volume when added to VM, but still unpluggable after restart", func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
 
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 
 				By(addingVolumeRunningVM)
 				addDVVolumeVM(vm.Name, vm.Namespace, "testvolume", dvBlock.Name, v1.DiskBusSCSI, false)
 				By(verifyingVolumeDiskInVM)
-				tests.VerifyVolumeAndDiskVMAdded(virtClient, vm, "testvolume")
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				tests.VerifyVolumeAndDiskVMAdded(f.KubevirtClient, vm, "testvolume")
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "testvolume")
 				verifyVolumeStatus(vmi, v1.VolumeReady, "testvolume")
 				verifySingleAttachmentPod(vmi)
 
@@ -821,11 +814,11 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				By("starting VM")
 				vm = tests.StartVirtualMachine(vm)
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying that the hotplugged volume is hotpluggable after a restart")
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "testvolume")
 				verifyVolumeStatus(vmi, v1.VolumeReady, "testvolume")
 
 				By("Verifying the hotplug device is auto-mounted during booting")
@@ -834,7 +827,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				By("Remove volume from a running VM")
 				removeVolumeVM(vm.Name, vm.Namespace, "testvolume", false)
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying that the hotplugged volume can be unplugged after a restart")
@@ -843,12 +836,12 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			It("should reject hotplugging a volume with the same name as an existing volume", func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 
 				By(addingVolumeRunningVM)
-				err = virtClient.VirtualMachine(vm.Namespace).AddVolume(vm.Name, getAddVolumeOptions("disk0", v1.DiskBusSCSI, &v1.HotplugVolumeSource{
+				err = f.KubevirtClient.VirtualMachine(vm.Namespace).AddVolume(vm.Name, getAddVolumeOptions("disk0", v1.DiskBusSCSI, &v1.HotplugVolumeSource{
 					DataVolume: &v1.DataVolumeSource{
 						Name: dvBlock.Name,
 					},
@@ -861,7 +854,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
 				dvFileSystem := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeFilesystem)
 
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 				getVmiConsoleAndLogin(vmi)
@@ -869,7 +862,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				By(addingVolumeRunningVM)
 				addDVVolumeVM(vm.Name, vm.Namespace, "block", dvBlock.Name, v1.DiskBusSCSI, false)
 				addDVVolumeVM(vm.Name, vm.Namespace, "fs", dvFileSystem.Name, v1.DiskBusSCSI, false)
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "block", "fs")
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "block", "fs")
 
 				verifyVolumeStatus(vmi, v1.VolumeReady, "block", "fs")
 				targets := getTargetsFromVolumeStatus(vmi, "block", "fs")
@@ -903,7 +896,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			verifyIsMigratable := func(vmi *v1.VirtualMachineInstance, expectedValue bool) {
 				Eventually(func() bool {
-					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					if err != nil {
 						return false
 					}
@@ -931,7 +924,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				// a node without CPU manager.
 				sourceNode = ""
 				targetNode = ""
-				for _, node := range libnode.GetAllSchedulableNodes(virtClient).Items {
+				for _, node := range libnode.GetAllSchedulableNodes(f.KubevirtClient).Items {
 					labels := node.GetLabels()
 					if val, ok := labels[v1.CPUManager]; ok && val == "true" {
 						// Use a node with CPU manager as migration source
@@ -948,17 +941,17 @@ var _ = SIGDescribe("Hotplug", func() {
 				}
 				// Ensure the virt-launcher pod is scheduled on the chosen source node and then
 				// migrated to the proper target.
-				libnode.AddLabelToNode(sourceNode, hotplugLabelKey, hotplugLabelValue)
+				libnode.AddLabelToNode(f.KubevirtClient, sourceNode, hotplugLabelKey, hotplugLabelValue)
 				vmi, _ = newVirtualMachineInstanceWithContainerDisk()
 				vmi.Spec.NodeSelector = map[string]string{hotplugLabelKey: hotplugLabelValue}
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
-				libnode.AddLabelToNode(targetNode, hotplugLabelKey, hotplugLabelValue)
+				libnode.AddLabelToNode(f.KubevirtClient, targetNode, hotplugLabelKey, hotplugLabelValue)
 			})
 
 			AfterEach(func() {
 				// Cleanup node labels
-				libnode.RemoveLabelFromNode(sourceNode, hotplugLabelKey)
-				libnode.RemoveLabelFromNode(targetNode, hotplugLabelKey)
+				libnode.RemoveLabelFromNode(f.KubevirtClient, sourceNode, hotplugLabelKey)
+				libnode.RemoveLabelFromNode(f.KubevirtClient, targetNode, hotplugLabelKey)
 			})
 
 			It("should allow live migration with attached hotplug volumes", func() {
@@ -968,7 +961,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				removeVolumeFunc := removeVolumeVMI
 				dv := createDataVolumeAndWaitForImport(sc, volumeMode)
 
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err := f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 				By("Verifying the VMI is migrateable")
@@ -977,9 +970,9 @@ var _ = SIGDescribe("Hotplug", func() {
 				By("Adding volume to running VMI")
 				addVolumeFunc(vmi.Name, vmi.Namespace, volumeName, dv.Name, v1.DiskBusSCSI, false)
 				By("Verifying the volume and disk are in the VMI")
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, volumeName)
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, volumeName)
 				verifyVolumeStatus(vmi, v1.VolumeReady, volumeName)
 
 				By("Verifying the VMI is still migrateable")
@@ -992,7 +985,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 				By("Starting the migration multiple times")
 				for i := 0; i < numberOfMigrations; i++ {
-					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					vmi, err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					sourceAttachmentPods := []string{}
 					for _, volumeStatus := range vmi.Status.VolumeStatus {
@@ -1003,15 +996,15 @@ var _ = SIGDescribe("Hotplug", func() {
 					Expect(sourceAttachmentPods).To(HaveLen(1))
 
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-					migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-					tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+					migrationUID := tests.RunMigrationAndExpectCompletion(f.KubevirtClient, migration, tests.MigrationWaitTime)
+					tests.ConfirmVMIPostMigration(f.KubevirtClient, vmi, migrationUID)
 					By("Verifying the volume is still accessible and usable")
 					verifyVolumeAccessible(vmi, targets[0])
 					verifyWriteReadData(vmi, targets[0])
 
 					By("Verifying the source attachment pods are deleted")
 					Eventually(func() bool {
-						_, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), sourceAttachmentPods[0], metav1.GetOptions{})
+						_, err := f.KubevirtClient.CoreV1().Pods(vmi.Namespace).Get(context.Background(), sourceAttachmentPods[0], metav1.GetOptions{})
 						return errors.IsNotFound(err)
 					}, 60*time.Second, 1*time.Second).Should(BeTrue())
 				}
@@ -1020,9 +1013,9 @@ var _ = SIGDescribe("Hotplug", func() {
 				removeVolumeFunc(vmi.Name, vmi.Namespace, volumeName, false)
 				verifyVolumeNolongerAccessible(vmi, targets[0])
 				addVolumeFunc(vmi.Name, vmi.Namespace, volumeName, dv.Name, v1.DiskBusSCSI, false)
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi, err = f.KubevirtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, volumeName)
+				tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, volumeName)
 				verifyVolumeStatus(vmi, v1.VolumeReady, volumeName)
 			})
 		})
@@ -1042,7 +1035,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 		BeforeEach(func() {
 			libstorage.CreateStorageClass(storageClassHostPath, &immediateBinding)
-			pvNode := tests.CreateHostPathPvWithSizeAndStorageClass(tests.CustomHostPath, hotplugPvPath, "1Gi", storageClassHostPath)
+			pvNode := tests.CreateHostPathPvWithSizeAndStorageClass(f.KubevirtClient, tests.CustomHostPath, hotplugPvPath, "1Gi", storageClassHostPath)
 			tests.CreatePVC(tests.CustomHostPath, "1Gi", storageClassHostPath, false)
 			template := libvmi.NewCirros()
 			if pvNode != "" {
@@ -1051,19 +1044,19 @@ var _ = SIGDescribe("Hotplug", func() {
 			}
 			vm = createVirtualMachine(true, template)
 			Eventually(func() bool {
-				vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
 		AfterEach(func() {
-			tests.DeletePvAndPvc(fmt.Sprintf("%s-disk-for-tests", tests.CustomHostPath))
+			tests.DeletePvAndPvc(f.KubevirtClient, fmt.Sprintf("%s-disk-for-tests", tests.CustomHostPath))
 			libstorage.DeleteStorageClass(storageClassHostPath)
 		})
 
 		It("should attach a hostpath based volume to running VM", func() {
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 
@@ -1072,9 +1065,9 @@ var _ = SIGDescribe("Hotplug", func() {
 			addPVCVolumeVMI(vm.Name, vm.Namespace, "testvolume", name, v1.DiskBusSCSI, false)
 
 			By(verifyingVolumeDiskInVM)
-			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+			tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "testvolume")
 			verifyVolumeStatus(vmi, v1.VolumeReady, "testvolume")
 
 			getVmiConsoleAndLogin(vmi)
@@ -1098,7 +1091,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			template.Spec.Domain.IOThreadsPolicy = &policy
 			vm = createVirtualMachine(true, template)
 			Eventually(func() bool {
-				vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
@@ -1110,10 +1103,10 @@ var _ = SIGDescribe("Hotplug", func() {
 				Skip("Skip no filesystem storage class available")
 			}
 			dv := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
 
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 
@@ -1121,9 +1114,9 @@ var _ = SIGDescribe("Hotplug", func() {
 			addPVCVolumeVMI(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false)
 
 			By(verifyingVolumeDiskInVM)
-			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+			tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "testvolume")
 			verifyVolumeStatus(vmi, v1.VolumeReady, "testvolume")
 
 			getVmiConsoleAndLogin(vmi)
@@ -1142,25 +1135,21 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 
 		BeforeEach(func() {
-			tests.CreateAllSeparateDeviceHostPathPvs(tests.CustomHostPath)
+			tests.CreateAllSeparateDeviceHostPathPvs(f.KubevirtClient, tests.CustomHostPath)
 			vm = createVirtualMachine(true, libvmi.NewCirros())
 			Eventually(func() bool {
-				vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				vm, err := f.KubevirtClient.VirtualMachine(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
-		AfterEach(func() {
-			tests.DeleteAllSeparateDeviceHostPathPvs()
-		})
-
 		It("should attach a hostpath based volume to running VM", func() {
 			dv := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, tests.StorageClassHostPathSeparateDevice, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
+			_, err := f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
 
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 
@@ -1168,9 +1157,9 @@ var _ = SIGDescribe("Hotplug", func() {
 			addPVCVolumeVMI(vm.Name, vm.Namespace, "testvolume", dv.Name, v1.DiskBusSCSI, false)
 
 			By(verifyingVolumeDiskInVM)
-			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			tests.VerifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+			tests.VerifyVolumeAndDiskVMIAdded(f.KubevirtClient, vmi, "testvolume")
 			verifyVolumeStatus(vmi, v1.VolumeReady, "testvolume")
 
 			getVmiConsoleAndLogin(vmi)
@@ -1199,18 +1188,18 @@ var _ = SIGDescribe("Hotplug", func() {
 		})
 
 		DescribeTable("should add volume according to options", func(dryRun bool) {
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 			dv := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
-			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
+			_, err = f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
 			Eventually(func() error {
-				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				_, err = f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
 				return err
 			}, 40*time.Second, 2*time.Second).Should(Succeed())
 
-			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			addVolumeVirtctl(vmi.Name, vmi.Namespace, "", dv.Name, "", dryRun)
 			if dryRun {
@@ -1228,18 +1217,18 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 
 		DescribeTable("should remove volume according to options", func(dryRun bool) {
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err := f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 			dv := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
-			_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
+			_, err = f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
 			Eventually(func() error {
-				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
+				_, err = f.KubevirtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.TODO(), dv.Name, metav1.GetOptions{})
 				return err
 			}, 40*time.Second, 2*time.Second).Should(Succeed())
 
-			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vmi, err = f.KubevirtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			addVolumeVirtctl(vmi.Name, vmi.Namespace, "", dv.Name, "", false)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -128,7 +128,7 @@ var _ = SIGDescribe("Storage", func() {
 				nodeName = tests.NodeNameWithHandler()
 				address, device = tests.CreateErrorDisk(nodeName)
 				var err error
-				_, pvc, err = tests.CreatePVandPVCwithFaultyDisk(nodeName, device, util.NamespaceTestDefault)
+				_, pvc, err = tests.CreatePVandPVCwithFaultyDisk(virtClient, nodeName, device, util.NamespaceTestDefault)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for faulty disk")
 			})
 
@@ -207,7 +207,7 @@ var _ = SIGDescribe("Storage", func() {
 				nodeName = tests.NodeNameWithHandler()
 				tests.CreateFaultyDisk(nodeName, deviceName)
 				var err error
-				pv, pvc, err = tests.CreatePVandPVCwithFaultyDisk(nodeName, "/dev/mapper/"+deviceName, util.NamespaceTestDefault)
+				pv, pvc, err = tests.CreatePVandPVCwithFaultyDisk(virtClient, nodeName, "/dev/mapper/"+deviceName, util.NamespaceTestDefault)
 				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for faulty disk")
 			})
 
@@ -402,13 +402,13 @@ var _ = SIGDescribe("Storage", func() {
 			BeforeEach(func() {
 				checks.SkipTestIfNoFeatureGate(virtconfig.VirtIOFSGate)
 				checks.SkipIfNonRoot("VirtioFS")
-				tests.CreateHostPathPv(pvc, filepath.Join(testsuite.HostPathBase, pvc))
+				tests.CreateHostPathPv(virtClient, pvc, filepath.Join(testsuite.HostPathBase, pvc))
 				tests.CreateHostPathPVC(pvc, "1G")
 			})
 
 			AfterEach(func() {
 				tests.DeletePVC(pvc)
-				tests.DeletePV(pvc)
+				tests.DeletePV(virtClient, pvc)
 			})
 
 			It("should be successfully started and virtiofs could be accessed", func() {
@@ -548,7 +548,7 @@ var _ = SIGDescribe("Storage", func() {
 					if pvName != "" && pvName != tests.DiskAlpineHostPath {
 						// PVs can't be reused
 						By("Deleting PV and PVC")
-						tests.DeletePvAndPvc(pvName)
+						tests.DeletePvAndPvc(virtClient, pvName)
 					}
 				})
 
@@ -640,7 +640,7 @@ var _ = SIGDescribe("Storage", func() {
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With VirtualMachineInstance with two PVCs", func() {
 			BeforeEach(func() {
 				// Setup second PVC to use in this context
-				tests.CreateHostPathPv(tests.CustomHostPath, testsuite.HostPathCustom)
+				tests.CreateHostPathPv(virtClient, tests.CustomHostPath, testsuite.HostPathCustom)
 				tests.CreateHostPathPVC(tests.CustomHostPath, "1Gi")
 			})
 
@@ -867,7 +867,7 @@ var _ = SIGDescribe("Storage", func() {
 					}
 					for _, pvc := range pvcs {
 						hostpath := filepath.Join(testsuite.HostPathBase, pvc)
-						node = tests.CreateHostPathPv(pvc, hostpath)
+						node = tests.CreateHostPathPv(virtClient, pvc, hostpath)
 						tests.CreateHostPathPVC(pvc, "1G")
 						if checks.HasFeature(virtconfig.NonRoot) {
 							nodeSelector = map[string]string{"kubernetes.io/hostname": node}
@@ -884,7 +884,7 @@ var _ = SIGDescribe("Storage", func() {
 				AfterEach(func() {
 					for _, pvc := range pvcs {
 						tests.DeletePVC(pvc)
-						tests.DeletePV(pvc)
+						tests.DeletePV(virtClient, pvc)
 					}
 				})
 
@@ -1367,7 +1367,7 @@ var _ = SIGDescribe("Storage", func() {
 				nodeName = tests.NodeNameWithHandler()
 				address, device = tests.CreateSCSIDisk(nodeName, []string{})
 				var err error
-				_, pvc, err = tests.CreatePVandPVCwithSCSIDisk(nodeName, device, util.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
+				_, pvc, err = tests.CreatePVandPVCwithSCSIDisk(virtClient, nodeName, device, util.NamespaceTestDefault, "scsi-disks", "scsipv", "scsipvc")
 				Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for scsi disk")
 			})
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -158,8 +158,8 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 			memToUseInTheVmKib := availableMemSizeKib + swapSizeToUseKib
 
 			//add label the node so we could schedule the vmi to it through node selector
-			libnode.AddLabelToNode(sourceNode.Name, "swaptest", "swaptest")
-			defer libnode.RemoveLabelFromNode(sourceNode.Name, "swaptest")
+			libnode.AddLabelToNode(virtClient, sourceNode.Name, "swaptest", "swaptest")
+			defer libnode.RemoveLabelFromNode(virtClient, sourceNode.Name, "swaptest")
 
 			By("Allowing post-copy")
 			kv := util.GetCurrentKv(virtClient)
@@ -193,8 +193,8 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 			}, 240*time.Second, 1*time.Second).Should(BeNumerically(">", totalMemKib))
 
 			//add the test label to the target node
-			libnode.AddLabelToNode(targetNode.Name, "swaptest", "swaptest")
-			defer libnode.RemoveLabelFromNode(targetNode.Name, "swaptest")
+			libnode.AddLabelToNode(virtClient, targetNode.Name, "swaptest", "swaptest")
+			defer libnode.RemoveLabelFromNode(virtClient, targetNode.Name, "swaptest")
 
 			// execute a migration, wait for finalized state
 			By("Starting the Migration")
@@ -232,8 +232,8 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 			memToUseInTargetNodeVmKib := availableMemSizeKib + swapSizeToUsekib - vmMemoryRequestkib
 
 			//add label the node so we could schedule the vmi to it through the targert node selector
-			libnode.AddLabelToNode(targetNode.Name, "swaptest", "swaptest")
-			defer libnode.RemoveLabelFromNode(targetNode.Name, "swaptest")
+			libnode.AddLabelToNode(virtClient, targetNode.Name, "swaptest", "swaptest")
+			defer libnode.RemoveLabelFromNode(virtClient, targetNode.Name, "swaptest")
 
 			//The vmi should have more memory than memToUseInTheVm
 			vmiMemSize := resource.MustParse(fmt.Sprintf("%dMi", int((float64(memToUseInTargetNodeVmKib)+float64(gigbytesInkib*2))/bytesInKib)))
@@ -256,15 +256,15 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 			vmiToMigrate.Spec.NodeSelector = map[string]string{"swaptestmigrate": "swaptestmigrate"}
 			vmiToMigrate.Spec.Domain.Resources.Requests["memory"] = vmiMemReq
 			//add label the source node to make sure that the vm we want to migrate will be scheduled to the source node
-			libnode.AddLabelToNode(sourceNode.Name, "swaptestmigrate", "swaptestmigrate")
-			defer libnode.RemoveLabelFromNode(sourceNode.Name, "swaptestmigrate")
+			libnode.AddLabelToNode(virtClient, sourceNode.Name, "swaptestmigrate", "swaptestmigrate")
+			defer libnode.RemoveLabelFromNode(virtClient, sourceNode.Name, "swaptestmigrate")
 
 			By("Starting the VirtualMachineInstance that we should migrate to the target node")
 			vmiToMigrate = runVMIAndExpectLaunch(vmiToMigrate, 240)
 			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
 			//add label the target node so the vm could be scheduled to it
-			libnode.AddLabelToNode(targetNode.Name, "swaptestmigrate", "swaptestmigrate")
-			defer libnode.RemoveLabelFromNode(targetNode.Name, "swaptestmigrate")
+			libnode.AddLabelToNode(virtClient, targetNode.Name, "swaptestmigrate", "swaptestmigrate")
+			defer libnode.RemoveLabelFromNode(virtClient, targetNode.Name, "swaptestmigrate")
 
 			// execute a migration, wait for finalized state
 			By("Starting the Migration")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR add a `TestClient` and Framework. The `TestClient` is a wrapped kubevirt client that exposes all client functionality and can be used as a normal client. In addition it provides a mechanism that track the non-namespaces resources created or updated during e2e tests, and functions to rollback (cleanup) them at the end of the execution.
This` Framework` supports common operations used by e2e tests; it will keep a client & clean the cluster for you. It is not necessary anymore to clean the cluster on `BeforeEach` of all tests if you use the framework because it cleans it for you. It contains a call to `tests.BeforeTestCleanup()` on its `BeforeEach()`. 
It also initializes the `TestClient` that can be used everywhere: in this way, writing tests, you have not to retrieve the `TestClient` because it creates one for you, you can simply use it. 
Looking at the tests files there where different cases where`tests.BeforeTestCleanup()` was defined inside `BeforeEach()` of the outer `Describe` block and also in the inner ones(`Context, It, Describe`..). Since `BeforeEach()` is executed for each specs it causes a multiple calls to `tests.BeforeTestCleanup()` function.
In other cases, it was not defined in any of the `BeforeEach()` causing a possible dependency between tests.
The union of these two gives the following advantages:
1. Make sure that each test will run in a cleaned cluster
2. Provides to you a `TestClient` that can be used without the necessity of retrieving ones
3. Gives the possibility to write a `BeforeEach()` that is specific for that set of tests

Since it cleans the cluster before each test this ensures that every test runs in the same cluster conditions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Only a subset of the tests is affected by changes in order to monitoring issues.
The tests were chosen on the basis of whether or not they contained changes to non-namespaces resources tracked by the test client:

- perstistenVolume CREATE
- node CREATE, UPDATE, PATCH
- namespace CREATE
- migrationPolicy CREATE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add TestClient to easily rollback non-namespaced resources created or updated during e2e tests
Add Framework to support common operations used by functional tests
```
