### PR TITLE
Skip migration tests on sig-storage and remove DataVolume custom cleanup

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -362,6 +362,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
   elif [[ $TARGET =~ sig-storage ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-storage\\]|\\[storage-req\\]"
+    export KUBEVIRT_E2E_SKIP="Migration"
   elif [[ $TARGET =~ vgpu.* ]]; then
     export KUBEVIRT_E2E_FOCUS=MediatedDevices
   elif [[ $TARGET =~ sig-compute-realtime ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Some migration tests were still executed on the sig-storage lane. Since they were executed in parallel there were not enough resources available. Skipping them now.

DataVolumes can take a little bit until they are fully imported.
Increase the timeout, as well as removing the custom cleanup, to collect
in our test reporter the DataVolume, in case something is wrong with the
DataVolume and the test fails.

This helps debugging issues like the one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
