### PR TITLE
Fix openshift/client-go version

### DIFF
--- a/staging/src/kubevirt.io/client-go/go.mod
+++ b/staging/src/kubevirt.io/client-go/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
-	github.com/openshift/client-go v0.0.0
+	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.23.1
 	k8s.io/apiextensions-apiserver v0.23.1
@@ -76,7 +76,6 @@ require (
 
 replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
-	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 
 	k8s.io/api => k8s.io/api v0.23.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`github.com/openshift/client-go  v0.0.0` is an unknown revision and makes it impossible to get `kubevirt/client-go` package, even if it is defined in the `replace` directive.

Signed-off-by: fossedihelm <ffossemo@redhat.com>
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7196 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
