### PR TITLE
Use /mnt instead of /tmp for hostpath hotplug test

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -32,6 +32,10 @@ cp -r /hostImages/alpine hostImages/alpine1
 cp -r /hostImages/alpine hostImages/alpine2
 cp -r /hostImages/alpine hostImages/alpine3
 rm -rf /hostImages/alpine
+mkdir -p /local-storage/hotplug-test
+cp -r /hostImages/custom/disk.img /local-storage/hotplug-test/disk.img
+chmod -R 777 /local-storage/hotplug-test
+
 echo "make the custom image ready for parallel use"
 cp -r /hostImages/custom hostImages/custom1
 cp -r /hostImages/custom hostImages/custom2

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1029,13 +1029,16 @@ var _ = SIGDescribe("Hotplug", func() {
 			vm *v1.VirtualMachine
 		)
 
+		const (
+			hotplugPvPath = "/mnt/local-storage/hotplug-test"
+		)
+
 		storageClassHostPath := "host-path"
 		immediateBinding := storagev1.VolumeBindingImmediate
 
 		BeforeEach(func() {
 			tests.CreateStorageClass(storageClassHostPath, &immediateBinding)
-			// Setup second PVC to use in this context
-			pvNode := tests.CreateHostPathPvWithSizeAndStorageClass(tests.CustomHostPath, tests.HostPathCustom, "1Gi", storageClassHostPath)
+			pvNode := tests.CreateHostPathPvWithSizeAndStorageClass(tests.CustomHostPath, hotplugPvPath, "1Gi", storageClassHostPath)
 			tests.CreatePVC(tests.CustomHostPath, "1Gi", storageClassHostPath, false)
 			template := libvmi.NewCirros()
 			if pvNode != "" {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On certain OSs /tmp is tmpfs, and when the hotplug code tries to resolve the actual path on the host, it uses findmnt to do so, and if the actual path is on tmpfs it is unable to locate the real path. Now using hostpath on tmpfs is not something someone will do anyway so this commit modifies the path used from potentially a tmpfs to a real path.

This is just a test fix for certain types of hosts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Note kubevirtci /tmp is a real directory not tmpfs, we specifically spotted this on an RHCOS node.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
