### PR TITLE
Fix race condition in monitor tests

### DIFF
--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -238,7 +238,9 @@ func FindPid(commandNamePrefix string) (int, error) {
 	for _, entry := range entries {
 		// #nosec No risk for path injection. Reading specific entries under /proc
 		content, err := ioutil.ReadFile(entry)
-		if err != nil {
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
 			return 0, err
 		}
 


### PR DESCRIPTION
One more attempt to fix the process monitor tests. This is a follow-up of the https://github.com/kubevirt/kubevirt/pull/7149.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Do not try to manage the fake qemu process from goroutines as it leads to races and makes the tests flaky.

Fixes panic in one of the test cases:

```
• [SLOW TEST:32.006 seconds]
VirtLauncher
pkg/virt-launcher/monitor_test.go:43
  VirtLauncher
  pkg/virt-launcher/monitor_test.go:139
    process monitor
    pkg/virt-launcher/monitor_test.go:140
      verify graceful shutdown trigger works
      pkg/virt-launcher/monitor_test.go:203
------------------------------
panic: 
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.

But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call

	defer GinkgoRecover()

at the top of the goroutine that caused this panic.


goroutine 9 [running]:
kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo.Fail({0xc0000aac80, 0x47}, {0xc00047f6e0, 0xc0000aac80, 0xc000456820})
	vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:267 +0xdd
kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).match(0xc00052d508, {0xe3bda8, 0x151ac18}, 0x0, {0x0, 0x0, 0x0})
	vendor/github.com/onsi/gomega/internal/assertion/assertion.go:79 +0x1bd
kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).ToNot(0xc00052d508, {0xe3bda8, 0x151ac18}, {0x0, 0x0, 0x0})
	vendor/github.com/onsi/gomega/internal/assertion/assertion.go:43 +0x92
kubevirt.io/kubevirt/pkg/virt-launcher.glob..func1.6.1(0xe2c7a0)
	pkg/virt-launcher/monitor_test.go:119 +0x129
kubevirt.io/kubevirt/pkg/virt-launcher.(*monitor).refresh(0xc000462840)
	pkg/virt-launcher/monitor.go:164 +0xc5e
kubevirt.io/kubevirt/pkg/virt-launcher.(*monitor).monitorLoop(0xc000462840, 0x3b9aca00, 0xc000048600)
	pkg/virt-launcher/monitor.go:189 +0x3d3
kubevirt.io/kubevirt/pkg/virt-launcher.glob..func1.8.1.5.2()
	pkg/virt-launcher/monitor_test.go:212 +0x32
created by kubevirt.io/kubevirt/pkg/virt-launcher.glob..func1.8.1.5
	pkg/virt-launcher/monitor_test.go:211 +0x136
===============================================================================
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
