### PR TITLE
tests: minor network expose cleanup

### DIFF
--- a/tests/job.go
+++ b/tests/job.go
@@ -110,7 +110,7 @@ func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, time
 // NewHelloWorldJob takes a DNS entry or an IP and a port which it will use to create a job
 // which tries to contact the host on the provided port.
 // It expects to receive "Hello World!" to succeed.
-func NewHelloWorldJob(host string, port string) *batchv1.Job {
+func NewHelloWorldJobTCP(host string, port string) *batchv1.Job {
 	check := fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 3 -w 3 --no-shutdown))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)
 	return newHelloWorldJob(check)
 }

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -563,8 +563,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		var vmrs *v1.VirtualMachineInstanceReplicaSet
 		BeforeEach(func() {
 			By("Creating a VMRS object with 2 replicas")
-			template := newLabeledVMI("vmirs")
-			vmrs = tests.NewRandomReplicaSetFromVMI(template, int32(numberOfVMs))
+			vmrs = tests.NewRandomReplicaSetFromVMI(newLabeledVMI("vmirs"), int32(numberOfVMs))
 			vmrs.Labels = map[string]string{"expose": "vmirs"}
 
 			By("Start the replica set")
@@ -662,8 +661,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 		createStoppedVM := func(virtClient kubecli.KubevirtClient, namespace string) (*v1.VirtualMachine, error) {
 			By("Creating an VM object")
-			template := newLabeledVMI("vm")
-			vm := tests.NewRandomVirtualMachine(template, false)
+			vm := tests.NewRandomVirtualMachine(newLabeledVMI("vm"), false)
 
 			By("Creating the VM")
 			vm, err = virtClient.VirtualMachine(namespace).Create(vm)

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -82,7 +82,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	})
 
 	runHelloWorldJob := func(host, port, namespace string) *batchv1.Job {
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), tests.NewHelloWorldJob(host, port), metav1.CreateOptions{})
+		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), tests.NewHelloWorldJobTCP(host, port), metav1.CreateOptions{})
 		ExpectWithOffset(2, err).ToNot(HaveOccurred())
 		return job
 	}

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -25,7 +25,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
@@ -45,7 +44,9 @@ func newLabeledVMI(label string, virtClient kubecli.KubevirtClient, createVMI bo
 		{Name: "test-port-tcp", Port: 1500, Protocol: "TCP"},
 		{Name: "udp", Port: 82, Protocol: "UDP"},
 		{Name: "test-port-udp", Port: 1500, Protocol: "UDP"}}
-	vmi = tests.NewRandomVMIWithMasqueradeInterfaceEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n", ports)
+	vmi = libvmi.NewCirros(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 	vmi.Labels = map[string]string{"expose": label}
 
 	var err error

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -81,24 +81,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		util.PanicOnError(err)
 	})
 
-	runHelloWorldJob := func(host, port, namespace string) *batchv1.Job {
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), tests.NewHelloWorldJobTCP(host, port), metav1.CreateOptions{})
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
-		return job
-	}
-
-	runHelloWorldJobUDP := func(host, port, namespace string) *batchv1.Job {
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), tests.NewHelloWorldJobUDP(host, port), metav1.CreateOptions{})
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
-		return job
-	}
-
-	runHelloWorldJobHttp := func(host, port, namespace string) *batchv1.Job {
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), tests.NewHelloWorldJobHTTP(host, port), metav1.CreateOptions{})
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
-		return job
-	}
-
 	randomizeName := func(currentName string) string {
 		return currentName + rand.String(5)
 	}
@@ -133,9 +115,11 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		return vmiExposeArgs
 	}
 
-	createAndWaitForJobToSucceed := func(helloWorldJobCreator func(host, port, namespace string) *batchv1.Job, namespace, ip, port, viaMessage string) error {
+	createAndWaitForJobToSucceed := func(jobFactory func(host, port string) *batchv1.Job, namespace, ip, port, viaMessage string) error {
 		By(fmt.Sprintf("Starting a job which tries to reach the VMI via the %s", viaMessage))
-		job := helloWorldJobCreator(ip, port, namespace)
+		job := jobFactory(ip, port)
+		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), job, metav1.CreateOptions{})
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 		By("Waiting for the job to report a successful connection attempt")
 		return tests.WaitForJobToSucceed(job, time.Duration(120)*time.Second)
@@ -155,13 +139,13 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		return svc, nil
 	}
 
-	runJobsAgainstService := func(svc *k8sv1.Service, namespace string, jobs ...func(host, port, namespace string) *batchv1.Job) {
+	runJobsAgainstService := func(svc *k8sv1.Service, namespace string, jobFactories ...func(host, port string) *batchv1.Job) {
 		serviceIPs := svc.Spec.ClusterIPs
-		for _, job := range jobs {
+		for _, jobFactory := range jobFactories {
 			for ipOrderNum, ip := range serviceIPs {
 				assert.XFail(xfailError, func() {
 					servicePort := fmt.Sprint(svc.Spec.Ports[0].Port)
-					Expect(createAndWaitForJobToSucceed(job, namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
+					Expect(createAndWaitForJobToSucceed(jobFactory, namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 				}, ipOrderNum > 0)
 			}
 		}
@@ -204,7 +188,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, tcpVM.Namespace, runHelloWorldJob)
+				runJobsAgainstService(svc, tcpVM.Namespace, tests.NewHelloWorldJobTCP)
 			},
 				table.Entry("[test_id:1531] over default IPv4 IP family", ipv4),
 				table.Entry(overIPv6Family, ipv6),
@@ -406,7 +390,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					if ipFamily != ipv6 {
 						By("Connecting to IPv4 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
 						}, ipFamily == dualIPv6Primary)
 					}
 					if doesSupportIpv6(ipFamily) {
@@ -420,7 +404,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 						By("Connecting to IPv6 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
 						}, ipFamily == dualIPv4Primary)
 					}
 				}
@@ -471,7 +455,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, udpVM.Namespace, runHelloWorldJobUDP)
+				runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
 			},
 				table.Entry("[test_id:1535] over default IPv4 IP family", ipv4),
 				table.Entry(overIPv6Family, ipv6),
@@ -514,7 +498,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(nodePort).To(BeNumerically(">", 0))
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, udpVM.Namespace, runHelloWorldJobUDP)
+				runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
 
 				By("Getting the node IP from all nodes")
 				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
@@ -538,13 +522,13 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					if ipFamily != ipv6 {
 						By("Connecting to IPv4 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
 						}, ipFamily == dualIPv6Primary)
 					}
 					if doesSupportIpv6(ipFamily) {
 						By("Connecting to IPv6 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
 						}, ipFamily == dualIPv4Primary)
 					}
 				}
@@ -619,7 +603,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vmrs.Namespace, runHelloWorldJob)
+				runJobsAgainstService(svc, vmrs.Namespace, tests.NewHelloWorldJobTCP)
 			},
 				table.Entry("[test_id:1537] over default IPv4 IP family", ipv4),
 				table.Entry(overIPv6Family, ipv6),
@@ -713,7 +697,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vm.Namespace, runHelloWorldJob, runHelloWorldJobHttp)
+				runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobHTTP)
 			},
 				table.Entry("[test_id:1538] over default IPv4 IP family", ipv4),
 				table.Entry(overIPv6Family, ipv6),
@@ -740,7 +724,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vmObj.Namespace, runHelloWorldJob)
+				runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
 
 				// Retrieve the current VMI UID, to be compared with the new UID after restart.
 				vmi, err = virtClient.VirtualMachineInstance(vmObj.Namespace).Get(vmObj.Name, &k8smetav1.GetOptions{})
@@ -769,7 +753,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 				By("Repeating the sequence as prior to restarting the VM: Connect to exposed ClusterIP service.")
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vmObj.Namespace, runHelloWorldJob)
+				runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
 			},
 				table.Entry("[test_id:345] over default IPv4 IP family", ipv4),
 				table.Entry(overIPv6Family, ipv6),
@@ -812,7 +796,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vm.Namespace, runHelloWorldJob, runHelloWorldJob)
+				runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobTCP)
 
 				By("Comparing the service's endpoints IP address to the VM pod IP address.")
 				// Get the IP address of the VM pod.
@@ -862,7 +846,9 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(svcEndpoints.Subsets).To(BeNil())
 
 				By("Starting a job which tries to reach the VMI via the ClusterIP service.")
-				job := runHelloWorldJob(svc.Spec.ClusterIP, servicePort, vm.Namespace)
+				job := tests.NewHelloWorldJobTCP(svc.Spec.ClusterIP, servicePort)
+				job, err = virtClient.BatchV1().Jobs(vm.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for the job to report a failed connection attempt.")
 				Expect(tests.WaitForJobToFail(job, 240*time.Second)).To(Succeed())

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -56,7 +56,7 @@ var _ = SIGDescribe("Services", func() {
 	var virtClient kubecli.KubevirtClient
 
 	runTCPClientExpectingHelloWorldFromServer := func(host, port, namespace string, retries int32) *batchv1.Job {
-		job := tests.NewHelloWorldJob(host, port)
+		job := tests.NewHelloWorldJobTCP(host, port)
 		job.Spec.BackoffLimit = &retries
 		var err error
 		job, err = virtClient.BatchV1().Jobs(namespace).Create(context.Background(), job, k8smetav1.CreateOptions{})

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -242,7 +242,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					Skip("Skip network test that requires multiple nodes when only one node is present.")
 				}
 
-				job := tests.NewHelloWorldJob(ip, strconv.Itoa(testPort))
+				job := tests.NewHelloWorldJobTCP(ip, strconv.Itoa(testPort))
 				job.Spec.Template.Spec.Affinity = &v12.Affinity{
 					NodeAffinity: &v12.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2861,14 +2861,6 @@ func NewRandomVMIWithSlirpInterfaceEphemeralDiskAndUserdata(containerImage strin
 	return vmi
 }
 
-func NewRandomVMIWithMasqueradeInterfaceEphemeralDiskAndUserdata(containerImage string, userData string, Ports []v1.Port) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, userData)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", Ports: Ports, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}}
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-
-	return vmi
-}
-
 func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}


### PR DESCRIPTION
Reuse `tests.RunVMIAndExpectLaunch` and `libvmi.NewCirros`, and fix a function that did two things based on a boolean argument.

```release-note
NONE
```
/cc @maiqueb @EdDev 