### PR TITLE
Set abort outcome on succeeding and failed migrations

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -61,6 +61,7 @@ var _ = Describe("ImageUpload", func() {
 
 		imagePath       string
 		archiveFilePath string
+		tmpDir          string
 	)
 
 	BeforeEach(func() {
@@ -76,12 +77,17 @@ var _ = Describe("ImageUpload", func() {
 		defer imageFile.Close()
 
 		imagePath = imageFile.Name()
+		tmpDir, err = ioutil.TempDir("", "imageupload")
+		Expect(err).ToNot(HaveOccurred())
 
-		archiveFilePath = tests.ArchiveFiles("archive", os.TempDir(), imagePath)
+		archiveFilePath = tests.ArchiveFiles("archive", tmpDir, imagePath)
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
+		if tmpDir != "" {
+			os.RemoveAll(tmpDir)
+		}
 		os.Remove(imagePath)
 		os.Remove(archiveFilePath)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

In some cases migrations are failing or succeeding when we request an
abort.

If a migration which should be aborted fails, the abort succeeded. If
the migration still succeeds, the abort failed.

Ensure that we don't stay in Aborting state in these cases.

Revealed in migration cancel tests like this:

```
 VM Live Migration Starting a VirtualMachineInstance live migration cancelation Immediate migration cancellation [sig-compute][test_id:3241]cancel a migration right after posting it 
```

An example job is https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7201/pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations/1491446864820572160. One can see the the migration failed and the the abort status still stayed in Aborting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure that the migration abort status gets properly updated if migrations fail or succeed
```
