### PR TITLE
[e2e]: taking out quarantined infra test since its stable now

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1566,7 +1566,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				_, err = virtClient.ClusterProfiler().Dump(&v1.ClusterProfilerRequest{})
 				Expect(err).ToNot(BeNil())
 			})
-			It("[QUARANTINE] is enabled it should allow subresource access", func() {
+			It("is enabled it should allow subresource access", func() {
 				tests.EnableFeatureGate("ClusterProfiler")
 
 				err := virtClient.ClusterProfiler().Start()


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The infra test related to pporf proved to be stable. Results [here](https://search.ci.kubevirt.io/?search=ClusterProfiler&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

**Which issue(s) this PR fixes**:
https://github.com/kubevirt/kubevirt/pull/6787

**Release note**:
```release-note
NONE
```
