### PR TITLE
Flaky test fix - make archive file random

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -77,7 +77,12 @@ var _ = Describe("ImageUpload", func() {
 
 		imagePath = imageFile.Name()
 
-		archiveFilePath = tests.ArchiveFiles("archive", os.TempDir(), imagePath)
+		archiveFile, err := ioutil.TempFile("", "archive")
+		Expect(err).ToNot(HaveOccurred())
+		defer archiveFile.Close()
+		archiveFilePath = archiveFile.Name()
+
+		tests.ArchiveToFile(archiveFile, imagePath)
 	})
 
 	AfterEach(func() {

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -237,7 +237,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 		var archivePath string
 
 		BeforeEach(func() {
-			archivePath = tests.ArchiveFiles("archive", os.TempDir(), imagePath)
+			archivePath = tests.CreateArchive("archive", os.TempDir(), imagePath)
 		})
 
 		AfterEach(func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5206,12 +5206,18 @@ func CreateBlockPVC(virtClient kubecli.KubevirtClient, name string, size resourc
 	return createdPvc
 }
 
-func ArchiveFiles(targetFile, tgtDir string, sourceFilesNames ...string) string {
+func CreateArchive(targetFile, tgtDir string, sourceFilesNames ...string) string {
 	tgtPath := filepath.Join(tgtDir, filepath.Base(targetFile)+".tar")
 	tgtFile, err := os.Create(tgtPath)
 	Expect(err).ToNot(HaveOccurred())
 	defer tgtFile.Close()
 
+	ArchiveToFile(tgtFile, sourceFilesNames...)
+
+	return tgtPath
+}
+
+func ArchiveToFile(tgtFile *os.File, sourceFilesNames ...string) {
 	w := tar.NewWriter(tgtFile)
 	defer w.Close()
 
@@ -5232,8 +5238,6 @@ func ArchiveFiles(targetFile, tgtDir string, sourceFilesNames ...string) string 
 		_, err = io.Copy(w, srcFile)
 		Expect(err).ToNot(HaveOccurred())
 	}
-
-	return tgtPath
 }
 
 func GetPolicyMatchedToVmi(name string, vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int) *migrationsv1.MigrationPolicy {


### PR DESCRIPTION

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The archive file was reused in many tests. Tests were 
failing when multiple tests created and deleted it at the 
same time (parallel tests). Fix is easy - create a 
temporary file with random name.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://github.com/kubevirt/kubevirt/issues/7203

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
