### PR TITLE
cluster-clean: Remove finalizers from CRDs

### DIFF
--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -85,6 +85,12 @@ function delete_resources() {
 
     # Not namespaced resources
     for label in ${labels[@]}; do
+        # Remove the finalizers added by virt-operator from CRDs
+        _kubectl get customresourcedefinitions --no-headers -o=custom-columns=NAME:.metadata.name,FINALIZERS:.metadata.finalizers -l ${label} | grep -e "kubevirt.io/virtOperatorFinalizer" | while read p; do
+            local arr=($p)
+            local name="${arr[0]}"
+            patch_remove_finalizers customresourcedefinitions ${name}
+        done
         _kubectl delete apiservices,clusterroles,clusterrolebinding,customresourcedefinitions,pv,validatingwebhookconfiguration -l ${label}
     done
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The CRDs may have finalizers added by virt-operator (https://github.com/kubevirt/kubevirt/pull/7064). Those need to be removed in order not to block the cleanup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
