### PR TITLE
RunStrategy: Once

### DIFF
--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -697,11 +697,13 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			table.Entry("Always", v1.RunStrategyAlways, "VM is not running", &v1.RestartOptions{}),
 			table.Entry("Manual", v1.RunStrategyManual, "VM is not running", &v1.RestartOptions{}),
 			table.Entry("RerunOnFailure", v1.RunStrategyRerunOnFailure, "VM is not running", &v1.RestartOptions{}),
+			table.Entry("Once", v1.RunStrategyOnce, "Once does not support manual restart requests", &v1.RestartOptions{}),
 			table.Entry("Halted", v1.RunStrategyHalted, "Halted does not support manual restart requests", &v1.RestartOptions{}),
 
 			table.Entry("Always with dry-run option", v1.RunStrategyAlways, "VM is not running", &v1.RestartOptions{DryRun: getDryRunOption()}),
 			table.Entry("Manual with dry-run option", v1.RunStrategyManual, "VM is not running", &v1.RestartOptions{DryRun: getDryRunOption()}),
 			table.Entry("RerunOnFailure with dry-run option", v1.RunStrategyRerunOnFailure, "VM is not running", &v1.RestartOptions{DryRun: getDryRunOption()}),
+			table.Entry("Once with dry-run option", v1.RunStrategyOnce, "Once does not support manual restart requests", &v1.RestartOptions{DryRun: getDryRunOption()}),
 			table.Entry("Halted with dry-run option", v1.RunStrategyHalted, "Halted does not support manual restart requests", &v1.RestartOptions{DryRun: getDryRunOption()}),
 		)
 	})
@@ -1091,10 +1093,12 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			},
 			table.Entry("Always without VMI", v1.RunStrategyAlways, v1.VmPhaseUnset, http.StatusNotFound, "Always does not support manual start requests", &v1.StartOptions{}),
 			table.Entry("Always with VMI in phase Running", v1.RunStrategyAlways, v1.Running, http.StatusOK, "VM is already running", &v1.StartOptions{}),
+			table.Entry("Once", v1.RunStrategyOnce, v1.VmPhaseUnset, http.StatusNotFound, "Once does not support manual start requests", &v1.StartOptions{}),
 			table.Entry("RerunOnFailure with VMI in phase Failed", v1.RunStrategyRerunOnFailure, v1.Failed, http.StatusOK, "RerunOnFailure does not support starting VM from failed state", &v1.StartOptions{}),
 
 			table.Entry("Always without VMI and with dry-run option", v1.RunStrategyAlways, v1.VmPhaseUnset, http.StatusNotFound, "Always does not support manual start requests", &v1.StartOptions{DryRun: getDryRunOption()}),
 			table.Entry("Always with VMI in phase Running and with dry-run option", v1.RunStrategyAlways, v1.Running, http.StatusOK, "VM is already running", &v1.StartOptions{DryRun: getDryRunOption()}),
+			table.Entry("Once with dry-run option", v1.RunStrategyOnce, v1.VmPhaseUnset, http.StatusNotFound, "Once does not support manual start requests", &v1.StartOptions{DryRun: getDryRunOption()}),
 			table.Entry("RerunOnFailure with VMI in phase Failed and with dry-run option", v1.RunStrategyRerunOnFailure, v1.Failed, http.StatusOK, "RerunOnFailure does not support starting VM from failed state", &v1.StartOptions{DryRun: getDryRunOption()}),
 		)
 
@@ -1160,11 +1164,13 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 		},
 			table.Entry("RunStrategyAlways", v1.RunStrategyAlways, "", false, &v1.StopOptions{}),
+			table.Entry("RunStrategyOnce", v1.RunStrategyOnce, "", false, &v1.StopOptions{}),
 			table.Entry("RunStrategyRerunOnFailure", v1.RunStrategyRerunOnFailure, "", false, &v1.StopOptions{}),
 			table.Entry("RunStrategyManual", v1.RunStrategyManual, "VM is not running", true, &v1.StopOptions{}),
 			table.Entry("RunStrategyHalted", v1.RunStrategyHalted, "VM is not running", true, &v1.StopOptions{}),
 
 			table.Entry("RunStrategyAlways with dry-run option", v1.RunStrategyAlways, "", false, &v1.StopOptions{DryRun: getDryRunOption()}),
+			table.Entry("RunStrategyOnce with dry-run option", v1.RunStrategyOnce, "", false, &v1.StopOptions{DryRun: getDryRunOption()}),
 			table.Entry("RunStrategyRerunOnFailure with dry-run option", v1.RunStrategyRerunOnFailure, "", false, &v1.StopOptions{DryRun: getDryRunOption()}),
 			table.Entry("RunStrategyManual with dry-run option", v1.RunStrategyManual, "VM is not running", true, &v1.StopOptions{DryRun: getDryRunOption()}),
 			table.Entry("RunStrategyHalted with dry-run option", v1.RunStrategyHalted, "VM is not running", true, &v1.StopOptions{DryRun: getDryRunOption()}),
@@ -1217,6 +1223,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		},
 			table.Entry("Always", v1.RunStrategyAlways),
 			table.Entry("RerunOnFailure", v1.RunStrategyRerunOnFailure),
+			table.Entry("Once", v1.RunStrategyOnce),
 			table.Entry("Manual", v1.RunStrategyManual),
 		)
 	})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -43,7 +43,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-var validRunStrategies = []v1.VirtualMachineRunStrategy{v1.RunStrategyHalted, v1.RunStrategyManual, v1.RunStrategyAlways, v1.RunStrategyRerunOnFailure}
+var validRunStrategies = []v1.VirtualMachineRunStrategy{v1.RunStrategyHalted, v1.RunStrategyManual, v1.RunStrategyAlways, v1.RunStrategyRerunOnFailure, v1.RunStrategyOnce}
 
 type CloneAuthFunc func(pvcNamespace, pvcName, saNamespace, saName string) (bool, string, error)
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1237,6 +1237,9 @@ const (
 	// VMI will initially be running--and restarted if a failure occurs.
 	// It will not be restarted upon successful completion.
 	RunStrategyRerunOnFailure VirtualMachineRunStrategy = "RerunOnFailure"
+	// VMI will run once and not be restarted upon completion regardless
+	// if the completion is of phase Failure or Success
+	RunStrategyOnce VirtualMachineRunStrategy = "Once"
 )
 
 // VirtualMachineSpec describes how the proper VirtualMachine

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1412,6 +1412,89 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 			})
 
+			Context("Using RunStrategyOnce", func() {
+				It("[Serial] Should leave a failed VMI", func() {
+					By("creating a VM with RunStrategyOnce")
+					virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyOnce)
+
+					By("Waiting for VM to be ready")
+					Eventually(func() bool {
+						virtualMachine, err = virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return virtualMachine.Status.Ready
+					}, 360*time.Second, 1*time.Second).Should(BeTrue())
+
+					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("killing qemu process")
+					err = pkillAllVMIs(virtClient, vmi.Status.NodeName)
+					Expect(err).To(BeNil(), "Should kill VMI successfully")
+
+					By("Ensuring the VirtualMachineInstance enters Failed phase")
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+
+						Expect(err).ToNot(HaveOccurred())
+						return vmi.Status.Phase
+					}, 240*time.Second, 1*time.Second).Should(Equal(v1.Failed))
+
+					By("Ensuring the VirtualMachine remains stopped")
+					Consistently(func() v1.VirtualMachineInstancePhase {
+						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vmi.Status.Phase
+					}, 1*time.Minute, 5*time.Second).Should(Equal(v1.Failed))
+
+					By("Ensuring the VirtualMachine remains Ready=false")
+					vm, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vm.Status.Ready).To(BeFalse())
+				})
+
+				It("Should leave a succeeded VMI", func() {
+					By("creating a VM with RunStrategyOnce")
+					virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyOnce)
+
+					By("Waiting for VM to be ready")
+					Eventually(func() bool {
+						virtualMachine, err = virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return virtualMachine.Status.Ready
+					}, 360*time.Second, 1*time.Second).Should(BeTrue())
+
+					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+
+					By("Issuing a poweroff command from inside VM")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "sudo poweroff\n"},
+						&expect.BExp{R: console.PromptExpression},
+					}, 10)).To(Succeed())
+
+					By("Ensuring the VirtualMachineInstance enters Succeeded phase")
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+
+						Expect(err).ToNot(HaveOccurred())
+						return vmi.Status.Phase
+					}, 240*time.Second, 1*time.Second).Should(Equal(v1.Succeeded))
+
+					By("Ensuring the VirtualMachine remains stopped")
+					Consistently(func() v1.VirtualMachineInstancePhase {
+						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vmi.Status.Phase
+					}, 1*time.Minute, 5*time.Second).Should(Equal(v1.Succeeded))
+
+					By("Ensuring the VirtualMachine remains Ready=false")
+					vm, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vm.Status.Ready).To(BeFalse())
+				})
+			})
+
 			Context("Using RunStrategyManual", func() {
 				It("[test_id:2036] should start", func() {
 					By("creating a VM with RunStrategyManual")


### PR DESCRIPTION
This PR adds a new RunStrategy to the VM api called `Once`.

The `Once` RunStrategy allows someone to declare that their VM should run exactly once to completion (a finalized phase) and should remain stopped after completion. This is similar in concept to the `RunStrategy: RerunOnFailure`, with the key difference here being that `RunStrategy: Once` will remained stopped regardless if the vmi fails or succeeds. 

These are the subresource rules when RunStrategy: Once is set

* Start - fails because it doesn't make sense. vm will automatically start the first time similar to `Always`
* Restart - fails because it invalidates the guarantee that the VMI will only run `Once`
* Stop - succeeds if VM is currently running.

**Use Case**

There are scenarios in the [cluster-api-provider-kubevirt](https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt) project where we want a VM (hosting a k8s worker node) to only run once. This could be because the VM uses ephemeral storage which invalidates the node from being started again after the VMI's pod exits, or it could because we have encountered a scenario where we don't want to allow a VM to come back online with a different IP address allocated from the pod network.

Essentially, we want the ability to use a VM object similar to a VMI object, where the VM is only allowed to run a single time to completion. 

The reason we don't use a VMI instead of a VM is that this scenario where we only want the VM to run once isn't a hard rule. There are scenarios where it's okay to allow the VM to restart as well. We made the decision that the cluster-api-provider-kubevirt KubeVirtMachine object works with VMs rather than VMIs, so this ability to tell a VM to run once is desirable for consistency. It's also possible we need the DataVolumeTemplates of a VM while using RunStrategy: Once, which isn't feasible by using a VMI directly.

```release-note
RunStrategy: Once - allows declaring a VM should run once to a finalized state 
```
