### PR TITLE
Add a name label to virt-operator pods 

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1006,6 +1006,7 @@ spec:
             metadata:
               labels:
                 kubevirt.io: virt-operator
+                name: virt-operator
                 prometheus.kubevirt.io: "true"
               name: virt-operator
             spec:

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -450,6 +450,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						virtv1.AppLabel:    VirtOperatorName,
+						virtv1.AppName:     VirtOperatorName,
 						prometheusLabelKey: prometheusLabelValue,
 					},
 					Name: VirtOperatorName,

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -668,9 +668,10 @@ const (
 )
 
 const (
-	// This label marks resources that belong to KubeVirt. An optional value
+	// AppLabel and AppName labels marks resources that belong to KubeVirt. An optional value
 	// may indicate which specific KubeVirt component a resource belongs to.
 	AppLabel string = "kubevirt.io"
+	AppName  string = "name"
 	// This annotation is used to match virtual machine instances represented as
 	// libvirt XML domains with their pods. Among other things, the annotation is
 	// used to detect virtual machines with dead pods. Used on Pod.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://bugzilla.redhat.com/show_bug.cgi?id=2001385

virt-operator pods should have name label like other operator pods 
among the OLM deployments within the openshift-cnv namespace.

we need this for consistency among  the OLM deployments
 within the openshift-cnv namespace and for easier testing.

How to verify that other operators pods have this label:
` oc get pod -l "app.kubernetes.io/managed-by=olm" -n openshift-cnv -ojson |jq '.items[].metadata.labels'`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a name label to virt-operator pods 
```
