### PR TITLE
tests: inline RunVMIAndExpectLaunchWithIgnoreWarningArg

### DIFF
--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -158,7 +158,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
 				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, tests.MigrationWaitTime, false)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, tests.MigrationWaitTime)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToCirros(vmi)).To(Succeed())

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -176,11 +176,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	})
 
 	runVMIAndExpectLaunch := func(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-		return tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, timeout, false)
+		return tests.RunVMIAndExpectLaunch(vmi, timeout)
 	}
 
 	runVMIAndExpectLaunchIgnoreWarnings := func(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
-		return tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, timeout, true)
+		return tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, timeout)
 	}
 
 	confirmVMIPostMigrationFailed := func(vmi *v1.VirtualMachineInstance, migrationUID string) {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1347,19 +1347,19 @@ var _ = SIGDescribe("Macvtap", func() {
 	}
 
 	createCirrosVMIRandomNode := func(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
-		runningVMI := tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(
+		runningVMI := tests.RunVMIAndExpectLaunch(
 			newCirrosVMIWithExplicitMac(networkName, mac),
 			180,
-			false)
+		)
 		err := console.LoginToCirros(runningVMI)
 		return runningVMI, err
 	}
 
 	createFedoraVMIRandomNode := func(networkName string, mac string) (*v1.VirtualMachineInstance, error) {
-		runningVMI := tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(
+		runningVMI := tests.RunVMIAndExpectLaunch(
 			newFedoraVMIWithExplicitMacAndGuestAgent(networkName, mac),
 			180,
-			false)
+		)
 		err := console.LoginToFedora(runningVMI)
 		return runningVMI, err
 	}

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -942,7 +942,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
 
-				vmi = tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 240, false)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 				By("Starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -502,7 +502,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Starting a Cirros VMI")
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
-			vmi = tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 240, false)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -257,7 +257,6 @@ var _ = SIGDescribe("Storage", func() {
 						libnet.SkipWhenNotDualStackCluster(virtClient)
 					}
 
-					var ignoreWarnings bool
 					var nodeName string
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {
@@ -267,13 +266,16 @@ var _ = SIGDescribe("Storage", func() {
 						}
 						nfsPod = storageframework.InitNFS(targetImage, nodeName)
 						pvName = createNFSPvAndPvc(family, nfsPod)
-						ignoreWarnings = true
 					} else {
 						pvName = tests.DiskAlpineHostPath
 					}
 					vmi = newVMI(pvName)
 
-					tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 180, ignoreWarnings)
+					if storageEngine == "nfs" {
+						tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+					} else {
+						tests.RunVMIAndExpectLaunch(vmi, 180)
+					}
 
 					By(checkingVMInstanceConsoleOut)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -551,17 +553,20 @@ var _ = SIGDescribe("Storage", func() {
 					if family == k8sv1.IPv6Protocol {
 						libnet.SkipWhenNotDualStackCluster(virtClient)
 					}
-					var ignoreWarnings bool
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {
 						nfsPod = storageframework.InitNFS(tests.HostPathAlpine, "")
 						pvName = createNFSPvAndPvc(family, nfsPod)
-						ignoreWarnings = true
 					} else {
 						pvName = tests.DiskAlpineHostPath
 					}
 					vmi = newVMI(pvName)
-					vmi = tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 120, ignoreWarnings)
+
+					if storageEngine == "nfs" {
+						vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 120)
+					} else {
+						vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+					}
 
 					By(checkingVMInstanceConsoleOut)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1632,14 +1632,6 @@ func RunVMIAndExpectLaunchIgnoreWarnings(vmi *v1.VirtualMachineInstance, timeout
 	return obj
 }
 
-func RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi *v1.VirtualMachineInstance, timeout int, ignoreWarnings bool) *v1.VirtualMachineInstance {
-	if ignoreWarnings {
-		return RunVMIAndExpectLaunchIgnoreWarnings(vmi, timeout)
-	} else {
-		return RunVMIAndExpectLaunch(vmi, timeout)
-	}
-}
-
 func RunVMIAndExpectScheduling(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
 	obj := RunVMI(vmi, timeout)
 	By("Waiting until the VirtualMachineInstance will be scheduled")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1633,24 +1633,11 @@ func RunVMIAndExpectLaunchIgnoreWarnings(vmi *v1.VirtualMachineInstance, timeout
 }
 
 func RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi *v1.VirtualMachineInstance, timeout int, ignoreWarnings bool) *v1.VirtualMachineInstance {
-	By(StartingVMInstance)
-	var obj *v1.VirtualMachineInstance
-	var err error
-	virtClient, err := kubecli.GetKubevirtClient()
-	Expect(err).ToNot(HaveOccurred())
-	Eventually(func() error {
-		obj, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
-		return err
-	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
-	By("Waiting until the VirtualMachineInstance starts")
 	if ignoreWarnings {
-		WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(obj, timeout)
+		return RunVMIAndExpectLaunchIgnoreWarnings(vmi, timeout)
 	} else {
-		WaitForSuccessfulVMIStartWithTimeout(obj, timeout)
+		return RunVMIAndExpectLaunch(vmi, timeout)
 	}
-	vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	return vmi
 }
 
 func RunVMIAndExpectScheduling(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {


### PR DESCRIPTION
The reader of `tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, timeout, false)` has a tough time guessing what "false" means. Using `tests.RunVMIAndExpectLaunch()` or `tests.RunVMIAndExpectLaunchIgnoreWarnings()` directly is clearer.

```release-note
NONE
```
