### PR TITLE
Remove the VMI informer from virt-api

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -911,7 +911,6 @@ func (app *virtAPIApp) Run() {
 	kubeInformerFactory.ApiAuthConfigMap()
 	kubeInformerFactory.KubeVirtCAConfigMap()
 	crdInformer := kubeInformerFactory.CRD()
-	vmiInformer := kubeInformerFactory.VMI()
 	vmiPresetInformer := kubeInformerFactory.VirtualMachinePreset()
 	namespaceLimitsInformer := kubeInformerFactory.LimitRanges()
 	vmRestoreInformer := kubeInformerFactory.VirtualMachineRestore()
@@ -949,7 +948,6 @@ func (app *virtAPIApp) Run() {
 	kubeInformerFactory.WaitForCacheSync(stopChan)
 
 	webhookInformers := &webhooks.Informers{
-		VMIInformer:             vmiInformer,
 		VMIPresetInformer:       vmiPresetInformer,
 		NamespaceLimitsInformer: namespaceLimitsInformer,
 		VMRestoreInformer:       vmRestoreInformer,

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -745,7 +745,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMIPreset(w, r)
 	})
 	http.HandleFunc(components.MigrationCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig, app.virtCli, informers)
+		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.MigrationUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationUpdate(w, r)

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -79,7 +79,6 @@ var MigrationGroupVersionResource = metav1.GroupVersionResource{
 type Informers struct {
 	VMIPresetInformer       cache.SharedIndexInformer
 	NamespaceLimitsInformer cache.SharedIndexInformer
-	VMIInformer             cache.SharedIndexInformer
 	VMRestoreInformer       cache.SharedIndexInformer
 	DataSourceInformer      cache.SharedIndexInformer
 	FlavorInformer          cache.SharedIndexInformer

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -30,7 +30,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/api"
 
@@ -47,13 +46,9 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	// Mock VirtualMachineInstanceMigration
 	var ctrl *gomock.Controller
 	var virtClient *kubecli.MockKubevirtClient
-	var vmiInformer cache.SharedIndexInformer
 	var migrationCreateAdmitter *MigrationCreateAdmitter
-
-	ctrl = gomock.NewController(GinkgoT())
-	migrationInterface := kubecli.NewMockVirtualMachineInstanceMigrationInterface(ctrl)
-	virtClient = kubecli.NewMockKubevirtClient(ctrl)
-	virtClient.EXPECT().VirtualMachineInstanceMigration("default").Return(migrationInterface).AnyTimes()
+	var migrationInterface *kubecli.MockVirtualMachineInstanceMigrationInterface
+	var mockVMIClient *kubecli.MockVirtualMachineInstanceInterface
 
 	enableFeatureGate := func(featureGate string) {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
@@ -79,187 +74,34 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	}
 
 	BeforeEach(func() {
-		vmiInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
-		migrationCreateAdmitter = &MigrationCreateAdmitter{ClusterConfig: config, VirtClient: virtClient, VMIInformer: vmiInformer}
-		migrationInterface.EXPECT().List(gomock.Any()).Return(&v1.VirtualMachineInstanceMigrationList{}, nil).Times(1)
-	})
-
-	AfterEach(func() {
-		disableFeatureGates()
-	})
-
-	It("should reject invalid Migration spec on create", func() {
-		migration := v1.VirtualMachineInstanceMigration{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "",
-			},
-		}
-		migrationBytes, _ := json.Marshal(&migration)
-
-		enableFeatureGate(virtconfig.LiveMigrationGate)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
-				},
-			},
-		}
-
-		resp := migrationCreateAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeFalse())
-		Expect(len(resp.Result.Details.Causes)).To(Equal(1))
-		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.vmiName"))
-	})
-
-	It("should accept valid Migration spec on create", func() {
-		vmi := api.NewMinimalVMI("testvmimigrate1")
-
-		migrationCreateAdmitter.VMIInformer.GetIndexer().Add(vmi)
-
-		migration := v1.VirtualMachineInstanceMigration{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vmi.Namespace,
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testvmimigrate1",
-			},
-		}
-		migrationBytes, _ := json.Marshal(&migration)
-
-		enableFeatureGate(virtconfig.LiveMigrationGate)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
-				},
-			},
-		}
-
-		resp := migrationCreateAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeTrue())
-	})
-
-	It("should reject valid Migration spec on create when feature gate isn't enabled", func() {
-		vmi := api.NewMinimalVMI("testvmimigrate1")
-
-		migrationCreateAdmitter.VMIInformer.GetIndexer().Add(vmi)
-
-		migration := v1.VirtualMachineInstanceMigration{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: vmi.Namespace,
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testvmimigrate1",
-			},
-		}
-		migrationBytes, _ := json.Marshal(&migration)
-
-		disableFeatureGates()
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
-				},
-			},
-		}
-
-		resp := migrationCreateAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeFalse())
+		ctrl = gomock.NewController(GinkgoT())
+		migrationInterface = kubecli.NewMockVirtualMachineInstanceMigrationInterface(ctrl)
+		mockVMIClient = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+		virtClient.EXPECT().VirtualMachineInstanceMigration("default").Return(migrationInterface).AnyTimes()
+		virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(mockVMIClient)
+		migrationCreateAdmitter = &MigrationCreateAdmitter{ClusterConfig: config, VirtClient: virtClient}
 	})
 
 	It("should reject Migration spec on create when another VMI migration is in-flight", func() {
+		vmi := api.NewMinimalVMI("testmigratevmi2")
 		inFlightMigration := v1.VirtualMachineInstanceMigration{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
+				Namespace: vmi.Namespace,
 			},
 			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testmigratevmi2",
+				VMIName: vmi.Name,
 			},
 		}
-
+		mockVMIClient.EXPECT().Get(inFlightMigration.Spec.VMIName, gomock.Any()).Return(vmi, nil)
 		migrationInterface.EXPECT().List(gomock.Any()).Return(kubecli.NewMigrationList(inFlightMigration), nil).AnyTimes()
 
 		migration := v1.VirtualMachineInstanceMigration{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testmigratevmi2",
-			},
-		}
-		migrationBytes, _ := json.Marshal(&migration)
-
-		enableFeatureGate(virtconfig.LiveMigrationGate)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
-				},
-			},
-		}
-
-		resp := migrationCreateAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeFalse())
-	})
-
-	It("should accept Migration spec on create when previous VMI migration completed", func() {
-		vmi := api.NewMinimalVMI("testmigratevmi4")
-		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-			MigrationUID: "123",
-			Completed:    true,
-			Failed:       false,
-		}
-
-		migrationCreateAdmitter.VMIInformer.GetIndexer().Add(vmi)
-
-		migration := v1.VirtualMachineInstanceMigration{
-			ObjectMeta: metav1.ObjectMeta{
 				Namespace: vmi.Namespace,
 			},
 			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testmigratevmi4",
-			},
-		}
-		migrationBytes, _ := json.Marshal(&migration)
-
-		enableFeatureGate(virtconfig.LiveMigrationGate)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
-				},
-			},
-		}
-
-		resp := migrationCreateAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeTrue())
-	})
-
-	It("should reject Migration spec on create when VMI is finalized", func() {
-		vmi := api.NewMinimalVMI("testmigratevmi3")
-		vmi.Status.Phase = v1.Succeeded
-
-		migrationCreateAdmitter.VMIInformer.GetIndexer().Add(vmi)
-
-		migration := v1.VirtualMachineInstanceMigration{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testmigratevmi3",
+				VMIName: vmi.Name,
 			},
 		}
 		migrationBytes, _ := json.Marshal(&migration)
@@ -279,77 +121,243 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 		Expect(resp.Allowed).To(BeFalse())
 	})
 
-	It("should reject Migration spec for non-migratable VMIs", func() {
-		vmi := api.NewMinimalVMI("testmigratevmi3")
-		vmi.Status.Phase = v1.Running
-		vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-			{
-				Type:    v1.VirtualMachineInstanceIsMigratable,
-				Status:  k8sv1.ConditionFalse,
-				Reason:  v1.VirtualMachineInstanceReasonDisksNotMigratable,
-				Message: "cannot migrate VMI with mixes shared and non-shared volumes",
-			},
-			{
-				Type:   v1.VirtualMachineInstanceReady,
-				Status: k8sv1.ConditionTrue,
-			},
-		}
+	Context("with no conflicting migration", func() {
 
-		migrationCreateAdmitter.VMIInformer.GetIndexer().Add(vmi)
+		BeforeEach(func() {
+			migrationInterface.EXPECT().List(gomock.Any()).Return(&v1.VirtualMachineInstanceMigrationList{}, nil).Times(1)
 
-		migration := v1.VirtualMachineInstanceMigration{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-			},
-			Spec: v1.VirtualMachineInstanceMigrationSpec{
-				VMIName: "testmigratevmi3",
-			},
-		}
-		migrationBytes, _ := json.Marshal(&migration)
+		})
 
-		enableFeatureGate(virtconfig.LiveMigrationGate)
+		AfterEach(func() {
+			disableFeatureGates()
+		})
 
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: webhooks.MigrationGroupVersionResource,
-				Object: runtime.RawExtension{
-					Raw: migrationBytes,
+		It("should reject invalid Migration spec on create", func() {
+			migration := v1.VirtualMachineInstanceMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
 				},
-			},
-		}
+				Spec: v1.VirtualMachineInstanceMigrationSpec{
+					VMIName: "",
+				},
+			}
+			migrationBytes, _ := json.Marshal(&migration)
 
-		resp := migrationCreateAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(BeFalse())
-		Expect(resp.Result.Message).To(ContainSubstring("DisksNotLiveMigratable"))
+			enableFeatureGate(virtconfig.LiveMigrationGate)
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: webhooks.MigrationGroupVersionResource,
+					Object: runtime.RawExtension{
+						Raw: migrationBytes,
+					},
+				},
+			}
+
+			resp := migrationCreateAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.vmiName"))
+		})
+
+		It("should accept valid Migration spec on create", func() {
+			vmi := api.NewMinimalVMI("testvmimigrate1")
+
+			mockVMIClient.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			migration := v1.VirtualMachineInstanceMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: vmi.Namespace,
+				},
+				Spec: v1.VirtualMachineInstanceMigrationSpec{
+					VMIName: "testvmimigrate1",
+				},
+			}
+			migrationBytes, _ := json.Marshal(&migration)
+
+			enableFeatureGate(virtconfig.LiveMigrationGate)
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: webhooks.MigrationGroupVersionResource,
+					Object: runtime.RawExtension{
+						Raw: migrationBytes,
+					},
+				},
+			}
+
+			resp := migrationCreateAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should reject valid Migration spec on create when feature gate isn't enabled", func() {
+			vmi := api.NewMinimalVMI("testvmimigrate1")
+
+			mockVMIClient.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			migration := v1.VirtualMachineInstanceMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: vmi.Namespace,
+				},
+				Spec: v1.VirtualMachineInstanceMigrationSpec{
+					VMIName: "testvmimigrate1",
+				},
+			}
+			migrationBytes, _ := json.Marshal(&migration)
+
+			disableFeatureGates()
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: webhooks.MigrationGroupVersionResource,
+					Object: runtime.RawExtension{
+						Raw: migrationBytes,
+					},
+				},
+			}
+
+			resp := migrationCreateAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should accept Migration spec on create when previous VMI migration completed", func() {
+			vmi := api.NewMinimalVMI("testmigratevmi4")
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: "123",
+				Completed:    true,
+				Failed:       false,
+			}
+
+			mockVMIClient.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			migration := v1.VirtualMachineInstanceMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: vmi.Namespace,
+				},
+				Spec: v1.VirtualMachineInstanceMigrationSpec{
+					VMIName: "testmigratevmi4",
+				},
+			}
+			migrationBytes, _ := json.Marshal(&migration)
+
+			enableFeatureGate(virtconfig.LiveMigrationGate)
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: webhooks.MigrationGroupVersionResource,
+					Object: runtime.RawExtension{
+						Raw: migrationBytes,
+					},
+				},
+			}
+
+			resp := migrationCreateAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeTrue())
+		})
+
+		It("should reject Migration spec on create when VMI is finalized", func() {
+			vmi := api.NewMinimalVMI("testmigratevmi3")
+			vmi.Status.Phase = v1.Succeeded
+
+			mockVMIClient.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			migration := v1.VirtualMachineInstanceMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: v1.VirtualMachineInstanceMigrationSpec{
+					VMIName: "testmigratevmi3",
+				},
+			}
+			migrationBytes, _ := json.Marshal(&migration)
+
+			enableFeatureGate(virtconfig.LiveMigrationGate)
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: webhooks.MigrationGroupVersionResource,
+					Object: runtime.RawExtension{
+						Raw: migrationBytes,
+					},
+				},
+			}
+
+			resp := migrationCreateAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeFalse())
+		})
+
+		It("should reject Migration spec for non-migratable VMIs", func() {
+			vmi := api.NewMinimalVMI("testmigratevmi3")
+			vmi.Status.Phase = v1.Running
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:    v1.VirtualMachineInstanceIsMigratable,
+					Status:  k8sv1.ConditionFalse,
+					Reason:  v1.VirtualMachineInstanceReasonDisksNotMigratable,
+					Message: "cannot migrate VMI with mixes shared and non-shared volumes",
+				},
+				{
+					Type:   v1.VirtualMachineInstanceReady,
+					Status: k8sv1.ConditionTrue,
+				},
+			}
+
+			mockVMIClient.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil)
+
+			migration := v1.VirtualMachineInstanceMigration{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: v1.VirtualMachineInstanceMigrationSpec{
+					VMIName: "testmigratevmi3",
+				},
+			}
+			migrationBytes, _ := json.Marshal(&migration)
+
+			enableFeatureGate(virtconfig.LiveMigrationGate)
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: webhooks.MigrationGroupVersionResource,
+					Object: runtime.RawExtension{
+						Raw: migrationBytes,
+					},
+				},
+			}
+
+			resp := migrationCreateAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(ContainSubstring("DisksNotLiveMigratable"))
+		})
+
+		table.DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
+			input := map[string]interface{}{}
+			json.Unmarshal([]byte(data), &input)
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: gvr,
+					Object: runtime.RawExtension{
+						Raw: []byte(data),
+					},
+				},
+			}
+			resp := review(ar)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Message).To(Equal(validationResult))
+		},
+			table.Entry("Migration creation ",
+				`{"very": "unknown", "spec": { "extremely": "unknown" }}`,
+				`.very in body is a forbidden property, spec.extremely in body is a forbidden property`,
+				webhooks.MigrationGroupVersionResource,
+				migrationCreateAdmitter.Admit,
+			),
+			table.Entry("Migration update",
+				`{"very": "unknown", "spec": { "extremely": "unknown" }}`,
+				`.very in body is a forbidden property, spec.extremely in body is a forbidden property`,
+				webhooks.MigrationGroupVersionResource,
+				migrationCreateAdmitter.Admit,
+			),
+		)
 	})
-
-	table.DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse) {
-		input := map[string]interface{}{}
-		json.Unmarshal([]byte(data), &input)
-
-		ar := &admissionv1.AdmissionReview{
-			Request: &admissionv1.AdmissionRequest{
-				Resource: gvr,
-				Object: runtime.RawExtension{
-					Raw: []byte(data),
-				},
-			},
-		}
-		resp := review(ar)
-		Expect(resp.Allowed).To(BeFalse())
-		Expect(resp.Result.Message).To(Equal(validationResult))
-	},
-		table.Entry("Migration creation ",
-			`{"very": "unknown", "spec": { "extremely": "unknown" }}`,
-			`.very in body is a forbidden property, spec.extremely in body is a forbidden property`,
-			webhooks.MigrationGroupVersionResource,
-			migrationCreateAdmitter.Admit,
-		),
-		table.Entry("Migration update",
-			`{"very": "unknown", "spec": { "extremely": "unknown" }}`,
-			`.very in body is a forbidden property, spec.extremely in body is a forbidden property`,
-			webhooks.MigrationGroupVersionResource,
-			migrationCreateAdmitter.Admit,
-		),
-	)
 })

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -54,8 +54,8 @@ func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.VMIPresetAdmitter{})
 }
 
-func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
-	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{ClusterConfig: clusterConfig, VirtClient: virtCli, VMIInformer: informers.VMIInformer})
+func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{ClusterConfig: clusterConfig, VirtClient: virtCli})
 }
 
 func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the VMI informers from virt-api due to the following reasons:

1. In contrast to virt-controller, virt-api only ever cares about a small subset of states on the cluster. Like the create webhook in this case only needs to know about the current VMI when the migration object is created.
2. There is no leader-election on virt-api. If virt-api scales out, then all instances have an active watcher where the apiserver has to transfer state to.
3. The VM webhook already gets a fresh state from the apiserver of the VM in question, the VMI webhook for the VMI, and so forth, so in contrast to virt-controller, we already get the main object in question "unasked" as part of the admission review.
4. We mostly care about VMIs in webhooks in cases where we later on, after a passing validation, modify the VMI status multiple times (e.g. migrations), leading to multiple transfers of the VMI object to virt-api, ultimately making the calls more expensive. This makes the attempt to safe a single GET more expensive than directly calling the GET.

Without the informer in virt-api, we have:

1. predictable API usage O(1)
2. less consumed bandwidth
3. less memory consumption of virt-api at scale
4. less active informers when scaling out virt-api

In addition it fixes errors like

```
Tests Suite: [sig-compute]Dry-Run requests Migrations [test_id:7636]delete a migration expand_less	1m3s
tests/dryrun_test.go:243
Expected
    <*errors.StatusError | 0xc0085988c0>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "admission webhook \"migration-create-validator.kubevirt.io\" denied the request: the VMI testvmi-txhzt does not exist under the cache",
            Reason: "",
            Details: nil,
            Code: 400,
        },
    }
to be nil
tests/dryrun_test.go:246
```

which can pop up if the system is under stress and the watchers can't be fed fast enough by the apiservers.

Example job: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7198/pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations/1493012434993025024

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Remove VMI informer from virt-api to improve scaling characteristics of virt-api
```
