### PR TITLE
Properly format PDB scaling event which is triggered during migrations

### DIFF
--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -453,7 +453,7 @@ func (c *DisruptionBudgetController) shrinkPDB(vmi *virtv1.VirtualMachineInstanc
 			c.recorder.Eventf(vmi, corev1.EventTypeWarning, FailedUpdatePodDisruptionBudgetReason, "Error updating the PodDisruptionBudget %s: %v", pdb.Name, err)
 			return err
 		}
-		c.recorder.Eventf(vmi, corev1.EventTypeNormal, SuccessfulUpdatePodDisruptionBudgetReason, "shrank PodDisruptionBudget", pdb.Name)
+		c.recorder.Eventf(vmi, corev1.EventTypeNormal, SuccessfulUpdatePodDisruptionBudgetReason, "shrank PodDisruptionBudget %s", pdb.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix improper formated events like this:

```
shrank PodDisruptionBudget%!(EXTRA string=kubevirt-disruption-budget-ae8fd)
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Properly format the PDB scale event during migrations
```
