### PR TITLE
Fix migration abort

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Manager", func() {
 		mockDirectIOChecker.EXPECT().CheckFile(gomock.Any()).AnyTimes().Return(true, nil)
 	})
 
-	expectIsolationDetectionForVMI := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {
+	expectedDomainFor := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {
 		domain := &api.Domain{}
 		hotplugVolumes := make(map[string]v1.VolumeStatus)
 		permanentVolumes := make(map[string]v1.VolumeStatus)
@@ -138,7 +138,7 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
@@ -159,7 +159,7 @@ var _ = Describe("Manager", func() {
 			vmi.Spec.StartStrategy = &strategy
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
@@ -181,7 +181,7 @@ var _ = Describe("Manager", func() {
 			userData := "fake\nuser\ndata\n"
 			networkData := ""
 			addCloudInitDisk(vmi, userData, networkData)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
@@ -201,7 +201,7 @@ var _ = Describe("Manager", func() {
 			userData := "fake\nuser\ndata\n"
 			networkData := "FakeNetwork"
 			addCloudInitDisk(vmi, userData, networkData)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
@@ -217,7 +217,7 @@ var _ = Describe("Manager", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -234,7 +234,7 @@ var _ = Describe("Manager", func() {
 				// Make sure that we always free the domain after use
 				mockDomain.EXPECT().Free()
 				vmi := newVMI(testNamespace, testVmName)
-				domainSpec := expectIsolationDetectionForVMI(vmi)
+				domainSpec := expectedDomainFor(vmi)
 				xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 				Expect(err).NotTo(HaveOccurred())
 
@@ -256,7 +256,7 @@ var _ = Describe("Manager", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -273,7 +273,7 @@ var _ = Describe("Manager", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -461,7 +461,7 @@ var _ = Describe("Manager", func() {
 				},
 			}
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Devices.Disks = []api.Disk{
 				{
 					Device: "disk",
@@ -563,7 +563,7 @@ var _ = Describe("Manager", func() {
 				return false, nil
 			}
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
@@ -692,7 +692,7 @@ var _ = Describe("Manager", func() {
 				return false, nil
 			}
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			detachDisk := api.Disk{
@@ -802,7 +802,7 @@ var _ = Describe("Manager", func() {
 				return false, nil
 			}
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
@@ -881,7 +881,7 @@ var _ = Describe("Manager", func() {
 				return false, nil
 			}
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
@@ -925,7 +925,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free().AnyTimes()
 
 			vmi := newVMI(testNamespace, testVmName)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 
 			oldXML, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
@@ -954,7 +954,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free().AnyTimes()
 
 			vmi := newVMI(testNamespace, testVmName)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
@@ -996,7 +996,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			manager := &LibvirtDomainManager{
@@ -1041,7 +1041,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			manager := &LibvirtDomainManager{
@@ -1095,7 +1095,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			manager := &LibvirtDomainManager{
 				virConn:      mockConn,
 				virtShareDir: testVirtShareDir,
@@ -1166,7 +1166,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			manager := &LibvirtDomainManager{
 				virConn:      mockConn,
 				virtShareDir: testVirtShareDir,
@@ -1244,7 +1244,7 @@ var _ = Describe("Manager", func() {
 				return string(xml)
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 				StartTimestamp: &now,
 				UID:            migrationUid,
@@ -1296,7 +1296,7 @@ var _ = Describe("Manager", func() {
 				StartTimestamp: &now,
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 				UID:            vmi.Status.MigrationState.MigrationUID,
 				AbortStatus:    string(v1.MigrationAbortInProgress),
@@ -1351,7 +1351,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 
 				UID:         vmi.Status.MigrationState.MigrationUID,
@@ -1426,7 +1426,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 				UID: vmi.Status.MigrationState.MigrationUID,
 			}
@@ -1513,7 +1513,7 @@ var _ = Describe("Manager", func() {
 			userData := "fake\nuser\ndata\n"
 			networkData := "FakeNetwork"
 			addCloudInitDisk(vmi, userData, networkData)
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{}
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
@@ -1568,7 +1568,7 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
 
 				UID: vmi.Status.MigrationState.MigrationUID,
@@ -1808,7 +1808,7 @@ var _ = Describe("Manager", func() {
 
 			vmi := newVMI(testNamespace, testVmName)
 
-			domainSpec := expectIsolationDetectionForVMI(vmi)
+			domainSpec := expectedDomainFor(vmi)
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
@@ -1910,7 +1910,7 @@ var _ = Describe("Manager", func() {
 				}},
 		)
 
-		domainSpec := expectIsolationDetectionForVMI(vmi)
+		domainSpec := expectedDomainFor(vmi)
 		xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1254,12 +1254,12 @@ var _ = Describe("Manager", func() {
 
 			//expect domainspecwithruntimeinfo todo this can be useful for other tests
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
-			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Times(1).DoAndReturn(
+			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().DoAndReturn(
 				func(_ libvirt.DomainXMLFlags) (string, error) {
 					return domainToXml(domainSpec), nil
 				})
 			mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).
-				Times(1).
+				AnyTimes().
 				DoAndReturn(func(_, _, _ interface{}) (string, error) {
 					return domainToMetadataXml(domainSpec), nil
 				})
@@ -1289,6 +1289,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free().AnyTimes()
 
 			now := metav1.Time{Time: time.Unix(time.Now().UTC().Unix(), 0)}
+			secondBefore := metav1.Time{Time: now.Add(-time.Second)}
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				MigrationUID:   "111222333",
@@ -1297,9 +1298,9 @@ var _ = Describe("Manager", func() {
 
 			domainSpec := expectIsolationDetectionForVMI(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
-
-				UID:         vmi.Status.MigrationState.MigrationUID,
-				AbortStatus: string(v1.MigrationAbortInProgress),
+				UID:            vmi.Status.MigrationState.MigrationUID,
+				AbortStatus:    string(v1.MigrationAbortInProgress),
+				StartTimestamp: &secondBefore,
 			}
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")


### PR DESCRIPTION
**What this PR does / why we need it**:
[Job](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7218/pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations/1492080339227512832) & [kubevirtci search](https://search.ci.kubevirt.io/?search=live+migration+cancelation&maxAge=48h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) show we have problem in migrations. 

Findings from the analysis:
1. We have not accurate logging as in [this case](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/cmd-server/server.go#L135). The migration might not be reported because the abort is async.
2. We don't "abort fast". [Here](https://github.com/kubevirt/kubevirt/blob/467ea8b35cc97f40226f68c18ff322b45fe65b5a/pkg/virt-launcher/virtwrap/live-migration-source.go#L876) we can see that we post `FailedAbort` but not the successful.
3. We are checking [VMI](https://github.com/kubevirt/kubevirt/blob/467ea8b35cc97f40226f68c18ff322b45fe65b5a/pkg/virt-launcher/virtwrap/live-migration-source.go#L468) object that doesn't necessarily reflect reality. This can lead to overriding the abort status. (This will not eventually correct itself because the monitor might already finish)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Bug fix: Successfully aborted migrations should be reported now
```
