### PR TITLE
Skip migration in test 6870 if migration is not possible

### DIFF
--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -273,20 +273,9 @@ var _ = Describe("[rfe_id:3423][crit:high][arm64][vendor:cnv-qe@redhat.com][leve
 		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), MatchRegexp(vmReadyRegex)),
 			"VM should be in the %s status", v12.VirtualMachineStatusRunning)
 
-		// The previous tests would be done, once succeed the following tests would be skipped on the Arm64 cluster
-		// Otherwise, it would show the failures
-		// TODO: remove this once we have more than one node in the Arm64 cluster
-		tests.SkipIfARM64("arm64 cluster only have one node")
+		tests.SkipIfMigrationIsNotPossible()
 
 		By("Migrating the VirtualMachine")
-
-		// Verify we have more than one scheduleable node
-		virtClient, err := kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-
-		nodes := util.GetAllSchedulableNodes(virtClient)
-		Expect(len(nodes.Items)).To(BeNumerically(">=", 2),
-			"Migration requires at least 2 schedulable nodes")
 
 		migrateCommand := tests.NewRepeatableVirtctlCommand(virtctlvm.COMMAND_MIGRATE, "--namespace", vm.Namespace, vm.Name)
 		Expect(migrateCommand()).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Skips the migration part in test 6870 in case of migration not being possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
