### PR TITLE
Remove make clean from trap in automation script to do not hide failures

### DIFF
--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -24,8 +24,7 @@ kubectl() { KUBEVIRTCI_VERBOSE=false cluster-up/kubectl.sh "$@"; }
 _prometheus_port_forward_pid=""
 trap "clean_up" EXIT SIGINT SIGTERM SIGQUIT
 clean_up() {
-  kill -9 $_prometheus_port_forward_pid 2> /dev/null
-  make cluster-clean
+  kill -9 $_prometheus_port_forward_pid 2> /dev/null | exit 0
 }
 
 echo "Nodes are ready:"
@@ -92,3 +91,6 @@ fi
 
 # Run performance tests
 ./hack/perfscale-tests.sh
+
+# Undeploy kubevirt from the cluster
+make cluster-clean


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The [periodic-kubevirt-performance-cluster-100-density-test](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-performance-cluster-100-density-test/1489821217111150592) is failing because when it finishes it calls `make cluster-clean`. There is no message why it failed.

This PR moves the `make cluster-clean` from the trap command in the script to run right after the test finished.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The `make cluster-clean` should not fail. But If it still fails in the test, we will be able to see in the logs what is failing...

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @dhiller @rthallisey 

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>