### PR TITLE
pool_test: simplify by using libvmi.NewCirros and tidying newPoolFromVMI up

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//pkg/virtctl:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
-        "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
@@ -101,11 +102,13 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 
 		vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault)
 
-		newPool := tests.NewRandomPoolFromVMI(&v1.VirtualMachineInstance{
+		newPool := newPoolFromVMI(&v1.VirtualMachineInstance{
 			ObjectMeta: vm.Spec.Template.ObjectMeta,
 			Spec:       vm.Spec.Template.Spec,
-		}, int32(0), true)
+		})
 		newPool.Spec.VirtualMachineTemplate.Spec.DataVolumeTemplates = vm.Spec.DataVolumeTemplates
+		running := true
+		newPool.Spec.VirtualMachineTemplate.Spec.Running = &running
 		newPool, err = virtClient.VirtualMachinePool(util.NamespaceTestDefault).Create(context.Background(), newPool, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -114,14 +117,15 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 
 	newVirtualMachinePool := func() *poolv1.VirtualMachinePool {
 		By("Create a new VirtualMachinePool")
+		pool := newPoolFromVMI(libvmi.NewCirros())
 		running := true
-		return createVirtualMachinePool(tests.NewRandomPoolFromVMI(libvmi.NewCirros(), int32(0), running))
+		pool.Spec.VirtualMachineTemplate.Spec.Running = &running
+		return createVirtualMachinePool(pool)
 	}
 
 	newOfflineVirtualMachinePool := func() *poolv1.VirtualMachinePool {
 		By("Create a new VirtualMachinePool")
-		running := false
-		return createVirtualMachinePool(tests.NewRandomPoolFromVMI(libvmi.NewCirros(), int32(0), running))
+		return createVirtualMachinePool(newPoolFromVMI(libvmi.NewCirros()))
 	}
 
 	table.DescribeTable("[Serial]pool should scale", func(startScale int, stopScale int) {
@@ -507,3 +511,33 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		}, 10*time.Second, 1*time.Second).Should(Equal(int32(1)))
 	})
 })
+
+func newPoolFromVMI(vmi *v1.VirtualMachineInstance) *poolv1.VirtualMachinePool {
+	selector := "pool" + rand.String(5)
+	running := false
+	replicas := int32(0)
+	pool := &poolv1.VirtualMachinePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool" + rand.String(5)},
+		Spec: poolv1.VirtualMachinePoolSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"select": selector},
+			},
+			VirtualMachineTemplate: &poolv1.VirtualMachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"select": selector},
+				},
+				Spec: v1.VirtualMachineSpec{
+					Running: &running,
+					Template: &v1.VirtualMachineInstanceTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"select": selector},
+						},
+						Spec: vmi.Spec,
+					},
+				},
+			},
+		},
+	}
+	return pool
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -100,7 +100,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 
 	v1 "kubevirt.io/api/core/v1"
-	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -3081,34 +3080,6 @@ func LoginToVM(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction) 
 
 func NewInt32(x int32) *int32 {
 	return &x
-}
-
-func NewRandomPoolFromVMI(vmi *v1.VirtualMachineInstance, replicas int32, running bool) *poolv1.VirtualMachinePool {
-	selector := "pool" + rand.String(5)
-	pool := &poolv1.VirtualMachinePool{
-		ObjectMeta: metav1.ObjectMeta{Name: "pool" + rand.String(5)},
-		Spec: poolv1.VirtualMachinePoolSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"select": selector},
-			},
-			VirtualMachineTemplate: &poolv1.VirtualMachineTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"select": selector},
-				},
-				Spec: v1.VirtualMachineSpec{
-					Running: &running,
-					Template: &v1.VirtualMachineInstanceTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"select": selector},
-						},
-						Spec: vmi.Spec,
-					},
-				},
-			},
-		},
-	}
-	return pool
 }
 
 func NewRandomReplicaSetFromVMI(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {


### PR DESCRIPTION
The test code is slightly clearer due to this change, as arcane implementation details are encapsulated (Cirros's requirement of coud-init userData has nothing to do with VM pools) and the signature of newPoolFromVMI() is made simpler.

```release-note
NONE
```
