### PR TITLE
sysprep: Allow only unattend.xml to be provided

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/pkg/config/sysprep.go
+++ b/pkg/config/sysprep.go
@@ -47,20 +47,20 @@ func sysprepVolumeHasContents(sysprepVolume *v1.SysprepSource) bool {
 }
 
 // Explained here: https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-setup-automation-overview
-const sysprepFileName = "autounattend.xml"
+const autounattendFilename = "autounattend.xml"
+const unattendFilename = "unattend.xml"
 
-func validateAutounattendPresence(dirPath string) error {
+func validateUnattendPresence(dirPath string) error {
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
-		return fmt.Errorf("Error validating %s presence: %w", sysprepFileName, err)
+		return fmt.Errorf("Error validating that %s or %s have been provided: %w", autounattendFilename, unattendFilename, err)
 	}
 	for _, file := range files {
-		if strings.ToLower(file.Name()) == sysprepFileName {
+		if f := strings.ToLower(file.Name()); f == autounattendFilename || f == unattendFilename {
 			return nil
 		}
 	}
-
-	return fmt.Errorf("Sysprep drive should contain %s, but it was not found", sysprepFileName)
+	return fmt.Errorf("Sysprep drive should contain %s or %s but neither were found.", autounattendFilename, unattendFilename)
 }
 
 // CreateSysprepDisks creates Sysprep iso disks which are attached to vmis from either ConfigMap or Secret as a source
@@ -86,7 +86,7 @@ func shouldCreateSysprepDisk(volumeSysprep *v1.SysprepSource) bool {
 
 func createSysprepDisk(volumeName string, size int64) error {
 	sysprepSourcePath := GetSysprepSourcePath(volumeName)
-	if err := validateAutounattendPresence(sysprepSourcePath); err != nil {
+	if err := validateUnattendPresence(sysprepSourcePath); err != nil {
 		return err
 	}
 	filesPath, err := getFilesLayout(sysprepSourcePath)


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously validateAutounattendPresence would ensure autounattend.xml
had to be provided along with unattend.xml. Thus blocking the usecase
where a user might want to provide *only* unattend.xml to a previously
sealed Windows guest.

This change corrects this by allowing unattend.xml to be provided
without autounattend.xml.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7240

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that prevents only a unattend.xml configmap or secret being provided as contents for a sysprep disk. (#7240, @lyarwood)
```
