### PR TITLE
e2e: mark http service external explicitly for istio

### DIFF
--- a/pkg/network/istio/BUILD.bazel
+++ b/pkg/network/istio/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "annotations.go",
+        "const.go",
         "ports.go",
         "proxy.go",
     ],

--- a/pkg/network/istio/const.go
+++ b/pkg/network/istio/const.go
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package istio
+
+const (
+	ServiceEntriesResource = "serviceentries"
+	SidecarsResource       = "sidecars"
+	VirtualServices        = "virtualservices"
+	DestinationRules       = "destinationrules"
+	Gateways               = "gateways"
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/network/istio:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/net/ip:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -49,6 +49,7 @@ import (
 	"sync"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/network/istio"
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
@@ -1939,8 +1940,8 @@ func cleanNamespaces() {
 			util2.PanicOnError(virtCli.NetworkClient().K8sCniCncfIoV1().NetworkAttachmentDefinitions(namespace).Delete(context.Background(), netDef.GetName(), metav1.DeleteOptions{}))
 		}
 
-		// Remove all Istio Sidecars, VirtualServices, DestinationRules and Gateways
-		for _, res := range []string{"sidecars", "virtualservices", "destinationrules", "gateways"} {
+		// Remove all Istio Resources
+		for _, res := range []string{istio.SidecarsResource, istio.VirtualServices, istio.DestinationRules, istio.Gateways, istio.ServiceEntriesResource} {
 			util2.PanicOnError(removeAllGroupVersionResourceFromNamespace(schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1beta1", Resource: res}, namespace))
 		}
 


### PR DESCRIPTION
Istio 1.12 and above seems to require marking the test http
server as an external service explicitly, in order to deny the
VMI to access it (which is how we verify that outbound traffic
is being proxied).

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
