### PR TITLE
e2e: enrich phase matcher

### DIFF
--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -38,12 +38,15 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/framework/matcher/helper:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/tests/framework/matcher/getter.go
+++ b/tests/framework/matcher/getter.go
@@ -29,6 +29,8 @@ func ThisPodWith(namespace string, name string) func() (*v1.Pod, error) {
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
+		//Since https://github.com/kubernetes/client-go/issues/861 we manually add the Kind
+		p.Kind = "Pod"
 		return
 	}
 }
@@ -101,6 +103,8 @@ func ThisDVWith(namespace string, name string) func() (*v1beta1.DataVolume, erro
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
+		//Since https://github.com/kubernetes/client-go/issues/861 we manually add the Kind
+		p.Kind = "DataVolume"
 		return
 	}
 }
@@ -121,6 +125,8 @@ func ThisPVCWith(namespace string, name string) func() (*v1.PersistentVolumeClai
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
+		//Since https://github.com/kubernetes/client-go/issues/861 we manually add the Kind
+		p.Kind = "PersistentVolumeClaim"
 		return
 	}
 }
@@ -156,6 +162,8 @@ func ThisDeploymentWith(namespace string, name string) func() (*k8sv1.Deployment
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
+		//Since https://github.com/kubernetes/client-go/issues/861 we manually add the Kind
+		p.Kind = "Deployment"
 		return
 	}
 }

--- a/tests/framework/matcher/helper/BUILD.bazel
+++ b/tests/framework/matcher/helper/BUILD.bazel
@@ -5,4 +5,8 @@ go_library(
     srcs = ["reflect.go"],
     importpath = "kubevirt.io/kubevirt/tests/framework/matcher/helper",
     visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
 )

--- a/tests/framework/matcher/helper/reflect.go
+++ b/tests/framework/matcher/helper/reflect.go
@@ -1,6 +1,12 @@
 package helper
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 func IsNil(actual interface{}) bool {
 	return actual == nil || (reflect.ValueOf(actual).Kind() == reflect.Ptr && reflect.ValueOf(actual).IsNil())
@@ -44,4 +50,16 @@ func MatchElementsInSlice(actual interface{}, matcher func(actual interface{}) (
 		return success
 	})
 	return success, err
+}
+
+func ToUnstructured(actual interface{}) (*unstructured.Unstructured, error) {
+	if IsNil(actual) {
+		return nil, fmt.Errorf("object does not exist")
+	}
+	actual = ToPointer(actual)
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(actual)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
 }

--- a/tests/framework/matcher/owner.go
+++ b/tests/framework/matcher/owner.go
@@ -3,11 +3,9 @@ package matcher
 import (
 	"fmt"
 
-	"github.com/onsi/gomega/types"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
+
+	"github.com/onsi/gomega/types"
 )
 
 func BeOwned() types.GomegaMatcher {
@@ -22,7 +20,7 @@ type ownedMatcher struct {
 }
 
 func (o ownedMatcher) Match(actual interface{}) (success bool, err error) {
-	u, err := toUnstructured(actual)
+	u, err := helper.ToUnstructured(actual)
 	if err != nil {
 		return false, nil
 	}
@@ -33,7 +31,7 @@ func (o ownedMatcher) Match(actual interface{}) (success bool, err error) {
 }
 
 func (o ownedMatcher) FailureMessage(actual interface{}) (message string) {
-	u, err := toUnstructured(actual)
+	u, err := helper.ToUnstructured(actual)
 	if err != nil {
 		return err.Error()
 	}
@@ -41,20 +39,9 @@ func (o ownedMatcher) FailureMessage(actual interface{}) (message string) {
 }
 
 func (o ownedMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	u, err := toUnstructured(actual)
+	u, err := helper.ToUnstructured(actual)
 	if err != nil {
 		return err.Error()
 	}
 	return fmt.Sprintf("Expected owner references to be empty, but got '%v'", u)
-}
-
-func toUnstructured(actual interface{}) (*unstructured.Unstructured, error) {
-	if helper.IsNil(actual) {
-		return nil, fmt.Errorf("object does not exist")
-	}
-	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(actual)
-	if err != nil {
-		return nil, err
-	}
-	return &unstructured.Unstructured{Object: obj}, nil
 }

--- a/tests/framework/matcher/phase_test.go
+++ b/tests/framework/matcher/phase_test.go
@@ -1,10 +1,17 @@
 package matcher
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v13 "kubevirt.io/api/core/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
 )
 
 var _ = Describe("Matcher", func() {
@@ -21,6 +28,69 @@ var _ = Describe("Matcher", func() {
 	var stoppedPod = &v1.Pod{
 		Status: v1.PodStatus{
 			Phase: v1.PodSucceeded,
+		},
+	}
+
+	var nameAndKindPod = &v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "testpod",
+		},
+		TypeMeta: v12.TypeMeta{
+			Kind: "Pod",
+		},
+	}
+
+	var nameAndKindDV = &v1beta1.DataVolume{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "testdv",
+		},
+		TypeMeta: v12.TypeMeta{
+			Kind: "DataVolume",
+		},
+	}
+
+	var nameAndKindVMI = &v13.VirtualMachineInstance{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "testvmi",
+		},
+		TypeMeta: v12.TypeMeta{
+			Kind: "VirtualMachineInstance",
+		},
+	}
+
+	var onlyKindPod = &v1.Pod{
+		TypeMeta: v12.TypeMeta{
+			Kind: "Pod",
+		},
+	}
+
+	var onlyKindDV = &v1beta1.DataVolume{
+		TypeMeta: v12.TypeMeta{
+			Kind: "DataVolume",
+		},
+	}
+
+	var onlyKindVMI = &v13.VirtualMachineInstance{
+		TypeMeta: v12.TypeMeta{
+			Kind: "VirtualMachineInstance",
+		},
+	}
+
+	var onlyNamePod = &v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "testpod",
+		},
+	}
+
+	var onlyNameDV = &v1beta1.DataVolume{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "testdv",
+		},
+	}
+
+	var onlyNameVMI = &v13.VirtualMachineInstance{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "testvmi",
 		},
 	}
 
@@ -58,5 +128,41 @@ var _ = Describe("Matcher", func() {
 		table.Entry("cope with an object which has no phase", v1.PodRunning, []*v1.Service{{}}, false),
 		table.Entry("cope with a non-stringable object as expected phase", nil, []*v1.Pod{runningPod}, false),
 		table.Entry("with expected phase not match the pod phase", "Succeeded", []*v1.Pod{runningPod}, false),
+	)
+
+	table.DescribeTable("should print kind and name of the object depending on fields", func(object interface{}, kind string, name string) {
+		unstructured, err := helper.ToUnstructured(object)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(unstructured.GetKind()).To(Equal(kind))
+		Expect(unstructured.GetName()).To(Equal(name))
+		if kind != "" && name != "" {
+			Expect(BeInPhase("testPhase").FailureMessage(object)).Should(HavePrefix(fmt.Sprintf("%s/%s", unstructured.GetKind(), unstructured.GetName())))
+			Expect(BeInPhase("testPhase").NegatedFailureMessage(object)).Should(HavePrefix(fmt.Sprintf("%s/%s", unstructured.GetKind(), unstructured.GetName())))
+		} else if kind != "" {
+			Expect(BeInPhase("testPhase").FailureMessage(object)).Should(HavePrefix(fmt.Sprintf("%s/", unstructured.GetKind())))
+			Expect(BeInPhase("testPhase").NegatedFailureMessage(object)).Should(HavePrefix(fmt.Sprintf("%s/", unstructured.GetKind())))
+		} else if name != "" {
+			Expect(BeInPhase("testPhase").FailureMessage(object)).Should(HavePrefix(fmt.Sprintf("%s", unstructured.GetName())))
+			Expect(BeInPhase("testPhase").NegatedFailureMessage(object)).Should(HavePrefix(fmt.Sprintf("%s", unstructured.GetName())))
+		} else {
+			Expect(BeInPhase("testPhase").FailureMessage(object)).ShouldNot(HavePrefix(fmt.Sprintf("%s/", unstructured.GetKind())))
+			Expect(BeInPhase("testPhase").NegatedFailureMessage(object)).ShouldNot(HavePrefix(fmt.Sprintf("%s/", unstructured.GetKind())))
+			Expect(BeInPhase("testPhase").FailureMessage(object)).Should(HavePrefix(" expected"))
+			Expect(BeInPhase("testPhase").NegatedFailureMessage(object)).Should(HavePrefix(" expected"))
+		}
+
+	},
+		table.Entry("with a Pod having name and kind", nameAndKindPod, nameAndKindPod.Kind, nameAndKindPod.Name),
+		table.Entry("with a DataVolume having name and kind", nameAndKindDV, nameAndKindDV.Kind, nameAndKindDV.Name),
+		table.Entry("with a VirtualMachineInstance having name and kind", nameAndKindVMI, nameAndKindVMI.Kind, nameAndKindVMI.Name),
+		table.Entry("with a Pod having only kind", onlyKindPod, onlyKindPod.Kind, onlyKindPod.Name),
+		table.Entry("with a DataVolume having only kind", onlyKindDV, onlyKindDV.Kind, onlyKindDV.Name),
+		table.Entry("with a VirtualMachineInstance having only kind", onlyKindVMI, onlyKindVMI.Kind, onlyKindVMI.Name),
+		table.Entry("with a Pod having only name", onlyNamePod, onlyNamePod.Kind, onlyNamePod.Name),
+		table.Entry("with a DataVolume having only name", onlyNameDV, onlyNameDV.Kind, onlyNameDV.Name),
+		table.Entry("with a VirtualMachineInstance having only name", onlyNameVMI, onlyNameVMI.Kind, onlyNameVMI.Name),
+		table.Entry("with a Pod having no kind and name", &v1.Pod{}, "", ""),
+		table.Entry("with a DataVolume having no kind and name", &v1beta1.DataVolume{}, "", ""),
+		table.Entry("with a VirtualMachineInstance having no kind and name", &v13.VirtualMachineInstance{}, "", ""),
 	)
 })


### PR DESCRIPTION
Signed-off-by: fossedihelm <ffossemo@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds `kind` and the `name` of the object (if exist) when the phase matcher fails. 
Makes it easier to spot the failing object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://github.com/kubevirt/kubevirt/issues/7216](https://github.com/kubevirt/kubevirt/issues/7216)

**Special notes for your reviewer**:
Moved the `toUnstructured(actual interface{})` function from `owner.go` to `helper.go`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
