### PR TITLE
clean container_disk_test a bit

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -58,13 +58,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		tests.BeforeTestCleanup()
 	})
 
-	LaunchVMI := func(vmi *v1.VirtualMachineInstance) runtime.Object {
-		By("Starting a VirtualMachineInstance")
-		obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
-		Expect(err).To(BeNil())
-		return obj
-	}
-
 	verifyContainerDiskVMI := func(vmi *v1.VirtualMachineInstance, obj runtime.Object) {
 		_, ok := obj.(*v1.VirtualMachineInstance)
 		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
@@ -186,7 +179,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					// FIXME if we give too much ram, the vmis really boot and eat all our memory (cache?)
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1M")
-					obj := LaunchVMI(vmi)
+					obj := tests.RunVMI(vmi, 10)
 					vmis = append(vmis, vmi)
 					objs = append(objs, obj)
 				}


### PR DESCRIPTION
Using libvmi.NewAlpine, libvmi.NewCirros and tests.RunVMIAndExpectScheduling
makes container disk tests slightly shorter and clearer.

Simple replacement did not work right away in some of the tests, e.g test_id:1463.
I don't understand those test and their
peculiar usage of objs on top of vmis so I leave their cleanup to a
future PR.

```release-note
NONE
```
