### PR TITLE
partial cleanup of network probes tests

### DIFF
--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -95,10 +95,10 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with readiness probe")
 
 				By(specifyingVMReadinessProbe)
-				vmi = createReadyCirrosVMIWithReadinessProbe(virtClient, readinessProbe)
+				vmi = createReadyCirrosVMIWithReadinessProbe(readinessProbe)
 			} else if !isExecProbe {
 				By(specifyingVMReadinessProbe)
-				vmi = createReadyCirrosVMIWithReadinessProbe(virtClient, readinessProbe)
+				vmi = createReadyCirrosVMIWithReadinessProbe(readinessProbe)
 
 				assertPodNotReady(virtClient, vmi)
 
@@ -197,10 +197,10 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with livness probe")
 
 				By(specifyingVMLivenessProbe)
-				vmi = createReadyCirrosVMIWithLivenessProbe(virtClient, livenessProbe)
+				vmi = createReadyCirrosVMIWithLivenessProbe(livenessProbe)
 			} else if !isExecProbe {
 				By(specifyingVMLivenessProbe)
-				vmi = createReadyCirrosVMIWithLivenessProbe(virtClient, livenessProbe)
+				vmi = createReadyCirrosVMIWithLivenessProbe(livenessProbe)
 
 				By("Starting the server inside the VMI")
 				serverStarter(vmi, livenessProbe, 1500)
@@ -235,7 +235,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi.Spec.LivenessProbe = livenessProbe
 				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 			} else {
-				vmi = createReadyCirrosVMIWithLivenessProbe(virtClient, livenessProbe)
+				vmi = createReadyCirrosVMIWithLivenessProbe(livenessProbe)
 			}
 
 			By("Checking that the VMI is in a final state after a minute")
@@ -252,14 +252,14 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 	})
 })
 
-func createReadyCirrosVMIWithReadinessProbe(virtClient kubecli.KubevirtClient, probe *v1.Probe) *v1.VirtualMachineInstance {
+func createReadyCirrosVMIWithReadinessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
 	vmi := libvmi.NewCirros()
 	vmi.Spec.ReadinessProbe = probe
 
 	return tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 
-func createReadyCirrosVMIWithLivenessProbe(virtClient kubecli.KubevirtClient, probe *v1.Probe) *v1.VirtualMachineInstance {
+func createReadyCirrosVMIWithLivenessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
 	vmi := libvmi.NewCirros()
 	vmi.Spec.LivenessProbe = probe
 

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -152,12 +152,8 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 			vmi.Spec.ReadinessProbe = readinessProbe
 			vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 
-			// pod is not ready until our probe contacts the server
-			assertPodNotReady(virtClient, vmi)
-
-			By("Checking that the VMI and the pod will consistently stay in a not-ready state")
+			By("Checking that the VMI is consistently non-ready")
 			Consistently(isVMIReady).Should(Equal(false))
-			Expect(tests.PodReady(tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault))).To(Equal(corev1.ConditionFalse))
 		},
 			table.Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", tcpProbe, libvmi.NewCirros),
 			table.Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", httpProbe, libvmi.NewCirros),

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -206,7 +206,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 			}
 
-			By("Checking that the VMI is still running after a minute")
+			By("Checking that the VMI is still running after a while")
 			Consistently(func() bool {
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -226,7 +226,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 			vmi.Spec.LivenessProbe = livenessProbe
 			vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 
-			By("Checking that the VMI is in a final state after a minute")
+			By("Checking that the VMI is in a final state after a while")
 			Eventually(func() bool {
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -120,7 +120,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo systemctl stop qemu-guest-agent -\n"},
+					&expect.BSnd{S: "sudo systemctl stop qemu-guest-agent\n"},
 					&expect.BExp{R: console.PromptExpression},
 				}, 120)).ToNot(HaveOccurred())
 
@@ -129,7 +129,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 
 				By("Enabling the guest-agent again")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo systemctl start qemu-guest-agent -\n"},
+					&expect.BSnd{S: "sudo systemctl start qemu-guest-agent\n"},
 					&expect.BExp{R: console.PromptExpression},
 				}, 120)).ToNot(HaveOccurred())
 

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -90,7 +90,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				}()
 
 				By("Attaching the readiness probe to an external pod server")
-				readinessProbe, err = pointProbeToSupportPod(probeBackendPod, IPFamily, readinessProbe)
+				readinessProbe, err = pointIpv6ProbeToSupportPod(probeBackendPod, readinessProbe)
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with readiness probe")
 
 				By(specifyingVMReadinessProbe)
@@ -184,7 +184,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				}()
 
 				By("Attaching the liveness probe to an external pod server")
-				livenessProbe, err = pointProbeToSupportPod(probeBackendPod, IPFamily, livenessProbe)
+				livenessProbe, err = pointIpv6ProbeToSupportPod(probeBackendPod, livenessProbe)
 				Expect(err).ToNot(HaveOccurred(), "should attach the backend pod with livness probe")
 
 				By(specifyingVMLivenessProbe)
@@ -327,10 +327,10 @@ func serverStarter(vmi *v1.VirtualMachineInstance, probe *v1.Probe, port int) {
 	}
 }
 
-func pointProbeToSupportPod(pod *corev1.Pod, IPFamily corev1.IPFamily, probe *v1.Probe) (*v1.Probe, error) {
-	supportPodIP := libnet.GetPodIpByFamily(pod, IPFamily)
+func pointIpv6ProbeToSupportPod(pod *corev1.Pod, probe *v1.Probe) (*v1.Probe, error) {
+	supportPodIP := libnet.GetPodIpByFamily(pod, corev1.IPv6Protocol)
 	if supportPodIP == "" {
-		return nil, fmt.Errorf("pod's %s %s IP address does not exist", pod.Name, IPFamily)
+		return nil, fmt.Errorf("pod/%s does not have an IPv6 address", pod.Name)
 	}
 
 	return patchProbeWithIPAddr(probe, supportPodIP), nil

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -18,8 +18,8 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 const (
@@ -253,18 +253,14 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 })
 
 func createReadyCirrosVMIWithReadinessProbe(virtClient kubecli.KubevirtClient, probe *v1.Probe) *v1.VirtualMachineInstance {
-	dummyUserData := "#!/bin/bash\necho 'hello'\n"
-	vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(
-		cd.ContainerDiskFor(cd.ContainerDiskCirros), dummyUserData)
+	vmi := libvmi.NewCirros()
 	vmi.Spec.ReadinessProbe = probe
 
 	return createAndBlockUntilVMIHasStarted(virtClient, vmi)
 }
 
 func createReadyCirrosVMIWithLivenessProbe(virtClient kubecli.KubevirtClient, probe *v1.Probe) *v1.VirtualMachineInstance {
-	dummyUserData := "#!/bin/bash\necho 'hello'\n"
-	vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(
-		cd.ContainerDiskFor(cd.ContainerDiskCirros), dummyUserData)
+	vmi := libvmi.NewCirros()
 	vmi.Spec.LivenessProbe = probe
 
 	return createAndBlockUntilVMIHasStarted(virtClient, vmi)

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -43,9 +43,8 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 	})
 
 	buildProbeBackendPodSpec := func(probe *v1.Probe) (*corev1.Pod, func() error) {
-		isHTTPProbe := probe.Handler.HTTPGet != nil
 		var probeBackendPod *corev1.Pod
-		if isHTTPProbe {
+		if isHTTPProbe(*probe) {
 			port := probe.HTTPGet.Port.IntVal
 			probeBackendPod = tests.StartHTTPServerPod(int(port))
 		} else {

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -256,27 +256,14 @@ func createReadyCirrosVMIWithReadinessProbe(virtClient kubecli.KubevirtClient, p
 	vmi := libvmi.NewCirros()
 	vmi.Spec.ReadinessProbe = probe
 
-	return createAndBlockUntilVMIHasStarted(virtClient, vmi)
+	return tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 
 func createReadyCirrosVMIWithLivenessProbe(virtClient kubecli.KubevirtClient, probe *v1.Probe) *v1.VirtualMachineInstance {
 	vmi := libvmi.NewCirros()
 	vmi.Spec.LivenessProbe = probe
 
-	return createAndBlockUntilVMIHasStarted(virtClient, vmi)
-}
-
-func createAndBlockUntilVMIHasStarted(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
-	_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-	Expect(err).ToNot(HaveOccurred())
-
-	// It may come to modify retries on the VMI because of the kubelet updating the pod, which can trigger controllers more often
-	tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
-
-	// read back the created VMI, so it has the UID available on it
-	startedVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	return startedVMI
+	return tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 
 func vmiReady(vmi *v1.VirtualMachineInstance) corev1.ConditionStatus {

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -74,14 +74,14 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 			return vmiReady(readVmi) == corev1.ConditionTrue
 		}
 
-		table.DescribeTable("should succeed", func(readinessProbe *v1.Probe, IPFamily corev1.IPFamily, isExecProbe bool, disableEnableCycle bool) {
+		table.DescribeTable("should succeed", func(readinessProbe *v1.Probe, ipFamily corev1.IPFamily, isExecProbe bool, disableEnableCycle bool) {
 			checkStatus := func(ready bool, condition corev1.ConditionStatus, timeout int) {
 				By("Checking that the VMI and the pod will be marked as ready to receive traffic")
 				Eventually(isVMIReady, timeout, 1).Should(Equal(ready))
 				Expect(tests.PodReady(tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault))).To(Equal(condition))
 			}
 
-			if IPFamily == corev1.IPv6Protocol {
+			if ipFamily == corev1.IPv6Protocol {
 				libnet.SkipWhenNotDualStackCluster(virtClient)
 				By("Create a support pod which will reply to kubelet's probes ...")
 				probeBackendPod, supportPodCleanupFunc := buildProbeBackendPodSpec(readinessProbe)
@@ -172,9 +172,9 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		tcpProbe := createTCPProbe(period, initialSeconds, port)
 		httpProbe := createHTTPProbe(period, initialSeconds, port)
 
-		table.DescribeTable("should not fail the VMI", func(livenessProbe *v1.Probe, IPFamily corev1.IPFamily, isExecProbe bool) {
+		table.DescribeTable("should not fail the VMI", func(livenessProbe *v1.Probe, ipFamily corev1.IPFamily, isExecProbe bool) {
 
-			if IPFamily == corev1.IPv6Protocol {
+			if ipFamily == corev1.IPv6Protocol {
 				libnet.SkipWhenNotDualStackCluster(virtClient)
 
 				By("Create a support pod which will reply to kubelet's probes ...")


### PR DESCRIPTION
This PR aims to simplify `tests/network/probes.go` by using `libvmi` to define VMIs, dropping confusing helper functions, removing non-important-yet-confusing tests, and avoiding few opaque boolean arguments. There is more to be done there: two of the `table.DescribeTable` functions are left with a complex `if-else` that is yet to be cleaned.

```release-note
NONE
```
