### PR TITLE
[tests] Try reducing disk pressure by asking for smaller disks

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2112,7 +2112,7 @@ func newDataVolume(namespace, storageClass string, size string, accessMode k8sv1
 }
 
 func NewRandomDataVolumeWithRegistryImportInStorageClass(imageUrl, namespace, storageClass string, accessMode k8sv1.PersistentVolumeAccessMode, volumeMode k8sv1.PersistentVolumeMode) *cdiv1.DataVolume {
-	size := "1Gi"
+	size := "512Mi"
 	dataVolumeSource := cdiv1.DataVolumeSource{
 		Registry: &cdiv1.DataVolumeSourceRegistry{
 			URL: &imageUrl,


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduce the default CDI DataVolume disk size to 512Mi in tests, to reduce
in small clusters the disk write pressure since CDI started in Okt. 21.
to write zero to the whole disk.

Picking up the suggestion from @awels  in https://github.com/kubevirt/containerized-data-importer/issues/2160#issuecomment-1040296927.

Potentially fixes issues like in this job: https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7226/pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations/1493609770421063680

manifesting themselves with "stuck" looking block storage imports at 98%+.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
