### PR TITLE
virt-launcher: adjust overhead calculation for processes

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -122,6 +122,14 @@ const EXT_LOG_VERBOSITY_THRESHOLD = 5
 
 const ephemeralStorageOverheadSize = "50M"
 
+const (
+	VirtLauncherMonitorOverhead = "25Mi" // The `ps` RSS for virt-launcher-monitor
+	VirtLauncherOverhead        = "75Mi" // The `ps` RSS for the virt-launcher process
+	VirtlogdOverhead            = "16Mi" // The `ps` RSS for virtlogd
+	LibvirtdOverhead            = "33Mi" // The `ps` RSS for libvirtd
+	QemuOverhead                = "30Mi" // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
+)
+
 type TemplateService interface {
 	RenderMigrationManifest(vmi *v1.VirtualMachineInstance, sourcePod *k8sv1.Pod) (*k8sv1.Pod, error)
 	RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error)
@@ -1873,9 +1881,14 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource
 	pagetableMemory.Set(pagetableMemory.Value() / 512)
 	overhead.Add(*pagetableMemory)
 
-	// Add fixed overhead for shared libraries and such
-	// TODO account for the overhead of kubevirt components running in the pod
-	overhead.Add(resource.MustParse("138Mi"))
+	// Add fixed overhead for KubeVirt components, as seen in a random run, rounded up to the nearest MiB
+	// Note: shared libraries are included in the size, so every library is counted (wrongly) as many times as there are
+	//   processes using it. However, the extra memory is only in the order of 10MiB and makes for a nice safety margin.
+	overhead.Add(resource.MustParse(VirtLauncherMonitorOverhead))
+	overhead.Add(resource.MustParse(VirtLauncherOverhead))
+	overhead.Add(resource.MustParse(VirtlogdOverhead))
+	overhead.Add(resource.MustParse(LibvirtdOverhead))
+	overhead.Add(resource.MustParse(QemuOverhead))
 
 	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
 	// overhead per vcpu in MiB

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1647,8 +1647,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1180211045", "2180211045"),
-				Entry("on arm64", "arm64", "1314428773", "2314428773"),
+				Entry("on amd64", "amd64", "1223202661", "2223202661"),
+				Entry("on arm64", "arm64", "1357420389", "2357420389"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1683,8 +1683,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2180211045"),
-				Entry("on arm64", "arm64", "2314428773"),
+				Entry("on amd64", "amd64", "2223202661"),
+				Entry("on arm64", "arm64", "2357420389"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1721,8 +1721,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 260),
-				Entry("on arm64", "arm64", 394),
+				Entry("on amd64", "amd64", 303),
+				Entry("on arm64", "arm64", 437),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1757,12 +1757,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 260),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 260),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 243),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 394),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 394),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 377),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 303),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 303),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 286),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 437),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 437),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 420),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1950,10 +1950,10 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 179),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 179),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 313),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 313),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 222),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 222),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 356),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 356),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -2008,8 +2008,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
 			},
-				Entry("on amd64", "amd64", 179),
-				Entry("on arm64", "arm64", 313),
+				Entry("on amd64", "amd64", 222),
+				Entry("on arm64", "arm64", 356),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -20,6 +20,7 @@
 package tests_test
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -28,6 +29,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
@@ -273,7 +276,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(296)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(339)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -2932,6 +2935,73 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				&expect.BSnd{S: "$(sudo /usr/libexec/virt-what-cpuid-helper | grep -q KVMKVMKVM) && echo 'pass'\n"},
 				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)).To(Succeed())
+		})
+	})
+	Context("virt-launcher processes memory usage", func() {
+		It("should be lower than allocated size", func() {
+			By("Starting a VirtualMachineInstance")
+			vmi := tests.NewRandomFedoraVMI()
+			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Expecting console")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+			By("Running ps in virt-launcher")
+			pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
+			})
+			Expect(err).ToNot(HaveOccurred(), "Should list pods successfully")
+			var stdout, stderr string
+			errorMassageFormat := "failed after running the `ps` command with stdout:\n %v \n stderr:\n %v \n err: \n %v \n"
+			Eventually(func() error {
+				stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, &pods.Items[0], "compute",
+					[]string{
+						"ps",
+						"--no-header",
+						"axo",
+						"rss,command",
+					})
+				return err
+			}, time.Second, 50*time.Millisecond).Should(BeNil(), fmt.Sprintf(errorMassageFormat, stdout, stderr, err))
+
+			By("Parsing the output of ps")
+			processRss := make(map[string]resource.Quantity)
+			scanner := bufio.NewScanner(strings.NewReader(stdout))
+			for scanner.Scan() {
+				fields := strings.Fields(scanner.Text())
+				Expect(len(fields)).To(BeNumerically(">=", 2))
+				rss := fields[0]
+				command := filepath.Base(fields[1])
+				switch command {
+				case "virt-launcher-monitor", "virt-launcher", "virtlogd", "libvirtd", "qemu-kvm":
+					Expect(processRss).ToNot(HaveKey(command), "multiple %s processes found", command)
+					value := resource.MustParse(rss + "Ki")
+					processRss[command] = value
+				}
+			}
+			for _, process := range []string{"virt-launcher-monitor", "virt-launcher", "virtlogd", "libvirtd", "qemu-kvm"} {
+				Expect(processRss).To(HaveKey(process), "no %s process found", process)
+			}
+
+			By("Ensuring no process is using too much ram")
+			expected := resource.MustParse(services.VirtLauncherMonitorOverhead)
+			actual := processRss["virt-launcher-monitor"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virt-launcher-monitor process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.VirtLauncherOverhead)
+			actual = processRss["virt-launcher"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the /usr/bin/virt-launcher process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.VirtlogdOverhead)
+			actual = processRss["virtlogd"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virtlogd process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.LibvirtdOverhead)
+			actual = processRss["libvirtd"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the libvirtd process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.QemuOverhead)
+			expected.Add(vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory])
+			actual = processRss["qemu-kvm"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the qemu-kvm process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR effectively addresses a TODO in the memory overhead calculation for virt-launcher.
It replaces an arbitrary overhead value with the observed memory usage of each process running inside virt-launcher.
A test also ensures we catch any future growth.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
