### PR TITLE
Always show applied migration configuration in VMI status

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -351,6 +351,16 @@ var _ = Describe("Migration watcher", func() {
 		}
 	}
 
+	getMigrationConfigPatch := func() string {
+		migrationConfiguration := controller.clusterConfig.GetMigrationConfiguration()
+		Expect(migrationConfiguration).ToNot(BeNil())
+
+		marshalledConfigs, err := json.Marshal(migrationConfiguration)
+		Expect(err).ToNot(HaveOccurred())
+
+		return fmt.Sprintf(`"migrationConfiguration":%s`, string(marshalledConfigs))
+	}
+
 	Context("Migration with hotplug volumes", func() {
 		var (
 			vmi           *virtv1.VirtualMachineInstance
@@ -400,7 +410,7 @@ var _ = Describe("Migration watcher", func() {
 			podFeeder.Add(targetPod)
 			podFeeder.Add(attachmentPod)
 
-			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","targetAttachmentPodUID":"%s","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, targetPod.Name, attachmentPod.UID)
+			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","targetAttachmentPodUID":"%s","sourceNode":"node02","migrationUid":"testmigration",%s} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, targetPod.Name, attachmentPod.UID, getMigrationConfigPatch())
 
 			shouldExpectVirtualMachineInstancePatch(vmi, patch)
 
@@ -916,7 +926,7 @@ var _ = Describe("Migration watcher", func() {
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(pod)
 
-			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, pod.Name)
+			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration",%s} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, pod.Name, getMigrationConfigPatch())
 
 			shouldExpectVirtualMachineInstancePatch(vmi, patch)
 
@@ -972,7 +982,7 @@ var _ = Describe("Migration watcher", func() {
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(pod)
 
-			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, pod.Name)
+			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration",%s} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, pod.Name, getMigrationConfigPatch())
 			shouldExpectVirtualMachineInstancePatch(vmi, patch)
 
 			controller.Execute()
@@ -996,7 +1006,7 @@ var _ = Describe("Migration watcher", func() {
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(pod)
 
-			patch := fmt.Sprintf(`[{ "op": "test", "path": "/status/migrationState", "value": {"migrationUid":"1111-2222-3333-4444"} }, { "op": "replace", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, pod.Name)
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/status/migrationState", "value": {"migrationUid":"1111-2222-3333-4444"} }, { "op": "replace", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration",%s} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, pod.Name, getMigrationConfigPatch())
 
 			shouldExpectVirtualMachineInstancePatch(vmi, patch)
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2347,6 +2347,13 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.Vir
 			AllowPostCopy:           *migrationConfiguration.AllowPostCopy,
 		}
 
+		marshalledOptions, err := json.Marshal(options)
+		if err != nil {
+			log.Log.Object(vmi).Warning("failed to marshall matched migration options")
+		} else {
+			log.Log.Object(vmi).Infof("migration options matched for vmi %s: %s", vmi.Name, string(marshalledOptions))
+		}
+
 		err = client.MigrateVirtualMachine(vmi, options)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR https://github.com/kubevirt/kubevirt/pull/6399 that introduced Migration Policies, new fields were introduced to `VirtualMachineInstanceMigrationState` struct which is a property of the VMI status. One of those fields is named `MigrationConfiguration` which lists the actual migration configurations that were applied.

Before this PR this information was part of a VMI status only if the migration was matched to a migration policy.
After this PR this information would be part of VMI status for every migration - not only migrations that were matched to a policy.

Usually, when a VMI migrates without matching to a policy (which means the configs are taken from Kubevirt CR) the applied configurations can be found in Kubevirt CR. This is not guaranteed, however, since Kubevirt CR can be changed at any moment. In such circumstances we wouldn't know the actual applied migration configs.

This information is valuable for debugging or inspecting the actual migration configs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Applied migration configurations can now be found in VMI's status
```
