### PR TITLE
virt-operator: remove redundant object DeepCopy

### DIFF
--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -626,7 +626,6 @@ func (r *Reconciler) createOrRollBackSystem(apiDeploymentsRolledOver bool) (bool
 
 	// create/update API Deployments
 	for _, deployment := range r.targetStrategy.ApiDeployments() {
-		deployment := deployment.DeepCopy()
 		deployment, err := r.syncDeployment(deployment)
 		if err != nil {
 			return false, err

--- a/pkg/virt-operator/resource/apply/update.go
+++ b/pkg/virt-operator/resource/apply/update.go
@@ -36,7 +36,6 @@ func (r *Reconciler) updateKubeVirtSystem(controllerDeploymentsRolledOver bool) 
 
 	// create/update API Deployments
 	for _, deployment := range r.targetStrategy.ApiDeployments() {
-		deployment := deployment.DeepCopy()
 		deployment, err := r.syncDeployment(deployment)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
the deployment object is already deep-copied inside the syncDeployment
function, there's no need to do it twice.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
