### PR TITLE
[WIP] NIC hot-unplug - cleanup

### DIFF
--- a/cmd/virt-chroot/tap-device-maker.go
+++ b/cmd/virt-chroot/tap-device-maker.go
@@ -49,6 +49,15 @@ func createTapDevice(name string, owner uint, group uint, queueNumber int, mtu i
 	return nil
 }
 
+func deleteTapDevice(name string) error {
+	tapDevice, err := netlink.LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("failed to find tap device named %s. Reason: %v", name, err)
+	}
+
+	return netlink.LinkDel(tapDevice)
+}
+
 func NewCreateTapCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "create-tap",
@@ -76,6 +85,18 @@ func NewCreateTapCommand() *cobra.Command {
 			}
 
 			return createTapDevice(tapName, uint(uid), uint(gid), int(queueNumber), int(mtu))
+		},
+	}
+}
+
+func NewDeleteTapCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete-tap",
+		Short: "delete a tap device in a given PID net ns",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tapName := cmd.Flag("tap-name").Value.String()
+
+			return deleteTapDevice(tapName)
 		},
 	}
 }

--- a/pkg/network/cache/cache.go
+++ b/pkg/network/cache/cache.go
@@ -40,6 +40,7 @@ type cacheFS interface {
 	Stat(name string) (os.FileInfo, error)
 	MkdirAll(path string, perm os.FileMode) error
 	RemoveAll(path string) error
+	Remove(path string) error
 	ReadFile(filename string) ([]byte, error)
 	WriteFile(filename string, data []byte, perm fs.FileMode) error
 }
@@ -79,7 +80,11 @@ func (c Cache) Write(data interface{}) error {
 	return writeToCachedFile(c.fs, data, c.path)
 }
 
-func (c Cache) Delete() error {
+func (c Cache) Delete(data interface{}) error {
+	return c.fs.Remove(c.path)
+}
+
+func (c Cache) DeleteAll() error {
 	return c.fs.RemoveAll(c.path)
 }
 

--- a/pkg/network/cache/dhcpconfig.go
+++ b/pkg/network/cache/dhcpconfig.go
@@ -33,6 +33,14 @@ type DHCPInterfaceCache struct {
 	cache *Cache
 }
 
+func RemoveDHCPInterfaceCache(c cacheCreator, pid, ifaceName string) error {
+	dhcpCache, err := NewDHCPInterfaceCache(c, pid).IfaceEntry(ifaceName)
+	if err != nil {
+		return err
+	}
+	return dhcpCache.Remove()
+}
+
 func ReadDHCPInterfaceCache(c cacheCreator, pid, ifaceName string) (*DHCPConfig, error) {
 	dhcpCache, err := NewDHCPInterfaceCache(c, pid).IfaceEntry(ifaceName)
 	if err != nil {
@@ -63,6 +71,11 @@ func (d DHCPInterfaceCache) IfaceEntry(ifaceName string) (DHCPInterfaceCache, er
 	}
 
 	return DHCPInterfaceCache{&cache}, nil
+}
+
+func (d DHCPInterfaceCache) Remove() error {
+	cachedIface := &DHCPConfig{}
+	return d.cache.Delete(cachedIface)
 }
 
 func (d DHCPInterfaceCache) Read() (*DHCPConfig, error) {

--- a/pkg/network/cache/domaininterface.go
+++ b/pkg/network/cache/domaininterface.go
@@ -31,6 +31,14 @@ type DomainInterfaceCache struct {
 	cache *Cache
 }
 
+func RemoveDomainInterfaceCache(c cacheCreator, pid, ifaceName string) error {
+	domainCache, err := NewDomainInterfaceCache(c, pid).IfaceEntry(ifaceName)
+	if err != nil {
+		return err
+	}
+	return domainCache.Remove()
+}
+
 func ReadDomainInterfaceCache(c cacheCreator, pid, ifaceName string) (*api.Interface, error) {
 	domainCache, err := NewDomainInterfaceCache(c, pid).IfaceEntry(ifaceName)
 	if err != nil {
@@ -61,6 +69,11 @@ func (d DomainInterfaceCache) IfaceEntry(ifaceName string) (DomainInterfaceCache
 	}
 
 	return DomainInterfaceCache{&cache}, nil
+}
+
+func (d DomainInterfaceCache) Remove() error {
+	iface := &api.Interface{}
+	return d.cache.Delete(iface)
 }
 
 func (d DomainInterfaceCache) Read() (*api.Interface, error) {

--- a/pkg/network/cache/podinterface.go
+++ b/pkg/network/cache/podinterface.go
@@ -32,6 +32,8 @@ const (
 	PodIfaceNetworkPreparationPending PodIfaceState = iota
 	PodIfaceNetworkPreparationStarted
 	PodIfaceNetworkPreparationFinished
+	PodIfaceNetworkCleanStarted
+	PodIfaceNetworkCleanFinished
 )
 
 type PodIfaceCacheData struct {
@@ -43,6 +45,14 @@ type PodIfaceCacheData struct {
 
 type PodInterfaceCache struct {
 	cache *Cache
+}
+
+func RemovePodInterfaceCache(c cacheCreator, uid, ifaceName string) error {
+	podCache, err := NewPodInterfaceCache(c, uid).IfaceEntry(ifaceName)
+	if err != nil {
+		return err
+	}
+	return podCache.Remove()
 }
 
 func ReadPodInterfaceCache(c cacheCreator, uid, ifaceName string) (*PodIfaceCacheData, error) {
@@ -86,5 +96,7 @@ func (p PodInterfaceCache) Write(cacheInterface *PodIfaceCacheData) error {
 }
 
 func (p PodInterfaceCache) Remove() error {
-	return p.cache.Delete()
+	iface := &PodIfaceCacheData{}
+	err := p.cache.Delete(iface)
+	return err
 }

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -20,6 +20,11 @@ type MockNetworkHandler struct {
 	recorder *_MockNetworkHandlerRecorder
 }
 
+func (_m *MockNetworkHandler) DeleteTapDevice(tapName string, launcherPID int) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 // Recorder for MockNetworkHandler (not exported)
 type _MockNetworkHandlerRecorder struct {
 	mock *MockNetworkHandler
@@ -146,6 +151,11 @@ func (_m *MockNetworkHandler) LinkAdd(link netlink.Link) error {
 	return ret0
 }
 
+func (_m *MockNetworkHandler) LinkDel(link netlink.Link) error {
+	//todo impl
+	return nil
+}
+
 func (_mr *_MockNetworkHandlerRecorder) LinkAdd(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkAdd", arg0)
 }
@@ -203,8 +213,8 @@ func (_mr *_MockNetworkHandlerRecorder) LinkSetMaster(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetMaster", arg0, arg1)
 }
 
-func (_m *MockNetworkHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
-	ret := _m.ctrl.Call(_m, "StartDHCP", nic, bridgeInterfaceName, dhcpOptions)
+func (_m *MockNetworkHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, stopChan chan string) error {
+	ret := _m.ctrl.Call(_m, "StartDHCP", nic, bridgeInterfaceName, dhcpOptions, stopChan)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -33,6 +33,7 @@ import (
 type PodNetworkInfraConfigurator interface {
 	DiscoverPodNetworkInterface(podIfaceName string) error
 	PreparePodNetworkInterface() error
+	CleanPodNetworkInterface() error
 	GenerateNonRecoverableDomainIfaceSpec() *api.Interface
 	// The method should return dhcp configuration that cannot be calculated in virt-launcher's phase2
 	GenerateNonRecoverableDHCPConfig() *cache.DHCPConfig
@@ -44,6 +45,10 @@ func createAndBindTapToBridge(handler netdriver.NetworkHandler, deviceName strin
 		return err
 	}
 	return handler.BindTapDeviceToBridge(deviceName, bridgeIfaceName)
+}
+
+func deleteTapDevice(handler netdriver.NetworkHandler, deviceName string, launcherPID int) error {
+	return handler.DeleteTapDevice(deviceName, launcherPID)
 }
 
 func calculateNetworkQueues(vmi *v1.VirtualMachineInstance) uint32 {

--- a/pkg/network/infraconfigurators/generated_mock_common.go
+++ b/pkg/network/infraconfigurators/generated_mock_common.go
@@ -41,6 +41,11 @@ func (_mr *_MockPodNetworkInfraConfiguratorRecorder) DiscoverPodNetworkInterface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiscoverPodNetworkInterface", arg0)
 }
 
+func (_m *MockPodNetworkInfraConfigurator) CleanPodNetworkInterface() error {
+	//TODO impl
+	return nil
+}
+
 func (_m *MockPodNetworkInfraConfigurator) PreparePodNetworkInterface() error {
 	ret := _m.ctrl.Call(_m, "PreparePodNetworkInterface")
 	ret0, _ := ret[0].(error)

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -106,6 +106,10 @@ func (b *MasqueradePodNetworkConfigurator) GenerateNonRecoverableDHCPConfig() *c
 	return nil
 }
 
+func (b *MasqueradePodNetworkConfigurator) CleanPodNetworkInterface() error {
+	return nil
+}
+
 func (b *MasqueradePodNetworkConfigurator) PreparePodNetworkInterface() error {
 	if err := b.createBridge(); err != nil {
 		return err

--- a/pkg/network/link/names.go
+++ b/pkg/network/link/names.go
@@ -21,6 +21,7 @@ package link
 
 import (
 	"fmt"
+	"strings"
 )
 
 func GenerateTapDeviceName(podInterfaceName string) string {
@@ -29,5 +30,8 @@ func GenerateTapDeviceName(podInterfaceName string) string {
 
 func GenerateNewBridgedVmiInterfaceName(originalPodInterfaceName string) string {
 	return fmt.Sprintf("%s-nic", originalPodInterfaceName)
+}
 
+func RecoverOriginalPodInterfaceName(generatedPodInterfaceName string) string {
+	return strings.TrimSuffix(generatedPodInterfaceName, "--nic")
 }

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -70,7 +70,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				iface := v1.DefaultBridgeNetworkInterface()
 				defaultNet := v1.DefaultPodNetwork()
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
 					vmi:              vm,
@@ -92,7 +92,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				vmi := api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(BeEmpty())
 			})
@@ -109,7 +109,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				vmi.Spec.Networks = []v1.Network{*cniNet}
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
 					vmi:              vmi,
@@ -176,7 +176,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vm, &baseCacheCreator)
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ContainElements([]podNIC{
 					{


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of NIC hot-unplug support feature,
Clean 'interface-to-unplug' resources:
- Support secondary bridge network only
- Stop corresponding DHCP server (if running)
- Delete interface related cache files

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This PR is blocked due to a delay in necessary support on multus side.
Current status of the code is WIP.
Design draft, committed work status and leftovers can be found below:
https://docs.google.com/document/d/1SxvKTceZ4n27XRJtu8zKMcvHz3Wldg1894eiVOMvTCI/edit#heading=h.t6qqv33gmqut

**Release note**:
```
NONE
```