### PR TITLE
[virt-operator] Add observedGeneration to Kubevirt CR status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14038,6 +14038,10 @@
      "observedDeploymentID": {
       "type": "string"
      },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64"
+     },
      "observedKubeVirtRegistry": {
       "type": "string"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -2595,6 +2595,9 @@ spec:
                 type: string
               observedDeploymentID:
                 type: string
+              observedGeneration:
+                format: int64
+                type: integer
               observedKubeVirtRegistry:
                 type: string
               observedKubeVirtVersion:
@@ -5200,6 +5203,9 @@ spec:
                 type: string
               observedDeploymentID:
                 type: string
+              observedGeneration:
+                format: int64
+                type: integer
               observedKubeVirtRegistry:
                 type: string
               observedKubeVirtVersion:

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -107,6 +107,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1064,6 +1064,7 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 			logger.Info("All KubeVirt components ready")
 			kv.Status.Phase = v1.KubeVirtPhaseDeployed
 			util.UpdateConditionsAvailable(kv)
+			kv.Status.ObservedGeneration = &kv.ObjectMeta.Generation
 			return nil
 		}
 	}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -36,7 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
+
+	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	secv1 "github.com/openshift/api/security/v1"
@@ -64,7 +68,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/version"
-	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	kubecontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
@@ -1569,7 +1572,8 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 				Status: v1.KubeVirtStatus{
-					Phase: v1.KubeVirtPhaseDeleted,
+					Phase:              v1.KubeVirtPhaseDeleted,
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			// Add kubevirt deployment and mark everything as ready
@@ -1639,8 +1643,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					ImageTag: "custom.tag",
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 
@@ -1664,7 +1669,6 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 			kv = kvTestData.getLatestKubeVirt(kv)
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
-
 		}, 60)
 
 		It("delete temporary validation webhook once virt-api is deployed", func(done Done) {
@@ -1682,8 +1686,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					Generation: int64(1),
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
@@ -1770,8 +1775,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					Generation: int64(1),
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
@@ -1831,8 +1837,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					Generation: int64(1),
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -2931,6 +2931,9 @@ var CRDsValidation map[string]string = map[string]string{
           type: string
         observedDeploymentID:
           type: string
+        observedGeneration:
+          format: int64
+          type: integer
         observedKubeVirtRegistry:
           type: string
         observedKubeVirtVersion:

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2298,6 +2298,11 @@ func (in *KubeVirtStatus) DeepCopyInto(out *KubeVirtStatus) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.ObservedGeneration != nil {
+		in, out := &in.ObservedGeneration, &out.ObservedGeneration
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Generations != nil {
 		in, out := &in.Generations, &out.Generations
 		*out = make([]GenerationStatus, len(*in))

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1745,6 +1745,7 @@ type KubeVirtStatus struct {
 	ObservedDeploymentConfig                string              `json:"observedDeploymentConfig,omitempty" optional:"true"`
 	ObservedDeploymentID                    string              `json:"observedDeploymentID,omitempty" optional:"true"`
 	OutdatedVirtualMachineInstanceWorkloads *int                `json:"outdatedVirtualMachineInstanceWorkloads,omitempty" optional:"true"`
+	ObservedGeneration                      *int64              `json:"observedGeneration,omitempty"`
 	// +listType=atomic
 	Generations []GenerationStatus `json:"generations,omitempty" optional:"true"`
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17613,6 +17613,12 @@ func schema_kubevirtio_api_core_v1_KubeVirtStatus(ref common.ReferenceCallback) 
 							Format: "int32",
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -361,8 +361,20 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 				}
 
 				if !available || progressing || degraded || !created {
+					if kv.Status.ObservedGeneration != nil {
+						if *kv.Status.ObservedGeneration == kv.ObjectMeta.Generation {
+							return fmt.Errorf("observed generation must not match the current configuration")
+						}
+					}
 					return fmt.Errorf("Waiting for conditions to indicate deployment (conditions: %+v)", kv.Status.Conditions)
 				}
+
+				if kv.Status.ObservedGeneration != nil {
+					if *kv.Status.ObservedGeneration != kv.ObjectMeta.Generation {
+						return fmt.Errorf("the observed generation must match the current generation")
+					}
+				}
+
 				return nil
 			}, time.Duration(timeoutSeconds)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}


### PR DESCRIPTION
In a resource, when `objectMeta.generation` is being incremented it means the user desire has changed
and the controller execution loop starting the reconciliation work. When the controller finishes to process the desired
state, it puts the value of `objectMeta.generation` in `status.observedGeneration`. 
We would like to achieve the same in virt-operator. 

This pattern is already being used by various controllers in kube-controller.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Currently we don't have any indication about the progress of the virt-operator sync loop. There are cases
where the operator sync process can be asynchronous, for example if one of the control-plane components is not ready
the virt-operator will wait till it be ready before finishing the sync.

**Special notes for your reviewer**:
it makes sense to update `UpdateKubeVirtConfigValueAndWait` to watch for the observed generation
but I would like to do it in a follow-up PR, because it will also make sense to consolidate the updates of CR `spec` and
`spec.Configuration` into a single helper function, since in both cases we need to assert on the observed generation.

**Release note**:
```release-note
Add observedGeneration to virt-operator to have a race-free way to detect KubeVirt config rollouts
```
