### PR TITLE
[WIP] network: get rid of libmacouflage

### DIFF
--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -5,7 +5,9 @@ go_library(
     srcs = [
         "common.go",
         "generated_mock_common.go",
+        "mac.go",
     ],
+    cgo = True,
     importpath = "kubevirt.io/kubevirt/pkg/network/driver",
     visibility = ["//visibility:public"],
     deps = [
@@ -21,7 +23,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
-        "//vendor/github.com/subgraph/libmacouflage:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -28,7 +28,6 @@ import (
 	"os/exec"
 
 	"github.com/coreos/go-iptables/iptables"
-	lmf "github.com/subgraph/libmacouflage"
 	"github.com/vishvananda/netlink"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
@@ -294,12 +293,7 @@ func (h *NetworkUtilsHandler) ReadIPAddressesFromLink(interfaceName string) (str
 
 // GetMacDetails from an interface
 func (h *NetworkUtilsHandler) GetMacDetails(iface string) (net.HardwareAddr, error) {
-	currentMac, err := lmf.GetCurrentMac(iface)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to get mac information for interface: %s", iface)
-		return nil, err
-	}
-	return currentMac, nil
+	return getMacDetails(iface)
 }
 
 // SetRandomMac changes the MAC address for a given interface to a randomly generated, preserving the vendor prefix
@@ -314,7 +308,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 	changed := false
 
 	for i := 0; i < randomMacGenerationAttempts; i++ {
-		changed, err = lmf.SpoofMacSameVendor(iface, false)
+		changed, err = spoofMacSameVendor(iface, currentMac)
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to spoof MAC for an interface: %s", iface)
 			return nil, err

--- a/pkg/network/driver/mac.go
+++ b/pkg/network/driver/mac.go
@@ -1,0 +1,140 @@
+/*
+ * This file is part of the KubeVirt project
+ * Most of it originates from https://github.com/subgraph/libmacouflage
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) 2020 Subgraph
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package driver
+
+import "C"
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+	"syscall"
+	"unsafe"
+)
+
+type NetInfo struct {
+	name   [16]byte
+	family uint16
+	data   [6]byte
+}
+type EthtoolPermAddr struct {
+	cmd  uint32
+	size uint32
+	data [6]byte
+}
+
+type ifreq struct {
+	name [16]byte
+	epa  *EthtoolPermAddr
+}
+
+const (
+	SIOCSIFHWADDR    = 0x8924
+	SIOCETHTOOL      = 0x8946
+	ETHTOOLGPERMADDR = 0x00000020
+	IFHWADDRLEN      = 6
+)
+
+func getMacDetails(name string) (net.HardwareAddr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return iface.HardwareAddr, nil
+}
+
+func setMac(name string, mac string) (err error) {
+	sockfd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, 0)
+	defer syscall.Close(sockfd)
+	iface, err := net.ParseMAC(mac)
+	if err != nil {
+		return
+	}
+	var netinfo NetInfo
+	copy(netinfo.name[:], name)
+	netinfo.family = syscall.AF_UNIX
+	copy(netinfo.data[:], iface)
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(sockfd), SIOCSIFHWADDR, uintptr(unsafe.Pointer(&netinfo)))
+	if errno != 0 {
+		err = errno
+	}
+	return
+}
+
+func getPermanentMac(name string) (mac net.HardwareAddr, err error) {
+	sockfd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, 0)
+	defer syscall.Close(sockfd)
+	var ifr ifreq
+	copy(ifr.name[:], name)
+	var epa EthtoolPermAddr
+	epa.cmd = ETHTOOLGPERMADDR
+	epa.size = IFHWADDRLEN
+	ifr.epa = &epa
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(sockfd), SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr)))
+	if errno != 0 {
+		err = errno
+		return
+	}
+	mac = net.HardwareAddr(C.GoBytes(unsafe.Pointer(&ifr.epa.data), 6))
+	return
+}
+
+func macChanged(iface string) (changed bool, err error) {
+	current, err := getMacDetails(iface)
+	if err != nil {
+		return false, err
+	}
+	permanent, err := getPermanentMac(iface)
+	if err != nil {
+		return false, err
+	}
+	if current.String() == permanent.String() {
+		return false, err
+	}
+	return true, nil
+}
+
+func spoofMacSameVendor(name string, mac net.HardwareAddr) (changed bool, err error) {
+	if len(mac) != 6 {
+		err = fmt.Errorf("invalid size for macbytes byte array: %d",
+			len(mac))
+		return
+	}
+	for i := 3; i < 6; i++ {
+		buf := make([]byte, 1)
+		_, err = rand.Read(buf)
+		if err != nil {
+			return false, err
+		}
+		mac[i] = buf[0]
+	}
+	mac[0] |= 2
+
+	err = setMac(name, mac.String())
+	if err != nil {
+		return false, err
+	}
+	changed, err = macChanged(name)
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
While profiling virt-launcher RAM usage, I noticed that a big chunk got allocated by libmacouflage (~25MB out of 135MB)
We use that lib mainly to change interface mac addresses. The lib is ultimately used by virt-handler, but apparently just using imports from pkg/network is enough for it to get loaded into virt-launcher as well.

I'd like to use this PR as a starting point for a discussion around libmacouflage.
- The last code modification on the lib is from 6 years ago
- On init, the lib loads a huge binary blob, supposedly some json info about mac vendors and whatnot (which we don't need/use). Most likely the source of the big RAM consumption

This PR adds ~100 lines of code to maintain in KubeVirt, which is usually not ideal.
However in this case I think makes sense, since it saves ~25MB of memory per VM, and the upstream code doesn't seem to be maintained anyway.

An alternative would be to ensure the lib stays out of virt-launcher, by maybe moving the code that uses it to a different package, imported only by virt-handler.

I'd love to get some thoughts on this. If this gets positive feedback, I will finish the PR by writing some unit tests and reducing the allocated RAM overhead for virt-launcher.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Memory overhead reduced by ~25MB per VMI
```
