### PR TITLE
Update KubevirtVmHighMemoryUsage alert

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -441,12 +441,64 @@ tests:
         alertname: LowKVMNodesCount
         exp_alerts: []
 
-  # Memory utilization less than 20MB close to requested memory
+  # Memory utilization less than 20MB close to requested memory - based on memory working set
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "47185920 48234496 48234496 49283072"
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "19922944 18874368 18874368 17825792"
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KubevirtVmHighMemoryUsage
+        exp_alerts:
+          - exp_annotations:
+              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to requested memory"
+              summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              pod: "virt-launcher-testvm-123"
+              container: "compute"
+
+  # Memory utilization less than 20MB close to requested memory - based on memory RSS
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+        values: "67108864 67108864 67108864 67108864"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "19922944 18874368 18874368 17825792"
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "47185920 48234496 48234496 49283072"
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KubevirtVmHighMemoryUsage
+        exp_alerts:
+          - exp_annotations:
+              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to requested memory"
+              summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              pod: "virt-launcher-testvm-123"
+              container: "compute"
+
+  # Memory utilization less than 20MB close to requested memory - based on memory RSS and memory working set
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+        values: "67108864 67108864 67108864 67108864"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "47185920 48234496 48234496 49283072"
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
         values: "47185920 48234496 48234496 49283072"
 
     alert_rule_test:
@@ -470,6 +522,8 @@ tests:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "19922944 18874368 18874368 17825792"
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
         values: "19922944 18874368 18874368 17825792"
 
     alert_rule_test:

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -397,12 +397,16 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:   intstr.FromString("kubevirt_vmi_memory_available_bytes-kubevirt_vmi_memory_usable_bytes"),
 					},
 					{
-						Record: "kubevirt_vm_container_free_memory_bytes",
-						Expr:   intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
+						Record: "kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes",
+						Expr:   intstr.FromString("sum by(pod, container) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
+					},
+					{
+						Record: "kubevirt_vm_container_free_memory_bytes_based_on_rss",
+						Expr:   intstr.FromString("sum by(pod, container) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_rss{pod=~'virt-launcher-.*', container='compute'})"),
 					},
 					{
 						Alert: "KubevirtVmHighMemoryUsage",
-						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes < 20971520"),
+						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 20971520 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 20971520"),
 						For:   "1m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} free memory is less than 20 MB and it is close to requested memory",


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added a condition to KubevirtVmHighMemoryUsage
alert, to check the free memory based on container_memory_rss,
in addition to the container_memory_working_set_bytes since
there are both are considered when the scheduler checks if the container should be evicted. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
