### PR TITLE
[e2e]: taking test_id:4744 out of quarantine

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1365,7 +1365,7 @@ spec:
 
 	Describe("[test_id:4744]should apply component customization", func() {
 
-		It("[QUARANTINE]test applying and removing a patch", func() {
+		It("test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"
 			annotationPatchKey := "applied-patch"
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Test passed the period of stability check, as can be seen from the [searchCI](https://search.ci.kubevirt.io/?search=test_id%3A4744&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

**Release note**:
```release-note
NONE
```
