### PR TITLE
Update pr-creator in builder image

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -96,7 +96,7 @@ RUN set -x && \
     source /etc/profile.d/gimme.sh && \
     git clone https://github.com/kubernetes/test-infra.git && \
     cd /test-infra && \
-    git checkout fd0699b906b0593a33ba2bddd3b1ae8822f42dd8 && \
+    git checkout f2693aba912dd40c974304caca999d45ee8dce33 && \
     cd /test-infra/robots/pr-creator && \
     go install && \
     cd /test-infra/robots/issue-creator && \

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2202010936-905b3aae5"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2203011706-a6a84d038"
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
periodics are failing due to outdated pr-creator instance in the builder
image:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-mirror-uploader/1498554960588050432
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/bump-kubevirt-rpms-weekly/1498305451098378240

This PR updates the pr-creator version in the builder. Updated images
have already been pushed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
