### PR TITLE
remove the annoying timeout error from being an error during cluster cleanup

### DIFF
--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -32,8 +32,8 @@ function patch_remove_finalizers() {
 function delete_kubevirt_cr() {
     # Delete KubeVirt CR, timeout after 10 seconds
     set +e
-    _kubectl -n ${namespace} delete kv kubevirt --timeout=10s --ignore-not-found
-    _kubectl -n cdi delete service cdi-uploadproxy-nodeport
+    _kubectl -n ${namespace} delete kv kubevirt --timeout=10s --ignore-not-found || true
+    _kubectl -n cdi delete service cdi-uploadproxy-nodeport || true
     patch_remove_finalizers -n ${namespace} kv kubevirt
     set -e
 }


### PR DESCRIPTION
Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, in the prow performance job, the `make cluster-clean` command is failing with a timeout when deleting the kubevirt object. However, this timeout is somehow expected as there is a logic to remove finalizers right after the timeout. In fact, although there is the error, kubevirt is successfully deleted from the cluster after removing the finalizers. However, the timeout error in the [logs](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-performance-cluster-100-density-test/1498880868951789568 ) is very annoying, showing the timeout as a failure.

So this PR increases the kv delete timeout and removes the timeout from being an error in the cluster cleanup script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7235

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
