### PR TITLE
Make "delete a KubeVirt CR" test Serial

### DIFF
--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -491,7 +491,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7648]delete a KubeVirt CR", func() {
+		It("[Serial][test_id:7648]delete a KubeVirt CR", func() {
 			By("Make a Dry-Run request to delete a KubeVirt CR")
 			deletePolicy := metav1.DeletePropagationForeground
 			opts := metav1.DeleteOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:
Deleting Kubevirt object is usually only allowed when no VMI and other Kubevirt objects exist. Therefore this test needs to be serial.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
