### PR TITLE
tests/network/vmi_multus: use matcher.ThisVMI

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnet/service:go_default_library",
         "//tests/libvmi:go_default_library",

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -492,10 +492,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				vmiOne := createVMIOnNode(interfaces, networks)
 
-				tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
-
-				updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiOne.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				updatedVmi := tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 
 				Expect(len(updatedVmi.Status.Interfaces)).To(Equal(2))
 				interfacesByName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)


### PR DESCRIPTION
`ThisVMI` seems like a useful shorthand. It clears some boilerplace code and helps the reader to focus on the logic of the tests

```release-note
NONE
```