### PR TITLE
tests/network/vmi_networking: use WaitUntilVMIReady return value

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -870,10 +870,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(vmi, loginMethod)
-
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				vmi = tests.WaitUntilVMIReady(vmi, loginMethod)
 
 				if ipFamily == k8sv1.IPv6Protocol {
 					err = configureIpv6(vmi, api.DefaultVMIpv6CIDR)
@@ -1002,13 +999,9 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for VMIs to be ready")
-				tests.WaitUntilVMIReady(anotherVmi, libnet.WithIPv6(console.LoginToCirros))
-				anotherVmi, err = virtClient.VirtualMachineInstance(anotherVmi.Namespace).Get(anotherVmi.Name, &v13.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				anotherVmi = tests.WaitUntilVMIReady(anotherVmi, libnet.WithIPv6(console.LoginToCirros))
 
-				tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
 			})
 
 			table.DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {


### PR DESCRIPTION
There is no need to Get another vmi update, as tests.WaitUntilVMIReady
already returns a fresh one.

```release-note
NONE
```
