### PR TITLE
[VM Restore]: Support restoring to a target VM different than the source

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16894,6 +16894,14 @@
      "virtualMachineSnapshotName"
     ],
     "properties": {
+     "patches": {
+      "description": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be applied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}",
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "target": {
       "description": "initially only VirtualMachine type supported",
       "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -172,9 +172,8 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			ar := createRestoreAdmissionReview(restore)
 			resp := createTestVMRestoreAdmitter(config, nil).Admit(ar)
 			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Details.Causes).To(HaveLen(2))
-			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
-			Expect(resp.Result.Details.Causes[1].Field).To(Equal("spec.virtualMachineSnapshotName"))
+			Expect(resp.Result.Details.Causes).To(HaveLen(1))
+			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
 		})
 
 		It("should reject spec update", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -153,30 +153,7 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target.apiGroup"))
 		})
 
-		It("should reject when VM does not exist", func() {
-			restore := &snapshotv1.VirtualMachineRestore{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "restore",
-					Namespace: "default",
-				},
-				Spec: snapshotv1.VirtualMachineRestoreSpec{
-					Target: corev1.TypedLocalObjectReference{
-						APIGroup: &apiGroup,
-						Kind:     "VirtualMachine",
-						Name:     vmName,
-					},
-					VirtualMachineSnapshotName: vmSnapshotName,
-				},
-			}
-
-			ar := createRestoreAdmissionReview(restore)
-			resp := createTestVMRestoreAdmitter(config, nil, snapshot).Admit(ar)
-			Expect(resp.Allowed).To(BeFalse())
-			Expect(resp.Result.Details.Causes).To(HaveLen(1))
-			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target"))
-		})
-
-		It("should reject when VM and snapshot do not exist", func() {
+		It("should reject when snapshot does not exist", func() {
 			restore := &snapshotv1.VirtualMachineRestore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "restore",
@@ -466,31 +443,6 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.target.apiGroup"))
 			})
 
-			It("should reject invalid source ID", func() {
-				restore := &snapshotv1.VirtualMachineRestore{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "restore",
-						Namespace: "default",
-					},
-					Spec: snapshotv1.VirtualMachineRestoreSpec{
-						Target: corev1.TypedLocalObjectReference{
-							APIGroup: &apiGroup,
-							Kind:     "VirtualMachine",
-							Name:     vmName,
-						},
-						VirtualMachineSnapshotName: vmSnapshotName,
-					},
-				}
-
-				vm.UID = "foo"
-
-				ar := createRestoreAdmissionReview(restore)
-				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Details.Causes).To(HaveLen(1))
-				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
-			})
-
 			It("should reject if restore in progress", func() {
 				restore := &snapshotv1.VirtualMachineRestore{
 					ObjectMeta: metav1.ObjectMeta{
@@ -551,6 +503,44 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				resp := createTestVMRestoreAdmitter(config, vm, snapshot).Admit(ar)
 				Expect(resp.Allowed).To(BeTrue())
 			})
+
+			DescribeTable("when target VM is different from source VM", func(doesTargetExist bool) {
+				const targetVMName = "new-test-vm"
+
+				var targetVM *v1.VirtualMachine
+				if doesTargetExist {
+					targetVM = vm.DeepCopy()
+					targetVM.Name = targetVMName
+					targetVM.UID = "new-uid"
+				}
+
+				restore := &snapshotv1.VirtualMachineRestore{
+					Spec: snapshotv1.VirtualMachineRestoreSpec{
+						Target: corev1.TypedLocalObjectReference{
+							APIGroup: &apiGroup,
+							Kind:     "VirtualMachine",
+							Name:     targetVMName,
+						},
+						VirtualMachineSnapshotName: vmSnapshotName,
+					},
+				}
+
+				ar := createRestoreAdmissionReview(restore)
+				resp := createTestVMRestoreAdmitter(config, targetVM, snapshot).Admit(ar)
+
+				if doesTargetExist {
+					Expect(resp.Allowed).To(BeFalse())
+					Expect(resp.Result.Details.Causes).To(HaveLen(1))
+					Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.virtualMachineSnapshotName"))
+					Expect(resp.Result.Details.Causes[0].Message).To(ContainSubstring("target VM must not exist"))
+				} else {
+					Expect(resp.Allowed).To(BeTrue())
+				}
+			},
+				Entry("should allow if target doesn't exist", false),
+				Entry("should reject if target exists", true),
+			)
+
 		})
 	})
 })
@@ -621,11 +611,14 @@ func createTestVMRestoreAdmitter(
 		}
 	}
 
-	if vm == nil {
+	vmInterface.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(name string, getOptions *metav1.GetOptions) (*v1.VirtualMachine, error) {
+		if vm != nil && name == vm.Name {
+			return vm, nil
+		}
+
 		err := errors.NewNotFound(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"}, "foo")
-		vmInterface.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, err).AnyTimes()
-	} else {
-		vmInterface.EXPECT().Get(vm.Name, gomock.Any()).Return(vm, nil).AnyTimes()
-	}
+		return nil, err
+	}).AnyTimes()
+
 	return &VMRestoreAdmitter{Config: config, Client: virtClient, VMRestoreInformer: restoreInformer}
 }

--- a/pkg/virt-controller/watch/snapshot/BUILD.bazel
+++ b/pkg/virt-controller/watch/snapshot/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/snapshot/BUILD.bazel
+++ b/pkg/virt-controller/watch/snapshot/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -572,10 +572,6 @@ func (ctrl *VMRestoreController) getSnapshotContent(vmRestore *snapshotv1.Virtua
 		return nil, fmt.Errorf("VMSnapshot %s not ready", objKey)
 	}
 
-	if vms.Status.SourceUID == nil || *vms.Status.SourceUID != targetUID {
-		return nil, fmt.Errorf("VMSnapshot source and restore target differ")
-	}
-
 	if vms.Status.VirtualMachineSnapshotContentName == nil {
 		return nil, fmt.Errorf("no snapshot content name in %s", objKey)
 	}

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -2001,6 +2001,7 @@ func createVirtualMachine(namespace, name string) *v1.VirtualMachine {
 									},
 								},
 							},
+							Interfaces: []v1.Interface{{Name: "fake-interface", MacAddress: ""}},
 						},
 						Resources: v1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -17667,6 +17667,16 @@ var CRDsValidation map[string]string = map[string]string{
     spec:
       description: VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource
       properties:
+        patches:
+          description: "If the target for the restore does not exist, it will be created.
+            Patches holds JSON patches that would be applied to the target manifest
+            before it's created. Patches should fit the target's Kind. \n Example
+            for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\":
+            \"new-vm-name\"}"
+          items:
+            type: string
+          type: array
+          x-kubernetes-list-type: atomic
         target:
           description: initially only VirtualMachine type supported
           properties:

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/deepcopy_generated.go
@@ -180,6 +180,11 @@ func (in *VirtualMachineRestoreList) DeepCopyObject() runtime.Object {
 func (in *VirtualMachineRestoreSpec) DeepCopyInto(out *VirtualMachineRestoreSpec) {
 	*out = *in
 	in.Target.DeepCopyInto(&out.Target)
+	if in.Patches != nil {
+		in, out := &in.Patches, &out.Patches
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -286,6 +286,15 @@ type VirtualMachineRestoreSpec struct {
 	Target corev1.TypedLocalObjectReference `json:"target"`
 
 	VirtualMachineSnapshotName string `json:"virtualMachineSnapshotName"`
+
+	// If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be
+	// applied to the target manifest before it's created. Patches should fit the target's Kind.
+	//
+	// Example for a patch: {"op": "replace", "path": "/metadata/name", "value": "new-vm-name"}
+	//
+	// +optional
+	// +listType=atomic
+	Patches []string `json:"patches,omitempty"`
 }
 
 // VirtualMachineRestoreStatus is the spec for a VirtualMachineRestoreresource

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
@@ -123,8 +123,9 @@ func (VirtualMachineRestore) SwaggerDoc() map[string]string {
 
 func (VirtualMachineRestoreSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":       "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource",
-		"target": "initially only VirtualMachine type supported",
+		"":        "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource",
+		"target":  "initially only VirtualMachine type supported",
+		"patches": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}\n\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23022,6 +23022,25 @@ func schema_kubevirtio_api_snapshot_v1alpha1_VirtualMachineRestoreSpec(ref commo
 							Format: "",
 						},
 					},
+					"patches": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be applied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"target", "virtualMachineSnapshotName"},
 			},

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -3,13 +3,11 @@ package tests_test
 import (
 	"context"
 	goerrors "errors"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -185,38 +183,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("Flavor application", func() {
-		startVM := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
-			runStrategyAlways := v1.RunStrategyAlways
-			By("Starting the VirtualMachine")
-
-			Eventually(func() error {
-				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				updatedVM.Spec.Running = nil
-				updatedVM.Spec.RunStrategy = &runStrategyAlways
-				_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(updatedVM)
-				return err
-			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
-			updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Observe the VirtualMachineInstance created
-			Eventually(func() error {
-				_, err := virtClient.VirtualMachineInstance(updatedVM.Namespace).Get(updatedVM.Name, &k8smetav1.GetOptions{})
-				return err
-			}, 300*time.Second, 1*time.Second).Should(Succeed())
-
-			By("VMI has the running condition")
-			Eventually(func() bool {
-				vm, err := virtClient.VirtualMachine(updatedVM.Namespace).Get(updatedVM.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return vm.Status.Ready
-			}, 300*time.Second, 1*time.Second).Should(BeTrue())
-
-			return updatedVM
-		}
-
 		Context("CPU", func() {
 			It("[test_id:TODO] should apply flavor to CPU", func() {
 				cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1, Model: v1.DefaultCPUModel}
@@ -242,7 +208,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				startVM(vm)
+				tests.StartVMAndExpectRunning(virtClient, vm)
 
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -422,6 +422,9 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(vm.Spec).To(Equal(newVM.Spec))
+
+				By("Making sure new VM is runnable")
+				tests.StartVMAndExpectRunning(virtClient, vm)
 			})
 		})
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4464,3 +4464,35 @@ func GetKubevirtVMMetricsFunc(virtClient *kubecli.KubevirtClient, pod *k8sv1.Pod
 func PrepareMetricsURL(ip string, port int) string {
 	return fmt.Sprintf("https://%s/metrics", net.JoinHostPort(ip, strconv.Itoa(port)))
 }
+
+func StartVMAndExpectRunning(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine) *v1.VirtualMachine {
+	runStrategyAlways := v1.RunStrategyAlways
+	By("Starting the VirtualMachine")
+
+	Eventually(func() error {
+		updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		updatedVM.Spec.Running = nil
+		updatedVM.Spec.RunStrategy = &runStrategyAlways
+		_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(updatedVM)
+		return err
+	}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+	updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	// Observe the VirtualMachineInstance created
+	Eventually(func() error {
+		_, err := virtClient.VirtualMachineInstance(updatedVM.Namespace).Get(updatedVM.Name, &metav1.GetOptions{})
+		return err
+	}, 300*time.Second, 1*time.Second).Should(Succeed())
+
+	By("VMI has the running condition")
+	Eventually(func() bool {
+		vm, err := virtClient.VirtualMachine(updatedVM.Namespace).Get(updatedVM.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return vm.Status.Ready
+	}, 300*time.Second, 1*time.Second).Should(BeTrue())
+
+	return updatedVM
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to restore a snapshot to a target VM that is different from the source VM. For exmaple, `VM 1` could take a snapshot and restore it to `VM 2` could restore from that snapshot. Before this PR such action is considered as an error.

This change is a first step towards supporting VM cloning. To have a better context, I suggest taking a look on [the design proposal](https://github.com/kubevirt/community/pull/159), and especially [this comment](https://github.com/kubevirt/community/pull/159#pullrequestreview-880329021) that summarizes up the path forward.

-------

Summary of the changes that were made:
* Possibility to restore to a VM that is different than the source VM
  * Such a restore is valid **only if the target VM does not exist**. In this case, the target VM would be auto-created by the restore controller.
  * If the target VM both exists and is different than the source VM - the restore is considered illegal and would be rejected by validation webhooks.
* New `restore.Spec.Patches` field of type `[]string` is now added to the `VirtualMachineRestore` object.
  * These patches are being applied on the target VM during the restore contoller's reconciliation loop.
  * This facilitates a way to create a new VM that is different than the source VM without adding any custom logic to the restore controller.
  * The idea is that the cloning controller, which includes the different cloning options and logic, would use this mechanism to instruct the restore controller on how to modify the source VM. For example, this can be used to change a cloned VM's MAC address.

------

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Snapshot restores now support restoring to a target VM different than the source
```
