### PR TITLE
[WIP] Clean-code: Use libvmi in test utils

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1931,19 +1931,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[test_id:1681]should set appropriate cache modes", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.NewWithNamespace(util.NamespaceTestDefault,
+				libvmi.WithNamedContainerImage("ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
+				libvmi.WithNamedContainerImage("ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
+				libvmi.WithNamedContainerImage("ephemeral-disk5", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
+				libvmi.WithNamedContainerImage("ephemeral-disk3", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros)))
 
 			By("adding disks to a VMI")
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
-
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			vmi.Spec.Domain.Devices.Disks[1].Cache = v1.CacheWriteThrough
-
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk5", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			vmi.Spec.Domain.Devices.Disks[2].Cache = v1.CacheWriteBack
 
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk3", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 			tmpHostDiskDir := tests.RandTmpDir()
 			tests.AddHostDisk(vmi, filepath.Join(tmpHostDiskDir, "test-disk.img"), v1.HostDiskExistsOrCreate, "hostdisk")

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[sig-compute]IOThreads", func() {
@@ -54,7 +55,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 		util.PanicOnError(err)
 
 		tests.BeforeTestCleanup()
-		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+		vmi = libvmi.NewWithNamespace(util.NamespaceTestDefault, libvmi.WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpine)))
 	})
 
 	Context("IOThreads Policies", func() {


### PR DESCRIPTION
This PR is about creating VMIs using libvmi instead of the functions in tests/utils

This PR is a partial and preliminary work, because replacing all the VMI creation in all the test is a huge and non-manageble task.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
