### PR TITLE
[Migration Policies]: Precedence to VMI labels over Namespace labels

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1400,10 +1400,10 @@ var _ = Describe("Migration watcher", func() {
 				Entry("only one policy should be matched", "one", policyInfo{"one", 1, 4}),
 				Entry("most detail policy should be matched", "two",
 					policyInfo{"one", 1, 4}, policyInfo{"two", 4, 2}),
-				Entry("if two policies are detailed at the same level, matching policy should be the first name in lexicographic order (1)", "one",
-					policyInfo{"one", 1, 2}, policyInfo{"two", 2, 1}),
-				Entry("if two policies are detailed at the same level, matching policy should be the first name in lexicographic order (2)", "a_two",
-					policyInfo{"one", 1, 2}, policyInfo{"a_two", 2, 1}),
+				Entry("if two policies are detailed at the same level, matching policy should be the first name in lexicographic order (1)", "aa",
+					policyInfo{"aa", 2, 2}, policyInfo{"zz", 2, 2}),
+				Entry("if two policies are detailed at the same level, matching policy should be the first name in lexicographic order (2)", "aa",
+					policyInfo{"zz", 2, 2}, policyInfo{"aa", 2, 2}),
 			)
 
 			It("policy with one non-fitting label should not match", func() {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1427,6 +1427,20 @@ var _ = Describe("Migration watcher", func() {
 				matchedPolicy := policyList.MatchPolicy(vmi, &namespace)
 				Expect(matchedPolicy).To(BeNil())
 			})
+
+			It("VMI labels should have precedence over namespace labels", func() {
+				numberOfLabels := rand.Intn(5) + 1
+
+				By(fmt.Sprintf("Defining two policies with %d labels, one with VMI labels and one with NS labels", numberOfLabels))
+				policyWithNSLabels := tests.GetPolicyMatchedToVmi("aa-policy-with-ns-labels", vmi, &namespace, 0, numberOfLabels)
+				policyWithVmiLabels := tests.GetPolicyMatchedToVmi("zz-policy-with-vmi-labels", vmi, &namespace, numberOfLabels, 0)
+
+				policyList := kubecli.NewMinimalMigrationPolicyList(*policyWithNSLabels, *policyWithVmiLabels)
+
+				By("Expecting VMI labels policy to be matched")
+				matchedPolicy := policyList.MatchPolicy(vmi, &namespace)
+				Expect(matchedPolicy.Name).To(Equal(policyWithVmiLabels.Name), "policy with VMI labels should match")
+			})
 		})
 
 		DescribeTable("should override cluster-wide migration configurations when", func(defineMigrationPolicy func(*migrationsv1.MigrationPolicySpec), testMigrationConfigs func(configuration *virtv1.MigrationConfiguration), expectConfigUpdate bool) {

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
@@ -102,6 +102,32 @@ func (m *MigrationPolicy) GetMigrationConfByPolicy(clusterMigrationConfiguration
 	return changed, nil
 }
 
+// +k8s:openapi-gen=false
+type migrationPolicyMatchScore struct {
+	matchingVMILabels int
+	matchingNSLabels  int
+}
+
+func (score migrationPolicyMatchScore) equals(otherScore migrationPolicyMatchScore) bool {
+	return score.matchingVMILabels == otherScore.matchingVMILabels &&
+		score.matchingNSLabels == otherScore.matchingNSLabels
+}
+
+func (score migrationPolicyMatchScore) greaterThan(otherScore migrationPolicyMatchScore) bool {
+	thisTotalScore := score.matchingNSLabels + score.matchingVMILabels
+	otherTotalScore := otherScore.matchingNSLabels + otherScore.matchingVMILabels
+
+	if thisTotalScore == otherTotalScore {
+		return score.matchingVMILabels > otherScore.matchingVMILabels
+	}
+
+	return thisTotalScore > otherTotalScore
+}
+
+func (score migrationPolicyMatchScore) lessThan(otherScore migrationPolicyMatchScore) bool {
+	return !score.equals(otherScore) && !score.greaterThan(otherScore)
+}
+
 // MatchPolicy returns the policy that is matched to the vmi, or nil of no policy is matched.
 //
 // Since every policy can specify VMI and Namespace labels to match to, matching is done by returning the most

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types_swagger_generated.go
@@ -35,3 +35,9 @@ func (MigrationPolicyList) SwaggerDoc() map[string]string {
 		"items": "+listType=atomic",
 	}
 }
+
+func (migrationPolicyMatchScore) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"": "+k8s:openapi-gen=false",
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In Live Migration Policies' design proposal [it says](https://github.com/kubevirt/community/blob/main/design-proposals/migration-policies.md#policies-precedence) that `It is possible that a multiple policies apply to the same VMI. In such cases, the precedence is in the same order as the bullets above (VMI labels first, then namespace labels)`.

This PR gives precedence to VMI labels over namespace labels.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Migration Policies]: precedence to VMI labels over Namespace labels
```
