### PR TITLE
[Migration Policies]: Introduce wildcard label support

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1424,6 +1424,28 @@ var _ = Describe("Migration watcher", func() {
 				Expect(matchedPolicy).To(BeNil())
 			})
 
+			It("label with an empty value should match any value", func() {
+				const labelKey = "mp-key-0"
+				labelValue := rand.String(5)
+
+				By("Defining a policy that matches a key with empty value")
+				policy := kubecli.NewMinimalMigrationPolicy("testpolicy")
+				policy.Spec.Selectors = &migrationsv1.Selectors{
+					VirtualMachineInstanceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{labelKey: ""},
+					},
+				}
+
+				By(fmt.Sprintf("Adding a label with same key but random value (%s) to vmi", labelValue))
+				vmi.Labels = map[string]string{labelKey: labelValue}
+
+				By("Expecting the policy to match")
+				policyList := kubecli.NewMinimalMigrationPolicyList(*policy)
+				matchedPolicy := policyList.MatchPolicy(vmi, &namespace)
+				Expect(matchedPolicy).ToNot(BeNil())
+				Expect(matchedPolicy.Name).To(Equal(policy.Name))
+			})
+
 			It("when no policies exist, MatchPolicy() should return nil", func() {
 				policyList := kubecli.NewMinimalMigrationPolicyList()
 				matchedPolicy := policyList.MatchPolicy(vmi, &namespace)

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
@@ -161,7 +161,7 @@ func countMatchingLabels(policy *MigrationPolicy, vmiLabels, namespaceLabels map
 	countLabelsHelper := func(policyLabels, labelsToMatch map[string]string) {
 		for policyKey, policyValue := range policyLabels {
 			value, exists := labelsToMatch[policyKey]
-			if exists && value == policyValue {
+			if exists && (value == policyValue || policyValue == "") {
 				matchingLabels++
 			} else {
 				doesMatch = false


### PR DESCRIPTION
**What this PR does / why we need it**:
According to Migration Policies' [design proposal](https://github.com/kubevirt/community/blob/main/design-proposals/migration-policies.md), a policy that's defined with an empty label value should match any value.

For example, if a policy is supposed to match VMIs with label `"key":""` (empty value), and a VMI has a label `"key":"something-random"`, this label should be counted as matched. This allows the user to specify that only the label key should be taken into account.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Migration Policies]: Introduce wildcard label support
```
