### PR TITLE
tests: make secondary NIC configurable

### DIFF
--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -15,6 +15,7 @@ kubevirtci_git_hash="2203021427-243853c"
 conn_check_ipv4_address=${CONN_CHECK_IPV4_ADDRESS:-""}
 conn_check_ipv6_address=${CONN_CHECK_IPV6_ADDRESS:-""}
 conn_check_dns=${CONN_CHECK_DNS:-""}
+migration_network_nic=${MIGRATION_NETWORK_NIC:-"eth1"}
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -53,6 +53,7 @@ function functest() {
 	    -conn-check-ipv4-address=${conn_check_ipv4_address} \
 	    -conn-check-ipv6-address=${conn_check_ipv6_address} \
 	    -conn-check-dns=${conn_check_dns} \
+	    -migration-network-nic=${migration_network_nic} \
 	    ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|k8s-sriov.* ]]; then
         echo "Will skip test asserting the cluster is in dual-stack mode."

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -57,6 +57,8 @@ var PathToTestingInfrastrucureManifests = ""
 var DNSServiceName = ""
 var DNSServiceNamespace = ""
 
+var MigrationNetworkNIC = "eth1"
+
 func init() {
 	kubecli.Init()
 	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
@@ -88,6 +90,7 @@ func init() {
 	flag.BoolVar(&ApplyDefaulte2eConfiguration, "apply-default-e2e-configuration", false, "Apply the default e2e test configuration (feature gates, selinux contexts, ...)")
 	flag.StringVar(&DNSServiceName, "dns-service-name", "kube-dns", "cluster DNS service name")
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
+	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
 }
 
 func NormalizeFlags() {

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -160,7 +160,7 @@ func GenerateMigrationCNINetworkAttachmentDefinition() *k8snetworkplumbingwgv1.N
       "cniVersion": "0.3.1",
       "name": "migration-bridge",
       "type": "macvlan",
-      "master": "eth1",
+      "master": "` + flags.MigrationNetworkNIC + `",
       "mode": "bridge",
       "ipam": {
         "type": "whereabouts",


### PR DESCRIPTION
**What this PR does / why we need it**:
Dedicated migration network tests currently fail on clusters nodes that use another NIC than eth1, since the value is hardcoded.
This PR makes it configurable at runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
