### PR TITLE
append identity file with local-ssh

### DIFF
--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -37,6 +37,9 @@ func (o *SSH) buildProxyCommandOption(kind, namespace, name string) string {
 
 func (o *SSH) buildSSHTarget(kind, namespace, name string) string {
 	target := strings.Builder{}
+	if o.options.IdentityFilePathProvided {
+		target.WriteString(fmt.Sprintf(" -i %s ", o.options.IdentityFilePath))
+	}
 	if len(o.options.SshUsername) > 0 {
 		target.WriteString(o.options.SshUsername)
 		target.WriteRune('@')


### PR DESCRIPTION
**What this PR does / why we need it**:
Appends the `-i <identity-file-path>` when custom identity-file is specified with `--local-ssh` option for `virtctl`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7071

**Special notes for your reviewer**:
- I am still familiarizing myself with the kubervirt's flow. Please let me know, in case this change leads to an unexpected behavior. :)

**Release note**:
```release-note
Don't ignore --identity-file when setting --local-ssh=true on `virtctl ssh`
```