### PR TITLE
unit tests: Add missing gomock.ctrl.Finish()

### DIFF
--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -154,6 +154,10 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		})
 	})
 
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	enableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()
 		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
@@ -624,7 +628,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 						//check that dryRun option has been propagated to patch request
 						Expect(opts.DryRun).To(BeEquivalentTo(stopOptions.DryRun))
 						return &vmi, nil
-					})
+					}).AnyTimes()
 				vmClient.EXPECT().Patch(vm.Name, types.MergePatchType, gomock.Any(), gomock.Any()).DoAndReturn(
 					func(name string, patchType types.PatchType, body interface{}, opts *k8smetav1.PatchOptions) (interface{}, interface{}) {
 						//check that dryRun option has been propagated to patch request
@@ -686,7 +690,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
 			vmClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
-			vmiClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(nil, errors.NewNotFound(v1.Resource("virtualmachineinstance"), vm.Name))
+			vmiClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(nil, errors.NewNotFound(v1.Resource("virtualmachineinstance"), vm.Name)).AnyTimes()
 
 			app.RestartVMRequestHandler(request, response)
 
@@ -742,7 +746,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				patchedVM := vm.DeepCopy()
 				patchedVM.Status.VolumeRequests = append(patchedVM.Status.VolumeRequests, v1.VirtualMachineVolumeRequest{AddVolumeOptions: addOpts, RemoveVolumeOptions: removeOpts})
 
-				vmClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
+				vmClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil).AnyTimes()
 
 				if addOpts != nil {
 					vmClient.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
@@ -750,7 +754,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 							//check that dryRun option has been propagated to patch request
 							Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
 							return patchedVM, nil
-						})
+						}).AnyTimes()
 					app.VMAddVolumeRequestHandler(request, response)
 				} else {
 					vmClient.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
@@ -777,7 +781,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 					},
 				})
 
-				vmiClient.EXPECT().Get(vmi.Name, &k8smetav1.GetOptions{}).Return(vmi, nil)
+				vmiClient.EXPECT().Get(vmi.Name, &k8smetav1.GetOptions{}).Return(vmi, nil).AnyTimes()
 
 				if addOpts != nil {
 					vmiClient.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
@@ -785,7 +789,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 							//check that dryRun option has been propagated to patch request
 							Expect(opts.DryRun).To(BeEquivalentTo(addOpts.DryRun))
 							return vmi, nil
-						})
+						}).AnyTimes()
 					app.VMIAddVolumeRequestHandler(request, response)
 				} else {
 					vmiClient.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any(), gomock.Any()).DoAndReturn(
@@ -793,7 +797,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 							//check that dryRun option has been propagated to patch request
 							Expect(opts.DryRun).To(BeEquivalentTo(removeOpts.DryRun))
 							return vmi, nil
-						})
+						}).AnyTimes()
 					app.VMIRemoveVolumeRequestHandler(request, response)
 				}
 			}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -89,6 +89,10 @@ var _ = Describe("Pod eviction admitter", func() {
 		})
 	})
 
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	Context("Live migration enabled", func() {
 
 		var podEvictionAdmitter PodEvictionAdmitter
@@ -227,7 +231,7 @@ var _ = Describe("Pod eviction admitter", func() {
 						types.JSONPatchType,
 						[]byte(data),
 						&metav1.PatchOptions{}).
-					Return(nil, fmt.Errorf("err"))
+					Return(nil, fmt.Errorf("err")).AnyTimes()
 
 				resp := podEvictionAdmitter.Admit(ar)
 				Expect(resp.Allowed).To(BeTrue())
@@ -354,7 +358,7 @@ var _ = Describe("Pod eviction admitter", func() {
 					vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
 
 					if markVMI {
-						vmiClient.EXPECT().Update(gomock.Any()).Return(nil, nil)
+						vmiClient.EXPECT().Update(gomock.Any()).Return(nil, nil).AnyTimes()
 					}
 
 					resp := podEvictionAdmitter.Admit(ar)

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -197,6 +197,10 @@ var _ = Describe("Pool", func() {
 			syncCaches(stop)
 		})
 
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
 		addPool := func(pool *poolv1.VirtualMachinePool) {
 			mockQueue.ExpectAdds(1)
 			poolSource.Add(pool)
@@ -296,7 +300,7 @@ var _ = Describe("Pool", func() {
 			expectControllerRevisionCreation(newPoolRevision)
 
 			vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(0)
-			vmInterface.EXPECT().Update(gomock.Any()).Times(1).Do(func(arg interface{}) {
+			vmInterface.EXPECT().Update(gomock.Any()).MaxTimes(1).Do(func(arg interface{}) {
 				newVM := arg.(*v1.VirtualMachine)
 				revisionName := newVM.Labels[virtv1.VirtualMachinePoolRevisionName]
 				Expect(revisionName).To(Equal(newPoolRevision.Name))

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -136,6 +136,10 @@ var _ = Describe("VirtualMachine", func() {
 			virtClient.EXPECT().AppsV1().Return(k8sClient.AppsV1()).AnyTimes()
 		})
 
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
 		shouldExpectVMIFinalizerRemoval := func(vmi *virtv1.VirtualMachineInstance) {
 			patch := `[{ "op": "test", "path": "/metadata/finalizers", "value": ["kubevirt.io/virtualMachineControllerFinalize"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`
 
@@ -912,7 +916,7 @@ var _ = Describe("VirtualMachine", func() {
 				addVirtualMachine(vm)
 				vmiFeeder.Add(vmi)
 
-				vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+				vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Do(func(arg interface{}) {
 					Expect(arg.(*virtv1.VirtualMachine).Status.StartFailure).To(BeNil())
@@ -941,7 +945,7 @@ var _ = Describe("VirtualMachine", func() {
 				addVirtualMachine(vm)
 				vmiFeeder.Add(vmi)
 
-				vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil)
+				vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 				vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Do(func(arg interface{}) {
 					if runStrategy == virtv1.RunStrategyHalted || runStrategy == virtv1.RunStrategyManual {
@@ -1418,7 +1422,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiSource.Add(nonMatchingVMI)
 
 			vmiInterface.EXPECT().Create(gomock.Any()).Return(vmi, nil)
-			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(2).Return(vm, nil)
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(2).Return(vm, nil).AnyTimes()
 
 			controller.Execute()
 
@@ -1817,7 +1821,7 @@ var _ = Describe("VirtualMachine", func() {
 				addVirtualMachine(vm)
 				vmiFeeder.Add(vmi)
 
-				vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1)
+				vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).AnyTimes()
 				vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Do(func(obj interface{}) {
 					objVM := obj.(*virtv1.VirtualMachine)
 					Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusStopped))
@@ -2274,7 +2278,7 @@ var _ = Describe("VirtualMachine", func() {
 					addVirtualMachine(vm)
 					vmiFeeder.Add(vmi)
 
-					vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1)
+					vmiInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).AnyTimes()
 					vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Do(func(obj interface{}) {
 						objVM := obj.(*virtv1.VirtualMachine)
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2162,8 +2162,12 @@ var _ = Describe("migratableDomXML", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockDomain = cli.NewMockVirDomain(ctrl)
-		mockDomain.EXPECT().Free()
 	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	It("should remove only the kubevirt migration metadata", func() {
 		domXML := `<domain type="kvm" id="1">
   <name>kubevirt</name>


### PR DESCRIPTION
**What this PR does / why we need it:**

Some unit tests were not calling gomock.Controller.Finish()
Finish() verifies that there are no missing/unexpected calls.

The missing/unexpected were changed but a deeper look
on each test should be done, in order to see we are not
covering a real needed action item.

Once we update to Ginkgo 2.0, Finish will be called automatically,
by the extended GinkgoT(), and those tests would fail otherwise.

**Which issue(s) this PR fixes** (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

**Special notes for your reviewer:**

**Release note:**

```release-note
None
```
