### PR TITLE
Add `make format` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,9 @@ bump-kubevirtci:
 fossa:
 	hack/dockerized "FOSSA_TOKEN_FILE=${FOSSA_TOKEN_FILE} ./hack/fossa.sh"
 
+format:
+	./hack/dockerized "hack/bazel-fmt.sh"	
+
 .PHONY: \
 	build-verify \
 	conformance \

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,9 @@ fossa:
 	hack/dockerized "FOSSA_TOKEN_FILE=${FOSSA_TOKEN_FILE} ./hack/fossa.sh"
 
 format:
-	./hack/dockerized "hack/bazel-fmt.sh"	
+	./hack/dockerized "hack/bazel-fmt.sh"
+
+fmt: format
 
 .PHONY: \
 	build-verify \
@@ -221,4 +223,6 @@ format:
 	goveralls \
 	build-functests \
 	fossa \
-	realtime-perftest
+	realtime-perftest \
+	format \
+	fmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Often when I write code I don't want to waste time on formatting it in a nice human-readable way, therefore I'm writing it in a messy way and then execute `./hack/dockerized "hack/bazel-fmt.sh"`. This PR introduces a shortcut to do that via `make format`.

This is especially helpful for things like struct definitions:
```go
type SomeStruct struct {
  x string
  y int
  z byte
}
```

When adding an element to the struct:
```go
type SomeStruct struct {
  x string
  y int
  z byte
  variableWithLongerName bool
}
```

After `make format`:
```go
type SomeStruct struct {
  x                       string
  y                       int
  z                       byte
  variableWithLongerName  bool
}
```

Obviously, the more variables in the struct the more valuable it is to use auto formatting.

If it's valuable for others, we can merge it in. If not I can always make an alias for myself :)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
