### PR TITLE
Avoid to return nil failure message

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -723,8 +723,10 @@ func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualM
 			return nil
 		}
 		log.Log.Object(vm).Infof("%s with VMI in phase %s due to runStrategy: %s", stoppingVmMsg, vmi.Status.Phase, runStrategy)
-		err := c.stopVMI(vm, vmi)
-		return &syncErrorImpl{fmt.Errorf(failureDeletingVmiErrFormat, err), VMIFailedDeleteReason}
+		if err := c.stopVMI(vm, vmi); err != nil {
+			return &syncErrorImpl{fmt.Errorf(failureDeletingVmiErrFormat, err), VMIFailedDeleteReason}
+		}
+		return nil
 	case virtv1.RunStrategyOnce:
 		if vmi == nil {
 			log.Log.Object(vm).Infof("%s due to start request and runStrategy: %s", startingVmMsg, runStrategy)


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid return `nil` failure message like following:

```
lastProbeTime: <nil>
lastTransitionTime: 2022-03-10T03:19:06Z
message: Failure attempting to delete VMI: <nil>
reason: FailedDelete
status: True
type: Failure
```

Logs in virt-controller:

```
{"component":"virt-controller","kind":"","level":"info","msg":"Stopping VM with VMI in phase Running due to runStrategy: Halted","name":"test-stop","namespace":"default","pos":"vm.go:725","timestamp":"2022-03-10T03:19:06.757895Z","uid":"598f466b-0932-4998-b316-e93710635251"}
{"component":"virt-controller","kind":"","level":"info","msg":"Dispatching delete event for vmi default/test-stop with phase Running","name":"test-stop","namespace":"default","pos":"vm.go:991","timestamp":"2022-03-10T03:19:06.773812Z","uid":"598f466b-0932-4998-b316-e93710635251"}
{"component":"virt-controller","kind":"","level":"error","msg":"Reconciling the VirtualMachine failed.","name":"test-stop","namespace":"default","pos":"vm.go:306","reason":"Failure attempting to delete VMI: \u003cnil\u003e","timestamp":"2022-03-10T03:19:06.773870Z","uid":"598f466b-0932-4998-b316-e93710635251"}
{"component":"virt-controller","level":"info","msg":"re-enqueuing VirtualMachine default/test-stop","pos":"vm.go:199","reason":"Failure attempting to delete VMI: \u003cnil\u003e","timestamp":"2022-03-10T03:19:06.803926Z"}
{"component":"virt-controller","kind":"","level":"info","msg":"Stopping VM with VMI in phase Running due to runStrategy: Halted","name":"test-stop","namespace":"default","pos":"vm.go:725","timestamp":"2022-03-10T03:19:06.803985Z","uid":"598f466b-0932-4998-b316-e93710635251"}
{"component":"virt-controller","kind":"","level":"error","msg":"Reconciling the VirtualMachine failed.","name":"test-stop","namespace":"default","pos":"vm.go:306","reason":"Failure attempting to delete VMI: \u003cnil\u003e","timestamp":"2022-03-10T03:19:06.804002Z","uid":"598f466b-0932-4998-b316-e93710635251"}
```

**Which issue(s) this PR fixes**:

Fixes #7339 

**Special notes for your reviewer**:

Reproduce steps:

1. Create a VM with `runStrategy: RunStrategyAlways`.
2. Stop the VM.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
