### PR TITLE
tests/network: drop remaining NewRandomVMIWithEphemeralDiskAndUserdata

### DIFF
--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -34,9 +34,11 @@ func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
 		volume := getVolume(vmi, diskName)
 		if b64Encoding {
 			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
+			volume.CloudInitNoCloud.UserData = ""
 			volume.CloudInitNoCloud.UserDataBase64 = encodedData
 		} else {
 			volume.CloudInitNoCloud.UserData = data
+			volume.CloudInitNoCloud.UserDataBase64 = ""
 		}
 	}
 }

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -56,7 +56,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
@@ -672,7 +671,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
-				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userdata)
+				agentVMI := libvmi.NewTestToolingFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks


### PR DESCRIPTION
`tests.NewRandomVMIWithEphemeralDiskAndUserdata` is long and rigid relative to the alternative provided by `libvmi.WithCloudInitNoCloudUserData`. Make the required changes to stop using it in tests/network (mostly reading the return
value of tests.Wait* commands to collect a vmi object with its namespace set)

```release-note
NONE
```
