### PR TITLE
Remove the logic and TODO

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1100,7 +1100,7 @@ func (c *VMController) createVMRevision(vm *virtv1.VirtualMachine) (string, erro
 	return cr.Name, nil
 }
 
-// setupVMIfromVM creates a VirtualMachineInstance object from one VirtualMachine object.
+// setupVMIFromVM creates a VirtualMachineInstance object from one VirtualMachine object.
 func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.VirtualMachineInstance {
 
 	vmi := virtv1.NewVMIReferenceFromNameWithNS(vm.ObjectMeta.Namespace, "")
@@ -1117,8 +1117,6 @@ func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.Virtual
 
 	setupStableFirmwareUUID(vm, vmi)
 
-	// TODO check if vmi labels exist, and when make sure that they match. For now just override them
-	vmi.ObjectMeta.Labels = vm.Spec.Template.ObjectMeta.Labels
 	vmi.ObjectMeta.OwnerReferences = []v1.OwnerReference{
 		*v1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind),
 	}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -1347,6 +1347,20 @@ var _ = Describe("VirtualMachine", func() {
 			Expect(vmi1.Spec.Domain.Firmware.UUID).NotTo(Equal(vmi3.Spec.Domain.Firmware.UUID))
 		})
 
+		It("vmi labels should have same labels with vm.Spec.Template.ObjectMeta.Labels", func() {
+			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")
+			labels := vm1.GetLabels()
+			if labels == nil {
+				labels = make(map[string]string)
+			}
+
+			labels["testvm1"] = "testvm1"
+			vm1.SetLabels(labels)
+			vmi1 := controller.setupVMIFromVM(vm1)
+
+			Expect(vm1.Spec.Template.ObjectMeta.Labels).To(Equal(vmi1.ObjectMeta.Labels))
+		})
+
 		It("should honour any firmware UUID present in the template", func() {
 			uid := uuid.NewRandom().String()
 			vm1, _ := DefaultVirtualMachineWithNames(true, "testvm1", "testvmi1")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

VMI is initialized for the first time. There is no labels
And the objectmeta has been assigned as a whole，There is no need to assign values to labels
```
...
vmi.ObjectMeta = vm.Spec.Template.ObjectMeta
...
# This is unnecessary
vmi.ObjectMeta.Labels = vm.Spec.Template.ObjectMeta.Labels
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
