### PR TITLE
Fix/Skip tests that are incompatible with single-replica environments

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -70,6 +70,11 @@ else
   export KUBEVIRT_PROVIDER=${TARGET}
 fi
 
+# Single-node single-replica test lanes need nfs csi to run sig-storage tests
+if [[ $KUBEVIRT_NUM_NODES = "1" && $KUBEVIRT_INFRA_REPLICAS = "1" ]]; then
+  export KUBEVIRT_DEPLOY_NFS_CSI=true
+fi
+
 if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
   echo "The cluster provider $KUBEVIRT_PROVIDER does not exist"
   exit 1
@@ -412,6 +417,16 @@ else
     export KUBEVIRT_E2E_SKIP="\\[verify-nonroot\\]"
   else
     export KUBEVIRT_E2E_SKIP="$KUBEVIRT_E2E_SKIP|\\[verify-nonroot\\]"
+  fi
+fi
+
+# Single-node single-replica test lanes obviously can't run live migrations,
+# but also currently lack the requirements for SRIOV, GPU, Macvtap and MDEVs.
+if [[ $KUBEVIRT_NUM_NODES = "1" && $KUBEVIRT_INFRA_REPLICAS = "1" ]]; then
+  if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+    export KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|SRIOV|GPU|Macvtap|MediatedDevices|Migration"
+  else
+    export KUBEVIRT_E2E_SKIP="SRIOV|GPU|Macvtap|MediatedDevices|Migration"
   fi
 fi
 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -48,6 +48,7 @@ ARCHITECTURE="${BUILD_ARCH:-$(uname -m)}"
 HOST_ARCHITECTURE="$(uname -m)"
 KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 OPERATOR_MANIFEST_PATH=$MANIFESTS_OUT_DIR/release/kubevirt-operator.yaml
+TESTING_MANIFEST_PATH=$MANIFESTS_OUT_DIR/testing
 KUBEVIRT_CRI="$(determine_cri_bin)"
 
 function build_func_tests() {

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -61,7 +61,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
+    _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
 }
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -49,7 +49,8 @@ rm -rf $ARTIFACTS
 mkdir -p $ARTIFACTS
 
 function functest() {
-    KUBEVIRT_FUNC_TEST_SUITE_ARGS="-apply-default-e2e-configuration \
+    KUBEVIRT_FUNC_TEST_SUITE_ARGS="--ginkgo.trace
+	    -apply-default-e2e-configuration \
 	    -conn-check-ipv4-address=${conn_check_ipv4_address} \
 	    -conn-check-ipv6-address=${conn_check_ipv6_address} \
 	    -conn-check-dns=${conn_check_dns} \

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1031,12 +1031,13 @@ spec:
                       topologyKey: kubernetes.io/hostname
                     weight: 1
               containers:
-              - command:
-                - virt-operator
+              - args:
                 - --port
                 - "8443"
                 - -v
                 - {{.Verbosity}}
+                command:
+                - virt-operator
                 env:
                 - name: OPERATOR_IMAGE
                   value: {{.DockerPrefix}}/virt-operator{{if .VirtOperatorSha}}@{{.VirtOperatorSha}}{{else}}:{{.DockerTag}}{{end}}

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -116,6 +116,8 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 	container := &pod.Containers[0]
 	container.Command = []string{
 		VirtHandlerName,
+	}
+	container.Args = []string{
 		"--port",
 		"8443",
 		"--hostname-override",

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -291,6 +291,8 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	container := &deployment.Spec.Template.Spec.Containers[0]
 	container.Command = []string{
 		VirtAPIName,
+	}
+	container.Args = []string{
 		portName,
 		"8443",
 		"--console-server-port",
@@ -357,6 +359,8 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 	container := &deployment.Spec.Template.Spec.Containers[0]
 	container.Command = []string{
 		VirtControllerName,
+	}
+	container.Args = []string{
 		"--launcher-image",
 		fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", launcherVersion),
 		portName,
@@ -467,6 +471,8 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 							ImagePullPolicy: pullPolicy,
 							Command: []string{
 								VirtOperatorName,
+							},
+							Args: []string{
 								portName,
 								"8443",
 								"-v",

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/checks"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -57,6 +59,10 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", func() {
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
+
+		if !checks.HasAtLeastTwoNodes() {
+			Skip("this test requires at least 2 nodes")
+		}
 
 		virtCli, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -50,6 +50,7 @@ var IPV6ConnectivityCheckAddress = ""
 var ConnectivityCheckDNS = ""
 var ArtifactsDir string
 var OperatorManifestPath string
+var TestingManifestPath string
 var ApplyDefaulte2eConfiguration bool
 
 var DeployTestingInfrastructureFlag = false
@@ -82,6 +83,7 @@ func init() {
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
 	flag.StringVar(&OperatorManifestPath, "operator-manifest-path", "", "Set path to virt-operator manifest file")
+	flag.StringVar(&TestingManifestPath, "testing-manifest-path", "", "Set path to testing manifests directory")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presence of IPv6 address in the cluster pods.")
 	flag.StringVar(&IPV4ConnectivityCheckAddress, "conn-check-ipv4-address", "", "Address that is used for testing IPV4 connectivity to the outside world")

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -2,6 +2,9 @@ package checks
 
 import (
 	"fmt"
+	"time"
+
+	"kubevirt.io/kubevirt/tests/libnode"
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -78,6 +81,19 @@ func IsARM64(arch string) bool {
 
 func HasLiveMigration() bool {
 	return HasFeature("LiveMigration")
+}
+
+func HasAtLeastTwoNodes() bool {
+	var nodes *v1.NodeList
+	virtClient, err := kubecli.GetKubevirtClient()
+	util.PanicOnError(err)
+
+	gomega.Eventually(func() []v1.Node {
+		nodes = libnode.GetAllSchedulableNodes(virtClient)
+		return nodes.Items
+	}, 60*time.Second, time.Second).ShouldNot(gomega.BeEmpty(), "There should be some compute node")
+
+	return len(nodes.Items) >= 2
 }
 
 func IsOpenShift() bool {

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -222,13 +222,7 @@ func SkipIfMigrationIsNotPossible() {
 		ginkgo.Skip("LiveMigration feature gate is not enabled in kubevirt-config")
 	}
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
-
-	nodes := libnode.GetAllSchedulableNodes(virtClient)
-	gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty(), "There should be some compute node")
-
-	if len(nodes.Items) < 2 {
+	if !HasAtLeastTwoNodes() {
 		ginkgo.Skip("Migration tests require at least 2 nodes")
 	}
 }

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -36,6 +36,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"kubevirt.io/kubevirt/tests/framework/checks"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1118,6 +1120,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		Context("when the controller pod is not running and an election happens", func() {
 			It("[test_id:4642]should succeed afterwards", func() {
+				// This test needs at least 2 controller pods. Skip on single-replica.
+				checks.SkipIfSingleReplica(virtClient)
+
 				newLeaderPod := getNewLeaderPod(virtClient)
 				Expect(newLeaderPod).NotTo(BeNil())
 

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/framework/checks"
+
 	"kubevirt.io/kubevirt/tests/libvmi"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
@@ -149,6 +151,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 		var virtClient kubecli.KubevirtClient
 
 		BeforeEach(func() {
+			checks.SkipIfMigrationIsNotPossible()
+
 			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1248,19 +1248,20 @@ spec:
 					vc, err := virtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					vc.Spec.Template.Spec.Containers[0].Env = []k8sv1.EnvVar{
-						{
-							Name:  envVarDeploymentKeyToUpdate,
-							Value: "value",
-						},
-					}
+					vc.Spec.Template.Spec.Containers[0].Env = append(vc.Spec.Template.Spec.Containers[0].Env, k8sv1.EnvVar{
+						Name:  envVarDeploymentKeyToUpdate,
+						Value: "value",
+					})
 
 					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 						vc, err = virtClient.AppsV1().DaemonSets(originalKv.Namespace).Update(context.Background(), vc, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ToNot(HaveOccurred())
-					Expect(vc.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal(envVarDeploymentKeyToUpdate))
+					Expect(vc.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{
+						Name:  envVarDeploymentKeyToUpdate,
+						Value: "value",
+					}))
 				},
 
 				func() runtime.Object {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1229,6 +1229,9 @@ spec:
 				},
 
 				func() runtime.Object {
+					// No virt-controller PDB on single-replica deployments
+					checks.SkipIfSingleReplica(virtClient)
+
 					pdb, err := virtClient.PolicyV1().PodDisruptionBudgets(originalKv.Namespace).Get(context.Background(), "virt-controller-pdb", metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return pdb

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -697,7 +697,6 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		}
 
 		generateMigratableVMIs = func(num int) []*v1.VirtualMachineInstance {
-
 			vmis := []*v1.VirtualMachineInstance{}
 			for i := 0; i < num; i++ {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
@@ -1452,7 +1451,16 @@ spec:
 				Skip("Skip operator update test when operator manifest path isn't configured")
 			}
 
-			migratableVMIs := generateMigratableVMIs(2)
+			// This test should run fine on single-node setups as long as no VM is created pre-update
+			createVMs := true
+			if !checks.HasLiveMigration() || !checks.HasAtLeastTwoNodes() {
+				createVMs = false
+			}
+
+			var migratableVMIs []*v1.VirtualMachineInstance
+			if createVMs {
+				migratableVMIs = generateMigratableVMIs(2)
+			}
 			launcherSha := getVirtLauncherSha()
 			if !flags.SkipShasumCheck {
 				Expect(launcherSha).ToNot(Equal(""))
@@ -1545,8 +1553,12 @@ spec:
 			// needs to be a VM created for every api. This is how we will ensure
 			// our api remains upgradable and supportable from previous release.
 
-			generatePreviousVersionVmYamls(previousUtilityRegistry, previousUtilityTag)
-			generatePreviousVersionVmsnapshotYamls()
+			if createVMs {
+				generatePreviousVersionVmYamls(previousUtilityRegistry, previousUtilityTag)
+				generatePreviousVersionVmsnapshotYamls()
+			} else {
+				Expect(vmYamls).To(BeEmpty())
+			}
 			for _, vmYaml := range vmYamls {
 				By(fmt.Sprintf("Creating VM with %s api", vmYaml.vmName))
 				// NOTE: using kubectl to post yaml directly
@@ -1735,11 +1747,13 @@ spec:
 			By("Verifying all migratable vmi workloads are updated via live migration")
 			verifyVMIsUpdated(migratableVMIs, launcherSha)
 
-			By("Verifying that a once migrated VMI after an update can be migrated again")
-			vmi := migratableVMIs[0]
-			migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(tests.NewRandomMigration(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
+			if len(migratableVMIs) > 0 {
+				By("Verifying that a once migrated VMI after an update can be migrated again")
+				vmi := migratableVMIs[0]
+				migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(tests.NewRandomMigration(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
+			}
 
 			By("Deleting migratable VMIs")
 			deleteAllVMIs(migratableVMIs)
@@ -1759,8 +1773,11 @@ spec:
 
 			// This ensures that we can remove kubevirt while workloads are running
 			By("Starting some vmis")
-			vmis := generateMigratableVMIs(2)
-			startAllVMIs(vmis)
+			var vmis []*v1.VirtualMachineInstance
+			if checks.HasLiveMigration() && checks.HasAtLeastTwoNodes() {
+				vmis = generateMigratableVMIs(2)
+				startAllVMIs(vmis)
+			}
 
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false)
@@ -1927,7 +1944,10 @@ spec:
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}
 
-			vmis := generateMigratableVMIs(2)
+			var vmis []*v1.VirtualMachineInstance
+			if checks.HasLiveMigration() && checks.HasAtLeastTwoNodes() {
+				vmis = generateMigratableVMIs(2)
+			}
 			vmisNonMigratable := generateNonMigratableVMIs(2)
 
 			allPodsAreReady(originalKv)
@@ -2543,13 +2563,11 @@ spec:
 			patchKvInfra(infra, true, "infra replica count can't be 0")
 		})
 		It("should dynamically adjust virt- pod count and PDBs", func() {
-			for _, replicas := range []uint8{3, 1, 2} { // End with 2 so cluster is back to normal
+			for _, replicas := range []uint8{3, 1, 2} {
 				By(fmt.Sprintf("Setting the replica count in kvInfra to %d", replicas))
 				var infra *v1.ComponentConfig
-				if replicas != 2 { // Ensure that nil infra brings us back to 2 replicas
-					infra = &v1.ComponentConfig{
-						Replicas: &replicas,
-					}
+				infra = &v1.ComponentConfig{
+					Replicas: &replicas,
 				}
 				patchKvInfra(infra, false, "")
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -126,12 +126,14 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 	}
 
 	BeforeEach(func() {
+		checks.SkipIfMigrationIsNotPossible()
+
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
 		nodes := libnode.GetAllSchedulableNodes(virtClient)
 		Expect(len(nodes.Items)).To(BeNumerically(">", 1),
-			"should have at least two shcedulable nodes in the cluster")
+			"should have at least two schedulable nodes in the cluster")
 
 		checks.SkipIfVersionBelow("swap requires v1.22 and above", k8sSwapVer)
 		skipIfSwapOff(fmt.Sprintf("swap should be enabled through env var: KUBEVIRT_SWAP_ON=true "+
@@ -140,7 +142,6 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 	})
 
 	Context("Migration to/from memory overcommitted nodes", func() {
-
 		It("Postcopy Migration of vmi that is dirtying(stress-ng) more memory than the source node's memory", func() {
 			nodes := libnode.GetAllSchedulableNodes(virtClient).Items
 			sourceNode := nodes[0]


### PR DESCRIPTION
**What this PR does / why we need it**:
- Test 4642 ensure another replica of virt-controller will take over if the leader dies. That obviously won't work in single-replica, added a skip.
- The kubectl test that runs a migration should be skipped when migrations are not possible
- Test 6256 uses the virt-controller PDB, which doesn't exist on single-replica deployments. Added a skip.
- Both swap tests do migrations, they should be skipped when migration is not possible
- The `Command` for virt-handler containers include args. Those should be moved to `Args`.
- Test 6308 can cause a crash loop since it removes all environment variables on virt-handler containers. It should append its env var instead.
- The operator update (KubeVirt upgrade) tests create VMs and expect them to migrate. Such VMs should only be created when migration is enabled and at least 2 nodes are present.
- The canary test fails on single-node deployments. Skip that test on such deployments.
- Single-node lanes should skip migration tests, as well as tests that require specific environments (SRIOV, GPU, ...)
- Ginkgo should print the whole stack trace on failure to help with debugging
- `parseDaemonset` returns a bunch of values that are never used, those should be removed
- `sanityCheckDeploymentsDeleted` doesn't fail if the deployments are still present!
- Most importantly, one of the operator update (KubeVirt upgrade) tests removes the `disks-images-provider` pod, breaking subsequent tests that need it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2060585

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```