### PR TITLE
Remove Get Nodes API calls

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -308,12 +308,15 @@ func (app *virtHandlerApp) Run() {
 	defer close(stop)
 	// Currently nodeLabeller only support x86_64
 	var capabilities *api.Capabilities
+	var hostCpuModel string
 	if virtconfig.IsAMD64(runtime.GOARCH) {
 		nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig, app.virtCli, app.HostOverride, app.namespace)
 		if err != nil {
 			panic(err)
 		}
 		capabilities = nodeLabellerController.HostCapabilities()
+
+		hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
 
 		go nodeLabellerController.Run(10, stop)
 	}
@@ -342,6 +345,7 @@ func (app *virtHandlerApp) Run() {
 		podIsolationDetector,
 		migrationProxy,
 		capabilities,
+		hostCpuModel,
 	)
 
 	promErrCh := make(chan error)

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -82,7 +82,6 @@ go_test(
         "//pkg/virt-handler/hotplug-disk:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
-        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/virt-handler/hotplug-disk:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
+        "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -80,7 +80,7 @@ func (n *NodeLabeller) getSupportedCpuFeatures() cpuFeatures {
 	return supportedCpuFeatures
 }
 
-func (n *NodeLabeller) getHostCpuModel() hostCPUModel {
+func (n *NodeLabeller) GetHostCpuModel() hostCPUModel {
 	return n.hostCPUModel
 }
 
@@ -103,7 +103,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 				log.Log.Warning("host model mode is expected to contain only one model")
 			}
 
-			n.hostCPUModel.name = hostCpuModel.Name
+			n.hostCPUModel.Name = hostCpuModel.Name
 			n.hostCPUModel.fallback = hostCpuModel.Fallback
 
 			for _, feature := range mode.Feature {

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -143,11 +143,11 @@ var _ = Describe("Node-labeller config", func() {
 			err := nlController.loadHostSupportedFeatures()
 			Expect(err).ToNot(HaveOccurred())
 
-			hostCpuModel = nlController.getHostCpuModel()
+			hostCpuModel = nlController.GetHostCpuModel()
 		})
 
 		It("model", func() {
-			Expect(hostCpuModel.name).To(Equal("Skylake-Client-IBRS"))
+			Expect(hostCpuModel.Name).To(Equal("Skylake-Client-IBRS"))
 			Expect(hostCpuModel.fallback).To(Equal("allow"))
 		})
 

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -25,7 +25,7 @@ type supportedFeatures struct {
 }
 
 type hostCPUModel struct {
-	name             string
+	Name             string
 	fallback         string
 	requiredFeatures cpuFeatures
 }

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -162,7 +162,7 @@ func (n *NodeLabeller) loadAll() error {
 func (n *NodeLabeller) run() error {
 	cpuModels := n.getSupportedCpuModels()
 	cpuFeatures := n.getSupportedCpuFeatures()
-	hostCPUModel := n.getHostCpuModel()
+	hostCPUModel := n.GetHostCpuModel()
 
 	originalNode, err := n.clientset.CoreV1().Nodes().Get(context.Background(), n.host, metav1.GetOptions{})
 	if err != nil {
@@ -266,7 +266,7 @@ func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures
 	}
 
 	newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
-	newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.name] = "true"
+	newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
 
 	capable, err := isNodeRealtimeCapable()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Andrey Odarenko <andreyo@il.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
virt-handler VirtualMachineController performs GET Node API calls when trying to access its associated Node object labels to detect the host CPU model.
This PR will remove direct API calls by using NodeLabeller field which indicates that the host CPU model was successfully detected.
Reducing direct API calls should improve the system performance and scalability.

For reference: https://github.com/kubevirt/kubevirt/pull/7236

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
