### PR TITLE
Move Zvi to emeritus approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,7 +14,6 @@ aliases:
       - jean-edouard
       - mhenriks
       - enp0s3
-      - zcahana
   emeritus_approvers:
       - cynepco3hahue
       - slintes
@@ -22,6 +21,7 @@ aliases:
       - SchSeba
       - codificat
       - ashleyschuett
+      - zcahana
   code-reviewers:
       - davidvossel
       - rmohr


### PR DESCRIPTION
**What this PR does / why we need it**:

Since I've left my job at IBM, I expect to have much less time to invest in the KubeVirt project.
Therefore I feel it's better to step down from my approver role.

I hope to remain involved to some extent, as much as time permits.
And either way I definitely stick around, so feel free to tag me here or on Slack if anything relevant comes up.

**Release note**:
```release-note
NONE
```
