### PR TITLE
istio,launcher: Log msg about istio not found as Info

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -659,7 +659,7 @@ func istioProxyPresent(httpClient *http.Client) bool {
 	err := retry.OnError(retry.DefaultBackoff, isRetriable, func() error {
 		resp, err := httpClient.Get(fmt.Sprintf("http://localhost:%d/healthz/ready", istio.EnvoyHealthCheckPort))
 		if err != nil {
-			log.Log.Reason(err).Error("error when checking for istio-proxy presence")
+			log.Log.Reason(err).V(4).Info("error when checking for istio-proxy presence")
 			return err
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
Logging the message about Istio-proxy not found as Error
may cause confusion when investigating the virt-launcher log.

Since this error is expected on Virtual Machines with no istio-proxy,
this message is merely informative. This change makes it so by loggin
as Info.
Also, increasing the versbosity level to 4.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
