### PR TITLE
tests/network: avoid Expect(len())

### DIFF
--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -240,9 +240,9 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				endpoints, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(endpoints.Subsets)).To(Equal(1))
+				Expect(endpoints.Subsets).To(HaveLen(1))
 				endpoint := endpoints.Subsets[0]
-				Expect(len(endpoint.Ports)).To(Equal(1))
+				Expect(endpoint.Ports).To(HaveLen(1))
 				Expect(endpoint.Ports[0].Port).To(Equal(int32(80)))
 
 				isDualStack := isDualStack(ipFamily)
@@ -251,7 +251,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					numOfIps = 2
 				}
 				assert.XFail(xfailError, func() {
-					Expect(len(endpoints.Subsets[0].Addresses)).To(Equal(numOfIps))
+					Expect(endpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
 				}, isDualStack)
 			},
 				table.Entry("[test_id:1532] over default IPv4 IP family", ipv4),
@@ -290,9 +290,9 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				endpoints, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(endpoints.Subsets)).To(Equal(1))
+				Expect(endpoints.Subsets).To(HaveLen(1))
 				endpoint := endpoints.Subsets[0]
-				Expect(len(endpoint.Ports)).To(Equal(4))
+				Expect(endpoint.Ports).To(HaveLen(4))
 				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-1", Port: 80, Protocol: "TCP"}))
 				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-2", Port: 1500, Protocol: "TCP"}))
 				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-3", Port: 82, Protocol: "UDP"}))
@@ -351,7 +351,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Validating the num of cluster ips")
-				Expect(len(svc.Spec.ClusterIPs)).To(Equal(calcNumOfClusterIPs()))
+				Expect(svc.Spec.ClusterIPs).To(HaveLen(calcNumOfClusterIPs()))
 			},
 				table.Entry("over SingleStack IP family policy", k8sv1.IPFamilyPolicySingleStack),
 				table.Entry("over PreferDualStack IP family policy", k8sv1.IPFamilyPolicyPreferDualStack),
@@ -827,14 +827,14 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				// There should be one - and only one - subset for this endpoint,
 				// pointing to a single pod (the VMI's virt-launcher pod).
 				// This subset should hold a single IP address only - the VM's pod address.
-				Expect(len(svcEndpoints.Subsets)).To(Equal(1))
+				Expect(svcEndpoints.Subsets).To(HaveLen(1))
 
 				numOfIps := 1
 				if secondaryVmPodAddr != "" {
 					numOfIps = 2
 				}
 				assert.XFail(xfailError, func() {
-					Expect(len(svcEndpoints.Subsets[0].Addresses)).To(Equal(numOfIps))
+					Expect(svcEndpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
 				}, secondaryVmPodAddr != "")
 
 				endptSubsetIpAddress := svcEndpoints.Subsets[0].Addresses[0].IP

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -178,7 +178,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 		tests.BeforeTestCleanup()
 
 		nodes = util.GetAllSchedulableNodes(virtClient)
-		Expect(len(nodes.Items) > 0).To(BeTrue())
+		Expect(nodes.Items).NotTo(BeEmpty())
 
 		const vlanID100 = 100
 		Expect(createBridgeNetworkAttachmentDefinition(util.NamespaceTestDefault, linuxBridgeVlan100Network, bridge10CNIType, bridge10Name, vlanID100, "", bridge10MacSpoofCheck)).To(Succeed())
@@ -494,7 +494,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiOne.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(updatedVmi.Status.Interfaces)).To(Equal(2))
+				Expect(updatedVmi.Status.Interfaces).To(HaveLen(2))
 				interfacesByName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)
 				for _, ifc := range updatedVmi.Status.Interfaces {
 					interfacesByName[ifc.Name] = ifc
@@ -698,7 +698,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(updatedVmi.Status.Interfaces)).To(Equal(4))
+				Expect(updatedVmi.Status.Interfaces).To(HaveLen(4))
 				interfaceByIfcName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)
 				for _, ifc := range updatedVmi.Status.Interfaces {
 					interfaceByIfcName[ifc.InterfaceName] = ifc
@@ -1385,7 +1385,7 @@ var _ = SIGDescribe("Macvtap", func() {
 		})
 
 		It("should have the specified MAC address reported back via the API", func() {
-			Expect(len(serverVMI.Status.Interfaces)).To(Equal(1), "should have a single interface")
+			Expect(serverVMI.Status.Interfaces).To(HaveLen(1), "should have a single interface")
 			Expect(serverVMI.Status.Interfaces[0].MAC).To(Equal(chosenMAC), "the expected MAC address should be set in the VMI")
 		})
 


### PR DESCRIPTION
The gomega-idiomatic form
```
   Expect(x).To(HaveLen(n))
```
is better than
```
   Expect(len(x)).To(Equal(n))
```
because when the expectation fails, the tester sees the value of x, not just its length, and has more information to debug it. In my humble opinion, reviewers and maintainers should enforce this for the benefit of future testers.

```release-note
NONE
```
