### PR TITLE
tests/storage: avoid Expect(len())

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -812,7 +812,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				By("Verifying the volume is attached and usable")
 				getVmiConsoleAndLogin(vmi)
 				targets := verifyHotplugAttachedAndUseable(vmi, []string{"testvolume"})
-				Expect(len(targets)).To(Equal(1))
+				Expect(targets).To(HaveLen(1))
 
 				By("stopping VM")
 				vm = tests.StopVirtualMachine(vm)
@@ -986,7 +986,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				By("Verifying the volume is attached and usable")
 				getVmiConsoleAndLogin(vmi)
 				targets := verifyHotplugAttachedAndUseable(vmi, []string{volumeName})
-				Expect(len(targets) == 1).To(BeTrue())
+				Expect(targets).To(HaveLen(1))
 
 				By("Starting the migration multiple times")
 				for i := 0; i < numberOfMigrations; i++ {
@@ -998,7 +998,7 @@ var _ = SIGDescribe("Hotplug", func() {
 							sourceAttachmentPods = append(sourceAttachmentPods, volumeStatus.HotplugVolume.AttachPodName)
 						}
 					}
-					Expect(len(sourceAttachmentPods) == 1).To(BeTrue())
+					Expect(sourceAttachmentPods).To(HaveLen(1))
 
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 					migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1033,7 +1033,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(vmi.Spec.Volumes)).To(Equal(2))
+				Expect(vmi.Spec.Volumes).To(HaveLen(2))
 				foundHotPlug := false
 				foundTempHotPlug := false
 				for _, volume := range vmi.Spec.Volumes {


### PR DESCRIPTION
The gomega-idiomatic form
```
    Expect(x).To(HaveLen(n))
```
is better than
```
    Expect(len(x)).To(Equal(n))
```
because when the expectation fails, the tester sees the value of x, not just its length, and has more information to debug it.

```release-note
NONE
```
