### PR TITLE
Preserve path for cluster server endpoints (fixes virtctl with Rancher)

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -147,7 +148,10 @@ func RequestFromConfig(config *rest.Config, resource, name, namespace, subresour
 		return nil, fmt.Errorf("Unsupported Protocol %s", u.Scheme)
 	}
 
-	u.Path = fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/%s/%s/%s/%s", v1.ApiStorageVersion, namespace, resource, name, subresource)
+	u.Path = path.Join(
+		u.Path,
+		fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/%s/%s/%s/%s", v1.ApiStorageVersion, namespace, resource, name, subresource),
+	)
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    u,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes `virtctl` so that it can be used with clusters accessed via Rancher's authentication proxy.

Here is an example kubeconfig to illustrate the problem:

```yaml
apiVersion: v1
kind: Config
clusters:
- name: "rancher-managed-cluster"
  cluster:
    server: "https://rancher.example.com/k8s/clusters/c-137"  # this is a cluster managed by Rancher
- name: "rancher-server"
  cluster:
    server: "https://rancher.example.com"  # the cluster running Rancher Server, similar URL but no path
...
```

As you can see, the URL for the `rancher-managed-cluster` contains a path component, which is valid, but uncommon so one might assume that they are never present if they have not encountered it before.

I ran `virtctl console myvmi` with a debugger until I found where the path component was being discarded:

https://github.com/kubevirt/kubevirt/blob/a424098832ec184f1c0bf4008ac17b53b3ea3d9c/staging/src/kubevirt.io/client-go/kubecli/vmi.go#L150

Before the above line is executed, the value of u.Path was:

```
/k8s/clusters/c-137
```

After the line was executed the observed value was:

```
/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachinesinstances/myvmi/console
```

The correct value that should be expected is:

```
/k8s/clusters/c-137/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachinesinstances/myvmi/console
```

The result is that the API request ends up going to the `rancher-server` cluster instead of `rancher-managed-cluster`, which results in very confusing error messages since it was not obvious that the wrong cluster was responding.

The proposed code change appends to the `u.Path` value instead of replacing it.

**Which issue(s) this PR fixes**:

Fixes #3760, Fixes #2608

**Special notes for your reviewer**:

Tested with my cluster accessed through Rancher, and tests in `vmi_test.go` passed, but no other testing was performed.

**Release note**:

```release-note
Fixed a bug that prevents virtctl from working with clusters accessed via Rancher authentication proxy, or any other cluster where the server URL contains a path component. (#3760)
```
