### PR TITLE
Fix `KubeVirtComponentExceedsRequestedMemory` alert on duplicate series

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -35,7 +35,7 @@ tests:
   # Pod is using more memory than expected
   - interval: 1m
     input_series:
-      - series: 'container_memory_usage_bytes{namespace="ci",container="virt-controller",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
+      - series: 'container_memory_working_set_bytes{namespace="ci",container="",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: "157286400 157286400 157286400 157286400 157286400 157286400 157286400 157286400"
       - series: 'kube_pod_container_resource_requests{namespace="ci",container="virt-controller",resource="memory",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: "118325248 118325248 118325248 118325248 118325248 118325248 118325248 118325248"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -448,7 +448,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "KubeVirtComponentExceedsRequestedMemory",
-						Expr:  intstr.FromString(fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_usage_bytes{namespace="%s"}) < 0`, ns, ns)),
+						Expr:  intstr.FromString(fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="%s"}) < 0`, ns, ns)),
 						For:   "5m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage exceeds the memory requested",


### PR DESCRIPTION
**What this PR does / why we need it**:

The alert rule complains in OpenShift 4.9/4.10 (OpenShift Virtualization 4.9.3) about:

```
ts=2022-03-16T10:31:02.800Z caller=manager.go:609 level=warn
component="rule manager" group=kubevirt.rules msg="Evaluating rule
failed" rule="alert: KubeVirtComponentExceedsRequestedMemory\nexpr:
((kube_pod_container_resource_requests{container=~\"virt-controller|virt-api|virt-handler|virt-operator\",namespace=\"openshift-cnv\",resource=\"memory\"})\n
- on(pod) group_left(node)
container_memory_usage_bytes{namespace=\"openshift-cnv\"})\n  < 0\nfor:
5m\nlabels:\n  severity: warning\nannotations:\n  description: Container
{{ $labels.container }} in pod {{ $labels.pod }} memory usage\n
exceeds the memory requested\n  summary: The container is using more
memory than what is defined in the containers\n    resource requests\n"
err="found duplicate series for the match group
{pod=\"bridge-marker-cwlb4\"} on the right hand-side of the operation:
[{__name__=\"container_memory_usage_bytes\",
container=\"bridge-marker\", endpoint=\"https-metrics\",
id=\"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1026cbd2_286a_4f57_9605_942cf68d9ab0.slice/crio-81a3afe2fad5b6b61c935dc6384cae0475236d52dd459727a9680b77dd596321.scope\",
image=\"registry.redhat.io/container-native-virtualization/bridge-marker@sha256:ac602257a8d36cf11713f507dc931254b49f5892af460808cc57fec5e94ecebc\",
instance=\"10.60.60.29:10250\", job=\"kubelet\",
metrics_path=\"/metrics/cadvisor\",
name=\"k8s_bridge-marker_bridge-marker-cwlb4_openshift-cnv_1026cbd2-286a-4f57-9605-942cf68d9ab0_0\",
namespace=\"openshift-cnv\", node=\"control-1.kube.direct\",
pod=\"bridge-marker-cwlb4\", service=\"kubelet\"},
{__name__=\"container_memory_usage_bytes\", container=\"POD\",
endpoint=\"https-metrics\",
id=\"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1026cbd2_286a_4f57_9605_942cf68d9ab0.slice/crio-db2dae4250f72cf00fc17430a420535bbc115b8bbbd5166f38ae830e503dcc6b.scope\",
instance=\"10.60.60.29:10250\", job=\"kubelet\",
metrics_path=\"/metrics/cadvisor\",
name=\"k8s_POD_bridge-marker-cwlb4_openshift-cnv_1026cbd2-286a-4f57-9605-942cf68d9ab0_0\",
namespace=\"openshift-cnv\", node=\"control-1.kube.direct\",
pod=\"bridge-marker-cwlb4\", service=\"kubelet\"}];many-to-many matching
not allowed: matching labels must be unique on one side"
```

The issue is that we have multiple container names matching the `container_memory_usage_bytes` metric. We now scope them to only match `container=""` as well as using the `container_memory_working_set_bytes`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubevirt/kubevirt/issues/6481

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Fixed `KubeVirtComponentExceedsRequestedMemory` alert complaining about many-to-many matching not allowed.
  Refers to: https://bugzilla.redhat.com/show_bug.cgi?id=2029357, https://bugzilla.redhat.com/show_bug.cgi?id=2045086 and https://bugzilla.redhat.com/show_bug.cgi?id=2033077
```
