### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in vmi create admitter test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		resp := vmiCreateAdmitter.Admit(ar)
 		Expect(resp.Allowed).To(BeFalse())
-		Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[0].name"))
 	})
 	It("should reject VMIs without memory after presets were applied", func() {
@@ -135,7 +135,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		}
 		resp := vmiCreateAdmitter.Admit(ar)
 		Expect(resp.Allowed).To(BeFalse())
-		Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Message).To(ContainSubstring("no memory requested"))
 	})
 
@@ -383,7 +383,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Expect(resp.Allowed).To(BeTrue())
 				} else {
 					Expect(resp.Allowed).To(BeFalse())
-					Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+					Expect(resp.Result.Details.Causes).To(HaveLen(1))
 					Expect(resp.Result.Details.Causes[0].Message).To(Equal("creation of the following reserved kubevirt.io/ labels on a VMI object is prohibited"))
 				}
 			},
@@ -420,7 +420,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceMetadata(k8sfield.NewPath("metadata"), &vmi.ObjectMeta, config, "fake-account")
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
 			Expect(causes[0].Message).To(ContainSubstring(expectedMsg))
 		},
@@ -441,7 +441,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Annotations: annotations,
 			}
 			causes := ValidateVirtualMachineInstanceMetadata(k8sfield.NewPath("metadata"), &vmi.ObjectMeta, config, "fake-account")
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		},
 			table.Entry("with ExperimentalIgnitionSupport feature gate enabled",
 				map[string]string{v1.IgnitionAnnotation: "fake-data"},
@@ -466,14 +466,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject invalid machine type", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Machine = &v1.Machine{Type: "test"}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.domain.machine.type"))
 			Expect(causes[0].Message).To(ContainSubstring("fake.domain.machine.type is not supported: test (allowed values:"))
@@ -484,14 +484,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Hostname = "test"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject invalid hostname", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Hostname = "test+bad"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.hostname"))
 			Expect(causes[0].Message).To(ContainSubstring("does not conform to the kubernetes DNS_LABEL rules : "))
@@ -501,14 +501,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Subdomain = "testsubdomain"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject invalid subdomain name", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Subdomain = "bad+domain"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.subdomain"))
 		})
 		It("should accept disk and volume lists equal to max element length", func() {
@@ -528,7 +528,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject disk lists greater than max element length", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -543,7 +543,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			// if this is processed correctly, it should result in a single error
 			// If multiple causes occurred, then the spec was processed too far.
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks"))
 		})
 		It("should reject volume lists greater than max element length", func() {
@@ -562,7 +562,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			// if this is processed correctly, it should result in a single error
 			// If multiple causes occurred, then the spec was processed too far.
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.volumes"))
 		})
 		It("should reject disk with missing volume", func() {
@@ -573,7 +573,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].name"))
 		})
 		It("should allow supported audio devices", func() {
@@ -586,7 +586,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Model: deviceName,
 				}
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			}
 		})
 		It("should reject unsupported audio devices", func() {
@@ -598,7 +598,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.Sound"))
 		})
 		It("should reject audio devices without name fields", func() {
@@ -609,7 +609,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Model: supportedAudioDevice,
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.Sound"))
 		})
 		It("should reject volume with missing disk / file system", func() {
@@ -623,7 +623,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.volumes[0].name"))
 		})
 		It("should reject multiple disks referencing same volume", func() {
@@ -644,7 +644,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].name"))
 		})
 		It("should generate multiple causes", func() {
@@ -660,7 +660,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			// missing volume and multiple targets set. should result in 2 causes
-			Expect(len(causes)).To(Equal(2))
+			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].name"))
 			Expect(causes[1].Field).To(Equal("fake.domain.devices.disks[0]"))
 		})
@@ -670,7 +670,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi := api.NewMinimalVMI("testvmi")
 				vmi.Spec.Domain.Devices.Inputs = append(vmi.Spec.Domain.Devices.Inputs, input)
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(expectedErrors), fmt.Sprintf("Expect %d errors", expectedErrors))
+				Expect(causes).To(HaveLen(expectedErrors), fmt.Sprintf("Expect %d errors", expectedErrors))
 				for i, errorType := range expectedErrorTypes {
 					Expect(causes[i].Field).To(Equal(errorType), expectMessage)
 				}
@@ -726,7 +726,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.cpu"))
 		})
 		It("should reject negative limits.cpu size value", func() {
@@ -737,7 +737,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.cpu"))
 		})
 		It("should reject greater requests.cpu than limits.cpu", func() {
@@ -751,7 +751,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.cpu"))
 		})
 		It("should accept correct cpu size values", func() {
@@ -765,7 +765,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject negative requests.memory size value", func() {
@@ -776,7 +776,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
 		It("should reject small requests.memory size value", func() {
@@ -787,7 +787,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
 		It("should reject negative limits.memory size value", func() {
@@ -798,7 +798,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.memory"))
 		})
 		It("should reject greater requests.memory than limits.memory", func() {
@@ -812,7 +812,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
 		It("should accept correct memory size values", func() {
@@ -826,7 +826,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject incorrect hugepages size format", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -838,7 +838,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2ab"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.hugepages.size"))
 		})
 		It("should reject greater hugepages.size than requests.memory", func() {
@@ -851,7 +851,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "1Gi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
 		It("should allow smaller guest memory than requested memory", func() {
@@ -864,7 +864,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject bigger guest memory than the memory limit", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -876,7 +876,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
 		})
 		It("should allow guest memory which is between requests and limits", func() {
@@ -916,7 +916,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Gi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
 		It("should accept correct memory and hugepages size values", func() {
@@ -929,7 +929,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject incorrect memory and hugepages size values", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -941,7 +941,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "10Mi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 			Expect(causes[0].Message).To(Equal("fake.domain.resources.requests.memory '64Mi' " +
@@ -962,7 +962,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		table.DescribeTable("should verify LUN is mapped to PVC volume",
 			func(volume *v1.Volume, expectedErrors int) {
@@ -976,7 +976,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Volumes = append(vmi.Spec.Volumes, *volume)
 
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(expectedErrors))
+				Expect(causes).To(HaveLen(expectedErrors))
 			},
 			table.Entry("and reject non PVC sources",
 				&v1.Volume{
@@ -999,7 +999,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should accept interface and network lists equal to max element length", func() {
@@ -1019,7 +1019,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						Multus: &v1.MultusNetwork{NetworkName: networkName}}})
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject interface lists greater than max element length", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -1032,7 +1032,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 							Bridge: &v1.InterfaceBridge{}}})
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.domain.devices.interfaces "+
 				"list exceeds the %d element limit in length", arrayLenMax)))
 		})
@@ -1046,7 +1046,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						Multus: &v1.MultusNetwork{NetworkName: networkName}}})
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.networks "+
 				"list exceeds the %d element limit in length", arrayLenMax)))
 		})
@@ -1066,7 +1066,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					ContainerDisk: testutils.NewFakeContainerDiskSource()}}}...)
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].bootOrder"))
 			Expect(causes[0].Message).To(Equal("Boot order for " +
 				"fake.domain.devices.disks[1].bootOrder already set for a different device."))
@@ -1080,7 +1080,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			// if this is processed correctly, it should result an error
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
 		})
 		It("should accept network lists with more than one element", func() {
@@ -1091,7 +1091,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				{Name: "default2", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
 			// if this is processed correctly, it should result an error only about duplicate pod network configuration
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
 		})
 
@@ -1104,7 +1104,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].Model = model
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			}
 		})
 
@@ -1114,7 +1114,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmi.Spec.Domain.Devices.Interfaces[0].Model = "invalid_model"
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject interfaces with missing network", func() {
@@ -1130,7 +1130,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(2))
+			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 			Expect(causes[1].Field).To(Equal("fake.networks[0].name"))
 		})
@@ -1147,7 +1147,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[0].name"))
 		})
 		It("should reject networks with duplicate names", func() {
@@ -1169,7 +1169,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[1].name"))
 			Expect(causes[0].Message).To(Equal("Network with name \"default\" already exists, every network must have a unique name"))
 		})
@@ -1193,7 +1193,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 			Expect(causes[0].Message).To(Equal("Network interface name can only contain alphabetical characters, numbers, dashes (-) or underscores (_)"))
 		})
@@ -1216,7 +1216,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[1].name"))
 		})
 		It("should accept networks with a pod network source and bridge interface", func() {
@@ -1230,7 +1230,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should accept networks with a multus network source and bridge interface", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1407,7 +1407,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 		It("should accept networks with a pod network source and slirp interface", func() {
 			enableSlirpInterface()
@@ -1426,7 +1426,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should accept networks with a pod network source and slirp interface with port", func() {
 			enableSlirpInterface()
@@ -1446,7 +1446,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject networks with a pod network source and slirp interface without specific port", func() {
 			enableSlirpInterface()
@@ -1466,7 +1466,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0]"))
 		})
 		It("should reject a masquerade interface on a network different than pod", func() {
@@ -1486,7 +1486,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 		})
 		It("should reject a masquerade interface with a specified MAC address which is reserved by the BindMechanism", func() {
@@ -1507,7 +1507,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal("The requested MAC address is reserved for the in-pod bridge. Please choose another one."))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].macAddress"))
 		})
@@ -1516,7 +1516,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject a bridge interface on a pod network when it is not permitted", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1524,7 +1524,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			disableBridgeOnPodNetwork()
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 		})
 		It("should reject a bad port name", func() {
@@ -1564,7 +1564,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0].protocol"))
 		})
 		It("should accept networks with a pod network source and slirp interface with multiple Ports", func() {
@@ -1585,7 +1585,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject a macvtap interface on a network different than multus", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1668,7 +1668,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0]"))
 		})
 		It("should reject interface with two ports with the same name", func() {
@@ -1689,7 +1689,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[1].name"))
 		})
 		It("should reject two interfaces with same port name", func() {
@@ -1716,7 +1716,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(2))
+			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
 			Expect(causes[1].Field).To(Equal("fake.domain.devices.interfaces[1].ports[0].name"))
 		})
@@ -1738,7 +1738,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject specs with multiple pod interfaces", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1756,7 +1756,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.interfaces"))
 		})
 
@@ -1768,7 +1768,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress // missing octet
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			}
 		})
 
@@ -1779,7 +1779,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			for _, macAddress := range []string{"de:ad:00:00:be", "de-ad-00-00-be", "de:ad:00:00:be:af:be:af"} {
 				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(1))
+				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].macAddress"))
 			}
 		})
@@ -1791,7 +1791,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			}
 		})
 
@@ -1802,7 +1802,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			for _, pciAddress := range []string{"0000:80.10.1", "0000:80:80:1.0", "0000:80:11.15"} {
 				vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(1))
+				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].pciAddress"))
 			}
 		})
@@ -1815,7 +1815,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				NTPServers: []string{"127.0.0.1", "127.0.0.2"},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject non-IPv4 NTP servers", func() {
@@ -1826,7 +1826,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				NTPServers: []string{"::1", "hostname"},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(2))
+			Expect(causes).To(HaveLen(2))
 		})
 
 		It("should accept valid DHCPPrivateOptions", func() {
@@ -1837,7 +1837,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "extra.options.kubevirt.io"}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject invalid DHCPPrivateOptions", func() {
@@ -1848,7 +1848,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 223, Value: "extra.options.kubevirt.io"}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject duplicate DHCPPrivateOptions", func() {
@@ -1861,7 +1861,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					{Option: 240, Value: "sameextra.options.kubevirt.io"}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should accept unique DHCPPrivateOptions", func() {
@@ -1874,7 +1874,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					{Option: 241, Value: "sameextra.options.kubevirt.io"}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should return error if not unique DHCPPrivateOptions", func() {
@@ -1904,7 +1904,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
 		})
 
@@ -1916,7 +1916,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("5")
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should ignore CPU settings for explicitly rejected BlockMultiQueue", func() {
@@ -1925,7 +1925,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should allow valid ioThreadsPolicy", func() {
@@ -1934,7 +1934,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			ioThreadPolicy = "auto"
 			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject invalid ioThreadsPolicy", func() {
@@ -1943,7 +1943,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			ioThreadPolicy = "bad"
 			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("Invalid IOThreadsPolicy (%s)", ioThreadPolicy)))
 		})
 
@@ -1957,7 +1957,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.GPUs"))
 		})
 		It("should reject virtiofs filesystems when feature gate is disabled", func() {
@@ -1980,7 +1980,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.Filesystems"))
 		})
 		It("should allow virtiofs filesystems when feature gate is enabled", func() {
@@ -2005,7 +2005,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
 			kvConfig := kv.DeepCopy()
@@ -2020,7 +2020,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should accept permitted GPU devices", func() {
 			kvConfig := kv.DeepCopy()
@@ -2043,7 +2043,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject host devices when feature gate is disabled", func() {
 			vmi := api.NewMinimalVMI("testvm")
@@ -2055,7 +2055,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.HostDevices"))
 		})
 		It("should accept host devices that are not permitted in the hostdev config", func() {
@@ -2078,7 +2078,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should accept permitted host devices", func() {
 			kvConfig := kv.DeepCopy()
@@ -2100,7 +2100,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		table.DescribeTable("Should accept valid DNSPolicy and DNSConfig",
 			func(dnsPolicy k8sv1.DNSPolicy, dnsConfig *k8sv1.PodDNSConfig) {
@@ -2108,7 +2108,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.DNSPolicy = dnsPolicy
 				vmi.Spec.DNSConfig = dnsConfig
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			},
 			table.Entry("with DNSPolicy ClusterFirstWithHostNet", k8sv1.DNSClusterFirstWithHostNet, &k8sv1.PodDNSConfig{}),
 			table.Entry("with DNSPolicy ClusterFirst", k8sv1.DNSClusterFirst, &k8sv1.PodDNSConfig{}),
@@ -2131,7 +2131,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.DNSPolicy = dnsPolicy
 				vmi.Spec.DNSConfig = dnsConfig
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(causeCount))
+				Expect(causes).To(HaveLen(causeCount))
 				for i := 0; i < causeCount; i++ {
 					Expect(causes[i].Message).To(Equal(causeMessage[i]))
 				}
@@ -2173,13 +2173,13 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.StartStrategy = &strategy
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should allow no start strategy to be set", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.StartStrategy = nil
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 		It("should reject invalid start strategy", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -2187,7 +2187,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.StartStrategy = &strategy
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.startStrategy"))
 			Expect(causes[0].Message).To(Equal("fake.startStrategy is set with an unrecognized option: invalid"))
@@ -2206,7 +2206,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.startStrategy"))
 			Expect(causes[0].Message).To(Equal("either fake.startStrategy or fake.livenessProbe should be provided.Pausing VMI with LivenessProbe is not supported"))
@@ -2328,7 +2328,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 		It("should reject specs without cpu reqirements", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.dedicatedCpuPlacement"))
 		})
 		It("should reject specs with IsolateEmulatorThread without DedicatedCPUPlacement set", func() {
@@ -2338,7 +2338,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				IsolateEmulatorThread: true,
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.isolateEmulatorThread"))
 		})
 		It("should reject specs without inconsistent cpu reqirements", func() {
@@ -2347,7 +2347,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("2"),
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.dedicatedCpuPlacement"))
 		})
 		It("should reject specs with non-integer cpu limits values", func() {
@@ -2355,7 +2355,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("800m"),
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.cpu"))
 		})
 		It("should reject specs with non-integer cpu requests values", func() {
@@ -2364,7 +2364,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("8Mi"),
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.cpu"))
 		})
 		It("should not allow cpu overcommit", func() {
@@ -2377,7 +2377,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("8Mi"),
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.dedicatedCpuPlacement"))
 		})
 		It("should reject specs without a memory specification", func() {
@@ -2388,7 +2388,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("4"),
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.memory"))
 		})
 		It("should reject specs with inconsistent memory specification", func() {
@@ -2401,7 +2401,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("4Mi"),
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
 	})
@@ -2434,7 +2434,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should accept a valid ssh access credential with qemu agent propagation", func() {
@@ -2457,7 +2457,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should accept a valid user password access credential with qemu agent propagation", func() {
@@ -2478,7 +2478,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject a configDrive ssh access credential when no configDrive volume exists", func() {
@@ -2509,7 +2509,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 		It("should reject a ssh access credential without a source", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -2533,7 +2533,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject a ssh access credential with qemu agent propagation with no authorized key files listed", func() {
@@ -2553,7 +2553,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject a userpassword access credential without a source", func() {
@@ -2569,7 +2569,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject a ssh access credential without a propagationMethod", func() {
@@ -2596,7 +2596,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject a userpassword credential without a propagationMethod", func() {
@@ -2613,7 +2613,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 	})
 
@@ -2631,7 +2631,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			for policy := range validCPUFeaturePolicies {
 				vmi.Spec.Domain.CPU.Features[0].Policy = policy
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			}
 		})
 
@@ -2646,7 +2646,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 	})
 
@@ -2658,7 +2658,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 
 			},
 			table.Entry("with Disk target",
@@ -2687,7 +2687,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject disks with duplicate names ", func() {
@@ -2706,7 +2706,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake[1].name"))
 		})
 
@@ -2722,7 +2722,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks.disk[0].pciAddress"))
 		})
 
@@ -2738,7 +2738,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks.disk[0].pciAddress"))
 		})
 
@@ -2760,7 +2760,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake[0]"))
 		})
 		It("should reject cd-roms using virtio bus", func() {
@@ -2782,7 +2782,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].cdrom.bus"))
 			Expect(causes[0].Message).To(Equal("Bus type virtio is invalid for CD-ROM device"))
 		})
@@ -2800,7 +2800,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject a disk with a boot order of '0'", func() {
@@ -2816,7 +2816,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake[0].bootOrder"))
 		})
 
@@ -2855,7 +2855,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should reject disks with unsupported buses", func() {
@@ -2879,7 +2879,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(2))
+			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake[0].disk.bus"))
 			Expect(causes[1].Field).To(Equal("fake[1].lun.bus"))
 		})
@@ -2897,7 +2897,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].io"))
 		})
 
@@ -2908,7 +2908,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Disk: &v1.DiskTarget{}}})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake[0].cache"))
 			Expect(causes[0].Message).To(Equal("fake[0].cache has invalid value unspported"))
@@ -2920,7 +2920,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Disk: &v1.DiskTarget{}}})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		},
 			table.Entry("none", v1.CacheNone),
 			table.Entry("writethrough", v1.CacheWriteThrough),
@@ -2936,7 +2936,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake"))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake list exceeds the %d "+
@@ -2958,7 +2958,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake[0].serial"))
 		})
 
@@ -2977,7 +2977,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake[0].serial"))
 		})
 
@@ -2995,7 +2995,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("Should reject disk with DedicatedIOThread and SATA bus", func() {
@@ -3028,7 +3028,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			)
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1)) // Only first disk should fail
+			Expect(causes).To(HaveLen(1)) // Only first disk should fail
 			Expect(string(causes[0].Type)).To(Equal("FieldValueNotSupported"))
 			Expect(causes[0].Field).To(ContainSubstring("domain.devices.disks"))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("IOThreads are not supported for disks on a SATA bus")))
@@ -3051,7 +3051,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			},
 				table.Entry("a 512n disk", 512, 512),
 				table.Entry("a 512e disk", 512, 4096),
@@ -3073,7 +3073,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(2))
+				Expect(causes).To(HaveLen(2))
 				Expect(causes[0].Field).To(Equal("fake[0].blockSize.custom.logical"))
 				Expect(causes[1].Field).To(Equal("fake[0].blockSize.custom.physical"))
 			},
@@ -3096,7 +3096,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(1))
+				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Field).To(Equal("fake[0].blockSize.custom.logical"))
 			})
 
@@ -3114,7 +3114,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			})
 
 			It("Should reject disk with custom block size and size matching enabled", func() {
@@ -3135,7 +3135,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(1))
+				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Field).To(Equal("fake[0].blockSize"))
 			})
 
@@ -3157,7 +3157,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(len(causes)).To(Equal(0))
+				Expect(causes).To(HaveLen(0))
 			})
 		})
 	})
@@ -3341,7 +3341,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should accept BIOS", func() {
@@ -3355,7 +3355,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should accept EFI with SMM", func() {
@@ -3375,7 +3375,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should not accept EFI without SMM", func() {
@@ -3389,7 +3389,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should accept EFI without secureBoot and without SMM", func() {
@@ -3406,7 +3406,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
+			Expect(causes).To(HaveLen(0))
 		})
 
 		It("should not accept BIOS and EFI together", func() {
@@ -3427,7 +3427,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject disk without a valid DNS-1123 name", func() {
@@ -3441,7 +3441,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 	})
 
@@ -3455,7 +3455,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := webhooks.ValidateVirtualMachineInstanceArm64Setting(k8sfield.NewPath("spec"), &vmi.Spec)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject UEFI default bootloader", func() {
@@ -3467,7 +3467,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := webhooks.ValidateVirtualMachineInstanceArm64Setting(k8sfield.NewPath("spec"), &vmi.Spec)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject UEFI secure bootloader", func() {
@@ -3483,7 +3483,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := webhooks.ValidateVirtualMachineInstanceArm64Setting(k8sfield.NewPath("spec"), &vmi.Spec)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 
 		It("should reject setting cpu model to host-model", func() {
@@ -3491,7 +3491,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.CPU = &v1.CPU{Model: "host-model"}
 
 			causes := webhooks.ValidateVirtualMachineInstanceArm64Setting(k8sfield.NewPath("spec"), &vmi.Spec)
-			Expect(len(causes)).To(Equal(1))
+			Expect(causes).To(HaveLen(1))
 		})
 	})
 
@@ -3810,7 +3810,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
 
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(len(causes)).To(Equal(0))
+		Expect(causes).To(HaveLen(0))
 	})
 
 	It("Should validate VMIs without HyperV configuration", func() {
@@ -3818,7 +3818,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		Expect(vmi.Spec.Domain.Features).To(BeNil())
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(0))
+		Expect(causes).To(HaveLen(0))
 	})
 
 	It("Should validate VMIs with empty HyperV configuration", func() {
@@ -3828,7 +3828,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(0))
+		Expect(causes).To(HaveLen(0))
 	})
 
 	It("Should validate VMIs with hyperv configuration without deps", func() {
@@ -3849,7 +3849,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(0))
+		Expect(causes).To(HaveLen(0))
 	})
 
 	It("Should validate VMIs with hyperv EVMCS configuration without deps and detect multiple issues", func() {
@@ -4012,6 +4012,6 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(0))
+		Expect(causes).To(HaveLen(0))
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Annotations: annotations,
 			}
 			causes := ValidateVirtualMachineInstanceMetadata(k8sfield.NewPath("metadata"), &vmi.ObjectMeta, config, "fake-account")
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		},
 			table.Entry("with ExperimentalIgnitionSupport feature gate enabled",
 				map[string]string{v1.IgnitionAnnotation: "fake-data"},
@@ -466,7 +466,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid machine type", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -484,7 +484,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Hostname = "test"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid hostname", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -501,7 +501,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Subdomain = "testsubdomain"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid subdomain name", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -528,7 +528,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject disk lists greater than max element length", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -586,7 +586,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Model: deviceName,
 				}
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			}
 		})
 		It("should reject unsupported audio devices", func() {
@@ -765,7 +765,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject negative requests.memory size value", func() {
@@ -826,7 +826,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject incorrect hugepages size format", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -864,7 +864,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject bigger guest memory than the memory limit", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -929,7 +929,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject incorrect memory and hugepages size values", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -962,7 +962,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		table.DescribeTable("should verify LUN is mapped to PVC volume",
 			func(volume *v1.Volume, expectedErrors int) {
@@ -999,7 +999,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should accept interface and network lists equal to max element length", func() {
@@ -1019,7 +1019,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						Multus: &v1.MultusNetwork{NetworkName: networkName}}})
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject interface lists greater than max element length", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -1104,7 +1104,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].Model = model
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			}
 		})
 
@@ -1230,7 +1230,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should accept networks with a multus network source and bridge interface", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1426,7 +1426,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should accept networks with a pod network source and slirp interface with port", func() {
 			enableSlirpInterface()
@@ -1446,7 +1446,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject networks with a pod network source and slirp interface without specific port", func() {
 			enableSlirpInterface()
@@ -1516,7 +1516,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject a bridge interface on a pod network when it is not permitted", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1585,7 +1585,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject a macvtap interface on a network different than multus", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1648,7 +1648,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			enableFeatureGate(virtconfig.MacvtapGate)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject port out of range", func() {
 			enableSlirpInterface()
@@ -1738,7 +1738,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject specs with multiple pod interfaces", func() {
 			vm := api.NewMinimalVMI("testvm")
@@ -1768,7 +1768,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress // missing octet
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			}
 		})
 
@@ -1791,7 +1791,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			}
 		})
 
@@ -1815,7 +1815,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				NTPServers: []string{"127.0.0.1", "127.0.0.2"},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject non-IPv4 NTP servers", func() {
@@ -1837,7 +1837,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "extra.options.kubevirt.io"}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject invalid DHCPPrivateOptions", func() {
@@ -1874,7 +1874,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					{Option: 241, Value: "sameextra.options.kubevirt.io"}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should return error if not unique DHCPPrivateOptions", func() {
@@ -1916,7 +1916,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("5")
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should ignore CPU settings for explicitly rejected BlockMultiQueue", func() {
@@ -1925,7 +1925,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should allow valid ioThreadsPolicy", func() {
@@ -1934,7 +1934,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			ioThreadPolicy = "auto"
 			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject invalid ioThreadsPolicy", func() {
@@ -2005,7 +2005,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
 			kvConfig := kv.DeepCopy()
@@ -2020,7 +2020,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should accept permitted GPU devices", func() {
 			kvConfig := kv.DeepCopy()
@@ -2043,7 +2043,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject host devices when feature gate is disabled", func() {
 			vmi := api.NewMinimalVMI("testvm")
@@ -2078,7 +2078,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should accept permitted host devices", func() {
 			kvConfig := kv.DeepCopy()
@@ -2100,7 +2100,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		table.DescribeTable("Should accept valid DNSPolicy and DNSConfig",
 			func(dnsPolicy k8sv1.DNSPolicy, dnsConfig *k8sv1.PodDNSConfig) {
@@ -2108,7 +2108,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.DNSPolicy = dnsPolicy
 				vmi.Spec.DNSConfig = dnsConfig
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			},
 			table.Entry("with DNSPolicy ClusterFirstWithHostNet", k8sv1.DNSClusterFirstWithHostNet, &k8sv1.PodDNSConfig{}),
 			table.Entry("with DNSPolicy ClusterFirst", k8sv1.DNSClusterFirst, &k8sv1.PodDNSConfig{}),
@@ -2173,13 +2173,13 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.StartStrategy = &strategy
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should allow no start strategy to be set", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.StartStrategy = nil
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid start strategy", func() {
 			vmi := api.NewMinimalVMI("testvmi")
@@ -2434,7 +2434,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should accept a valid ssh access credential with qemu agent propagation", func() {
@@ -2457,7 +2457,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should accept a valid user password access credential with qemu agent propagation", func() {
@@ -2478,7 +2478,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject a configDrive ssh access credential when no configDrive volume exists", func() {
@@ -2631,7 +2631,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			for policy := range validCPUFeaturePolicies {
 				vmi.Spec.Domain.CPU.Features[0].Policy = policy
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			}
 		})
 
@@ -2658,7 +2658,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 
 			},
 			table.Entry("with Disk target",
@@ -2687,7 +2687,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject disks with duplicate names ", func() {
@@ -2800,7 +2800,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject a disk with a boot order of '0'", func() {
@@ -2855,7 +2855,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject disks with unsupported buses", func() {
@@ -2920,7 +2920,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Disk: &v1.DiskTarget{}}})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		},
 			table.Entry("none", v1.CacheNone),
 			table.Entry("writethrough", v1.CacheWriteThrough),
@@ -2995,7 +2995,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("Should reject disk with DedicatedIOThread and SATA bus", func() {
@@ -3051,7 +3051,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			},
 				table.Entry("a 512n disk", 512, 512),
 				table.Entry("a 512e disk", 512, 4096),
@@ -3114,7 +3114,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			})
 
 			It("Should reject disk with custom block size and size matching enabled", func() {
@@ -3157,7 +3157,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 
 				causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			})
 		})
 	})
@@ -3341,7 +3341,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should accept BIOS", func() {
@@ -3355,7 +3355,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should accept EFI with SMM", func() {
@@ -3375,7 +3375,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should not accept EFI without SMM", func() {
@@ -3406,7 +3406,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should not accept BIOS and EFI together", func() {
@@ -3545,7 +3545,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should accept when the feature gate is enabled and OVMF is configured", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(0))
+			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject when the feature gate is disabled", func() {
@@ -3698,7 +3698,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 	It("should fail when invalid boot order is given to interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
@@ -3748,7 +3748,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		spec.Volumes = []v1.Volume{volume}
 		spec.Domain.Devices.Disks = []v1.Disk{disk}
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 	It("should fail when same boot order is given to more than one device", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
@@ -3810,7 +3810,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
 
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 
 	It("Should validate VMIs without HyperV configuration", func() {
@@ -3818,7 +3818,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		Expect(vmi.Spec.Domain.Features).To(BeNil())
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 
 	It("Should validate VMIs with empty HyperV configuration", func() {
@@ -3828,7 +3828,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 
 	It("Should validate VMIs with hyperv configuration without deps", func() {
@@ -3849,7 +3849,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 
 	It("Should validate VMIs with hyperv EVMCS configuration without deps and detect multiple issues", func() {
@@ -4012,6 +4012,6 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(causes).To(HaveLen(0))
+		Expect(causes).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
