### PR TITLE
network, unit tests: avoid Expect(len())...

### DIFF
--- a/pkg/network/dhcp/serverv6/serverv6_test.go
+++ b/pkg/network/dhcp/serverv6/serverv6_test.go
@@ -35,7 +35,7 @@ var _ = Describe("DHCPv6", func() {
 			clientIP := net.ParseIP("fd10:0:2::2")
 			serverInterfaceMac, _ := net.ParseMAC("12:34:56:78:9A:BC")
 			modifiers := prepareDHCPv6Modifiers(clientIP, serverInterfaceMac)
-			Expect(len(modifiers)).To(Equal(2))
+			Expect(modifiers).To(HaveLen(2))
 
 			msg := &dhcpv6.Message{
 				MessageType: dhcpv6.MessageTypeAdvertise,
@@ -44,7 +44,7 @@ var _ = Describe("DHCPv6", func() {
 			modifiers[0](msg)
 			opt := msg.GetOneOption(dhcpv6.OptionIANA)
 			optIana := opt.(*dhcpv6.OptIANA)
-			Expect(len(optIana.Options.Addresses())).To(Equal(1))
+			Expect(optIana.Options.Addresses()).To(HaveLen(1))
 			Expect(optIana.Options.OneAddress().String()).To(Equal(expectedIaAddr.String()))
 
 			duid := dhcpv6.Duid{Type: dhcpv6.DUID_LL, HwType: iana.HWTypeEthernet, LinkLayerAddr: serverInterfaceMac}
@@ -108,7 +108,8 @@ var _ = Describe("DHCPv6", func() {
 
 			replyMessage, err := handler.buildResponse(clientMessage)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(replyMessage.Options.Options)).To(Equal(len(handler.modifiers) + 1))
+			expectedLength := len(handler.modifiers) + 1
+			Expect(replyMessage.Options.Options).To(HaveLen(expectedLength))
 		})
 	})
 })

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -77,8 +77,8 @@ var _ = Describe("Pod Network", func() {
 				specGenerator := NewSlirpLibvirtSpecGenerator(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
 				Expect(specGenerator.Generate()).To(Succeed())
 
-				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
-				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				Expect(domain.Spec.Devices.Interfaces).To(BeEmpty())
+				Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default"}))
 			})
@@ -88,8 +88,8 @@ var _ = Describe("Pod Network", func() {
 				specGenerator := NewSlirpLibvirtSpecGenerator(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
 				Expect(specGenerator.Generate()).To(Succeed())
 
-				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
-				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				Expect(domain.Spec.Devices.Interfaces).To(BeEmpty())
+				Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default,mac=de-ad-00-00-be-af"}))
 			})
@@ -107,8 +107,8 @@ var _ = Describe("Pod Network", func() {
 				specGenerator := NewSlirpLibvirtSpecGenerator(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
 				Expect(specGenerator.Generate()).To(Succeed())
 
-				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(1))
-				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				Expect(domain.Spec.Devices.Interfaces).To(HaveLen(1))
+				Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default"}))
 			})
@@ -134,7 +134,7 @@ var _ = Describe("Pod Network", func() {
 			It("Should pass a non-privileged macvtap interface to qemu", func() {
 				Expect(specGenerator.Generate()).To(Succeed())
 
-				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(1), "should have a single interface")
+				Expect(domain.Spec.Devices.Interfaces).To(HaveLen(1), "should have a single interface")
 				Expect(domain.Spec.Devices.Interfaces[0].Target).To(Equal(&api.InterfaceTarget{Device: primaryPodIfaceName, Managed: "no"}), "should have an unmanaged interface")
 				Expect(domain.Spec.Devices.Interfaces[0].MAC).To(Equal(&api.MAC{MAC: fakeMac.String()}), "should have the expected MAC address")
 				Expect(domain.Spec.Devices.Interfaces[0].MTU).To(Equal(&api.MTU{Size: "1410"}), "should have the expected MTU")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The gomega-idiomatic form
    `Expect(x).To(HaveLen(n))`
is better than
    `Expect(len(x)).To(Equal(n))`
because when the expectation fails, the tester sees the value of x, not
just its length, and has more information to debug it.

Similarly,
    Expect(x).To(BeEmpty())
fails more clearly than
    Expect(len(x)).To(Equal(0)).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
