### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in vmi preset admitter test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Validating VMIPreset Admitter", func() {
 
 		resp := vmiPresetAdmitter.Admit(ar)
 		Expect(resp.Allowed).To(BeFalse())
-		Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[0]"))
 	})
 	It("should accept valid vmi spec", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
