### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in vmsnapshot admitter test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			ar := createSnapshotAdmissionReview(snapshot)
 			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
 			Expect(resp.Allowed).To(BeFalse())
-			Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.apiGroup"))
 		})
 
@@ -130,7 +130,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			ar := createSnapshotAdmissionReview(snapshot)
 			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
 			Expect(resp.Allowed).To(BeFalse())
-			Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.name"))
 		})
 
@@ -158,7 +158,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 			ar := createSnapshotUpdateAdmissionReview(oldSnapshot, snapshot)
 			resp := createTestVMSnapshotAdmitter(config, nil).Admit(ar)
 			Expect(resp.Allowed).To(BeFalse())
-			Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
 		})
 
@@ -238,7 +238,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				ar := createSnapshotAdmissionReview(snapshot)
 				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
 				Expect(resp.Allowed).To(BeFalse())
-				Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.kind"))
 			})
 
@@ -260,7 +260,7 @@ var _ = Describe("Validating VirtualMachineSnapshot Admitter", func() {
 				ar := createSnapshotAdmissionReview(snapshot)
 				resp := createTestVMSnapshotAdmitter(config, vm).Admit(ar)
 				Expect(resp.Allowed).To(BeFalse())
-				Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+				Expect(resp.Result.Details.Causes).To(HaveLen(1))
 				Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.apiGroup"))
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
