### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in pool test

### DIFF
--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Pool", func() {
 
 		newNames := calculateNewVMNames(count, baseName, namespace, vmInformer.GetStore())
 
-		Expect(len(newNames)).To(Equal(len(expected)))
+		Expect(newNames).To(HaveLen(len(expected)))
 		Expect(newNames).To(Equal(expected))
 
 	},
@@ -418,7 +418,7 @@ var _ = Describe("Pool", func() {
 				Expect(ok).To(BeTrue())
 				updateObj := update.GetObject().(*poolv1.VirtualMachinePool)
 				Expect(updateObj.Status.Replicas).To(Equal(int32(0)))
-				Expect(len(updateObj.Status.Conditions)).To(Equal(1))
+				Expect(updateObj.Status.Conditions).To(HaveLen(1))
 				Expect(updateObj.Status.Conditions[0].Type).To(Equal(poolv1.VirtualMachinePoolReplicaPaused))
 				Expect(updateObj.Status.Conditions[0].Status).To(Equal(k8sv1.ConditionTrue))
 				return true, update.GetObject(), nil
@@ -445,7 +445,7 @@ var _ = Describe("Pool", func() {
 				Expect(ok).To(BeTrue())
 				updateObj := update.GetObject().(*poolv1.VirtualMachinePool)
 				Expect(updateObj.Status.Replicas).To(Equal(int32(0)))
-				Expect(len(updateObj.Status.Conditions)).To(Equal(1))
+				Expect(updateObj.Status.Conditions).To(HaveLen(1))
 				Expect(updateObj.Status.Conditions[0].Type).To(Equal(poolv1.VirtualMachinePoolReplicaFailure))
 				Expect(updateObj.Status.Conditions[0].Status).To(Equal(k8sv1.ConditionTrue))
 				return true, update.GetObject(), nil
@@ -482,7 +482,7 @@ var _ = Describe("Pool", func() {
 				update, ok := action.(testing.UpdateAction)
 				Expect(ok).To(BeTrue())
 				updateObj := update.GetObject().(*poolv1.VirtualMachinePool)
-				Expect(len(updateObj.Status.Conditions)).To(Equal(0))
+				Expect(updateObj.Status.Conditions).To(HaveLen(0))
 				return true, update.GetObject(), nil
 			})
 
@@ -515,7 +515,7 @@ var _ = Describe("Pool", func() {
 				update, ok := action.(testing.UpdateAction)
 				Expect(ok).To(BeTrue())
 				updateObj := update.GetObject().(*poolv1.VirtualMachinePool)
-				Expect(len(updateObj.Status.Conditions)).To(Equal(0))
+				Expect(updateObj.Status.Conditions).To(HaveLen(0))
 				return true, update.GetObject(), nil
 			})
 

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -482,7 +482,7 @@ var _ = Describe("Pool", func() {
 				update, ok := action.(testing.UpdateAction)
 				Expect(ok).To(BeTrue())
 				updateObj := update.GetObject().(*poolv1.VirtualMachinePool)
-				Expect(updateObj.Status.Conditions).To(HaveLen(0))
+				Expect(updateObj.Status.Conditions).To(BeEmpty())
 				return true, update.GetObject(), nil
 			})
 
@@ -515,7 +515,7 @@ var _ = Describe("Pool", func() {
 				update, ok := action.(testing.UpdateAction)
 				Expect(ok).To(BeTrue())
 				updateObj := update.GetObject().(*poolv1.VirtualMachinePool)
-				Expect(updateObj.Status.Conditions).To(HaveLen(0))
+				Expect(updateObj.Status.Conditions).To(BeEmpty())
 				return true, update.GetObject(), nil
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
