### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in snapshot test

### DIFF
--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -1404,7 +1404,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					Do(func(objs ...interface{}) {
 						vm := objs[0].(*v1.VirtualMachine)
 
-						Expect(len(vm.Status.VolumeSnapshotStatuses)).To(Equal(2))
+						Expect(vm.Status.VolumeSnapshotStatuses).To(HaveLen(2))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[1].Enabled).To(BeFalse())
 						updateCalled = true
@@ -1469,7 +1469,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					Do(func(objs ...interface{}) {
 						vm := objs[0].(*v1.VirtualMachine)
 
-						Expect(len(vm.Status.VolumeSnapshotStatuses)).To(Equal(2))
+						Expect(vm.Status.VolumeSnapshotStatuses).To(HaveLen(2))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeTrue())
 						Expect(vm.Status.VolumeSnapshotStatuses[1].Enabled).To(BeTrue())
 						updateCalled = true
@@ -1674,7 +1674,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					Do(func(objs ...interface{}) {
 						vm := objs[0].(*v1.VirtualMachine)
 
-						Expect(len(vm.Status.VolumeSnapshotStatuses)).To(Equal(8))
+						Expect(vm.Status.VolumeSnapshotStatuses).To(HaveLen(8))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Name).To(Equal("disk1"))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeFalse())
@@ -1763,7 +1763,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					Do(func(objs ...interface{}) {
 						vm := objs[0].(*v1.VirtualMachine)
 
-						Expect(len(vm.Status.VolumeSnapshotStatuses)).To(Equal(1))
+						Expect(vm.Status.VolumeSnapshotStatuses).To(HaveLen(1))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeFalse())
 						updateCalled = true
 					})
@@ -1782,7 +1782,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					Do(func(objs ...interface{}) {
 						vm := objs[0].(*v1.VirtualMachine)
 
-						Expect(len(vm.Status.VolumeSnapshotStatuses)).To(Equal(1))
+						Expect(vm.Status.VolumeSnapshotStatuses).To(HaveLen(1))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeTrue())
 						updateCalled = true
 					})
@@ -1848,7 +1848,7 @@ var _ = Describe("Snapshot controlleer", func() {
 					Do(func(objs ...interface{}) {
 						vm := objs[0].(*v1.VirtualMachine)
 
-						Expect(len(vm.Status.VolumeSnapshotStatuses)).To(Equal(2))
+						Expect(vm.Status.VolumeSnapshotStatuses).To(HaveLen(2))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeTrue())
 						Expect(vm.Status.VolumeSnapshotStatuses[1].Enabled).To(BeTrue())
 						updateCalled = true


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
