### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in vmi test

### DIFF
--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -430,7 +430,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			res, err := controller.waitForFirstConsumerTemporaryPods(vmi, pod)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(res)).To(Equal(1))
+			Expect(res).To(HaveLen(1))
 		})
 
 		table.DescribeTable("VMI should handle doppleganger Pod status while DV is in WaitForFirstConsumer phase",
@@ -1178,7 +1178,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
 						Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
-					Expect(len(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps)).To(Equal(0))
+					Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).To(HaveLen(0))
 				}).Return(vmi, nil)
 			}
 
@@ -2133,7 +2133,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		table.DescribeTable("should calculate deleted volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []k8sv1.Volume) {
 			res := controller.getDeletedHotplugVolumes(hotplugPods, hotplugVolumes)
-			Expect(len(res)).To(Equal(len(expected)))
+			Expect(res).To(HaveLen(len(expected)))
 			for i, volume := range res {
 				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
 			}
@@ -2145,7 +2145,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		table.DescribeTable("should calculate new volumes based on current pods and volumes", func(hotplugPods []*k8sv1.Pod, hotplugVolumes []*virtv1.Volume, expected []*virtv1.Volume) {
 			res := controller.getNewHotplugVolumes(hotplugPods, hotplugVolumes)
-			Expect(len(res)).To(Equal(len(expected)))
+			Expect(res).To(HaveLen(len(expected)))
 			for i, volume := range res {
 				Expect(equality.Semantic.DeepEqual(volume, expected[i])).To(BeTrue(), "%v does not match %v", volume, expected[i])
 			}
@@ -2295,7 +2295,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			res, err := kvcontroller.AttachmentPods(virtlauncherPod, podInformer)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(res)).To(Equal(podCount))
+			Expect(res).To(HaveLen(podCount))
 		},
 			table.Entry("should return number (0) of pods passed in", 0),
 			table.Entry("should return number (1) of pods passed in", 1),
@@ -2310,7 +2310,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			virtlauncherPod.Spec.Volumes = virtlauncherVolumes
 			res := getHotplugVolumes(vmi, virtlauncherPod)
-			Expect(len(res)).To(Equal(len(expectedIndexes)))
+			Expect(res).To(HaveLen(len(expectedIndexes)))
 			for _, index := range expectedIndexes {
 				found := false
 				for _, volume := range res {


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
