### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in client test 

### DIFF
--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Virt remote commands", func() {
 			// listing all sockets should detect both the new and legacy sockets
 			sockets, err := ListAllSockets()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(sockets)).To(Equal(2))
+			Expect(sockets).To(HaveLen(2))
 		})
 
 		It("Detect unresponsive socket", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
