### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in mount test

### DIFF
--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -137,7 +137,7 @@ var _ = Describe("ContainerDisk", func() {
 			// verify we can read a result
 			record, err = m.getMountTargetRecord(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(record.MountTargetEntries)).To(Equal(1))
+			Expect(record.MountTargetEntries).To(HaveLen(1))
 			Expect(record.MountTargetEntries[0].TargetFile).To(Equal("sometargetfile"))
 			Expect(record.MountTargetEntries[0].SocketFile).To(Equal("somesocketfile"))
 
@@ -146,7 +146,7 @@ var _ = Describe("ContainerDisk", func() {
 			delete(m.mountRecords, vmi.UID)
 			record, err = m.getMountTargetRecord(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(record.MountTargetEntries)).To(Equal(1))
+			Expect(record.MountTargetEntries).To(HaveLen(1))
 			Expect(record.MountTargetEntries[0].TargetFile).To(Equal("sometargetfile"))
 			Expect(record.MountTargetEntries[0].SocketFile).To(Equal("somesocketfile"))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
