### PR TITLE
[Code Cleaning]: Use "HaveLen()" instead of "len(...).To(Equal(..)" in mediated device types test

### DIFF
--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			// in cases where multiple mdev types are required to be configured but the amount of cards is significantly lower
 			// it will be hard to estimate which of the requested types will be created. Simply check that amount of created types matches the avaiable cards.
 			if len(sc.expectedConfiguredTypes) == 1 && sc.expectedConfiguredTypes[0] == "ANY" {
-				Expect(len(configuredMdevTypesOnCards)).To(Equal(len(sc.pciMDEVDevicesMap)))
+				Expect(configuredMdevTypesOnCards).To(HaveLen(len(sc.pciMDEVDevicesMap)))
 			} else {
 				for mdevType, _ := range mdevTypesDetailsMap {
 					numberOfCreatedMDEVs := countCreatedMdevs(mdevType)
@@ -412,7 +412,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			// in cases where multiple mdev types are required to be configured but the amount of cards is significantly lower
 			// it will be hard to estimate which of the requested types will be created. Simply check that amount of created types matches the avaiable cards.
 			if len(sc.expectedConfiguredTypes) == 1 && sc.expectedConfiguredTypes[0] == "ANY" {
-				Expect(len(configuredMdevTypesOnCards)).To(Equal(len(sc.pciMDEVDevicesMap)))
+				Expect(configuredMdevTypesOnCards).To(HaveLen(len(sc.pciMDEVDevicesMap)))
 			} else {
 				for mdevType, _ := range mdevTypesDetailsMap {
 					numberOfCreatedMDEVs := countCreatedMdevs(mdevType)


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR replaces all appearences of `Expect(len(X)).To(Equal(Y))` to `Expect(X).To(HaveLen(Y))` for better readability and error presentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
