### PR TITLE
cloud-init, test: replace `Expect(len(..).To(Equal(..))` with `Expect(..).To(HaveLen(..))`

### DIFF
--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -535,14 +535,14 @@ var _ = Describe("CloudInit", func() {
 						Expect(err).To(Not(HaveOccurred()), "could not resolve secret volume")
 						Expect(testVolume.CloudInitConfigDrive.UserData).To(Equal("secret-userdata"))
 						Expect(testVolume.CloudInitConfigDrive.NetworkData).To(Equal("secret-networkdata"))
-						Expect(len(keys)).To(Equal(2))
+						Expect(keys).To(HaveLen(2))
 					})
 
 					It("should resolve empty config-drive volume and do nothing", func() {
 						vmi := createEmptyVMIWithVolumes([]v1.Volume{})
 						keys, err := resolveConfigDriveSecrets(vmi, tmpDir)
 						Expect(err).To(Not(HaveOccurred()), "failed to resolve empty volumes")
-						Expect(len(keys)).To(Equal(0))
+						Expect(keys).To(BeEmpty())
 					})
 
 					It("should fail if both userdata and network data does not exist", func() {
@@ -551,7 +551,7 @@ var _ = Describe("CloudInit", func() {
 						keys, err := resolveConfigDriveSecrets(vmi, tmpDir)
 						Expect(err).To(HaveOccurred(), "expected a failure when no sources found")
 						Expect(err.Error()).To(Equal("no cloud-init data-source found at volume: test-volume"))
-						Expect(len(keys)).To(Equal(0))
+						Expect(keys).To(BeEmpty())
 
 					})
 				})


### PR DESCRIPTION
Replace occurrences of `Expect(len($VAR)).To(Equal($X))` with
`Expect($VAR).To(HaveLen($X)` which is more gomega-idiomatic and gives
better error messages when the expectation fails.

Use the `BeEmpty()` matcher where the expected len is 0.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
