### PR TITLE
tests: Use DefaultInterfaceName const instead of "default" literal

### DIFF
--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -44,7 +44,7 @@ func WithNetwork(network *kvirtv1.Network) Option {
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
 func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
-		Name: "default",
+		Name: DefaultInterfaceName,
 		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
 			Masquerade: &kvirtv1.InterfaceMasquerade{},
 		},


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use constant `DefaultInterfaceName` that is already defined, instead of "default" literal
for default masquerade interface factory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
