### PR TITLE
container-disk, test: replace `Expect(len(..).To(Equal(..))` with `Expect(..).To(HaveLen(..))`

### DIFF
--- a/pkg/container-disk/container-disk_test.go
+++ b/pkg/container-disk/container-disk_test.go
@@ -218,7 +218,7 @@ var _ = Describe("ContainerDisk", func() {
 				containers := GenerateContainers(vmi, nil, "libvirt-runtime", "bin-volume")
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(containers)).To(Equal(2))
+				Expect(containers).To(HaveLen(2))
 				Expect(containers[0].ImagePullPolicy).To(Equal(k8sv1.PullAlways))
 				Expect(containers[1].ImagePullPolicy).To(Equal(k8sv1.PullAlways))
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replace occurrences of `Expect(len($VAR)).To(Equal($X))` with
`Expect($VAR).To(HaveLen($X)` which is more gomega-idiomatic and gives
better error messages when the expectation fails.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
