### PR TITLE
conditions, test: replace `Expect(len(..).To(Equal(..))` with `Expect(..).To(HaveLen(..))`

### DIFF
--- a/pkg/controller/conditions_test.go
+++ b/pkg/controller/conditions_test.go
@@ -67,7 +67,7 @@ var _ = Describe("VirtualMachineInstance ConditionManager", func() {
 			It("should only have 1 condition", func() {
 				cm.AddPodCondition(vmi, pc1)
 				cm.AddPodCondition(vmi, pc2)
-				Expect(len(vmi.Status.Conditions)).To(Equal(1))
+				Expect(vmi.Status.Conditions).To(HaveLen(1))
 			})
 		})
 	})
@@ -100,7 +100,7 @@ var _ = Describe("VirtualMachineInstance ConditionManager", func() {
 			}
 
 			cm.UpdateCondition(vmi, vc2)
-			Expect(len(vmi.Status.Conditions)).To(Equal(1))
+			Expect(vmi.Status.Conditions).To(HaveLen(1))
 			Expect(cm.GetCondition(vmi, vc1.Type)).To(Equal(vc2))
 		})
 
@@ -113,7 +113,7 @@ var _ = Describe("VirtualMachineInstance ConditionManager", func() {
 			}
 
 			cm.UpdateCondition(vmi, vc2)
-			Expect(len(vmi.Status.Conditions)).To(Equal(1))
+			Expect(vmi.Status.Conditions).To(HaveLen(1))
 			Expect(cm.GetCondition(vmi, vc1.Type)).To(Equal(vc2))
 		})
 
@@ -126,7 +126,7 @@ var _ = Describe("VirtualMachineInstance ConditionManager", func() {
 			}
 
 			cm.UpdateCondition(vmi, vc2)
-			Expect(len(vmi.Status.Conditions)).To(Equal(1))
+			Expect(vmi.Status.Conditions).To(HaveLen(1))
 			Expect(cm.GetCondition(vmi, vc1.Type)).To(Equal(vc1))
 		})
 	})


### PR DESCRIPTION
Replace occurrences of `Expect(len($VAR)).To(Equal($X))` with
`Expect($VAR).To(HaveLen($X)` which is more gomega-idiomatic and gives
better error messages when the expectation fails.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
