### PR TITLE
Scale virt-api deployment replicas according to number of nodes

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -289,6 +289,11 @@ func (k *KubeVirtTestData) BeforeTest() {
 		if action.GetVerb() == "get" && action.GetResource().Resource == "configmaps" {
 			return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmaps"}, "whatever")
 		}
+		if action.GetVerb() == "list" && action.GetResource().Resource == "nodes" {
+			dummyNode := k8sv1.Node{}
+			nodeList := &k8sv1.NodeList{Items: []k8sv1.Node{dummyNode, *dummyNode.DeepCopy(), *dummyNode.DeepCopy()}}
+			return true, nodeList, nil
+		}
 		if action.GetVerb() != "get" || action.GetResource().Resource != "namespaces" {
 			Expect(action).To(BeNil())
 		}

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -231,6 +231,7 @@ go_test(
         "//tests/performance:go_default_library",
         "//tests/realtime:go_default_library",
         "//tests/reporter:go_default_library",
+        "//tests/scale:go_default_library",
         "//tests/storage:go_default_library",
         "//tests/util:go_default_library",
         "//tools/vms-generator/utils:go_default_library",

--- a/tests/scale/BUILD.bazel
+++ b/tests/scale/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["virt-api.go"],
+    importpath = "kubevirt.io/kubevirt/tests/scale",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-operator/resource/generate/components:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -27,6 +27,11 @@ var _ = Describe("[sig-compute] virt-api scaling", func() {
 	})
 
 	calcExpectedReplicas := func(nodesCount int) (expectedReplicas int32) {
+		// Please note that this logic is temporary. For more information take a look on the comment in
+		// getDesiredApiReplicas() function in pkg/virt-operator/resource/apply/apps.go.
+		//
+		// When the logic is replaced for getDesiredApiReplicas(), it needs to be replaced here as well.
+
 		if nodesCount == 1 {
 			return 1
 		}

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -1,0 +1,66 @@
+package scale
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = Describe("[sig-compute] virt-api scaling", func() {
+
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+		tests.BeforeTestCleanup()
+	})
+
+	calcExpectedReplicas := func(nodesCount int) (expectedReplicas int32) {
+		if nodesCount == 1 {
+			return 1
+		}
+
+		const minReplicas = 2
+
+		expectedReplicas = int32(nodesCount) / 10
+		if expectedReplicas < minReplicas {
+			expectedReplicas = minReplicas
+		}
+
+		return expectedReplicas
+	}
+
+	It("virt-api replicas should be scaled as expected", func() {
+		By("Finding out nodes count")
+		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		numberOfNodes := len(nodes.Items)
+
+		Eventually(func() int32 {
+			By("Finding out virt-api replica number")
+			kv := util.GetCurrentKv(virtClient)
+			Expect(kv).ToNot(BeNil())
+
+			apiDeployment, err := virtClient.AppsV1().Deployments(kv.GetNamespace()).Get(context.Background(), components.VirtAPIName, v1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Expecting number of replicas to be as expected")
+			Expect(apiDeployment.Spec.Replicas).ToNot(BeNil())
+
+			return *apiDeployment.Spec.Replicas
+		}, 1*time.Minute, 5*time.Second).Should(Equal(calcExpectedReplicas(numberOfNodes)), "number of virt API should be as expected")
+	})
+
+})

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -44,6 +44,7 @@ import (
 	_ "kubevirt.io/kubevirt/tests/numa"
 	_ "kubevirt.io/kubevirt/tests/performance"
 	_ "kubevirt.io/kubevirt/tests/realtime"
+	_ "kubevirt.io/kubevirt/tests/scale"
 	_ "kubevirt.io/kubevirt/tests/storage"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Today Kubevirt has severe scalability issues that are caused by the bounded number of replicas for our component.

For example, an experiment was recently made where Kubevirt was deployed over a 100 nodes cluster with 500 VMs that were created at once. Kubevirt got stuck and the main bottle-neck seemed to be virt-api. With 10 replicas everything worked like a charm. This makes sense, as today the number of replicas is hardcoded to 2, but 2 replicas is not enough for a load caused by a huge cluster.

Several alternatives were discussed in [this issue](https://github.com/kubevirt/kubevirt/issues/7101), and the conclusions are:
- **In the short term** we should be scalable. This should be achieved immediately. To achieve this we can start with a very simple heuristic to determine the number of replicas.
- **In the long term** we should investigate further to find the bottlenecks and different scaling solutions (e.g. [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)), then use a more sophisticated way to determine the number of replicas. We should also extend this research to all of Kubevirt's components, not just virt-api.

This PR aims to fulfil the **short term** goal from above. For more info, please look at the relevant issue linked below.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Issue for scaling virt-api: https://github.com/kubevirt/kubevirt/issues/7101

**Special notes for your reviewer**:
I've used an API call during deployment reconciliation to determine nodes count on the cluster. I did so because I saw there is no node informer / cache defined. Do you think we should introduce a new informer for nodes instead?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-api deployment is now scalable - replicas are determined by the number of nodes in the cluster
```
