### PR TITLE
tests/utils: drop public constant TempDirPrefix

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1018,8 +1018,7 @@ spec:
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
 
-		workDir, err = ioutil.TempDir("", tests.TempDirPrefix+"-")
-		Expect(err).ToNot(HaveOccurred())
+		workDir = GinkgoT().TempDir()
 
 		vmYamls = make(map[string]*vmYamlDefinition)
 
@@ -1044,12 +1043,6 @@ spec:
 		By("Waiting for original KV to stabilize")
 		waitForKvWithTimeout(originalKv, 420)
 		allPodsAreReady(originalKv)
-
-		if workDir != "" {
-			err = os.RemoveAll(workDir)
-			workDir = ""
-			Expect(err).ToNot(HaveOccurred())
-		}
 
 		// repost original CDI object if it doesn't still exist
 		// in order to restore original environment

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -22,9 +22,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
 	"strings"
 	"time"
 
@@ -578,7 +576,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 	Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl", func() {
 		var vm *v1.VirtualMachine
 		var err error
-		var workDir string
 		var vmJson string
 		var dataVolumeName string
 		var pvcName string
@@ -594,18 +591,9 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
 			pvcName = dataVolumeName
 
-			workDir, err := ioutil.TempDir("", tests.TempDirPrefix+"-")
-			Expect(err).ToNot(HaveOccurred())
+			workDir := GinkgoT().TempDir()
 			vmJson, err = tests.GenerateVMJson(vm, workDir)
 			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			if workDir != "" {
-				err = os.RemoveAll(workDir)
-				Expect(err).ToNot(HaveOccurred())
-				workDir = ""
-			}
 		})
 
 		It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", func() {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -591,8 +591,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
 			pvcName = dataVolumeName
 
-			workDir := GinkgoT().TempDir()
-			vmJson, err = tests.GenerateVMJson(vm, workDir)
+			vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -71,16 +70,7 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 		SetDefaultEventuallyTimeout(120 * time.Second)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
-		workDir, err = ioutil.TempDir("", tests.TempDirPrefix+"-")
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if workDir != "" {
-			err := os.RemoveAll(workDir)
-			Expect(err).ToNot(HaveOccurred())
-			workDir = ""
-		}
+		workDir = GinkgoT().TempDir()
 	})
 
 	Describe("Creating VM from Template", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -142,8 +142,6 @@ var Arch string
 
 type EventType string
 
-const TempDirPrefix = "kubevirt-test"
-
 const (
 	defaultEventuallyTimeout         = 5 * time.Second
 	defaultEventuallyPollingInterval = 1 * time.Second

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -22,9 +22,7 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1805,19 +1803,10 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		BeforeEach(func() {
 			k8sClient = tests.GetK8sCmdClient()
 			tests.SkipIfNoCmd(k8sClient)
-			workDir, err = ioutil.TempDir("", tests.TempDirPrefix+"-")
-			Expect(err).ToNot(HaveOccurred())
+			workDir = GinkgoT().TempDir()
 
 			// By default "." does not match newline: "Phase" and "Running" only match if on same line.
 			vmRunningRe = regexp.MustCompile("Phase.*Running")
-		})
-
-		AfterEach(func() {
-			if workDir != "" {
-				err = os.RemoveAll(workDir)
-				Expect(err).ToNot(HaveOccurred())
-				workDir = ""
-			}
 		})
 
 		It("[test_id:243][posneg:negative]should create VM only once", func() {

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -22,9 +22,7 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -310,22 +308,12 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	})
 
 	Context("[ref_id:142]with kubectl command", func() {
-		var workDir string
 		var yamlFile string
 		BeforeEach(func() {
 			tests.SkipIfNoCmd("kubectl")
-			workDir, err = ioutil.TempDir("", tests.TempDirPrefix+"-")
-			Expect(err).ToNot(HaveOccurred())
+			workDir := GinkgoT().TempDir()
 			yamlFile, err = tests.GenerateVMIJson(windowsVMI, workDir)
 			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			if workDir != "" {
-				err = os.RemoveAll(workDir)
-				Expect(err).ToNot(HaveOccurred())
-				workDir = ""
-			}
 		})
 
 		It("[test_id:223]should succeed to start a vmi", func() {

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -311,8 +311,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		var yamlFile string
 		BeforeEach(func() {
 			tests.SkipIfNoCmd("kubectl")
-			workDir := GinkgoT().TempDir()
-			yamlFile, err = tests.GenerateVMIJson(windowsVMI, workDir)
+			yamlFile, err = tests.GenerateVMIJson(windowsVMI, GinkgoT().TempDir())
 			Expect(err).ToNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
Thanks to our recent adoption of Ginkgo2, we can now use `GinkgoT().TempDir()` instead of defining our own temp dir creation and deletion code.

~~Several of our tests create a work dir on the machine executing the functional tests for their temporary files. The directory are named kubevirt-test-* so it is clear to the machine owner what has created them.~~

~~None of the tests care about the precise name of the directory, they just need to create it. Therefore, it is cleaner to expose a function that creates the directory and hide the constant name prefix.~~


```release-note
NONE
```
