### PR TITLE
replace gomega `Equal(nil)` matchers, with `BeNil()`

### DIFF
--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(exists).To(BeTrue())
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(domain.ObjectMeta.Name).To(Equal("testvmi1"))
 			Expect(domain.Status.OSInfo).To(Equal(api.GuestOSInfo{}))
 			Expect(domain.Status.Interfaces).To(BeNil())
@@ -190,7 +190,7 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(exists).To(BeFalse())
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 		})
 
 		It("client should return disconnected after server stops", func() {
@@ -224,7 +224,7 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(exists).To(BeTrue())
-			Expect(domStats).ToNot(Equal(nil))
+			Expect(domStats).ToNot(BeNil())
 			Expect(domStats.Name).To(Equal(list[0].Name))
 			Expect(domStats.UUID).To(Equal(list[0].UUID))
 		})

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2032,7 +2032,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
 		})
 		It("Should create two network configuration for slirp device", func() {
@@ -2054,7 +2054,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface1, iface2}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(4))
 		})
 		It("Should create two network configuration one for slirp device and one for bridge device", func() {
@@ -2076,7 +2076,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*iface1, iface2}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
 			Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(2))
 			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
@@ -2116,7 +2116,7 @@ var _ = Describe("Converter", func() {
 			}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(3))
 			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
 			Expect(domain.Spec.Devices.Interfaces[1].Type).To(Equal("ethernet"))
@@ -2146,7 +2146,7 @@ var _ = Describe("Converter", func() {
 			}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
 			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
 			Expect(domain.Spec.Devices.Interfaces[1].Type).To(Equal("ethernet"))
@@ -2168,7 +2168,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*iface1, *iface2}
 			vmi.Spec.Networks = []v1.Network{*net1, *net2}
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
 			Expect(domain.Spec.Devices.Interfaces[0].BootOrder).NotTo(BeNil())
 			Expect(domain.Spec.Devices.Interfaces[0].BootOrder.Order).To(Equal(uint(bootOrder)))
@@ -2187,7 +2187,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(1))
 			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
 		})
@@ -2212,7 +2212,7 @@ var _ = Describe("Converter", func() {
 				}}
 
 			domain := vmiToDomain(vmi, c)
-			Expect(domain).ToNot(Equal(nil))
+			Expect(domain).ToNot(BeNil())
 			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
 			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
 			Expect(domain.Spec.Devices.Interfaces[1].Type).To(Equal("ethernet"))

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2442,7 +2442,7 @@ var _ = Describe("Manager helper functions", func() {
 			size, ok := possibleGuestSize(properDisk)
 			Expect(ok).To(BeTrue())
 			capacity := properDisk.Capacity
-			Expect(capacity).ToNot(Equal(nil))
+			Expect(capacity).ToNot(BeNil())
 
 			expectedSize := int64((1 - fakePercentFloat) * float64(*capacity))
 			// The size is expected to be 1MiB-aligned

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -113,7 +113,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 				}
 			}
 			Expect(container.Name).ToNot(Equal(""))
-			Expect(container.Ports).ToNot(Equal(nil))
+			Expect(container.Ports).ToNot(BeNil())
 			Expect(container.Ports[0].Name).To(Equal("http"))
 			Expect(container.Ports[0].Protocol).To(Equal(k8sv1.Protocol("TCP")))
 			Expect(container.Ports[0].ContainerPort).To(Equal(int32(80)))


### PR DESCRIPTION
Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

replace the wrong `Equal(nil)` matchers, with the gomega dedicated `BeNil()`, to get better readability.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
