### PR TITLE
tests: Avoid Expect(len())

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2848,8 +2848,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret + DownwardAPI + External Kernel Boot", func() {
 			vmi := prepareVMIWithAllVolumeSources()
 
-			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(6))
-			Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
+			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(6))
+			Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
 
 			vmi = runVMIAndExpectLaunch(vmi, 180)
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -523,8 +523,8 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 			image = daemonSet.Spec.Template.Spec.Containers[0].Image
 			imageRegEx := regexp.MustCompile(fmt.Sprintf("%s%s%s", `^(.*)/(.*)`, name, `([@:].*)?$`))
 			matches := imageRegEx.FindAllStringSubmatch(image, 1)
-			Expect(len(matches)).To(Equal(1))
-			Expect(len(matches[0])).To(Equal(4))
+			Expect(matches).To(HaveLen(1))
+			Expect(matches[0]).To(HaveLen(4))
 			registry = matches[0][1]
 			imagePrefix = matches[0][2]
 			version = matches[0][3]
@@ -534,8 +534,8 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		parseImage = func(name, image string) (registry, imagePrefix, version string) {
 			imageRegEx := regexp.MustCompile(fmt.Sprintf("%s%s%s", `^(.*)/(.*)`, name, `([@:].*)?$`))
 			matches := imageRegEx.FindAllStringSubmatch(image, 1)
-			Expect(len(matches)).To(Equal(1))
-			Expect(len(matches[0])).To(Equal(4))
+			Expect(matches).To(HaveLen(1))
+			Expect(matches[0]).To(HaveLen(4))
 			registry = matches[0][1]
 			imagePrefix = matches[0][2]
 			version = matches[0][3]
@@ -690,7 +690,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 		if tests.HasDataVolumeCRD() {
 			cdiList, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(cdiList.Items)).To(Equal(1))
+			Expect(cdiList.Items).To(HaveLen(1))
 
 			originalCDI = &cdiList.Items[0]
 		}
@@ -1341,7 +1341,7 @@ spec:
 			labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
 			pods, err := virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 			Expect(err).ToNot(HaveOccurred(), "Should list pods")
-			Expect(len(pods.Items)).To(Equal(1))
+			Expect(pods.Items).To(HaveLen(1))
 			Expect(usesSha(pods.Items[0].Spec.Containers[0].Image)).To(BeTrue(), "launcher pod should use shasum")
 
 		})
@@ -2193,7 +2193,7 @@ spec:
 				labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
 				pods, err = virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 				Expect(err).ToNot(HaveOccurred(), "Should get virt-launcher")
-				Expect(len(pods.Items)).To(Equal(1))
+				Expect(pods.Items).To(HaveLen(1))
 				Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
 					Equal("kubevirt-controller"), "Should virt-launcher be assigned to kubevirt-controller SCC",
 				)

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -96,9 +96,9 @@ var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", 
 			&expect.BExp{R: console.RetValue("[0-9]+")},
 		}, int(5+cyclicTestDurationInSeconds))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(res)).To(Equal(1))
+		Expect(res).To(HaveLen(1))
 		sout := strings.Split(res[0].Output, "\r\n")
-		Expect(len(sout)).To(Equal(3))
+		Expect(sout).To(HaveLen(3))
 		max, err := strconv.ParseInt(sout[1], 10, 64)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(max).NotTo(BeNumerically(">", realtimeThreshold), fmt.Sprintf("Maximum CPU latency of %d is greater than threshold %d", max, realtimeThreshold))

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -316,7 +316,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		vms, err := virtClient.VirtualMachine(newPool.ObjectMeta.Namespace).List(&v12.ListOptions{})
 
 		Expect(err).To(BeNil())
-		Expect(len(vms.Items)).To(Equal(1))
+		Expect(vms.Items).To(HaveLen(1))
 
 		name := vms.Items[0].Name
 		vmi, err := virtClient.VirtualMachineInstance(newPool.Namespace).Get(name, &metav1.GetOptions{})
@@ -369,7 +369,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		vms, err := virtClient.VirtualMachine(newPool.ObjectMeta.Namespace).List(&v12.ListOptions{})
 
 		Expect(err).To(BeNil())
-		Expect(len(vms.Items)).To(Equal(1))
+		Expect(vms.Items).To(HaveLen(1))
 
 		name := vms.Items[0].Name
 		vmi, err := virtClient.VirtualMachineInstance(newPool.Namespace).Get(name, &metav1.GetOptions{})

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -93,7 +93,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
-		Expect(len(slice)).To(Equal(2))
+		Expect(slice).To(HaveLen(2))
 		for _, l := range slice {
 			Expect(parsePriority(l)).To(BeEquivalentTo(1))
 		}
@@ -135,7 +135,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
-		Expect(len(slice)).To(Equal(1))
+		Expect(slice).To(HaveLen(1))
 		Expect(parsePriority(slice[0])).To(BeEquivalentTo(1))
 
 		By("Validating the VCPU mask matches the scheduler profile for all cores")
@@ -147,7 +147,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		slice = strings.Split(strings.TrimSpace(psOutput), "\n")
-		Expect(len(slice)).To(Equal(2))
+		Expect(slice).To(HaveLen(2))
 		Expect(slice[0]).To(Equal("FF 0/KVM"))
 		Expect(slice[1]).To(Equal("TS 1/KVM"))
 
@@ -162,7 +162,7 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 
 func parsePriority(psLine string) int64 {
 	s := strings.Split(psLine, " ")
-	Expect(len(s)).To(Equal(1))
+	Expect(s).To(HaveLen(1))
 	prio, err := strconv.ParseInt(s[0], 10, 8)
 	Expect(err).NotTo(HaveOccurred())
 	return prio

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -210,7 +210,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		err = json.Unmarshal(body, reviewResponse)
 		Expect(err).To(BeNil())
 
-		Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
+		Expect(reviewResponse.Details.Causes).To(HaveLen(1))
 		Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].name"))
 	})
 	It("[test_id:1413]should update readyReplicas once VMIs are up", func() {
@@ -383,7 +383,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		vmi := vmis.Items[0]
 		pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(&vmi))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(pods.Items)).To(Equal(1))
+		Expect(pods.Items).To(HaveLen(1))
 		pod := pods.Items[0]
 
 		By("Deleting one of the RS VMS pods")
@@ -430,7 +430,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		vmi := &vmis.Items[0]
 		pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(pods.Items)).To(Equal(1))
+		Expect(pods.Items).To(HaveLen(1))
 		pod := pods.Items[0]
 
 		By("Deleting one of the RS VMS pods, which will take some time to really stop the VMI")

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -131,7 +131,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				Expect(strings.Split(qemuProcessSelinuxContext, ":")[2]).To(Equal("container_t"))
 
 				By("Checking that qemu-kvm process has SELinux category_set")
-				Expect(len(strings.Split(qemuProcessSelinuxContext, ":"))).To(Equal(5))
+				Expect(strings.Split(qemuProcessSelinuxContext, ":")).To(HaveLen(5))
 
 				err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -239,10 +239,10 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 			}
 			caps := *container.SecurityContext.Capabilities
 			if checks.HasFeature(virtconfig.NonRoot) {
-				Expect(len(caps.Add)).To(Equal(1), fmt.Sprintf("Expecting to found \"NET_BIND_SERVICE\". Found capabilities %s", caps.Add))
+				Expect(caps.Add).To(HaveLen(1), fmt.Sprintf("Expecting to found \"NET_BIND_SERVICE\". Found capabilities %s", caps.Add))
 				Expect(caps.Add[0]).To(Equal(k8sv1.Capability("NET_BIND_SERVICE")))
 			} else {
-				Expect(len(caps.Add)).To(Equal(2), fmt.Sprintf("Found capabilities %s, expecting SYS_NICE and NET_BIND_SERVICE ", caps.Add))
+				Expect(caps.Add).To(HaveLen(2), fmt.Sprintf("Found capabilities %s, expecting SYS_NICE and NET_BIND_SERVICE ", caps.Add))
 				Expect(caps.Add).To(ContainElements(k8sv1.Capability("NET_BIND_SERVICE"), k8sv1.Capability("SYS_NICE")))
 			}
 
@@ -251,7 +251,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				Expect(tests.IsLauncherCapabilityValid(cap)).To(BeTrue(), "Expected compute container of virt_launcher to be granted only specific capabilities")
 			}
 			By("Checking virt-launcher Pod's compute container has precisely the documented dropped capabilities")
-			Expect(len(caps.Drop)).To(Equal(1))
+			Expect(caps.Drop).To(HaveLen(1))
 			for _, cap := range caps.Drop {
 				Expect(tests.IsLauncherCapabilityDropped(cap)).To(BeTrue(), "Expected compute container of virt_launcher to drop only specific capabilities")
 			}

--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -144,7 +144,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					// 2. Capabilities can change over time which means the message would be different then the one hardcoded, correct nonetheless.
 					// I'm keeping the helloMessageRemote to have a proof of working example that could also be used if needed.
 					Expect(response).ToNot(BeEmpty(), "response should not be empty")
-					Expect(len(response)).To(Equal(len(helloMessageRemote)))
+					Expect(response).To(HaveLen(len(helloMessageRemote)))
 				case err = <-k8ResChan:
 					Expect(err).ToNot(HaveOccurred())
 				case <-time.After(45 * time.Second):

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -121,7 +121,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			err = json.Unmarshal(body, reviewResponse)
 			Expect(err).To(BeNil())
 
-			Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
+			Expect(reviewResponse.Details.Causes).To(HaveLen(1))
 			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].name"))
 		})
 	})
@@ -521,7 +521,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Getting the pod backing the VirtualMachineInstance")
 			pods, err := virtClient.CoreV1().Pods(newVM.Namespace).List(context.Background(), tests.UnfinishedVMIPodSelector(firstVMI))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(pods.Items)).To(Equal(1))
+			Expect(pods.Items).To(HaveLen(1))
 			firstPod := pods.Items[0]
 
 			// Delete the Pod
@@ -551,7 +551,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Verifying a new pod backs the VMI")
 			pods, err = virtClient.CoreV1().Pods(newVM.Namespace).List(context.Background(), tests.UnfinishedVMIPodSelector(curVMI))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(pods.Items)).To(Equal(1))
+			Expect(pods.Items).To(HaveLen(1))
 			pod := pods.Items[0]
 			Expect(pod.Name).ToNot(Equal(firstPod.Name))
 		})
@@ -1101,7 +1101,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred())
 					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
 					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyHalted))
-					Expect(len(newVM.Status.StateChangeRequests)).To(Equal(0))
+					Expect(newVM.Status.StateChangeRequests).To(HaveLen(0))
 				})
 
 				It("[test_id:3164]should restart a running VM", func() {
@@ -1280,7 +1280,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
 					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyHalted))
 					By("Ensuring stateChangeRequests list is cleared")
-					Expect(len(newVM.Status.StateChangeRequests)).To(Equal(0))
+					Expect(newVM.Status.StateChangeRequests).To(HaveLen(0))
 				})
 
 				It("[test_id:2187] should restart a running VM", func() {
@@ -1408,7 +1408,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
 					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyAlways))
 					By("Ensuring stateChangeRequests list is cleared")
-					Expect(len(newVM.Status.StateChangeRequests)).To(Equal(0))
+					Expect(newVM.Status.StateChangeRequests).To(HaveLen(0))
 				})
 			})
 
@@ -1516,7 +1516,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
 					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyManual))
 					By("Ensuring stateChangeRequests list is cleared")
-					Expect(len(newVM.Status.StateChangeRequests)).To(Equal(0))
+					Expect(newVM.Status.StateChangeRequests).To(HaveLen(0))
 				})
 
 				It("[test_id:2189] should stop", func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1009,7 +1009,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				// https://github.com/kubernetes/kubernetes/issues/64691
 				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(pods.Items)).To(Equal(1))
+				Expect(pods.Items).To(HaveLen(1))
 
 				hugepagesSize := resource.MustParse(hugepagesVmi.Spec.Domain.Memory.Hugepages.PageSize)
 				hugepagesDir := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%dkB", hugepagesSize.Value()/int64(1024))
@@ -1955,7 +1955,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			disks := runningVMISpec.Devices.Disks
 			By("checking if number of attached disks is equal to real disks number")
-			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
+			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
 			cacheNone := string(v1.CacheNone)
 			cacheWritethrough := string(v1.CacheWriteThrough)
@@ -2012,7 +2012,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			disks := runningVMISpec.Devices.Disks
 			By("checking if number of attached disks is equal to real disks number")
-			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
+			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
 			ioNative := v1.IONative
 			ioThreads := v1.IOThreads
@@ -2075,7 +2075,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			By("checking if number of attached disks is equal to real disks number")
 			disks := runningVMISpec.Devices.Disks
-			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
+			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
 			By("checking if BlockIO is set to the custom block size")
 			Expect(disks[0].Alias.GetName()).To(Equal("disk0"))
@@ -2107,7 +2107,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			By("checking if number of attached disks is equal to real disks number")
 			disks := runningVMISpec.Devices.Disks
-			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
+			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
 			By("checking if BlockIO is set for the disk")
 			Expect(disks[0].Alias.GetName()).To(Equal("disk0"))
@@ -2155,7 +2155,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			By("checking if number of attached disks is equal to real disks number")
 			disks := runningVMISpec.Devices.Disks
-			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
+			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
 			By("checking if BlockIO is set for the disk")
 			Expect(disks[0].Alias.GetName()).To(Equal("host-disk"))
@@ -2354,7 +2354,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				pinnedCPUsList, err := hw_utils.ParseCPUSetLine(output, 100)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(len(pinnedCPUsList)).To(Equal(int(cpuVmi.Spec.Domain.CPU.Cores)))
+				Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores)))
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
@@ -2470,7 +2470,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// 1 additioan pcpus should be allocated on the pod for the emulation threads
-				Expect(len(pinnedCPUsList)).To(Equal(int(cpuVmi.Spec.Domain.CPU.Cores) + 1))
+				Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores) + 1))
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -128,7 +128,7 @@ var _ = Describe("[Serial][sig-compute]GPU", func() {
 			Expect(err).ToNot(HaveOccurred())
 			addrList := parseDeviceAddress(gpuOutput)
 
-			Expect(len(addrList)).To(Equal(len(domSpec.Devices.HostDevices)))
+			Expect(addrList).To(HaveLen(len(domSpec.Devices.HostDevices)))
 			for n, addr := range addrList {
 				Expect(domSpec.Devices.HostDevices[n].Type).To(Equal("pci"))
 				Expect(domSpec.Devices.HostDevices[n].Managed).To(Equal("yes"))

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -87,7 +87,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			expectedIOThreads := 1
 			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
 
-			Expect(len(newVMI.Spec.Domain.Devices.Disks)).To(Equal(1))
+			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(1))
 		})
 
 		It("[test_id:864][ref_id:2065] Should honor a mix of shared and dedicated ioThreadsPolicy", func() {
@@ -124,7 +124,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
 
 			By("Ensuring there are the expected number of disks")
-			Expect(len(newVMI.Spec.Domain.Devices.Disks)).To(Equal(len(vmi.Spec.Domain.Devices.Disks)))
+			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(len(vmi.Spec.Domain.Devices.Disks)))
 
 			By("Verifying the ioThread mapping for disks")
 			disk0, err := getDiskByName(domSpec, "disk0")
@@ -184,7 +184,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
 
 			By("Ensuring there are the expected number of disks")
-			Expect(len(newVMI.Spec.Domain.Devices.Disks)).To(Equal(len(vmi.Spec.Domain.Devices.Disks)))
+			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(len(vmi.Spec.Domain.Devices.Disks)))
 
 			By("Verifying the ioThread mapping for disks")
 			disk0, err := getDiskByName(domSpec, "disk0")
@@ -268,7 +268,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
 
 			By("Ensuring there are the expected number of disks")
-			Expect(len(newVMI.Spec.Domain.Devices.Disks)).To(Equal(len(vmi.Spec.Domain.Devices.Disks)))
+			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(len(vmi.Spec.Domain.Devices.Disks)))
 
 			By("Verifying the ioThread mapping for disks")
 			disk0, err := getDiskByName(domSpec, "disk0")

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -116,7 +116,7 @@ func checkXMLSoundCard(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachine
 	Expect(err).ToNot(HaveOccurred())
 	domSpec := &api.DomainSpec{}
 	Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
-	Expect(len(domSpec.Devices.SoundCards)).To(Equal(1))
+	Expect(domSpec.Devices.SoundCards).To(HaveLen(1))
 	Expect(domSpec.Devices.SoundCards).To(ContainElement(api.SoundCard{
 		Alias: api.NewUserDefinedAlias("test-audio-device"),
 		Model: model,

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -133,7 +133,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			err = json.Unmarshal(body, reviewResponse)
 			Expect(err).To(BeNil())
 
-			Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
+			Expect(reviewResponse.Details.Causes).To(HaveLen(1))
 			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1]"))
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

The gomega-idiomatic form `Expect(x).To(HaveLen(n))`
is better than `Expect(len(x)).To(Equal(n))`
because when the expectation fails, the tester sees the value of x,
not just its length, and has more information to debug it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```