### PR TITLE
[tests] Ensure that virt-handler watcher can reach the apiserver after outage

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4340,12 +4340,12 @@ func ExpectResourceVersionToBeLessThanConfigVersion(resourceVersion, configVersi
 }
 
 func waitForConfigToBePropagated(resourceVersion string) {
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-controller", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion)
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-api", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion)
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-controller", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion, 10*time.Second)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-api", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion, 10*time.Second)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion, 10*time.Second)
 }
 
-func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion string, compareResourceVersions compare) {
+func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion string, compareResourceVersions compare, duration time.Duration) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
@@ -4380,7 +4380,7 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 			}
 		}
 		return nil
-	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	}, duration, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
 func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4265,9 +4265,8 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 	}, 60)).To(Succeed())
 }
 
-// UpdateKubeVirtConfigValueAndWait updates the given configuration in the kubevirt custom resource
-// and then waits  to allow the configuration events to be propagated to the consumers.
-func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
+// UpdateKubeVirtConfigValue updates the given configuration in the kubevirt custom resource
+func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
@@ -4296,6 +4295,14 @@ func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.Kub
 	kv, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.GetName(), types.MergePatchType, patch, &metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
+	return kv
+}
+
+// UpdateKubeVirtConfigValueAndWait updates the given configuration in the kubevirt custom resource
+// and then waits  to allow the configuration events to be propagated to the consumers.
+func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
+	kv := UpdateKubeVirtConfigValue(kvConfig)
+
 	waitForConfigToBePropagated(kv.ResourceVersion)
 	log.DefaultLogger().Infof("system is in sync with kubevirt config resource version %s", kv.ResourceVersion)
 
@@ -4318,7 +4325,7 @@ func resetToDefaultConfig() {
 
 type compare func(string, string) bool
 
-func ExpectResourceVersionToBeLessThanConfigVersion(resourceVersion, configVersion string) bool {
+func ExpectResourceVersionToBeLessEqualThanConfigVersion(resourceVersion, configVersion string) bool {
 	rv, err := strconv.ParseInt(resourceVersion, 10, 32)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Resource version is unable to be parsed")
@@ -4340,9 +4347,9 @@ func ExpectResourceVersionToBeLessThanConfigVersion(resourceVersion, configVersi
 }
 
 func waitForConfigToBePropagated(resourceVersion string) {
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-controller", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion, 10*time.Second)
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-api", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion, 10*time.Second)
-	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", resourceVersion, ExpectResourceVersionToBeLessThanConfigVersion, 10*time.Second)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-controller", resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, 10*time.Second)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-api", resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, 10*time.Second)
+	WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", resourceVersion, ExpectResourceVersionToBeLessEqualThanConfigVersion, 10*time.Second)
 }
 
 func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion string, compareResourceVersions compare, duration time.Duration) {

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -304,9 +304,8 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 				kv.Spec.Configuration.MigrationConfiguration = &k6sv1.MigrationConfiguration{
 					BandwidthPerMigration: &migrationBandwidth,
 				}
-				tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
-				kv = util.GetCurrentKv(virtCli)
-				tests.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", kv.ResourceVersion, tests.ExpectResourceVersionToBeLessThanConfigVersion, 80*time.Second)
+				kv = tests.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
+				tests.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", kv.ResourceVersion, tests.ExpectResourceVersionToBeLessEqualThanConfigVersion, 60*time.Second)
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not only ensure that the readiness check, which tries to reach the
apiserver succeeds, but also ensure that at least the config watchers
resume their work. Due to repreated failed connects, they can have
accumulated some back-off penalty, therefore give it a bigger grace
period to resume.

Doing this gives us two things:

 1. We also test that the watchers indeed reconnect
 2. We ensure in the follow-up test, that config changes are updated within a reasonable amount of time

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Fixes one of our more flaky tests (https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-03-20-168h.html#row2) which is executed after the test in question.

The symptoms typically are something like

```
Tests Suite: [rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachine [Serial]A mutated VirtualMachine given [test_id:3312]should set the default MachineType when created without explicit value expand_less	28s
tests/vm_test.go:133
Timed out after 10.001s.
Unexpected error:
    <*errors.errorString | 0xc002602700>: {
        s: "resource & config versions (52127 and 49900 respectively) are not as expected. component: \"virt-handler\", pod: \"virt-handler-m9jw2\" ",
    }
    resource & config versions (52127 and 49900 respectively) are not as expected. component: "virt-handler", pod: "virt-handler-m9jw2" 
occurred
tests/vm_test.go:138
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
