### PR TITLE
[Code Cleaning]: Change HaveLen(0) to BeEmpty()

### DIFF
--- a/pkg/flavor/flavor_test.go
+++ b/pkg/flavor/flavor_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Flavor", func() {
 				vm.Spec.Flavor.Kind = ""
 
 				conflicts := flavorMethods.ApplyToVmi(k8sfield.NewPath("spec"), profile, vm, vmi)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(uint32(2)))
 				Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(1)))
@@ -277,7 +277,7 @@ var _ = Describe("Flavor", func() {
 				vm.Spec.Flavor.Kind = "VirtualMachineClusterFlavor"
 
 				conflicts := flavorMethods.ApplyToVmi(k8sfield.NewPath("spec"), profile, vm, vmi)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(uint32(2)))
 				Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(1)))
@@ -302,7 +302,7 @@ var _ = Describe("Flavor", func() {
 				profile.CPU = nil
 
 				conflicts := flavorMethods.ApplyToVmi(k8sfield.NewPath("spec"), profile, vm, vmi)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(vmiCpuCount))
 				Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(1)))
@@ -316,7 +316,7 @@ var _ = Describe("Flavor", func() {
 				vmi.Spec.Domain.CPU = nil
 
 				conflicts := flavorMethods.ApplyToVmi(k8sfield.NewPath("spec"), profile, vm, vmi)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.CPU).To(Equal(profile.CPU))
 				Expect(vmi.Annotations[v1.FlavorAnnotation]).To(Equal(testFlavor))

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -686,7 +686,7 @@ var _ = Describe("Replicaset", func() {
 			rsInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(obj interface{}) {
 				objRS := obj.(*v1.VirtualMachineInstanceReplicaSet)
 				Expect(objRS.Status.Replicas).To(Equal(int32(1)))
-				Expect(objRS.Status.Conditions).To(HaveLen(0))
+				Expect(objRS.Status.Conditions).To(BeEmpty())
 			})
 
 			controller.Execute()

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1178,7 +1178,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Phase).To(Equal(virtv1.Scheduling))
 					Expect(arg.(*virtv1.VirtualMachineInstance).Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras,
 						Fields{"Type": Equal(virtv1.VirtualMachineInstanceReady)})))
-					Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).To(HaveLen(0))
+					Expect(arg.(*virtv1.VirtualMachineInstance).Status.PhaseTransitionTimestamps).To(BeEmpty())
 				}).Return(vmi, nil)
 			}
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -884,7 +884,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						rootPortController = append(rootPortController, c)
 					}
 				}
-				Expect(rootPortController).To(HaveLen(0), "libvirt should not add additional buses to the root one")
+				Expect(rootPortController).To(BeEmpty(), "libvirt should not add additional buses to the root one")
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -2934,7 +2934,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						pdbs, err := virtClient.PolicyV1().PodDisruptionBudgets(util.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{})
 						Expect(err).ToNot(HaveOccurred())
 						return pdbs.Items
-					}, 3*time.Second, 500*time.Millisecond).Should(HaveLen(0))
+					}, 3*time.Second, 500*time.Millisecond).Should(BeEmpty())
 					Eventually(func() bool {
 						_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 						return errors.IsNotFound(err)

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1053,7 +1053,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 						rootPortController = append(rootPortController, c)
 					}
 				}
-				Expect(rootPortController).To(HaveLen(0), "libvirt should not add additional buses to the root one")
+				Expect(rootPortController).To(BeEmpty(), "libvirt should not add additional buses to the root one")
 			})
 
 			It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", func() {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2069,7 +2069,7 @@ spec:
 		It("[test_id:4612]should create non-namespaces resources without owner references", func() {
 			crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(crd.ObjectMeta.OwnerReferences).To(HaveLen(0))
+			Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
 		})
 
 		It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", func() {
@@ -2111,7 +2111,7 @@ spec:
 				Expect(err).ToNot(HaveOccurred())
 				return crd.OwnerReferences
 			}, 20*time.Second, 1*time.Second).Should(BeEmpty())
-			Expect(crd.ObjectMeta.OwnerReferences).To(HaveLen(0))
+			Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
 		})
 
 		It("[test_id:5010]should be able to update product related labels of kubevirt install", func() {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -243,8 +243,8 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				restore = waitRestoreComplete(restore, vm)
-				Expect(restore.Status.Restores).To(HaveLen(0))
-				Expect(restore.Status.DeletedDataVolumes).To(HaveLen(0))
+				Expect(restore.Status.Restores).To(BeEmpty())
+				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
 			})
 		})
 
@@ -298,8 +298,8 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				restore = waitRestoreComplete(restore, vm)
-				Expect(restore.Status.Restores).To(HaveLen(0))
-				Expect(restore.Status.DeletedDataVolumes).To(HaveLen(0))
+				Expect(restore.Status.Restores).To(BeEmpty())
+				Expect(restore.Status.DeletedDataVolumes).To(BeEmpty())
 
 				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 				Expect(vm.Spec).To(Equal(*origSpec))

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -124,7 +124,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					rootPortController = append(rootPortController, c)
 				}
 			}
-			Expect(rootPortController).To(HaveLen(0), "libvirt should not add additional buses to the root one")
+			Expect(rootPortController).To(BeEmpty(), "libvirt should not add additional buses to the root one")
 		})
 	})
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -590,7 +590,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				nodes := util.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				for _, node := range nodes.Items {
-					Expect(node.Annotations[v1.VirtHandlerHeartbeat]).ToNot(HaveLen(0), "Nodes should have be ready for VMI")
+					Expect(node.Annotations[v1.VirtHandlerHeartbeat]).ToNot(BeEmpty(), "Nodes should have be ready for VMI")
 				}
 
 				node := &nodes.Items[0]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes `HaveLen(0)` to `BeEmpty()` in our tests' expectation for better readability and more idiomatic style.

For example, instead of `Expect(SomeSlice).To(HaveLen(0))`, replace with `Expect(SomeSlice).To(BeEmpty())`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
