### PR TITLE
Code cleanup: Improve gomega matchers in `pkg/virt-launcher/virtwrap`

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -238,7 +238,7 @@ var _ = Describe("AccessCredentials", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		secretDirs := getSecretDirs(vmi)
-		Expect(len(secretDirs)).To(Equal(1))
+		Expect(secretDirs).To(HaveLen(1))
 		Expect(secretDirs[0]).To(Equal(fmt.Sprintf("%s/%s-access-cred", tmpDir, secretID)))
 
 		for _, dir := range secretDirs {

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -96,9 +96,7 @@ var _ = Describe("AccessCredentials", func() {
 		mockConn.EXPECT().QemuAgentCommand(expectedCmd, domName).Return(`{"return":{"pid":789}}`, nil)
 		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(`{"return":{"exitcode":0,"out-data":"c3NoIHNvbWVrZXkxMjMgdGVzdC1rZXkK","exited":true}}`, nil)
 
-		res, err := manager.agentGuestExec(domName, command, args)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(Equal("ssh somekey123 test-key\n"))
+		Expect(manager.agentGuestExec(domName, command, args)).To(Equal("ssh somekey123 test-key\n"))
 	})
 
 	It("should handle dynamically updating user/password with qemu agent", func() {

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -240,7 +240,7 @@ var _ = Describe("AccessCredentials", func() {
 		Expect(secretDirs[0]).To(Equal(fmt.Sprintf("%s/%s-access-cred", tmpDir, secretID)))
 
 		for _, dir := range secretDirs {
-			os.Mkdir(dir, 0755)
+			Expect(os.Mkdir(dir, 0755)).To(Succeed())
 			Expect(manager.watcher.Add(dir)).To(Succeed())
 		}
 

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -97,7 +97,7 @@ var _ = Describe("AccessCredentials", func() {
 		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(`{"return":{"exitcode":0,"out-data":"c3NoIHNvbWVrZXkxMjMgdGVzdC1rZXkK","exited":true}}`, nil)
 
 		res, err := manager.agentGuestExec(domName, command, args)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(res).To(Equal("ssh somekey123 test-key\n"))
 	})
 
@@ -110,8 +110,7 @@ var _ = Describe("AccessCredentials", func() {
 		cmdSetPassword := fmt.Sprintf(`{"execute":"guest-set-user-password", "arguments": {"username":"%s", "password": "%s", "crypted": false }}`, user, base64Str)
 		mockConn.EXPECT().QemuAgentCommand(cmdSetPassword, domName).Return("", nil)
 
-		err := manager.agentSetUserPassword(domName, user, password)
-		Expect(err).To(BeNil())
+		Expect(manager.agentSetUserPassword(domName, user, password)).To(Succeed())
 	})
 
 	It("should handle dynamically updating ssh key with qemu agent", func() {
@@ -208,8 +207,7 @@ var _ = Describe("AccessCredentials", func() {
 		mockConn.EXPECT().QemuAgentCommand(expectedFileChmodCmd, domName).Return(expectedExecReturn, nil)
 		mockConn.EXPECT().QemuAgentCommand(expectedStatusCmd, domName).Return(expectedFileChmodRes, nil)
 
-		err := manager.agentWriteAuthorizedKeys(domName, user, authorizedKeys)
-		Expect(err).To(BeNil())
+		Expect(manager.agentWriteAuthorizedKeys(domName, user, authorizedKeys)).To(Succeed())
 	})
 
 	It("should trigger updating a credential when secret propagation change occurs.", func() {
@@ -237,7 +235,7 @@ var _ = Describe("AccessCredentials", func() {
 		domName := util.VMINamespaceKeyFunc(vmi)
 
 		manager.watcher, err = fsnotify.NewWatcher()
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 
 		secretDirs := getSecretDirs(vmi)
 		Expect(len(secretDirs)).To(Equal(1))
@@ -245,13 +243,11 @@ var _ = Describe("AccessCredentials", func() {
 
 		for _, dir := range secretDirs {
 			os.Mkdir(dir, 0755)
-			err = manager.watcher.Add(dir)
-			Expect(err).To(BeNil())
+			Expect(manager.watcher.Add(dir)).To(Succeed())
 		}
 
 		// Write the file
-		err = ioutil.WriteFile(filepath.Join(secretDirs[0], user), []byte(password), 0644)
-		Expect(err).To(BeNil())
+		Expect(ioutil.WriteFile(filepath.Join(secretDirs[0], user), []byte(password), 0644)).To(Succeed())
 
 		// set the expected command
 		base64Str := base64.StdEncoding.EncodeToString([]byte(password))
@@ -302,8 +298,7 @@ var _ = Describe("AccessCredentials", func() {
 		matched = false
 		manager.stopCh = make(chan struct{})
 		password = password + "morefake"
-		err = ioutil.WriteFile(filepath.Join(secretDirs[0], user), []byte(password), 0644)
-		Expect(err).To(BeNil())
+		Expect(ioutil.WriteFile(filepath.Join(secretDirs[0], user), []byte(password), 0644)).To(Succeed())
 		base64Str = base64.StdEncoding.EncodeToString([]byte(password))
 		cmdSetPassword = fmt.Sprintf(`{"execute":"guest-set-user-password", "arguments": {"username":"%s", "password": "%s", "crypted": false }}`, user, base64Str)
 		mockConn.EXPECT().QemuAgentCommand(cmdSetPassword, domName).MinTimes(1).Return("", nil)

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -197,12 +197,8 @@ var _ = Describe("Qemu agent poller", func() {
 
 		It("should parse FSFreezeStatus", func() {
 			jsonInput := `{"return":"frozen"}`
-
-			fsFreezeStatus, err := ParseFSFreezeStatus(jsonInput)
 			expectedFSFreezeStatus := api.FSFreeze{Status: "frozen"}
-
-			Expect(err).ToNot(HaveOccurred(), "FSFreezeStatus should be parsed normally")
-			Expect(fsFreezeStatus).To(Equal(expectedFSFreezeStatus))
+			Expect(ParseFSFreezeStatus(jsonInput)).To(Equal(expectedFSFreezeStatus))
 		})
 
 		It("should not parse FSFreezeStatus", func() {
@@ -224,11 +220,7 @@ var _ = Describe("Qemu agent poller", func() {
                 }
             }`
 
-			hostname, err := parseHostname(jsonInput)
-			expectedHostname := "TestHost"
-
-			Expect(err).ToNot(HaveOccurred(), "hostname should be parser normally")
-			Expect(hostname).To(Equal(expectedHostname))
+			Expect(parseHostname(jsonInput)).To(Equal("TestHost"))
 		})
 
 		It("should parse Agent", func() {
@@ -238,11 +230,8 @@ var _ = Describe("Qemu agent poller", func() {
                 }
             }`
 
-			agent, err := parseAgent(jsonInput)
 			expectedAgent := AgentInfo{Version: "4.1"}
-
-			Expect(err).ToNot(HaveOccurred(), "agent version should be parsed normally")
-			Expect(agent).To(Equal(expectedAgent))
+			Expect(parseAgent(jsonInput)).To(Equal(expectedAgent))
 		})
 
 		It("should strip Agent response", func() {
@@ -263,14 +252,11 @@ var _ = Describe("Qemu agent poller", func() {
                 }
             }`
 
-			timezone, err := parseTimezone(jsonInput)
 			expectedTimezone := api.Timezone{
 				Zone:   "Prague",
 				Offset: 2,
 			}
-
-			Expect(err).ToNot(HaveOccurred(), "timezone should be parsed normally")
-			Expect(timezone).To(Equal(expectedTimezone))
+			Expect(parseTimezone(jsonInput)).To(Equal(expectedTimezone))
 		})
 
 		It("should parse Filesystem", func() {
@@ -287,7 +273,6 @@ var _ = Describe("Qemu agent poller", func() {
                 ]
             }`
 
-			filesystem, err := parseFilesystem(jsonInput)
 			expectedFilesystem := []api.Filesystem{
 				{
 					Name:       "main",
@@ -297,9 +282,7 @@ var _ = Describe("Qemu agent poller", func() {
 					UsedBytes:  33333,
 				},
 			}
-
-			Expect(err).ToNot(HaveOccurred(), "filesystem should be parsed normally")
-			Expect(filesystem).To(Equal(expectedFilesystem))
+			Expect(parseFilesystem(jsonInput)).To(Equal(expectedFilesystem))
 		})
 
 		It("should parse Users", func() {
@@ -314,7 +297,6 @@ var _ = Describe("Qemu agent poller", func() {
                 ]
             }`
 
-			users, err := parseUsers(jsonInput)
 			expectedUsers := []api.User{
 				{
 					Name:      "bob",
@@ -322,9 +304,7 @@ var _ = Describe("Qemu agent poller", func() {
 					LoginTime: 99999,
 				},
 			}
-
-			Expect(err).ToNot(HaveOccurred(), "users should be parsed normally")
-			Expect(users).To(Equal(expectedUsers))
+			Expect(parseUsers(jsonInput)).To(Equal(expectedUsers))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -412,11 +412,10 @@ var _ = ginkgo.Describe("Schema", func() {
 		ginkgo.It("Generate expected libvirt xml", func() {
 			domain := NewMinimalDomainSpec("mynamespace_testvmi")
 			buf, err := xml.Marshal(domain)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			newDomain := DomainSpec{}
-			err = xml.Unmarshal(buf, &newDomain)
-			Expect(err).To(BeNil())
+			Expect(xml.Unmarshal(buf, &newDomain)).To(Succeed())
 
 			domain.XMLName.Local = "domain"
 			Expect(newDomain).To(Equal(*domain))
@@ -425,10 +424,9 @@ var _ = ginkgo.Describe("Schema", func() {
 	unmarshalTest := func(arch, domainStr string, domain *Domain) {
 		NewDefaulter(arch).SetObjectDefaults_Domain(domain)
 		newDomain := DomainSpec{}
-		err := xml.Unmarshal([]byte(domainStr), &newDomain)
+		Expect(xml.Unmarshal([]byte(domainStr), &newDomain)).To(Succeed())
 		newDomain.XMLName.Local = ""
 		newDomain.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
-		Expect(err).To(BeNil())
 
 		Expect(newDomain).To(Equal(domain.Spec))
 	}
@@ -436,7 +434,7 @@ var _ = ginkgo.Describe("Schema", func() {
 	marshalTest := func(arch, domainStr string, domain *Domain) {
 		NewDefaulter(arch).SetObjectDefaults_Domain(domain)
 		buf, err := xml.MarshalIndent(domain.Spec, "", "  ")
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(string(buf)).To(Equal(domainStr))
 	}
 	ginkgo.Context("With example schema", func() {
@@ -563,8 +561,7 @@ var _ = ginkgo.Describe("Schema", func() {
 
 		ginkgo.It("Unmarshal into struct", func() {
 			newCpuTune := CPUTune{}
-			err := xml.Unmarshal([]byte(testXML), &newCpuTune)
-			Expect(err).To(BeNil())
+			Expect(xml.Unmarshal([]byte(testXML), &newCpuTune)).To(Succeed())
 			Expect(newCpuTune).To(Equal(exampleCpuTune))
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/cli/libvirt_test.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt_test.go
@@ -20,7 +20,6 @@
 package cli
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,9 +30,7 @@ var _ = Describe("Libvirt Suite", func() {
 	Context("Upon attempt to connect to Libvirt", func() {
 		It("should time out while waiting for libvirt", func() {
 			_, err := NewConnectionWithTimeout("http://", "", "", 1*time.Microsecond, 100*time.Millisecond, 500*time.Millisecond)
-			msg := fmt.Sprintf("%v", err)
-			Expect(err).To(HaveOccurred())
-			Expect(msg).To(Equal("cannot connect to libvirt daemon: timed out waiting for the condition"))
+			Expect(err).To(MatchError("cannot connect to libvirt daemon: timed out waiting for the condition"))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -86,44 +86,38 @@ var _ = Describe("Virt remote commands", func() {
 			domain := api.NewMinimalDomain("testvmi")
 			domainManager.EXPECT().SyncVMI(vmi, allowEmulation, &cmdv1.VirtualMachineOptions{}).Return(&domain.Spec, nil)
 
-			err := client.SyncVirtualMachine(vmi, &cmdv1.VirtualMachineOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.SyncVirtualMachine(vmi, &cmdv1.VirtualMachineOptions{})).To(Succeed())
 		})
 
 		It("should kill a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().KillVMI(vmi)
 
-			err := client.KillVirtualMachine(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.KillVirtualMachine(vmi)).To(Succeed())
 		})
 
 		It("should shutdown a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().SignalShutdownVMI(vmi)
-			err := client.ShutdownVirtualMachine(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.ShutdownVirtualMachine(vmi)).To(Succeed())
 		})
 
 		It("should freeze a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().FreezeVMI(vmi, int32(0))
-			err := client.FreezeVirtualMachine(vmi, int32(0))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.FreezeVirtualMachine(vmi, int32(0))).To(Succeed())
 		})
 
 		It("should unfreeze a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().UnfreezeVMI(vmi)
-			err := client.UnfreezeVirtualMachine(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.UnfreezeVirtualMachine(vmi)).To(Succeed())
 		})
 
 		It("should soft reboot a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().SoftRebootVMI(vmi)
-			err := client.SoftRebootVirtualMachine(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.SoftRebootVirtualMachine(vmi)).To(Succeed())
 		})
 
 		It("should call memory dump", func() {
@@ -137,15 +131,13 @@ var _ = Describe("Virt remote commands", func() {
 		It("should pause a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().PauseVMI(vmi)
-			err := client.PauseVirtualMachine(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.PauseVirtualMachine(vmi)).To(Succeed())
 		})
 
 		It("should unpause a vmi", func() {
 			vmi := v1.NewVMIReferenceFromName("testvmi")
 			domainManager.EXPECT().UnpauseVMI(vmi)
-			err := client.UnpauseVirtualMachine(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.UnpauseVirtualMachine(vmi)).To(Succeed())
 		})
 
 		It("should list domains when no guest agent info exists", func() {
@@ -201,8 +193,7 @@ var _ = Describe("Virt remote commands", func() {
 		})
 
 		It("client should return disconnected after server stops", func() {
-			err := client.Ping()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.Ping()).To(Succeed())
 
 			close(stop)
 			stopped = true
@@ -210,7 +201,7 @@ var _ = Describe("Virt remote commands", func() {
 
 			client.Close()
 
-			err = client.Ping()
+			err := client.Ping()
 			Expect(err).To(HaveOccurred())
 			Expect(cmdclient.IsDisconnected(err)).To(BeTrue())
 
@@ -341,19 +332,19 @@ var _ = Describe("Virt remote commands", func() {
 			It("does not return exit code errors", func() {
 				expectExec().Times(1).Return("", agent.ExecExitCode{ExitCode: 1})
 				_, err := server.Exec(context.TODO(), execRequest())
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 			It("returns non-zero exit code and stdOut if possible", func() {
 				expectExec().Times(1).Return(testStdOut, agent.ExecExitCode{ExitCode: 1})
 				resp, err := server.Exec(context.TODO(), execRequest())
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.ExitCode).To(BeEquivalentTo(1))
 				Expect(resp.StdOut).To(Equal(testStdOut))
 			})
 			It("returns zero exit code and stdOut if possible", func() {
 				expectExec().Times(1).Return(testStdOut, nil)
 				resp, err := server.Exec(context.TODO(), execRequest())
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.ExitCode).To(BeEquivalentTo(0))
 				Expect(resp.StdOut).To(Equal(testStdOut))
 			})
@@ -364,7 +355,7 @@ var _ = Describe("Virt remote commands", func() {
 				// then success should not be true.
 				expectExec().Times(1).Return(testStdOut, agent.ExecExitCode{ExitCode: 1})
 				resp, err := server.Exec(context.TODO(), execRequest())
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.Response.Success).To(BeTrue())
 			})
 			It("should call guest ping", func() {
@@ -381,7 +372,7 @@ var _ = Describe("Virt remote commands", func() {
 			It("returns zero exit code", func() {
 				expectGuestPing().Times(1).Return(nil)
 				resp, err := server.GuestPing(context.TODO(), guestPingRequest())
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.Response.Success).To(BeTrue())
 			})
 		})

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1740,7 +1740,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Sound = nil
 			domain := vmiToDomain(vmi, c)
-			Expect(len(domain.Spec.Devices.SoundCards)).To(Equal(0))
+			Expect(domain.Spec.Devices.SoundCards).To(BeEmpty())
 		})
 
 		It("should enable default sound card with existing but empty sound devices", func() {
@@ -1750,7 +1750,7 @@ var _ = Describe("Converter", func() {
 				Name: name,
 			}
 			domain := vmiToDomain(vmi, c)
-			Expect(len(domain.Spec.Devices.SoundCards)).To(Equal(1))
+			Expect(domain.Spec.Devices.SoundCards).To(HaveLen(1))
 			Expect(domain.Spec.Devices.SoundCards).To(ContainElement(api.SoundCard{
 				Alias: api.NewUserDefinedAlias(name),
 				Model: "ich9",
@@ -1765,7 +1765,7 @@ var _ = Describe("Converter", func() {
 				Model: "ac97",
 			}
 			domain := vmiToDomain(vmi, c)
-			Expect(len(domain.Spec.Devices.SoundCards)).To(Equal(1))
+			Expect(domain.Spec.Devices.SoundCards).To(HaveLen(1))
 			Expect(domain.Spec.Devices.SoundCards).To(ContainElement(api.SoundCard{
 				Alias: api.NewUserDefinedAlias(name),
 				Model: "ac97",
@@ -1776,7 +1776,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.ClientPassthrough = &v1.ClientPassthroughDevices{}
 			domain := vmiToDomain(vmi, c)
-			Expect(len(domain.Spec.Devices.Redirs)).To(Equal(4))
+			Expect(domain.Spec.Devices.Redirs).To(HaveLen(4))
 			Expect(domain.Spec.Devices.Controllers).To(ContainElement(api.Controller{
 				Type:  "usb",
 				Index: "0",
@@ -2026,7 +2026,7 @@ var _ = Describe("Converter", func() {
 
 			domain := vmiToDomain(vmi, c)
 			Expect(domain).ToNot(BeNil())
-			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+			Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
 		})
 		It("Should create two network configuration for slirp device", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -2048,7 +2048,7 @@ var _ = Describe("Converter", func() {
 
 			domain := vmiToDomain(vmi, c)
 			Expect(domain).ToNot(BeNil())
-			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(4))
+			Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(4))
 		})
 		It("Should create two network configuration one for slirp device and one for bridge device", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -2070,8 +2070,8 @@ var _ = Describe("Converter", func() {
 
 			domain := vmiToDomain(vmi, c)
 			Expect(domain).ToNot(BeNil())
-			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
-			Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(2))
+			Expect(domain.Spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
 			Expect(domain.Spec.Devices.Interfaces[0].Type).To(Equal("ethernet"))
 			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("virtio-non-transitional"))
 			Expect(domain.Spec.Devices.Interfaces[1].Type).To(Equal("user"))
@@ -3092,7 +3092,7 @@ var _ = Describe("Converter", func() {
 
 		It("should automatically add virtio-scsi controller", func() {
 			domain := vmiToDomain(vmi, c)
-			Expect(len(domain.Spec.Devices.Controllers)).To(Equal(3))
+			Expect(domain.Spec.Devices.Controllers).To(HaveLen(3))
 			foundScsiController := false
 			for _, controller := range domain.Spec.Devices.Controllers {
 				if controller.Type == "scsi" {
@@ -3107,7 +3107,7 @@ var _ = Describe("Converter", func() {
 		It("should not automatically add virtio-scsi controller, if hotplug disabled", func() {
 			vmi.Spec.Domain.Devices.DisableHotplug = true
 			domain := vmiToDomain(vmi, c)
-			Expect(len(domain.Spec.Devices.Controllers)).To(Equal(2))
+			Expect(domain.Spec.Devices.Controllers).To(HaveLen(2))
 		})
 
 		DescribeTable("should convert",

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -22,6 +22,7 @@ package converter
 import (
 	"encoding/xml"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path"
@@ -3310,29 +3311,24 @@ var _ = Describe("direct IO checker", func() {
 		_, err := directIOChecker.CheckFile(nonExistingFile)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = os.Stat(nonExistingFile)
-		Expect(err).To(HaveOccurred())
-		Expect(os.IsNotExist(err)).To(BeTrue())
+		Expect(err).To(MatchError(fs.ErrNotExist))
 	})
 
 	It("should fail when device does not exist", func() {
 		_, err := directIOChecker.CheckBlockDevice(nonExistingFile)
 		Expect(err).To(HaveOccurred())
 		_, err = os.Stat(nonExistingFile)
-		Expect(err).To(HaveOccurred())
-		Expect(os.IsNotExist(err)).To(BeTrue())
+		Expect(err).To(MatchError(fs.ErrNotExist))
 	})
 
 	It("should fail when the path does not exist", func() {
 		nonExistingPath := "/non/existing/path/disk.img"
 		_, err = directIOChecker.CheckFile(nonExistingPath)
-		Expect(err).To(HaveOccurred())
-		Expect(os.IsNotExist(err)).To(BeTrue())
+		Expect(err).To(MatchError(fs.ErrNotExist))
 		_, err = directIOChecker.CheckBlockDevice(nonExistingPath)
-		Expect(err).To(HaveOccurred())
-		Expect(os.IsNotExist(err)).To(BeTrue())
+		Expect(err).To(MatchError(fs.ErrNotExist))
 		_, err = os.Stat(nonExistingPath)
-		Expect(err).To(HaveOccurred())
-		Expect(os.IsNotExist(err)).To(BeTrue())
+		Expect(err).To(MatchError(fs.ErrNotExist))
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -216,8 +216,7 @@ var _ = Describe("Converter", func() {
   <blockio logical_block_size="1234" physical_block_size="1234"></blockio>
 </Disk>`
 			libvirtDisk := &api.Disk{}
-			err := Convert_v1_BlockSize_To_api_BlockIO(kubevirtDisk, libvirtDisk)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(Convert_v1_BlockSize_To_api_BlockIO(kubevirtDisk, libvirtDisk)).To(Succeed())
 			data, err := xml.MarshalIndent(libvirtDisk, "", "  ")
 			Expect(err).ToNot(HaveOccurred())
 			xml := string(data)
@@ -1921,20 +1920,17 @@ var _ = Describe("Converter", func() {
 		DescribeTable("Validate that QEMU SeaBios debug logs are ",
 			func(toDefineVerbosityEnvVariable bool, virtLauncherLogVerbosity int, shouldEnableDebugLogs bool) {
 
-				var err error
 				if toDefineVerbosityEnvVariable {
-					err = os.Setenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY, strconv.Itoa(virtLauncherLogVerbosity))
-					Expect(err).To(BeNil())
+					Expect(os.Setenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY, strconv.Itoa(virtLauncherLogVerbosity))).
+						To(Succeed())
 					defer func() {
-						err = os.Unsetenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY)
-						Expect(err).To(BeNil())
+						Expect(os.Unsetenv(services.ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY)).To(Succeed())
 					}()
 				}
 
 				domain := api.Domain{}
 
-				err = Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, &domain, c)
-				Expect(err).To(BeNil())
+				Expect(Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, &domain, c)).To(Succeed())
 
 				if domain.Spec.QEMUCmd == nil || (domain.Spec.QEMUCmd.QEMUArg == nil) {
 					return
@@ -2007,8 +2003,7 @@ var _ = Describe("Converter", func() {
 			iface.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
 			qemuArg := api.Arg{Value: fmt.Sprintf("user,id=%s", iface.Name)}
 
-			err := configPortForward(&qemuArg, iface)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(configPortForward(&qemuArg, iface)).To(Succeed())
 			Expect(qemuArg.Value).To(Equal(fmt.Sprintf("user,id=%s,hostfwd=tcp::80-:80", iface.Name)))
 		})
 		It("should not fail for duplicate port with different protocol configuration", func() {
@@ -2016,8 +2011,7 @@ var _ = Describe("Converter", func() {
 			iface.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}
 			qemuArg := api.Arg{Value: fmt.Sprintf("user,id=%s", iface.Name)}
 
-			err := configPortForward(&qemuArg, iface)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(configPortForward(&qemuArg, iface)).To(Succeed())
 			Expect(qemuArg.Value).To(Equal(fmt.Sprintf("user,id=%s,hostfwd=tcp::80-:80,hostfwd=udp::80-:80", iface.Name)))
 		})
 		It("Should create network configuration for slirp device", func() {
@@ -2698,8 +2692,8 @@ var _ = Describe("Converter", func() {
 			}
 			apiDisk := api.Disk{}
 			devicePerBus := map[string]deviceNamer{}
-			err := Convert_v1_Disk_To_api_Disk(context, &v1Disk, &apiDisk, devicePerBus, nil, make(map[string]v1.VolumeStatus))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(Convert_v1_Disk_To_api_Disk(context, &v1Disk, &apiDisk, devicePerBus, nil, make(map[string]v1.VolumeStatus))).
+				To(Succeed())
 			Expect(apiDisk.Device).To(Equal("disk"), "expected disk device to be defined")
 			Expect(apiDisk.Driver.Queues).To(BeNil(), "expected no queues to be requested")
 		})
@@ -2771,8 +2765,7 @@ var _ = Describe("Converter", func() {
 			domain.Spec.IOThreads = &api.IOThreads{}
 			domain.Spec.IOThreads.IOThreads = uint(6)
 
-			err := vcpu.FormatDomainIOThreadPin(vmi, domain, 0, c.CPUSet)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(vcpu.FormatDomainIOThreadPin(vmi, domain, 0, c.CPUSet)).To(Succeed())
 			expectedLayout := []api.CPUTuneIOThreadPin{
 				{IOThread: 1, CPUSet: "5,6,7"},
 				{IOThread: 2, CPUSet: "8,9,10"},
@@ -2804,8 +2797,7 @@ var _ = Describe("Converter", func() {
 			domain.Spec.IOThreads = &api.IOThreads{}
 			domain.Spec.IOThreads.IOThreads = uint(6)
 
-			err := vcpu.FormatDomainIOThreadPin(vmi, domain, 0, c.CPUSet)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(vcpu.FormatDomainIOThreadPin(vmi, domain, 0, c.CPUSet)).To(Succeed())
 			expectedLayout := []api.CPUTuneIOThreadPin{
 				{IOThread: 1, CPUSet: "6"},
 				{IOThread: 2, CPUSet: "5"},
@@ -3299,14 +3291,12 @@ var _ = Describe("direct IO checker", func() {
 		tmpDir, err = os.MkdirTemp("", "direct-io-checker")
 		Expect(err).ToNot(HaveOccurred())
 		existingFile = filepath.Join(tmpDir, "disk.img")
-		err = ioutil.WriteFile(existingFile, []byte("test"), 0644)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(ioutil.WriteFile(existingFile, []byte("test"), 0644)).To(Succeed())
 		nonExistingFile = filepath.Join(tmpDir, "non-existing-file")
 	})
 
 	AfterEach(func() {
-		err = os.RemoveAll(tmpDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	It("should not fail when file/device exists", func() {
@@ -3426,10 +3416,9 @@ func vmiToDomain(vmi *v1.VirtualMachineInstance, c *ConverterContext) *api.Domai
 
 func xmlToDomainSpec(data string) *api.DomainSpec {
 	newDomain := &api.DomainSpec{}
-	err := xml.Unmarshal([]byte(data), newDomain)
+	ExpectWithOffset(1, xml.Unmarshal([]byte(data), newDomain)).To(Succeed())
 	newDomain.XMLName.Local = ""
 	newDomain.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
-	Expect(err).To(BeNil())
 	return newDomain
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1836,9 +1836,7 @@ var _ = Describe("Converter", func() {
 
 		DescribeTable("should calculate mebibyte from a quantity", func(quantity string, mebibyte int) {
 			mi64, _ := resource.ParseQuantity(quantity)
-			q, err := vcpu.QuantityToMebiByte(mi64)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(q).To(BeNumerically("==", mebibyte))
+			Expect(vcpu.QuantityToMebiByte(mi64)).To(BeNumerically("==", mebibyte))
 		},
 			Entry("when 0M is given", "0M", 0),
 			Entry("when 0 is given", "0", 0),

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/numa_placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/numa_placement_test.go
@@ -134,7 +134,6 @@ var _ = Describe("NumaPlacement", func() {
 			givenSpec.Memory, err = QuantityToByte(memory)
 			Expect(err).ToNot(HaveOccurred())
 			givenVMI.Spec.Domain.Memory.Guest = &memory
-			Expect(err).ToNot(HaveOccurred())
 			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).ToNot(Succeed())
 		})
 

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
@@ -108,8 +108,7 @@ var _ = Describe("VCPU pinning", func() {
 			shuffleCPUSet(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
 		)
 		_, err := pool.FitCores()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("not enough exclusive threads provided, could not fit 1 core(s)"))
+		Expect(err).To(MatchError(ContainSubstring("not enough exclusive threads provided, could not fit 1 core(s)")))
 	})
 
 	It("should fail assigning vCPUs with the strict policy if cores can't fully be place on a numa node", func() {
@@ -124,8 +123,7 @@ var _ = Describe("VCPU pinning", func() {
 			shuffleCPUSet(0, 1, 2, 6, 7, 8),
 		)
 		_, err := pool.FitCores()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("could not fit 1 core(s) without crossing numa cell boundaries for individual cores"))
+		Expect(err).To(MatchError(ContainSubstring("could not fit 1 core(s) without crossing numa cell boundaries for individual cores")))
 	})
 
 	It("should pass assigning vCPUs with the relaxed policy if cores can't fully be place on a numa node", func() {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
@@ -71,9 +71,6 @@ var _ = Describe("Generic HostDevice", func() {
 		mdevPool := newAddressPoolStub()
 		mdevPool.AddResource(hostdevResource1, hostdevMDEVAddress1)
 
-		hostDevices, err := generic.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.HostDevices, pciPool, mdevPool)
-		Expect(err).NotTo(HaveOccurred())
-
 		hostPCIAddress := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
 		expectHostDevice0 := api.HostDevice{
 			Alias:   api.NewUserDefinedAlias(generic.AliasPrefix + hostdevName0),
@@ -91,7 +88,8 @@ var _ = Describe("Generic HostDevice", func() {
 			Model:  "vfio-pci",
 		}
 
-		Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice0, expectHostDevice1}))
+		Expect(generic.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.HostDevices, pciPool, mdevPool)).
+			To(Equal([]api.HostDevice{expectHostDevice0, expectHostDevice1}))
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
@@ -71,9 +71,6 @@ var _ = Describe("GPU HostDevice", func() {
 		mdevPool := newAddressPoolStub()
 		mdevPool.AddResource(gpuResource1, gpuMDEVAddress1)
 
-		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
-		Expect(err).NotTo(HaveOccurred())
-
 		hostPCIAddress := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
 		expectHostDevice0 := api.HostDevice{
 			Alias:   api.NewUserDefinedAlias(gpu.AliasPrefix + gpuName0),
@@ -93,7 +90,8 @@ var _ = Describe("GPU HostDevice", func() {
 			RamFB:   "on",
 		}
 
-		Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice0, expectHostDevice1}))
+		Expect(gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)).
+			To(Equal([]api.HostDevice{expectHostDevice0, expectHostDevice1}))
 	})
 	It("creates MDEV with display option turned off", func() {
 		_false := false
@@ -113,9 +111,6 @@ var _ = Describe("GPU HostDevice", func() {
 		mdevPool := newAddressPoolStub()
 		mdevPool.AddResource(gpuResource1, gpuMDEVAddress1)
 
-		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
-		Expect(err).NotTo(HaveOccurred())
-
 		hostMDEVAddress := api.Address{UUID: gpuMDEVAddress1}
 		expectHostDevice1 := api.HostDevice{
 			Alias:  api.NewUserDefinedAlias(gpu.AliasPrefix + gpuName1),
@@ -125,7 +120,8 @@ var _ = Describe("GPU HostDevice", func() {
 			Model:  "vfio-pci",
 		}
 
-		Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		Expect(gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)).
+			To(Equal([]api.HostDevice{expectHostDevice1}))
 	})
 	It("creates MDEV with display ramFB option turned off", func() {
 		_false := false
@@ -147,9 +143,6 @@ var _ = Describe("GPU HostDevice", func() {
 		mdevPool := newAddressPoolStub()
 		mdevPool.AddResource(gpuResource1, gpuMDEVAddress1)
 
-		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
-		Expect(err).NotTo(HaveOccurred())
-
 		hostMDEVAddress := api.Address{UUID: gpuMDEVAddress1}
 		expectHostDevice1 := api.HostDevice{
 			Alias:   api.NewUserDefinedAlias(gpu.AliasPrefix + gpuName1),
@@ -160,7 +153,8 @@ var _ = Describe("GPU HostDevice", func() {
 			Display: "on",
 		}
 
-		Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		Expect(gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)).
+			To(Equal([]api.HostDevice{expectHostDevice1}))
 	})
 	It("creates MDEV with enabled display and ramfb by default", func() {
 		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
@@ -177,9 +171,6 @@ var _ = Describe("GPU HostDevice", func() {
 		mdevPool := newAddressPoolStub()
 		mdevPool.AddResource(gpuResource1, gpuMDEVAddress1)
 
-		hostDevices, err := gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)
-		Expect(err).NotTo(HaveOccurred())
-
 		hostMDEVAddress := api.Address{UUID: gpuMDEVAddress1}
 		expectHostDevice1 := api.HostDevice{
 			Alias:   api.NewUserDefinedAlias(gpu.AliasPrefix + gpuName1),
@@ -191,7 +182,8 @@ var _ = Describe("GPU HostDevice", func() {
 			RamFB:   "on",
 		}
 
-		Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		Expect(gpu.CreateHostDevicesFromPools(vmi.Spec.Domain.Devices.GPUs, pciPool, mdevPool)).
+			To(Equal([]api.HostDevice{expectHostDevice1}))
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c.sendEvent("foo")
 			d := deviceDetacherStub{}
 			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(Succeed())
-			Expect(len(c.EventChannel())).To(Equal(1))
+			Expect(c.EventChannel()).To(HaveLen(1))
 		})
 
 		It("fails to register a callback", func() {
@@ -81,7 +81,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c.sendEvent("foo")
 			d := deviceDetacherStub{}
 			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).ToNot(Succeed())
-			Expect(len(c.EventChannel())).To(Equal(1))
+			Expect(c.EventChannel()).To(HaveLen(1))
 		})
 
 		It("fails to detach device", func() {
@@ -91,7 +91,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c.sendEvent("foo")
 			d := deviceDetacherStub{fail: true}
 			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).ToNot(Succeed())
-			Expect(len(c.EventChannel())).To(Equal(1))
+			Expect(c.EventChannel()).To(HaveLen(1))
 		})
 
 		It("fails on timeout due to no detach event", func() {
@@ -109,7 +109,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c.sendEvent("unknown-device")
 			d := deviceDetacherStub{}
 			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 10*time.Millisecond)).ToNot(Succeed())
-			Expect(len(c.EventChannel())).To(Equal(0))
+			Expect(c.EventChannel()).To(BeEmpty())
 		})
 
 		// Failure to deregister the callback only emits a logging error.

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c := newCallbackerStub(true, false)
 			c.sendEvent("foo")
 			d := deviceDetacherStub{}
-			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(HaveOccurred())
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).ToNot(Succeed())
 			Expect(len(c.EventChannel())).To(Equal(1))
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c := newCallbackerStub(false, false)
 			c.sendEvent("foo")
 			d := deviceDetacherStub{fail: true}
-			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(HaveOccurred())
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).ToNot(Succeed())
 			Expect(len(c.EventChannel())).To(Equal(1))
 		})
 
@@ -99,7 +99,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 
 			c := newCallbackerStub(false, false)
 			d := deviceDetacherStub{}
-			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).To(HaveOccurred())
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 0)).ToNot(Succeed())
 		})
 
 		It("fails due to a missing event from a device", func() {
@@ -108,7 +108,7 @@ var _ = Describe("Hot(un)Plug HostDevice", func() {
 			c := newCallbackerStub(false, false)
 			c.sendEvent("unknown-device")
 			d := deviceDetacherStub{}
-			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 10*time.Millisecond)).To(HaveOccurred())
+			Expect(hostdevice.SafelyDetachHostDevices(domainSpec.Devices.HostDevices, c, d, 10*time.Millisecond)).ToNot(Succeed())
 			Expect(len(c.EventChannel())).To(Equal(0))
 		})
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -302,7 +302,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c.sendEvent("foo")
 			d := deviceDetacherStub{}
 			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 0)).To(Succeed())
-			Expect(len(c.EventChannel())).To(Equal(1))
+			Expect(c.EventChannel()).To(HaveLen(1))
 		})
 
 		It("fails to register a callback", func() {
@@ -312,7 +312,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c.sendEvent("foo")
 			d := deviceDetacherStub{}
 			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 0)).To(HaveOccurred())
-			Expect(len(c.EventChannel())).To(Equal(1))
+			Expect(c.EventChannel()).To(HaveLen(1))
 		})
 
 		It("fails to detach device", func() {
@@ -322,7 +322,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c.sendEvent("foo")
 			d := deviceDetacherStub{fail: true}
 			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 0)).To(HaveOccurred())
-			Expect(len(c.EventChannel())).To(Equal(1))
+			Expect(c.EventChannel()).To(HaveLen(1))
 		})
 
 		It("fails on timeout due to no detach event", func() {
@@ -340,7 +340,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c.sendEvent("non-sriov")
 			d := deviceDetacherStub{}
 			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 10*time.Millisecond)).To(HaveOccurred())
-			Expect(len(c.EventChannel())).To(Equal(0))
+			Expect(c.EventChannel()).To(BeEmpty())
 		})
 
 		// Failure to deregister the callback only emits a logging error.

--- a/pkg/virt-launcher/virtwrap/efi/efi_test.go
+++ b/pkg/virt-launcher/virtwrap/efi/efi_test.go
@@ -36,12 +36,12 @@ var _ = Describe("EFI environment detection", func() {
 
 	createEFIRoms := func(efiRoms ...string) string {
 		ovmfPath, err := os.MkdirTemp("", "kubevirt-ovmf")
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 
 		for i := range efiRoms {
 			if efiRoms[i] != "" {
 				f, err := os.Create(path.Join(ovmfPath, efiRoms[i]))
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				f.Close()
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2160,8 +2160,7 @@ var _ = Describe("Manager", func() {
 		}
 
 		err := libvirtmanager.generateCloudInitEmptyISO(vmi, nil)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to find the status of volume test1"))
+		Expect(err).To(MatchError(ContainSubstring("failed to find the status of volume test1")))
 	})
 
 	// TODO: test error reporting on non successful VirtualMachineInstance syncs and kill attempts

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2044,9 +2044,8 @@ var _ = Describe("Manager", func() {
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
 
-		virtualMachineInstanceGuestAgentInfo, err := libvirtmanager.GetGuestInfo()
+		_, err := libvirtmanager.GetGuestInfo()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeNil())
 	})
 
 	It("executes GetUsers", func() {
@@ -2066,7 +2065,7 @@ var _ = Describe("Manager", func() {
 
 		virtualMachineInstanceGuestAgentInfo, err := libvirtmanager.GetUsers()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeNil())
+		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeEmpty())
 	})
 
 	It("executes GetFilesystems", func() {
@@ -2088,7 +2087,7 @@ var _ = Describe("Manager", func() {
 
 		virtualMachineInstanceGuestAgentInfo, err := libvirtmanager.GetFilesystems()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeNil())
+		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeEmpty())
 	})
 
 	It("executes generateCloudInitEmptyISO and succeeds", func() {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -70,8 +70,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	DeferCleanup(os.RemoveAll, tmpDir)
 
-	err = cloudinit.SetLocalDirectory(tmpDir)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(cloudinit.SetLocalDirectory(tmpDir)).To(Succeed())
 
 	ephemeraldiskutils.MockDefaultOwnershipManager()
 	cloudinit.SetIsoCreationFunction(isoCreationFunc)
@@ -138,14 +137,14 @@ var _ = Describe("Manager", func() {
 			domainSpec := expectedDomainFor(vmi)
 
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should define and start a new VirtualMachineInstance with StartStrategy paused", func() {
@@ -159,14 +158,14 @@ var _ = Describe("Manager", func() {
 			domainSpec := expectedDomainFor(vmi)
 
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().CreateWithFlags(libvirt.DOMAIN_START_PAUSED).Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should define and start a new VirtualMachineInstance with userData", func() {
@@ -180,14 +179,14 @@ var _ = Describe("Manager", func() {
 			addCloudInitDisk(vmi, userData, networkData)
 			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should define and start a new VirtualMachineInstance with userData and networkData", func() {
@@ -200,14 +199,14 @@ var _ = Describe("Manager", func() {
 			addCloudInitDisk(vmi, userData, networkData)
 			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should leave a defined and started VirtualMachineInstance alone", func() {
@@ -223,7 +222,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		DescribeTable("should try to start a VirtualMachineInstance in state",
@@ -241,7 +240,7 @@ var _ = Describe("Manager", func() {
 				mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
 				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 				newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(newspec).ToNot(BeNil())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
@@ -263,7 +262,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should not unpause a paused VirtualMachineInstance on SyncVMI, which was paused by user", func() {
@@ -279,8 +278,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Suspend().Return(nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
-			err = manager.PauseVMI(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.PauseVMI(vmi)).To(Succeed())
 
 			mockDomain.EXPECT().Free()
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
@@ -289,7 +287,7 @@ var _ = Describe("Manager", func() {
 			// no expected call to unpause
 
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should freeze a VirtualMachineInstance", func() {
@@ -299,8 +297,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
-			err := manager.FreezeVMI(vmi, 0)
-			Expect(err).To(BeNil())
+			Expect(manager.FreezeVMI(vmi, 0)).To(Succeed())
 		})
 		It("should unfreeze a VirtualMachineInstance", func() {
 			vmi := newVMI(testNamespace, testVmName)
@@ -309,8 +306,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
-			err := manager.UnfreezeVMI(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.UnfreezeVMI(vmi)).To(Succeed())
 		})
 		It("should automatically unfreeze after a timeout a frozen VirtualMachineInstance", func() {
 			vmi := newVMI(testNamespace, testVmName)
@@ -322,8 +318,7 @@ var _ = Describe("Manager", func() {
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
 			var unfreezeTimeout time.Duration = 3 * time.Second
-			err := manager.FreezeVMI(vmi, int32(unfreezeTimeout.Seconds()))
-			Expect(err).To(BeNil())
+			Expect(manager.FreezeVMI(vmi, int32(unfreezeTimeout.Seconds()))).To(Succeed())
 			// wait for the unfreeze timeout
 			time.Sleep(unfreezeTimeout + 2*time.Second)
 		})
@@ -338,11 +333,9 @@ var _ = Describe("Manager", func() {
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
 			var unfreezeTimeout time.Duration = 3 * time.Second
-			err := manager.FreezeVMI(vmi, int32(unfreezeTimeout.Seconds()))
-			Expect(err).To(BeNil())
+			Expect(manager.FreezeVMI(vmi, int32(unfreezeTimeout.Seconds()))).To(Succeed())
 			time.Sleep(time.Second)
-			err = manager.UnfreezeVMI(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.UnfreezeVMI(vmi)).To(Succeed())
 			// wait for the unfreeze timeout
 			time.Sleep(unfreezeTimeout + 2*time.Second)
 		})
@@ -480,8 +473,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Suspend().Return(nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
-			err := manager.PauseVMI(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.PauseVMI(vmi)).To(Succeed())
 		})
 		It("should not try to pause a paused VirtualMachineInstance", func() {
 			// Make sure that we always free the domain after use
@@ -493,8 +485,7 @@ var _ = Describe("Manager", func() {
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			// no call to suspend
 
-			err := manager.PauseVMI(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.PauseVMI(vmi)).To(Succeed())
 		})
 		It("should unpause a VirtualMachineInstance", func() {
 			isSetTimeCalled := make(chan bool, 1)
@@ -518,8 +509,7 @@ var _ = Describe("Manager", func() {
 				})
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", "fake", nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 
-			err := manager.UnpauseVMI(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 			Eventually(func() bool {
 				select {
 				case isCalled := <-isSetTimeCalled:
@@ -546,9 +536,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			// no call to unpause
-			err := manager.UnpauseVMI(vmi)
-			Expect(err).To(BeNil())
-
+			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 		})
 		It("should not add discard=unmap if a disk is preallocated", func() {
 			// Make sure that we always free the domain after use
@@ -618,7 +606,7 @@ var _ = Describe("Manager", func() {
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				PreallocatedVolumes:  []string{"permvolume1"},
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should hotplug a disk if a volume was hotplugged", func() {
@@ -686,7 +674,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
 				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
 				return true, nil
@@ -747,7 +735,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
 			manager, _ := newLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should unplug a disk if a volume was unplugged", func() {
@@ -815,7 +803,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			detachDisk := api.Disk{
 				Device: "disk",
 				Type:   "file",
@@ -857,7 +845,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain), nil)
 			manager, _ := newLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should not plug/unplug a disk if nothing changed", func() {
@@ -925,7 +913,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
 				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
 				return true, nil
@@ -936,7 +924,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain), nil)
 			manager, _ := newLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 		It("should not hotplug a disk if a volume was hotplugged, but the disk is not ready yet", func() {
@@ -1004,7 +992,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 			domainSpec := expectedDomainFor(vmi)
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
 				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
 				return false, nil
@@ -1037,7 +1025,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
 			manager, _ := newLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, mockDirectIOChecker)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
 	})
@@ -1049,12 +1037,11 @@ var _ = Describe("Manager", func() {
 			domainSpec := expectedDomainFor(vmi)
 
 			oldXML, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			t := true
 			domainSpec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{MarkedForGracefulShutdown: &t}
 
-			Expect(err).To(BeNil())
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(oldXML), nil)
@@ -1078,9 +1065,8 @@ var _ = Describe("Manager", func() {
 			domainSpec := expectedDomainFor(vmi)
 
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
-			Expect(err).To(BeNil())
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(xml), nil)
@@ -1120,7 +1106,7 @@ var _ = Describe("Manager", func() {
 
 			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			manager := &LibvirtDomainManager{
 				virConn:      mockConn,
 				virtShareDir: testVirtShareDir,
@@ -1166,7 +1152,7 @@ var _ = Describe("Manager", func() {
 
 			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			manager := &LibvirtDomainManager{
 				virConn:      mockConn,
 				virtShareDir: testVirtShareDir,
@@ -1232,7 +1218,7 @@ var _ = Describe("Manager", func() {
 			})
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().DoAndReturn(func(_ libvirt.DomainXMLFlags) (string, error) {
 				xmlOriginal, err := xml.MarshalIndent(domainSpec, "", "\t")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				return string(xmlOriginal), nil
 			})
 			mockDomain.EXPECT().MigrateStartPostCopy(gomock.Eq(uint32(0))).Times(1).Return(nil)
@@ -1304,7 +1290,7 @@ var _ = Describe("Manager", func() {
 			})
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().DoAndReturn(func(_ libvirt.DomainXMLFlags) (string, error) {
 				xmlOriginal, err := xml.MarshalIndent(domainSpec, "", "\t")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				return string(xmlOriginal), nil
 			})
 
@@ -1394,7 +1380,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetJobInfo().MaxTimes(1).Return(migrationInProgress, nil)
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
-			Expect(manager.CancelVMIMigration(vmi)).To(BeNil())
+			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
 
 		})
 
@@ -1418,7 +1404,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).AnyTimes().Return(string(domainXml), nil)
@@ -1431,8 +1417,7 @@ var _ = Describe("Manager", func() {
 				Return(string(metadataXml), nil)
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
-			err = manager.CancelVMIMigration(vmi)
-			Expect(err).To(BeNil())
+			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
 		})
 		It("migration cancellation should be finilized even if we missed status update", func() {
 			isMigrationAbortSet := make(chan bool, 1)
@@ -1474,7 +1459,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			metadataXml, err := xml.MarshalIndent(domainSpec.Metadata.KubeVirt, "", "\t")
 			Expect(err).NotTo(HaveOccurred())
 			mockDomain.EXPECT().GetXMLDesc(gomock.Any()).AnyTimes().Return(string(domainXml), nil)
@@ -1548,7 +1533,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			metadataXml, err := xml.MarshalIndent(domainSpec.Metadata.KubeVirt, "", "\t")
 			Expect(err).NotTo(HaveOccurred())
 			mockDomain.EXPECT().GetXMLDesc(gomock.Any()).AnyTimes().Return(string(domainXml), nil)
@@ -1604,8 +1589,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
-			err := manager.PrepareMigrationTarget(vmi, true, &cmdv1.VirtualMachineOptions{})
-			Expect(err).To(BeNil())
+			Expect(manager.PrepareMigrationTarget(vmi, true, &cmdv1.VirtualMachineOptions{})).To(Succeed())
 		})
 		It("should verify that migration failure is set in the monitor thread", func() {
 			isMigrationFailedSet := make(chan bool, 1)
@@ -1639,7 +1623,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			mockDomain.EXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
 			gomock.InOrder(
 				mockConn.EXPECT().DomainDefineXML(gomock.Any()).Return(mockDomain, nil),
@@ -1664,8 +1648,7 @@ var _ = Describe("Manager", func() {
 				ProgressTimeout:         150,
 				CompletionTimeoutPerGiB: 300,
 			}
-			err = manager.MigrateVMI(vmi, options)
-			Expect(err).To(BeNil())
+			Expect(manager.MigrateVMI(vmi, options)).To(Succeed())
 			Eventually(func() bool {
 				select {
 				case isSet := <-isMigrationFailedSet:
@@ -1696,7 +1679,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(domainXml), nil)
 
@@ -1712,8 +1695,7 @@ var _ = Describe("Manager", func() {
 				ProgressTimeout:         150,
 				CompletionTimeoutPerGiB: 300,
 			}
-			err = manager.MigrateVMI(vmi, options)
-			Expect(err).To(BeNil())
+			Expect(manager.MigrateVMI(vmi, options)).To(Succeed())
 		})
 		It("should correctly collect a list of disks for migration", func() {
 			_true := true
@@ -1804,8 +1786,7 @@ var _ = Describe("Manager", func() {
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_NVRAM).Return(nil)
 				manager, _ := NewLibvirtDomainManager(mockConn, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock)
-				err := manager.DeleteVMI(newVMI(testNamespace, testVmName))
-				Expect(err).To(BeNil())
+				Expect(manager.DeleteVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
 			Entry("shutoff", libvirt.DOMAIN_SHUTOFF),
@@ -1818,8 +1799,7 @@ var _ = Describe("Manager", func() {
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().DestroyFlags(libvirt.DOMAIN_DESTROY_GRACEFUL).Return(nil)
 				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
-				err := manager.KillVMI(newVMI(testNamespace, testVmName))
-				Expect(err).To(BeNil())
+				Expect(manager.KillVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("shuttingDown", libvirt.DOMAIN_SHUTDOWN),
 			Entry("running", libvirt.DOMAIN_RUNNING),
@@ -1869,7 +1849,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(state, libvirtReason, nil).AnyTimes()
 			mockDomain.EXPECT().GetName().Return("test", nil)
 			x, err := xml.MarshalIndent(api.NewMinimalDomainSpec("test"), "", "\t")
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(x), nil)
 			mockConn.EXPECT().ListAllDomains(gomock.Eq(libvirt.CONNECT_LIST_DOMAINS_ACTIVE|libvirt.CONNECT_LIST_DOMAINS_INACTIVE)).Return([]cli.VirDomain{mockDomain}, nil)
@@ -1914,7 +1894,7 @@ var _ = Describe("Manager", func() {
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			domStats, err := manager.GetDomainStats()
 
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(domStats)).To(Equal(1))
 		})
 	})
@@ -2038,8 +2018,7 @@ var _ = Describe("Manager", func() {
 		mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 		mockDomain.EXPECT().AttachDeviceFlags(`<hostdev type="pci" managed="no"><source><address type="pci" domain="0x05EA" bus="0xFc" slot="0x1d" function="0x6"></address></source><alias name="ua-sriov-test1"></alias></hostdev>`, libvirt.DomainDeviceModifyFlags(3)).Return(nil)
 
-		err = libvirtmanager.hotPlugHostDevices(vmi)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(libvirtmanager.hotPlugHostDevices(vmi)).To(Succeed())
 	})
 
 	It("executes GetGuestInfo", func() {
@@ -2145,8 +2124,7 @@ var _ = Describe("Manager", func() {
 			VolumeName: "test1",
 		}
 
-		err := libvirtmanager.generateCloudInitEmptyISO(vmi, nil)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(libvirtmanager.generateCloudInitEmptyISO(vmi, nil)).To(Succeed())
 
 		isoPath := cloudinit.GetIsoFilePath(libvirtmanager.cloudInitDataStore.DataSource, vmi.Name, vmi.Namespace)
 		stats, err := os.Stat(isoPath)
@@ -2373,10 +2351,9 @@ var _ = Describe("migratableDomXML", func() {
 		vmi := newVMI("testns", "kubevirt")
 		mockDomain.EXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
 		domain := &api.Domain{}
-		err := xml.Unmarshal([]byte(domXML), domain)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(xml.Unmarshal([]byte(domXML), domain)).To(Succeed())
 		newXML, err := migratableDomXML(mockDomain, vmi, &domain.Spec)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	})
 	It("should change CPU pinning according to migration metadata", func() {
@@ -2452,10 +2429,9 @@ var _ = Describe("migratableDomXML", func() {
 		By("generated the domain XML for a migration to that target")
 		mockDomain.EXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
 		domain := &api.Domain{}
-		err = xml.Unmarshal([]byte(domXML), domain)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(xml.Unmarshal([]byte(domXML), domain)).To(Succeed())
 		newXML, err := migratableDomXML(mockDomain, vmi, &domain.Spec)
-		Expect(err).To(BeNil(), "failed to generate target domain XML")
+		Expect(err).ToNot(HaveOccurred(), "failed to generate target domain XML")
 
 		By("ensuring the generated XML is accurate")
 		Expect(newXML).To(Equal(expectedXML), "the target XML is not as expected")
@@ -2503,16 +2479,14 @@ var _ = Describe("Manager helper functions", func() {
 
 		It("successful run with non-zero size", func() {
 			By("Creating a file with non-zero size")
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("file contents"), 0666)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("file contents"), 0666)).To(Succeed())
 
 			expectNonZeroQuantity(tmpDir)
 		})
 
 		It("successful run with zero size", func() {
 			By("Creating a file with non-zero size")
-			err := ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("file contents"), 0666)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ioutil.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("file contents"), 0666)).To(Succeed())
 
 			expectNonZeroQuantity(tmpDir)
 		})

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1862,8 +1862,7 @@ var _ = Describe("Manager", func() {
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
 			doms, err := manager.ListAllDomains()
 			Expect(err).NotTo(HaveOccurred())
-
-			Expect(len(doms)).To(Equal(1))
+			Expect(doms).To(HaveLen(1))
 
 			domain := doms[0]
 			domain.Spec.XMLName = xml.Name{}
@@ -1895,7 +1894,7 @@ var _ = Describe("Manager", func() {
 			domStats, err := manager.GetDomainStats()
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domStats)).To(Equal(1))
+			Expect(domStats).To(HaveLen(1))
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
@@ -82,9 +82,9 @@ var _ = Describe("StatsConverter", func() {
 			Expect(out.Cpu).To(Not(BeNil()))
 			Expect(out.Memory).To(Not(BeNil()))
 			Expect(out.MigrateDomainJobInfo).To(Not(BeNil()))
-			Expect(len(out.Vcpu)).To(Equal(len(testStats[0].Vcpu)))
-			Expect(len(out.Net)).To(Equal(len(testStats[0].Net)))
-			Expect(len(out.Block)).To(Equal(len(testStats[0].Block)))
+			Expect(out.Vcpu).To(HaveLen(len(testStats[0].Vcpu)))
+			Expect(out.Net).To(HaveLen(len(testStats[0].Net)))
+			Expect(out.Block).To(HaveLen(len(testStats[0].Block)))
 		})
 
 		It("should convert valid input", func() {

--- a/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
@@ -58,9 +58,9 @@ var _ = Describe("StatsConverter", func() {
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, inJobInfo, &out)
+			Expect(Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, inJobInfo, &out)).
+				To(Succeed())
 
-			Expect(err).To(BeNil())
 			Expect(out.Name).To(Equal("testName"))
 			Expect(out.UUID).To(Equal("testUUID"))
 		})
@@ -75,9 +75,9 @@ var _ = Describe("StatsConverter", func() {
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, inJobInfo, &out)
+			Expect(Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, inJobInfo, &out)).
+				To(Succeed())
 
-			Expect(err).To(BeNil())
 			// very very basic sanity check
 			Expect(out.Cpu).To(Not(BeNil()))
 			Expect(out.Memory).To(Not(BeNil()))
@@ -97,21 +97,18 @@ var _ = Describe("StatsConverter", func() {
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &inJobInfo, &out)
-
-			Expect(err).To(BeNil())
+			Expect(Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &inJobInfo, &out)).
+				To(Succeed())
 
 			loaded := new(bytes.Buffer)
 			enc := json.NewEncoder(loaded)
-			err = enc.Encode(out)
-			Expect(err).To(BeNil())
+			Expect(enc.Encode(out)).To(Succeed())
 
 			equal, err := JSONEqual(loaded, strings.NewReader(util.Testdataexpected))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			if !equal {
 				enc := json.NewEncoder(os.Stderr)
-				err = enc.Encode(out)
-				Expect(err).To(BeNil())
+				Expect(enc.Encode(out)).To(Succeed())
 			}
 			Expect(equal).To(BeTrue())
 		})

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -150,7 +150,7 @@ var _ = Describe("LibvirtHelper", func() {
 			//delete(entry, "timestamp")
 			loggedLines = append(loggedLines, entry)
 		}
-		Expect(scanner.Err()).To(Not(HaveOccurred()))
+		Expect(scanner.Err()).ToNot(HaveOccurred())
 
 		expectedLines := []map[string]string{}
 		scanner = bufio.NewScanner(strings.NewReader(formattedLogs))
@@ -160,7 +160,7 @@ var _ = Describe("LibvirtHelper", func() {
 			//delete(entry, "timestamp")
 			expectedLines = append(expectedLines, entry)
 		}
-		Expect(scanner.Err()).To(Not(HaveOccurred()))
+		Expect(scanner.Err()).ToNot(HaveOccurred())
 
 		Expect(loggedLines).To(Equal(expectedLines))
 	})
@@ -187,7 +187,7 @@ var _ = Describe("LibvirtHelper", func() {
 			delete(entry, "timestamp")
 			loggedLines = append(loggedLines, entry)
 		}
-		Expect(scanner.Err()).To(Not(HaveOccurred()))
+		Expect(scanner.Err()).ToNot(HaveOccurred())
 
 		expectedLines := []map[string]string{}
 		scanner = bufio.NewScanner(strings.NewReader(qemuFormattedLogs))
@@ -197,7 +197,7 @@ var _ = Describe("LibvirtHelper", func() {
 			delete(entry, "timestamp")
 			expectedLines = append(expectedLines, entry)
 		}
-		Expect(scanner.Err()).To(Not(HaveOccurred()))
+		Expect(scanner.Err()).ToNot(HaveOccurred())
 
 		Expect(loggedLines).To(Equal(expectedLines))
 	})

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -146,8 +146,7 @@ var _ = Describe("LibvirtHelper", func() {
 
 		for scanner.Scan() {
 			entry := map[string]string{}
-			err := json.Unmarshal(scanner.Bytes(), &entry)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(json.Unmarshal(scanner.Bytes(), &entry)).To(Succeed())
 			//delete(entry, "timestamp")
 			loggedLines = append(loggedLines, entry)
 		}
@@ -157,8 +156,7 @@ var _ = Describe("LibvirtHelper", func() {
 		scanner = bufio.NewScanner(strings.NewReader(formattedLogs))
 		for scanner.Scan() {
 			entry := map[string]string{}
-			err := json.Unmarshal(scanner.Bytes(), &entry)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(json.Unmarshal(scanner.Bytes(), &entry)).To(Succeed())
 			//delete(entry, "timestamp")
 			expectedLines = append(expectedLines, entry)
 		}
@@ -185,8 +183,7 @@ var _ = Describe("LibvirtHelper", func() {
 
 		for scanner.Scan() {
 			entry := map[string]string{}
-			err := json.Unmarshal(scanner.Bytes(), &entry)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(json.Unmarshal(scanner.Bytes(), &entry)).To(Succeed())
 			delete(entry, "timestamp")
 			loggedLines = append(loggedLines, entry)
 		}
@@ -196,8 +193,7 @@ var _ = Describe("LibvirtHelper", func() {
 		scanner = bufio.NewScanner(strings.NewReader(qemuFormattedLogs))
 		for scanner.Scan() {
 			entry := map[string]string{}
-			err := json.Unmarshal(scanner.Bytes(), &entry)
-			Expect(err).To(Not(HaveOccurred()))
+			Expect(json.Unmarshal(scanner.Bytes(), &entry)).To(Succeed())
 			delete(entry, "timestamp")
 			expectedLines = append(expectedLines, entry)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves matching for errors, length, and substrings.

**Release note**:
```release-note
None
```
