### PR TITLE
tests: replace To(Equal(...)) to To(HaveLen(...))

### DIFF
--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Hardware utils test", func() {
 			cpusetLine := "0-2,7,12-14"
 			lst, err := ParseCPUSetLine(cpusetLine, 100)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(lst)).To(Equal(7))
+			Expect(lst).To(HaveLen(7))
 			Expect(lst).To(Equal(expectedList))
 		})
 

--- a/pkg/util/lookup/lookup_test.go
+++ b/pkg/util/lookup/lookup_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Lookup", func() {
 
 		returnedVMIs, err := VirtualMachinesOnNode(virtClient, "node01")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(returnedVMIs)).To(Equal(2))
+		Expect(returnedVMIs).To(HaveLen(2))
 	})
 
 	It("should return active vmis on a node", func() {
@@ -63,7 +63,7 @@ var _ = Describe("Lookup", func() {
 
 		returnedVMIs, err := ActiveVirtualMachinesOnNode(virtClient, "node01")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(returnedVMIs)).To(Equal(1))
+		Expect(returnedVMIs).To(HaveLen(1))
 		Expect(returnedVMIs[0].Status.Phase).To(Equal(virtv1.Running))
 	})
 


### PR DESCRIPTION
Signed-off-by: Ben Oukhanov <boukhano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replace `Expect(len(...)).To(Equal(...))` with `Expect(...).To(HaveLen(...))` to get a better info when it fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
