### PR TITLE
tests: use HaveLen(...) and BeEmpty()

### DIFF
--- a/pkg/monitoring/domainstats/collector_test.go
+++ b/pkg/monitoring/domainstats/collector_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Collector", func() {
 
 			skipped, completed := cc.Collect(vmis, fs, 1*time.Second)
 
-			Expect(len(skipped)).To(Equal(0))
+			Expect(skipped).To(BeEmpty())
 			Expect(completed).To(BeTrue())
 		})
 	})
@@ -73,7 +73,7 @@ var _ = Describe("Collector", func() {
 
 			skipped, completed := cc.Collect(vmis, fs, 1*time.Second)
 
-			Expect(len(skipped)).To(Equal(0))
+			Expect(skipped).To(BeEmpty())
 			Expect(completed).To(BeFalse())
 		})
 
@@ -85,19 +85,19 @@ var _ = Describe("Collector", func() {
 			By("Doing a first collection")
 			skipped, completed := cc.Collect(vmis, fs, 1*time.Second)
 			// first collection is not aware of the blocked source
-			Expect(len(skipped)).To(Equal(0))
+			Expect(skipped).To(BeEmpty())
 			Expect(completed).To(BeFalse())
 
 			By("Doing a second collection")
 			skipped, completed = cc.Collect(vmis, fs, 1*time.Second)
 			// second collection is not aware of the blocked source
-			Expect(len(skipped)).To(Equal(0))
+			Expect(skipped).To(BeEmpty())
 			Expect(completed).To(BeFalse())
 
 			By("Collecting again with a blocked source")
 			skipped, completed = cc.Collect(vmis, fs, 1*time.Second)
 			// second collection is aware of the blocked source
-			Expect(len(skipped)).To(Equal(1))
+			Expect(skipped).To(HaveLen(1))
 			Expect(skipped[0]).To(Equal("a"))
 			Expect(completed).To(BeTrue())
 
@@ -111,13 +111,13 @@ var _ = Describe("Collector", func() {
 			By("Doing a first collection")
 			skipped, completed := cc.Collect(vmis, fs, 1*time.Second)
 			// first collection is not aware of the blocked source
-			Expect(len(skipped)).To(Equal(0))
+			Expect(skipped).To(BeEmpty())
 			Expect(completed).To(BeFalse())
 
 			By("Collecting again with a blocked source")
 			skipped, completed = cc.Collect(vmis, fs, 1*time.Second)
 			// second collection is aware of the blocked source
-			Expect(len(skipped)).To(Equal(1))
+			Expect(skipped).To(HaveLen(1))
 			Expect(skipped[0]).To(Equal("b"))
 			Expect(completed).To(BeTrue())
 
@@ -128,7 +128,7 @@ var _ = Describe("Collector", func() {
 
 			By("Restored a clean state")
 			skipped, completed = cc.Collect(vmis, fs, 1*time.Second)
-			Expect(len(skipped)).To(Equal(0))
+			Expect(skipped).To(BeEmpty())
 			Expect(completed).To(BeTrue())
 		})
 	})

--- a/pkg/monitoring/domainstats/downwardmetrics/hostmetrics_test.go
+++ b/pkg/monitoring/domainstats/downwardmetrics/hostmetrics_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Hostmetrics", func() {
 
 		metrics := hostmetrics.Collect()
 
-		Expect(len(metrics)).To(Equal(9))
+		Expect(metrics).To(HaveLen(9))
 		Expect(metrics[0].Name).To(Equal("NumberOfPhysicalCPUs"))
 		Expect(metrics[0].Unit).To(Equal(""))
 		Expect(metrics[0].Value).To(Equal("3"))
@@ -58,7 +58,7 @@ var _ = Describe("Hostmetrics", func() {
 		}
 
 		metrics := hostmetrics.Collect()
-		Expect(len(metrics)).To(Equal(count))
+		Expect(metrics).To(HaveLen(count))
 
 	},
 		table.Entry("cpuinfo", "nonexistent", "testdata/meminfo", "testdata/stat", "testdata/vmstat", 8),

--- a/pkg/monitoring/vmistats/collector_test.go
+++ b/pkg/monitoring/vmistats/collector_test.go
@@ -108,12 +108,12 @@ var _ = Describe("Utility functions", func() {
 
 			countMap = makeVMICountMetricMap(nil)
 			Expect(countMap).NotTo(BeNil())
-			Expect(len(countMap)).To(Equal(0))
+			Expect(countMap).To(BeEmpty())
 
 			vmis := []*k6tv1.VirtualMachineInstance{}
 			countMap = makeVMICountMetricMap(vmis)
 			Expect(countMap).NotTo(BeNil())
-			Expect(len(countMap)).To(Equal(0))
+			Expect(countMap).To(BeEmpty())
 		})
 
 		It("should handle different VMI phases", func() {
@@ -189,7 +189,7 @@ var _ = Describe("Utility functions", func() {
 
 			countMap := makeVMICountMetricMap(vmis)
 			Expect(countMap).NotTo(BeNil())
-			Expect(len(countMap)).To(Equal(3))
+			Expect(countMap).To(HaveLen(3))
 
 			running := vmiCountMetric{
 				Phase:    "running",


### PR DESCRIPTION
Signed-off-by: Ben Oukhanov <boukhano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replace `Expect(len(...)).To(Equal(...))`
with `Expect(...).To(HaveLen(...))` and `Expect(...).To(BeEmpty())` to get
a better info when it fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
