### PR TITLE
Properly manage knownhosts files

### DIFF
--- a/pkg/virtctl/ssh/BUILD.bazel
+++ b/pkg/virtctl/ssh/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "knownhosts_test.go",
         "ssh_suite_test.go",
         "wrapped_test.go",
     ],
@@ -36,5 +37,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/golang.org/x/crypto/ssh:go_default_library",
     ],
 )

--- a/pkg/virtctl/ssh/knownhosts.go
+++ b/pkg/virtctl/ssh/knownhosts.go
@@ -15,6 +15,15 @@ import (
 // InteractiveHostKeyCallback verifying the host key against known_hosts and adding the key if
 // the user replies accordingly.
 func InteractiveHostKeyCallback(knownHostsFilePath string) (ssh.HostKeyCallback, error) {
+	if _, err := os.Stat(knownHostsFilePath); os.IsNotExist(err) {
+		f, err := os.Create(knownHostsFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed creating known hosts file %q: %v", knownHostsFilePath, err)
+		}
+		_ = f.Close()
+	} else if err != nil {
+		return nil, fmt.Errorf("failed reading known host file %q: %v", knownHostsFilePath, err)
+	}
 	validator, err := knownhosts.New(knownHostsFilePath)
 	if err != nil {
 		return nil, err

--- a/pkg/virtctl/ssh/knownhosts.go
+++ b/pkg/virtctl/ssh/knownhosts.go
@@ -32,7 +32,7 @@ func InteractiveHostKeyCallback(knownHostsFilePath string) (ssh.HostKeyCallback,
 			if err != nil || !shouldAdd {
 				return err
 			}
-			if err := addHostKey(knownHostsFilePath, hostname, remote, key); err != nil {
+			if err := addHostKey(knownHostsFilePath, hostname, key); err != nil {
 				return err
 			}
 			return nil
@@ -67,7 +67,7 @@ Are you sure you want to continue connecting (yes/no)? `,
 	return askToAddHostKey(hostname, remote, key)
 }
 
-func addHostKey(knownHostsFilePath string, hostname string, remote net.Addr, key ssh.PublicKey) error {
+func addHostKey(knownHostsFilePath string, hostname string, key ssh.PublicKey) error {
 	f, err := os.OpenFile(knownHostsFilePath, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
@@ -75,6 +75,6 @@ func addHostKey(knownHostsFilePath string, hostname string, remote net.Addr, key
 	defer f.Close()
 
 	addresses := []string{hostname}
-	_, err = f.WriteString(knownhosts.Line(addresses, key))
+	_, err = fmt.Fprintln(f, knownhosts.Line(addresses, key))
 	return err
 }

--- a/pkg/virtctl/ssh/knownhosts_test.go
+++ b/pkg/virtctl/ssh/knownhosts_test.go
@@ -1,0 +1,64 @@
+package ssh
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+)
+
+var _ = Describe("Known Hosts", func() {
+
+	var knowHostFile string
+	BeforeEach(func() {
+		tmpDir := GinkgoT().TempDir()
+		knowHostFile = filepath.Join(tmpDir, "knownhosts")
+		f, err := os.Create(knowHostFile)
+		Expect(err).ToNot(HaveOccurred())
+		_ = f.Close()
+	})
+
+	It("should be added with a newline", func() {
+		publicKey, err := newPublicKey()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(addHostKey(knowHostFile, "host1", publicKey)).To(Succeed())
+		Expect(addHostKey(knowHostFile, "host2", publicKey)).To(Succeed())
+		Expect(addHostKey(knowHostFile, "host3", publicKey)).To(Succeed())
+
+		Expect(numberOfLines(knowHostFile)).To(Equal(3))
+	})
+})
+
+func newPublicKey() (ssh.PublicKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, err
+	}
+	pub, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return pub, nil
+}
+
+func numberOfLines(knowHostFile string) (int, error) {
+	f, err := os.Open(knowHostFile)
+	if err != nil {
+		return -1, err
+	}
+	scanner := bufio.NewScanner(f)
+
+	lineCount := 0
+	for {
+		if !scanner.Scan() {
+			break
+		}
+		lineCount++
+	}
+	return lineCount, nil
+}

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -61,7 +61,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	}
 
 	if len(homeDir) > 0 {
-		c.options.KnownHostsFilePathDefault = filepath.Join(homeDir, ".ssh", "known_hosts")
+		c.options.KnownHostsFilePathDefault = filepath.Join(homeDir, ".ssh", "kubevirt_known_hosts")
 	}
 
 	cmd := &cobra.Command{
@@ -81,7 +81,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVarP(&c.options.IdentityFilePath, identityFilePathFlag, identityFilePathFlagShort, c.options.IdentityFilePath,
 		fmt.Sprintf("--%s=/home/jdoe/.ssh/id_rsa: Set the path to a private key used for authenticating to the server; If not provided, the client will try to use the local ssh-agent at $SSH_AUTH_SOCK", identityFilePathFlag))
 	cmd.Flags().StringVar(&c.options.KnownHostsFilePath, knownHostsFilePathFlag, c.options.KnownHostsFilePathDefault,
-		fmt.Sprintf("--%s=/home/jdoe/.ssh/known_hosts: Set the path to the known_hosts file; If not provided, the client will skip host checks", knownHostsFilePathFlag))
+		fmt.Sprintf("--%s=/home/jdoe/.ssh/kubevirt_known_hosts: Set the path to the known_hosts file.", knownHostsFilePathFlag))
 	cmd.Flags().IntVarP(&c.options.SshPort, portFlag, portFlagShort, c.options.SshPort,
 		fmt.Sprintf(`--%s=22: Specify a port on the VM to send SSH traffic to`, portFlag))
 	cmd.Flags().BoolVar(&c.options.WrapLocalSSH, wrapLocalSSHFlag, c.options.WrapLocalSSH,


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Ensure that newlines are appended to know hosts file entries. Otherwise some tools are just adding
keys to the previous key on the same line.
 * Manage known hosts file entries in a separate `~/.ssh/kubevirt_known_hosts` file, similar to `gcould compute ssh`.
 * Ensure that the known_hosts file gets created if not present.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7357

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix knowhosts file corruption for virtctl ssh
```
