### PR TITLE
virt-launcher, hostdevice: Respect SR-IOV guest pciAddress and bootOrder

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         ":go_default_library",
         "//pkg/network/sriov:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -164,6 +165,61 @@ var _ = Describe("SRIOV HostDevice", func() {
 			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
 
+		DescribeTable("create two devices with custom guest PCI address",
+			func(iface1, iface2 v1.Interface) {
+				var expectedGuestPCIAddress1 *api.Address
+				var expectedGuestPCIAddress2 *api.Address
+
+				var err error
+				if iface1.PciAddress != "" {
+					expectedGuestPCIAddress1, err = device.NewPciAddressField(iface1.PciAddress)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				if iface2.PciAddress != "" {
+					expectedGuestPCIAddress2, err = device.NewPciAddressField(iface2.PciAddress)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				pool := newPCIAddressPoolStub("0000:81:00.0", "0000:81:01.0")
+				hostPCIAddress1 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x00", Function: "0x0"}
+				hostPCIAddress2 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+
+				devices, err := sriov.CreateHostDevicesFromIfacesAndPool([]v1.Interface{iface1, iface2}, pool)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectHostDevice1 := api.HostDevice{
+					Alias:   newSRIOVAlias(netname1),
+					Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
+					Address: expectedGuestPCIAddress1,
+					Type:    "pci",
+					Managed: "no",
+				}
+
+				expectHostDevice2 := api.HostDevice{
+					Alias:   newSRIOVAlias(netname2),
+					Source:  api.HostDeviceSource{Address: &hostPCIAddress2},
+					Address: expectedGuestPCIAddress2,
+					Type:    "pci",
+					Managed: "no",
+				}
+
+				Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
+			},
+			Entry("both interfaces have a custom guest PCI address",
+				newSRIOVInterfaceWithPCIAddress(netname1, "0000:20:00.0"),
+				newSRIOVInterfaceWithPCIAddress(netname2, "0000:20:01.0"),
+			),
+			Entry("only the first interface has a custom guest PCI address",
+				newSRIOVInterfaceWithPCIAddress(netname1, "0000:20:00.0"),
+				newSRIOVInterface(netname2),
+			),
+			Entry("only the second interface has a custom guest PCI address",
+				newSRIOVInterface(netname1),
+				newSRIOVInterfaceWithPCIAddress(netname2, "0000:20:01.0"),
+			),
+		)
+
 		It("creates 1 device that includes boot-order", func() {
 			iface := newSRIOVInterface(netname1)
 			val := uint(1)
@@ -182,6 +238,58 @@ var _ = Describe("SRIOV HostDevice", func() {
 			}
 			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
+
+		DescribeTable("create two devices with custom boot-order",
+			func(iface1, iface2 v1.Interface) {
+				var expectedBootOrder1 *api.BootOrder
+				var expectedBootOrder2 *api.BootOrder
+
+				if iface1.BootOrder != nil {
+					expectedBootOrder1 = &api.BootOrder{Order: *iface1.BootOrder}
+				}
+
+				if iface2.BootOrder != nil {
+					expectedBootOrder2 = &api.BootOrder{Order: *iface2.BootOrder}
+				}
+
+				pool := newPCIAddressPoolStub("0000:81:00.0", "0000:81:01.0")
+				hostPCIAddress1 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x00", Function: "0x0"}
+				hostPCIAddress2 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+
+				devices, err := sriov.CreateHostDevicesFromIfacesAndPool([]v1.Interface{iface1, iface2}, pool)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectHostDevice1 := api.HostDevice{
+					Alias:     newSRIOVAlias(netname1),
+					Source:    api.HostDeviceSource{Address: &hostPCIAddress1},
+					Type:      "pci",
+					Managed:   "no",
+					BootOrder: expectedBootOrder1,
+				}
+
+				expectHostDevice2 := api.HostDevice{
+					Alias:     newSRIOVAlias(netname2),
+					Source:    api.HostDeviceSource{Address: &hostPCIAddress2},
+					Type:      "pci",
+					Managed:   "no",
+					BootOrder: expectedBootOrder2,
+				}
+
+				Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
+			},
+			Entry("both interfaces have a custom bootOrder",
+				newSRIOVInterfaceWithBootOrder(netname1, 1),
+				newSRIOVInterfaceWithBootOrder(netname2, 2),
+			),
+			Entry("only the first interface has a custom bootOrder",
+				newSRIOVInterfaceWithBootOrder(netname1, 1),
+				newSRIOVInterface(netname2),
+			),
+			Entry("only the second interface has a custom bootOrder",
+				newSRIOVInterface(netname1),
+				newSRIOVInterfaceWithBootOrder(netname2, 2),
+			),
+		)
 	})
 
 	Context("safe detachment", func() {
@@ -266,6 +374,20 @@ func newDomainSpec(hostDevices ...api.HostDevice) *api.DomainSpec {
 
 func newSRIOVAlias(netName string) *api.Alias {
 	return api.NewUserDefinedAlias(netsriov.AliasPrefix + netName)
+}
+
+func newSRIOVInterfaceWithPCIAddress(name, customPCIAddress string) v1.Interface {
+	iface := newSRIOVInterface(name)
+	iface.PciAddress = customPCIAddress
+
+	return iface
+}
+
+func newSRIOVInterfaceWithBootOrder(name string, bootOrder uint) v1.Interface {
+	iface := newSRIOVInterface(name)
+	iface.BootOrder = &bootOrder
+
+	return iface
 }
 
 type stubPCIAddressPool struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This fixes the ability to set the following fields on a list of SR-IOV NICs:
- pciAddress (as seen by the Guest)
- bootOrder

This also adds tests to check SR-IOV NICs with custom guest PCI addresses and boot order in different configurations.

There was a closure created inside a loop, which captured the iteration variable.
This caused the guest PCI address and boot order settings of the last item in the list to be applied on all other list items.

For more information about capturing the iteration variable in a closure, please see:
https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed setting custom guest pciAddress and bootOrder parameter(s) to a list of SR-IOV NICs.
```