### PR TITLE
Add warning for manually determining core kubevirt infra component replica count

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12593,7 +12593,7 @@
       "$ref": "#/definitions/v1.NodePlacement"
      },
      "replicas": {
-      "description": "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2.",
+      "description": "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2. WARNING: this is an advanced feature that prevents auto-scaling for core kubevirt components. Please use with caution!",
       "type": "integer",
       "format": "byte"
      }

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1490,9 +1490,11 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    description: replicas indicates how many replicas should be created
+                    description: 'replicas indicates how many replicas should be created
                       for each KubeVirt infrastructure component (like virt-api or
-                      virt-controller). Defaults to 2.
+                      virt-controller). Defaults to 2. WARNING: this is an advanced
+                      feature that prevents auto-scaling for core kubevirt components.
+                      Please use with caution!'
                     type: integer
                 type: object
               monitorAccount:
@@ -2519,9 +2521,11 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    description: replicas indicates how many replicas should be created
+                    description: 'replicas indicates how many replicas should be created
                       for each KubeVirt infrastructure component (like virt-api or
-                      virt-controller). Defaults to 2.
+                      virt-controller). Defaults to 2. WARNING: this is an advanced
+                      feature that prevents auto-scaling for core kubevirt components.
+                      Please use with caution!'
                     type: integer
                 type: object
             type: object
@@ -4098,9 +4102,11 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    description: replicas indicates how many replicas should be created
+                    description: 'replicas indicates how many replicas should be created
                       for each KubeVirt infrastructure component (like virt-api or
-                      virt-controller). Defaults to 2.
+                      virt-controller). Defaults to 2. WARNING: this is an advanced
+                      feature that prevents auto-scaling for core kubevirt components.
+                      Please use with caution!'
                     type: integer
                 type: object
               monitorAccount:
@@ -5127,9 +5133,11 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    description: replicas indicates how many replicas should be created
+                    description: 'replicas indicates how many replicas should be created
                       for each KubeVirt infrastructure component (like virt-api or
-                      virt-controller). Defaults to 2.
+                      virt-controller). Defaults to 2. WARNING: this is an advanced
+                      feature that prevents auto-scaling for core kubevirt components.
+                      Please use with caution!'
                     type: integer
                 type: object
             type: object

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -54,6 +54,8 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		replicas := int32(*kv.Spec.Infra.Replicas)
 		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != replicas {
 			deployment.Spec.Replicas = &replicas
+			r.recorder.Eventf(deployment, corev1.EventTypeWarning, "AdvancedFeatureUse", "applying custom number of infra replica. this is an advanced feature that prevents "+
+				"auto-scaling for core kubevirt components. Please use with caution!")
 		}
 	}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1898,9 +1898,10 @@ var CRDsValidation map[string]string = map[string]string{
                   type: array
               type: object
             replicas:
-              description: replicas indicates how many replicas should be created
+              description: 'replicas indicates how many replicas should be created
                 for each KubeVirt infrastructure component (like virt-api or virt-controller).
-                Defaults to 2.
+                Defaults to 2. WARNING: this is an advanced feature that prevents
+                auto-scaling for core kubevirt components. Please use with caution!'
               type: integer
           type: object
         monitorAccount:
@@ -2858,9 +2859,10 @@ var CRDsValidation map[string]string = map[string]string{
                   type: array
               type: object
             replicas:
-              description: replicas indicates how many replicas should be created
+              description: 'replicas indicates how many replicas should be created
                 for each KubeVirt infrastructure component (like virt-api or virt-controller).
-                Defaults to 2.
+                Defaults to 2. WARNING: this is an advanced feature that prevents
+                auto-scaling for core kubevirt components. Please use with caution!'
               type: integer
           type: object
       type: object

--- a/staging/src/kubevirt.io/api/core/v1/componentconfig.go
+++ b/staging/src/kubevirt.io/api/core/v1/componentconfig.go
@@ -42,6 +42,7 @@ type ComponentConfig struct {
 	NodePlacement *NodePlacement `json:"nodePlacement,omitempty"`
 	// replicas indicates how many replicas should be created for each KubeVirt infrastructure
 	// component (like virt-api or virt-controller). Defaults to 2.
+	// WARNING: this is an advanced feature that prevents auto-scaling for core kubevirt components. Please use with caution!
 	//+optional
 	Replicas *uint8 `json:"replicas,omitempty"`
 }

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -14823,7 +14823,7 @@ func schema_kubevirtio_api_core_v1_ComponentConfig(ref common.ReferenceCallback)
 					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2.",
+							Description: "replicas indicates how many replicas should be created for each KubeVirt infrastructure component (like virt-api or virt-controller). Defaults to 2. WARNING: this is an advanced feature that prevents auto-scaling for core kubevirt components. Please use with caution!",
 							Type:        []string{"integer"},
 							Format:      "byte",
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
[This PR](https://github.com/kubevirt/kubevirt/pull/6663) introduces an option in Kubevirt CR's spec to manually determine the number of replicas for Kubevirt's core components like `virt-api`, `virt-controller`, etc.

As laid out in [this discussion](https://github.com/kubevirt/kubevirt/pull/7397#discussion_r828858282), this is problematic as it prevents us from auto-scaling the component in a smart way. As we're heading for auto-piloting and auto-scaling our component (e.g. [this PR](https://github.com/kubevirt/kubevirt/pull/7401)), this field is not recommended for use, expect for maybe advanced users that know exactly what they're doing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add warning for manually determining core-component replica count in Kubevirt CR
```
