### PR TITLE
tests libvmi: factory cleanup

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -196,7 +196,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 	Describe("downwardMetrics", func() {
 		It("[test_id:6535]should be published to a vmi and periodically updated", func() {
-			vmi := libvmi.NewTestToolingFedora()
+			vmi := libvmi.NewFedora()
 			tests.AddDownwardMetricsVolume(vmi, "vhostmd")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
 			Expect(console.LoginToFedora(vmi)).To(Succeed())

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -20,7 +20,8 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", func(
 	})
 
 	It("should start a SEV VM", func() {
-		vmi := libvmi.NewSEVFedora()
+		const secureBoot = false
+		vmi := libvmi.NewFedora(libvmi.WithUefi(secureBoot), libvmi.WithSEV())
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 		By("Expecting the VirtualMachineInstance console")

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -31,26 +31,6 @@ const (
 	DefaultVmiName               = "testvmi"
 )
 
-// NewFedora instantiates a new Fedora based VMI configuration,
-// building its extra properties based on the specified With* options.
-func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	return NewTestToolingFedora(opts...)
-}
-
-// NewTestToolingFedora instantiates a new Fedora based VMI configuration,
-// building its extra properties based on the specified With* options.
-// This image has tooling for the guest agent, stress, and more
-func NewTestToolingFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	return newFedora(cd.ContainerDiskFedoraTestTooling, opts...)
-}
-
-// NewSriovFedora instantiates a new Fedora based VMI configuration,
-// building its extra properties based on the specified With* options, the
-// image used include Guest Agent and some moduled needed by SRIOV.
-func NewSriovFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	return newFedora(cd.ContainerDiskFedoraTestTooling, opts...)
-}
-
 // NewSEVFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options, the
 // image used is configured for UEFI boot and it supports AMD SEV.
@@ -61,18 +41,18 @@ func NewSEVFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithSEV(),
 	}
 	opts = append(sevOptions, opts...)
-	return newFedora(cd.ContainerDiskFedoraTestTooling, opts...)
+	return NewFedora(opts...)
 }
 
-// NewFedora instantiates a new Fedora based VMI configuration with specified
-// containerDisk, building its extra properties based on the specified With*
-// options.
-func newFedora(containerDisk cd.ContainerDisk, opts ...Option) *kvirtv1.VirtualMachineInstance {
+// NewFedora instantiates a new Fedora based VMI configuration,
+// building its extra properties based on the specified With* options.
+// This image has tooling for the guest agent, stress, SR-IOV and more.
+func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	fedoraOptions := []Option{
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory("512M"),
 		WithRng(),
-		WithContainerImage(cd.ContainerDiskFor(containerDisk)),
+		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
 	}
 	opts = append(fedoraOptions, opts...)
 	return New(RandName(DefaultVmiName), opts...)

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -31,19 +31,6 @@ const (
 	DefaultVmiName               = "testvmi"
 )
 
-// NewSEVFedora instantiates a new Fedora based VMI configuration,
-// building its extra properties based on the specified With* options, the
-// image used is configured for UEFI boot and it supports AMD SEV.
-func NewSEVFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	const secureBoot = false
-	sevOptions := []Option{
-		WithUefi(secureBoot),
-		WithSEV(),
-	}
-	opts = append(sevOptions, opts...)
-	return NewFedora(opts...)
-}
-
 // NewFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options.
 // This image has tooling for the guest agent, stress, SR-IOV and more.

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -233,7 +233,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		secretName := createSecret()
 		configMapName := createConfigMap()
 
-		return libvmi.NewTestToolingFedora(
+		return libvmi.NewFedora(
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			withLabels(map[string]string{"downwardTestLabelKey": "downwardTestLabelVal"}),
@@ -772,7 +772,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:6971]should migrate with a downwardMetrics disk", func() {
-				vmi := libvmi.NewTestToolingFedora(
+				vmi := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -232,7 +232,7 @@ func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.Virtual
 		return nil, err
 	}
 
-	vmi := libvmi.NewTestToolingFedora(
+	vmi := libvmi.NewFedora(
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -430,7 +430,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 			customMacAddress := "50:00:00:00:90:0d"
 			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
 				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
-				vmiTwo := libvmi.NewTestToolingFedora(
+				vmiTwo := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
@@ -441,7 +441,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
 				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
-				vmiOne := libvmi.NewTestToolingFedora(
+				vmiOne := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
@@ -611,14 +611,14 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterfaceWithMACSpoofCheck
 				libvmi.InterfaceWithMac(&linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
 
-				vmiUnderTest := libvmi.NewTestToolingFedora(
+				vmiUnderTest := libvmi.NewFedora(
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask), false))
 				vmiUnderTest = tests.CreateVmiOnNode(vmiUnderTest, nodes.Items[0].Name)
 
 				By("Creating a target VM with Linux bridge CNI network interface and default MAC address.")
-				targetVmi := libvmi.NewTestToolingFedora(
+				targetVmi := libvmi.NewFedora(
 					libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
 					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth0", targetVMIPAddress+bridgeSubnetMask), false))
@@ -670,7 +670,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
-				agentVMI := libvmi.NewTestToolingFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
+				agentVMI := libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks
@@ -769,7 +769,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 					libvmi.WithNetwork(libvmi.MultusNetwork(name, name)),
 				)
 			}
-			return libvmi.NewSriovFedora(withVmiOptions...)
+			return libvmi.NewFedora(withVmiOptions...)
 		}
 
 		startVmi := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
@@ -1318,7 +1318,7 @@ var _ = SIGDescribe("Macvtap", func() {
 	}
 
 	newFedoraVMIWithExplicitMacAndGuestAgent := func(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {
-		return libvmi.NewTestToolingFedora(
+		return libvmi.NewFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithInterface(
 				*libvmi.InterfaceWithMac(

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -507,7 +507,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	Context("VirtualMachineInstance with dhcp options", func() {
 		It("[test_id:1778]should offer extra dhcp options to pod iface", func() {
 			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-			dhcpVMI := libvmi.NewTestToolingFedora()
+			dhcpVMI := libvmi.NewFedora()
 			tests.AddExplicitPodNetworkInterface(dhcpVMI)
 
 			dhcpVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi with agent connected via API", func() {
 			It("should succeed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewTestToolingFedora(withoutACPI()), vmiLaunchTimeout)
+				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(withoutACPI()), vmiLaunchTimeout)
 
 				tests.WaitAgentConnected(virtClient, vmi)
 
@@ -107,7 +107,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi with agent connected via virtctl", func() {
 			It("should succeed", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewTestToolingFedora(withoutACPI()), vmiLaunchTimeout)
+				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(withoutACPI()), vmiLaunchTimeout)
 
 				tests.WaitAgentConnected(virtClient, vmi)
 
@@ -148,7 +148,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		When("soft reboot vmi after paused and unpaused via virtctl", func() {
 			It("should failed to soft reboot a paused vmi", func() {
-				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewTestToolingFedora(), vmiLaunchTimeout)
+				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(), vmiLaunchTimeout)
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				command := tests.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_PAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2454,7 +2454,7 @@ func NewRandomFedoraVMIWithGuestAgent() *v1.VirtualMachineInstance {
 	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
 	Expect(err).NotTo(HaveOccurred())
 
-	return libvmi.NewTestToolingFedora(
+	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
@@ -2465,7 +2465,7 @@ func NewRandomFedoraVMIWithBlacklistGuestAgent(commands string) *v1.VirtualMachi
 	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
 	Expect(err).NotTo(HaveOccurred())
 
-	return libvmi.NewTestToolingFedora(
+	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithCloudInitNoCloudUserData(GetFedoraToolsGuestAgentBlacklistUserData(commands), false),

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2592,9 +2592,9 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some nodes")
 				node = nodes.Items[1].Name
 
-				vmi = libvmi.NewTestToolingFedora()
+				vmi = libvmi.NewFedora()
 
-				cpuvmi = libvmi.NewTestToolingFedora()
+				cpuvmi = libvmi.NewFedora()
 				cpuvmi.Spec.Domain.CPU = &v1.CPU{
 					Cores:                 2,
 					DedicatedCPUPlacement: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Unify several NewFedora factories
    
Several Fedora based factories pointed to the same underline
image, containing no differences.
Therefore, these have been unified into a single factory.

---

Remove NewSEVFedora
    
NewSEVFedora is being used in only one place, therefore
it seems reasonable to use the options directly at the
caller.
    
Generally speaking, libvmi should contain only factories
that are frequently used by the tests.
Specific usages should use options to compose the
needed VMI spec, either directly or through local helpers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```