### PR TITLE
libvmi, factory: Increase memory for Cirros to 256M

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -86,7 +86,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		withNonEmptyUserData,
-		WithResourceMemory("128Mi"),
+		WithResourceMemory("256Mi"),
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)


### PR DESCRIPTION
**What this PR does / why we need it**:

Cirros image needs 256M to boot on ARM64 [1].

Although it is possible to check the node architecture in advance
and set the optimize value, it adds complexity to the code base.
The added amount is negligible and we do not have memory resource
constraints due to other VM images we support (e.g. Fedora).

Therefore, the memory resource is increased by 128M to 256M.

[1] https://github.com/kubevirt/kubevirt/issues/6363

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
