### PR TITLE
docs, network: update the required capabilities for networking

### DIFF
--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -56,7 +56,7 @@ the following operations, in this order:
 The virt-launcher is an untrusted component of KubeVirt (since it wraps the
 libvirt process that will run third party workloads). As a result, it must be
 run with as little privileges as required. As of now, the only capability
-required by virt-launcher to configure networking is the `CAP_NET_ADMIN`.
+required by virt-launcher to configure networking is `CAP_NET_BIND_SERVICE`.
 
 In this second phase, virt-launcher also has to select the correct
 `BindMechanism`, and afterwards will uses it to retrieve the configuration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Unprivileged networking does not require `NET_ADMIN` since KubeVirt
0.41.0 - [0] - featured PR [1].

Currently, the only capability required is `CAP_NET_BIND_SERVICE`.

[0] - https://kubevirt.io/2021/changelog-v0.41.0.html
[1] - https://github.com/kubevirt/kubevirt/pull/5147

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
