### PR TITLE
Drop recording rule for orphaned VMs alert and fix alert definition

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -153,33 +153,76 @@ tests:
         exp_alerts: [ ]
 
 
-    # vmi running on a node without a virt-handler pod
+    # vmi running on a node with an unready virt-handler pod
   - interval: 1m
     input_series:
-      - series: 'node_namespace_pod:kube_pod_info:{pod="virt-launcher-vmi", node="node01"}'
-        values: '1+0x100'
-      - series: 'kube_pod_container_status_ready{pod="virt-handler-asdf", node="node01"}'
-        values: '0+0x100'
-      - series: 'node_namespace_pod:kube_pod_info:{pod="virt-handler-asdf", node="node01"}'
-        values: '0+0x100'
-      - series: 'kube_pod_container_status_ready{pod="virt-handler-asdfg", node="node02"}'
-        values: '1+0x100'
-      - series: 'node_namespace_pod:kube_pod_info:{pod="virt-handler-asdfg", node="node02"}'
-        values: '1+0x100'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="false"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
 
     alert_rule_test:
-      - eval_time: 60m
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts: [ ]
+      - eval_time: 10m
         alertname: OrphanedVirtualMachineInstances
         exp_alerts:
           - exp_annotations:
-              summary: "No virt-handler pod detected on node node01 with running vmis for more than an hour"
+              summary: "No ready virt-handler pod detected on node node01 with running vmis for more than 10 minutes"
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
-              pod: "virt-handler-asdf"
               severity: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+
+
+    # vmi running on a node without a virt-handler pod
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-handler pod detected on node node01 with running vmis for more than 10 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
+            exp_labels:
+              node: "node01"
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
 
   # Some virt controllers are not ready
   - interval: 1m

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -418,15 +418,11 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 					},
 					{
-						Record: "kubevirt_num_virt_handlers_by_node_running_virt_launcher",
-						Expr:   intstr.FromString("count by(node)(node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} ) * on (node) group_left(pod) (1*(kube_pod_container_status_ready{pod=~'virt-handler-.*'} + on (pod) group_left(node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-handler-.*'} ))) or on (node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} )"),
-					},
-					{
 						Alert: "OrphanedVirtualMachineInstances",
-						Expr:  intstr.FromString("(kubevirt_num_virt_handlers_by_node_running_virt_launcher) == 0"),
-						For:   "60m",
+						Expr:  intstr.FromString("((count by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} * on(pod) group_left(node) kube_pod_info{pod=~'virt-handler.*'})) or (count by (node)(kube_pod_info{pod=~'virt-launcher.*'})*0)) == 0"),
+						For:   "10m",
 						Annotations: map[string]string{
-							"summary":     "No virt-handler pod detected on node {{ $labels.node }} with running vmis for more than an hour",
+							"summary":     "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
 							"runbook_url": runbookUrlBasePath + "OrphanedVirtualMachineInstances",
 						},
 						Labels: map[string]string{


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removed recording rule kubevirt_num_virt_handlers_by_node_running_virt_launcher and updated the alert to fire when there is a node that is running VMs but doesn't have a ready virt-handler pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
