### PR TITLE
Replace Cirros with Alpine

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -395,7 +395,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutputCfgMap).To(Equal(expectedOutputCfgMap), "Expected %s to Equal value1value2value3", podOutputCfgMap)
 
 				By("Checking mounted ConfigMap image")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount ConfigMap image
@@ -515,7 +515,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
 
 				By("Checking mounted secrets sshkeys image")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount iso Secret image

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -38,7 +38,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", func() {
@@ -395,7 +394,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutputCfgMap).To(Equal(expectedOutputCfgMap), "Expected %s to Equal value1value2value3", podOutputCfgMap)
 
 				By("Checking mounted ConfigMap image")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount ConfigMap image
@@ -515,7 +514,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
 
 				By("Checking mounted secrets sshkeys image")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount iso Secret image

--- a/tests/console/BUILD.bazel
+++ b/tests/console/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//tests/libnet/cluster:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -13,7 +13,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
-	"kubevirt.io/kubevirt/tests/libnet/cluster"
 )
 
 // LoginToFunction represents any of the LoginTo* functions
@@ -51,7 +50,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 		&expect.BExp{R: "Password:"},
 		&expect.BSnd{S: "gocubsgo\n"},
 		&expect.BExp{R: PromptExpression}})
-	resp, err := expecter.ExpectBatch(b, 240*time.Second)
+	resp, err := expecter.ExpectBatch(b, 180*time.Second)
 
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", resp)
@@ -98,21 +97,7 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 		&expect.BExp{R: "localhost login:"},
 		&expect.BSnd{S: "root\n"},
 		&expect.BExp{R: PromptExpression}})
-
-	timeout := 180 * time.Second
-
-	clusterSupportsIpv4, err := cluster.SupportsIpv4(virtClient)
-	if err != nil {
-		return err
-	}
-	clusterSupportsIpv6, err := cluster.SupportsIpv6(virtClient)
-	if err != nil {
-		return err
-	}
-	if !clusterSupportsIpv4 && clusterSupportsIpv6 {
-		timeout = 240 * time.Second
-	}
-	res, err := expecter.ExpectBatch(b, timeout)
+	res, err := expecter.ExpectBatch(b, 180*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
 		return err

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -3,11 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "alpine.go",
         "cloudinit.go",
         "dns.go",
         "expose_util.go",
         "ipaddress.go",
-        "ipv6.go",
         "namespace.go",
         "ping.go",
         "skips.go",

--- a/tests/libnet/alpine.go
+++ b/tests/libnet/alpine.go
@@ -11,7 +11,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
+func configureAlpineVMI(vmi *v1.VirtualMachineInstance) error {
 	alreadyConfigured := func() bool {
 		err := console.RunCommand(vmi, " ip a show lo | grep UP", 30*time.Second)
 		return err == nil
@@ -86,12 +86,12 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func WithIPv6(loginTo console.LoginToFunction) console.LoginToFunction {
+func WithAlpineConfig(loginTo console.LoginToFunction) console.LoginToFunction {
 	return func(vmi *v1.VirtualMachineInstance) error {
 		err := loginTo(vmi)
 		if err != nil {
 			return err
 		}
-		return configureIPv6OnVMI(vmi)
+		return configureAlpineVMI(vmi)
 	}
 }

--- a/tests/libnet/ipv6.go
+++ b/tests/libnet/ipv6.go
@@ -12,15 +12,27 @@ import (
 )
 
 func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
-
-	hasEth0Iface := func() bool {
-		err := console.RunCommand(vmi, "ip a | grep -q eth0", 30*time.Second)
+	alreadyConfigured := func() bool {
+		err := console.RunCommand(vmi, " ip a show lo | grep UP", 30*time.Second)
 		return err == nil
 	}
 
-	hasGlobalIPv6 := func() bool {
-		err := console.RunCommand(vmi, "ip -6 address show dev eth0 scope global | grep -q inet6", 30*time.Second)
-		return err == nil
+	if (vmi.Spec.Domain.Devices.Interfaces == nil || len(vmi.Spec.Domain.Devices.Interfaces) == 0) ||
+		(vmi.Spec.Domain.Devices.AutoattachPodInterface != nil && !*vmi.Spec.Domain.Devices.AutoattachPodInterface) ||
+		alreadyConfigured() {
+		return nil
+	}
+
+	err := console.RunCommand(vmi, "ip link set dev eth0 up", 30*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("activating eth0 failed: %v", err)
+		return err
+	}
+
+	err = console.RunCommand(vmi, "ip link set dev lo up", 30*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("activation lo failed: %v", err)
+		return err
 	}
 
 	virtClient, err := kubecli.GetKubevirtClient()
@@ -28,18 +40,36 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
 		panic(err)
 	}
 
+	clusterSupportsIpv4, err := cluster.SupportsIpv4(virtClient)
+	if err != nil {
+		return err
+	}
+	if clusterSupportsIpv4 {
+		err = console.RunCommand(vmi, "udhcpc", 30*time.Second)
+		if err != nil {
+			log.DefaultLogger().Object(vmi).Infof("udhcpc failed: %v", err)
+			return err
+		}
+	}
+
 	clusterSupportsIpv6, err := cluster.SupportsIpv6(virtClient)
 	if err != nil {
 		return err
 	}
-
-	if !clusterSupportsIpv6 ||
-		(vmi.Spec.Domain.Devices.Interfaces == nil || len(vmi.Spec.Domain.Devices.Interfaces) == 0 || vmi.Spec.Domain.Devices.Interfaces[0].InterfaceBindingMethod.Masquerade == nil) ||
-		(vmi.Spec.Domain.Devices.AutoattachPodInterface != nil && !*vmi.Spec.Domain.Devices.AutoattachPodInterface) ||
-		(!hasEth0Iface() || hasGlobalIPv6()) {
+	if !clusterSupportsIpv6 {
 		return nil
 	}
-	err = console.RunCommand(vmi, "sudo ip -6 addr add fd10:0:2::2/120 dev eth0", 30*time.Second)
+
+	err = console.RunCommand(vmi, "modprobe ipv6", 30*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("ipv6 activation failed: %v", err)
+		return err
+	}
+
+	if vmi.Spec.Domain.Devices.Interfaces[0].InterfaceBindingMethod.Masquerade == nil {
+		return nil
+	}
+	err = console.RunCommand(vmi, "ip -6 addr add fd10:0:2::2/120 dev eth0", 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6Address failed: %v", err)
 		return err
@@ -47,7 +77,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance) error {
 
 	time.Sleep(5 * time.Second)
 
-	err = console.RunCommand(vmi, "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2", 30*time.Second)
+	err = console.RunCommand(vmi, "ip -6 route add default via fd10:0:2::1 src fd10:0:2::2", 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6DefaultRoute failed: %v", err)
 		return err

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -539,7 +539,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			tests.WaitAgentConnected(virtClient, vmi)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+			Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 			if mode == v1.MigrationPostCopy {
 				By("Running stress test to allow transition to post-copy")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -539,7 +539,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			tests.WaitAgentConnected(virtClient, vmi)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 			if mode == v1.MigrationPostCopy {
 				By("Running stress test to allow transition to post-copy")
@@ -629,7 +629,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				for x := 0; x < repeat; x++ {
 					By("Checking that the VirtualMachineInstance console has expected output")
-					Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+					Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 					By("starting the migration")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -678,7 +678,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -705,7 +705,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -742,7 +742,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				// execute a migration, wait for finalized state
 				By("starting the migration")
@@ -874,7 +874,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				// execute a migration, wait for finalized state
 				By("starting the migration")
@@ -913,7 +913,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				num := 4
 
@@ -959,7 +959,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{
 					LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
@@ -1015,7 +1015,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				// execute a migration, wait for finalized state
 				By(fmt.Sprintf("Starting the Migration"))
@@ -1049,7 +1049,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				By("Pausing the VirtualMachineInstance")
 				virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
@@ -1747,7 +1747,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					vmi = runVMIAndExpectLaunch(vmi, 240)
 
 					By("Checking that the VirtualMachineInstance console has expected output")
-					Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+					Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 					By("starting the migration")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -2446,7 +2446,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				gotExpectedCondition := false
 				for _, c := range vmi.Status.Conditions {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -169,7 +169,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		BeforeEach(func() {
 			tcpVM = newLabeledVMI("vm")
 			tcpVM = tests.RunVMIAndExpectLaunch(tcpVM, 180)
-			tests.GenerateHelloWorldServer(tcpVM, testPort, "tcp", libnet.WithIPv6(console.LoginToAlpine), false)
+			tests.GenerateHelloWorldServer(tcpVM, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 		})
 
 		Context("Expose ClusterIP service", func() {
@@ -435,7 +435,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		BeforeEach(func() {
 			udpVM = newLabeledVMI("udp-vm")
 			udpVM = tests.RunVMIAndExpectLaunch(udpVM, 180)
-			tests.GenerateHelloWorldServer(udpVM, testPort, "udp", libnet.WithIPv6(console.LoginToAlpine), false)
+			tests.GenerateHelloWorldServer(udpVM, testPort, "udp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 		})
 
 		Context("Expose ClusterIP UDP service", func() {
@@ -582,7 +582,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			Expect(err).ToNot(HaveOccurred())
 			for _, vm := range vms.Items {
 				if vm.OwnerReferences != nil {
-					tests.GenerateHelloWorldServer(&vm, testPort, "tcp", libnet.WithIPv6(console.LoginToAlpine), false)
+					tests.GenerateHelloWorldServer(&vm, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 				}
 			}
 		})
@@ -671,7 +671,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			if vmi == nil {
 				return nil
 			}
-			tests.GenerateHelloWorldServer(vmi, port, protocol, libnet.WithIPv6(console.LoginToAlpine), false)
+			tests.GenerateHelloWorldServer(vmi, port, protocol, libnet.WithAlpineConfig(console.LoginToAlpine), false)
 			return vmi
 		}
 
@@ -762,7 +762,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				}, 120*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Creating a TCP server on the VM.")
-				tests.GenerateHelloWorldServer(vmi, testPort, "tcp", libnet.WithIPv6(console.LoginToAlpine), false)
+				tests.GenerateHelloWorldServer(vmi, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 
 				By("Repeating the sequence as prior to restarting the VM: Connect to exposed ClusterIP service.")
 				By(iteratingClusterIPs)

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Macvtap", func() {
 			newAlpineVMIWithExplicitMac(networkName, mac),
 			180,
 		)
-		err := libnet.WithIPv6(console.LoginToAlpine)(runningVMI)
+		err := libnet.WithAlpineConfig(console.LoginToAlpine)(runningVMI)
 		return runningVMI, err
 	}
 

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -253,6 +253,8 @@ var _ = SIGDescribe("Macvtap", func() {
 			})
 
 			BeforeEach(func() {
+				// TODO test also the IPv6 address (issue- https://github.com/kubevirt/kubevirt/issues/7506)
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *before* migrating the VMI")
 			})
 

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -46,7 +46,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 		serverVMILabels = map[string]string{"type": "test"}
 	})
 
-	Context("when three cirros VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
+	Context("when three alpine VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
 		var serverVMI, clientVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -403,7 +403,7 @@ func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
 }
 
 func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.VirtualMachineInstance, error) {
-	clientVMI := libvmi.NewCirros(libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+	clientVMI := libvmi.NewAlpine(libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 	var err error
 	clientVMI, err = virtClient.VirtualMachineInstance(namespace).Create(clientVMI)
@@ -411,12 +411,12 @@ func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.V
 		return nil, err
 	}
 
-	clientVMI = tests.WaitUntilVMIReady(clientVMI, libnet.WithIPv6(console.LoginToCirros))
+	clientVMI = tests.WaitUntilVMIReady(clientVMI, libnet.WithIPv6(console.LoginToAlpine))
 	return clientVMI, nil
 }
 
 func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, serverVMILabels map[string]string) (*v1.VirtualMachineInstance, error) {
-	serverVMI := libvmi.NewCirros(
+	serverVMI := libvmi.NewAlpine(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(
 			v1.Port{
 				Name:     "http80",
@@ -436,7 +436,7 @@ func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, server
 	if err != nil {
 		return nil, err
 	}
-	serverVMI = tests.WaitUntilVMIReady(serverVMI, libnet.WithIPv6(console.LoginToCirros))
+	serverVMI = tests.WaitUntilVMIReady(serverVMI, libnet.WithIPv6(console.LoginToAlpine))
 
 	By("Start HTTP server at serverVMI on ports 80 and 81")
 	tests.HTTPServer.Start(serverVMI, 80)

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -388,10 +388,10 @@ func checkHTTPPingAndStopOnFailure(fromVmi, toVmi *v1.VirtualMachineInstance, po
 }
 
 func checkHTTPPing(vmi *v1.VirtualMachineInstance, ip string, port int) error {
-	const curlCheckCmd = "curl --head %s --connect-timeout 5\n"
+	const wgetCheckCmd = "wget -S --spider %s -T 5\n"
 	url := fmt.Sprintf("http://%s", net.JoinHostPort(ip, strconv.Itoa(port)))
-	curlCheck := fmt.Sprintf(curlCheckCmd, url)
-	err := console.RunCommand(vmi, curlCheck, 10*time.Second)
+	wgetCheck := fmt.Sprintf(wgetCheckCmd, url)
+	err := console.RunCommand(vmi, wgetCheck, 10*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed HTTP ping from vmi(%s/%s) to url(%s): %v", vmi.Namespace, vmi.Name, url, err)
 	}

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -411,7 +411,7 @@ func createClientVmi(namespace string, virtClient kubecli.KubevirtClient) (*v1.V
 		return nil, err
 	}
 
-	clientVMI = tests.WaitUntilVMIReady(clientVMI, libnet.WithIPv6(console.LoginToAlpine))
+	clientVMI = tests.WaitUntilVMIReady(clientVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 	return clientVMI, nil
 }
 
@@ -436,7 +436,7 @@ func createServerVmi(virtClient kubecli.KubevirtClient, namespace string, server
 	if err != nil {
 		return nil, err
 	}
-	serverVMI = tests.WaitUntilVMIReady(serverVMI, libnet.WithIPv6(console.LoginToAlpine))
+	serverVMI = tests.WaitUntilVMIReady(serverVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 	By("Start HTTP server at serverVMI on ports 80 and 81")
 	tests.HTTPServer.Start(serverVMI, 80)

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -72,7 +72,7 @@ var _ = SIGDescribe("Port-forward", func() {
 			}
 
 			vmi := createCirrosVMIWithPortsAndBlockUntilReady(virtClient, vmiDeclaredPorts)
-			tests.StartHTTPServerWithSourceIp(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily))
+			tests.StartHTTPServerWithSourceIp(vmi, vmiHttpServerPort, getMasqueradeInternalAddress(ipFamily), console.LoginToCirros)
 
 			localPort = 1500 + GinkgoParallelProcess()
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -168,7 +168,7 @@ func createCirrosVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClien
 
 	vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 	Expect(err).ToNot(HaveOccurred())
-	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 	return vmi
 }

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -168,7 +168,7 @@ func createCirrosVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClien
 
 	vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 	Expect(err).ToNot(HaveOccurred())
-	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+	vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 	return vmi
 }

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -228,14 +228,20 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 })
 
 func createReadyAlpineVMIWithReadinessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
-	vmi := libvmi.NewAlpine()
+	vmi := libvmi.NewAlpine(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+	)
 	vmi.Spec.ReadinessProbe = probe
 
 	return tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 }
 
 func createReadyAlpineVMIWithLivenessProbe(probe *v1.Probe) *v1.VirtualMachineInstance {
-	vmi := libvmi.NewAlpine()
+	vmi := libvmi.NewAlpine(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+	)
 	vmi.Spec.LivenessProbe = probe
 
 	return tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -299,9 +299,9 @@ func isHTTPProbe(probe v1.Probe) bool {
 
 func serverStarter(vmi *v1.VirtualMachineInstance, probe *v1.Probe, port int) {
 	if isHTTPProbe(*probe) {
-		tests.StartHTTPServer(vmi, port, libnet.WithIPv6(console.LoginToAlpine))
+		tests.StartHTTPServer(vmi, port, libnet.WithAlpineConfig(console.LoginToAlpine))
 	} else {
-		tests.StartTCPServer(vmi, port, libnet.WithIPv6(console.LoginToAlpine))
+		tests.StartTCPServer(vmi, port, libnet.WithAlpineConfig(console.LoginToAlpine))
 	}
 }
 

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -242,7 +242,7 @@ var _ = SIGDescribe("Services", func() {
 				libvmi.WithNetwork(v1.DefaultPodNetwork()))
 			return readyVMI(
 				exposeExistingVMISpec(vmi, subdomain, hostname, selectorLabelKey, selectorLabelValue),
-				libnet.WithIPv6(console.LoginToAlpine))
+				libnet.WithAlpineConfig(console.LoginToAlpine))
 		}
 
 		BeforeEach(func() {
@@ -250,7 +250,7 @@ var _ = SIGDescribe("Services", func() {
 			hostname := "inbound"
 
 			inboundVMI = createReadyVMIWithMasqueradeBindingAndExposedService(hostname, subdomain)
-			tests.StartTCPServer(inboundVMI, servicePort, libnet.WithIPv6(console.LoginToAlpine))
+			tests.StartTCPServer(inboundVMI, servicePort, libnet.WithAlpineConfig(console.LoginToAlpine))
 		})
 
 		AfterEach(func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -99,7 +99,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 	Context("Virtual Machine with masquerade interface", func() {
 		createJobCheckingVMIReachability := func(serverVMI *v1.VirtualMachineInstance, targetPort int) (*batchv1.Job, error) {
 			By("Starting HTTP Server")
-			tests.StartHTTPServer(vmi, targetPort)
+			tests.StartHTTPServer(vmi, targetPort, console.LoginToCirros)
 
 			By("Getting back the VMI IP")
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
@@ -349,7 +349,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 
 				Expect(console.LoginToCirros(serverVMI)).To(Succeed())
 				By("Starting HTTP Server")
-				tests.StartHTTPServer(serverVMI, vmiServerTestPort)
+				tests.StartHTTPServer(serverVMI, vmiServerTestPort, console.LoginToCirros)
 
 				By("Creating Istio VirtualService")
 				virtualServicesRes := schema.GroupVersionResource{Group: networkingIstioIO, Version: istioApiVersion, Resource: "virtualservices"}

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -189,7 +189,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmi.NewCirros()
+				detachedVMI := libvmi.NewAlpine()
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -199,7 +199,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToAlpine))
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 			})
@@ -207,7 +207,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
 				checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
 				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmi.NewCirros()
+				detachedVMI := libvmi.NewAlpine()
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -217,7 +217,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToAlpine))
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 			})
@@ -261,7 +261,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 		Context("VirtualMachineInstance with multus network as default network", func() {
 			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", func() {
-				detachedVMI := libvmi.NewCirros()
+				detachedVMI := libvmi.NewAlpine()
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -273,7 +273,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToAlpine))
 
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
@@ -318,6 +318,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				By("Creating a VM with custom MAC address on its ptp interface.")
 				interfaces[0].MacAddress = customMacAddress
+
 				vmiOne := createVMIOnNode(interfaces, networks)
 				tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 
@@ -384,7 +385,6 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
 				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
 				Expect(checkInterface(vmiTwo, ifaceName)).To(Succeed())
-
 				ipAddr := ""
 				if staticIPVm2 != "" {
 					ipAddr, err = libnet.CidrToIP(staticIPVm2)

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -238,7 +238,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(detachedVMI, console.LoginToCirros)
 
 				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
 				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -187,6 +187,9 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.", func() {
 		const ptpGateway = ptpSubnetIP1
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
+			BeforeEach(func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			})
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmi.NewAlpine()
@@ -261,6 +264,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 		Context("VirtualMachineInstance with multus network as default network", func() {
 			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				detachedVMI := libvmi.NewAlpine()
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -199,7 +199,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToAlpine))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 			})
@@ -217,7 +217,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToAlpine))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 			})
@@ -238,7 +238,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
 				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
@@ -273,7 +273,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithIPv6(console.LoginToAlpine))
+				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -176,7 +176,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				expectedMtuString := fmt.Sprintf("mtu %d", mtu)
 
 				By("checking eth0 MTU inside the VirtualMachineInstance")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(outboundVMI)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(outboundVMI)).To(Succeed())
 
 				addrShow = "ip address show eth0\n"
 				Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
@@ -957,7 +957,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for VMIs to be ready")
-				anotherVmi = tests.WaitUntilVMIReady(anotherVmi, libnet.WithIPv6(console.LoginToAlpine))
+				anotherVmi = tests.WaitUntilVMIReady(anotherVmi, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
 			})
@@ -1090,7 +1090,7 @@ func runVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 
 	vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 	Expect(err).ToNot(HaveOccurred())
-	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 	return vmi
 }
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -176,7 +176,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				expectedMtuString := fmt.Sprintf("mtu %d", mtu)
 
 				By("checking eth0 MTU inside the VirtualMachineInstance")
-				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(outboundVMI)).To(Succeed())
+				Expect(console.LoginToCirros(outboundVMI)).To(Succeed())
 
 				addrShow = "ip address show eth0\n"
 				Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
@@ -1090,7 +1090,7 @@ func runVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 
 	vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 	Expect(err).ToNot(HaveOccurred())
-	vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+	vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 	return vmi
 }
 

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -107,7 +107,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
-			tests.GenerateHelloWorldServer(vmi, 80, "tcp")
+			tests.GenerateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
 
 			By("have containerPort in the pod manifest")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
@@ -164,7 +164,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
-			tests.GenerateHelloWorldServer(vmi, 80, "tcp")
+			tests.GenerateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
 
 			dns := "google.com"
 			if flags.ConnectivityCheckDNS != "" {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -74,7 +74,6 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 type vmSnapshotDef struct {
@@ -1639,7 +1638,7 @@ spec:
 				Eventually(func() error {
 					vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					if err := libnet.WithIPv6(console.LoginToCirros)(vmi); err != nil {
+					if err := console.LoginToCirros(vmi); err != nil {
 						return err
 					}
 					return nil

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -45,7 +45,6 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Pausing", func() {
@@ -506,7 +505,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
-			Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 			By("checking uptime difference between guest and host")
 			uptimeDiffBeforePausing = hostUptime() - grepGuestUptime(vmi)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -439,7 +439,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 			doRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, expectedRestores int) {
 				By("creating 'message with initial value")
-				Expect(libnet.WithIPv6(login)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(login)(vmi)).To(Succeed())
 
 				var batch []expect.Batcher
 				if device != "" {
@@ -495,7 +495,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(libnet.WithIPv6(login)(vmi)).To(Succeed())
+					Expect(libnet.WithAlpineConfig(login)(vmi)).To(Succeed())
 
 					if device != "" {
 						batch = append(batch, []expect.Batcher{
@@ -553,7 +553,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying original file contents")
-				Expect(libnet.WithIPv6(login)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(login)(vmi)).To(Succeed())
 
 				batch = nil
 
@@ -955,7 +955,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
 
@@ -974,7 +974,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				By("Updating the VM template spec")
 				initialMemory := vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
@@ -1022,7 +1022,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
 				persistVolName := tests.AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, false)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -29,7 +29,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 const (
@@ -439,7 +438,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 			doRestore := func(device string, login console.LoginToFunction, onlineSnapshot bool, expectedRestores int) {
 				By("creating 'message with initial value")
-				Expect(libnet.WithAlpineConfig(login)(vmi)).To(Succeed())
+				Expect(login(vmi)).To(Succeed())
 
 				var batch []expect.Batcher
 				if device != "" {
@@ -495,7 +494,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(libnet.WithAlpineConfig(login)(vmi)).To(Succeed())
+					Expect(login(vmi)).To(Succeed())
 
 					if device != "" {
 						batch = append(batch, []expect.Batcher{
@@ -553,7 +552,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying original file contents")
-				Expect(libnet.WithAlpineConfig(login)(vmi)).To(Succeed())
+				Expect(login(vmi)).To(Succeed())
 
 				batch = nil
 
@@ -955,7 +954,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
 
@@ -974,7 +973,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Updating the VM template spec")
 				initialMemory := vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
@@ -1022,7 +1021,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
 				persistVolName := tests.AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, false)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -25,7 +25,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -306,7 +305,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				Expect(snapshot.Status.Conditions[1].Type).To(Equal(snapshotv1.ConditionReady))
 				Expect(snapshot.Status.Conditions[1].Status).To(Equal(corev1.ConditionTrue))
 
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 				journalctlCheck := "journalctl --file /var/log/journal/*/system.journal"
 				expectedFreezeOutput := "executing fsfreeze hook with arg 'freeze'"
 				expectedThawOutput := "executing fsfreeze hook with arg 'thaw'"
@@ -535,7 +534,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				createDenyVolumeSnapshotCreateWebhook()
 				defer deleteWebhook()
@@ -566,7 +565,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
@@ -615,7 +614,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
 				persistVolName := tests.AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, false)
@@ -701,7 +700,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Logging into Fedora")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Calling Velero pre-backup hook")
 				err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -306,7 +306,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				Expect(snapshot.Status.Conditions[1].Type).To(Equal(snapshotv1.ConditionReady))
 				Expect(snapshot.Status.Conditions[1].Status).To(Equal(corev1.ConditionTrue))
 
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 				journalctlCheck := "journalctl --file /var/log/journal/*/system.journal"
 				expectedFreezeOutput := "executing fsfreeze hook with arg 'freeze'"
 				expectedThawOutput := "executing fsfreeze hook with arg 'thaw'"
@@ -535,7 +535,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				createDenyVolumeSnapshotCreateWebhook()
 				defer deleteWebhook()
@@ -566,7 +566,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
@@ -615,7 +615,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
 				tests.WaitAgentConnected(virtClient, vmi)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
 				persistVolName := tests.AddVolumeAndVerify(virtClient, snapshotStorageClass, vm, false)
@@ -701,7 +701,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Logging into Fedora")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				By("Calling Velero pre-backup hook")
 				err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -335,7 +335,7 @@ var _ = SIGDescribe("Storage", func() {
 					},
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
-				
+
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
@@ -432,7 +432,7 @@ var _ = SIGDescribe("Storage", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By(checkingVMInstanceConsoleOut)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+				Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", fs.Name)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
@@ -492,7 +492,7 @@ var _ = SIGDescribe("Storage", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By(checkingVMInstanceConsoleOut)
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+				Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 				By("Checking that virtio-fs is mounted")
 				listVirtioFSDisk := fmt.Sprintf("ls -l %s/*disk* | wc -l\n", virtiofsMountPath)
@@ -1043,7 +1043,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				By(checkingVMInstanceConsoleOut)
-				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 			})
 		})
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -334,7 +336,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -358,7 +360,10 @@ var _ = SIGDescribe("Storage", func() {
 			It("[test_id:3135]should create a writeable emptyDisk with the specified serial number", func() {
 
 				// Start the VirtualMachineInstance with the empty disk attached
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
+				vmi = libvmi.NewAlpine(
+					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				)
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
 					Name:   "emptydisk1",
 					Serial: diskSerial,
@@ -378,11 +383,11 @@ var _ = SIGDescribe("Storage", func() {
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				By("Checking for the specified serial number")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo find /sys -type f -regex \".*/block/.*/serial\" | xargs cat\n"},
+					&expect.BSnd{S: "find /sys -type f -regex \".*/block/.*/serial\" | xargs cat\n"},
 					&expect.BExp{R: diskSerial},
 				}, 10)).To(Succeed())
 			})

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -335,7 +335,7 @@ var _ = SIGDescribe("Storage", func() {
 					},
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
-
+				
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
@@ -383,7 +383,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				Expect(libnet.WithIPv6(console.LoginToAlpine)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
 
 				By("Checking for the specified serial number")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -432,7 +432,7 @@ var _ = SIGDescribe("Storage", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By(checkingVMInstanceConsoleOut)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", fs.Name)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
@@ -492,7 +492,7 @@ var _ = SIGDescribe("Storage", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By(checkingVMInstanceConsoleOut)
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 				By("Checking that virtio-fs is mounted")
 				listVirtioFSDisk := fmt.Sprintf("ls -l %s/*disk* | wc -l\n", virtiofsMountPath)
@@ -1043,7 +1043,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				By(checkingVMInstanceConsoleOut)
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(vmi)).To(Succeed())
 			})
 		})
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -54,7 +54,6 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
@@ -635,7 +634,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 240*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Obtaining the serial console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				By("Guest shutdown")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1165,7 +1164,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1346,7 +1345,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 
-					Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1463,7 +1462,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1692,7 +1691,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -38,7 +38,6 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
@@ -128,7 +127,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", func() {
 			It("[test_id:3169]should have cloud-init user-data from sidecar", func() {
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				By("mouting cloudinit iso")
 				MountCloudInit(vmi)
 				By("checking cloudinit user-data")

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 const (
@@ -215,7 +214,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, time.Second*120)
 
 				By("applying the hostname from meta-data")
-				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
@@ -238,7 +237,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, time.Second*120)
 
 				By("applying the hostname from meta-data")
-				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
@@ -300,7 +299,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -315,7 +314,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -364,7 +363,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -391,7 +390,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -412,7 +411,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 				vmi.Annotations[v1.FlavorAnnotation] = testFlavor
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
@@ -458,7 +457,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				By("mouting cloudinit iso")
@@ -507,7 +506,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -583,7 +582,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -215,7 +215,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, time.Second*120)
 
 				By("applying the hostname from meta-data")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
@@ -238,7 +238,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, time.Second*120)
 
 				By("applying the hostname from meta-data")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToCirros)(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
@@ -300,7 +300,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -315,7 +315,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -364,7 +364,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -391,7 +391,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -412,7 +412,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 				vmi.Annotations[v1.FlavorAnnotation] = testFlavor
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
@@ -458,7 +458,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 				By("mouting cloudinit iso")
@@ -507,7 +507,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -583,7 +583,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -59,7 +59,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -2627,7 +2626,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node1).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(cpuvmi)).To(Succeed())
+				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance without dedicated cpus")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -2637,7 +2636,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node2).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 			})
 
 			It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", func() {
@@ -2650,7 +2649,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node2).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")
 				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
@@ -2660,7 +2659,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node1).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(cpuvmi)).To(Succeed())
+				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
 			})
 		})
 	})
@@ -2684,7 +2683,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
 
 			By("Expecting console")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Check value in VM with dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
@@ -2725,7 +2724,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
 
 			By("Expecting console")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Check values in dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
@@ -2761,7 +2760,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='version'>1.0</entry>"))
 
 			By("Expecting console")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Check values in dmidecode")
 
@@ -2912,7 +2911,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<hidden state='on'/>"))
 
 			By("Expecting console")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Check virt-what-cpuid-helper does not match KVM")
 			Expect(console.ExpectBatch(vmi, []expect.Batcher{
@@ -2930,7 +2929,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("Expecting console")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Check virt-what-cpuid-helper matches KVM")
 			Expect(console.ExpectBatch(vmi, []expect.Batcher{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -114,7 +114,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
-			Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			rootPortController := []api.Controller{}
@@ -135,7 +135,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.BoolPtr(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
-			Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			testutils.ExpectVirtioTransitionalOnly(domSpec)
@@ -595,7 +595,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
@@ -615,7 +615,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
@@ -671,7 +671,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
@@ -719,7 +719,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 			It("[test_id:732]Check Free memory on the VMI", func() {
 				By("Expecting console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				// Check on the VM, if the Free memory is roughly what we expected
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1540,7 +1540,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(timerFrequency).ToNot(BeEmpty())
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking the CPU model under the guest OS")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1573,7 +1573,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Logging to VMI")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				loc, err := time.LoadLocation(timezone)
 				Expect(err).ToNot(HaveOccurred())
@@ -1718,7 +1718,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 				By("Checking the CPU model under the guest OS")
 				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -1745,7 +1745,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				niceName := parseCPUNiceName(output)
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 				By("Checking the CPU model under the guest OS")
 				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -1767,7 +1767,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				niceName := parseCPUNiceName(output)
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 				By("Checking the CPU model under the guest OS")
 				console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -1795,7 +1795,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 			})
 		})
 	})
@@ -2197,7 +2197,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
-			Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				// keep the ordering!
@@ -2214,7 +2214,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+			tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
 		})
@@ -2356,7 +2356,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores)))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 				By("Checking the number of CPU cores under guest OS")
 				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -2404,7 +2404,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
 
 				//-------------------------------------------------------------------
-				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
@@ -2472,7 +2472,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores) + 1))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 				By("Checking the number of CPU cores under guest OS")
 				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -2507,7 +2507,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToCirros)(cpuVmi)).To(Succeed())
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 				By("Checking the number of CPU cores under guest OS")
 				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -2627,7 +2627,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node1).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(cpuvmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(cpuvmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance without dedicated cpus")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -2637,7 +2637,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node2).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 			})
 
 			It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", func() {
@@ -2650,7 +2650,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node2).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")
 				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
@@ -2660,7 +2660,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(node1).To(Equal(node))
 
 				By("Expecting the VirtualMachineInstance console")
-				Expect(libnet.WithIPv6(console.LoginToFedora)(cpuvmi)).To(Succeed())
+				Expect(libnet.WithAlpineConfig(console.LoginToFedora)(cpuvmi)).To(Succeed())
 			})
 		})
 	})
@@ -2684,7 +2684,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
 
 			By("Expecting console")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 			By("Check value in VM with dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
@@ -2725,7 +2725,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
 
 			By("Expecting console")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 			By("Check values in dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
@@ -2761,7 +2761,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='version'>1.0</entry>"))
 
 			By("Expecting console")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 			By("Check values in dmidecode")
 
@@ -2912,7 +2912,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<hidden state='on'/>"))
 
 			By("Expecting console")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 			By("Check virt-what-cpuid-helper does not match KVM")
 			Expect(console.ExpectBatch(vmi, []expect.Batcher{
@@ -2930,7 +2930,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("Expecting console")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 
 			By("Check virt-what-cpuid-helper matches KVM")
 			Expect(console.ExpectBatch(vmi, []expect.Batcher{

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -56,7 +56,6 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -1564,7 +1563,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
 				// wait until booted
-				vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				By("Deleting the VirtualMachineInstance")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -78,7 +78,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 
 			By("Checking if we can login")
-			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
 		})
 
 		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -38,7 +38,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -78,7 +77,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 
 			By("Checking if we can login")
-			Expect(libnet.WithAlpineConfig(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
 		})
 
 		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {

--- a/tests/vmi_servers.go
+++ b/tests/vmi_servers.go
@@ -9,32 +9,31 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/kubevirt/tests/console"
-	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 type server string
 
 const (
-	TCPServer  = server("\"Hello World!\"\n")
-	HTTPServer = server("\"HTTP/1.1 200 OK\\nContent-Length: 12\\n\\nHello World!\"\n")
+	TCPServer  = server("\"Hello World!\"&\n")
+	HTTPServer = server("\"HTTP/1.1 200 OK\\nContent-Length: 12\\n\\nHello World!\"&\n")
 )
 
 func (s server) composeNetcatServerCommand(port int, extraArgs ...string) string {
-	return fmt.Sprintf("screen -d -m sudo nc %s -klp %d -e echo -e %s", strings.Join(extraArgs, " "), port, string(s))
+	return fmt.Sprintf("nc %s -klp %d -e echo -e %s", strings.Join(extraArgs, " "), port, string(s))
 }
 
-func StartTCPServer(vmi *v1.VirtualMachineInstance, port int) {
-	libnet.WithIPv6(console.LoginToCirros)(vmi)
+func StartTCPServer(vmi *v1.VirtualMachineInstance, port int, loginTo console.LoginToFunction) {
+	loginTo(vmi)
 	TCPServer.Start(vmi, port)
 }
 
-func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int) {
-	libnet.WithIPv6(console.LoginToCirros)(vmi)
+func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, loginTo console.LoginToFunction) {
+	loginTo(vmi)
 	HTTPServer.Start(vmi, port)
 }
 
-func StartHTTPServerWithSourceIp(vmi *v1.VirtualMachineInstance, port int, sourceIP string) {
-	libnet.WithIPv6(console.LoginToCirros)(vmi)
+func StartHTTPServerWithSourceIp(vmi *v1.VirtualMachineInstance, port int, sourceIP string, loginTo console.LoginToFunction) {
+	loginTo(vmi)
 	HTTPServer.Start(vmi, port, fmt.Sprintf("-s %s", sourceIP))
 }
 

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -32,7 +32,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -54,7 +53,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		BeforeEach(func() {
 			vmi, err = createSoundVMI(virtClient, "test-model-empty")
 			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 		})
 
 		It("should create an ich9 sound device on empty model", func() {
@@ -66,7 +65,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		BeforeEach(func() {
 			vmi, err = createSoundVMI(virtClient, "ich9")
 			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 		})
 
 		It("should create ich9 sound device on ich9 model ", func() {
@@ -79,7 +78,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		BeforeEach(func() {
 			vmi, err = createSoundVMI(virtClient, "ac97")
 			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
+			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 		})
 
 		It("should create ac97 sound device on ac97 model", func() {

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -54,7 +54,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		BeforeEach(func() {
 			vmi, err = createSoundVMI(virtClient, "test-model-empty")
 			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 		})
 
 		It("should create an ich9 sound device on empty model", func() {
@@ -66,7 +66,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		BeforeEach(func() {
 			vmi, err = createSoundVMI(virtClient, "ich9")
 			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 		})
 
 		It("should create ich9 sound device on ich9 model ", func() {
@@ -79,7 +79,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		BeforeEach(func() {
 			vmi, err = createSoundVMI(virtClient, "ac97")
 			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToCirros))
+			vmi = tests.WaitUntilVMIReady(vmi, libnet.WithAlpineConfig(console.LoginToCirros))
 		})
 
 		It("should create ac97 sound device on ac97 model", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Cirros has a very slow startup in case there is no DHCP server responding to it.
To allow using the same tests for dual stack and IPv6 only clusters, tests using Cirros will now use Alpine.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
In this PR Cirros tests that run in IPv6 only cluster were switched to use the existing Alpine image.
The existing Alpine image needs some configuration for the network work. Cloud init is not installed, so the console has to be used for the configuration.

A follow up PR will use a new Alpine image that includes cloud-init so the manual console configuration will be removed,

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
