### PR TITLE
Use HaveLen gomega matcher

### DIFF
--- a/pkg/virt-handler/hotplug-disk/findmnt_test.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt_test.go
@@ -81,11 +81,11 @@ var _ = Describe("findmnt", func() {
 	DescribeTable("Should return a list of values, with valid input", func(findMntFunc func() ([]FindmntInfo, error)) {
 		res, err := findMntFunc()
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(res)).To(Equal(1))
+		Expect(res).To(HaveLen(1))
 		Expect(res[0].GetSourcePath()).To(Equal("/test/path"))
 		Expect(res[0].Target).To(Equal("/testvolume"))
 		Expect(res[0].Fstype).To(Equal("xfs"))
-		Expect(len(res[0].GetOptions())).To(Equal(8))
+		Expect(res[0].GetOptions()).To(HaveLen(8))
 		Expect(res[0].GetOptions()[0]).To(Equal("rw"))
 		Expect(res[0].GetOptions()[1]).To(Equal("relatime"))
 		Expect(res[0].GetOptions()[2]).To(Equal("seclabel"))
@@ -156,7 +156,7 @@ var _ = Describe("findmnt", func() {
 		test := FindmntInfo{
 			Options: "aa,bb,cc,dd",
 		}
-		Expect(len(test.GetOptions())).To(Equal(4))
+		Expect(test.GetOptions()).To(HaveLen(4))
 		Expect(test.GetOptions()[0]).To(Equal("aa"))
 		Expect(test.GetOptions()[1]).To(Equal("bb"))
 		Expect(test.GetOptions()[2]).To(Equal("cc"))

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -679,7 +679,7 @@ var _ = Describe("HotplugVolume", func() {
 
 			err = m.mountFileSystemHotplugVolume(vmi, "testvolume", types.UID(sourcePodUID), record)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(record.MountTargetEntries)).To(Equal(1))
+			Expect(record.MountTargetEntries).To(HaveLen(1))
 			Expect(record.MountTargetEntries[0].TargetFile).To(Equal(targetFilePath))
 
 			unmountCommand = func(diskPath string) ([]byte, error) {

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -110,9 +110,9 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels()
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(len(cpuModels)).To(Equal(3), "number of models must match")
+		Expect(cpuModels).To(HaveLen(3), "number of models must match")
 
-		Expect(len(cpuFeatures)).To(Equal(2), "number of features must match")
+		Expect(cpuFeatures).To(HaveLen(2), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(counter).ToNot(BeNil())
@@ -131,9 +131,9 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels()
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(len(cpuModels)).To(Equal(0), "number of models doesn't match")
+		Expect(cpuModels).To(BeEmpty(), "number of models doesn't match")
 
-		Expect(len(cpuFeatures)).To(Equal(2), "number of features doesn't match")
+		Expect(cpuFeatures).To(HaveLen(2), "number of features doesn't match")
 	})
 
 	Context("should return correct host cpu", func() {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -691,7 +691,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			vmiInterface.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj interface{}) (*v1.VirtualMachineInstance, error) {
 				vmi := obj.(*v1.VirtualMachineInstance)
-				Expect(len(vmi.Status.PhaseTransitionTimestamps)).ToNot(Equal(0))
+				Expect(vmi.Status.PhaseTransitionTimestamps).ToNot(BeEmpty())
 				updatedVMI.Status.PhaseTransitionTimestamps = vmi.Status.PhaseTransitionTimestamps
 
 				Expect(vmi).To(Equal(updatedVMI))
@@ -1464,11 +1464,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 				testStatusMap["test"] = vmi.Status.VolumeStatus[0]
 				testStatusMap["test2"] = vmi.Status.VolumeStatus[0]
 				testStatusMap["test3"] = vmi.Status.VolumeStatus[0]
-				Expect(len(testStatusMap)).To(Equal(3))
+				Expect(testStatusMap).To(HaveLen(3))
 				controller.generateEventsForVolumeStatusChange(vmi, testStatusMap)
 				testutils.ExpectEvent(recorder, "message")
 				testutils.ExpectEvent(recorder, "message")
-				Expect(len(testStatusMap)).To(Equal(3))
+				Expect(testStatusMap).To(HaveLen(3))
 			})
 		})
 
@@ -2663,7 +2663,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any()).Return(nil)
 			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any()).Return(nil)
 			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-				Expect(len(arg.(*v1.VirtualMachineInstance).Status.VolumeStatus)).To(Equal(2))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.VolumeStatus).To(HaveLen(2))
 				for _, status := range arg.(*v1.VirtualMachineInstance).Status.VolumeStatus {
 					if status.Name == "hpvolume" {
 						Expect(status.Target).To(Equal("sda"))


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Replace occurrences of 
```
Expect(len($VAR)).To(Equal($X))
``` 
with
```
Expect($VAR).To(HaveLen($X)
``` 
which is more gomega-idiomatic and gives better error messages when the expectation fails.

Use the `BeEmpty()` matcher where the expected len is 0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
