### PR TITLE
Attempt to fix error disk flakes by looping over path

### DIFF
--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -21,7 +21,9 @@ package tests
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -85,24 +87,34 @@ func CreateSCSIDisk(nodeName string, opts []string) (address string, device stri
 	_, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create faulty disk")
 
-	args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/bin/lsscsi"}
-	stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to find out address of  SCSI disk")
-
-	// Example output
-	// [2:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.5+  /dev/sr0
-	// [6:0:0:0]    disk    Linux    scsi_debug       0190  /dev/sda
-	lines := strings.Split(stdout, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "scsi_debug") {
-			line = strings.TrimSpace(line)
-			disk := strings.Split(line, " ")
-			address = disk[0]
-			address = address[1 : len(address)-1]
-			device = disk[len(disk)-1]
-			break
+	EventuallyWithOffset(1, func() error {
+		args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/bin/lsscsi"}
+		stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
+		if err != nil {
+			return err
 		}
-	}
+
+		// Example output
+		// [2:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.5+  /dev/sr0
+		// [6:0:0:0]    disk    Linux    scsi_debug       0190  /dev/sda
+		lines := strings.Split(stdout, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "scsi_debug") {
+				line = strings.TrimSpace(line)
+				disk := strings.Split(line, " ")
+				address = disk[0]
+				address = address[1 : len(address)-1]
+				device = disk[len(disk)-1]
+				break
+			}
+		}
+
+		if !filepath.IsAbs(device) {
+			return fmt.Errorf("Device path extracted from lsscsi is not populated: %s", device)
+		}
+
+		return nil
+	}, 20*time.Second, 5*time.Second).ShouldNot(HaveOccurred())
 
 	return address, device
 }


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some runs like:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7404/pull-kubevirt-e2e-k8s-1.23-sig-storage/1504849982212018176
Show a flake where we pass `-` to the PV as the device path:
```bash
                "capacity": {
                    "storage": "1Gi"
                },
                "local": {
                    "path": "-"
                },
```

Let's try a few times so a path that is not yet populated (like `-`) does not end up on the PV,
or, if we don't converge to a legitimate path in time, we'll fail much earlier (prior to PV creation).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
