### PR TITLE
Code Cleanup: Improve gomega matchers in several packages

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2155,7 +2155,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.controller.stores.CrdCache.List()).To(HaveLen(12))
 			Expect(kvTestData.controller.stores.ServiceCache.List()).To(HaveLen(3))
 			Expect(kvTestData.controller.stores.DeploymentCache.List()).To(HaveLen(1))
-			Expect(kvTestData.controller.stores.DaemonSetCache.List()).To(HaveLen(0))
+			Expect(kvTestData.controller.stores.DaemonSetCache.List()).To(BeEmpty())
 			Expect(kvTestData.controller.stores.ValidationWebhookCache.List()).To(HaveLen(3))
 			Expect(kvTestData.controller.stores.PodDisruptionBudgetCache.List()).To(HaveLen(1))
 			Expect(kvTestData.controller.stores.SCCCache.List()).To(HaveLen(3))

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -334,7 +334,7 @@ type finalizerPatch struct {
 func extractFinalizers(data []byte) []string {
 	patches := make([]finalizerPatch, 0)
 	err := json.Unmarshal(data, &patches)
-	Expect(len(patches)).To(Equal(1))
+	Expect(patches).To(HaveLen(1))
 	patch := patches[0]
 	Expect(err).ToNot(HaveOccurred())
 	Expect(patch.Op).To(Equal("replace"))
@@ -388,7 +388,7 @@ func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusVersion(times int, co
 func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusFailureCondition(reason string) {
 	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
 	update.Do(func(kv *v1.KubeVirt) {
-		Expect(len(kv.Status.Conditions)).To(Equal(1))
+		Expect(kv.Status.Conditions).To(HaveLen(1))
 		Expect(kv.Status.Conditions[0].Reason).To(Equal(reason))
 		k.kvInformer.GetStore().Update(kv)
 		update.Return(kv, nil)
@@ -1617,7 +1617,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectKubeVirtFinalizersPatch(1)
 			kvTestData.controller.Execute()
 			kv = kvTestData.getLatestKubeVirt(kv)
-			Expect(len(kv.ObjectMeta.Finalizers)).To(Equal(0))
+			Expect(kv.ObjectMeta.Finalizers).To(BeEmpty())
 		})
 
 		It("should observe custom image tag in status during deploy", func() {
@@ -2134,8 +2134,8 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeploying))
-			Expect(len(kv.Status.Conditions)).To(Equal(3))
-			Expect(len(kv.ObjectMeta.Finalizers)).To(Equal(1))
+			Expect(kv.Status.Conditions).To(HaveLen(3))
+			Expect(kv.ObjectMeta.Finalizers).To(HaveLen(1))
 			shouldExpectHCOConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
 
 			// 3 in total are yet missing at this point
@@ -2147,20 +2147,20 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources))
 
-			Expect(len(kvTestData.controller.stores.ServiceAccountCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.ClusterRoleCache.List())).To(Equal(7))
-			Expect(len(kvTestData.controller.stores.ClusterRoleBindingCache.List())).To(Equal(5))
-			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.CrdCache.List())).To(Equal(12))
-			Expect(len(kvTestData.controller.stores.ServiceCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.DeploymentCache.List())).To(Equal(1))
-			Expect(len(kvTestData.controller.stores.DaemonSetCache.List())).To(Equal(0))
-			Expect(len(kvTestData.controller.stores.ValidationWebhookCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.PodDisruptionBudgetCache.List())).To(Equal(1))
-			Expect(len(kvTestData.controller.stores.SCCCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.ServiceMonitorCache.List())).To(Equal(1))
-			Expect(len(kvTestData.controller.stores.PrometheusRuleCache.List())).To(Equal(1))
+			Expect(kvTestData.controller.stores.ServiceAccountCache.List()).To(HaveLen(3))
+			Expect(kvTestData.controller.stores.ClusterRoleCache.List()).To(HaveLen(7))
+			Expect(kvTestData.controller.stores.ClusterRoleBindingCache.List()).To(HaveLen(5))
+			Expect(kvTestData.controller.stores.RoleCache.List()).To(HaveLen(3))
+			Expect(kvTestData.controller.stores.RoleBindingCache.List()).To(HaveLen(3))
+			Expect(kvTestData.controller.stores.CrdCache.List()).To(HaveLen(12))
+			Expect(kvTestData.controller.stores.ServiceCache.List()).To(HaveLen(3))
+			Expect(kvTestData.controller.stores.DeploymentCache.List()).To(HaveLen(1))
+			Expect(kvTestData.controller.stores.DaemonSetCache.List()).To(HaveLen(0))
+			Expect(kvTestData.controller.stores.ValidationWebhookCache.List()).To(HaveLen(3))
+			Expect(kvTestData.controller.stores.PodDisruptionBudgetCache.List()).To(HaveLen(1))
+			Expect(kvTestData.controller.stores.SCCCache.List()).To(HaveLen(3))
+			Expect(kvTestData.controller.stores.ServiceMonitorCache.List()).To(HaveLen(1))
+			Expect(kvTestData.controller.stores.PrometheusRuleCache.List()).To(HaveLen(1))
 
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Added]).To(Equal(1))
 
@@ -2609,7 +2609,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeleted))
-			Expect(len(kv.Status.Conditions)).To(Equal(3))
+			Expect(kv.Status.Conditions).To(HaveLen(3))
 			shouldExpectHCOConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionFalse, k8sv1.ConditionTrue)
 		})
 
@@ -2746,9 +2746,9 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.controller.Execute()
 
-			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(2))
-			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(2))
-			Expect(len(kvTestData.controller.stores.ServiceMonitorCache.List())).To(Equal(0))
+			Expect(kvTestData.controller.stores.RoleCache.List()).To(HaveLen(2))
+			Expect(kvTestData.controller.stores.RoleBindingCache.List()).To(HaveLen(2))
+			Expect(kvTestData.controller.stores.ServiceMonitorCache.List()).To(BeEmpty())
 		})
 	})
 

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -860,14 +860,14 @@ var _ = Describe("Apply Apps", func() {
 		It("should succeed if componentConfig is nil", func() {
 			// if componentConfig is nil
 			injectPlacementMetadata(nil, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
 		It("should succeed if nodePlacement is nil", func() {
 			componentConfig.NodePlacement = nil
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
@@ -882,7 +882,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector["foo"] = "bar"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(2))
+			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -893,7 +893,7 @@ var _ = Describe("Apply Apps", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["existing"] = "value"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(3))
+			Expect(podSpec.NodeSelector).To(HaveLen(3))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector["existing"]).To(Equal("value"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -905,7 +905,7 @@ var _ = Describe("Apply Apps", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(2))
+			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -920,7 +920,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector[kubernetesOSLabel] = "linux-custom"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
 
@@ -928,7 +928,7 @@ var _ = Describe("Apply Apps", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector[kubernetesOSLabel] = "linux-custom"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
 
@@ -936,7 +936,7 @@ var _ = Describe("Apply Apps", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(2))
+			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -950,14 +950,14 @@ var _ = Describe("Apply Apps", func() {
 			}
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Tolerations)).To(Equal(1))
+			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
 
 		It("should preserve tolerations when nodePlacement is empty", func() {
 			podSpec.Tolerations = []corev1.Toleration{toleration}
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Tolerations)).To(Equal(1))
+			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
 
@@ -965,7 +965,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			podSpec.Tolerations = []corev1.Toleration{toleration2}
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Tolerations)).To(Equal(2))
+			Expect(podSpec.Tolerations).To(HaveLen(2))
 		})
 
 		It("It should copy NodePlacement if podSpec Affinity is empty", func() {
@@ -987,12 +987,12 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity = affinity
 			podSpec.Affinity = affinity2
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)).To(Equal(2))
-			Expect(len(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
+			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(2))
+			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeFalse())
 		})
 
@@ -1001,7 +1001,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)).To(Equal(1))
+			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 		})
 
 		It("It should copy Preferred NodeAffinity", func() {
@@ -1009,7 +1009,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Required PodAffinity", func() {
@@ -1017,7 +1017,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Preferred PodAffinity", func() {
@@ -1025,7 +1025,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Required PodAntiAffinity", func() {
@@ -1033,7 +1033,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Preferred PodAntiAffinity", func() {
@@ -1041,7 +1041,7 @@ var _ = Describe("Apply Apps", func() {
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 	})
 

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -400,7 +400,7 @@ var _ = Describe("Apply", func() {
 				}
 
 				if !expectSpecPatch && !expectLabelsAnnotationsPatch {
-					Expect(len(ops)).To(Equal(0))
+					Expect(ops).To(BeEmpty())
 				}
 			},
 			Entry("should do nothing if cached service has ClusterIP set and target does not (clusterIP is dynamically assigned when empty)",

--- a/pkg/virt-operator/resource/apply/delete_test.go
+++ b/pkg/virt-operator/resource/apply/delete_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Deletion", func() {
 
 			needAdded := crdFilterNeedFinalizerAdded(crds)
 
-			Expect(len(needAdded)).To(Equal(1))
+			Expect(needAdded).To(HaveLen(1))
 			Expect(needAdded[0].Name).To(Equal("needs-finalizer"))
 		})
 
@@ -127,7 +127,7 @@ var _ = Describe("Deletion", func() {
 			}
 
 			needRemoved := crdFilterNeedFinalizerRemoved(crds)
-			Expect(len(needRemoved)).To(Equal(3))
+			Expect(needRemoved).To(HaveLen(3))
 		})
 
 		It("Should block finalizer removal until all CRD CRs are removed", func() {
@@ -166,7 +166,7 @@ var _ = Describe("Deletion", func() {
 			}
 
 			needRemoved := crdFilterNeedFinalizerRemoved(crds)
-			Expect(len(needRemoved)).To(Equal(0))
+			Expect(needRemoved).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Patches", func() {
 
 		It("should return flags in the proper format", func() {
 			fa := flagsToArray(flags)
-			Expect(len(fa)).To(Equal(5))
+			Expect(fa).To(HaveLen(5))
 
 			Expect(strings.Join(fa, " ")).To(ContainSubstring("--flag-one 1"))
 			Expect(strings.Join(fa, " ")).To(ContainSubstring("--flag 3"))
@@ -221,7 +221,7 @@ var _ = Describe("Patches", func() {
 
 		It("should add flag patch", func() {
 			patches := addFlagsPatch(components.VirtAPIName, resource, flags, []v1.CustomizeComponentsPatch{})
-			Expect(len(patches)).To(Equal(1))
+			Expect(patches).To(HaveLen(1))
 			patch := patches[0]
 
 			Expect(patch.ResourceName).To(Equal(components.VirtAPIName))
@@ -235,10 +235,10 @@ var _ = Describe("Patches", func() {
 
 		It("should chain patches", func() {
 			patches := addFlagsPatch(components.VirtAPIName, resource, flags, []v1.CustomizeComponentsPatch{})
-			Expect(len(patches)).To(Equal(1))
+			Expect(patches).To(HaveLen(1))
 
 			patches = addFlagsPatch(components.VirtControllerName, resource, flags, patches)
-			Expect(len(patches)).To(Equal(2))
+			Expect(patches).To(HaveLen(2))
 		})
 
 		It("should return all flag patches", func() {
@@ -247,7 +247,7 @@ var _ = Describe("Patches", func() {
 			}
 
 			patches := flagsToPatches(f)
-			Expect(len(patches)).To(Equal(1))
+			Expect(patches).To(HaveLen(1))
 		})
 	})
 

--- a/pkg/virt-operator/resource/apply/prometheus_test.go
+++ b/pkg/virt-operator/resource/apply/prometheus_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Apply Prometheus", func() {
 			pr := &promv1.PrometheusRule{}
 			Expect(json.Unmarshal(obj, pr)).To(Succeed())
 			Expect(pr.Spec.Groups).To(Equal(updatedGroups))
-			Expect(len(pr.Spec.Groups)).To(Equal(1))
+			Expect(pr.Spec.Groups).To(HaveLen(1))
 
 			return true, pr, nil
 		})

--- a/pkg/virt-operator/resource/apply/reconcile_test.go
+++ b/pkg/virt-operator/resource/apply/reconcile_test.go
@@ -337,14 +337,14 @@ var _ = Describe("Apply", func() {
 		It("should succeed if componentConfig is nil", func() {
 			// if componentConfig is nil
 			injectPlacementMetadata(nil, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
 		It("should succeed if nodePlacement is nil", func() {
 			componentConfig.NodePlacement = nil
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
 
@@ -359,7 +359,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector["foo"] = "bar"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(2))
+			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -370,7 +370,7 @@ var _ = Describe("Apply", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["existing"] = "value"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(3))
+			Expect(podSpec.NodeSelector).To(HaveLen(3))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("bar"))
 			Expect(podSpec.NodeSelector["existing"]).To(Equal("value"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
@@ -382,7 +382,7 @@ var _ = Describe("Apply", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(2))
+			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -397,7 +397,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.NodeSelector = make(map[string]string)
 			nodePlacement.NodeSelector[kubernetesOSLabel] = "linux-custom"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
 
@@ -405,7 +405,7 @@ var _ = Describe("Apply", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector[kubernetesOSLabel] = "linux-custom"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(1))
+			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal("linux-custom"))
 		})
 
@@ -413,7 +413,7 @@ var _ = Describe("Apply", func() {
 			podSpec.NodeSelector = make(map[string]string)
 			podSpec.NodeSelector["foo"] = "from-podspec"
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.NodeSelector)).To(Equal(2))
+			Expect(podSpec.NodeSelector).To(HaveLen(2))
 			Expect(podSpec.NodeSelector["foo"]).To(Equal("from-podspec"))
 			Expect(podSpec.NodeSelector[kubernetesOSLabel]).To(Equal(kubernetesOSLinux))
 		})
@@ -427,14 +427,14 @@ var _ = Describe("Apply", func() {
 			}
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Tolerations)).To(Equal(1))
+			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
 
 		It("should preserve tolerations when nodePlacement is empty", func() {
 			podSpec.Tolerations = []corev1.Toleration{toleration}
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Tolerations)).To(Equal(1))
+			Expect(podSpec.Tolerations).To(HaveLen(1))
 			Expect(podSpec.Tolerations[0].Key).To(Equal("test-taint"))
 		})
 
@@ -442,7 +442,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Tolerations = []corev1.Toleration{toleration}
 			podSpec.Tolerations = []corev1.Toleration{toleration2}
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Tolerations)).To(Equal(2))
+			Expect(podSpec.Tolerations).To(HaveLen(2))
 		})
 
 		It("It should copy NodePlacement if podSpec Affinity is empty", func() {
@@ -464,12 +464,12 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity = affinity
 			podSpec.Affinity = affinity2
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)).To(Equal(2))
-			Expect(len(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
-			Expect(len(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(2))
+			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(2))
+			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
+			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(2))
 			Expect(equality.Semantic.DeepEqual(nodePlacement.Affinity, podSpec.Affinity)).To(BeFalse())
 		})
 
@@ -478,7 +478,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)).To(Equal(1))
+			Expect(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 		})
 
 		It("It should copy Preferred NodeAffinity", func() {
@@ -486,7 +486,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity.NodeAffinity = &corev1.NodeAffinity{}
 			nodePlacement.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Required PodAffinity", func() {
@@ -494,7 +494,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Preferred PodAffinity", func() {
@@ -502,7 +502,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity.PodAffinity = &corev1.PodAffinity{}
 			nodePlacement.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Required PodAntiAffinity", func() {
@@ -510,7 +510,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 
 		It("It should copy Preferred PodAntiAffinity", func() {
@@ -518,7 +518,7 @@ var _ = Describe("Apply", func() {
 			nodePlacement.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 			nodePlacement.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 			injectPlacementMetadata(componentConfig, podSpec)
-			Expect(len(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)).To(Equal(1))
+			Expect(podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
 		})
 	})
 })

--- a/pkg/virt-operator/util/client_test.go
+++ b/pkg/virt-operator/util/client_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Operator Client", func() {
 			Context("When it doesn't exist yet", func() {
 				It("Should add the condition", func() {
 					updateCondition(kv, v1.KubeVirtConditionAvailable, k8sv1.ConditionTrue, "NewReason", "new message")
-					Expect(len(kv.Status.Conditions)).To(Equal(2), "should have 2 conditions")
+					Expect(kv.Status.Conditions).To(HaveLen(2), "should have 2 conditions")
 					condition1 := kv.Status.Conditions[0]
 					Expect(condition1.Type).To(Equal(v1.KubeVirtConditionCreated), "should keep old condition type")
 					condition2 := kv.Status.Conditions[1]
@@ -81,7 +81,7 @@ var _ = Describe("Operator Client", func() {
 			Context("When it exists", func() {
 				It("Should update the condition", func() {
 					updateCondition(kv, v1.KubeVirtConditionCreated, k8sv1.ConditionTrue, "NewReason", "new message")
-					Expect(len(kv.Status.Conditions)).To(Equal(1), "should still have 1 condition")
+					Expect(kv.Status.Conditions).To(HaveLen(1), "should still have 1 condition")
 					condition1 := kv.Status.Conditions[0]
 					Expect(condition1.Type).To(Equal(v1.KubeVirtConditionCreated), "should keep old condition type")
 					Expect(condition1.Status).To(Equal(k8sv1.ConditionTrue), "should update condition status")
@@ -97,7 +97,7 @@ var _ = Describe("Operator Client", func() {
 			Context("When it doesn't exist", func() {
 				It("Should not change existing conditions", func() {
 					removeCondition(kv, v1.KubeVirtConditionAvailable)
-					Expect(len(kv.Status.Conditions)).To(Equal(1), "should still have 1 condition")
+					Expect(kv.Status.Conditions).To(HaveLen(1), "should still have 1 condition")
 					condition1 := kv.Status.Conditions[0]
 					Expect(condition1.Type).To(Equal(v1.KubeVirtConditionCreated))
 					Expect(condition1.Status).To(Equal(k8sv1.ConditionFalse))
@@ -119,13 +119,13 @@ var _ = Describe("Operator Client", func() {
 			Context("When another one already exists", func() {
 				It("Should add it", func() {
 					AddFinalizer(kv)
-					Expect(len(kv.Finalizers)).To(Equal(2), "should have 2 finalizers")
+					Expect(kv.Finalizers).To(HaveLen(2), "should have 2 finalizers")
 					Expect(kv.Finalizers[0]).To(Equal("oldFinalizer"), "should keep first old finalizer")
 					Expect(kv.Finalizers[1]).To(Equal(KubeVirtFinalizer), "should add new finalizer")
 				})
 				It("Should not add it again", func() {
 					AddFinalizer(kv)
-					Expect(len(kv.Finalizers)).To(Equal(2), "should still have 2 finalizers")
+					Expect(kv.Finalizers).To(HaveLen(2), "should still have 2 finalizers")
 					Expect(kv.Finalizers[0]).To(Equal("oldFinalizer"), "should keep first old finalizer")
 					Expect(kv.Finalizers[1]).To(Equal(KubeVirtFinalizer), "should keep second old finalizer")
 				})

--- a/pkg/watchdog/watchdog_test.go
+++ b/pkg/watchdog/watchdog_test.go
@@ -61,18 +61,18 @@ var _ = Describe("Watchdog", func() {
 			now := time.Now()
 			domains, err := getExpiredDomains(1, tmpVirtShareDir, now)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domains)).To(Equal(0))
+			Expect(domains).To(BeEmpty())
 
 			now = now.Add(time.Second * 3)
 			domains, err = getExpiredDomains(1, tmpVirtShareDir, now)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domains)).To(Equal(1))
+			Expect(domains).To(HaveLen(1))
 
 			Expect(os.Create(fileName)).ToNot(BeNil())
 			now = time.Now()
 			domains, err = getExpiredDomains(1, tmpVirtShareDir, now)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domains)).To(Equal(0))
+			Expect(domains).To(BeEmpty())
 		})
 
 		It("should successfully remove watchdog file", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Watchdog", func() {
 			Expect(os.Create(fileName)).ToNot(BeNil())
 			domains, err := getExpiredDomains(1, tmpVirtShareDir, now)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domains)).To(Equal(0))
+			Expect(domains).To(BeEmpty())
 
 			expired, err := watchdogFileIsExpired(1, tmpVirtShareDir, vmi, now)
 			Expect(err).ToNot(HaveOccurred())
@@ -95,7 +95,7 @@ var _ = Describe("Watchdog", func() {
 			now = now.Add(time.Second * 3)
 			domains, err = getExpiredDomains(1, tmpVirtShareDir, now)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domains)).To(Equal(1))
+			Expect(domains).To(HaveLen(1))
 
 			expired, err = watchdogFileIsExpired(1, tmpVirtShareDir, vmi, now)
 			Expect(err).ToNot(HaveOccurred())
@@ -110,7 +110,7 @@ var _ = Describe("Watchdog", func() {
 
 			domains, err = getExpiredDomains(1, tmpVirtShareDir, now)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(domains)).To(Equal(0))
+			Expect(domains).To(BeEmpty())
 
 			exists, err = WatchdogFileExists(tmpVirtShareDir, vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -127,7 +127,7 @@ var _ = Describe("Watchdog", func() {
 				now = now.Add(time.Second * 1)
 				domains, err := getExpiredDomains(2, tmpVirtShareDir, now)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(domains)).To(Equal(0))
+				Expect(domains).To(BeEmpty())
 			}
 		})
 

--- a/staging/src/kubevirt.io/client-go/api/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/defaults_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 	It("should append pod interface if interface is not defined", func() {
 		vmi := &v1.VirtualMachineInstance{}
 		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
 		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
 		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
 		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())
@@ -300,7 +300,7 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 
 		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
 		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("testnet"))
 		Expect(vmi.Spec.Networks[0].Name).To(Equal("testnet"))
 		Expect(vmi.Spec.Networks[0].Pod).To(BeNil())
@@ -312,8 +312,8 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 		vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
 
 		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(0))
-		Expect(len(vmi.Spec.Networks)).To(Equal(0))
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(BeEmpty())
+		Expect(vmi.Spec.Networks).To(BeEmpty())
 	})
 
 	It("should append pod interface if auto attach is true", func() {
@@ -321,7 +321,7 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 		vmi := &v1.VirtualMachineInstance{}
 		vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
 		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
+		Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(1))
 		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
 		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
 		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())

--- a/staging/src/kubevirt.io/client-go/api/types_test.go
+++ b/staging/src/kubevirt.io/client-go/api/types_test.go
@@ -69,8 +69,8 @@ var _ = Describe("PodSelectors", func() {
 			affinity := v1.UpdateAntiAffinityFromVMINode(pod, vmi)
 			newSelector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
 			Expect(newSelector).ToNot(BeNil())
-			Expect(len(newSelector.MatchExpressions)).To(Equal(1))
-			Expect(len(newSelector.MatchExpressions[0].Values)).To(Equal(1))
+			Expect(newSelector.MatchExpressions).To(HaveLen(1))
+			Expect(newSelector.MatchExpressions[0].Values).To(HaveLen(1))
 			Expect(newSelector.MatchExpressions[0].Values[0]).To(Equal("test-node"))
 		})
 
@@ -111,14 +111,14 @@ var _ = Describe("PodSelectors", func() {
 
 			selector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
 			Expect(selector).ToNot(BeNil())
-			Expect(len(selector.MatchExpressions)).To(Equal(1))
-			Expect(len(selector.MatchExpressions[0].Values)).To(Equal(1))
+			Expect(selector.MatchExpressions).To(HaveLen(1))
+			Expect(selector.MatchExpressions[0].Values).To(HaveLen(1))
 			Expect(selector.MatchExpressions[0].Values[0]).To(Equal("test-node"))
 
 			selector = affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[1]
 			Expect(selector).ToNot(BeNil())
-			Expect(len(selector.MatchExpressions)).To(Equal(2))
-			Expect(len(selector.MatchExpressions[1].Values)).To(Equal(1))
+			Expect(selector.MatchExpressions).To(HaveLen(2))
+			Expect(selector.MatchExpressions[1].Values).To(HaveLen(1))
 			Expect(selector.MatchExpressions[1].Values[0]).To(Equal("test-node"))
 		})
 	})


### PR DESCRIPTION
Change all `Expect(len(var)).To(Equal(some-length))` to `Expect(var).To(HaveLen(some-length))` in pkg/virt-operator, taging/src/kubevirt.io/client-go/api and pkg/watchdog. 

If the expected length is 0, the the new matcher is `BeEmpty()`

```release-note
None
```
