### PR TITLE
Use libvmi consistently in storage tests

### DIFF
--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -21,6 +21,7 @@ package libvmi
 
 import (
 	k8sv1 "k8s.io/api/core/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 )
 

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -221,7 +221,12 @@ var _ = SIGDescribe("Storage", func() {
 
 			It("[QUARANTINE] should pause VMI on IO error", func() {
 				By("Creating VMI with faulty disk")
-				vmi := tests.NewRandomVMIWithPVC(pvc.Name)
+				vmi := libvmi.New(
+					libvmi.WithPersistentVolumeClaim("disk0", pvc.Name),
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
+
 				_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil(), failedCreateVMI)
 
@@ -248,6 +253,12 @@ var _ = SIGDescribe("Storage", func() {
 		})
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]with Alpine PVC", func() {
+			newRandomVMIWithPVC := func(claimName string) *virtv1.VirtualMachineInstance {
+				return libvmi.New(
+					libvmi.WithPersistentVolumeClaim("disk0", claimName),
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithRng())
+			}
 
 			Context("should be successfully", func() {
 				var pvName string
@@ -275,19 +286,19 @@ var _ = SIGDescribe("Storage", func() {
 					vmi = newVMI(pvName)
 
 					if storageEngine == "nfs" {
-						tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+						vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 					} else {
-						tests.RunVMIAndExpectLaunch(vmi, 180)
+						vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
 					}
 
 					By(checkingVMInstanceConsoleOut)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				},
-					Entry("[test_id:3130]with Disk PVC", tests.NewRandomVMIWithPVC, "", nil, true),
+					Entry("[test_id:3130]with Disk PVC", newRandomVMIWithPVC, "", nil, true),
 					Entry("[test_id:3131]with CDRom PVC", tests.NewRandomVMIWithCDRom, "", nil, true),
-					Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
-					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
-					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
+					Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
+					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
+					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
 				)
 			})
 
@@ -311,7 +322,7 @@ var _ = SIGDescribe("Storage", func() {
 					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 				}
 			},
-				Entry("[test_id:3132]with Disk PVC", tests.NewRandomVMIWithPVC),
+				Entry("[test_id:3132]with Disk PVC", newRandomVMIWithPVC),
 				Entry("[test_id:3133]with CDRom PVC", tests.NewRandomVMIWithCDRom),
 			)
 		})
@@ -647,8 +658,11 @@ var _ = SIGDescribe("Storage", func() {
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3138]should start vmi multiple times", func() {
-				vmi = tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
-				tests.AddPVCDisk(vmi, "disk1", v1.DiskBusVirtio, tests.DiskCustomHostPath)
+				vmi = libvmi.New(
+					libvmi.WithPersistentVolumeClaim("disk0", tests.DiskAlpineHostPath),
+					libvmi.WithPersistentVolumeClaim("disk1", tests.DiskCustomHostPath),
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithRng())
 
 				num := 3
 				By("Starting and stopping the VirtualMachineInstance number of times")
@@ -659,9 +673,9 @@ var _ = SIGDescribe("Storage", func() {
 					// after being restarted multiple times
 					if i == num {
 						By("Checking that the second disk is present")
-						Expect(console.LoginToAlpine(vmi)).To(Succeed())
+						Expect(console.LoginToAlpine(obj)).To(Succeed())
 
-						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						Expect(console.SafeExpectBatch(obj, []expect.Batcher{
 							&expect.BSnd{S: "blockdev --getsize64 /dev/vdb\n"},
 							&expect.BExp{R: "1013972992"},
 						}, 200)).To(Succeed())
@@ -893,6 +907,12 @@ var _ = SIGDescribe("Storage", func() {
 				It("[test_id:868] Should initialize an empty PVC by creating a disk.img", func() {
 					for _, pvc := range pvcs {
 						By(startingVMInstance)
+						vmi = libvmi.New(
+							libvmi.WithPersistentVolumeClaim("disk0", fmt.Sprintf("disk-%s", pvc)),
+							libvmi.WithResourceMemory("256Mi"),
+							libvmi.WithNetwork(v1.DefaultPodNetwork()),
+							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
+
 						vmi = tests.NewRandomVMIWithPVC(fmt.Sprintf("disk-%s", pvc))
 						vmi.Spec.NodeSelector = nodeSelector
 						tests.RunVMIAndExpectLaunch(vmi, 90)


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Use `libvmi` where possible in storage tests. Many tests already use this new lib, so using it here makes codebase more consistent (simpler to maintain). This is one of required steps to remove big universal utils.go.

With this PR a new factory functions were added to create a VM with provided DV or PVC. Also new function was used in a few places as an example. In a followup PR I'll try to replace all tests.RandomVM usages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
