### PR TITLE
Code Cleanup: Improve gomega matchers in pkg/virt-api/webhooks

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			preset.ObjectMeta.Name = "test-preset"
 
 			annotateVMI(&vmi, preset)
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(v1.GroupVersion.String()))
 		})
 
@@ -57,7 +57,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			preset.ObjectMeta.Name = "preset-bar"
 			annotateVMI(&vmi, preset)
 
-			Expect(len(vmi.Annotations)).To(Equal(2))
+			Expect(vmi.Annotations).To(HaveLen(2))
 			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/preset-foo"]).To(Equal(v1.GroupVersion.String()))
 			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/preset-bar"]).To(Equal(v1.GroupVersion.String()))
 		})
@@ -132,7 +132,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			applyPresets(&vmi, presetInformer)
 
 			By("checking annotations were applied and CPU count remains the same")
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 			Expect(int(vmi.Spec.Domain.CPU.Cores)).To(Equal(4))
 
 			By("showing an override occurred")
@@ -146,7 +146,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			applyPresets(&vmi, presetInformer)
 
 			By("checking annotations were not applied and CPU count remains the same")
-			Expect(len(vmi.Annotations)).To(Equal(0))
+			Expect(vmi.Annotations).To(BeEmpty())
 			Expect(int(vmi.Spec.Domain.CPU.Cores)).To(Equal(4))
 		})
 
@@ -169,7 +169,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			memory, ok := vmi.Spec.Domain.Resources.Requests["memory"]
 			Expect(ok).To(BeTrue())
 			Expect(int(memory.Value())).To(Equal(64000000))
-			Expect(len(vmi.Annotations)).To(Equal(0))
+			Expect(vmi.Annotations).To(BeEmpty())
 
 			preset.Spec.Domain.Resources = v1.ResourceRequirements{Requests: k8sv1.ResourceList{
 				"memory": memory,
@@ -188,7 +188,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			memory, ok = vmi.Spec.Domain.Resources.Requests["memory"]
 			Expect(ok).To(BeTrue())
 			Expect(int(memory.Value())).To(Equal(64000000))
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 		})
 
 		It("Should detect Firmware overrides", func() {
@@ -206,7 +206,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(0))
+			Expect(vmi.Annotations).To(BeEmpty())
 			Expect(vmi.Spec.Domain.Firmware.UUID).To(Equal(matchUuid))
 
 			preset.Spec.Domain.Firmware = &v1.Firmware{UUID: matchUuid}
@@ -220,7 +220,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 			Expect(vmi.Spec.Domain.Firmware.UUID).To(Equal(matchUuid))
 		})
 
@@ -238,7 +238,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(0))
+			Expect(vmi.Annotations).To(BeEmpty())
 			Expect(vmi.Spec.Domain.Clock.Timer.HPET.TickPolicy).To(Equal(v1.HPETTickPolicyDelay))
 
 			preset.Spec.Domain.Clock = &v1.Clock{ClockOffset: v1.ClockOffset{},
@@ -254,7 +254,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			vmi.Annotations = map[string]string{}
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 			Expect(vmi.Spec.Domain.Clock.Timer.HPET.TickPolicy).To(Equal(v1.HPETTickPolicyDelay))
 		})
 
@@ -271,7 +271,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(0))
+			Expect(vmi.Annotations).To(BeEmpty())
 			Expect(*vmi.Spec.Domain.Features.ACPI.Enabled).To(BeTrue())
 
 			preset.Spec.Domain.Features = &v1.Features{ACPI: v1.FeatureState{Enabled: &truthy},
@@ -288,7 +288,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 			Expect(*vmi.Spec.Domain.Features.ACPI.Enabled).To(BeTrue())
 		})
 
@@ -304,7 +304,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(0))
+			Expect(vmi.Annotations).To(BeEmpty())
 			Expect(vmi.Spec.Domain.Devices.Watchdog.Name).To(Equal("testcase"))
 
 			preset.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "testcase", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionReset}}}
@@ -318,7 +318,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(1))
+			Expect(vmi.Annotations).To(HaveLen(1))
 			Expect(vmi.Spec.Domain.Devices.Watchdog.Name).To(Equal("testcase"))
 		})
 
@@ -338,7 +338,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(0), "There should not be annotations if presets weren't applied")
+			Expect(vmi.Annotations).To(BeEmpty(), "There should not be annotations if presets weren't applied")
 			Expect(*vmi.Spec.Domain.IOThreadsPolicy).To(Equal(automaticPolicy), "IOThreads policy should not have been overridden")
 
 			preset.Spec.Domain.IOThreadsPolicy = &automaticPolicy
@@ -351,7 +351,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			presetInformer.GetIndexer().Add(preset)
 			applyPresets(&vmi, presetInformer)
 
-			Expect(len(vmi.Annotations)).To(Equal(1), "There should be an annotation indicating presets were applied")
+			Expect(vmi.Annotations).To(HaveLen(1), "There should be an annotation indicating presets were applied")
 			Expect(*vmi.Spec.Domain.IOThreadsPolicy).To(Equal(automaticPolicy), "IOThreadsPolicy should not have been changed")
 		})
 	})
@@ -511,7 +511,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			Expect(ok).To(BeTrue())
 
 			By("checking settings were applied")
-			Expect(len(vmi.Spec.Domain.Resources.Requests)).To(Equal(1))
+			Expect(vmi.Spec.Domain.Resources.Requests).To(HaveLen(1))
 			memory := vmi.Spec.Domain.Resources.Requests["memory"]
 			Expect(int(memory.Value())).To(Equal(64000000))
 
@@ -669,7 +669,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			allPresets := []v1.VirtualMachineInstancePreset{matchingPreset, nonmatchingPreset}
 			matchingPresets, err := filterPresets(allPresets, &vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(matchingPresets)).To(Equal(1))
+			Expect(matchingPresets).To(HaveLen(1))
 			Expect(matchingPresets[0].Name).To(Equal(matchingPresetName))
 		})
 
@@ -677,7 +677,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			allPresets := []v1.VirtualMachineInstancePreset{nonmatchingPreset}
 			matchingPresets, err := filterPresets(allPresets, &vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(matchingPresets)).To(Equal(0))
+			Expect(matchingPresets).To(BeEmpty())
 		})
 
 		It("Should not ignore bogus selectors", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 
 			resp := migrationCreateAdmitter.Admit(ar)
 			Expect(resp.Allowed).To(BeFalse())
-			Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.vmiName"))
 		})
 


### PR DESCRIPTION
Change all `Expect(len(var)).To(Equal(some-length))` to `Expect(var).To(HaveLen(some-length))`
in two files under pkg/virt-api/webhooks:
* pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
* pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go

If the expected length is 0, the the new matcher is BeEmpty()

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```
