### PR TITLE
Add NonRoot feature gate

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -42,7 +42,8 @@ const (
 	VirtIOFSGate               = "ExperimentalVirtiofsSupport"
 	MacvtapGate                = "Macvtap"
 	DownwardMetricsFeatureGate = "DownwardMetrics"
-	NonRoot                    = "NonRootExperimental"
+	NonRootDeprecated          = "NonRootExperimental"
+	NonRoot                    = "NonRoot"
 	ClusterProfiler            = "ClusterProfiler"
 	WorkloadEncryptionSEV      = "WorkloadEncryptionSEV"
 )
@@ -126,7 +127,7 @@ func (config *ClusterConfig) HostDevicesPassthroughEnabled() bool {
 }
 
 func (config *ClusterConfig) NonRootEnabled() bool {
-	return config.isFeatureGateEnabled(NonRoot)
+	return config.isFeatureGateEnabled(NonRoot) || config.isFeatureGateEnabled(NonRootDeprecated)
 }
 
 func (config *ClusterConfig) ClusterProfilerEnabled() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
We are going to test NonRoot extensively from now on
and therefore there is no reason to call it
Experimental. Let's rename it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Users can now enable the NonRoot feature gate instead of NonRootExperimental
```
