### PR TITLE
libvmi/cloudinit: Add WithCloudInitConfigDriveUserData

### DIFF
--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -59,6 +59,22 @@ func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
 	}
 }
 
+// WithCloudInitConfigDriveUserData adds cloud-init config-drive user data.
+func WithCloudInitConfigDriveUserData(data string, b64Encoding bool) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		diskName, bus := "disk1", "virtio"
+		addDiskVolumeWithCloudInitConfigDrive(vmi, diskName, bus)
+
+		volume := getVolume(vmi, diskName)
+		if b64Encoding {
+			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
+			volume.CloudInitConfigDrive.UserDataBase64 = encodedData
+		} else {
+			volume.CloudInitConfigDrive.UserData = data
+		}
+	}
+}
+
 func addDiskVolumeWithCloudInitNoCloud(vmi *kvirtv1.VirtualMachineInstance, diskName, bus string) {
 	addDisk(vmi, newDisk(diskName, bus))
 	v := newVolume(diskName)
@@ -68,4 +84,15 @@ func addDiskVolumeWithCloudInitNoCloud(vmi *kvirtv1.VirtualMachineInstance, disk
 
 func setCloudInitNoCloud(volume *kvirtv1.Volume, source *kvirtv1.CloudInitNoCloudSource) {
 	volume.VolumeSource = kvirtv1.VolumeSource{CloudInitNoCloud: source}
+}
+
+func addDiskVolumeWithCloudInitConfigDrive(vmi *kvirtv1.VirtualMachineInstance, diskName, bus string) {
+	addDisk(vmi, newDisk(diskName, bus))
+	v := newVolume(diskName)
+	setCloudInitConfigDrive(&v, &kvirtv1.CloudInitConfigDriveSource{})
+	addVolume(vmi, v)
+}
+
+func setCloudInitConfigDrive(volume *kvirtv1.Volume, source *kvirtv1.CloudInitConfigDriveSource) {
+	volume.VolumeSource = kvirtv1.VolumeSource{CloudInitConfigDrive: source}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This change allows libvmi to add a cloudInitConfigDrive with user data
to VMIs.

The user data in a cloudInitConfigDrive can be used to provide an
ignition config to CoreOS / RHCOS guests.

Needed by https://github.com/kubevirt/containerdisks/pull/18

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
