### PR TITLE
libvmi/vmi: Add WithSMM

### DIFF
--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -125,6 +125,18 @@ func WithSEV() Option {
 	}
 }
 
+// WithSMM enables the SMM domain feature (needed by SecureBoot)
+func WithSMM() Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.Features == nil {
+			vmi.Spec.Domain.Features = &v1.Features{}
+		}
+		vmi.Spec.Domain.Features.SMM = &v1.FeatureState{
+			Enabled: pointer.Bool(true),
+		}
+	}
+}
+
 func baseVmi(name string) *kvirtv1.VirtualMachineInstance {
 	vmi := kvirtv1.NewVMIReferenceFromNameWithNS("", name)
 	vmi.Spec = kvirtv1.VirtualMachineInstanceSpec{Domain: kvirtv1.DomainSpec{}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This change allows libvmi to enable the SMM domain feature on VMIs.

This is needed when enabling secure boot and not enabling SEV.

Needed by https://github.com/kubevirt/containerdisks/pull/18

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
