### PR TITLE
[release-0.49] virt-launcher, hostdevice: Respect SR-IOV guest pciAddress and bootOrder

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
@@ -28,10 +28,12 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -50,23 +50,27 @@ func createHostDevicesMetadata(ifaces []v1.Interface) []hostdevice.HostDeviceMet
 			AliasPrefix:  AliasPrefix,
 			Name:         iface.Name,
 			ResourceName: iface.Name,
-			DecorateHook: func(hostDevice *api.HostDevice) error {
-				if guestPCIAddress := iface.PciAddress; guestPCIAddress != "" {
-					addr, err := device.NewPciAddressField(guestPCIAddress)
-					if err != nil {
-						return fmt.Errorf("failed to interpret the guest PCI address: %v", err)
-					}
-					hostDevice.Address = addr
-				}
-
-				if iface.BootOrder != nil {
-					hostDevice.BootOrder = &api.BootOrder{Order: *iface.BootOrder}
-				}
-				return nil
-			},
+			DecorateHook: newDecorateHook(iface),
 		})
 	}
 	return hostDevicesMetaData
+}
+
+func newDecorateHook(iface v1.Interface) func(hostDevice *api.HostDevice) error {
+	return func(hostDevice *api.HostDevice) error {
+		if guestPCIAddress := iface.PciAddress; guestPCIAddress != "" {
+			addr, err := device.NewPciAddressField(guestPCIAddress)
+			if err != nil {
+				return fmt.Errorf("failed to interpret the guest PCI address: %v", err)
+			}
+			hostDevice.Address = addr
+		}
+
+		if iface.BootOrder != nil {
+			hostDevice.BootOrder = &api.BootOrder{Order: *iface.BootOrder}
+		}
+		return nil
+	}
 }
 
 func SafelyDetachHostDevices(domainSpec *api.DomainSpec, eventDetach hostdevice.EventRegistrar, dom hostdevice.DeviceDetacher, timeout time.Duration) error {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -23,9 +23,11 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"libvirt.org/go/libvirt"
@@ -163,6 +165,61 @@ var _ = Describe("SRIOV HostDevice", func() {
 			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
 
+		table.DescribeTable("create two devices with custom guest PCI address",
+			func(iface1, iface2 v1.Interface) {
+				var expectedGuestPCIAddress1 *api.Address
+				var expectedGuestPCIAddress2 *api.Address
+
+				var err error
+				if iface1.PciAddress != "" {
+					expectedGuestPCIAddress1, err = device.NewPciAddressField(iface1.PciAddress)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				if iface2.PciAddress != "" {
+					expectedGuestPCIAddress2, err = device.NewPciAddressField(iface2.PciAddress)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				pool := newPCIAddressPoolStub("0000:81:00.0", "0000:81:01.0")
+				hostPCIAddress1 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x00", Function: "0x0"}
+				hostPCIAddress2 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+
+				devices, err := sriov.CreateHostDevicesFromIfacesAndPool([]v1.Interface{iface1, iface2}, pool)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectHostDevice1 := api.HostDevice{
+					Alias:   newSRIOVAlias(netname1),
+					Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
+					Address: expectedGuestPCIAddress1,
+					Type:    "pci",
+					Managed: "no",
+				}
+
+				expectHostDevice2 := api.HostDevice{
+					Alias:   newSRIOVAlias(netname2),
+					Source:  api.HostDeviceSource{Address: &hostPCIAddress2},
+					Address: expectedGuestPCIAddress2,
+					Type:    "pci",
+					Managed: "no",
+				}
+
+				Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
+			},
+			table.Entry("both interfaces have a custom guest PCI address",
+				newSRIOVInterfaceWithPCIAddress(netname1, "0000:20:00.0"),
+				newSRIOVInterfaceWithPCIAddress(netname2, "0000:20:01.0"),
+			),
+			table.Entry("only the first interface has a custom guest PCI address",
+				newSRIOVInterfaceWithPCIAddress(netname1, "0000:20:00.0"),
+				newSRIOVInterface(netname2),
+			),
+			table.Entry("only the second interface has a custom guest PCI address",
+				newSRIOVInterface(netname1),
+				newSRIOVInterfaceWithPCIAddress(netname2, "0000:20:01.0"),
+			),
+		)
+
 		It("creates 1 device that includes boot-order", func() {
 			iface := newSRIOVInterface(netname1)
 			val := uint(1)
@@ -181,6 +238,58 @@ var _ = Describe("SRIOV HostDevice", func() {
 			}
 			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
+
+		table.DescribeTable("create two devices with custom boot-order",
+			func(iface1, iface2 v1.Interface) {
+				var expectedBootOrder1 *api.BootOrder
+				var expectedBootOrder2 *api.BootOrder
+
+				if iface1.BootOrder != nil {
+					expectedBootOrder1 = &api.BootOrder{Order: *iface1.BootOrder}
+				}
+
+				if iface2.BootOrder != nil {
+					expectedBootOrder2 = &api.BootOrder{Order: *iface2.BootOrder}
+				}
+
+				pool := newPCIAddressPoolStub("0000:81:00.0", "0000:81:01.0")
+				hostPCIAddress1 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x00", Function: "0x0"}
+				hostPCIAddress2 := api.Address{Type: "pci", Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+
+				devices, err := sriov.CreateHostDevicesFromIfacesAndPool([]v1.Interface{iface1, iface2}, pool)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectHostDevice1 := api.HostDevice{
+					Alias:     newSRIOVAlias(netname1),
+					Source:    api.HostDeviceSource{Address: &hostPCIAddress1},
+					Type:      "pci",
+					Managed:   "no",
+					BootOrder: expectedBootOrder1,
+				}
+
+				expectHostDevice2 := api.HostDevice{
+					Alias:     newSRIOVAlias(netname2),
+					Source:    api.HostDeviceSource{Address: &hostPCIAddress2},
+					Type:      "pci",
+					Managed:   "no",
+					BootOrder: expectedBootOrder2,
+				}
+
+				Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
+			},
+			table.Entry("both interfaces have a custom bootOrder",
+				newSRIOVInterfaceWithBootOrder(netname1, 1),
+				newSRIOVInterfaceWithBootOrder(netname2, 2),
+			),
+			table.Entry("only the first interface has a custom bootOrder",
+				newSRIOVInterfaceWithBootOrder(netname1, 1),
+				newSRIOVInterface(netname2),
+			),
+			table.Entry("only the second interface has a custom bootOrder",
+				newSRIOVInterface(netname1),
+				newSRIOVInterfaceWithBootOrder(netname2, 2),
+			),
+		)
 	})
 
 	Context("safe detachment", func() {
@@ -265,6 +374,20 @@ func newDomainSpec(hostDevices ...api.HostDevice) *api.DomainSpec {
 
 func newSRIOVAlias(netName string) *api.Alias {
 	return api.NewUserDefinedAlias(sriov.AliasPrefix + netName)
+}
+
+func newSRIOVInterfaceWithPCIAddress(name, customPCIAddress string) v1.Interface {
+	iface := newSRIOVInterface(name)
+	iface.PciAddress = customPCIAddress
+
+	return iface
+}
+
+func newSRIOVInterfaceWithBootOrder(name string, bootOrder uint) v1.Interface {
+	iface := newSRIOVInterface(name)
+	iface.BootOrder = &bootOrder
+
+	return iface
 }
 
 type stubPCIAddressPool struct {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1111,6 +1111,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 			It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
 				sriovNetworks := []string{sriovnet1, sriovnet2}
 				vmi := getSriovVmi(sriovNetworks, defaultCloudInitNetworkData())
+				vmi.Spec.Domain.Devices.Interfaces[1].PciAddress = "0000:06:00.0"
+				vmi.Spec.Domain.Devices.Interfaces[2].PciAddress = "0000:07:00.0"
 				vmi = startVmi(vmi)
 				vmi = waitVmi(vmi)
 
@@ -1124,9 +1126,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 				By("checking virtual machine instance has three interfaces")
 				checkInterfacesInGuest(vmi, []string{"eth0", "eth1", "eth2"})
 
-				// there is little we can do beyond just checking three devices are present: PCI slots are different inside
-				// the guest, and DP doesn't pass information about vendor IDs of allocated devices into the pod, so
-				// it's hard to match them.
+				Expect(pciAddressExistsInGuest(vmi, vmi.Spec.Domain.Devices.Interfaces[1].PciAddress)).To(Succeed())
+				Expect(pciAddressExistsInGuest(vmi, vmi.Spec.Domain.Devices.Interfaces[2].PciAddress)).To(Succeed())
 			})
 		})
 
@@ -1534,6 +1535,11 @@ func runSafeCommand(vmi *v1.VirtualMachineInstance, command string) error {
 		&expect.BSnd{S: tests.EchoLastReturnValue},
 		&expect.BExp{R: console.RetValue("0")},
 	}, 15)
+}
+
+func pciAddressExistsInGuest(vmi *v1.VirtualMachineInstance, pciAddress string) error {
+	command := fmt.Sprintf("grep -q %s /sys/class/net/*/device/uevent\n", pciAddress)
+	return console.RunCommand(vmi, command, 15*time.Second)
 }
 
 func getInterfaceNameByMAC(vmi *v1.VirtualMachineInstance, mac string) (string, error) {


### PR DESCRIPTION
This is a manual cherry-pick of #7422 and #7501.
It fixes Bugzilla [2070050](https://bugzilla.redhat.com/show_bug.cgi?id=2070050).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed setting custom guest pciAddress and bootOrder parameter(s) to a list of SR-IOV NICs.
```
