### PR TITLE
Fix stable.txt location

### DIFF
--- a/automation/release.sh
+++ b/automation/release.sh
@@ -81,7 +81,9 @@ function generate_stable_version_file() {
         sort -rV |
         head -1
     ) > _out/stable.txt
+    # this place is deprecated. Combining "devel" and stable is not optimal
     gsutil cp "_out/stable.txt" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/"
+    gsutil cp "_out/stable.txt" "gs://kubevirt-prow/release/kubevirt/kubevirt/"
 }
 
 function main() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Host our `stable.txt` file at `gs://kubevirt-prow/release/kubevirt/kubevirt/` instead of `gs://kubevirt-prow/devel/release/kubevirt/kubevirt/` since it is not realted to `devel` releases.

Keep the old location too to not break scripts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move stable.txt location to a more appropriate path
```
