### PR TITLE
Add test labels

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -200,8 +200,8 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		}
 
 		BeforeEach(func() {
-		    k8sClient = clientcmd.GetK8sCmdClient()
-		    clientcmd.SkipIfNoCmd(k8sClient)
+			k8sClient = clientcmd.GetK8sCmdClient()
+			clientcmd.SkipIfNoCmd(k8sClient)
 			virtClient, err := kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
 			authClient, err = authClientV1.NewForConfig(virtClient.Config())
@@ -369,7 +369,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				BeforeEach(func() {
 					// Generate unique usernames based on the test namespace which is unique per ginkgo node
 					testUser = "testuser-" + util.NamespaceTestDefault
-			        clientcmd.SkipIfNoCmd("oc")
+					clientcmd.SkipIfNoCmd("oc")
 					if !checks.IsOpenShift() {
 						Skip("Skip tests which require an openshift managed test user if not running on openshift")
 					}
@@ -381,7 +381,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				testAction := func(resource, verb string, right string) {
 					// AS A TEST USER
 					By(fmt.Sprintf("verifying user rights for verb %s", verb))
-			        result, _, _ := clientcmd.RunCommand(k8sClient, "auth", "can-i", "--as", testUser, verb, resource)
+					result, _, _ := clientcmd.RunCommand(k8sClient, "auth", "can-i", "--as", testUser, verb, resource)
 					Expect(result).To(ContainSubstring(right))
 				}
 
@@ -395,12 +395,12 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				Context("should fail without admin rights for the project", func() {
 					BeforeEach(func() {
-				    stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "project", util.NamespaceTestDefault)
+						stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "project", util.NamespaceTestDefault)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
 					AfterEach(func() {
-				    stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "delete", "user", testUser)
+						stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "delete", "user", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
@@ -433,15 +433,15 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					BeforeEach(func() {
 						By("Ensuring user has the admin rights for the test namespace project")
 						// This is ussually done in backgroung when creating new user with login and by creating new project by that user
-				        stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "adm", "policy", "add-role-to-user", "-n", util.NamespaceTestDefault, "admin", testUser)
+						stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "adm", "policy", "add-role-to-user", "-n", util.NamespaceTestDefault, "admin", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 
-				        stdOut, stdErr, err = clientcmd.RunCommandWithNS("", k8sClient, "project", util.NamespaceTestDefault)
+						stdOut, stdErr, err = clientcmd.RunCommandWithNS("", k8sClient, "project", util.NamespaceTestDefault)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
 					AfterEach(func() {
-				        stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "delete", "user", testUser)
+						stdOut, stdErr, err := clientcmd.RunCommandWithNS("", k8sClient, "delete", "user", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -160,7 +160,7 @@ func (r rights) list() (e []rightsEntry) {
 }
 
 var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]User Access",
-	Labels{"rfe_id:500", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:500", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var k8sClient string
@@ -221,7 +221,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				}
 			},
 				Entry("[test_id:526]given a vmi",
-					Labels{"test_id:526"},
+					Label("test_id:526"),
 					core.GroupName,
 					"virtualmachineinstances",
 					allowAllFor("admin"),
@@ -230,7 +230,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyAllFor("default")),
 
 				Entry("[test_id:527]given a vm",
-					Labels{"test_id:527"},
+					Label("test_id:527"),
 					core.GroupName,
 					"virtualmachines",
 					allowAllFor("admin"),
@@ -247,7 +247,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyAllFor("default")),
 
 				Entry("[test_id:528]given a vmi preset",
-					Labels{"test_id:528"},
+					Label("test_id:528"),
 					core.GroupName,
 					"virtualmachineinstancepresets",
 					allowAllFor("admin"),
@@ -256,7 +256,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyAllFor("default")),
 
 				Entry("[test_id:529][crit:low]given a vmi replica set",
-					Labels{"test_id:529"},
+					Label("test_id:529"),
 					core.GroupName,
 					"virtualmachineinstancereplicasets",
 					allowAllFor("admin"),
@@ -265,7 +265,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyAllFor("default")),
 
 				Entry("[test_id:3230]given a vmi migration",
-					Labels{"test_id:3230"},
+					Label("test_id:3230"),
 					core.GroupName,
 					"virtualmachineinstancemigrations",
 					allowAllFor("admin"),
@@ -274,7 +274,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyAllFor("default")),
 
 				Entry("[test_id:5243]given a vmsnapshot",
-					Labels{"test_id:5243"},
+					Label("test_id:5243"),
 					v1alpha1.SchemeGroupVersion.Group,
 					"virtualmachinesnapshots",
 					allowAllFor("admin"),
@@ -283,7 +283,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyAllFor("default")),
 
 				Entry("[test_id:5244]given a vmsnapshotcontent",
-					Labels{"test_id:5244"},
+					Label("test_id:5244"),
 					v1alpha1.SchemeGroupVersion.Group,
 					"virtualmachinesnapshotcontents",
 					allowAllFor("admin"),
@@ -291,7 +291,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					denyModificationsFor("view"),
 					denyAllFor("default")),
 				Entry("[test_id:5245]given a vmsrestore",
-					Labels{"test_id:5245"},
+					Label("test_id:5245"),
 					v1alpha1.SchemeGroupVersion.Group,
 					"virtualmachinerestores",
 					allowAllFor("admin"),
@@ -310,17 +310,17 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				}
 			},
 				Entry("[test_id:3232]on vm start",
-					Labels{"test_id:3232"},
+					Label("test_id:3232"),
 					"virtualmachines", "start",
 					allowUpdateFor("admin", "edit"),
 					denyAllFor("view", "default")),
 				Entry("[test_id:3233]on vm stop",
-					Labels{"test_id:3233"},
+					Label("test_id:3233"),
 					"virtualmachines", "stop",
 					allowUpdateFor("admin", "edit"),
 					denyAllFor("view", "default")),
 				Entry("[test_id:3234]on vm restart",
-					Labels{"test_id:3234"},
+					Label("test_id:3234"),
 					"virtualmachines", "restart",
 					allowUpdateFor("admin", "edit"),
 					denyAllFor("view", "default")),
@@ -361,7 +361,7 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		Describe("[rfe_id:2919][crit:high][vendor:cnv-qe@redhat.com][level:component] With regular OpenShift user",
-			Labels{"rfe_id:2919", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:2919", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 
 				var testUser string
@@ -407,25 +407,25 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					DescribeTable("should verify permissions on resources are correct for view, edit, and admin", func(resource string) {
 						testRights(resource, "no")
 					},
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances"),
-						Entry("[test_id:2915]given a vm", Labels{"test_id:2915"}, "virtualmachines"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances"),
+						Entry("[test_id:2915]given a vm", Label("test_id:2915"), "virtualmachines"),
 						Entry("given a vmpool", "virtualmachinepools"),
-						Entry("[test_id:2917]given a vmi preset", Labels{"test_id:2917"}, "virtualmachineinstancepresets"),
-						Entry("[test_id:2919]given a vmi replica set", Labels{"test_id:2919"}, "virtualmachineinstancereplicasets"),
-						Entry("[test_id:3235]given a vmi migration", Labels{"test_id:3235"}, "virtualmachineinstancemigrations"),
-						Entry("[test_id:5246]given a vmsnapshot", Labels{"test_id:5246"}, "virtualmachinesnapshots"),
-						Entry("[test_id:5247]given a vmsnapshotcontent", Labels{"test_id:5247"}, "virtualmachinesnapshotcontents"),
-						Entry("[test_id:5248]given a vmsrestore", Labels{"test_id:5248"}, "virtualmachinerestores"),
+						Entry("[test_id:2917]given a vmi preset", Label("test_id:2917"), "virtualmachineinstancepresets"),
+						Entry("[test_id:2919]given a vmi replica set", Label("test_id:2919"), "virtualmachineinstancereplicasets"),
+						Entry("[test_id:3235]given a vmi migration", Label("test_id:3235"), "virtualmachineinstancemigrations"),
+						Entry("[test_id:5246]given a vmsnapshot", Label("test_id:5246"), "virtualmachinesnapshots"),
+						Entry("[test_id:5247]given a vmsnapshotcontent", Label("test_id:5247"), "virtualmachinesnapshotcontents"),
+						Entry("[test_id:5248]given a vmsrestore", Label("test_id:5248"), "virtualmachinerestores"),
 					)
 
 					DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 						testAction(resource, action, "no")
 					},
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/pause", "update"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/unpause", "update"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/softreboot", "update"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/console", "get"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/vnc", "get"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/pause", "update"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/unpause", "update"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/softreboot", "update"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/console", "get"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/vnc", "get"),
 					)
 				})
 
@@ -448,26 +448,26 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					DescribeTable("should verify permissions on resources are correct the test user", func(resource string) {
 						testRights(resource, "yes")
 					},
-						Entry("[test_id:2920]given a vmi", Labels{"test_id:2920"}, "virtualmachineinstances"),
-						Entry("[test_id:2831]given a vm", Labels{"test_id:2831"}, "virtualmachines"),
+						Entry("[test_id:2920]given a vmi", Label("test_id:2920"), "virtualmachineinstances"),
+						Entry("[test_id:2831]given a vm", Label("test_id:2831"), "virtualmachines"),
 						Entry("given a vmpool", "virtualmachinepools"),
-						Entry("[test_id:2916]given a vmi preset", Labels{"test_id:2916"}, "virtualmachineinstancepresets"),
-						Entry("[test_id:2918][crit:low]given a vmi replica set", Labels{"test_id:2918"}, "virtualmachineinstancereplicasets"),
-						Entry("[test_id:2837]given a vmi migration", Labels{"test_id:2837"}, "virtualmachineinstancemigrations"),
-						Entry("[test_id:5249]given a vmsnapshot", Labels{"test_id:5249"}, "virtualmachinesnapshots"),
-						Entry("[test_id:5250]given a vmsnapshotcontent", Labels{"test_id:5250"}, "virtualmachinesnapshotcontents"),
-						Entry("[test_id:5251]given a vmsrestore", Labels{"test_id:5251"}, "virtualmachinerestores"),
+						Entry("[test_id:2916]given a vmi preset", Label("test_id:2916"), "virtualmachineinstancepresets"),
+						Entry("[test_id:2918][crit:low]given a vmi replica set", Label("test_id:2918"), "virtualmachineinstancereplicasets"),
+						Entry("[test_id:2837]given a vmi migration", Label("test_id:2837"), "virtualmachineinstancemigrations"),
+						Entry("[test_id:5249]given a vmsnapshot", Label("test_id:5249"), "virtualmachinesnapshots"),
+						Entry("[test_id:5250]given a vmsnapshotcontent", Label("test_id:5250"), "virtualmachinesnapshotcontents"),
+						Entry("[test_id:5251]given a vmsrestore", Label("test_id:5251"), "virtualmachinerestores"),
 					)
 
 					DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 						testAction(resource, action, "yes")
 					},
 						Entry(EntryDescription("[test_id:2921]given a vmi"), "[test_id:2921]given a vmi", "virtualmachineinstances/pause", "update"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/unpause", "update"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/softreboot", "update"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/console", "get"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/vnc", "get"),
-						Entry("[test_id:2921]given a vmi", Labels{"test_id:2921"}, "virtualmachineinstances/guestosinfo", "get"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/unpause", "update"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/softreboot", "update"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/console", "get"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/vnc", "get"),
+						Entry("[test_id:2921]given a vmi", Label("test_id:2921"), "virtualmachineinstances/guestosinfo", "get"),
 					)
 				})
 			})

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Labels{"Serial", "sig-operator"}, func() {
+var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Label("Serial", "sig-operator"), func() {
 
 	var err error
 	var originalKV *v1.KubeVirt

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", func() {
+var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Labels{"Serial", "sig-operator"}, func() {
 
 	var err error
 	var originalKV *v1.KubeVirt

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config",
-	Labels{"Serial", "rfe_id:899", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("Serial", "rfe_id:899", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var virtClient kubecli.KubevirtClient
@@ -103,7 +103,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					tests.DeleteConfigMap(configMapName)
 				})
 
-				It("[test_id:782]Should be the fs layout the same for a pod and vmi", Labels{"test_id:782"}, func() {
+				It("[test_id:782]Should be the fs layout the same for a pod and vmi", Label("test_id:782"), func() {
 					expectedOutput := "value1value2value3"
 
 					By("Running VMI")
@@ -163,7 +163,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					configMaps = nil
 				})
 
-				It("[test_id:783]Should start VMI with multiple ConfigMaps", Labels{"test_id:783"}, func() {
+				It("[test_id:783]Should start VMI with multiple ConfigMaps", Label("test_id:783"), func() {
 					vmi := tests.NewRandomVMIWithConfigMap(configMaps[0])
 					tests.AddConfigMapDisk(vmi, configMaps[1], configMaps[1])
 					tests.AddConfigMapDisk(vmi, configMaps[2], configMaps[2])
@@ -197,7 +197,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					tests.DeleteSecret(secretName)
 				})
 
-				It("[test_id:779]Should be the fs layout the same for a pod and vmi", Labels{"test_id:779"}, func() {
+				It("[test_id:779]Should be the fs layout the same for a pod and vmi", Label("test_id:779"), func() {
 					expectedOutput := "adminredhat"
 
 					By("Running VMI")
@@ -256,7 +256,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					secrets = nil
 				})
 
-				It("[test_id:780]Should start VMI with multiple Secrets", Labels{"test_id:780"}, func() {
+				It("[test_id:780]Should start VMI with multiple Secrets", Label("test_id:780"), func() {
 					vmi := tests.NewRandomVMIWithSecret(secrets[0])
 					tests.AddSecretDisk(vmi, secrets[1], secrets[1])
 					tests.AddSecretDisk(vmi, secrets[2], secrets[2])
@@ -272,7 +272,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 
 			serviceAccountPath := config.ServiceAccountSourceDir
 
-			It("[test_id:998]Should be the namespace and token the same for a pod and vmi", Labels{"test_id:998"}, func() {
+			It("[test_id:998]Should be the namespace and token the same for a pod and vmi", Label("test_id:998"), func() {
 				By("Running VMI")
 				vmi := tests.NewRandomVMIWithServiceAccount("default")
 				tests.RunVMIAndExpectLaunch(vmi, 90)
@@ -358,7 +358,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					tests.DeleteSecret(secretName)
 				})
 
-				It("[test_id:786]Should be that cfgMap and secret fs layout same for the pod and vmi", Labels{"test_id:786"}, func() {
+				It("[test_id:786]Should be that cfgMap and secret fs layout same for the pod and vmi", Label("test_id:786"), func() {
 					expectedOutputCfgMap := "value1value2value3"
 					expectedOutputSecret := "adminredhat"
 
@@ -395,8 +395,8 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					Expect(err).To(BeNil())
 					Expect(podOutputCfgMap).To(Equal(expectedOutputCfgMap), "Expected %s to Equal value1value2value3", podOutputCfgMap)
 
-				By("Checking mounted ConfigMap image")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
+					By("Checking mounted ConfigMap image")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						// mount ConfigMap image
@@ -478,7 +478,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					tests.DeleteSecret(secretName)
 				})
 
-				It("[test_id:778]Should be the fs layout the same for a pod and vmi", Labels{"test_id:778"}, func() {
+				It("[test_id:778]Should be the fs layout the same for a pod and vmi", Label("test_id:778"), func() {
 					expectedPrivateKey := string(privateKeyBytes)
 					expectedPublicKey := string(publicKeyBytes)
 
@@ -515,8 +515,8 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					Expect(err).To(BeNil())
 					Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
 
-				By("Checking mounted secrets sshkeys image")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
+					By("Checking mounted secrets sshkeys image")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						// mount iso Secret image
@@ -544,7 +544,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			testLabelVal := "downwardAPIValue"
 			expectedOutput := testLabelKey + "=" + "\"" + testLabelVal + "\""
 
-			It("[test_id:790]Should be the namespace and token the same for a pod and vmi", Labels{"test_id:790"}, func() {
+			It("[test_id:790]Should be the namespace and token the same for a pod and vmi", Label("test_id:790"), func() {
 				By("Running VMI")
 				vmi := tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 				//Add the testing label to the VMI

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -40,546 +40,548 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", func() {
+var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config",
+	Labels{"Serial", "rfe_id:899", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	func() {
 
-	var virtClient kubecli.KubevirtClient
+		var virtClient kubecli.KubevirtClient
 
-	var CheckIsoVolumeSizes = func(vmi *v1.VirtualMachineInstance) {
-		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+		var CheckIsoVolumeSizes = func(vmi *v1.VirtualMachineInstance) {
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 
-		for _, volume := range vmi.Spec.Volumes {
-			var path = ""
-			if volume.ConfigMap != nil {
-				path = config.GetConfigMapDiskPath(volume.Name)
-				By(fmt.Sprintf("Checking ConfigMap at '%s' is 4k-block fs compatible", path))
-			}
-			if volume.Secret != nil {
-				path = config.GetSecretDiskPath(volume.Name)
-				By(fmt.Sprintf("Checking Secret at '%s' is 4k-block fs compatible", path))
-			}
-			if len(path) > 0 {
-				cmdCheck := []string{"stat", "--printf='%s'", path}
-				out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
-				Expect(err).NotTo(HaveOccurred())
-				size, err := strconv.Atoi(strings.Trim(out, "'"))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(size % 4096).To(Equal(0))
+			for _, volume := range vmi.Spec.Volumes {
+				var path = ""
+				if volume.ConfigMap != nil {
+					path = config.GetConfigMapDiskPath(volume.Name)
+					By(fmt.Sprintf("Checking ConfigMap at '%s' is 4k-block fs compatible", path))
+				}
+				if volume.Secret != nil {
+					path = config.GetSecretDiskPath(volume.Name)
+					By(fmt.Sprintf("Checking Secret at '%s' is 4k-block fs compatible", path))
+				}
+				if len(path) > 0 {
+					cmdCheck := []string{"stat", "--printf='%s'", path}
+					out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+					Expect(err).NotTo(HaveOccurred())
+					size, err := strconv.Atoi(strings.Trim(out, "'"))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(size % 4096).To(Equal(0))
+				}
 			}
 		}
-	}
 
-	BeforeEach(func() {
-		var err error
+		BeforeEach(func() {
+			var err error
 
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
-	})
+			tests.BeforeTestCleanup()
+		})
 
-	Context("With a ConfigMap defined", func() {
+		Context("With a ConfigMap defined", func() {
 
-		Context("With a single volume", func() {
-			var (
-				configMapName string
-				configMapPath string
-			)
+			Context("With a single volume", func() {
+				var (
+					configMapName string
+					configMapPath string
+				)
 
-			BeforeEach(func() {
-				configMapName = "configmap-" + uuid.NewRandom().String()
-				configMapPath = config.GetConfigMapSourcePath(configMapName)
+				BeforeEach(func() {
+					configMapName = "configmap-" + uuid.NewRandom().String()
+					configMapPath = config.GetConfigMapSourcePath(configMapName)
 
-				data := map[string]string{
-					"option1": "value1",
-					"option2": "value2",
-					"option3": "value3",
-				}
-				tests.CreateConfigMap(configMapName, data)
+					data := map[string]string{
+						"option1": "value1",
+						"option2": "value2",
+						"option3": "value3",
+					}
+					tests.CreateConfigMap(configMapName, data)
+				})
+
+				AfterEach(func() {
+					tests.DeleteConfigMap(configMapName)
+				})
+
+				It("[test_id:782]Should be the fs layout the same for a pod and vmi", Labels{"test_id:782"}, func() {
+					expectedOutput := "value1value2value3"
+
+					By("Running VMI")
+					vmi := tests.NewRandomVMIWithConfigMap(configMapName)
+					tests.RunVMIAndExpectLaunch(vmi, 90)
+
+					CheckIsoVolumeSizes(vmi)
+
+					By("Checking if ConfigMap has been attached to the pod")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					podOutput, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						vmiPod.Spec.Containers[0].Name,
+						[]string{"cat",
+							configMapPath + "/option1",
+							configMapPath + "/option2",
+							configMapPath + "/option3",
+						},
+					)
+					Expect(err).To(BeNil())
+					Expect(podOutput).To(Equal(expectedOutput))
+
+					By("Checking mounted iso image")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						// mount iso ConfigMap image
+						&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+						&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
+						&expect.BExp{R: expectedOutput},
+					}, 200)).To(Succeed())
+				})
 			})
 
-			AfterEach(func() {
-				tests.DeleteConfigMap(configMapName)
+			Context("With multiple volumes", func() {
+				var (
+					configMaps    []string
+					configMapsCnt int = 3
+				)
+
+				BeforeEach(func() {
+					for i := 0; i < configMapsCnt; i++ {
+						name := "configmap-" + uuid.NewRandom().String()
+						tests.CreateConfigMap(name, map[string]string{"option": "value"})
+						configMaps = append(configMaps, name)
+					}
+				})
+
+				AfterEach(func() {
+					for _, configMap := range configMaps {
+						tests.DeleteConfigMap(configMap)
+					}
+					configMaps = nil
+				})
+
+				It("[test_id:783]Should start VMI with multiple ConfigMaps", Labels{"test_id:783"}, func() {
+					vmi := tests.NewRandomVMIWithConfigMap(configMaps[0])
+					tests.AddConfigMapDisk(vmi, configMaps[1], configMaps[1])
+					tests.AddConfigMapDisk(vmi, configMaps[2], configMaps[2])
+
+					tests.RunVMIAndExpectLaunch(vmi, 90)
+					CheckIsoVolumeSizes(vmi)
+				})
+			})
+		})
+
+		Context("With a Secret defined", func() {
+
+			Context("With a single volume", func() {
+				var (
+					secretName string
+					secretPath string
+				)
+
+				BeforeEach(func() {
+					secretName = "secret-" + uuid.NewRandom().String()
+					secretPath = config.GetSecretSourcePath(secretName)
+
+					data := map[string]string{
+						"user":     "admin",
+						"password": "redhat",
+					}
+					tests.CreateSecret(secretName, data)
+				})
+
+				AfterEach(func() {
+					tests.DeleteSecret(secretName)
+				})
+
+				It("[test_id:779]Should be the fs layout the same for a pod and vmi", Labels{"test_id:779"}, func() {
+					expectedOutput := "adminredhat"
+
+					By("Running VMI")
+					vmi := tests.NewRandomVMIWithSecret(secretName)
+					tests.RunVMIAndExpectLaunch(vmi, 90)
+
+					CheckIsoVolumeSizes(vmi)
+
+					By("Checking if Secret has been attached to the pod")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					podOutput, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						vmiPod.Spec.Containers[0].Name,
+						[]string{"cat",
+							secretPath + "/user",
+							secretPath + "/password",
+						},
+					)
+					Expect(err).To(BeNil())
+					Expect(podOutput).To(Equal(expectedOutput))
+
+					By("Checking mounted iso image")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						// mount iso Secret image
+						&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+						&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
+						&expect.BExp{R: expectedOutput},
+					}, 200)).To(Succeed())
+				})
 			})
 
-			It("[test_id:782]Should be the fs layout the same for a pod and vmi", func() {
-				expectedOutput := "value1value2value3"
+			Context("With multiple volumes", func() {
+				var (
+					secrets    []string
+					secretsCnt int = 3
+				)
 
+				BeforeEach(func() {
+					for i := 0; i < secretsCnt; i++ {
+						name := "secret-" + uuid.NewRandom().String()
+						tests.CreateSecret(name, map[string]string{"option": "value"})
+						secrets = append(secrets, name)
+					}
+				})
+
+				AfterEach(func() {
+					for _, secret := range secrets {
+						tests.DeleteSecret(secret)
+					}
+					secrets = nil
+				})
+
+				It("[test_id:780]Should start VMI with multiple Secrets", Labels{"test_id:780"}, func() {
+					vmi := tests.NewRandomVMIWithSecret(secrets[0])
+					tests.AddSecretDisk(vmi, secrets[1], secrets[1])
+					tests.AddSecretDisk(vmi, secrets[2], secrets[2])
+
+					tests.RunVMIAndExpectLaunch(vmi, 90)
+					CheckIsoVolumeSizes(vmi)
+				})
+			})
+
+		})
+
+		Context("With a ServiceAccount defined", func() {
+
+			serviceAccountPath := config.ServiceAccountSourceDir
+
+			It("[test_id:998]Should be the namespace and token the same for a pod and vmi", Labels{"test_id:998"}, func() {
 				By("Running VMI")
-				vmi := tests.NewRandomVMIWithConfigMap(configMapName)
+				vmi := tests.NewRandomVMIWithServiceAccount("default")
 				tests.RunVMIAndExpectLaunch(vmi, 90)
-
 				CheckIsoVolumeSizes(vmi)
 
-				By("Checking if ConfigMap has been attached to the pod")
+				By("Checking if ServiceAccount has been attached to the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				podOutput, err := tests.ExecuteCommandOnPod(
+				namespace, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
 					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
-						configMapPath + "/option1",
-						configMapPath + "/option2",
-						configMapPath + "/option3",
+						serviceAccountPath + "/namespace",
 					},
 				)
+
 				Expect(err).To(BeNil())
-				Expect(podOutput).To(Equal(expectedOutput))
+				Expect(namespace).To(Equal(util.NamespaceTestDefault))
+
+				token, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[0].Name,
+					[]string{"tail", "-c", "20",
+						serviceAccountPath + "/token",
+					},
+				)
+
+				Expect(err).To(BeNil())
 
 				By("Checking mounted iso image")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					// mount iso ConfigMap image
+					// mount service account iso image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
-					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
-					&expect.BExp{R: expectedOutput},
+					&expect.BSnd{S: "cat /mnt/namespace\n"},
+					&expect.BExp{R: util.NamespaceTestDefault},
+					&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
+					&expect.BExp{R: token},
 				}, 200)).To(Succeed())
 			})
+
 		})
 
-		Context("With multiple volumes", func() {
-			var (
-				configMaps    []string
-				configMapsCnt int = 3
-			)
+		Context("With a Secret and a ConfigMap defined", func() {
 
-			BeforeEach(func() {
-				for i := 0; i < configMapsCnt; i++ {
-					name := "configmap-" + uuid.NewRandom().String()
-					tests.CreateConfigMap(name, map[string]string{"option": "value"})
-					configMaps = append(configMaps, name)
-				}
-			})
-
-			AfterEach(func() {
-				for _, configMap := range configMaps {
-					tests.DeleteConfigMap(configMap)
-				}
-				configMaps = nil
-			})
-
-			It("[test_id:783]Should start VMI with multiple ConfigMaps", func() {
-				vmi := tests.NewRandomVMIWithConfigMap(configMaps[0])
-				tests.AddConfigMapDisk(vmi, configMaps[1], configMaps[1])
-				tests.AddConfigMapDisk(vmi, configMaps[2], configMaps[2])
-
-				tests.RunVMIAndExpectLaunch(vmi, 90)
-				CheckIsoVolumeSizes(vmi)
-			})
-		})
-	})
-
-	Context("With a Secret defined", func() {
-
-		Context("With a single volume", func() {
-			var (
-				secretName string
-				secretPath string
-			)
-
-			BeforeEach(func() {
-				secretName = "secret-" + uuid.NewRandom().String()
-				secretPath = config.GetSecretSourcePath(secretName)
-
-				data := map[string]string{
-					"user":     "admin",
-					"password": "redhat",
-				}
-				tests.CreateSecret(secretName, data)
-			})
-
-			AfterEach(func() {
-				tests.DeleteSecret(secretName)
-			})
-
-			It("[test_id:779]Should be the fs layout the same for a pod and vmi", func() {
-				expectedOutput := "adminredhat"
-
-				By("Running VMI")
-				vmi := tests.NewRandomVMIWithSecret(secretName)
-				tests.RunVMIAndExpectLaunch(vmi, 90)
-
-				CheckIsoVolumeSizes(vmi)
-
-				By("Checking if Secret has been attached to the pod")
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				podOutput, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					vmiPod.Spec.Containers[0].Name,
-					[]string{"cat",
-						secretPath + "/user",
-						secretPath + "/password",
-					},
+			Context("With a single volume", func() {
+				var (
+					configMapName string
+					configMapPath string
+					secretName    string
+					secretPath    string
 				)
-				Expect(err).To(BeNil())
-				Expect(podOutput).To(Equal(expectedOutput))
 
-				By("Checking mounted iso image")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				BeforeEach(func() {
+					configMapName = "configmap-" + uuid.NewRandom().String()
+					configMapPath = config.GetConfigMapSourcePath(configMapName)
+					secretName = "secret-" + uuid.NewRandom().String()
+					secretPath = config.GetSecretSourcePath(secretName)
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					// mount iso Secret image
-					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: console.RetValue("0")},
-					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
-					&expect.BExp{R: expectedOutput},
-				}, 200)).To(Succeed())
-			})
-		})
+					configData := map[string]string{
+						"config1": "value1",
+						"config2": "value2",
+						"config3": "value3",
+					}
 
-		Context("With multiple volumes", func() {
-			var (
-				secrets    []string
-				secretsCnt int = 3
-			)
+					secretData := map[string]string{
+						"user":     "admin",
+						"password": "redhat",
+					}
 
-			BeforeEach(func() {
-				for i := 0; i < secretsCnt; i++ {
-					name := "secret-" + uuid.NewRandom().String()
-					tests.CreateSecret(name, map[string]string{"option": "value"})
-					secrets = append(secrets, name)
-				}
-			})
+					tests.CreateConfigMap(configMapName, configData)
 
-			AfterEach(func() {
-				for _, secret := range secrets {
-					tests.DeleteSecret(secret)
-				}
-				secrets = nil
-			})
+					tests.CreateSecret(secretName, secretData)
+				})
 
-			It("[test_id:780]Should start VMI with multiple Secrets", func() {
-				vmi := tests.NewRandomVMIWithSecret(secrets[0])
-				tests.AddSecretDisk(vmi, secrets[1], secrets[1])
-				tests.AddSecretDisk(vmi, secrets[2], secrets[2])
+				AfterEach(func() {
+					tests.DeleteConfigMap(configMapName)
+					tests.DeleteSecret(secretName)
+				})
 
-				tests.RunVMIAndExpectLaunch(vmi, 90)
-				CheckIsoVolumeSizes(vmi)
-			})
-		})
+				It("[test_id:786]Should be that cfgMap and secret fs layout same for the pod and vmi", Labels{"test_id:786"}, func() {
+					expectedOutputCfgMap := "value1value2value3"
+					expectedOutputSecret := "adminredhat"
 
-	})
+					By("Running VMI")
 
-	Context("With a ServiceAccount defined", func() {
+					vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(
+						cd.ContainerDiskFor(
+							cd.ContainerDiskFedoraTestTooling))
+					tests.AddConfigMapDisk(vmi, configMapName, configMapName)
+					tests.AddSecretDisk(vmi, secretName, secretName)
+					tests.AddConfigMapDiskWithCustomLabel(vmi, configMapName, "random1", "configlabel")
+					tests.AddSecretDiskWithCustomLabel(vmi, secretName, "random2", "secretlabel")
 
-		serviceAccountPath := config.ServiceAccountSourceDir
+					// Ensure virtio for consistent order
+					for i := range vmi.Spec.Domain.Devices.Disks {
+						vmi.Spec.Domain.Devices.Disks[i].Disk = &v1.DiskTarget{Bus: "virtio"}
+					}
 
-		It("[test_id:998]Should be the namespace and token the same for a pod and vmi", func() {
-			By("Running VMI")
-			vmi := tests.NewRandomVMIWithServiceAccount("default")
-			tests.RunVMIAndExpectLaunch(vmi, 90)
-			CheckIsoVolumeSizes(vmi)
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+					CheckIsoVolumeSizes(vmi)
 
-			By("Checking if ServiceAccount has been attached to the pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-			namespace, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[0].Name,
-				[]string{"cat",
-					serviceAccountPath + "/namespace",
-				},
-			)
-
-			Expect(err).To(BeNil())
-			Expect(namespace).To(Equal(util.NamespaceTestDefault))
-
-			token, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[0].Name,
-				[]string{"tail", "-c", "20",
-					serviceAccountPath + "/token",
-				},
-			)
-
-			Expect(err).To(BeNil())
-
-			By("Checking mounted iso image")
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				// mount service account iso image
-				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-				&expect.BSnd{S: "cat /mnt/namespace\n"},
-				&expect.BExp{R: util.NamespaceTestDefault},
-				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
-				&expect.BExp{R: token},
-			}, 200)).To(Succeed())
-		})
-
-	})
-
-	Context("With a Secret and a ConfigMap defined", func() {
-
-		Context("With a single volume", func() {
-			var (
-				configMapName string
-				configMapPath string
-				secretName    string
-				secretPath    string
-			)
-
-			BeforeEach(func() {
-				configMapName = "configmap-" + uuid.NewRandom().String()
-				configMapPath = config.GetConfigMapSourcePath(configMapName)
-				secretName = "secret-" + uuid.NewRandom().String()
-				secretPath = config.GetSecretSourcePath(secretName)
-
-				configData := map[string]string{
-					"config1": "value1",
-					"config2": "value2",
-					"config3": "value3",
-				}
-
-				secretData := map[string]string{
-					"user":     "admin",
-					"password": "redhat",
-				}
-
-				tests.CreateConfigMap(configMapName, configData)
-
-				tests.CreateSecret(secretName, secretData)
-			})
-
-			AfterEach(func() {
-				tests.DeleteConfigMap(configMapName)
-				tests.DeleteSecret(secretName)
-			})
-
-			It("[test_id:786]Should be that cfgMap and secret fs layout same for the pod and vmi", func() {
-				expectedOutputCfgMap := "value1value2value3"
-				expectedOutputSecret := "adminredhat"
-
-				By("Running VMI")
-
-				vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(
-					cd.ContainerDiskFor(
-						cd.ContainerDiskFedoraTestTooling))
-				tests.AddConfigMapDisk(vmi, configMapName, configMapName)
-				tests.AddSecretDisk(vmi, secretName, secretName)
-				tests.AddConfigMapDiskWithCustomLabel(vmi, configMapName, "random1", "configlabel")
-				tests.AddSecretDiskWithCustomLabel(vmi, secretName, "random2", "secretlabel")
-
-				// Ensure virtio for consistent order
-				for i := range vmi.Spec.Domain.Devices.Disks {
-					vmi.Spec.Domain.Devices.Disks[i].Disk = &v1.DiskTarget{Bus: "virtio"}
-				}
-
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
-				CheckIsoVolumeSizes(vmi)
-
-				By("Checking if ConfigMap has been attached to the pod")
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				podOutputCfgMap, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					vmiPod.Spec.Containers[0].Name,
-					[]string{"cat",
-						configMapPath + "/config1",
-						configMapPath + "/config2",
-						configMapPath + "/config3",
-					},
-				)
-				Expect(err).To(BeNil())
-				Expect(podOutputCfgMap).To(Equal(expectedOutputCfgMap), "Expected %s to Equal value1value2value3", podOutputCfgMap)
+					By("Checking if ConfigMap has been attached to the pod")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					podOutputCfgMap, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						vmiPod.Spec.Containers[0].Name,
+						[]string{"cat",
+							configMapPath + "/config1",
+							configMapPath + "/config2",
+							configMapPath + "/config3",
+						},
+					)
+					Expect(err).To(BeNil())
+					Expect(podOutputCfgMap).To(Equal(expectedOutputCfgMap), "Expected %s to Equal value1value2value3", podOutputCfgMap)
 
 				By("Checking mounted ConfigMap image")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					// mount ConfigMap image
-					&expect.BSnd{S: "sudo su -\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "mount /dev/vdb /mnt\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: console.RetValue("0")},
-					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
-					&expect.BExp{R: expectedOutputCfgMap},
-				}, 200)).To(Succeed())
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						// mount ConfigMap image
+						&expect.BSnd{S: "sudo su -\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "mount /dev/vdb /mnt\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+						&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
+						&expect.BExp{R: expectedOutputCfgMap},
+					}, 200)).To(Succeed())
 
-				By("Checking if Secret has also been attached to the same pod")
-				podOutputSecret, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					vmiPod.Spec.Containers[0].Name,
-					[]string{"cat",
-						secretPath + "/user",
-						secretPath + "/password",
-					},
-				)
-				Expect(err).To(BeNil())
-				Expect(podOutputSecret).To(Equal(expectedOutputSecret), "Expected %s to Equal adminredhat", podOutputSecret)
+					By("Checking if Secret has also been attached to the same pod")
+					podOutputSecret, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						vmiPod.Spec.Containers[0].Name,
+						[]string{"cat",
+							secretPath + "/user",
+							secretPath + "/password",
+						},
+					)
+					Expect(err).To(BeNil())
+					Expect(podOutputSecret).To(Equal(expectedOutputSecret), "Expected %s to Equal adminredhat", podOutputSecret)
 
-				By("Checking mounted secret image")
+					By("Checking mounted secret image")
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					// mount Secret image
-					&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: console.RetValue("0")},
-					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
-					&expect.BExp{R: expectedOutputSecret},
-				}, 200)).To(Succeed())
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						// mount Secret image
+						&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+						&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
+						&expect.BExp{R: expectedOutputSecret},
+					}, 200)).To(Succeed())
 
-				By("checking that all disk labels match the expectations")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdb\n"},
-					&expect.BExp{R: "cfgdata"}, // default value
-					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdc\n"},
-					&expect.BExp{R: "cfgdata"}, // default value
-					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdd\n"},
-					&expect.BExp{R: "configlabel"}, // custom value
-					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vde\n"},
-					&expect.BExp{R: "secretlabel"}, // custom value
-				}, 200)).To(Succeed())
+					By("checking that all disk labels match the expectations")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdb\n"},
+						&expect.BExp{R: "cfgdata"}, // default value
+						&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdc\n"},
+						&expect.BExp{R: "cfgdata"}, // default value
+						&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdd\n"},
+						&expect.BExp{R: "configlabel"}, // custom value
+						&expect.BSnd{S: "blkid -s LABEL -o value /dev/vde\n"},
+						&expect.BExp{R: "secretlabel"}, // custom value
+					}, 200)).To(Succeed())
+				})
 			})
 		})
-	})
 
-	Context("With SSH Keys as a Secret defined", func() {
+		Context("With SSH Keys as a Secret defined", func() {
 
-		Context("With a single volume", func() {
-			var (
-				secretName string
-				secretPath string
-			)
-
-			var bitSize int = 2048
-			privateKey, _ := tests.GeneratePrivateKey(bitSize)
-			publicKeyBytes, _ := tests.GeneratePublicKey(&privateKey.PublicKey)
-			privateKeyBytes := tests.EncodePrivateKeyToPEM(privateKey)
-
-			BeforeEach(func() {
-				secretName = "secret-" + uuid.NewRandom().String()
-				secretPath = config.GetSecretSourcePath(secretName)
-
-				data := map[string]string{
-					"ssh-privatekey": string(privateKeyBytes),
-					"ssh-publickey":  string(publicKeyBytes),
-				}
-				tests.CreateSecret(secretName, data)
-			})
-
-			AfterEach(func() {
-				tests.DeleteSecret(secretName)
-			})
-
-			It("[test_id:778]Should be the fs layout the same for a pod and vmi", func() {
-				expectedPrivateKey := string(privateKeyBytes)
-				expectedPublicKey := string(publicKeyBytes)
-
-				By("Running VMI")
-				vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(
-					cd.ContainerDiskFor(
-						cd.ContainerDiskFedoraTestTooling))
-				tests.AddSecretDisk(vmi, secretName, secretName)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
-
-				CheckIsoVolumeSizes(vmi)
-
-				By("Checking if Secret has been attached to the pod")
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				podOutput1, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					vmiPod.Spec.Containers[0].Name,
-					[]string{"cat",
-						secretPath + "/ssh-privatekey",
-					},
+			Context("With a single volume", func() {
+				var (
+					secretName string
+					secretPath string
 				)
-				Expect(err).To(BeNil())
-				Expect(podOutput1).To(Equal(expectedPrivateKey), "Expected pod output of private key to match genereated one.")
 
-				podOutput2, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					vmiPod.Spec.Containers[0].Name,
-					[]string{"cat",
-						secretPath + "/ssh-publickey",
-					},
-				)
-				Expect(err).To(BeNil())
-				Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
+				var bitSize int = 2048
+				privateKey, _ := tests.GeneratePrivateKey(bitSize)
+				publicKeyBytes, _ := tests.GeneratePublicKey(&privateKey.PublicKey)
+				privateKeyBytes := tests.EncodePrivateKeyToPEM(privateKey)
+
+				BeforeEach(func() {
+					secretName = "secret-" + uuid.NewRandom().String()
+					secretPath = config.GetSecretSourcePath(secretName)
+
+					data := map[string]string{
+						"ssh-privatekey": string(privateKeyBytes),
+						"ssh-publickey":  string(publicKeyBytes),
+					}
+					tests.CreateSecret(secretName, data)
+				})
+
+				AfterEach(func() {
+					tests.DeleteSecret(secretName)
+				})
+
+				It("[test_id:778]Should be the fs layout the same for a pod and vmi", Labels{"test_id:778"}, func() {
+					expectedPrivateKey := string(privateKeyBytes)
+					expectedPublicKey := string(publicKeyBytes)
+
+					By("Running VMI")
+					vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(
+						cd.ContainerDiskFor(
+							cd.ContainerDiskFedoraTestTooling))
+					tests.AddSecretDisk(vmi, secretName, secretName)
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+
+					CheckIsoVolumeSizes(vmi)
+
+					By("Checking if Secret has been attached to the pod")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					podOutput1, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						vmiPod.Spec.Containers[0].Name,
+						[]string{"cat",
+							secretPath + "/ssh-privatekey",
+						},
+					)
+					Expect(err).To(BeNil())
+					Expect(podOutput1).To(Equal(expectedPrivateKey), "Expected pod output of private key to match genereated one.")
+
+					podOutput2, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						vmiPod.Spec.Containers[0].Name,
+						[]string{"cat",
+							secretPath + "/ssh-publickey",
+						},
+					)
+					Expect(err).To(BeNil())
+					Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
 
 				By("Checking mounted secrets sshkeys image")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					// mount iso Secret image
-					&expect.BSnd{S: "sudo su -\n"},
-					&expect.BExp{R: console.PromptExpression},
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						// mount iso Secret image
+						&expect.BSnd{S: "sudo su -\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+						&expect.BSnd{S: "grep -c \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
+						&expect.BExp{R: console.RetValue(`[1-9]\d*`)},
+						&expect.BSnd{S: "grep -c ssh-rsa /mnt/ssh-publickey\n"},
+						&expect.BExp{R: console.RetValue(`[1-9]\d*`)},
+					}, 200)).To(Succeed())
+				})
+			})
+		})
+
+		Context("With a DownwardAPI defined", func() {
+
+			downwardAPIName := "downwardapi-" + uuid.NewRandom().String()
+			downwardAPIPath := config.GetDownwardAPISourcePath(downwardAPIName)
+
+			testLabelKey := "kubevirt.io.testdownwardapi"
+			testLabelVal := "downwardAPIValue"
+			expectedOutput := testLabelKey + "=" + "\"" + testLabelVal + "\""
+
+			It("[test_id:790]Should be the namespace and token the same for a pod and vmi", Labels{"test_id:790"}, func() {
+				By("Running VMI")
+				vmi := tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
+				//Add the testing label to the VMI
+				if vmi.ObjectMeta.Labels == nil {
+					vmi.ObjectMeta.Labels = map[string]string{testLabelKey: testLabelVal}
+				} else {
+					vmi.ObjectMeta.Labels[testLabelKey] = testLabelVal
+				}
+				tests.AddLabelDownwardAPIVolume(vmi, downwardAPIName)
+
+				tests.RunVMIAndExpectLaunch(vmi, 90)
+				CheckIsoVolumeSizes(vmi)
+
+				By("Checking if DownwardAPI has been attached to the pod")
+				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				podOutput, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					vmiPod.Spec.Containers[0].Name,
+					[]string{"grep", testLabelKey,
+						downwardAPIPath + "/labels",
+					},
+				)
+				Expect(err).To(BeNil())
+				Expect(podOutput).To(Equal(expectedOutput + "\n"))
+
+				By("Checking mounted iso image")
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+				Expect(console.ExpectBatch(vmi, []expect.Batcher{
+					// mount iso DownwardAPI image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
-					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
-					&expect.BSnd{S: "grep -c \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
-					&expect.BExp{R: console.RetValue(`[1-9]\d*`)},
-					&expect.BSnd{S: "grep -c ssh-rsa /mnt/ssh-publickey\n"},
-					&expect.BExp{R: console.RetValue(`[1-9]\d*`)},
-				}, 200)).To(Succeed())
+					&expect.BSnd{S: "grep " + testLabelKey + " /mnt/labels\n"},
+					&expect.BExp{R: expectedOutput},
+				}, 200*time.Second)).To(Succeed())
 			})
 		})
 	})
-
-	Context("With a DownwardAPI defined", func() {
-
-		downwardAPIName := "downwardapi-" + uuid.NewRandom().String()
-		downwardAPIPath := config.GetDownwardAPISourcePath(downwardAPIName)
-
-		testLabelKey := "kubevirt.io.testdownwardapi"
-		testLabelVal := "downwardAPIValue"
-		expectedOutput := testLabelKey + "=" + "\"" + testLabelVal + "\""
-
-		It("[test_id:790]Should be the namespace and token the same for a pod and vmi", func() {
-			By("Running VMI")
-			vmi := tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
-			//Add the testing label to the VMI
-			if vmi.ObjectMeta.Labels == nil {
-				vmi.ObjectMeta.Labels = map[string]string{testLabelKey: testLabelVal}
-			} else {
-				vmi.ObjectMeta.Labels[testLabelKey] = testLabelVal
-			}
-			tests.AddLabelDownwardAPIVolume(vmi, downwardAPIName)
-
-			tests.RunVMIAndExpectLaunch(vmi, 90)
-			CheckIsoVolumeSizes(vmi)
-
-			By("Checking if DownwardAPI has been attached to the pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-			podOutput, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[0].Name,
-				[]string{"grep", testLabelKey,
-					downwardAPIPath + "/labels",
-				},
-			)
-			Expect(err).To(BeNil())
-			Expect(podOutput).To(Equal(expectedOutput + "\n"))
-
-			By("Checking mounted iso image")
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-			Expect(console.ExpectBatch(vmi, []expect.Batcher{
-				// mount iso DownwardAPI image
-				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-				&expect.BSnd{S: "grep " + testLabelKey + " /mnt/labels\n"},
-				&expect.BExp{R: expectedOutput},
-			}, 200*time.Second)).To(Succeed())
-		})
-	})
-})

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -56,7 +56,7 @@ func withNodeAffinityTo(label string, value string) libvmi.Option {
 }
 
 var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Console",
-	Labels{"rfe_id:127", "posneg:negative", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:127", "posneg:negative", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var virtClient kubecli.KubevirtClient
@@ -79,12 +79,12 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 		}
 
 		Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance",
-			Labels{"rfe_id:127", "posneg:negative", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:127", "posneg:negative", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with a serial console", func() {
 					Context("with a cirros image", func() {
 
-						It("[test_id:1588]should return that we are running cirros", Labels{"test_id:1588"}, func() {
+						It("[test_id:1588]should return that we are running cirros", Label("test_id:1588"), func() {
 							vmi := libvmi.NewCirros()
 							vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 							expectConsoleOutput(
@@ -95,7 +95,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 					})
 
 					Context("with a fedora image", func() {
-						It("[sig-compute][test_id:1589]should return that we are running fedora", Labels{"sig-compute", "test_id:1589"}, func() {
+						It("[sig-compute][test_id:1589]should return that we are running fedora", Label("sig-compute", "test_id:1589"), func() {
 							vmi := libvmi.NewFedora()
 							vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 							expectConsoleOutput(
@@ -123,12 +123,12 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 							vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
 							expectConsoleOutput(vmi, "login")
 						},
-							Entry("[test_id:4637][storage-req]with Filesystem Disk", Labels{"test_id:4637", "storage-req"}, newVirtualMachineInstanceWithAlpineFileDisk),
-							Entry("[test_id:4638][storage-req]with Block Disk", Labels{"test_id:4638", "storage-req"}, newVirtualMachineInstanceWithAlpineBlockDisk),
+							Entry("[test_id:4637][storage-req]with Filesystem Disk", Label("test_id:4637", "storage-req"), newVirtualMachineInstanceWithAlpineFileDisk),
+							Entry("[test_id:4638][storage-req]with Block Disk", Label("test_id:4638", "storage-req"), newVirtualMachineInstanceWithAlpineBlockDisk),
 						)
 					})
 
-					It("[test_id:1590]should be able to reconnect to console multiple times", Labels{"test_id:1590"}, func() {
+					It("[test_id:1590]should be able to reconnect to console multiple times", Label("test_id:1590"), func() {
 						vmi := libvmi.NewAlpine()
 						vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
@@ -137,7 +137,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 						}
 					})
 
-					It("[test_id:1591]should close console connection when new console connection is opened", Labels{"test_id:1591"}, func() {
+					It("[test_id:1591]should close console connection when new console connection is opened", Label("test_id:1591"), func() {
 						vmi := libvmi.NewAlpine()
 						vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
@@ -162,7 +162,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 						expectConsoleOutput(vmi, "login")
 					})
 
-					It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", Labels{"test_id:1592"}, func() {
+					It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", Label("test_id:1592"), func() {
 						vmi := libvmi.NewAlpine()
 						By("Creating a new VirtualMachineInstance")
 						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -173,7 +173,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 						Expect(err).ToNot(HaveOccurred())
 					})
 
-					It("[test_id:1593]should not be connected if scheduled to non-existing host", Labels{"test_id:1593"}, func() {
+					It("[test_id:1593]should not be connected if scheduled to non-existing host", Label("test_id:1593"), func() {
 						vmi := libvmi.NewAlpine(withNodeAffinityTo("kubernetes.io/hostname", "nonexistent"))
 
 						By("Creating a new VirtualMachineInstance")
@@ -188,7 +188,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 
 				Context("without a serial console", func() {
 
-					It("[test_id:4118]should run but not be connectable via the serial console", Labels{"test_id:4118"}, func() {
+					It("[test_id:4118]should run but not be connectable via the serial console", Label("test_id:4118"), func() {
 						vmi := libvmi.NewAlpine()
 						f := false
 						vmi.Spec.Domain.Devices.AutoattachSerialConsole = &f

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]ContainerDisk",
-	Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var virtClient kubecli.KubevirtClient
@@ -95,18 +95,18 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			container := tests.GetContainerDiskContainerOfPod(pod, vmi.Spec.Volumes[0].Name)
 			Expect(container.ImagePullPolicy).To(Equal(expectedPolicy))
 		},
-			Entry("[test_id:3246]generate and set Always pull policy", Labels{"test_id:3246"}, "test", k8sv1.PullPolicy(""), k8sv1.PullAlways),
-			Entry("[test_id:3247]generate and set Always pull policy", Labels{"test_id:3247"}, "test:latest", k8sv1.PullPolicy(""), k8sv1.PullAlways),
-			Entry("[test_id:3248]generate and set IfNotPresent pull policy", Labels{"test_id:3248"}, "test@sha256:9c2b78e11c25b3fd0b24b0ed684a112052dff03eee4ca4bdcc4f3168f9a14396", k8sv1.PullPolicy(""), k8sv1.PullIfNotPresent),
-			Entry("[test_id:3249]pass through Never pull policy to the pod", Labels{"test_id:3249"}, "test@sha256:9c2b78e11c25b3fd0b24b0ed684a112052dff03eee4ca4bdcc4f3168f9a14396", k8sv1.PullNever, k8sv1.PullNever),
-			Entry("[test_id:3250]pass through IfNotPresent pull policy to the pod", Labels{"test_id:3250"}, "test:latest", k8sv1.PullIfNotPresent, k8sv1.PullIfNotPresent),
+			Entry("[test_id:3246]generate and set Always pull policy", Label("test_id:3246"), "test", k8sv1.PullPolicy(""), k8sv1.PullAlways),
+			Entry("[test_id:3247]generate and set Always pull policy", Label("test_id:3247"), "test:latest", k8sv1.PullPolicy(""), k8sv1.PullAlways),
+			Entry("[test_id:3248]generate and set IfNotPresent pull policy", Label("test_id:3248"), "test@sha256:9c2b78e11c25b3fd0b24b0ed684a112052dff03eee4ca4bdcc4f3168f9a14396", k8sv1.PullPolicy(""), k8sv1.PullIfNotPresent),
+			Entry("[test_id:3249]pass through Never pull policy to the pod", Label("test_id:3249"), "test@sha256:9c2b78e11c25b3fd0b24b0ed684a112052dff03eee4ca4bdcc4f3168f9a14396", k8sv1.PullNever, k8sv1.PullNever),
+			Entry("[test_id:3250]pass through IfNotPresent pull policy to the pod", Label("test_id:3250"), "test:latest", k8sv1.PullIfNotPresent, k8sv1.PullIfNotPresent),
 		)
 
 		Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting and stopping the same VirtualMachineInstance",
-			Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with ephemeral registry disk", func() {
-					It("[test_id:1463][Conformance] should success multiple times", Labels{"test_id:1463", "Conformance"}, func() {
+					It("[test_id:1463][Conformance] should success multiple times", Label("test_id:1463", "Conformance"), func() {
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 						num := 2
 						for i := 0; i < num; i++ {
@@ -126,10 +126,10 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 
 		Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting a VirtualMachineInstance",
-			Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with ephemeral registry disk", func() {
-					It("[test_id:1464]should not modify the spec on status update", Labels{"test_id:1464"}, func() {
+					It("[test_id:1464]should not modify the spec on status update", Label("test_id:1464"), func() {
 						vmi := libvmi.NewCirros()
 						v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 
@@ -143,8 +143,8 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 						Expect(startedVMI.Spec).To(Equal(vmi.Spec))
 					})
 				})
-				Context("[Serial]should obey the disk verification limits in the KubeVirt CR", Labels{"Serial"}, func() {
-					It("[test_id:7182]disk verification should fail when the memory limit is too low", Labels{"test_id:7182"}, func() {
+				Context("[Serial]should obey the disk verification limits in the KubeVirt CR", Label("Serial"), func() {
+					It("[test_id:7182]disk verification should fail when the memory limit is too low", Label("test_id:7182"), func() {
 						By("Reducing the diskVerificaton memory usage limit")
 						kv := util.GetCurrentKv(virtClient)
 						kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
@@ -175,10 +175,10 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 
 		Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting multiple VMIs",
-			Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with ephemeral registry disk", func() {
-					It("[test_id:1465]should success", Labels{"test_id:1465"}, func() {
+					It("[test_id:1465]should success", Label("test_id:1465"), func() {
 						num := 5
 						vmis := make([]*v1.VirtualMachineInstance, 0, num)
 						objs := make([]runtime.Object, 0, num)
@@ -198,9 +198,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				})
 			})
 
-		Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting from custom image location", Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
+		Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting from custom image location", Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"), func() {
 			Context("with disk at /custom-disk/downloaded", func() {
-				It("[test_id:1466]should boot normally", Labels{"test_id:1466"}, func() {
+				It("[test_id:1466]should boot normally", Label("test_id:1466"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirrosCustomLocation), "#!/bin/bash\necho 'hello'\n")
 					for ind, volume := range vmi.Spec.Volumes {
 						if volume.ContainerDisk != nil {
@@ -215,10 +215,10 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting with virtio-win",
-			Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with virtio-win as secondary disk", func() {
-					It("[test_id:1467]should boot and have the virtio as sata CDROM", Labels{"test_id:1467"}, func() {
+					It("[test_id:1467]should boot and have the virtio as sata CDROM", Label("test_id:1467"), func() {
 						vmi := libvmi.NewAlpine()
 						tests.AddEphemeralCdrom(vmi, "disk4", "sata", cd.ContainerDiskFor(cd.ContainerDiskVirtio))
 						vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
@@ -244,10 +244,10 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 
 		Describe("[rfe_id:4052][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions",
-			Labels{"rfe_id:4052", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:4052", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with ephemeral registry disk", func() {
-					It("[test_id:4299]should not have world write permissions", Labels{"test_id:4299"}, func() {
+					It("[test_id:4299]should not have world write permissions", Label("test_id:4299"), func() {
 						vmi := libvmi.NewAlpine()
 						vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -41,7 +41,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[sig-compute]Guest Access Credentials", func() {
+var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -66,7 +66,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 	}
 
 	Context("with qemu guest agent", func() {
-		It("[test_id:6220]should propagate public ssh keys", func() {
+		It("[test_id:6220]should propagate public ssh keys", Labels{"test_id:6220"}, func() {
 			secretID := "my-pub-key"
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Namespace = util.NamespaceTestDefault
@@ -146,7 +146,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			}, time.Second*180)
 		})
 
-		It("[test_id:6221]should propagate user password", func() {
+		It("[test_id:6221]should propagate user password", Labels{"test_id:6221"}, func() {
 			secretID := "my-user-pass"
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Namespace = util.NamespaceTestDefault
@@ -216,7 +216,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			}, time.Second*180)
 		})
 
-		It("[test_id:6222]should update guest agent for public ssh keys", func() {
+		It("[test_id:6222]should update guest agent for public ssh keys", Labels{"test_id:6222"}, func() {
 			secretID := "my-pub-key"
 			vmi := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-exec")
 			vmi.Namespace = util.NamespaceTestDefault
@@ -278,7 +278,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 				"Should have unsupported agent connected condition")
 		})
 
-		It("[test_id:6223]should update guest agent for user password", func() {
+		It("[test_id:6223]should update guest agent for user password", Labels{"test_id:6223"}, func() {
 			secretID := "my-user-pass"
 			vmi := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-set-user-password")
 			vmi.Namespace = util.NamespaceTestDefault
@@ -341,7 +341,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 		})
 	})
 	Context("with secret and configDrive propagation", func() {
-		It("[test_id:6224]should have ssh-key under authorized keys", func() {
+		It("[test_id:6224]should have ssh-key under authorized keys", Labels{"test_id:6224"}, func() {
 			secretID := "my-pub-key"
 			userData := fmt.Sprintf(
 				"#cloud-config\npassword: %s\nchpasswd: { expire: False }\n",

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -41,7 +41,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Guest Access Credentials", Label("sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -66,7 +66,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"},
 	}
 
 	Context("with qemu guest agent", func() {
-		It("[test_id:6220]should propagate public ssh keys", Labels{"test_id:6220"}, func() {
+		It("[test_id:6220]should propagate public ssh keys", Label("test_id:6220"), func() {
 			secretID := "my-pub-key"
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Namespace = util.NamespaceTestDefault
@@ -146,7 +146,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"},
 			}, time.Second*180)
 		})
 
-		It("[test_id:6221]should propagate user password", Labels{"test_id:6221"}, func() {
+		It("[test_id:6221]should propagate user password", Label("test_id:6221"), func() {
 			secretID := "my-user-pass"
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Namespace = util.NamespaceTestDefault
@@ -216,7 +216,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"},
 			}, time.Second*180)
 		})
 
-		It("[test_id:6222]should update guest agent for public ssh keys", Labels{"test_id:6222"}, func() {
+		It("[test_id:6222]should update guest agent for public ssh keys", Label("test_id:6222"), func() {
 			secretID := "my-pub-key"
 			vmi := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-exec")
 			vmi.Namespace = util.NamespaceTestDefault
@@ -278,7 +278,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"},
 				"Should have unsupported agent connected condition")
 		})
 
-		It("[test_id:6223]should update guest agent for user password", Labels{"test_id:6223"}, func() {
+		It("[test_id:6223]should update guest agent for user password", Label("test_id:6223"), func() {
 			secretID := "my-user-pass"
 			vmi := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-set-user-password")
 			vmi.Namespace = util.NamespaceTestDefault
@@ -341,7 +341,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", Labels{"sig-compute"},
 		})
 	})
 	Context("with secret and configDrive propagation", func() {
-		It("[test_id:6224]should have ssh-key under authorized keys", Labels{"test_id:6224"}, func() {
+		It("[test_id:6224]should have ssh-key under authorized keys", Label("test_id:6224"), func() {
 			secretID := "my-pub-key"
 			userData := fmt.Sprintf(
 				"#cloud-config\npassword: %s\nchpasswd: { expire: False }\n",

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute]Dry-Run requests", func() {
+var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var restClient *rest.RESTClient
@@ -64,7 +64,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 		})
 
-		It("[test_id:7627]create a VirtualMachineInstance", func() {
+		It("[test_id:7627]create a VirtualMachineInstance", Labels{"test_id:7627"}, func() {
 			By("Make a Dry-Run request to create a Virtual Machine")
 			err = tests.DryRunCreate(restClient, resource, vmi.Namespace, vmi, nil)
 			Expect(err).To(BeNil())
@@ -74,7 +74,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7628]delete a VirtualMachineInstance", func() {
+		It("[test_id:7628]delete a VirtualMachineInstance", Labels{"test_id:7628"}, func() {
 			By("Create a VirtualMachineInstance")
 			_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 			Expect(err).To(BeNil())
@@ -93,7 +93,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7629]update a VirtualMachineInstance", func() {
+		It("[test_id:7629]update a VirtualMachineInstance", Labels{"test_id:7629"}, func() {
 			By("Create a VirtualMachineInstance")
 			_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 			Expect(err).To(BeNil())
@@ -116,7 +116,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(vmi.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7630]patch a VirtualMachineInstance", func() {
+		It("[test_id:7630]patch a VirtualMachineInstance", Labels{"test_id:7630"}, func() {
 			By("Create a VirtualMachineInstance")
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 			Expect(err).To(BeNil())
@@ -149,7 +149,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 
 		})
 
-		It("[test_id:7631]create a VirtualMachine", func() {
+		It("[test_id:7631]create a VirtualMachine", Labels{"test_id:7631"}, func() {
 			By("Make a Dry-Run request to create a Virtual Machine")
 			err = tests.DryRunCreate(restClient, resource, vm.Namespace, vm, nil)
 			Expect(err).To(BeNil())
@@ -159,7 +159,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7632]delete a VirtualMachine", func() {
+		It("[test_id:7632]delete a VirtualMachine", Labels{"test_id:7632"}, func() {
 			By("Create a VirtualMachine")
 			_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
 			Expect(err).To(BeNil())
@@ -178,7 +178,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7633]update a VirtualMachine", func() {
+		It("[test_id:7633]update a VirtualMachine", Labels{"test_id:7633"}, func() {
 			By("Create a VirtualMachine")
 			_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
 			Expect(err).To(BeNil())
@@ -202,7 +202,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(vm.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7634]patch a VirtualMachine", func() {
+		It("[test_id:7634]patch a VirtualMachine", Labels{"test_id:7634"}, func() {
 			By("Create a VirtualMachine")
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
 			Expect(err).To(BeNil())
@@ -230,7 +230,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			vmim = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 		})
 
-		It("[test_id:7635]create a migration", func() {
+		It("[test_id:7635]create a migration", Labels{"test_id:7635"}, func() {
 			By("Make a Dry-Run request to create a Migration")
 			err = tests.DryRunCreate(restClient, resource, vmim.Namespace, vmim, vmim)
 			Expect(err).To(BeNil())
@@ -240,7 +240,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7636]delete a migration", func() {
+		It("[test_id:7636]delete a migration", Labels{"test_id:7636"}, func() {
 			By("Create a migration")
 			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -259,7 +259,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7637]update a migration", func() {
+		It("[test_id:7637]update a migration", Labels{"test_id:7637"}, func() {
 			By("Create a migration")
 			vmim, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -285,7 +285,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(vmim.Annotations["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7638]patch a migration", func() {
+		It("[test_id:7638]patch a migration", Labels{"test_id:7638"}, func() {
 			By("Create a migration")
 			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -312,7 +312,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			preset = newVMIPreset("test-vmi-preset", presetLabelKey, presetLabelVal)
 		})
 
-		It("[test_id:7639]create a VMI preset", func() {
+		It("[test_id:7639]create a VMI preset", Labels{"test_id:7639"}, func() {
 			By("Make a Dry-Run request to create a VMI preset")
 			err = tests.DryRunCreate(restClient, resource, preset.Namespace, preset, nil)
 			Expect(err).To(BeNil())
@@ -322,7 +322,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7640]delete a VMI preset", func() {
+		It("[test_id:7640]delete a VMI preset", Labels{"test_id:7640"}, func() {
 			By("Create a VMI preset")
 			_, err := virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
 			Expect(err).To(BeNil())
@@ -341,7 +341,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7641]update a VMI preset", func() {
+		It("[test_id:7641]update a VMI preset", Labels{"test_id:7641"}, func() {
 			By("Create a VMI preset")
 			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
 			Expect(err).To(BeNil())
@@ -366,7 +366,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(preset.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7642]patch a VMI preset", func() {
+		It("[test_id:7642]patch a VMI preset", Labels{"test_id:7642"}, func() {
 			By("Create a VMI preset")
 			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
 			Expect(err).To(BeNil())
@@ -391,7 +391,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			vmirs = newVMIReplicaSet("test-vmi-rs")
 		})
 
-		It("[test_id:7643]create a VMI replicaset", func() {
+		It("[test_id:7643]create a VMI replicaset", Labels{"test_id:7643"}, func() {
 			By("Make a Dry-Run request to create a VMI replicaset")
 			err = tests.DryRunCreate(restClient, resource, vmirs.Namespace, vmirs, nil)
 			Expect(err).To(BeNil())
@@ -401,7 +401,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7644]delete a VMI replicaset", func() {
+		It("[test_id:7644]delete a VMI replicaset", Labels{"test_id:7644"}, func() {
 			By("Create a VMI replicaset")
 			_, err := virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
 			Expect(err).To(BeNil())
@@ -420,7 +420,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7645]update a VMI replicaset", func() {
+		It("[test_id:7645]update a VMI replicaset", Labels{"test_id:7645"}, func() {
 			By("Create a VMI replicaset")
 			_, err = virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
 			Expect(err).To(BeNil())
@@ -445,7 +445,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(vmirs.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7646]patch a VMI replicaset", func() {
+		It("[test_id:7646]patch a VMI replicaset", Labels{"test_id:7646"}, func() {
 			By("Create a VMI replicaset")
 			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
 			Expect(err).To(BeNil())
@@ -478,7 +478,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			return &kvCopy
 		}
 
-		It("[test_id:7647]create a KubeVirt CR", func() {
+		It("[test_id:7647]create a KubeVirt CR", Labels{"test_id:7647"}, func() {
 			kvCopy := copyKV(kv)
 			kvCopy.Name = "test-kubevirt-cr"
 
@@ -491,7 +491,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[Serial][test_id:7648]delete a KubeVirt CR", func() {
+		It("[Serial][test_id:7648]delete a KubeVirt CR", Labels{"Serial", "test_id:7648"}, func() {
 			By("Make a Dry-Run request to delete a KubeVirt CR")
 			deletePolicy := metav1.DeletePropagationForeground
 			opts := metav1.DeleteOptions{
@@ -506,7 +506,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7649]update a KubeVirt CR", func() {
+		It("[test_id:7649]update a KubeVirt CR", Labels{"test_id:7649"}, func() {
 			By("Make a Dry-Run request to update a KubeVirt CR")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
@@ -527,7 +527,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(kv.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7650]patch a KubeVirt CR", func() {
+		It("[test_id:7650]patch a KubeVirt CR", Labels{"test_id:7650"}, func() {
 			By("Make a Dry-Run request to patch a KubeVirt CR")
 			patch := []byte(`{"metadata": {"labels": {"key": "42"}}}`)
 			err = tests.DryRunPatch(restClient, resource, kv.Name, kv.Namespace, types.MergePatchType, patch, nil)
@@ -555,7 +555,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			snap = newVMSnapshot(vm)
 		})
 
-		It("[test_id:7651]create a VM Snapshot", func() {
+		It("[test_id:7651]create a VM Snapshot", Labels{"test_id:7651"}, func() {
 			By("Make a Dry-Run request to create a VM Snapshot")
 			opts := metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, opts)
@@ -566,7 +566,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7652]delete a VM Snapshot", func() {
+		It("[test_id:7652]delete a VM Snapshot", Labels{"test_id:7652"}, func() {
 			By("Create a VM Snapshot")
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -585,7 +585,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7653]update a VM Snapshot", func() {
+		It("[test_id:7653]update a VM Snapshot", Labels{"test_id:7653"}, func() {
 			By("Create a VM Snapshot")
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -613,7 +613,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(snap.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7654]patch a VM Snapshot", func() {
+		It("[test_id:7654]patch a VM Snapshot", Labels{"test_id:7654"}, func() {
 			By("Create a VM Snapshot")
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -651,7 +651,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			waitForSnapshotToBeReady(virtClient, snap, 120)
 		})
 
-		It("[test_id:7655]create a VM Restore", func() {
+		It("[test_id:7655]create a VM Restore", Labels{"test_id:7655"}, func() {
 			By("Make a Dry-Run request to create a VM Restore")
 			opts := metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, opts)
@@ -662,7 +662,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7656]delete a VM Restore", func() {
+		It("[test_id:7656]delete a VM Restore", Labels{"test_id:7656"}, func() {
 			By("Create a VM Restore")
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -681,7 +681,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7657]update a VM Restore", func() {
+		It("[test_id:7657]update a VM Restore", Labels{"test_id:7657"}, func() {
 			By("Create a VM Restore")
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -709,7 +709,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(restore.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7658]patch a VM Restore", func() {
+		It("[test_id:7658]patch a VM Restore", Labels{"test_id:7658"}, func() {
 			By("Create a VM Restore")
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Dry-Run requests", Label("sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var restClient *rest.RESTClient
@@ -64,7 +64,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 		})
 
-		It("[test_id:7627]create a VirtualMachineInstance", Labels{"test_id:7627"}, func() {
+		It("[test_id:7627]create a VirtualMachineInstance", Label("test_id:7627"), func() {
 			By("Make a Dry-Run request to create a Virtual Machine")
 			err = tests.DryRunCreate(restClient, resource, vmi.Namespace, vmi, nil)
 			Expect(err).To(BeNil())
@@ -74,7 +74,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7628]delete a VirtualMachineInstance", Labels{"test_id:7628"}, func() {
+		It("[test_id:7628]delete a VirtualMachineInstance", Label("test_id:7628"), func() {
 			By("Create a VirtualMachineInstance")
 			_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 			Expect(err).To(BeNil())
@@ -93,7 +93,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7629]update a VirtualMachineInstance", Labels{"test_id:7629"}, func() {
+		It("[test_id:7629]update a VirtualMachineInstance", Label("test_id:7629"), func() {
 			By("Create a VirtualMachineInstance")
 			_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 			Expect(err).To(BeNil())
@@ -116,7 +116,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(vmi.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7630]patch a VirtualMachineInstance", Labels{"test_id:7630"}, func() {
+		It("[test_id:7630]patch a VirtualMachineInstance", Label("test_id:7630"), func() {
 			By("Create a VirtualMachineInstance")
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 			Expect(err).To(BeNil())
@@ -149,7 +149,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 
 		})
 
-		It("[test_id:7631]create a VirtualMachine", Labels{"test_id:7631"}, func() {
+		It("[test_id:7631]create a VirtualMachine", Label("test_id:7631"), func() {
 			By("Make a Dry-Run request to create a Virtual Machine")
 			err = tests.DryRunCreate(restClient, resource, vm.Namespace, vm, nil)
 			Expect(err).To(BeNil())
@@ -159,7 +159,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7632]delete a VirtualMachine", Labels{"test_id:7632"}, func() {
+		It("[test_id:7632]delete a VirtualMachine", Label("test_id:7632"), func() {
 			By("Create a VirtualMachine")
 			_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
 			Expect(err).To(BeNil())
@@ -178,7 +178,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7633]update a VirtualMachine", Labels{"test_id:7633"}, func() {
+		It("[test_id:7633]update a VirtualMachine", Label("test_id:7633"), func() {
 			By("Create a VirtualMachine")
 			_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
 			Expect(err).To(BeNil())
@@ -202,7 +202,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(vm.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7634]patch a VirtualMachine", Labels{"test_id:7634"}, func() {
+		It("[test_id:7634]patch a VirtualMachine", Label("test_id:7634"), func() {
 			By("Create a VirtualMachine")
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
 			Expect(err).To(BeNil())
@@ -230,7 +230,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			vmim = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 		})
 
-		It("[test_id:7635]create a migration", Labels{"test_id:7635"}, func() {
+		It("[test_id:7635]create a migration", Label("test_id:7635"), func() {
 			By("Make a Dry-Run request to create a Migration")
 			err = tests.DryRunCreate(restClient, resource, vmim.Namespace, vmim, vmim)
 			Expect(err).To(BeNil())
@@ -240,7 +240,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7636]delete a migration", Labels{"test_id:7636"}, func() {
+		It("[test_id:7636]delete a migration", Label("test_id:7636"), func() {
 			By("Create a migration")
 			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -259,7 +259,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7637]update a migration", Labels{"test_id:7637"}, func() {
+		It("[test_id:7637]update a migration", Label("test_id:7637"), func() {
 			By("Create a migration")
 			vmim, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -285,7 +285,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(vmim.Annotations["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7638]patch a migration", Labels{"test_id:7638"}, func() {
+		It("[test_id:7638]patch a migration", Label("test_id:7638"), func() {
 			By("Create a migration")
 			vmim, err = virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Create(vmim, &metav1.CreateOptions{})
 			Expect(err).To(BeNil())
@@ -312,7 +312,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			preset = newVMIPreset("test-vmi-preset", presetLabelKey, presetLabelVal)
 		})
 
-		It("[test_id:7639]create a VMI preset", Labels{"test_id:7639"}, func() {
+		It("[test_id:7639]create a VMI preset", Label("test_id:7639"), func() {
 			By("Make a Dry-Run request to create a VMI preset")
 			err = tests.DryRunCreate(restClient, resource, preset.Namespace, preset, nil)
 			Expect(err).To(BeNil())
@@ -322,7 +322,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7640]delete a VMI preset", Labels{"test_id:7640"}, func() {
+		It("[test_id:7640]delete a VMI preset", Label("test_id:7640"), func() {
 			By("Create a VMI preset")
 			_, err := virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
 			Expect(err).To(BeNil())
@@ -341,7 +341,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7641]update a VMI preset", Labels{"test_id:7641"}, func() {
+		It("[test_id:7641]update a VMI preset", Label("test_id:7641"), func() {
 			By("Create a VMI preset")
 			_, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
 			Expect(err).To(BeNil())
@@ -366,7 +366,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(preset.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7642]patch a VMI preset", Labels{"test_id:7642"}, func() {
+		It("[test_id:7642]patch a VMI preset", Label("test_id:7642"), func() {
 			By("Create a VMI preset")
 			preset, err = virtClient.VirtualMachineInstancePreset(preset.Namespace).Create(preset)
 			Expect(err).To(BeNil())
@@ -391,7 +391,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			vmirs = newVMIReplicaSet("test-vmi-rs")
 		})
 
-		It("[test_id:7643]create a VMI replicaset", Labels{"test_id:7643"}, func() {
+		It("[test_id:7643]create a VMI replicaset", Label("test_id:7643"), func() {
 			By("Make a Dry-Run request to create a VMI replicaset")
 			err = tests.DryRunCreate(restClient, resource, vmirs.Namespace, vmirs, nil)
 			Expect(err).To(BeNil())
@@ -401,7 +401,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7644]delete a VMI replicaset", Labels{"test_id:7644"}, func() {
+		It("[test_id:7644]delete a VMI replicaset", Label("test_id:7644"), func() {
 			By("Create a VMI replicaset")
 			_, err := virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
 			Expect(err).To(BeNil())
@@ -420,7 +420,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7645]update a VMI replicaset", Labels{"test_id:7645"}, func() {
+		It("[test_id:7645]update a VMI replicaset", Label("test_id:7645"), func() {
 			By("Create a VMI replicaset")
 			_, err = virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
 			Expect(err).To(BeNil())
@@ -445,7 +445,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(vmirs.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7646]patch a VMI replicaset", Labels{"test_id:7646"}, func() {
+		It("[test_id:7646]patch a VMI replicaset", Label("test_id:7646"), func() {
 			By("Create a VMI replicaset")
 			vmirs, err = virtClient.ReplicaSet(vmirs.Namespace).Create(vmirs)
 			Expect(err).To(BeNil())
@@ -478,7 +478,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			return &kvCopy
 		}
 
-		It("[test_id:7647]create a KubeVirt CR", Labels{"test_id:7647"}, func() {
+		It("[test_id:7647]create a KubeVirt CR", Label("test_id:7647"), func() {
 			kvCopy := copyKV(kv)
 			kvCopy.Name = "test-kubevirt-cr"
 
@@ -491,7 +491,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[Serial][test_id:7648]delete a KubeVirt CR", Labels{"Serial", "test_id:7648"}, func() {
+		It("[Serial][test_id:7648]delete a KubeVirt CR", Label("Serial", "test_id:7648"), func() {
 			By("Make a Dry-Run request to delete a KubeVirt CR")
 			deletePolicy := metav1.DeletePropagationForeground
 			opts := metav1.DeleteOptions{
@@ -506,7 +506,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7649]update a KubeVirt CR", Labels{"test_id:7649"}, func() {
+		It("[test_id:7649]update a KubeVirt CR", Label("test_id:7649"), func() {
 			By("Make a Dry-Run request to update a KubeVirt CR")
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				kv, err = virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
@@ -527,7 +527,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(kv.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7650]patch a KubeVirt CR", Labels{"test_id:7650"}, func() {
+		It("[test_id:7650]patch a KubeVirt CR", Label("test_id:7650"), func() {
 			By("Make a Dry-Run request to patch a KubeVirt CR")
 			patch := []byte(`{"metadata": {"labels": {"key": "42"}}}`)
 			err = tests.DryRunPatch(restClient, resource, kv.Name, kv.Namespace, types.MergePatchType, patch, nil)
@@ -555,7 +555,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			snap = newVMSnapshot(vm)
 		})
 
-		It("[test_id:7651]create a VM Snapshot", Labels{"test_id:7651"}, func() {
+		It("[test_id:7651]create a VM Snapshot", Label("test_id:7651"), func() {
 			By("Make a Dry-Run request to create a VM Snapshot")
 			opts := metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, opts)
@@ -566,7 +566,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7652]delete a VM Snapshot", Labels{"test_id:7652"}, func() {
+		It("[test_id:7652]delete a VM Snapshot", Label("test_id:7652"), func() {
 			By("Create a VM Snapshot")
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -585,7 +585,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7653]update a VM Snapshot", Labels{"test_id:7653"}, func() {
+		It("[test_id:7653]update a VM Snapshot", Label("test_id:7653"), func() {
 			By("Create a VM Snapshot")
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -613,7 +613,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(snap.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7654]patch a VM Snapshot", Labels{"test_id:7654"}, func() {
+		It("[test_id:7654]patch a VM Snapshot", Label("test_id:7654"), func() {
 			By("Create a VM Snapshot")
 			_, err = virtClient.VirtualMachineSnapshot(snap.Namespace).Create(context.Background(), snap, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -651,7 +651,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			waitForSnapshotToBeReady(virtClient, snap, 120)
 		})
 
-		It("[test_id:7655]create a VM Restore", Labels{"test_id:7655"}, func() {
+		It("[test_id:7655]create a VM Restore", Label("test_id:7655"), func() {
 			By("Make a Dry-Run request to create a VM Restore")
 			opts := metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, opts)
@@ -662,7 +662,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[test_id:7656]delete a VM Restore", Labels{"test_id:7656"}, func() {
+		It("[test_id:7656]delete a VM Restore", Label("test_id:7656"), func() {
 			By("Create a VM Restore")
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -681,7 +681,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:7657]update a VM Restore", Labels{"test_id:7657"}, func() {
+		It("[test_id:7657]update a VM Restore", Label("test_id:7657"), func() {
 			By("Create a VM Restore")
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -709,7 +709,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", Labels{"sig-compute"}, func() 
 			Expect(restore.Labels["key"]).ToNot(Equal("42"))
 		})
 
-		It("[test_id:7658]patch a VM Restore", Labels{"test_id:7658"}, func() {
+		It("[test_id:7658]patch a VM Restore", Label("test_id:7658"), func() {
 			By("Create a VM Restore")
 			_, err = virtClient.VirtualMachineRestore(restore.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -20,7 +20,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Flavor", func() {
+var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Flavor", Labels{"crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute"}, func() {
 	const (
 		namespacedFlavorKind = "VirtualMachineFlavor"
 	)
@@ -38,14 +38,14 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("Flavor validation", func() {
-		It("[test_id:TODO] should allow valid flavor", func() {
+		It("[test_id:TODO] should allow valid flavor", Labels{"test_id:TODO"}, func() {
 			flavor := newVirtualMachineFlavor()
 			_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
 				Create(context.Background(), flavor, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:TODO] should fail flavor with no profiles", func() {
+		It("[test_id:TODO] should fail flavor with no profiles", Labels{"test_id:TODO"}, func() {
 			flavor := newVirtualMachineFlavor()
 			flavor.Profiles = []flavorv1alpha1.VirtualMachineFlavorProfile{}
 
@@ -63,7 +63,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("profiles"))
 		})
 
-		It("[test_id:TODO] should fail flavor with multiple default profiles", func() {
+		It("[test_id:TODO] should fail flavor with multiple default profiles", Labels{"test_id:TODO"}, func() {
 			flavor := newVirtualMachineFlavor()
 			flavor.Profiles = append(flavor.Profiles, flavorv1alpha1.VirtualMachineFlavorProfile{
 				Name:    "second-default",
@@ -86,7 +86,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("VM with invalid FlavorMatcher", func() {
-		It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", func() {
+		It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", Labels{"test_id:TODO"}, func() {
 			vmi := tests.NewRandomVMI()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Flavor = &v1.FlavorMatcher{
@@ -105,7 +105,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("spec.flavor"))
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", func() {
+		It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", Labels{"test_id:TODO"}, func() {
 			vmi := tests.NewRandomVMI()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Flavor = &v1.FlavorMatcher{
@@ -125,7 +125,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("spec.flavor"))
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing default flavor profile", func() {
+		It("[test_id:TODO] should fail to create VM with non-existing default flavor profile", Labels{"test_id:TODO"}, func() {
 			flavor := newVirtualMachineFlavor()
 			for i := range flavor.Profiles {
 				flavor.Profiles[i].Default = false
@@ -155,7 +155,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("spec.flavor"))
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing custom flavor profile", func() {
+		It("[test_id:TODO] should fail to create VM with non-existing custom flavor profile", Labels{"test_id:TODO"}, func() {
 			flavor := newVirtualMachineFlavor()
 
 			flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
@@ -218,7 +218,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		}
 
 		Context("CPU", func() {
-			It("[test_id:TODO] should apply flavor to CPU", func() {
+			It("[test_id:TODO] should apply flavor to CPU", Labels{"test_id:TODO"}, func() {
 				cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1, Model: v1.DefaultCPUModel}
 
 				flavor := newVirtualMachineFlavor()
@@ -251,7 +251,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				Expect(vmi.Annotations[v1.ClusterFlavorAnnotation]).To(Equal(""))
 			})
 
-			It("[test_id:TODO] should fail if flavor and VMI define CPU", func() {
+			It("[test_id:TODO] should fail if flavor and VMI define CPU", Labels{"test_id:TODO"}, func() {
 				flavor := newVirtualMachineFlavor()
 				flavor.Profiles[0].CPU = &v1.CPU{Sockets: 2, Cores: 1, Threads: 1}
 

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -20,249 +20,126 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Flavor", Label("crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute"), func() {
-	const (
-		namespacedFlavorKind = "VirtualMachineFlavor"
-	)
+var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Flavor",
+	Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
+	func() {
+		const (
+			namespacedFlavorKind = "VirtualMachineFlavor"
+		)
 
-	var (
-		virtClient kubecli.KubevirtClient
-	)
+		var (
+			virtClient kubecli.KubevirtClient
+		)
 
-	BeforeEach(func() {
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-
-		tests.BeforeTestCleanup()
-	})
-
-	Context("Flavor validation", func() {
-		It("[test_id:TODO] should allow valid flavor", Label("test_id:TODO"), func() {
-			flavor := newVirtualMachineFlavor()
-			_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
-				Create(context.Background(), flavor, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("[test_id:TODO] should fail flavor with no profiles", Label("test_id:TODO"), func() {
-			flavor := newVirtualMachineFlavor()
-			flavor.Profiles = []flavorv1alpha1.VirtualMachineFlavorProfile{}
-
-			_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
-				Create(context.Background(), flavor, metav1.CreateOptions{})
-
-			Expect(err).To(HaveOccurred())
-			var apiStatus errors.APIStatus
-			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
-			cause := apiStatus.Status().Details.Causes[0]
-			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueRequired))
-			Expect(cause.Message).To(HavePrefix("A flavor must have at least one profile"))
-			Expect(cause.Field).To(Equal("profiles"))
-		})
-
-		It("[test_id:TODO] should fail flavor with multiple default profiles", Label("test_id:TODO"), func() {
-			flavor := newVirtualMachineFlavor()
-			flavor.Profiles = append(flavor.Profiles, flavorv1alpha1.VirtualMachineFlavorProfile{
-				Name:    "second-default",
-				Default: true,
-			})
-
-			_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
-				Create(context.Background(), flavor, metav1.CreateOptions{})
-
-			Expect(err).To(HaveOccurred())
-			var apiStatus errors.APIStatus
-			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
-			cause := apiStatus.Status().Details.Causes[0]
-			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotSupported))
-			Expect(cause.Message).To(HavePrefix("Flavor contains more than one default profile"))
-			Expect(cause.Field).To(Equal("profiles"))
-		})
-	})
-
-	Context("VM with invalid FlavorMatcher", func() {
-		It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", Label("test_id:TODO"), func() {
-			vmi := tests.NewRandomVMI()
-			vm := tests.NewRandomVirtualMachine(vmi, false)
-			vm.Spec.Flavor = &v1.FlavorMatcher{
-				Name: "non-existing-cluster-flavor",
-			}
-
-			_, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-			Expect(err).To(HaveOccurred())
-			var apiStatus errors.APIStatus
-			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
-			cause := apiStatus.Status().Details.Causes[0]
-			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
-			Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
-			Expect(cause.Field).To(Equal("spec.flavor"))
-		})
-
-		It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", Label("test_id:TODO"), func() {
-			vmi := tests.NewRandomVMI()
-			vm := tests.NewRandomVirtualMachine(vmi, false)
-			vm.Spec.Flavor = &v1.FlavorMatcher{
-				Name: "non-existing-flavor",
-				Kind: namespacedFlavorKind,
-			}
-
-			_, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-			Expect(err).To(HaveOccurred())
-			var apiStatus errors.APIStatus
-			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
-			cause := apiStatus.Status().Details.Causes[0]
-			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
-			Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
-			Expect(cause.Field).To(Equal("spec.flavor"))
-		})
-
-		It("[test_id:TODO] should fail to create VM with non-existing default flavor profile", Label("test_id:TODO"), func() {
-			flavor := newVirtualMachineFlavor()
-			for i := range flavor.Profiles {
-				flavor.Profiles[i].Default = false
-			}
-
-			flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
-				Create(context.Background(), flavor, metav1.CreateOptions{})
+		BeforeEach(func() {
+			var err error
+			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi := tests.NewRandomVMI()
-			vm := tests.NewRandomVirtualMachine(vmi, false)
-
-			vm.Spec.Flavor = &v1.FlavorMatcher{
-				Name: flavor.Name,
-				Kind: namespacedFlavorKind,
-			}
-
-			_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-			Expect(err).To(HaveOccurred())
-			var apiStatus errors.APIStatus
-			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
-			cause := apiStatus.Status().Details.Causes[0]
-			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
-			Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
-			Expect(cause.Field).To(Equal("spec.flavor"))
+			tests.BeforeTestCleanup()
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing custom flavor profile", Label("test_id:TODO"), func() {
-			flavor := newVirtualMachineFlavor()
-
-			flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
-				Create(context.Background(), flavor, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi := tests.NewRandomVMI()
-			vm := tests.NewRandomVirtualMachine(vmi, false)
-
-			vm.Spec.Flavor = &v1.FlavorMatcher{
-				Name:    flavor.Name,
-				Kind:    namespacedFlavorKind,
-				Profile: "nonexisting-profile",
-			}
-
-			_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-			Expect(err).To(HaveOccurred())
-			var apiStatus errors.APIStatus
-			Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
-
-			Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
-			cause := apiStatus.Status().Details.Causes[0]
-			Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
-			Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
-			Expect(cause.Field).To(Equal("spec.flavor"))
-		})
-	})
-
-	Context("Flavor application", func() {
-		startVM := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
-			runStrategyAlways := v1.RunStrategyAlways
-			By("Starting the VirtualMachine")
-
-			Eventually(func() error {
-				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				updatedVM.Spec.Running = nil
-				updatedVM.Spec.RunStrategy = &runStrategyAlways
-				_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(updatedVM)
-				return err
-			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
-			updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Observe the VirtualMachineInstance created
-			Eventually(func() error {
-				_, err := virtClient.VirtualMachineInstance(updatedVM.Namespace).Get(updatedVM.Name, &k8smetav1.GetOptions{})
-				return err
-			}, 300*time.Second, 1*time.Second).Should(Succeed())
-
-			By("VMI has the running condition")
-			Eventually(func() bool {
-				vm, err := virtClient.VirtualMachine(updatedVM.Namespace).Get(updatedVM.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return vm.Status.Ready
-			}, 300*time.Second, 1*time.Second).Should(BeTrue())
-
-			return updatedVM
-		}
-
-		Context("CPU", func() {
-			It("[test_id:TODO] should apply flavor to CPU", Label("test_id:TODO"), func() {
-				cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1, Model: v1.DefaultCPUModel}
-
+		Context("Flavor validation", func() {
+			It("[test_id:TODO] should allow valid flavor", Label("test_id:TODO"), func() {
 				flavor := newVirtualMachineFlavor()
-				flavor.Profiles[0].CPU = cpu
-
-				flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
+				_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
 					Create(context.Background(), flavor, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
+			})
 
-				vmi := tests.NewRandomVMIWithEphemeralDisk(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros),
-				)
-				vmi.Spec.Domain.CPU = nil
+			It("[test_id:TODO] should fail flavor with no profiles", Label("test_id:TODO"), func() {
+				flavor := newVirtualMachineFlavor()
+				flavor.Profiles = []flavorv1alpha1.VirtualMachineFlavorProfile{}
 
+				_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
+					Create(context.Background(), flavor, metav1.CreateOptions{})
+
+				Expect(err).To(HaveOccurred())
+				var apiStatus errors.APIStatus
+				Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
+
+				Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
+				cause := apiStatus.Status().Details.Causes[0]
+				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueRequired))
+				Expect(cause.Message).To(HavePrefix("A flavor must have at least one profile"))
+				Expect(cause.Field).To(Equal("profiles"))
+			})
+
+			It("[test_id:TODO] should fail flavor with multiple default profiles", Label("test_id:TODO"), func() {
+				flavor := newVirtualMachineFlavor()
+				flavor.Profiles = append(flavor.Profiles, flavorv1alpha1.VirtualMachineFlavorProfile{
+					Name:    "second-default",
+					Default: true,
+				})
+
+				_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
+					Create(context.Background(), flavor, metav1.CreateOptions{})
+
+				Expect(err).To(HaveOccurred())
+				var apiStatus errors.APIStatus
+				Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
+
+				Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
+				cause := apiStatus.Status().Details.Causes[0]
+				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotSupported))
+				Expect(cause.Message).To(HavePrefix("Flavor contains more than one default profile"))
+				Expect(cause.Field).To(Equal("profiles"))
+			})
+		})
+
+		Context("VM with invalid FlavorMatcher", func() {
+			It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", Label("test_id:TODO"), func() {
+				vmi := tests.NewRandomVMI()
 				vm := tests.NewRandomVirtualMachine(vmi, false)
 				vm.Spec.Flavor = &v1.FlavorMatcher{
-					Name: flavor.Name,
+					Name: "non-existing-cluster-flavor",
+				}
+
+				_, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				Expect(err).To(HaveOccurred())
+				var apiStatus errors.APIStatus
+				Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
+
+				Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
+				cause := apiStatus.Status().Details.Causes[0]
+				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
+				Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
+				Expect(cause.Field).To(Equal("spec.flavor"))
+			})
+
+			It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", Label("test_id:TODO"), func() {
+				vmi := tests.NewRandomVMI()
+				vm := tests.NewRandomVirtualMachine(vmi, false)
+				vm.Spec.Flavor = &v1.FlavorMatcher{
+					Name: "non-existing-flavor",
 					Kind: namespacedFlavorKind,
 				}
 
-				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
+				_, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				Expect(err).To(HaveOccurred())
+				var apiStatus errors.APIStatus
+				Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
 
-				startVM(vm)
-
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Spec.Domain.CPU).To(Equal(cpu))
-				Expect(vmi.Annotations[v1.FlavorAnnotation]).To(Equal(flavor.Name))
-				Expect(vmi.Annotations[v1.ClusterFlavorAnnotation]).To(Equal(""))
+				Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
+				cause := apiStatus.Status().Details.Causes[0]
+				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
+				Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
+				Expect(cause.Field).To(Equal("spec.flavor"))
 			})
 
-			It("[test_id:TODO] should fail if flavor and VMI define CPU", Label("test_id:TODO"), func() {
+			It("[test_id:TODO] should fail to create VM with non-existing default flavor profile", Label("test_id:TODO"), func() {
 				flavor := newVirtualMachineFlavor()
-				flavor.Profiles[0].CPU = &v1.CPU{Sockets: 2, Cores: 1, Threads: 1}
+				for i := range flavor.Profiles {
+					flavor.Profiles[i].Default = false
+				}
 
 				flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
 					Create(context.Background(), flavor, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi := tests.NewRandomVMI()
-				vmi.Spec.Domain.CPU = &v1.CPU{Sockets: 1, Cores: 1, Threads: 1}
-
 				vm := tests.NewRandomVirtualMachine(vmi, false)
+
 				vm.Spec.Flavor = &v1.FlavorMatcher{
 					Name: flavor.Name,
 					Kind: namespacedFlavorKind,
@@ -275,14 +152,139 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 				Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
 				cause := apiStatus.Status().Details.Causes[0]
+				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
+				Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
+				Expect(cause.Field).To(Equal("spec.flavor"))
+			})
 
-				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-				Expect(cause.Message).To(Equal("VMI field conflicts with selected Flavor profile"))
-				Expect(cause.Field).To(Equal("spec.template.spec.domain.cpu"))
+			It("[test_id:TODO] should fail to create VM with non-existing custom flavor profile", Label("test_id:TODO"), func() {
+				flavor := newVirtualMachineFlavor()
+
+				flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
+					Create(context.Background(), flavor, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi := tests.NewRandomVMI()
+				vm := tests.NewRandomVirtualMachine(vmi, false)
+
+				vm.Spec.Flavor = &v1.FlavorMatcher{
+					Name:    flavor.Name,
+					Kind:    namespacedFlavorKind,
+					Profile: "nonexisting-profile",
+				}
+
+				_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				Expect(err).To(HaveOccurred())
+				var apiStatus errors.APIStatus
+				Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
+
+				Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
+				cause := apiStatus.Status().Details.Causes[0]
+				Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueNotFound))
+				Expect(cause.Message).To(HavePrefix("Could not find flavor profile:"))
+				Expect(cause.Field).To(Equal("spec.flavor"))
+			})
+		})
+
+		Context("Flavor application", func() {
+			startVM := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
+				runStrategyAlways := v1.RunStrategyAlways
+				By("Starting the VirtualMachine")
+
+				Eventually(func() error {
+					updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					updatedVM.Spec.Running = nil
+					updatedVM.Spec.RunStrategy = &runStrategyAlways
+					_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(updatedVM)
+					return err
+				}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				// Observe the VirtualMachineInstance created
+				Eventually(func() error {
+					_, err := virtClient.VirtualMachineInstance(updatedVM.Namespace).Get(updatedVM.Name, &k8smetav1.GetOptions{})
+					return err
+				}, 300*time.Second, 1*time.Second).Should(Succeed())
+
+				By("VMI has the running condition")
+				Eventually(func() bool {
+					vm, err := virtClient.VirtualMachine(updatedVM.Namespace).Get(updatedVM.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return vm.Status.Ready
+				}, 300*time.Second, 1*time.Second).Should(BeTrue())
+
+				return updatedVM
+			}
+
+			Context("CPU", func() {
+				It("[test_id:TODO] should apply flavor to CPU", Label("test_id:TODO"), func() {
+					cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1, Model: v1.DefaultCPUModel}
+
+					flavor := newVirtualMachineFlavor()
+					flavor.Profiles[0].CPU = cpu
+
+					flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
+						Create(context.Background(), flavor, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					vmi := tests.NewRandomVMIWithEphemeralDisk(
+						cd.ContainerDiskFor(cd.ContainerDiskCirros),
+					)
+					vmi.Spec.Domain.CPU = nil
+
+					vm := tests.NewRandomVirtualMachine(vmi, false)
+					vm.Spec.Flavor = &v1.FlavorMatcher{
+						Name: flavor.Name,
+						Kind: namespacedFlavorKind,
+					}
+
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					startVM(vm)
+
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Spec.Domain.CPU).To(Equal(cpu))
+					Expect(vmi.Annotations[v1.FlavorAnnotation]).To(Equal(flavor.Name))
+					Expect(vmi.Annotations[v1.ClusterFlavorAnnotation]).To(Equal(""))
+				})
+
+				It("[test_id:TODO] should fail if flavor and VMI define CPU", Label("test_id:TODO"), func() {
+					flavor := newVirtualMachineFlavor()
+					flavor.Profiles[0].CPU = &v1.CPU{Sockets: 2, Cores: 1, Threads: 1}
+
+					flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
+						Create(context.Background(), flavor, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					vmi := tests.NewRandomVMI()
+					vmi.Spec.Domain.CPU = &v1.CPU{Sockets: 1, Cores: 1, Threads: 1}
+
+					vm := tests.NewRandomVirtualMachine(vmi, false)
+					vm.Spec.Flavor = &v1.FlavorMatcher{
+						Name: flavor.Name,
+						Kind: namespacedFlavorKind,
+					}
+
+					_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).To(HaveOccurred())
+					var apiStatus errors.APIStatus
+					Expect(goerrors.As(err, &apiStatus)).To(BeTrue(), "error should be type APIStatus")
+
+					Expect(apiStatus.Status().Details.Causes).To(HaveLen(1))
+					cause := apiStatus.Status().Details.Causes[0]
+
+					Expect(cause.Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+					Expect(cause.Message).To(Equal("VMI field conflicts with selected Flavor profile"))
+					Expect(cause.Field).To(Equal("spec.template.spec.domain.cpu"))
+				})
 			})
 		})
 	})
-})
 
 func newVirtualMachineFlavor() *flavorv1alpha1.VirtualMachineFlavor {
 	return &flavorv1alpha1.VirtualMachineFlavor{

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -20,7 +20,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Flavor", Labels{"crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute"}, func() {
+var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Flavor", Label("crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute"), func() {
 	const (
 		namespacedFlavorKind = "VirtualMachineFlavor"
 	)
@@ -38,14 +38,14 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("Flavor validation", func() {
-		It("[test_id:TODO] should allow valid flavor", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should allow valid flavor", Label("test_id:TODO"), func() {
 			flavor := newVirtualMachineFlavor()
 			_, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
 				Create(context.Background(), flavor, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:TODO] should fail flavor with no profiles", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should fail flavor with no profiles", Label("test_id:TODO"), func() {
 			flavor := newVirtualMachineFlavor()
 			flavor.Profiles = []flavorv1alpha1.VirtualMachineFlavorProfile{}
 
@@ -63,7 +63,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("profiles"))
 		})
 
-		It("[test_id:TODO] should fail flavor with multiple default profiles", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should fail flavor with multiple default profiles", Label("test_id:TODO"), func() {
 			flavor := newVirtualMachineFlavor()
 			flavor.Profiles = append(flavor.Profiles, flavorv1alpha1.VirtualMachineFlavorProfile{
 				Name:    "second-default",
@@ -86,7 +86,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	})
 
 	Context("VM with invalid FlavorMatcher", func() {
-		It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", Label("test_id:TODO"), func() {
 			vmi := tests.NewRandomVMI()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Flavor = &v1.FlavorMatcher{
@@ -105,7 +105,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("spec.flavor"))
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", Label("test_id:TODO"), func() {
 			vmi := tests.NewRandomVMI()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Flavor = &v1.FlavorMatcher{
@@ -125,7 +125,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("spec.flavor"))
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing default flavor profile", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should fail to create VM with non-existing default flavor profile", Label("test_id:TODO"), func() {
 			flavor := newVirtualMachineFlavor()
 			for i := range flavor.Profiles {
 				flavor.Profiles[i].Default = false
@@ -155,7 +155,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(cause.Field).To(Equal("spec.flavor"))
 		})
 
-		It("[test_id:TODO] should fail to create VM with non-existing custom flavor profile", Labels{"test_id:TODO"}, func() {
+		It("[test_id:TODO] should fail to create VM with non-existing custom flavor profile", Label("test_id:TODO"), func() {
 			flavor := newVirtualMachineFlavor()
 
 			flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).
@@ -218,7 +218,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		}
 
 		Context("CPU", func() {
-			It("[test_id:TODO] should apply flavor to CPU", Labels{"test_id:TODO"}, func() {
+			It("[test_id:TODO] should apply flavor to CPU", Label("test_id:TODO"), func() {
 				cpu := &v1.CPU{Sockets: 2, Cores: 1, Threads: 1, Model: v1.DefaultCPUModel}
 
 				flavor := newVirtualMachineFlavor()
@@ -251,7 +251,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				Expect(vmi.Annotations[v1.ClusterFlavorAnnotation]).To(Equal(""))
 			})
 
-			It("[test_id:TODO] should fail if flavor and VMI define CPU", Labels{"test_id:TODO"}, func() {
+			It("[test_id:TODO] should fail if flavor and VMI define CPU", Label("test_id:TODO"), func() {
 				flavor := newVirtualMachineFlavor()
 				flavor.Profiles[0].CPU = &v1.CPU{Sockets: 2, Cores: 1, Threads: 1}
 

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -240,7 +240,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Label("Serial", "sig-com
 	})
 
 	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates",
-		Label("rfe_id:4102", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component]certificates"),
+		Label("rfe_id:4102", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			BeforeEach(func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -78,7 +78,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]Infrastructure", Label("Serial", "sig-compute"), func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset
@@ -151,7 +151,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 			Expect(slowDuration.Seconds()).To(BeNumerically(">", 2*fastDuration.Seconds()))
 		})
 
-		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", Labels{"QUARANTINE"}, func() {
+		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", Label("QUARANTINE"), func() {
 			By("first getting the basetime for a replicaset")
 			targetNode := util.GetAllSchedulableNodes(virtClient).Items[0]
 			vmi := libvmi.NewCirros(
@@ -195,7 +195,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 	})
 
 	Describe("downwardMetrics", func() {
-		It("[test_id:6535]should be published to a vmi and periodically updated", Labels{"test_id:6535"}, func() {
+		It("[test_id:6535]should be published to a vmi and periodically updated", Label("test_id:6535"), func() {
 			vmi := libvmi.NewFedora()
 			tests.AddDownwardMetricsVolume(vmi, "vhostmd")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
@@ -217,7 +217,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 	})
 
 	Describe("CRDs", func() {
-		It("[test_id:5177]Should have structural schema", Labels{"test_id:5177"}, func() {
+		It("[test_id:5177]Should have structural schema", Label("test_id:5177"), func() {
 			ourCRDs := []string{crds.VIRTUALMACHINE, crds.VIRTUALMACHINEINSTANCE, crds.VIRTUALMACHINEINSTANCEPRESET,
 				crds.VIRTUALMACHINEINSTANCEREPLICASET, crds.VIRTUALMACHINEINSTANCEMIGRATION, crds.KUBEVIRT,
 				crds.VIRTUALMACHINESNAPSHOT, crds.VIRTUALMACHINESNAPSHOTCONTENT,
@@ -240,14 +240,14 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 	})
 
 	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates",
-		Labels{"rfe_id:4102", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component]certificates"},
+		Label("rfe_id:4102", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component]certificates"),
 		func() {
 
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 			})
 
-			It("[test_id:4099] should be rotated when a new CA is created", Labels{"test_id:4099"}, func() {
+			It("[test_id:4099] should be rotated when a new CA is created", Label("test_id:4099"), func() {
 				By("checking that the config-map gets the new CA bundle attached")
 				Eventually(func() int {
 					_, crts := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
@@ -314,7 +314,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 			})
 
-			It("[sig-compute][test_id:4100] should be valid during the whole rotation process", Labels{"sig-compute", "test_id:4100"}, func() {
+			It("[sig-compute][test_id:4100] should be valid during the whole rotation process", Label("sig-compute", "test_id:4100"), func() {
 				oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
 				oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
 				Expect(err).ToNot(HaveOccurred())
@@ -360,11 +360,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					return tests.GetCertFromSecret(secretName)
 				}, 10*time.Second, 1*time.Second).Should(Not(BeEmpty()))
 			},
-				Entry("[test_id:4101] virt-operator", Labels{"test_id:4101"}, components.VirtOperatorCertSecretName),
-				Entry("[test_id:4103] virt-api", Labels{"test_id:4103"}, components.VirtApiCertSecretName),
-				Entry("[test_id:4104] virt-controller", Labels{"test_id:4104"}, components.VirtControllerCertSecretName),
-				Entry("[test_id:4105] virt-handlers client side", Labels{"test_id:4105"}, components.VirtHandlerCertSecretName),
-				Entry("[test_id:4106] virt-handlers server side", Labels{"test_id:4106"}, components.VirtHandlerServerCertSecretName),
+				Entry("[test_id:4101] virt-operator", Label("test_id:4101"), components.VirtOperatorCertSecretName),
+				Entry("[test_id:4103] virt-api", Label("test_id:4103"), components.VirtApiCertSecretName),
+				Entry("[test_id:4104] virt-controller", Label("test_id:4104"), components.VirtControllerCertSecretName),
+				Entry("[test_id:4105] virt-handlers client side", Label("test_id:4105"), components.VirtHandlerCertSecretName),
+				Entry("[test_id:4106] virt-handlers server side", Label("test_id:4106"), components.VirtHandlerServerCertSecretName),
 			)
 		})
 
@@ -385,7 +385,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 	}
 
 	Describe("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration",
-		Labels{"rfe_id:4126", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:4126", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			Context("CriticalAddonsOnly taint set on a node", func() {
@@ -423,7 +423,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					}
 				})
 
-				It("[test_id:4134] kubevirt components on that node should not evict", Labels{"test_id:4134"}, func() {
+				It("[test_id:4134] kubevirt components on that node should not evict", Label("test_id:4134"), func() {
 
 					By("finding all kubevirt pods")
 					pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
@@ -521,7 +521,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 		})
 
 	Describe("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus scraped metrics",
-		Labels{"rfe_id:3187", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:3187", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			/*
@@ -538,7 +538,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				}
 			})
 
-			It("[test_id:4135]should find VMI namespace on namespace label of the metric", Labels{"test_id:4135"}, func() {
+			It("[test_id:4135]should find VMI namespace on namespace label of the metric", Label("test_id:4135"), func() {
 
 				/*
 					This test is required because in cases of misconfigurations on
@@ -629,7 +629,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 		})
 
 	Describe("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints",
-		Labels{"rfe_id:3187", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:3187", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			var preparedVMIs []*v1.VirtualMachineInstance
 			var pod *k8sv1.Pod
@@ -752,7 +752,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 			})
 
 			PIt("[test_id:4136][flaky] should find one leading virt-controller and two ready",
-				Labels{"test_id:4136", "flaky"},
+				Label("test_id:4136", "flaky"),
 				func() {
 					endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -792,7 +792,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-controller")
 				})
 
-			It("[test_id:4137]should find one leading virt-operator and two ready", Labels{"test_id:4137"}, func() {
+			It("[test_id:4137]should find one leading virt-operator and two ready", Label("test_id:4137"), func() {
 				endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				foundMetrics := map[string]int{
@@ -831,7 +831,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-operator")
 			})
 
-			It("[test_id:4138]should be exposed and registered on the metrics endpoint", Labels{"test_id:4138"}, func() {
+			It("[test_id:4138]should be exposed and registered on the metrics endpoint", Label("test_id:4138"), func() {
 				endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				l, err := labels.Parse("prometheus.kubevirt.io=true")
@@ -857,7 +857,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					Expect(ips).To(HaveKey(pod.Status.PodIP), fmt.Sprintf("IP of Pod %s not found in metrics endpoint", pod.Name))
 				}
 			})
-			It("[test_id:4139]should return Prometheus metrics", Labels{"test_id:4139"}, func() {
+			It("[test_id:4139]should return Prometheus metrics", Label("test_id:4139"), func() {
 				endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, ep := range endpoint.Subsets[0].Addresses {
@@ -917,8 +917,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				err := validatedHTTPResponses(errorsChan, concurrency)
 				Expect(err).ToNot(HaveOccurred(), "Should throttle HTTP access without unexpected errors")
 			},
-				Entry("[test_id:4140] by using IPv4", Labels{"test_id:4140"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6226] by using IPv6", Labels{"test_id:6226"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4140] by using IPv4", Label("test_id:4140"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6226] by using IPv6", Label("test_id:6226"), k8sv1.IPv6Protocol),
 			)
 
 			DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
@@ -933,8 +933,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					return strings.Join(lines, "\n")
 				}, 30*time.Second, 2*time.Second).Should(ContainSubstring("kubevirt"))
 			},
-				Entry("[test_id:4141] by using IPv4", Labels{"test_id:4141"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6227] by using IPv6", Labels{"test_id:6227"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4141] by using IPv4", Label("test_id:4141"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6227] by using IPv6", Label("test_id:6227"), k8sv1.IPv6Protocol),
 			)
 
 			DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
@@ -957,22 +957,22 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					}
 				}
 			},
-				Entry("[test_id:4142] storage flush requests metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-				Entry("[test_id:6228] storage flush requests metric by using IPv6", Labels{"test_id:6228"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-				Entry("[test_id:4142] time (ms) spent on cache flushing metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
-				Entry("[test_id:6229] time (ms) spent on cache flushing metric by using IPv6", Labels{"test_id:6229"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
-				Entry("[test_id:4142] I/O read operations metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-				Entry("[test_id:6230] I/O read operations metric by using IPv6", Labels{"test_id:6230"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-				Entry("[test_id:4142] I/O write operations metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-				Entry("[test_id:6231] I/O write operations metric by using IPv6", Labels{"test_id:6231"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-				Entry("[test_id:4142] storage read operation time metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
-				Entry("[test_id:6232] storage read operation time metric by using IPv6", Labels{"test_id:6232"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
-				Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-				Entry("[test_id:6233] storage read traffic in bytes metric by using IPv6", Labels{"test_id:6233"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-				Entry("[test_id:4142] storage write operation time metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
-				Entry("[test_id:6234] storage write operation time metric by using IPv6", Labels{"test_id:6234"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
-				Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
-				Entry("[test_id:6235] storage write traffic in bytes metric by using IPv6", Labels{"test_id:6235"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+				Entry("[test_id:4142] storage flush requests metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
+				Entry("[test_id:6228] storage flush requests metric by using IPv6", Label("test_id:6228"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
+				Entry("[test_id:4142] time (ms) spent on cache flushing metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
+				Entry("[test_id:6229] time (ms) spent on cache flushing metric by using IPv6", Label("test_id:6229"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
+				Entry("[test_id:4142] I/O read operations metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
+				Entry("[test_id:6230] I/O read operations metric by using IPv6", Label("test_id:6230"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
+				Entry("[test_id:4142] I/O write operations metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
+				Entry("[test_id:6231] I/O write operations metric by using IPv6", Label("test_id:6231"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
+				Entry("[test_id:4142] storage read operation time metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
+				Entry("[test_id:6232] storage read operation time metric by using IPv6", Label("test_id:6232"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
+				Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+				Entry("[test_id:6233] storage read traffic in bytes metric by using IPv6", Label("test_id:6233"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+				Entry("[test_id:4142] storage write operation time metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
+				Entry("[test_id:6234] storage write operation time metric by using IPv6", Label("test_id:6234"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
+				Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4", Label("test_id:4142"), k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+				Entry("[test_id:6235] storage write traffic in bytes metric by using IPv6", Label("test_id:6235"), k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 			)
 
 			DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
@@ -989,16 +989,16 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					Expect(value).To(BeNumerically(operator, float64(0.0)))
 				}
 			},
-				Entry("[test_id:4143] network metrics by IPv4", Labels{"test_id:4143"}, k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
-				Entry("[test_id:6236] network metrics by IPv6", Labels{"test_id:6236"}, k8sv1.IPv6Protocol, "kubevirt_vmi_network_", ">="),
-				Entry("[test_id:4144] memory metrics by IPv4", Labels{"test_id:4144"}, k8sv1.IPv4Protocol, "kubevirt_vmi_memory", ">="),
-				Entry("[test_id:6237] memory metrics by IPv6", Labels{"test_id:6237"}, k8sv1.IPv6Protocol, "kubevirt_vmi_memory", ">="),
-				Entry("[test_id:4553] vcpu wait by IPv4", Labels{"test_id:4553"}, k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-				Entry("[test_id:6238] vcpu wait by IPv6", Labels{"test_id:6238"}, k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-				Entry("[test_id:4554] vcpu seconds by IPv4", Labels{"test_id:4554"}, k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
-				Entry("[test_id:6239] vcpu seconds by IPv6", Labels{"test_id:6239"}, k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
-				Entry("[test_id:4556] vmi unused memory by IPv4", Labels{"test_id:4556"}, k8sv1.IPv4Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
-				Entry("[test_id:6240] vmi unused memory by IPv6", Labels{"test_id:6240"}, k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
+				Entry("[test_id:4143] network metrics by IPv4", Label("test_id:4143"), k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
+				Entry("[test_id:6236] network metrics by IPv6", Label("test_id:6236"), k8sv1.IPv6Protocol, "kubevirt_vmi_network_", ">="),
+				Entry("[test_id:4144] memory metrics by IPv4", Label("test_id:4144"), k8sv1.IPv4Protocol, "kubevirt_vmi_memory", ">="),
+				Entry("[test_id:6237] memory metrics by IPv6", Label("test_id:6237"), k8sv1.IPv6Protocol, "kubevirt_vmi_memory", ">="),
+				Entry("[test_id:4553] vcpu wait by IPv4", Label("test_id:4553"), k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_wait", "=="),
+				Entry("[test_id:6238] vcpu wait by IPv6", Label("test_id:6238"), k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_wait", "=="),
+				Entry("[test_id:4554] vcpu seconds by IPv4", Label("test_id:4554"), k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
+				Entry("[test_id:6239] vcpu seconds by IPv6", Label("test_id:6239"), k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
+				Entry("[test_id:4556] vmi unused memory by IPv4", Label("test_id:4556"), k8sv1.IPv4Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
+				Entry("[test_id:6240] vmi unused memory by IPv6", Label("test_id:6240"), k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
 			)
 
 			DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
@@ -1034,8 +1034,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					))
 				}
 			},
-				Entry("[test_id:4145] by IPv4", Labels{"test_id:4145"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6241] by IPv6", Labels{"test_id:6241"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4145] by IPv4", Label("test_id:4145"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6241] by IPv6", Label("test_id:6241"), k8sv1.IPv6Protocol),
 			)
 
 			DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
@@ -1053,8 +1053,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					}
 				}
 			},
-				Entry("[test_id:4146] by IPv4", Labels{"test_id:4146"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6242] by IPv6", Labels{"test_id:6242"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4146] by IPv4", Label("test_id:4146"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6242] by IPv6", Label("test_id:6242"), k8sv1.IPv6Protocol),
 			)
 
 			DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
@@ -1071,8 +1071,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 					Expect(value).To(BeNumerically(">=", float64(0.0)))
 				}
 			},
-				Entry("[test_id:4148] by IPv4", Labels{"test_id:4148"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6243] by IPv6", Labels{"test_id:6243"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4148] by IPv4", Label("test_id:4148"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6243] by IPv6", Label("test_id:6243"), k8sv1.IPv6Protocol),
 			)
 
 			DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
@@ -1093,8 +1093,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				}
 				Expect(containK8sLabel).To(Equal(true))
 			},
-				Entry("[test_id:4147] by IPv4", Labels{"test_id:4147"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6244] by IPv6", Labels{"test_id:6244"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4147] by IPv4", Label("test_id:4147"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6244] by IPv6", Label("test_id:6244"), k8sv1.IPv6Protocol),
 			)
 
 			// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
@@ -1120,8 +1120,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Expect(in).To(BeTrue())
 				Expect(out).To(BeTrue())
 			},
-				Entry("[test_id:4555] by IPv4", Labels{"test_id:4555"}, k8sv1.IPv4Protocol),
-				Entry("[test_id:6245] by IPv6", Labels{"test_id:6245"}, k8sv1.IPv6Protocol),
+				Entry("[test_id:4555] by IPv4", Label("test_id:4555"), k8sv1.IPv4Protocol),
+				Entry("[test_id:6245] by IPv6", Label("test_id:6245"), k8sv1.IPv6Protocol),
 			)
 		})
 
@@ -1131,7 +1131,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 		})
 
 		Context("when the controller pod is not running and an election happens", func() {
-			It("[test_id:4642]should succeed afterwards", Labels{"test_id:4642"}, func() {
+			It("[test_id:4642]should succeed afterwards", Label("test_id:4642"), func() {
 				newLeaderPod := getNewLeaderPod(virtClient)
 				Expect(newLeaderPod).NotTo(BeNil())
 
@@ -1265,7 +1265,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				}, 15*time.Second, 1*time.Second).Should(Equal(true))
 			})
 
-			It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", Labels{"test_id:6246"}, func() {
+			It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", Label("test_id:6246"), func() {
 				for _, node := range nodesWithKVM {
 					Expect(err).ToNot(HaveOccurred())
 					cpuModelLabelPresent := false
@@ -1305,7 +1305,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				}
 			})
 
-			It("[test_id:6247] should set default obsolete cpu models filter when obsolete-cpus-models is not set in kubevirt config", Labels{"test_id:6247"}, func() {
+			It("[test_id:6247] should set default obsolete cpu models filter when obsolete-cpus-models is not set in kubevirt config", Label("test_id:6247"), func() {
 				node := nodesWithKVM[0]
 
 				for key := range node.Labels {
@@ -1318,7 +1318,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				}
 			})
 
-			It("[test_id:6248] should set default min cpu model filter when min-cpu is not set in kubevirt config", Labels{"test_id:6248"}, func() {
+			It("[test_id:6248] should set default min cpu model filter when min-cpu is not set in kubevirt config", Label("test_id:6248"), func() {
 				node := nodesWithKVM[0]
 
 				for key := range node.Labels {
@@ -1326,7 +1326,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				}
 			})
 
-			It("[test_id:6995]should expose tsc frequency and tsc scalability", Labels{"test_id:6995"}, func() {
+			It("[test_id:6995]should expose tsc frequency and tsc scalability", Label("test_id:6995"), func() {
 				node := nodesWithKVM[0]
 				Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
 				Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-scalable"))
@@ -1348,7 +1348,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				tests.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
 			})
 
-			It("[test_id:6249] should update node with new cpu model label set", Labels{"test_id:6249"}, func() {
+			It("[test_id:6249] should update node with new cpu model label set", Label("test_id:6249"), func() {
 				obsoleteModel := ""
 				node := nodesWithKVM[0]
 
@@ -1378,7 +1378,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Expect(found).To(Equal(false), "Node can't contain label "+v1.CPUModelLabel+obsoleteModel)
 			})
 
-			It("[test_id:6250] should update node with new cpu model vendor label", Labels{"test_id:6250"}, func() {
+			It("[test_id:6250] should update node with new cpu model vendor label", Label("test_id:6250"), func() {
 				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, node := range nodes.Items {
@@ -1392,7 +1392,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Fail("No node contains label " + v1.CPUModelVendorLabel)
 			})
 
-			It("[test_id:6251] should update node with new cpu feature label set", Labels{"test_id:6251"}, func() {
+			It("[test_id:6251] should update node with new cpu feature label set", Label("test_id:6251"), func() {
 				node := nodesWithKVM[0]
 
 				numberOfLabelsBeforeUpdate := len(node.Labels)
@@ -1408,7 +1408,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Expect(numberOfLabelsBeforeUpdate).ToNot(Equal(len(node.Labels)), "Node should have different number of labels")
 			})
 
-			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", Labels{"test_id:6252"}, func() {
+			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", Label("test_id:6252"), func() {
 				node := nodesWithKVM[0]
 
 				obsoleteModels := nodelabellerutil.DefaultObsoleteCPUModels
@@ -1475,7 +1475,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-co
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:6253] should remove old labeller labels and annotations", Labels{"test_id:6253"}, func() {
+			It("[test_id:6253] should remove old labeller labels and annotations", Label("test_id:6253"), func() {
 				originalNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -78,7 +78,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
+var _ = Describe("[Serial][sig-compute]Infrastructure", Labels{"Serial", "sig-compute"}, func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset
@@ -151,7 +151,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			Expect(slowDuration.Seconds()).To(BeNumerically(">", 2*fastDuration.Seconds()))
 		})
 
-		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", func() {
+		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", Labels{"QUARANTINE"}, func() {
 			By("first getting the basetime for a replicaset")
 			targetNode := util.GetAllSchedulableNodes(virtClient).Items[0]
 			vmi := libvmi.NewCirros(
@@ -195,7 +195,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("downwardMetrics", func() {
-		It("[test_id:6535]should be published to a vmi and periodically updated", func() {
+		It("[test_id:6535]should be published to a vmi and periodically updated", Labels{"test_id:6535"}, func() {
 			vmi := libvmi.NewFedora()
 			tests.AddDownwardMetricsVolume(vmi, "vhostmd")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
@@ -217,7 +217,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("CRDs", func() {
-		It("[test_id:5177]Should have structural schema", func() {
+		It("[test_id:5177]Should have structural schema", Labels{"test_id:5177"}, func() {
 			ourCRDs := []string{crds.VIRTUALMACHINE, crds.VIRTUALMACHINEINSTANCE, crds.VIRTUALMACHINEINSTANCEPRESET,
 				crds.VIRTUALMACHINEINSTANCEREPLICASET, crds.VIRTUALMACHINEINSTANCEMIGRATION, crds.KUBEVIRT,
 				crds.VIRTUALMACHINESNAPSHOT, crds.VIRTUALMACHINESNAPSHOTCONTENT,
@@ -239,132 +239,134 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 	})
 
-	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
+	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates",
+		Labels{"rfe_id:4102", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component]certificates"},
+		func() {
 
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
-		It("[test_id:4099] should be rotated when a new CA is created", func() {
-			By("checking that the config-map gets the new CA bundle attached")
-			Eventually(func() int {
-				_, crts := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
-				return len(crts)
-			}, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
-
-			By("destroying the certificate")
-			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				secret.Data = map[string][]byte{
-					"tls.crt": []byte(""),
-					"tls.key": []byte(""),
-				}
-
-				_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
-				return err
+			BeforeEach(func() {
+				tests.BeforeTestCleanup()
 			})
-			Expect(err).ToNot(HaveOccurred())
 
-			By("checking that the CA secret gets restored with a new ca bundle")
-			var newCA []byte
-			Eventually(func() []byte {
-				newCA = tests.GetCertFromSecret(components.KubeVirtCASecretName)
-				return newCA
-			}, 10*time.Second, 1*time.Second).Should(Not(BeEmpty()))
+			It("[test_id:4099] should be rotated when a new CA is created", Labels{"test_id:4099"}, func() {
+				By("checking that the config-map gets the new CA bundle attached")
+				Eventually(func() int {
+					_, crts := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+					return len(crts)
+				}, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
 
-			By("checking that one of the CAs in the config-map is the new one")
-			var caBundle []byte
-			Eventually(func() bool {
-				caBundle, _ = tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
-				return tests.ContainsCrt(caBundle, newCA)
-			}, 10*time.Second, 1*time.Second).Should(BeTrue(), "the new CA should be added to the config-map")
+				By("destroying the certificate")
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					secret.Data = map[string][]byte{
+						"tls.crt": []byte(""),
+						"tls.key": []byte(""),
+					}
 
-			By("checking that the ca bundle gets propagated to the validating webhook")
-			Eventually(func() bool {
-				webhook, err := virtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), components.VirtAPIValidatingWebhookName, metav1.GetOptions{})
+					_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+					return err
+				})
 				Expect(err).ToNot(HaveOccurred())
-				if len(webhook.Webhooks) > 0 {
-					return tests.ContainsCrt(webhook.Webhooks[0].ClientConfig.CABundle, newCA)
-				}
-				return false
-			}, 10*time.Second, 1*time.Second).Should(BeTrue())
-			By("checking that the ca bundle gets propagated to the mutating webhook")
-			Eventually(func() bool {
-				webhook, err := virtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), components.VirtAPIMutatingWebhookName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				if len(webhook.Webhooks) > 0 {
-					return tests.ContainsCrt(webhook.Webhooks[0].ClientConfig.CABundle, newCA)
-				}
-				return false
-			}, 10*time.Second, 1*time.Second).Should(BeTrue())
 
-			By("checking that the ca bundle gets propagated to the apiservice")
-			Eventually(func() bool {
-				apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return tests.ContainsCrt(apiService.Spec.CABundle, newCA)
-			}, 10*time.Second, 1*time.Second).Should(BeTrue())
+				By("checking that the CA secret gets restored with a new ca bundle")
+				var newCA []byte
+				Eventually(func() []byte {
+					newCA = tests.GetCertFromSecret(components.KubeVirtCASecretName)
+					return newCA
+				}, 10*time.Second, 1*time.Second).Should(Not(BeEmpty()))
 
-			By("checking that we can still start virtual machines and connect to the VMI")
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-		})
+				By("checking that one of the CAs in the config-map is the new one")
+				var caBundle []byte
+				Eventually(func() bool {
+					caBundle, _ = tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
+					return tests.ContainsCrt(caBundle, newCA)
+				}, 10*time.Second, 1*time.Second).Should(BeTrue(), "the new CA should be added to the config-map")
 
-		It("[sig-compute][test_id:4100] should be valid during the whole rotation process", func() {
-			oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
-			oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
-			Expect(err).ToNot(HaveOccurred())
+				By("checking that the ca bundle gets propagated to the validating webhook")
+				Eventually(func() bool {
+					webhook, err := virtClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.Background(), components.VirtAPIValidatingWebhookName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					if len(webhook.Webhooks) > 0 {
+						return tests.ContainsCrt(webhook.Webhooks[0].ClientConfig.CABundle, newCA)
+					}
+					return false
+				}, 10*time.Second, 1*time.Second).Should(BeTrue())
+				By("checking that the ca bundle gets propagated to the mutating webhook")
+				Eventually(func() bool {
+					webhook, err := virtClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), components.VirtAPIMutatingWebhookName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					if len(webhook.Webhooks) > 0 {
+						return tests.ContainsCrt(webhook.Webhooks[0].ClientConfig.CABundle, newCA)
+					}
+					return false
+				}, 10*time.Second, 1*time.Second).Should(BeTrue())
 
-			By("destroying the CA certificate")
-			err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Delete(context.Background(), components.KubeVirtCASecretName, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+				By("checking that the ca bundle gets propagated to the apiservice")
+				Eventually(func() bool {
+					apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return tests.ContainsCrt(apiService.Spec.CABundle, newCA)
+				}, 10*time.Second, 1*time.Second).Should(BeTrue())
 
-			By("repeatedly starting VMIs until virt-api and virt-handler certificates are updated")
-			Eventually(func() (rotated bool) {
+				By("checking that we can still start virtual machines and connect to the VMI")
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				newAPICert, _, err := tests.GetPodsCertIfSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
-				Expect(err).ToNot(HaveOccurred())
-				newHandlerCert, _, err := tests.GetPodsCertIfSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
-				Expect(err).ToNot(HaveOccurred())
-				return !reflect.DeepEqual(oldHandlerCert, newHandlerCert) && !reflect.DeepEqual(oldAPICert, newAPICert)
-			}, 120*time.Second).Should(BeTrue())
-		})
-
-		DescribeTable("should be rotated when deleted for ", func(secretName string) {
-			By("destroying the certificate")
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				secret.Data = map[string][]byte{
-					"tls.crt": []byte(""),
-					"tls.key": []byte(""),
-				}
-				_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
-
-				return err
 			})
-			Expect(err).ToNot(HaveOccurred())
 
-			By("checking that the secret gets restored with a new certificate")
-			Eventually(func() []byte {
-				return tests.GetCertFromSecret(secretName)
-			}, 10*time.Second, 1*time.Second).Should(Not(BeEmpty()))
-		},
-			Entry("[test_id:4101] virt-operator", components.VirtOperatorCertSecretName),
-			Entry("[test_id:4103] virt-api", components.VirtApiCertSecretName),
-			Entry("[test_id:4104] virt-controller", components.VirtControllerCertSecretName),
-			Entry("[test_id:4105] virt-handlers client side", components.VirtHandlerCertSecretName),
-			Entry("[test_id:4106] virt-handlers server side", components.VirtHandlerServerCertSecretName),
-		)
-	})
+			It("[sig-compute][test_id:4100] should be valid during the whole rotation process", Labels{"sig-compute", "test_id:4100"}, func() {
+				oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
+				oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("destroying the CA certificate")
+				err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Delete(context.Background(), components.KubeVirtCASecretName, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("repeatedly starting VMIs until virt-api and virt-handler certificates are updated")
+				Eventually(func() (rotated bool) {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					newAPICert, _, err := tests.GetPodsCertIfSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
+					Expect(err).ToNot(HaveOccurred())
+					newHandlerCert, _, err := tests.GetPodsCertIfSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
+					Expect(err).ToNot(HaveOccurred())
+					return !reflect.DeepEqual(oldHandlerCert, newHandlerCert) && !reflect.DeepEqual(oldAPICert, newAPICert)
+				}, 120*time.Second).Should(BeTrue())
+			})
+
+			DescribeTable("should be rotated when deleted for ", func(secretName string) {
+				By("destroying the certificate")
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					secret.Data = map[string][]byte{
+						"tls.crt": []byte(""),
+						"tls.key": []byte(""),
+					}
+					_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+
+					return err
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("checking that the secret gets restored with a new certificate")
+				Eventually(func() []byte {
+					return tests.GetCertFromSecret(secretName)
+				}, 10*time.Second, 1*time.Second).Should(Not(BeEmpty()))
+			},
+				Entry("[test_id:4101] virt-operator", Labels{"test_id:4101"}, components.VirtOperatorCertSecretName),
+				Entry("[test_id:4103] virt-api", Labels{"test_id:4103"}, components.VirtApiCertSecretName),
+				Entry("[test_id:4104] virt-controller", Labels{"test_id:4104"}, components.VirtControllerCertSecretName),
+				Entry("[test_id:4105] virt-handlers client side", Labels{"test_id:4105"}, components.VirtHandlerCertSecretName),
+				Entry("[test_id:4106] virt-handlers server side", Labels{"test_id:4106"}, components.VirtHandlerServerCertSecretName),
+			)
+		})
 
 	// start a VMI, wait for it to run and return the node it runs on
 	startVMI := func(vmi *v1.VirtualMachineInstance) string {
@@ -382,475 +384,272 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		return tests.WaitForSuccessfulVMIStart(obj).Status.NodeName
 	}
 
-	Describe("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration", func() {
+	Describe("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration",
+		Labels{"rfe_id:4126", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-		Context("CriticalAddonsOnly taint set on a node", func() {
+			Context("CriticalAddonsOnly taint set on a node", func() {
 
-			var selectedNodeName string
+				var selectedNodeName string
 
-			BeforeEach(func() {
-				selectedNodeName = ""
-			})
+				BeforeEach(func() {
+					selectedNodeName = ""
+				})
 
-			AfterEach(func() {
-				if selectedNodeName != "" {
-					By("removing the taint from the tainted node")
-					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				AfterEach(func() {
+					if selectedNodeName != "" {
+						By("removing the taint from the tainted node")
+						err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+							selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
+							if err != nil {
+								return err
+							}
+
+							var taints []k8sv1.Taint
+							for _, taint := range selectedNode.Spec.Taints {
+								if taint.Key != "CriticalAddonsOnly" {
+									taints = append(taints, taint)
+								}
+							}
+
+							nodeCopy := selectedNode.DeepCopy()
+							nodeCopy.ResourceVersion = ""
+							nodeCopy.Spec.Taints = taints
+
+							_, err = virtClient.CoreV1().Nodes().Update(context.Background(), nodeCopy, metav1.UpdateOptions{})
+							return err
+						})
+						Expect(err).ShouldNot(HaveOccurred())
+					}
+				})
+
+				It("[test_id:4134] kubevirt components on that node should not evict", Labels{"test_id:4134"}, func() {
+
+					By("finding all kubevirt pods")
+					pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+					Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
+					Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
+
+					By("finding all schedulable nodes")
+					schedulableNodesList := util.GetAllSchedulableNodes(virtClient)
+					schedulableNodes := map[string]*k8sv1.Node{}
+					for _, node := range schedulableNodesList.Items {
+						schedulableNodes[node.Name] = node.DeepCopy()
+					}
+
+					By("selecting one compute only node that runs kubevirt components")
+					// master nodes should never have the CriticalAddonsOnly taint because core components might not
+					// tolerate this taint because it is meant to be used on compute nodes only. If we set this taint
+					// on a master node, we risk in breaking the test cluster.
+					for _, pod := range pods.Items {
+						node, ok := schedulableNodes[pod.Spec.NodeName]
+						if !ok {
+							// Pod is running on a non-schedulable node?
+							continue
+						}
+						if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
+							continue
+						}
+						selectedNodeName = node.Name
+						break
+					}
+
+					// It is possible to run this test on a cluster that simply does not have worker nodes.
+					// Since KubeVirt can't control that, the only correct action is to halt the test.
+					if selectedNodeName == "" {
+						Skip("Could nould determine a node to safely taint")
+					}
+
+					By("setting up a watch for terminated pods")
+					lw, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Watch(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					// in the test env, we also deploy non core-kubevirt apps
+					kvCoreApps := map[string]string{
+						"virt-handler":    "",
+						"virt-controller": "",
+						"virt-api":        "",
+						"virt-operator":   "",
+					}
+
+					signalTerminatedPods := func(stopCn <-chan bool, eventsCn <-chan watch.Event, terminatedPodsCn chan<- bool) {
+						for {
+							select {
+							case <-stopCn:
+								return
+							case e := <-eventsCn:
+								pod, ok := e.Object.(*k8sv1.Pod)
+								Expect(ok).To(BeTrue())
+								if _, isCoreApp := kvCoreApps[pod.Name]; !isCoreApp {
+									continue
+								}
+								if pod.DeletionTimestamp != nil {
+									By(fmt.Sprintf("%s terminated", pod.Name))
+									terminatedPodsCn <- true
+									return
+								}
+							}
+						}
+					}
+					stopCn := make(chan bool, 1)
+					terminatedPodsCn := make(chan bool, 1)
+					go signalTerminatedPods(stopCn, lw.ResultChan(), terminatedPodsCn)
+
+					By("tainting the selected node")
+					err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 						selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
 						if err != nil {
 							return err
 						}
 
-						var taints []k8sv1.Taint
-						for _, taint := range selectedNode.Spec.Taints {
-							if taint.Key != "CriticalAddonsOnly" {
-								taints = append(taints, taint)
-							}
-						}
+						selectedNodeCopy := selectedNode.DeepCopy()
+						selectedNodeCopy.Spec.Taints = append(selectedNodeCopy.Spec.Taints, k8sv1.Taint{
+							Key:    "CriticalAddonsOnly",
+							Value:  "",
+							Effect: k8sv1.TaintEffectNoExecute,
+						})
 
-						nodeCopy := selectedNode.DeepCopy()
-						nodeCopy.ResourceVersion = ""
-						nodeCopy.Spec.Taints = taints
-
-						_, err = virtClient.CoreV1().Nodes().Update(context.Background(), nodeCopy, metav1.UpdateOptions{})
+						_, err = virtClient.CoreV1().Nodes().Update(context.Background(), selectedNodeCopy, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ShouldNot(HaveOccurred())
-				}
-			})
 
-			It("[test_id:4134] kubevirt components on that node should not evict", func() {
-
-				By("finding all kubevirt pods")
-				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
-				Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
-				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
-
-				By("finding all schedulable nodes")
-				schedulableNodesList := util.GetAllSchedulableNodes(virtClient)
-				schedulableNodes := map[string]*k8sv1.Node{}
-				for _, node := range schedulableNodesList.Items {
-					schedulableNodes[node.Name] = node.DeepCopy()
-				}
-
-				By("selecting one compute only node that runs kubevirt components")
-				// master nodes should never have the CriticalAddonsOnly taint because core components might not
-				// tolerate this taint because it is meant to be used on compute nodes only. If we set this taint
-				// on a master node, we risk in breaking the test cluster.
-				for _, pod := range pods.Items {
-					node, ok := schedulableNodes[pod.Spec.NodeName]
-					if !ok {
-						// Pod is running on a non-schedulable node?
-						continue
-					}
-					if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
-						continue
-					}
-					selectedNodeName = node.Name
-					break
-				}
-
-				// It is possible to run this test on a cluster that simply does not have worker nodes.
-				// Since KubeVirt can't control that, the only correct action is to halt the test.
-				if selectedNodeName == "" {
-					Skip("Could nould determine a node to safely taint")
-				}
-
-				By("setting up a watch for terminated pods")
-				lw, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Watch(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				// in the test env, we also deploy non core-kubevirt apps
-				kvCoreApps := map[string]string{
-					"virt-handler":    "",
-					"virt-controller": "",
-					"virt-api":        "",
-					"virt-operator":   "",
-				}
-
-				signalTerminatedPods := func(stopCn <-chan bool, eventsCn <-chan watch.Event, terminatedPodsCn chan<- bool) {
-					for {
-						select {
-						case <-stopCn:
-							return
-						case e := <-eventsCn:
-							pod, ok := e.Object.(*k8sv1.Pod)
-							Expect(ok).To(BeTrue())
-							if _, isCoreApp := kvCoreApps[pod.Name]; !isCoreApp {
-								continue
-							}
-							if pod.DeletionTimestamp != nil {
-								By(fmt.Sprintf("%s terminated", pod.Name))
-								terminatedPodsCn <- true
-								return
-							}
-						}
-					}
-				}
-				stopCn := make(chan bool, 1)
-				terminatedPodsCn := make(chan bool, 1)
-				go signalTerminatedPods(stopCn, lw.ResultChan(), terminatedPodsCn)
-
-				By("tainting the selected node")
-				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					selectedNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), selectedNodeName, metav1.GetOptions{})
-					if err != nil {
-						return err
-					}
-
-					selectedNodeCopy := selectedNode.DeepCopy()
-					selectedNodeCopy.Spec.Taints = append(selectedNodeCopy.Spec.Taints, k8sv1.Taint{
-						Key:    "CriticalAddonsOnly",
-						Value:  "",
-						Effect: k8sv1.TaintEffectNoExecute,
-					})
-
-					_, err = virtClient.CoreV1().Nodes().Update(context.Background(), selectedNodeCopy, metav1.UpdateOptions{})
-					return err
+					Consistently(terminatedPodsCn, 5*time.Second).ShouldNot(Receive(), "pods should not terminate")
+					stopCn <- true
 				})
-				Expect(err).ShouldNot(HaveOccurred())
 
-				Consistently(terminatedPodsCn, 5*time.Second).ShouldNot(Receive(), "pods should not terminate")
-				stopCn <- true
 			})
-
-		})
-	})
-
-	Describe("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus scraped metrics", func() {
-
-		/*
-			This test is querying the metrics from Prometheus *after* they were
-			scraped and processed by the different components on the way.
-		*/
-
-		BeforeEach(func() {
-			onOCP, err := clusterutil.IsOnOpenShift(virtClient)
-			Expect(err).ToNot(HaveOccurred(), "failed to detect cluster type")
-
-			if !onOCP {
-				Skip("test is verifying integration with OCP's cluster monitoring stack")
-			}
 		})
 
-		It("[test_id:4135]should find VMI namespace on namespace label of the metric", func() {
+	Describe("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus scraped metrics",
+		Labels{"rfe_id:3187", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
 			/*
-				This test is required because in cases of misconfigurations on
-				monitoring objects (such for the ServiceMonitor), our rules will
-				still be picked up by the monitoring-operator, but Prometheus
-				will fail to load it.
+				This test is querying the metrics from Prometheus *after* they were
+				scraped and processed by the different components on the way.
 			*/
 
-			By("creating a VMI in a user defined namespace")
-			vmi := tests.NewRandomVMIWithEphemeralDisk(
-				cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			startVMI(vmi)
+			BeforeEach(func() {
+				onOCP, err := clusterutil.IsOnOpenShift(virtClient)
+				Expect(err).ToNot(HaveOccurred(), "failed to detect cluster type")
 
-			By("finding virt-operator pod")
-			ops, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
-			Expect(err).ToNot(HaveOccurred(), "failed to list virt-operators")
-			Expect(ops.Size).ToNot(Equal(0), "no virt-operators found")
-			op := ops.Items[0]
-			Expect(op).ToNot(BeNil(), "virt-operator pod should not be nil")
-
-			var ep *k8sv1.Endpoints
-			By("finding Prometheus endpoint")
-			Eventually(func() bool {
-				ep, err = virtClient.CoreV1().Endpoints("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "failed to retrieve Prometheus endpoint")
-
-				if len(ep.Subsets) == 0 || len(ep.Subsets[0].Addresses) == 0 {
-					return false
+				if !onOCP {
+					Skip("test is verifying integration with OCP's cluster monitoring stack")
 				}
-				return true
-			}, 10*time.Second, time.Second).Should(BeTrue())
+			})
 
-			promIP := ep.Subsets[0].Addresses[0].IP
-			Expect(promIP).ToNot(Equal(0), "could not get Prometheus IP from endpoint")
-			var promPort int32
-			for _, port := range ep.Subsets[0].Ports {
-				if port.Name == "web" {
-					promPort = port.Port
+			It("[test_id:4135]should find VMI namespace on namespace label of the metric", Labels{"test_id:4135"}, func() {
+
+				/*
+					This test is required because in cases of misconfigurations on
+					monitoring objects (such for the ServiceMonitor), our rules will
+					still be picked up by the monitoring-operator, but Prometheus
+					will fail to load it.
+				*/
+
+				By("creating a VMI in a user defined namespace")
+				vmi := tests.NewRandomVMIWithEphemeralDisk(
+					cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				startVMI(vmi)
+
+				By("finding virt-operator pod")
+				ops, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
+				Expect(err).ToNot(HaveOccurred(), "failed to list virt-operators")
+				Expect(ops.Size).ToNot(Equal(0), "no virt-operators found")
+				op := ops.Items[0]
+				Expect(op).ToNot(BeNil(), "virt-operator pod should not be nil")
+
+				var ep *k8sv1.Endpoints
+				By("finding Prometheus endpoint")
+				Eventually(func() bool {
+					ep, err = virtClient.CoreV1().Endpoints("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred(), "failed to retrieve Prometheus endpoint")
+
+					if len(ep.Subsets) == 0 || len(ep.Subsets[0].Addresses) == 0 {
+						return false
+					}
+					return true
+				}, 10*time.Second, time.Second).Should(BeTrue())
+
+				promIP := ep.Subsets[0].Addresses[0].IP
+				Expect(promIP).ToNot(Equal(0), "could not get Prometheus IP from endpoint")
+				var promPort int32
+				for _, port := range ep.Subsets[0].Ports {
+					if port.Name == "web" {
+						promPort = port.Port
+					}
 				}
-			}
-			Expect(promPort).ToNot(Equal(0), "could not get Prometheus port from endpoint")
+				Expect(promPort).ToNot(Equal(0), "could not get Prometheus port from endpoint")
 
-			// We need a token from a service account that can view all namespaces in the cluster
-			By("extracting virt-operator sa token")
-			token, _, err := tests.ExecuteCommandOnPodV2(virtClient,
-				&op,
-				"virt-operator",
-				[]string{
-					"cat",
-					"/var/run/secrets/kubernetes.io/serviceaccount/token",
-				})
-			Expect(err).ToNot(HaveOccurred(), "failed executing command on virt-operator")
-			Expect(token).ToNot(BeEmpty(), "virt-operator sa token returned empty")
-
-			By("querying Prometheus API endpoint for a VMI exported metric")
-			stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
-				&op,
-				"virt-operator",
-				[]string{
-					"curl",
-					"-L",
-					"-k",
-					fmt.Sprintf("https://%s:%d/api/v1/query", promIP, promPort),
-					"-H",
-					fmt.Sprintf("Authorization: Bearer %s", token),
-					"--data-urlencode",
-					fmt.Sprintf(
-						`query=kubevirt_vmi_memory_resident_bytes{namespace="%s",name="%s"}`,
-						vmi.Namespace,
-						vmi.Name,
-					),
-				})
-			Expect(err).ToNot(HaveOccurred(), "failed to execute query")
-
-			// the Prometheus go-client does not export queryResult, and
-			// using an HTTP client for queries would require a port-forwarding
-			// since the cluster is running in a different network.
-			var queryResult map[string]json.RawMessage
-
-			err = json.Unmarshal([]byte(stdout), &queryResult)
-			Expect(err).ToNot(HaveOccurred(), "failed to unmarshal query result")
-
-			var status string
-			err = json.Unmarshal(queryResult["status"], &status)
-			Expect(err).ToNot(HaveOccurred(), "failed to unmarshal query status")
-			Expect(status).To(Equal("success"))
-		})
-	})
-
-	Describe("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints", func() {
-		var preparedVMIs []*v1.VirtualMachineInstance
-		var pod *k8sv1.Pod
-		var handlerMetricIPs []string
-		var controllerMetricIPs []string
-
-		pinVMIOnNode := func(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualMachineInstance {
-			if vmi == nil {
-				return nil
-			}
-			if vmi.Spec.NodeSelector == nil {
-				vmi.Spec.NodeSelector = make(map[string]string)
-			}
-			vmi.Spec.NodeSelector["kubernetes.io/hostname"] = nodeName
-			return vmi
-		}
-
-		// returns metrics from the node the VMI(s) runs on
-		getKubevirtVMMetrics := func(ip string) string {
-			metricsURL := prepareMetricsURL(ip, 8443)
-			stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
-				pod,
-				"virt-handler",
-				[]string{
-					"curl",
-					"-L",
-					"-k",
-					metricsURL,
-				})
-			Expect(err).ToNot(HaveOccurred())
-			return stdout
-		}
-
-		// collect metrics whose key contains the given string, expects non-empty result
-		collectMetrics := func(ip, metricSubstring string) map[string]float64 {
-			By("Scraping the Prometheus endpoint")
-			var metrics map[string]float64
-			var lines []string
-
-			Eventually(func() map[string]float64 {
-				out := getKubevirtVMMetrics(ip)
-				lines = takeMetricsWithPrefix(out, metricSubstring)
-				metrics, err = parseMetricsToMap(lines)
-				Expect(err).ToNot(HaveOccurred())
-				return metrics
-			}, 30*time.Second, 2*time.Second).ShouldNot(BeEmpty())
-
-			// troubleshooting helper
-			fmt.Fprintf(GinkgoWriter, "metrics [%s]:\nlines=%s\n%#v\n", metricSubstring, lines, metrics)
-			Expect(len(metrics)).To(BeNumerically(">=", float64(1.0)))
-			Expect(metrics).To(HaveLen(len(lines)))
-
-			return metrics
-		}
-
-		prepareVMIForTests := func(preferredNodeName string) string {
-			By("Creating the VirtualMachineInstance")
-
-			// WARNING: we assume the VM will have a VirtIO disk (vda)
-			// and we add our own vdb on which we do our test.
-			// but if the default disk is not vda, the test will break
-			// TODO: introspect the VMI and get the device name of this
-			// block device?
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			tests.AppendEmptyDisk(vmi, "testdisk", "virtio", "1Gi")
-
-			if preferredNodeName != "" {
-				pinVMIOnNode(vmi, preferredNodeName)
-			}
-			nodeName := startVMI(vmi)
-			if preferredNodeName != "" {
-				Expect(nodeName).To(Equal(preferredNodeName), "Should run VMIs on the same node")
-			}
-
-			By("Expecting the VirtualMachineInstance console")
-			// This also serves as a sync point to make sure the VM completed the boot
-			// (and reduce the risk of false negatives)
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-			By("Writing some data to the disk")
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "dd if=/dev/zero of=/dev/vdb bs=1M count=1\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "sync\n"},
-				&expect.BExp{R: console.PromptExpression},
-			}, 10)).To(Succeed())
-
-			preparedVMIs = append(preparedVMIs, vmi)
-			return nodeName
-		}
-
-		tests.DeprecatedBeforeAll(func() {
-			tests.BeforeTestCleanup()
-
-			By("Finding the virt-controller prometheus endpoint")
-			virtControllerLeaderPodName := getLeader()
-			leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), virtControllerLeaderPodName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred(), "Should find the virt-controller pod")
-
-			for _, ip := range leaderPod.Status.PodIPs {
-				controllerMetricIPs = append(controllerMetricIPs, ip.IP)
-			}
-
-			// The initial test for the metrics subsystem used only a single VM for the sake of simplicity.
-			// However, testing a single entity is a corner case (do we test handling sequences? potential clashes
-			// in maps? and so on).
-			// Thus, we run now two VMIs per testcase. A more realistic test would use a random number of VMIs >= 3,
-			// but we don't do now to make test run quickly and (more important) because lack of resources on CI.
-
-			nodeName := prepareVMIForTests("")
-			// any node is fine, we don't really care, as long as we run all VMIs on it.
-			prepareVMIForTests(nodeName)
-
-			By("Finding the virt-handler prometheus endpoint")
-			pod, err = kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
-			Expect(err).ToNot(HaveOccurred(), "Should find the virt-handler pod")
-			for _, ip := range pod.Status.PodIPs {
-				handlerMetricIPs = append(handlerMetricIPs, ip.IP)
-			}
-		})
-
-		PIt("[test_id:4136][flaky] should find one leading virt-controller and two ready", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			foundMetrics := map[string]int{
-				"ready":   0,
-				"leading": 0,
-			}
-			By("scraping the metrics endpoint on virt-controller pods")
-			for _, ep := range endpoint.Subsets[0].Addresses {
-				if !strings.HasPrefix(ep.TargetRef.Name, "virt-controller") {
-					continue
-				}
-				stdout, _, err := tests.ExecuteCommandOnPodV2(
-					virtClient,
-					pod,
-					"virt-handler",
+				// We need a token from a service account that can view all namespaces in the cluster
+				By("extracting virt-operator sa token")
+				token, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+					&op,
+					"virt-operator",
 					[]string{
-						"curl", "-L", "-k",
-						fmt.Sprintf("https://%s:8443/metrics", tests.FormatIPForURL(ep.IP)),
+						"cat",
+						"/var/run/secrets/kubernetes.io/serviceaccount/token",
 					})
-				Expect(err).ToNot(HaveOccurred())
-				scrapedData := strings.Split(stdout, "\n")
-				for _, data := range scrapedData {
-					if strings.HasPrefix(data, "#") {
-						continue
-					}
-					switch data {
-					case "kubevirt_virt_controller_leading 1":
-						foundMetrics["leading"]++
-					case "kubevirt_virt_controller_ready 1":
-						foundMetrics["ready"]++
-					}
-				}
-			}
+				Expect(err).ToNot(HaveOccurred(), "failed executing command on virt-operator")
+				Expect(token).ToNot(BeEmpty(), "virt-operator sa token returned empty")
 
-			Expect(foundMetrics["ready"]).To(Equal(2), "expected 2 ready virt-controllers")
-			Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-controller")
-		})
-
-		It("[test_id:4137]should find one leading virt-operator and two ready", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			foundMetrics := map[string]int{
-				"ready":   0,
-				"leading": 0,
-			}
-			By("scraping the metrics endpoint on virt-operator pods")
-			for _, ep := range endpoint.Subsets[0].Addresses {
-				if !strings.HasPrefix(ep.TargetRef.Name, "virt-operator") {
-					continue
-				}
-				stdout, _, err := tests.ExecuteCommandOnPodV2(
-					virtClient,
-					pod,
-					"virt-handler",
+				By("querying Prometheus API endpoint for a VMI exported metric")
+				stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+					&op,
+					"virt-operator",
 					[]string{
-						"curl", "-L", "-k",
-						fmt.Sprintf("https://%s:8443/metrics", tests.FormatIPForURL(ep.IP)),
+						"curl",
+						"-L",
+						"-k",
+						fmt.Sprintf("https://%s:%d/api/v1/query", promIP, promPort),
+						"-H",
+						fmt.Sprintf("Authorization: Bearer %s", token),
+						"--data-urlencode",
+						fmt.Sprintf(
+							`query=kubevirt_vmi_memory_resident_bytes{namespace="%s",name="%s"}`,
+							vmi.Namespace,
+							vmi.Name,
+						),
 					})
-				Expect(err).ToNot(HaveOccurred())
-				scrapedData := strings.Split(stdout, "\n")
-				for _, data := range scrapedData {
-					if strings.HasPrefix(data, "#") {
-						continue
-					}
-					switch data {
-					case "kubevirt_virt_operator_leading 1":
-						foundMetrics["leading"]++
-					case "kubevirt_virt_operator_ready 1":
-						foundMetrics["ready"]++
-					}
+				Expect(err).ToNot(HaveOccurred(), "failed to execute query")
+
+				// the Prometheus go-client does not export queryResult, and
+				// using an HTTP client for queries would require a port-forwarding
+				// since the cluster is running in a different network.
+				var queryResult map[string]json.RawMessage
+
+				err = json.Unmarshal([]byte(stdout), &queryResult)
+				Expect(err).ToNot(HaveOccurred(), "failed to unmarshal query result")
+
+				var status string
+				err = json.Unmarshal(queryResult["status"], &status)
+				Expect(err).ToNot(HaveOccurred(), "failed to unmarshal query status")
+				Expect(status).To(Equal("success"))
+			})
+		})
+
+	Describe("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component]Prometheus Endpoints",
+		Labels{"rfe_id:3187", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			var preparedVMIs []*v1.VirtualMachineInstance
+			var pod *k8sv1.Pod
+			var handlerMetricIPs []string
+			var controllerMetricIPs []string
+
+			pinVMIOnNode := func(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualMachineInstance {
+				if vmi == nil {
+					return nil
 				}
+				if vmi.Spec.NodeSelector == nil {
+					vmi.Spec.NodeSelector = make(map[string]string)
+				}
+				vmi.Spec.NodeSelector["kubernetes.io/hostname"] = nodeName
+				return vmi
 			}
 
-			Expect(foundMetrics["ready"]).To(Equal(2), "expected 2 ready virt-operators")
-			Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-operator")
-		})
-
-		It("[test_id:4138]should be exposed and registered on the metrics endpoint", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			l, err := labels.Parse("prometheus.kubevirt.io=true")
-			Expect(err).ToNot(HaveOccurred())
-			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(endpoint.Subsets).To(HaveLen(1))
-
-			By("checking if the endpoint contains the metrics port and only one matching subset")
-			Expect(endpoint.Subsets[0].Ports).To(HaveLen(1))
-			Expect(endpoint.Subsets[0].Ports[0].Name).To(Equal("metrics"))
-			Expect(endpoint.Subsets[0].Ports[0].Port).To(Equal(int32(8443)))
-
-			By("checking if  the IPs in the subset match the KubeVirt system Pod count")
-			Expect(len(pods.Items)).To(BeNumerically(">=", 3), "At least one api, controller and handler need to be present")
-			Expect(endpoint.Subsets[0].Addresses).To(HaveLen(len(pods.Items)))
-
-			ips := map[string]string{}
-			for _, ep := range endpoint.Subsets[0].Addresses {
-				ips[ep.IP] = ""
-			}
-			for _, pod := range pods.Items {
-				Expect(ips).To(HaveKey(pod.Status.PodIP), fmt.Sprintf("IP of Pod %s not found in metrics endpoint", pod.Name))
-			}
-		})
-		It("[test_id:4139]should return Prometheus metrics", func() {
-			endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			for _, ep := range endpoint.Subsets[0].Addresses {
+			// returns metrics from the node the VMI(s) runs on
+			getKubevirtVMMetrics := func(ip string) string {
+				metricsURL := prepareMetricsURL(ip, 8443)
 				stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
 					pod,
 					"virt-handler",
@@ -858,262 +657,473 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 						"curl",
 						"-L",
 						"-k",
-						fmt.Sprintf("https://%s:%s/metrics", tests.FormatIPForURL(ep.IP), "8443"),
+						metricsURL,
 					})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(stdout).To(ContainSubstring("go_goroutines"))
-			}
-		})
-
-		DescribeTable("should throttle the Prometheus metrics access", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
-
-			ip := getSupportedIP(handlerMetricIPs, family)
-
-			if netutils.IsIPv6String(ip) {
-				Skip("Skip testing with IPv6 until https://github.com/kubevirt/kubevirt/issues/4145 is fixed")
+				return stdout
 			}
 
-			concurrency := 100 // random value "much higher" than maxRequestsInFlight
+			// collect metrics whose key contains the given string, expects non-empty result
+			collectMetrics := func(ip, metricSubstring string) map[string]float64 {
+				By("Scraping the Prometheus endpoint")
+				var metrics map[string]float64
+				var lines []string
 
-			tr := &http.Transport{
-				MaxIdleConnsPerHost: concurrency,
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
+				Eventually(func() map[string]float64 {
+					out := getKubevirtVMMetrics(ip)
+					lines = takeMetricsWithPrefix(out, metricSubstring)
+					metrics, err = parseMetricsToMap(lines)
+					Expect(err).ToNot(HaveOccurred())
+					return metrics
+				}, 30*time.Second, 2*time.Second).ShouldNot(BeEmpty())
+
+				// troubleshooting helper
+				fmt.Fprintf(GinkgoWriter, "metrics [%s]:\nlines=%s\n%#v\n", metricSubstring, lines, metrics)
+				Expect(len(metrics)).To(BeNumerically(">=", float64(1.0)))
+				Expect(metrics).To(HaveLen(len(lines)))
+
+				return metrics
 			}
 
-			client := http.Client{
-				Timeout:   time.Duration(1 * time.Second),
-				Transport: tr,
+			prepareVMIForTests := func(preferredNodeName string) string {
+				By("Creating the VirtualMachineInstance")
+
+				// WARNING: we assume the VM will have a VirtIO disk (vda)
+				// and we add our own vdb on which we do our test.
+				// but if the default disk is not vda, the test will break
+				// TODO: introspect the VMI and get the device name of this
+				// block device?
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				tests.AppendEmptyDisk(vmi, "testdisk", "virtio", "1Gi")
+
+				if preferredNodeName != "" {
+					pinVMIOnNode(vmi, preferredNodeName)
+				}
+				nodeName := startVMI(vmi)
+				if preferredNodeName != "" {
+					Expect(nodeName).To(Equal(preferredNodeName), "Should run VMIs on the same node")
+				}
+
+				By("Expecting the VirtualMachineInstance console")
+				// This also serves as a sync point to make sure the VM completed the boot
+				// (and reduce the risk of false negatives)
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+				By("Writing some data to the disk")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "dd if=/dev/zero of=/dev/vdb bs=1M count=1\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "sync\n"},
+					&expect.BExp{R: console.PromptExpression},
+				}, 10)).To(Succeed())
+
+				preparedVMIs = append(preparedVMIs, vmi)
+				return nodeName
 			}
 
-			errorsChan := make(chan error)
-			By("Scraping the Prometheus endpoint")
-			metricsURL := prepareMetricsURL(ip, 8443)
-			for ix := 0; ix < concurrency; ix++ {
-				go func(ix int) {
-					req, _ := http.NewRequest("GET", metricsURL, nil)
-					resp, err := client.Do(req)
-					if err != nil {
-						fmt.Fprintf(GinkgoWriter, "client: request: %v #%d: %v\n", req, ix, err) // troubleshooting helper
-					} else {
-						resp.Body.Close()
+			tests.DeprecatedBeforeAll(func() {
+				tests.BeforeTestCleanup()
+
+				By("Finding the virt-controller prometheus endpoint")
+				virtControllerLeaderPodName := getLeader()
+				leaderPod, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).Get(context.Background(), virtControllerLeaderPodName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should find the virt-controller pod")
+
+				for _, ip := range leaderPod.Status.PodIPs {
+					controllerMetricIPs = append(controllerMetricIPs, ip.IP)
+				}
+
+				// The initial test for the metrics subsystem used only a single VM for the sake of simplicity.
+				// However, testing a single entity is a corner case (do we test handling sequences? potential clashes
+				// in maps? and so on).
+				// Thus, we run now two VMIs per testcase. A more realistic test would use a random number of VMIs >= 3,
+				// but we don't do now to make test run quickly and (more important) because lack of resources on CI.
+
+				nodeName := prepareVMIForTests("")
+				// any node is fine, we don't really care, as long as we run all VMIs on it.
+				prepareVMIForTests(nodeName)
+
+				By("Finding the virt-handler prometheus endpoint")
+				pod, err = kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
+				Expect(err).ToNot(HaveOccurred(), "Should find the virt-handler pod")
+				for _, ip := range pod.Status.PodIPs {
+					handlerMetricIPs = append(handlerMetricIPs, ip.IP)
+				}
+			})
+
+			PIt("[test_id:4136][flaky] should find one leading virt-controller and two ready",
+				Labels{"test_id:4136", "flaky"},
+				func() {
+					endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					foundMetrics := map[string]int{
+						"ready":   0,
+						"leading": 0,
 					}
-					errorsChan <- err
-				}(ix)
-			}
+					By("scraping the metrics endpoint on virt-controller pods")
+					for _, ep := range endpoint.Subsets[0].Addresses {
+						if !strings.HasPrefix(ep.TargetRef.Name, "virt-controller") {
+							continue
+						}
+						stdout, _, err := tests.ExecuteCommandOnPodV2(
+							virtClient,
+							pod,
+							"virt-handler",
+							[]string{
+								"curl", "-L", "-k",
+								fmt.Sprintf("https://%s:8443/metrics", tests.FormatIPForURL(ep.IP)),
+							})
+						Expect(err).ToNot(HaveOccurred())
+						scrapedData := strings.Split(stdout, "\n")
+						for _, data := range scrapedData {
+							if strings.HasPrefix(data, "#") {
+								continue
+							}
+							switch data {
+							case "kubevirt_virt_controller_leading 1":
+								foundMetrics["leading"]++
+							case "kubevirt_virt_controller_ready 1":
+								foundMetrics["ready"]++
+							}
+						}
+					}
 
-			err := validatedHTTPResponses(errorsChan, concurrency)
-			Expect(err).ToNot(HaveOccurred(), "Should throttle HTTP access without unexpected errors")
-		},
-			Entry("[test_id:4140] by using IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6226] by using IPv6", k8sv1.IPv6Protocol),
-		)
+					Expect(foundMetrics["ready"]).To(Equal(2), "expected 2 ready virt-controllers")
+					Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-controller")
+				})
 
-		DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			It("[test_id:4137]should find one leading virt-operator and two ready", Labels{"test_id:4137"}, func() {
+				endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				foundMetrics := map[string]int{
+					"ready":   0,
+					"leading": 0,
+				}
+				By("scraping the metrics endpoint on virt-operator pods")
+				for _, ep := range endpoint.Subsets[0].Addresses {
+					if !strings.HasPrefix(ep.TargetRef.Name, "virt-operator") {
+						continue
+					}
+					stdout, _, err := tests.ExecuteCommandOnPodV2(
+						virtClient,
+						pod,
+						"virt-handler",
+						[]string{
+							"curl", "-L", "-k",
+							fmt.Sprintf("https://%s:8443/metrics", tests.FormatIPForURL(ep.IP)),
+						})
+					Expect(err).ToNot(HaveOccurred())
+					scrapedData := strings.Split(stdout, "\n")
+					for _, data := range scrapedData {
+						if strings.HasPrefix(data, "#") {
+							continue
+						}
+						switch data {
+						case "kubevirt_virt_operator_leading 1":
+							foundMetrics["leading"]++
+						case "kubevirt_virt_operator_ready 1":
+							foundMetrics["ready"]++
+						}
+					}
+				}
 
-			ip := getSupportedIP(handlerMetricIPs, family)
+				Expect(foundMetrics["ready"]).To(Equal(2), "expected 2 ready virt-operators")
+				Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-operator")
+			})
 
-			By("Scraping the Prometheus endpoint")
-			Eventually(func() string {
-				out := getKubevirtVMMetrics(ip)
-				lines := takeMetricsWithPrefix(out, "kubevirt")
-				return strings.Join(lines, "\n")
-			}, 30*time.Second, 2*time.Second).Should(ContainSubstring("kubevirt"))
-		},
-			Entry("[test_id:4141] by using IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6227] by using IPv6", k8sv1.IPv6Protocol),
-		)
+			It("[test_id:4138]should be exposed and registered on the metrics endpoint", Labels{"test_id:4138"}, func() {
+				endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				l, err := labels.Parse("prometheus.kubevirt.io=true")
+				Expect(err).ToNot(HaveOccurred())
+				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(endpoint.Subsets).To(HaveLen(1))
 
-		DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+				By("checking if the endpoint contains the metrics port and only one matching subset")
+				Expect(endpoint.Subsets[0].Ports).To(HaveLen(1))
+				Expect(endpoint.Subsets[0].Ports[0].Name).To(Equal("metrics"))
+				Expect(endpoint.Subsets[0].Ports[0].Port).To(Equal(int32(8443)))
 
-			ip := getSupportedIP(handlerMetricIPs, family)
+				By("checking if  the IPs in the subset match the KubeVirt system Pod count")
+				Expect(len(pods.Items)).To(BeNumerically(">=", 3), "At least one api, controller and handler need to be present")
+				Expect(endpoint.Subsets[0].Addresses).To(HaveLen(len(pods.Items)))
 
-			metrics := collectMetrics(ip, metricSubstring)
-			By("Checking the collected metrics")
-			keys := getKeysFromMetrics(metrics)
-			for _, vmi := range preparedVMIs {
-				for _, vol := range vmi.Spec.Volumes {
-					key := getMetricKeyForVmiDisk(keys, vmi.Name, vol.Name)
-					Expect(key).To(Not(BeEmpty()))
+				ips := map[string]string{}
+				for _, ep := range endpoint.Subsets[0].Addresses {
+					ips[ep.IP] = ""
+				}
+				for _, pod := range pods.Items {
+					Expect(ips).To(HaveKey(pod.Status.PodIP), fmt.Sprintf("IP of Pod %s not found in metrics endpoint", pod.Name))
+				}
+			})
+			It("[test_id:4139]should return Prometheus metrics", Labels{"test_id:4139"}, func() {
+				endpoint, err := virtClient.CoreV1().Endpoints(flags.KubeVirtInstallNamespace).Get(context.Background(), "kubevirt-prometheus-metrics", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, ep := range endpoint.Subsets[0].Addresses {
+					stdout, _, err := tests.ExecuteCommandOnPodV2(virtClient,
+						pod,
+						"virt-handler",
+						[]string{
+							"curl",
+							"-L",
+							"-k",
+							fmt.Sprintf("https://%s:%s/metrics", tests.FormatIPForURL(ep.IP), "8443"),
+						})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(stdout).To(ContainSubstring("go_goroutines"))
+				}
+			})
 
+			DescribeTable("should throttle the Prometheus metrics access", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+
+				ip := getSupportedIP(handlerMetricIPs, family)
+
+				if netutils.IsIPv6String(ip) {
+					Skip("Skip testing with IPv6 until https://github.com/kubevirt/kubevirt/issues/4145 is fixed")
+				}
+
+				concurrency := 100 // random value "much higher" than maxRequestsInFlight
+
+				tr := &http.Transport{
+					MaxIdleConnsPerHost: concurrency,
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				}
+
+				client := http.Client{
+					Timeout:   time.Duration(1 * time.Second),
+					Transport: tr,
+				}
+
+				errorsChan := make(chan error)
+				By("Scraping the Prometheus endpoint")
+				metricsURL := prepareMetricsURL(ip, 8443)
+				for ix := 0; ix < concurrency; ix++ {
+					go func(ix int) {
+						req, _ := http.NewRequest("GET", metricsURL, nil)
+						resp, err := client.Do(req)
+						if err != nil {
+							fmt.Fprintf(GinkgoWriter, "client: request: %v #%d: %v\n", req, ix, err) // troubleshooting helper
+						} else {
+							resp.Body.Close()
+						}
+						errorsChan <- err
+					}(ix)
+				}
+
+				err := validatedHTTPResponses(errorsChan, concurrency)
+				Expect(err).ToNot(HaveOccurred(), "Should throttle HTTP access without unexpected errors")
+			},
+				Entry("[test_id:4140] by using IPv4", Labels{"test_id:4140"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6226] by using IPv6", Labels{"test_id:6226"}, k8sv1.IPv6Protocol),
+			)
+
+			DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+
+				ip := getSupportedIP(handlerMetricIPs, family)
+
+				By("Scraping the Prometheus endpoint")
+				Eventually(func() string {
+					out := getKubevirtVMMetrics(ip)
+					lines := takeMetricsWithPrefix(out, "kubevirt")
+					return strings.Join(lines, "\n")
+				}, 30*time.Second, 2*time.Second).Should(ContainSubstring("kubevirt"))
+			},
+				Entry("[test_id:4141] by using IPv4", Labels{"test_id:4141"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6227] by using IPv6", Labels{"test_id:6227"}, k8sv1.IPv6Protocol),
+			)
+
+			DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+
+				ip := getSupportedIP(handlerMetricIPs, family)
+
+				metrics := collectMetrics(ip, metricSubstring)
+				By("Checking the collected metrics")
+				keys := getKeysFromMetrics(metrics)
+				for _, vmi := range preparedVMIs {
+					for _, vol := range vmi.Spec.Volumes {
+						key := getMetricKeyForVmiDisk(keys, vmi.Name, vol.Name)
+						Expect(key).To(Not(BeEmpty()))
+
+						value := metrics[key]
+						fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
+						Expect(value).To(BeNumerically(operator, float64(0.0)))
+
+					}
+				}
+			},
+				Entry("[test_id:4142] storage flush requests metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
+				Entry("[test_id:6228] storage flush requests metric by using IPv6", Labels{"test_id:6228"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
+				Entry("[test_id:4142] time (ms) spent on cache flushing metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
+				Entry("[test_id:6229] time (ms) spent on cache flushing metric by using IPv6", Labels{"test_id:6229"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
+				Entry("[test_id:4142] I/O read operations metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
+				Entry("[test_id:6230] I/O read operations metric by using IPv6", Labels{"test_id:6230"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
+				Entry("[test_id:4142] I/O write operations metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
+				Entry("[test_id:6231] I/O write operations metric by using IPv6", Labels{"test_id:6231"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
+				Entry("[test_id:4142] storage read operation time metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
+				Entry("[test_id:6232] storage read operation time metric by using IPv6", Labels{"test_id:6232"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
+				Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+				Entry("[test_id:6233] storage read traffic in bytes metric by using IPv6", Labels{"test_id:6233"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+				Entry("[test_id:4142] storage write operation time metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
+				Entry("[test_id:6234] storage write operation time metric by using IPv6", Labels{"test_id:6234"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
+				Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4", Labels{"test_id:4142"}, k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+				Entry("[test_id:6235] storage write traffic in bytes metric by using IPv6", Labels{"test_id:6235"}, k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+			)
+
+			DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+
+				ip := getSupportedIP(handlerMetricIPs, family)
+
+				metrics := collectMetrics(ip, metricSubstring)
+				By("Checking the collected metrics")
+				keys := getKeysFromMetrics(metrics)
+				for _, key := range keys {
 					value := metrics[key]
 					fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
 					Expect(value).To(BeNumerically(operator, float64(0.0)))
-
 				}
-			}
-		},
-			Entry("[test_id:4142] storage flush requests metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-			Entry("[test_id:6228] storage flush requests metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
-			Entry("[test_id:4142] time (ms) spent on cache flushing metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
-			Entry("[test_id:6229] time (ms) spent on cache flushing metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
-			Entry("[test_id:4142] I/O read operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-			Entry("[test_id:6230] I/O read operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
-			Entry("[test_id:4142] I/O write operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-			Entry("[test_id:6231] I/O write operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
-			Entry("[test_id:4142] storage read operation time metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
-			Entry("[test_id:6232] storage read operation time metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
-			Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-			Entry("[test_id:6233] storage read traffic in bytes metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-			Entry("[test_id:4142] storage write operation time metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
-			Entry("[test_id:6234] storage write operation time metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
-			Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
-			Entry("[test_id:6235] storage write traffic in bytes metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
-		)
+			},
+				Entry("[test_id:4143] network metrics by IPv4", Labels{"test_id:4143"}, k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
+				Entry("[test_id:6236] network metrics by IPv6", Labels{"test_id:6236"}, k8sv1.IPv6Protocol, "kubevirt_vmi_network_", ">="),
+				Entry("[test_id:4144] memory metrics by IPv4", Labels{"test_id:4144"}, k8sv1.IPv4Protocol, "kubevirt_vmi_memory", ">="),
+				Entry("[test_id:6237] memory metrics by IPv6", Labels{"test_id:6237"}, k8sv1.IPv6Protocol, "kubevirt_vmi_memory", ">="),
+				Entry("[test_id:4553] vcpu wait by IPv4", Labels{"test_id:4553"}, k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_wait", "=="),
+				Entry("[test_id:6238] vcpu wait by IPv6", Labels{"test_id:6238"}, k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_wait", "=="),
+				Entry("[test_id:4554] vcpu seconds by IPv4", Labels{"test_id:4554"}, k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
+				Entry("[test_id:6239] vcpu seconds by IPv6", Labels{"test_id:6239"}, k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
+				Entry("[test_id:4556] vmi unused memory by IPv4", Labels{"test_id:4556"}, k8sv1.IPv4Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
+				Entry("[test_id:6240] vmi unused memory by IPv6", Labels{"test_id:6240"}, k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
+			)
 
-		DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
-			ip := getSupportedIP(handlerMetricIPs, family)
+				ip := getSupportedIP(handlerMetricIPs, family)
 
-			metrics := collectMetrics(ip, metricSubstring)
-			By("Checking the collected metrics")
-			keys := getKeysFromMetrics(metrics)
-			for _, key := range keys {
-				value := metrics[key]
-				fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
-				Expect(value).To(BeNumerically(operator, float64(0.0)))
-			}
-		},
-			Entry("[test_id:4143] network metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_network_", ">="),
-			Entry("[test_id:6236] network metrics by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_network_", ">="),
-			Entry("[test_id:4144] memory metrics by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_memory", ">="),
-			Entry("[test_id:6237] memory metrics by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory", ">="),
-			Entry("[test_id:4553] vcpu wait by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-			Entry("[test_id:6238] vcpu wait by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_wait", "=="),
-			Entry("[test_id:4554] vcpu seconds by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
-			Entry("[test_id:6239] vcpu seconds by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_vcpu_seconds", ">="),
-			Entry("[test_id:4556] vmi unused memory by IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
-			Entry("[test_id:6240] vmi unused memory by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
-		)
+				metrics := collectMetrics(ip, "kubevirt_vmi_")
+				By("Checking the collected metrics")
+				keys := getKeysFromMetrics(metrics)
+				nodeName := pod.Spec.NodeName
 
-		DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
-
-			ip := getSupportedIP(handlerMetricIPs, family)
-
-			metrics := collectMetrics(ip, "kubevirt_vmi_")
-			By("Checking the collected metrics")
-			keys := getKeysFromMetrics(metrics)
-			nodeName := pod.Spec.NodeName
-
-			nameMatchers := []gomegatypes.GomegaMatcher{}
-			for _, vmi := range preparedVMIs {
-				nameMatchers = append(nameMatchers, ContainSubstring(`name="%s"`, vmi.Name))
-			}
-
-			for _, key := range keys {
-				// we don't care about the ordering of the labels
-				if strings.HasPrefix(key, "kubevirt_vmi_phase_count") {
-					// special case: namespace and name don't make sense for this metric
-					Expect(key).To(ContainSubstring(`node="%s"`, nodeName))
-					continue
+				nameMatchers := []gomegatypes.GomegaMatcher{}
+				for _, vmi := range preparedVMIs {
+					nameMatchers = append(nameMatchers, ContainSubstring(`name="%s"`, vmi.Name))
 				}
 
-				Expect(key).To(SatisfyAll(
-					ContainSubstring(`node="%s"`, nodeName),
-					// all testing VMIs are on the same node and namespace,
-					// so checking the namespace of any random VMI is fine
-					ContainSubstring(`namespace="%s"`, preparedVMIs[0].Namespace),
-					// otherwise, each key must refer to exactly one the prepared VMIs.
-					SatisfyAny(nameMatchers...),
-				))
-			}
-		},
-			Entry("[test_id:4145] by IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6241] by IPv6", k8sv1.IPv6Protocol),
-		)
+				for _, key := range keys {
+					// we don't care about the ordering of the labels
+					if strings.HasPrefix(key, "kubevirt_vmi_phase_count") {
+						// special case: namespace and name don't make sense for this metric
+						Expect(key).To(ContainSubstring(`node="%s"`, nodeName))
+						continue
+					}
 
-		DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+					Expect(key).To(SatisfyAll(
+						ContainSubstring(`node="%s"`, nodeName),
+						// all testing VMIs are on the same node and namespace,
+						// so checking the namespace of any random VMI is fine
+						ContainSubstring(`namespace="%s"`, preparedVMIs[0].Namespace),
+						// otherwise, each key must refer to exactly one the prepared VMIs.
+						SatisfyAny(nameMatchers...),
+					))
+				}
+			},
+				Entry("[test_id:4145] by IPv4", Labels{"test_id:4145"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6241] by IPv6", Labels{"test_id:6241"}, k8sv1.IPv6Protocol),
+			)
 
-			ip := getSupportedIP(handlerMetricIPs, family)
+			DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
-			metrics := collectMetrics(ip, "kubevirt_vmi_")
-			By("Checking the collected metrics")
-			keys := getKeysFromMetrics(metrics)
-			for _, key := range keys {
-				if strings.Contains(key, `phase="running"`) {
+				ip := getSupportedIP(handlerMetricIPs, family)
+
+				metrics := collectMetrics(ip, "kubevirt_vmi_")
+				By("Checking the collected metrics")
+				keys := getKeysFromMetrics(metrics)
+				for _, key := range keys {
+					if strings.Contains(key, `phase="running"`) {
+						value := metrics[key]
+						Expect(value).To(Equal(float64(len(preparedVMIs))))
+					}
+				}
+			},
+				Entry("[test_id:4146] by IPv4", Labels{"test_id:4146"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6242] by IPv6", Labels{"test_id:6242"}, k8sv1.IPv6Protocol),
+			)
+
+			DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+
+				ip := getSupportedIP(controllerMetricIPs, family)
+
+				metrics := collectMetrics(ip, "kubevirt_vmi_non_evictable")
+				By("Checking the collected metrics")
+				keys := getKeysFromMetrics(metrics)
+				for _, key := range keys {
 					value := metrics[key]
-					Expect(value).To(Equal(float64(len(preparedVMIs))))
+					fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
+					Expect(value).To(BeNumerically(">=", float64(0.0)))
 				}
-			}
-		},
-			Entry("[test_id:4146] by IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6242] by IPv6", k8sv1.IPv6Protocol),
-		)
+			},
+				Entry("[test_id:4148] by IPv4", Labels{"test_id:4148"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6243] by IPv6", Labels{"test_id:6243"}, k8sv1.IPv6Protocol),
+			)
 
-		DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
-			ip := getSupportedIP(controllerMetricIPs, family)
+				ip := getSupportedIP(handlerMetricIPs, family)
 
-			metrics := collectMetrics(ip, "kubevirt_vmi_non_evictable")
-			By("Checking the collected metrics")
-			keys := getKeysFromMetrics(metrics)
-			for _, key := range keys {
-				value := metrics[key]
-				fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
-				Expect(value).To(BeNumerically(">=", float64(0.0)))
-			}
-		},
-			Entry("[test_id:4148] by IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6243] by IPv6", k8sv1.IPv6Protocol),
-		)
-
-		DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
-
-			ip := getSupportedIP(handlerMetricIPs, family)
-
-			// Every VMI is labeled with kubevirt.io/nodeName, so just creating a VMI should
-			// be enough to its metrics to contain a kubernetes label
-			metrics := collectMetrics(ip, "kubevirt_vmi_vcpu_seconds")
-			By("Checking collected metrics")
-			keys := getKeysFromMetrics(metrics)
-			containK8sLabel := false
-			for _, key := range keys {
-				if strings.Contains(key, "kubernetes_vmi_label_") {
-					containK8sLabel = true
+				// Every VMI is labeled with kubevirt.io/nodeName, so just creating a VMI should
+				// be enough to its metrics to contain a kubernetes label
+				metrics := collectMetrics(ip, "kubevirt_vmi_vcpu_seconds")
+				By("Checking collected metrics")
+				keys := getKeysFromMetrics(metrics)
+				containK8sLabel := false
+				for _, key := range keys {
+					if strings.Contains(key, "kubernetes_vmi_label_") {
+						containK8sLabel = true
+					}
 				}
-			}
-			Expect(containK8sLabel).To(Equal(true))
-		},
-			Entry("[test_id:4147] by IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6244] by IPv6", k8sv1.IPv6Protocol),
-		)
+				Expect(containK8sLabel).To(Equal(true))
+			},
+				Entry("[test_id:4147] by IPv4", Labels{"test_id:4147"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6244] by IPv6", Labels{"test_id:6244"}, k8sv1.IPv6Protocol),
+			)
 
-		// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
-		DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
+			DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
 
-			ip := getSupportedIP(handlerMetricIPs, family)
+				ip := getSupportedIP(handlerMetricIPs, family)
 
-			metrics := collectMetrics(ip, "kubevirt_vmi_memory_swap_")
-			var in, out bool
-			for k := range metrics {
-				if in && out {
-					break
+				metrics := collectMetrics(ip, "kubevirt_vmi_memory_swap_")
+				var in, out bool
+				for k := range metrics {
+					if in && out {
+						break
+					}
+					if strings.Contains(k, `swap_in`) {
+						in = true
+					}
+					if strings.Contains(k, `swap_out`) {
+						out = true
+					}
 				}
-				if strings.Contains(k, `swap_in`) {
-					in = true
-				}
-				if strings.Contains(k, `swap_out`) {
-					out = true
-				}
-			}
 
-			Expect(in).To(BeTrue())
-			Expect(out).To(BeTrue())
-		},
-			Entry("[test_id:4555] by IPv4", k8sv1.IPv4Protocol),
-			Entry("[test_id:6245] by IPv6", k8sv1.IPv6Protocol),
-		)
-	})
+				Expect(in).To(BeTrue())
+				Expect(out).To(BeTrue())
+			},
+				Entry("[test_id:4555] by IPv4", Labels{"test_id:4555"}, k8sv1.IPv4Protocol),
+				Entry("[test_id:6245] by IPv6", Labels{"test_id:6245"}, k8sv1.IPv6Protocol),
+			)
+		})
 
 	Describe("Start a VirtualMachineInstance", func() {
 		BeforeEach(func() {
@@ -1121,7 +1131,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 
 		Context("when the controller pod is not running and an election happens", func() {
-			It("[test_id:4642]should succeed afterwards", func() {
+			It("[test_id:4642]should succeed afterwards", Labels{"test_id:4642"}, func() {
 				newLeaderPod := getNewLeaderPod(virtClient)
 				Expect(newLeaderPod).NotTo(BeNil())
 
@@ -1255,7 +1265,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}, 15*time.Second, 1*time.Second).Should(Equal(true))
 			})
 
-			It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", func() {
+			It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", Labels{"test_id:6246"}, func() {
 				for _, node := range nodesWithKVM {
 					Expect(err).ToNot(HaveOccurred())
 					cpuModelLabelPresent := false
@@ -1295,7 +1305,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 			})
 
-			It("[test_id:6247] should set default obsolete cpu models filter when obsolete-cpus-models is not set in kubevirt config", func() {
+			It("[test_id:6247] should set default obsolete cpu models filter when obsolete-cpus-models is not set in kubevirt config", Labels{"test_id:6247"}, func() {
 				node := nodesWithKVM[0]
 
 				for key := range node.Labels {
@@ -1308,7 +1318,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 			})
 
-			It("[test_id:6248] should set default min cpu model filter when min-cpu is not set in kubevirt config", func() {
+			It("[test_id:6248] should set default min cpu model filter when min-cpu is not set in kubevirt config", Labels{"test_id:6248"}, func() {
 				node := nodesWithKVM[0]
 
 				for key := range node.Labels {
@@ -1316,7 +1326,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 			})
 
-			It("[test_id:6995]should expose tsc frequency and tsc scalability", func() {
+			It("[test_id:6995]should expose tsc frequency and tsc scalability", Labels{"test_id:6995"}, func() {
 				node := nodesWithKVM[0]
 				Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
 				Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-scalable"))
@@ -1338,7 +1348,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				tests.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
 			})
 
-			It("[test_id:6249] should update node with new cpu model label set", func() {
+			It("[test_id:6249] should update node with new cpu model label set", Labels{"test_id:6249"}, func() {
 				obsoleteModel := ""
 				node := nodesWithKVM[0]
 
@@ -1368,7 +1378,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				Expect(found).To(Equal(false), "Node can't contain label "+v1.CPUModelLabel+obsoleteModel)
 			})
 
-			It("[test_id:6250] should update node with new cpu model vendor label", func() {
+			It("[test_id:6250] should update node with new cpu model vendor label", Labels{"test_id:6250"}, func() {
 				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				for _, node := range nodes.Items {
@@ -1382,7 +1392,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				Fail("No node contains label " + v1.CPUModelVendorLabel)
 			})
 
-			It("[test_id:6251] should update node with new cpu feature label set", func() {
+			It("[test_id:6251] should update node with new cpu feature label set", Labels{"test_id:6251"}, func() {
 				node := nodesWithKVM[0]
 
 				numberOfLabelsBeforeUpdate := len(node.Labels)
@@ -1398,7 +1408,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				Expect(numberOfLabelsBeforeUpdate).ToNot(Equal(len(node.Labels)), "Node should have different number of labels")
 			})
 
-			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", func() {
+			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", Labels{"test_id:6252"}, func() {
 				node := nodesWithKVM[0]
 
 				obsoleteModels := nodelabellerutil.DefaultObsoleteCPUModels
@@ -1465,7 +1475,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:6253] should remove old labeller labels and annotations", func() {
+			It("[test_id:6253] should remove old labeller labels and annotations", Labels{"test_id:6253"}, func() {
 				originalNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -21,7 +21,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]oc/kubectl integration", Label("sig-compute"), func() {
 	var (
 		k8sClient, result string
 		err               error
@@ -33,7 +33,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, f
 		tests.BeforeTestCleanup()
 	})
 
-	DescribeTable("[test_id:3812]explain vm/vmi", Labels{"test_id:3812"}, func(resource string) {
+	DescribeTable("[test_id:3812]explain vm/vmi", Label("test_id:3812"), func(resource string) {
 		output, stderr, err := clientcmd.RunCommand(k8sClient, "explain", resource)
 		// kubectl will not find resource for the first time this command is issued
 		if err != nil {
@@ -46,15 +46,15 @@ var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, f
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 		Expect(output).To(ContainSubstring("status	<Object>"))
 	},
-		Entry("[test_id:3810]explain vm", Labels{"test_id:3810"}, "vm"),
-		Entry("[test_id:3811]explain vmi", Labels{"test_id:3811"}, "vmi"),
-		Entry("[test_id:5178]explain vmim", Labels{"test_id:5178"}, "vmim"),
-		Entry("[test_id:5179]explain kv", Labels{"test_id:5179"}, "kv"),
-		Entry("[test_id:5180]explain vmsnapshot", Labels{"test_id:5180"}, "vmsnapshot"),
-		Entry("[test_id:5181]explain vmsnapshotcontent", Labels{"test_id:5181"}, "vmsnapshotcontent"),
+		Entry("[test_id:3810]explain vm", Label("test_id:3810"), "vm"),
+		Entry("[test_id:3811]explain vmi", Label("test_id:3811"), "vmi"),
+		Entry("[test_id:5178]explain vmim", Label("test_id:5178"), "vmim"),
+		Entry("[test_id:5179]explain kv", Label("test_id:5179"), "kv"),
+		Entry("[test_id:5180]explain vmsnapshot", Label("test_id:5180"), "vmsnapshot"),
+		Entry("[test_id:5181]explain vmsnapshotcontent", Label("test_id:5181"), "vmsnapshotcontent"),
 	)
 
-	It("[test_id:5182]vmipreset have validation", Labels{"test_id:5182"}, func() {
+	It("[test_id:5182]vmipreset have validation", Label("test_id:5182"), func() {
 		output, _, err := clientcmd.RunCommand(k8sClient, "explain", "vmipreset")
 		if err != nil {
 			output, _, err = clientcmd.RunCommand(k8sClient, "explain", "vmipreset")
@@ -66,7 +66,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, f
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 
-	It("[test_id:5183]vmirs have validation", Labels{"test_id:5183"}, func() {
+	It("[test_id:5183]vmirs have validation", Label("test_id:5183"), func() {
 		output, _, err := clientcmd.RunCommand(k8sClient, "explain", "vmirs")
 		if err != nil {
 			output, _, err = clientcmd.RunCommand(k8sClient, "explain", "vmirs")
@@ -78,7 +78,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, f
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 
-	Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", Labels{"rfe_id:3423", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
+	Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", Label("rfe_id:3423", "vendor:cnv-qe@redhat.com", "level:component"), func() {
 		var (
 			virtCli kubecli.KubevirtClient
 			vm      *v1.VirtualMachine
@@ -115,8 +115,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, f
 			// Name will be there in all the cases, so verify name
 			Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 		},
-			Entry("[test_id:3464]virtualmachine", Labels{"test_id:3464"}, "get", "vm", []string{"NAME", "AGE", "STATUS", "READY"}),
-			Entry("[test_id:3465]virtualmachineinstance", Labels{"test_id:3465"}, "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY"}),
+			Entry("[test_id:3464]virtualmachine", Label("test_id:3464"), "get", "vm", []string{"NAME", "AGE", "STATUS", "READY"}),
+			Entry("[test_id:3465]virtualmachineinstance", Label("test_id:3465"), "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY"}),
 		)
 
 		DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
@@ -140,8 +140,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, f
 			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 
 		},
-			Entry("[test_id:3468]virtualmachine", Labels{"test_id:3468"}, "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "READY"}, 1, "True"),
-			Entry("[test_id:3466]virtualmachineinstance", Labels{"test_id:3466"}, "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
+			Entry("[test_id:3468]virtualmachine", Label("test_id:3468"), "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "READY"}, 1, "True"),
+			Entry("[test_id:3466]virtualmachineinstance", Label("test_id:3466"), "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 
 	})

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -21,7 +21,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[sig-compute]oc/kubectl integration", func() {
+var _ = Describe("[sig-compute]oc/kubectl integration", Labels{"sig-compute"}, func() {
 	var (
 		k8sClient, result string
 		err               error
@@ -33,7 +33,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 		tests.BeforeTestCleanup()
 	})
 
-	DescribeTable("[test_id:3812]explain vm/vmi", func(resource string) {
+	DescribeTable("[test_id:3812]explain vm/vmi", Labels{"test_id:3812"}, func(resource string) {
 		output, stderr, err := clientcmd.RunCommand(k8sClient, "explain", resource)
 		// kubectl will not find resource for the first time this command is issued
 		if err != nil {
@@ -46,15 +46,15 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 		Expect(output).To(ContainSubstring("status	<Object>"))
 	},
-		Entry("[test_id:3810]explain vm", "vm"),
-		Entry("[test_id:3811]explain vmi", "vmi"),
-		Entry("[test_id:5178]explain vmim", "vmim"),
-		Entry("[test_id:5179]explain kv", "kv"),
-		Entry("[test_id:5180]explain vmsnapshot", "vmsnapshot"),
-		Entry("[test_id:5181]explain vmsnapshotcontent", "vmsnapshotcontent"),
+		Entry("[test_id:3810]explain vm", Labels{"test_id:3810"}, "vm"),
+		Entry("[test_id:3811]explain vmi", Labels{"test_id:3811"}, "vmi"),
+		Entry("[test_id:5178]explain vmim", Labels{"test_id:5178"}, "vmim"),
+		Entry("[test_id:5179]explain kv", Labels{"test_id:5179"}, "kv"),
+		Entry("[test_id:5180]explain vmsnapshot", Labels{"test_id:5180"}, "vmsnapshot"),
+		Entry("[test_id:5181]explain vmsnapshotcontent", Labels{"test_id:5181"}, "vmsnapshotcontent"),
 	)
 
-	It("[test_id:5182]vmipreset have validation", func() {
+	It("[test_id:5182]vmipreset have validation", Labels{"test_id:5182"}, func() {
 		output, _, err := clientcmd.RunCommand(k8sClient, "explain", "vmipreset")
 		if err != nil {
 			output, _, err = clientcmd.RunCommand(k8sClient, "explain", "vmipreset")
@@ -66,7 +66,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 
-	It("[test_id:5183]vmirs have validation", func() {
+	It("[test_id:5183]vmirs have validation", Labels{"test_id:5183"}, func() {
 		output, _, err := clientcmd.RunCommand(k8sClient, "explain", "vmirs")
 		if err != nil {
 			output, _, err = clientcmd.RunCommand(k8sClient, "explain", "vmirs")
@@ -78,7 +78,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 
-	Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", func() {
+	Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", Labels{"rfe_id:3423", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
 		var (
 			virtCli kubecli.KubevirtClient
 			vm      *v1.VirtualMachine
@@ -115,8 +115,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			// Name will be there in all the cases, so verify name
 			Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 		},
-			Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "STATUS", "READY"}),
-			Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY"}),
+			Entry("[test_id:3464]virtualmachine", Labels{"test_id:3464"}, "get", "vm", []string{"NAME", "AGE", "STATUS", "READY"}),
+			Entry("[test_id:3465]virtualmachineinstance", Labels{"test_id:3465"}, "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY"}),
 		)
 
 		DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
@@ -140,8 +140,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 
 		},
-			Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "READY"}, 1, "True"),
-			Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
+			Entry("[test_id:3468]virtualmachine", Labels{"test_id:3468"}, "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "READY"}, 1, "True"),
+			Entry("[test_id:3466]virtualmachineinstance", Labels{"test_id:3466"}, "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 
 	})

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -12,7 +12,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", func() {
+var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", Labels{"sig-compute"}, func() {
 	BeforeEach(func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.WorkloadEncryptionSEV)
 		checks.SkipTestIfNotSEVCapable()

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -12,7 +12,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", Label("sig-compute"), func() {
 	BeforeEach(func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.WorkloadEncryptionSEV)
 		checks.SkipTestIfNotSEVCapable()

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -26,7 +26,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
+var _ = Describe("[Serial][sig-compute]MediatedDevices", Labels{"Serial", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -26,7 +26,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe("[Serial][sig-compute]MediatedDevices", Label("Serial", "sig-compute"), func() {
+var _ = Describe("[Serial][sig-compute]MediatedDevices", Label("Serial", "MediatedDevices", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -26,7 +26,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe("[Serial][sig-compute]MediatedDevices", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]MediatedDevices", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -134,7 +134,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Labels{"Serial", "sig-c
 			cleanupConfiguredMdevs()
 		})
 
-		It("[QUARANTINE]Should successfully passthrough a mediated device", func() {
+		It("[QUARANTINE]Should successfully passthrough a mediated device", Label("QUARANTINE"), func() {
 
 			By("Creating a Fedora VMI")
 			vmi = tests.NewRandomFedoraVMIWithGuestAgent()
@@ -194,7 +194,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Labels{"Serial", "sig-c
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*display=.?on.?`), "Display should not be enabled")
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should not be enabled")
 		})
-		It("[QUARANTINE]Should override default mdev configuration on a specific node", func() {
+		It("[QUARANTINE]Should override default mdev configuration on a specific node", Label("QUARANTINE"), func() {
 			newDesiredMdevTypeName := "nvidia-223"
 			newExpectedInstancesNum := 8
 			By("Creating a configuration for mediated devices")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -95,7 +95,7 @@ const (
 	stressDefaultTimeout = 1600
 )
 
-var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration", func() {
+var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration", Labels{"rfe_id:393", "crit:high", "vendor:cnv-qe@redhat.com", "level:system", "sig-compute"}, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 
@@ -575,7 +575,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		}
 
 		Context("with a bridge network interface", func() {
-			It("[test_id:3226]should reject a migration of a vmi with a bridge interface", func() {
+			It("[test_id:3226]should reject a migration of a vmi with a bridge interface", Labels{"test_id:3226"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
 					{
@@ -618,7 +618,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[Serial] with bandwidth limitations", func() {
+		Context("[Serial] with bandwidth limitations", Labels{"Serial"}, func() {
 
 			var repeatedlyMigrateWithBandwidthLimitation = func(vmi *v1.VirtualMachineInstance, bandwidth string, repeat int) time.Duration {
 				var migrationDurationTotal time.Duration
@@ -647,7 +647,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				return migrationDurationTotal
 			}
 
-			It("[test_id:6968]should apply them and result in different migration durations", func() {
+			It("[test_id:6968]should apply them and result in different migration durations", Labels{"test_id:6968"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -661,7 +661,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 		Context("with a Alpine disk", func() {
-			It("[test_id:6969]should be successfully migrate with a tablet device", func() {
+			It("[test_id:6969]should be successfully migrate with a tablet device", Labels{"test_id:6969"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -730,7 +730,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6970]should migrate vmi with cdroms on various bus types", func() {
+			It("[test_id:6970]should migrate vmi with cdroms on various bus types", Labels{"test_id:6970"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -780,7 +780,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 20*time.Second, 1*time.Second).Should(Equal(v1.LiveMigration), "migration method is expected to be Live Migration")
 			})
 
-			It("[test_id:6971]should migrate with a downwardMetrics disk", func() {
+			It("[test_id:6971]should migrate with a downwardMetrics disk", Labels{"test_id:6971"}, func() {
 				vmi := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -815,7 +815,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(getHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
 			})
 
-			It("[test_id:6842]should migrate with TSC frequency set", func() {
+			It("[test_id:6842]should migrate with TSC frequency set", Labels{"test_id:6842"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{
@@ -861,7 +861,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(timerFrequency).ToNot(BeEmpty())
 			})
 
-			It("[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus", func() {
+			It("[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus", Labels{"test_id:4113"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -903,7 +903,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", func() {
+			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", Labels{"test_id:1783"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -949,7 +949,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			// Previously, we'd stop getting events after libvirt reconnect, which
 			// prevented things like migration. This test verifies we can migrate after
 			// resetting libvirt
-			It("[test_id:4746]should migrate even if libvirt has restarted at some point.", func() {
+			It("[test_id:4746]should migrate even if libvirt has restarted at some point.", Labels{"test_id:4746"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -1005,7 +1005,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			})
 
-			It("[test_id:6972]should migrate to a persistent (non-transient) libvirt domain.", func() {
+			It("[test_id:6972]should migrate to a persistent (non-transient) libvirt domain.", Labels{"test_id:6972"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -1039,7 +1039,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 
 			})
-			It("[test_id:6973]should be able to successfully migrate with a paused vmi", func() {
+			It("[test_id:6973]should be able to successfully migrate with a paused vmi", Labels{"test_id:6973"}, func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -1221,7 +1221,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 		})
-		Context("[Serial] with auto converge enabled", func() {
+		Context("[Serial] with auto converge enabled", Labels{"Serial"}, func() {
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 
@@ -1232,7 +1232,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 			})
 
-			It("[test_id:3237]should complete a migration", func() {
+			It("[test_id:3237]should complete a migration", Labels{"test_id:3237"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1264,7 +1264,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 		Context("with setting guest time", func() {
-			It("[test_id:4114]should set an updated time after a migration", func() {
+			It("[test_id:4114]should set an updated time after a migration", Labels{"test_id:4114"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
@@ -1322,7 +1322,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 			})
-			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
+			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", Labels{"test_id:3239"}, func() {
 				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
@@ -1364,7 +1364,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				Expect(virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
 			})
-			It("[test_id:1479][storage-req] should migrate a vmi with a shared block disk", func() {
+			It("[test_id:1479][storage-req] should migrate a vmi with a shared block disk", Labels{"test_id:1479", "storage-req"}, func() {
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 
 				By("Starting the VirtualMachineInstance")
@@ -1387,7 +1387,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
-			It("[test_id:6974]should reject additional migrations on the same VMI if the first one is not finished", func() {
+			It("[test_id:6974]should reject additional migrations on the same VMI if the first one is not finished", Labels{"test_id:6974"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1435,9 +1435,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[storage-req]with an Alpine shared block volume PVC", func() {
+		Context("[storage-req]with an Alpine shared block volume PVC", Labels{"storage-req"}, func() {
 
-			It("[test_id:1854]should migrate a VMI with shared and non-shared disks", func() {
+			It("[test_id:1854]should migrate a VMI with shared and non-shared disks", Labels{"test_id:1854"}, func() {
 				// Start the VirtualMachineInstance with PVC and Ephemeral Disks
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				image := cd.ContainerDiskFor(cd.ContainerDiskAlpine)
@@ -1463,7 +1463,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
-			It("[release-blocker][test_id:1377]should be successfully migrated multiple times", func() {
+			It("[release-blocker][test_id:1377]should be successfully migrated multiple times", Labels{"release-blocker", "test_id:1377"}, func() {
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				vmi = runVMIAndExpectLaunch(vmi, 180)
@@ -1486,9 +1486,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[storage-req]with an Alpine shared block volume PVC", func() {
+		Context("[storage-req]with an Alpine shared block volume PVC", Labels{"storage-req"}, func() {
 
-			It("[test_id:3240]should be successfully with a cloud init", func() {
+			It("[test_id:3240]should be successfully with a cloud init", Labels{"test_id:3240"}, func() {
 				// Start the VirtualMachineInstance with the PVC attached
 
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
@@ -1541,11 +1541,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 
-			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", func() {
+			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", Labels{"test_id:2653"}, func() {
 				guestAgentMigrationTestFunc(v1.MigrationPreCopy)
 			})
 
-			It("[test_id:6975] should have guest agent functional after migration", func() {
+			It("[test_id:6975] should have guest agent functional after migration", Labels{"test_id:6975"}, func() {
 				By("Creating the VMI")
 				vmi = tests.NewRandomVMIWithPVC(pvName)
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
@@ -1575,7 +1575,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration to nonroot", func() {
+		Context("[Serial] migration to nonroot", Labels{"Serial"}, func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
 
@@ -1675,8 +1675,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			)
 		})
 		Context("migration security", func() {
-			Context("[Serial] with TLS disabled", func() {
-				It("[test_id:6976] should be successfully migrated", func() {
+			Context("[Serial] with TLS disabled", Labels{"Serial"}, func() {
+				It("[test_id:6976] should be successfully migrated", Labels{"test_id:6976"}, func() {
 					cfg := getCurrentKv()
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
@@ -1707,7 +1707,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 				})
 
-				It("[test_id:6977]should not secure migrations with TLS", func() {
+				It("[test_id:6977]should not secure migrations with TLS", Labels{"test_id:6977"}, func() {
 					cfg := getCurrentKv()
 					cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewMilliQuantity(1, resource.BinarySI)
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
@@ -1789,7 +1789,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}
 				})
 
-				It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
+				It("[test_id:2303][posneg:negative] should secure migrations with TLS", Labels{"test_id:2303", "posneg:negative"}, func() {
 					vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1870,7 +1870,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration postcopy", func() {
+		Context("[Serial] migration postcopy", Labels{"Serial"}, func() {
 			var dv *cdiv1.DataVolume
 
 			BeforeEach(func() {
@@ -1902,11 +1902,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 
-			It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", func() {
+			It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", Labels{"test_id:5004"}, func() {
 				guestAgentMigrationTestFunc(v1.MigrationPostCopy)
 			})
 
-			It("[test_id:4747] should migrate using cluster level config for postcopy", func() {
+			It("[test_id:4747] should migrate using cluster level config for postcopy", Labels{"test_id:4747"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequestSize
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
@@ -1940,7 +1940,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration monitor", func() {
+		Context("[Serial] migration monitor", Labels{"Serial"}, func() {
 			var createdPods []string
 			AfterEach(func() {
 				for _, podName := range createdPods {
@@ -1965,7 +1965,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
-			PIt("[test_id:2227] should abort a vmi migration without progress", func() {
+			PIt("[test_id:2227] should abort a vmi migration without progress", Labels{"test_id:2227"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -1996,7 +1996,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6978] Should detect a failed migration", func() {
+			It("[test_id:6978] Should detect a failed migration", Labels{"test_id:6978"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -2136,7 +2136,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6979]Target pod should exit after failed migration", func() {
+			It("[test_id:6979]Target pod should exit after failed migration", Labels{"test_id:6979"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -2176,7 +2176,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6980]Migration should fail if target pod fails during target preparation", func() {
+			It("[test_id:6980]Migration should fail if target pod fails during target preparation", Labels{"test_id:6980"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -2326,9 +2326,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 		})
-		Context("[storage-req]with an Alpine non-shared block volume PVC", func() {
+		Context("[storage-req]with an Alpine non-shared block volume PVC", Labels{"storage-req"}, func() {
 
-			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", func() {
+			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", Labels{"test_id:1862", "posneg:negative"}, func() {
 				// Start the VirtualMachineInstance with the PVC attached
 
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
@@ -2441,10 +2441,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Deleting the VMI")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 			},
-				Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk, false),
-				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", newVirtualMachineInstanceWithFedoraRWXBlockDisk, false),
-				Entry("[sig-storage][test_id:2228] with ContainerDisk and virtctl", newVirtualMachineInstanceWithFedoraContainerDisk, true),
-				Entry("[sig-storage][storage-req][test_id:2732] with RWX block disk and virtctl", newVirtualMachineInstanceWithFedoraRWXBlockDisk, true))
+				Entry("[sig-storage][test_id:2226] with ContainerDisk", Labels{"sig-storage", "test_id:2226"}, newVirtualMachineInstanceWithFedoraContainerDisk, false),
+				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", Labels{"sig-storage", "storage-req", "test_id:2731"}, newVirtualMachineInstanceWithFedoraRWXBlockDisk, false),
+				Entry("[sig-storage][test_id:2228] with ContainerDisk and virtctl", Labels{"sig-storage", "test_id:2228"}, newVirtualMachineInstanceWithFedoraContainerDisk, true),
+				Entry("[sig-storage][storage-req][test_id:2732] with RWX block disk and virtctl", Labels{"sig-storage", "storage-req", "test_id:2732"}, newVirtualMachineInstanceWithFedoraRWXBlockDisk, true))
 
 			DescribeTable("Immediate migration cancellation", func(with_virtctl bool) {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
@@ -2475,8 +2475,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			},
-				Entry("[sig-compute][test_id:3241]cancel a migration right after posting it", false),
-				Entry("[sig-compute][test_id:3246]cancel a migration with virtctl", true),
+				Entry("[sig-compute][test_id:3241]cancel a migration right after posting it", Labels{"sig-compute", "test_id:3241"}, false),
+				Entry("[sig-compute][test_id:3246]cancel a migration with virtctl", Labels{"sig-compute", "test_id:3246"}, true),
 			)
 		})
 
@@ -2557,7 +2557,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				return false
 			}
 
-			It("[test_id:6981]should migrate only to nodes supporting right cpu model", func() {
+			It("[test_id:6981]should migrate only to nodes supporting right cpu model", Labels{"test_id:6981"}, func() {
 				if !isHeterogeneousCluster() {
 					log.Log.Warning("all nodes have the same CPU model. Therefore the test is a happy-path since " +
 						"VMIs with default CPU can be migrated to every other node")
@@ -2596,7 +2596,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectFeatureToBeSupportedOnNode(newNode, requiredFeatures)
 			})
 
-			Context("[Serial]Should trigger event", func() {
+			Context("[Serial]Should trigger event", Labels{"Serial"}, func() {
 
 				var originalNodeLabels map[string]string
 				var originalNodeAnnotations map[string]string
@@ -2647,7 +2647,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Expect(node.Annotations).To(Equal(originalNodeAnnotations))
 				})
 
-				It("[test_id:7505]when no node is suited for host model", func() {
+				It("[test_id:7505]when no node is suited for host model", Labels{"test_id:7505"}, func() {
 					By("Changing node labels to support fake host model")
 					// Remove all supported host models
 					for key, _ := range node.Labels {
@@ -2690,7 +2690,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		})
 
-		Context("[Serial] with migration policies", func() {
+		Context("[Serial] with migration policies", Labels{"Serial"}, func() {
 
 			confirmMigrationPolicyName := func(vmi *v1.VirtualMachineInstance, expectedName *string) {
 				By("Verifying the VMI's configuration source")
@@ -2755,7 +2755,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	Context("with sata disks", func() {
 
-		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret + DownwardAPI + External Kernel Boot", func() {
+		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret + DownwardAPI + External Kernel Boot", Labels{"test_id:1853"}, func() {
 			vmi := prepareVMIWithAllVolumeSources()
 
 			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(6))
@@ -2781,7 +2781,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	})
 
 	Context("with a live-migrate eviction strategy set", func() {
-		Context("[ref_id:2293] with a VMI running with an eviction strategy set", func() {
+		Context("[ref_id:2293] with a VMI running with an eviction strategy set", Labels{"ref_id:2293"}, func() {
 
 			var vmi *v1.VirtualMachineInstance
 
@@ -2789,7 +2789,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = alpineVMIWithEvictionStrategy()
 			})
 
-			It("[test_id:3242]should block the eviction api and migrate", func() {
+			It("[test_id:3242]should block the eviction api and migrate", Labels{"test_id:3242"}, func() {
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 				vmiNodeOrig := vmi.Status.NodeName
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -2822,7 +2822,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(resVMI.Status.EvacuationNodeName).To(Equal(""), "vmi evacuation state should be clean")
 			})
 
-			It("[sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", func() {
+			It("[sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", Labels{"sig-compute", "test_id:3243"}, func() {
 				for x := 0; x < 3; x++ {
 					By("creating the VMI")
 					_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -2852,7 +2852,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 
-			It("[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller", func() {
+			It("[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller", Labels{"sig-compute", "test_id:7680"}, func() {
 				By("creating the VMI")
 				createdVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -2886,7 +2886,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 60*time.Second, 1*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:3244]should block the eviction api while a slow migration is in progress", func() {
+			It("[test_id:3244]should block the eviction api while a slow migration is in progress", Labels{"test_id:3244"}, func() {
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
@@ -2942,7 +2942,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 180*time.Second, 500*time.Millisecond).Should(Equal(v1.MigrationSucceeded))
 			})
 
-			Context("[Serial] with node tainted during node drain", func() {
+			Context("[Serial] with node tainted during node drain", Labels{"Serial"}, func() {
 
 				BeforeEach(func() {
 					// Taints defined by k8s are special and can't be applied manually.
@@ -2960,7 +2960,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					libnode.CleanNodes()
 				})
 
-				It("[test_id:6982]should migrate a VMI only one time", func() {
+				It("[test_id:6982]should migrate a VMI only one time", Labels{"test_id:6982"}, func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -3010,7 +3010,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				})
 
-				It("[test_id:2221] should migrate a VMI under load to another node", func() {
+				It("[test_id:2221] should migrate a VMI under load to another node", Labels{"test_id:2221"}, func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -3055,7 +3055,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}, 180*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 				})
 
-				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
+				It("[test_id:2222] should migrate a VMI when custom taint key is configured", Labels{"test_id:2222"}, func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = alpineVMIWithEvictionStrategy()
@@ -3093,7 +3093,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}, 180*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 				})
 
-				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", func() {
+				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", Labels{"test_id:2224"}, func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi_evict1 := alpineVMIWithEvictionStrategy()
@@ -3210,9 +3210,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 			})
 		})
-		Context("[Serial]with multiple VMIs with eviction policies set", func() {
+		Context("[Serial]with multiple VMIs with eviction policies set", Labels{"Serial"}, func() {
 
-			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
+			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", Labels{"release-blocker", "test_id:3245"}, func() {
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := alpineVMIWithEvictionStrategy()
@@ -3288,7 +3288,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	})
 
-	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", func() {
+	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", Labels{"Serial"}, func() {
 		var originalKV *v1.KubeVirt
 
 		BeforeEach(func() {
@@ -3356,7 +3356,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial] With Huge Pages", func() {
+	Context("[Serial] With Huge Pages", Labels{"Serial"}, func() {
 		var hugepagesVmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -3415,12 +3415,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			By("Waiting for VMI to disappear")
 			tests.WaitForVirtualMachineToDisappearWithTimeout(hugepagesVmi, 240)
 		},
-			Entry("[test_id:6983]hugepages-2Mi", "2Mi", "64Mi"),
-			Entry("[test_id:6984]hugepages-1Gi", "1Gi", "1Gi"),
+			Entry("[test_id:6983]hugepages-2Mi", Labels{"test_id:6983"}, "2Mi", "64Mi"),
+			Entry("[test_id:6984]hugepages-1Gi", Labels{"test_id:6984"}, "1Gi", "1Gi"),
 		)
 	})
 
-	Context("[Serial] with CPU pinning and huge pages", func() {
+	Context("[Serial] with CPU pinning and huge pages", Labels{"Serial"}, func() {
 		It("should not make migrations fail", func() {
 			checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(2)
 			var err error
@@ -3729,7 +3729,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial]with a dedicated migration network", func() {
+	Context("[Serial]with a dedicated migration network", Labels{"Serial"}, func() {
 		BeforeEach(func() {
 			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -95,7 +95,7 @@ const (
 	stressDefaultTimeout = 1600
 )
 
-var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration", Labels{"rfe_id:393", "crit:high", "vendor:cnv-qe@redhat.com", "level:system", "sig-compute"}, func() {
+var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration", Label("rfe_id:393", "crit:high", "vendor:cnv-qe@redhat.com", "level:system", "sig-compute"), func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 
@@ -575,7 +575,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		}
 
 		Context("with a bridge network interface", func() {
-			It("[test_id:3226]should reject a migration of a vmi with a bridge interface", Labels{"test_id:3226"}, func() {
+			It("[test_id:3226]should reject a migration of a vmi with a bridge interface", Label("test_id:3226"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
 					{
@@ -618,7 +618,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[Serial] with bandwidth limitations", Labels{"Serial"}, func() {
+		Context("[Serial] with bandwidth limitations", Label("Serial"), func() {
 
 			var repeatedlyMigrateWithBandwidthLimitation = func(vmi *v1.VirtualMachineInstance, bandwidth string, repeat int) time.Duration {
 				var migrationDurationTotal time.Duration
@@ -647,7 +647,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				return migrationDurationTotal
 			}
 
-			It("[test_id:6968]should apply them and result in different migration durations", Labels{"test_id:6968"}, func() {
+			It("[test_id:6968]should apply them and result in different migration durations", Label("test_id:6968"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -661,7 +661,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 		Context("with a Alpine disk", func() {
-			It("[test_id:6969]should be successfully migrate with a tablet device", Labels{"test_id:6969"}, func() {
+			It("[test_id:6969]should be successfully migrate with a tablet device", Label("test_id:6969"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -730,7 +730,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6970]should migrate vmi with cdroms on various bus types", Labels{"test_id:6970"}, func() {
+			It("[test_id:6970]should migrate vmi with cdroms on various bus types", Label("test_id:6970"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -780,7 +780,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 20*time.Second, 1*time.Second).Should(Equal(v1.LiveMigration), "migration method is expected to be Live Migration")
 			})
 
-			It("[test_id:6971]should migrate with a downwardMetrics disk", Labels{"test_id:6971"}, func() {
+			It("[test_id:6971]should migrate with a downwardMetrics disk", Label("test_id:6971"), func() {
 				vmi := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -815,7 +815,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(getHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
 			})
 
-			It("[test_id:6842]should migrate with TSC frequency set", Labels{"test_id:6842"}, func() {
+			It("[test_id:6842]should migrate with TSC frequency set", Label("test_id:6842"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{
@@ -861,7 +861,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(timerFrequency).ToNot(BeEmpty())
 			})
 
-			It("[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus", Labels{"test_id:4113"}, func() {
+			It("[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus", Label("test_id:4113"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -903,7 +903,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", Labels{"test_id:1783"}, func() {
+			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", Label("test_id:1783"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -949,7 +949,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			// Previously, we'd stop getting events after libvirt reconnect, which
 			// prevented things like migration. This test verifies we can migrate after
 			// resetting libvirt
-			It("[test_id:4746]should migrate even if libvirt has restarted at some point.", Labels{"test_id:4746"}, func() {
+			It("[test_id:4746]should migrate even if libvirt has restarted at some point.", Label("test_id:4746"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -1005,7 +1005,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			})
 
-			It("[test_id:6972]should migrate to a persistent (non-transient) libvirt domain.", Labels{"test_id:6972"}, func() {
+			It("[test_id:6972]should migrate to a persistent (non-transient) libvirt domain.", Label("test_id:6972"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -1039,7 +1039,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 
 			})
-			It("[test_id:6973]should be able to successfully migrate with a paused vmi", Labels{"test_id:6973"}, func() {
+			It("[test_id:6973]should be able to successfully migrate with a paused vmi", Label("test_id:6973"), func() {
 				vmi := libvmi.NewAlpine(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -1221,7 +1221,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 		})
-		Context("[Serial] with auto converge enabled", Labels{"Serial"}, func() {
+		Context("[Serial] with auto converge enabled", Label("Serial"), func() {
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 
@@ -1232,7 +1232,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 			})
 
-			It("[test_id:3237]should complete a migration", Labels{"test_id:3237"}, func() {
+			It("[test_id:3237]should complete a migration", Label("test_id:3237"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1264,7 +1264,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 		Context("with setting guest time", func() {
-			It("[test_id:4114]should set an updated time after a migration", Labels{"test_id:4114"}, func() {
+			It("[test_id:4114]should set an updated time after a migration", Label("test_id:4114"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
@@ -1322,7 +1322,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 			})
-			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", Labels{"test_id:3239"}, func() {
+			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", Label("test_id:3239"), func() {
 				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
@@ -1364,7 +1364,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				Expect(virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
 			})
-			It("[test_id:1479][storage-req] should migrate a vmi with a shared block disk", Labels{"test_id:1479", "storage-req"}, func() {
+			It("[test_id:1479][storage-req] should migrate a vmi with a shared block disk", Label("test_id:1479", "storage-req"), func() {
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 
 				By("Starting the VirtualMachineInstance")
@@ -1387,7 +1387,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
-			It("[test_id:6974]should reject additional migrations on the same VMI if the first one is not finished", Labels{"test_id:6974"}, func() {
+			It("[test_id:6974]should reject additional migrations on the same VMI if the first one is not finished", Label("test_id:6974"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1435,9 +1435,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[storage-req]with an Alpine shared block volume PVC", Labels{"storage-req"}, func() {
+		Context("[storage-req]with an Alpine shared block volume PVC", Label("storage-req"), func() {
 
-			It("[test_id:1854]should migrate a VMI with shared and non-shared disks", Labels{"test_id:1854"}, func() {
+			It("[test_id:1854]should migrate a VMI with shared and non-shared disks", Label("test_id:1854"), func() {
 				// Start the VirtualMachineInstance with PVC and Ephemeral Disks
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				image := cd.ContainerDiskFor(cd.ContainerDiskAlpine)
@@ -1463,7 +1463,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
-			It("[release-blocker][test_id:1377]should be successfully migrated multiple times", Labels{"release-blocker", "test_id:1377"}, func() {
+			It("[release-blocker][test_id:1377]should be successfully migrated multiple times", Label("release-blocker", "test_id:1377"), func() {
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				vmi = runVMIAndExpectLaunch(vmi, 180)
@@ -1486,9 +1486,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[storage-req]with an Alpine shared block volume PVC", Labels{"storage-req"}, func() {
+		Context("[storage-req]with an Alpine shared block volume PVC", Label("storage-req"), func() {
 
-			It("[test_id:3240]should be successfully with a cloud init", Labels{"test_id:3240"}, func() {
+			It("[test_id:3240]should be successfully with a cloud init", Label("test_id:3240"), func() {
 				// Start the VirtualMachineInstance with the PVC attached
 
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
@@ -1541,11 +1541,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 
-			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", Labels{"test_id:2653"}, func() {
+			It("[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration", Label("test_id:2653"), func() {
 				guestAgentMigrationTestFunc(v1.MigrationPreCopy)
 			})
 
-			It("[test_id:6975] should have guest agent functional after migration", Labels{"test_id:6975"}, func() {
+			It("[test_id:6975] should have guest agent functional after migration", Label("test_id:6975"), func() {
 				By("Creating the VMI")
 				vmi = tests.NewRandomVMIWithPVC(pvName)
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
@@ -1575,7 +1575,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration to nonroot", Labels{"Serial"}, func() {
+		Context("[Serial] migration to nonroot", Label("Serial"), func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
 
@@ -1675,8 +1675,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			)
 		})
 		Context("migration security", func() {
-			Context("[Serial] with TLS disabled", Labels{"Serial"}, func() {
-				It("[test_id:6976] should be successfully migrated", Labels{"test_id:6976"}, func() {
+			Context("[Serial] with TLS disabled", Label("Serial"), func() {
+				It("[test_id:6976] should be successfully migrated", Label("test_id:6976"), func() {
 					cfg := getCurrentKv()
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
 					tests.UpdateKubeVirtConfigValueAndWait(cfg)
@@ -1707,7 +1707,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 				})
 
-				It("[test_id:6977]should not secure migrations with TLS", Labels{"test_id:6977"}, func() {
+				It("[test_id:6977]should not secure migrations with TLS", Label("test_id:6977"), func() {
 					cfg := getCurrentKv()
 					cfg.MigrationConfiguration.BandwidthPerMigration = resource.NewMilliQuantity(1, resource.BinarySI)
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
@@ -1789,7 +1789,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}
 				})
 
-				It("[test_id:2303][posneg:negative] should secure migrations with TLS", Labels{"test_id:2303", "posneg:negative"}, func() {
+				It("[test_id:2303][posneg:negative] should secure migrations with TLS", Label("test_id:2303", "posneg:negative"), func() {
 					vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1870,7 +1870,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration postcopy", Labels{"Serial"}, func() {
+		Context("[Serial] migration postcopy", Label("Serial"), func() {
 			var dv *cdiv1.DataVolume
 
 			BeforeEach(func() {
@@ -1902,11 +1902,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 
-			It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", Labels{"test_id:5004"}, func() {
+			It("[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy", Label("test_id:5004"), func() {
 				guestAgentMigrationTestFunc(v1.MigrationPostCopy)
 			})
 
-			It("[test_id:4747] should migrate using cluster level config for postcopy", Labels{"test_id:4747"}, func() {
+			It("[test_id:4747] should migrate using cluster level config for postcopy", Label("test_id:4747"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = memoryRequestSize
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
@@ -1940,7 +1940,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration monitor", Labels{"Serial"}, func() {
+		Context("[Serial] migration monitor", Label("Serial"), func() {
 			var createdPods []string
 			AfterEach(func() {
 				for _, podName := range createdPods {
@@ -1965,7 +1965,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
-			PIt("[test_id:2227] should abort a vmi migration without progress", Labels{"test_id:2227"}, func() {
+			PIt("[test_id:2227] should abort a vmi migration without progress", Label("test_id:2227"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -1996,7 +1996,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6978] Should detect a failed migration", Labels{"test_id:6978"}, func() {
+			It("[test_id:6978] Should detect a failed migration", Label("test_id:6978"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -2136,7 +2136,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6979]Target pod should exit after failed migration", Labels{"test_id:6979"}, func() {
+			It("[test_id:6979]Target pod should exit after failed migration", Label("test_id:6979"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -2176,7 +2176,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6980]Migration should fail if target pod fails during target preparation", Labels{"test_id:6980"}, func() {
+			It("[test_id:6980]Migration should fail if target pod fails during target preparation", Label("test_id:6980"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -2326,9 +2326,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 		})
-		Context("[storage-req]with an Alpine non-shared block volume PVC", Labels{"storage-req"}, func() {
+		Context("[storage-req]with an Alpine non-shared block volume PVC", Label("storage-req"), func() {
 
-			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", Labels{"test_id:1862", "posneg:negative"}, func() {
+			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", Label("test_id:1862", "posneg:negative"), func() {
 				// Start the VirtualMachineInstance with the PVC attached
 
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
@@ -2441,10 +2441,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Deleting the VMI")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 			},
-				Entry("[sig-storage][test_id:2226] with ContainerDisk", Labels{"sig-storage", "test_id:2226"}, newVirtualMachineInstanceWithFedoraContainerDisk, false),
-				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", Labels{"sig-storage", "storage-req", "test_id:2731"}, newVirtualMachineInstanceWithFedoraRWXBlockDisk, false),
-				Entry("[sig-storage][test_id:2228] with ContainerDisk and virtctl", Labels{"sig-storage", "test_id:2228"}, newVirtualMachineInstanceWithFedoraContainerDisk, true),
-				Entry("[sig-storage][storage-req][test_id:2732] with RWX block disk and virtctl", Labels{"sig-storage", "storage-req", "test_id:2732"}, newVirtualMachineInstanceWithFedoraRWXBlockDisk, true))
+				Entry("[sig-storage][test_id:2226] with ContainerDisk", Label("sig-storage", "test_id:2226"), newVirtualMachineInstanceWithFedoraContainerDisk, false),
+				Entry("[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC", Label("sig-storage", "storage-req", "test_id:2731"), newVirtualMachineInstanceWithFedoraRWXBlockDisk, false),
+				Entry("[sig-storage][test_id:2228] with ContainerDisk and virtctl", Label("sig-storage", "test_id:2228"), newVirtualMachineInstanceWithFedoraContainerDisk, true),
+				Entry("[sig-storage][storage-req][test_id:2732] with RWX block disk and virtctl", Label("sig-storage", "storage-req", "test_id:2732"), newVirtualMachineInstanceWithFedoraRWXBlockDisk, true))
 
 			DescribeTable("Immediate migration cancellation", func(with_virtctl bool) {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
@@ -2475,8 +2475,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			},
-				Entry("[sig-compute][test_id:3241]cancel a migration right after posting it", Labels{"sig-compute", "test_id:3241"}, false),
-				Entry("[sig-compute][test_id:3246]cancel a migration with virtctl", Labels{"sig-compute", "test_id:3246"}, true),
+				Entry("[sig-compute][test_id:3241]cancel a migration right after posting it", Label("sig-compute", "test_id:3241"), false),
+				Entry("[sig-compute][test_id:3246]cancel a migration with virtctl", Label("sig-compute", "test_id:3246"), true),
 			)
 		})
 
@@ -2557,7 +2557,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				return false
 			}
 
-			It("[test_id:6981]should migrate only to nodes supporting right cpu model", Labels{"test_id:6981"}, func() {
+			It("[test_id:6981]should migrate only to nodes supporting right cpu model", Label("test_id:6981"), func() {
 				if !isHeterogeneousCluster() {
 					log.Log.Warning("all nodes have the same CPU model. Therefore the test is a happy-path since " +
 						"VMIs with default CPU can be migrated to every other node")
@@ -2596,7 +2596,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectFeatureToBeSupportedOnNode(newNode, requiredFeatures)
 			})
 
-			Context("[Serial]Should trigger event", Labels{"Serial"}, func() {
+			Context("[Serial]Should trigger event", Label("Serial"), func() {
 
 				var originalNodeLabels map[string]string
 				var originalNodeAnnotations map[string]string
@@ -2647,7 +2647,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Expect(node.Annotations).To(Equal(originalNodeAnnotations))
 				})
 
-				It("[test_id:7505]when no node is suited for host model", Labels{"test_id:7505"}, func() {
+				It("[test_id:7505]when no node is suited for host model", Label("test_id:7505"), func() {
 					By("Changing node labels to support fake host model")
 					// Remove all supported host models
 					for key, _ := range node.Labels {
@@ -2690,7 +2690,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		})
 
-		Context("[Serial] with migration policies", Labels{"Serial"}, func() {
+		Context("[Serial] with migration policies", Label("Serial"), func() {
 
 			confirmMigrationPolicyName := func(vmi *v1.VirtualMachineInstance, expectedName *string) {
 				By("Verifying the VMI's configuration source")
@@ -2755,7 +2755,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	Context("with sata disks", func() {
 
-		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret + DownwardAPI + External Kernel Boot", Labels{"test_id:1853"}, func() {
+		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret + DownwardAPI + External Kernel Boot", Label("test_id:1853"), func() {
 			vmi := prepareVMIWithAllVolumeSources()
 
 			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(6))
@@ -2781,7 +2781,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	})
 
 	Context("with a live-migrate eviction strategy set", func() {
-		Context("[ref_id:2293] with a VMI running with an eviction strategy set", Labels{"ref_id:2293"}, func() {
+		Context("[ref_id:2293] with a VMI running with an eviction strategy set", Label("ref_id:2293"), func() {
 
 			var vmi *v1.VirtualMachineInstance
 
@@ -2789,7 +2789,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = alpineVMIWithEvictionStrategy()
 			})
 
-			It("[test_id:3242]should block the eviction api and migrate", Labels{"test_id:3242"}, func() {
+			It("[test_id:3242]should block the eviction api and migrate", Label("test_id:3242"), func() {
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 				vmiNodeOrig := vmi.Status.NodeName
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -2822,7 +2822,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(resVMI.Status.EvacuationNodeName).To(Equal(""), "vmi evacuation state should be clean")
 			})
 
-			It("[sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", Labels{"sig-compute", "test_id:3243"}, func() {
+			It("[sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", Label("sig-compute", "test_id:3243"), func() {
 				for x := 0; x < 3; x++ {
 					By("creating the VMI")
 					_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -2852,7 +2852,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 
-			It("[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller", Labels{"sig-compute", "test_id:7680"}, func() {
+			It("[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller", Label("sig-compute", "test_id:7680"), func() {
 				By("creating the VMI")
 				createdVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -2886,7 +2886,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 60*time.Second, 1*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:3244]should block the eviction api while a slow migration is in progress", Labels{"test_id:3244"}, func() {
+			It("[test_id:3244]should block the eviction api while a slow migration is in progress", Label("test_id:3244"), func() {
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
@@ -2942,7 +2942,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 180*time.Second, 500*time.Millisecond).Should(Equal(v1.MigrationSucceeded))
 			})
 
-			Context("[Serial] with node tainted during node drain", Labels{"Serial"}, func() {
+			Context("[Serial] with node tainted during node drain", Label("Serial"), func() {
 
 				BeforeEach(func() {
 					// Taints defined by k8s are special and can't be applied manually.
@@ -2960,7 +2960,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					libnode.CleanNodes()
 				})
 
-				It("[test_id:6982]should migrate a VMI only one time", Labels{"test_id:6982"}, func() {
+				It("[test_id:6982]should migrate a VMI only one time", Label("test_id:6982"), func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -3010,7 +3010,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				})
 
-				It("[test_id:2221] should migrate a VMI under load to another node", Labels{"test_id:2221"}, func() {
+				It("[test_id:2221] should migrate a VMI under load to another node", Label("test_id:2221"), func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -3055,7 +3055,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}, 180*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 				})
 
-				It("[test_id:2222] should migrate a VMI when custom taint key is configured", Labels{"test_id:2222"}, func() {
+				It("[test_id:2222] should migrate a VMI when custom taint key is configured", Label("test_id:2222"), func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = alpineVMIWithEvictionStrategy()
@@ -3093,7 +3093,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}, 180*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 				})
 
-				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", Labels{"test_id:2224"}, func() {
+				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", Label("test_id:2224"), func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi_evict1 := alpineVMIWithEvictionStrategy()
@@ -3210,9 +3210,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 			})
 		})
-		Context("[Serial]with multiple VMIs with eviction policies set", Labels{"Serial"}, func() {
+		Context("[Serial]with multiple VMIs with eviction policies set", Label("Serial"), func() {
 
-			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", Labels{"release-blocker", "test_id:3245"}, func() {
+			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", Label("release-blocker", "test_id:3245"), func() {
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := alpineVMIWithEvictionStrategy()
@@ -3288,7 +3288,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	})
 
-	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", Labels{"Serial"}, func() {
+	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", Label("Serial"), func() {
 		var originalKV *v1.KubeVirt
 
 		BeforeEach(func() {
@@ -3356,7 +3356,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial] With Huge Pages", Labels{"Serial"}, func() {
+	Context("[Serial] With Huge Pages", Label("Serial"), func() {
 		var hugepagesVmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -3415,12 +3415,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			By("Waiting for VMI to disappear")
 			tests.WaitForVirtualMachineToDisappearWithTimeout(hugepagesVmi, 240)
 		},
-			Entry("[test_id:6983]hugepages-2Mi", Labels{"test_id:6983"}, "2Mi", "64Mi"),
-			Entry("[test_id:6984]hugepages-1Gi", Labels{"test_id:6984"}, "1Gi", "1Gi"),
+			Entry("[test_id:6983]hugepages-2Mi", Label("test_id:6983"), "2Mi", "64Mi"),
+			Entry("[test_id:6984]hugepages-1Gi", Label("test_id:6984"), "1Gi", "1Gi"),
 		)
 	})
 
-	Context("[Serial] with CPU pinning and huge pages", Labels{"Serial"}, func() {
+	Context("[Serial] with CPU pinning and huge pages", Label("Serial"), func() {
 		It("should not make migrations fail", func() {
 			checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(2)
 			var err error
@@ -3729,7 +3729,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial]with a dedicated migration network", Labels{"Serial"}, func() {
+	Context("[Serial]with a dedicated migration network", Label("Serial"), func() {
 		BeforeEach(func() {
 			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -44,7 +44,7 @@ const (
 	virtOperatorDeploymentName = "virt-operator"
 )
 
-var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
+var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Labels{"Serial", "sig-monitoring"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -44,7 +44,7 @@ const (
 	virtOperatorDeploymentName = "virt-operator"
 )
 
-var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Labels{"Serial", "sig-monitoring"}, func() {
+var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Label("Serial", "sig-monitoring"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -77,7 +77,7 @@ func includesIpv4(ipFamily ipFamily) bool {
 }
 
 var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose",
-	Labels{"rfe_id:253", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+	Label("rfe_id:253", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 	func() {
 
 		var virtClient kubecli.KubevirtClient
@@ -166,13 +166,13 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			}
 		}
 
-	Context("Expose service on a VM", func() {
-		var tcpVM *v1.VirtualMachineInstance
-		BeforeEach(func() {
-			tcpVM = newLabeledVMI("vm")
-			tcpVM = tests.RunVMIAndExpectLaunch(tcpVM, 180)
-			tests.GenerateHelloWorldServer(tcpVM, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
-		})
+		Context("Expose service on a VM", func() {
+			var tcpVM *v1.VirtualMachineInstance
+			BeforeEach(func() {
+				tcpVM = newLabeledVMI("vm")
+				tcpVM = tests.RunVMIAndExpectLaunch(tcpVM, 180)
+				tests.GenerateHelloWorldServer(tcpVM, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
+			})
 
 			Context("Expose ClusterIP service", func() {
 				const servicePort = "27017"
@@ -190,7 +190,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should expose a Cluster IP service on a VMI and connect to it",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
@@ -207,7 +207,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						By(iteratingClusterIPs)
 						runJobsAgainstService(svc, tcpVM.Namespace, tests.NewHelloWorldJobTCP)
 					},
-					Entry("[test_id:1531] over default IPv4 IP family", Labels{"test_id:1531"}, ipv4),
+					Entry("[test_id:1531] over default IPv4 IP family", Label("test_id:1531"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -260,7 +260,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						Expect(endpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
 					}, isDualStack)
 				},
-					Entry("[test_id:1532] over default IPv4 IP family", Labels{"test_id:1532"}, ipv4),
+					Entry("[test_id:1532] over default IPv4 IP family", Label("test_id:1532"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -304,7 +304,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-3", Port: 82, Protocol: "UDP"}))
 					Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-4", Port: 1500, Protocol: "UDP"}))
 				},
-					Entry("[test_id:1533] over default IPv4 IP family", Labels{"test_id:1533"}, ipv4),
+					Entry("[test_id:1533] over default IPv4 IP family", Label("test_id:1533"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -382,7 +382,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
@@ -428,7 +428,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 							}
 						}
 					},
-					Entry("[test_id:1534] over default IPv4 IP family", Labels{"test_id:1534"}, ipv4),
+					Entry("[test_id:1534] over default IPv4 IP family", Label("test_id:1534"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -436,13 +436,13 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 		})
 
-	Context("Expose UDP service on a VMI", func() {
-		var udpVM *v1.VirtualMachineInstance
-		BeforeEach(func() {
-			udpVM = newLabeledVMI("udp-vm")
-			udpVM = tests.RunVMIAndExpectLaunch(udpVM, 180)
-			tests.GenerateHelloWorldServer(udpVM, testPort, "udp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
-		})
+		Context("Expose UDP service on a VMI", func() {
+			var udpVM *v1.VirtualMachineInstance
+			BeforeEach(func() {
+				udpVM = newLabeledVMI("udp-vm")
+				udpVM = tests.RunVMIAndExpectLaunch(udpVM, 180)
+				tests.GenerateHelloWorldServer(udpVM, testPort, "udp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
+			})
 
 			Context("Expose ClusterIP UDP service", func() {
 				const servicePort = "28017"
@@ -461,7 +461,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should expose a ClusterIP service on a VMI and connect to it",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
@@ -478,7 +478,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						By(iteratingClusterIPs)
 						runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
 					},
-					Entry("[test_id:1535] over default IPv4 IP family", Labels{"test_id:1535"}, ipv4),
+					Entry("[test_id:1535] over default IPv4 IP family", Label("test_id:1535"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -503,7 +503,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
@@ -556,7 +556,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 							}
 						}
 					},
-					Entry("[test_id:1536] over default IPv4 IP family", Labels{"test_id:1536"}, ipv4),
+					Entry("[test_id:1536] over default IPv4 IP family", Label("test_id:1536"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -613,7 +613,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should create a ClusterIP service on VMRS and connect to it",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmirsExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmirsExposeArgs)
@@ -630,7 +630,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						By(iteratingClusterIPs)
 						runJobsAgainstService(svc, vmrs.Namespace, tests.NewHelloWorldJobTCP)
 					},
-					Entry("[test_id:1537] over default IPv4 IP family", Labels{"test_id:1537"}, ipv4),
+					Entry("[test_id:1537] over default IPv4 IP family", Label("test_id:1537"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
@@ -677,15 +677,15 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				return vm, err
 			}
 
-		startVMWithServer := func(virtClient kubecli.KubevirtClient, protocol string, port int) *v1.VirtualMachineInstance {
-			By("Calling the start command on the stopped VM")
-			vmi := startVMIFromVMTemplate(virtClient, vm.GetName(), vm.GetNamespace())
-			if vmi == nil {
-				return nil
+			startVMWithServer := func(virtClient kubecli.KubevirtClient, protocol string, port int) *v1.VirtualMachineInstance {
+				By("Calling the start command on the stopped VM")
+				vmi := startVMIFromVMTemplate(virtClient, vm.GetName(), vm.GetNamespace())
+				if vmi == nil {
+					return nil
+				}
+				tests.GenerateHelloWorldServer(vmi, port, protocol, libnet.WithAlpineConfig(console.LoginToAlpine), false)
+				return vmi
 			}
-			tests.GenerateHelloWorldServer(vmi, port, protocol, libnet.WithAlpineConfig(console.LoginToAlpine), false)
-			return vmi
-		}
 
 			Context("Expose a VM as a ClusterIP service.", func() {
 				var serviceName string
@@ -704,7 +704,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				DescribeTable("[label:masquerade_binding_connectivity]Connect to ClusterIP service that was set when VM was offline.",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmExposeArgs)
@@ -726,14 +726,14 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						By(iteratingClusterIPs)
 						runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobHTTP)
 					},
-					Entry("[test_id:1538] over default IPv4 IP family", Labels{"test_id:1538"}, ipv4),
+					Entry("[test_id:1538] over default IPv4 IP family", Label("test_id:1538"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
 				)
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should verify the exposed service is functional before and after VM restart.",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(ipFamily ipFamily) {
 						skipIfNotSupportedCluster(ipFamily)
 						vmExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmExposeArgs)
@@ -777,21 +777,21 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 							return vmi.Status.Phase == v1.Running && newUId
 						}, 120*time.Second, 1*time.Second).Should(BeTrue())
 
-				By("Creating a TCP server on the VM.")
-				tests.GenerateHelloWorldServer(vmi, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
+						By("Creating a TCP server on the VM.")
+						tests.GenerateHelloWorldServer(vmi, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 
 						By("Repeating the sequence as prior to restarting the VM: Connect to exposed ClusterIP service.")
 						By(iteratingClusterIPs)
 						runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
 					},
-					Entry("[test_id:345] over default IPv4 IP family", Labels{"test_id:345"}, ipv4),
+					Entry("[test_id:345] over default IPv4 IP family", Label("test_id:345"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),
 				)
 
 				DescribeTable("[label:masquerade_binding_connectivity]Should Verify an exposed service of a VM is not functional after VM deletion.",
-					Labels{"label:masquerade_binding_connectivity"},
+					Label("label:masquerade_binding_connectivity"),
 					func(svcIpFamily ipFamily) {
 						skipIfNotSupportedCluster(svcIpFamily)
 						vmExposeArgs = appendIpFamilyToExposeArgs(svcIpFamily, vmExposeArgs)
@@ -884,7 +884,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						By("Waiting for the job to report a failed connection attempt.")
 						Expect(tests.WaitForJobToFail(job, 240*time.Second)).To(Succeed())
 					},
-					Entry("[test_id:343] over default IPv4 IP family", Labels{"test_id:343"}, ipv4),
+					Entry("[test_id:343] over default IPv4 IP family", Label("test_id:343"), ipv4),
 					Entry(overIPv6Family, ipv6),
 					Entry(overDualStackIPv4, dualIPv4Primary),
 					Entry(overDualStackIPv6, dualIPv6Primary),

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -76,93 +76,95 @@ func includesIpv4(ipFamily ipFamily) bool {
 	return ipFamily != ipv6
 }
 
-var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", func() {
+var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose",
+	Labels{"rfe_id:253", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+	func() {
 
-	var virtClient kubecli.KubevirtClient
-	var err error
+		var virtClient kubecli.KubevirtClient
+		var err error
 
-	const testPort = 1500
+		const testPort = 1500
 
-	const xfailError = "Secondary ip on dual stack service is not working. Tracking issue - https://github.com/kubevirt/kubevirt/issues/5477"
+		const xfailError = "Secondary ip on dual stack service is not working. Tracking issue - https://github.com/kubevirt/kubevirt/issues/5477"
 
-	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-	})
+		BeforeEach(func() {
+			tests.BeforeTestCleanup()
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
+		})
 
-	randomizeName := func(currentName string) string {
-		return currentName + rand.String(5)
-	}
-
-	validateClusterIp := func(clusterIp string, ipFamily ipFamily) error {
-		var correctPrimaryFamily bool
-		switch ipFamily {
-		case ipv4, dualIPv4Primary:
-			correctPrimaryFamily = netutils.IsIPv4String(clusterIp)
-		case ipv6, dualIPv6Primary:
-			correctPrimaryFamily = netutils.IsIPv6String(clusterIp)
-		}
-		if !correctPrimaryFamily {
-			return fmt.Errorf("the ClusterIP %s belongs to the wrong ip family", clusterIp)
-		}
-		return nil
-	}
-
-	skipIfNotSupportedCluster := func(ipFamily ipFamily) {
-		if includesIpv4(ipFamily) {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-		}
-		if inlcudesIpv6(ipFamily) {
-			libnet.SkipWhenClusterNotSupportIpv6(virtClient)
-		}
-		if isDualStack(ipFamily) {
-			checks.SkipIfVersionBelow("Dual stack service requires v1.20 and above", "1.20")
-		}
-	}
-
-	appendIpFamilyToExposeArgs := func(ipFamily ipFamily, vmiExposeArgs []string) []string {
-		if inlcudesIpv6(ipFamily) {
-			vmiExposeArgs = append(vmiExposeArgs, "--ip-family", string(ipFamily))
-		}
-		return vmiExposeArgs
-	}
-
-	createAndWaitForJobToSucceed := func(jobFactory func(host, port string) *batchv1.Job, namespace, ip, port, viaMessage string) error {
-		By(fmt.Sprintf("Starting a job which tries to reach the VMI via the %s", viaMessage))
-		job := jobFactory(ip, port)
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), job, metav1.CreateOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		By("Waiting for the job to report a successful connection attempt")
-		return tests.WaitForJobToSucceed(job, time.Duration(120)*time.Second)
-	}
-
-	executeVirtctlExposeCommand := func(ExposeArgs []string) error {
-		virtctl := clientcmd.NewRepeatableVirtctlCommand(ExposeArgs...)
-		return virtctl()
-	}
-
-	getService := func(namespace, serviceName string) (*k8sv1.Service, error) {
-		svc, err := virtClient.CoreV1().Services(namespace).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
-		if err != nil {
-			return nil, err
+		randomizeName := func(currentName string) string {
+			return currentName + rand.String(5)
 		}
 
-		return svc, nil
-	}
+		validateClusterIp := func(clusterIp string, ipFamily ipFamily) error {
+			var correctPrimaryFamily bool
+			switch ipFamily {
+			case ipv4, dualIPv4Primary:
+				correctPrimaryFamily = netutils.IsIPv4String(clusterIp)
+			case ipv6, dualIPv6Primary:
+				correctPrimaryFamily = netutils.IsIPv6String(clusterIp)
+			}
+			if !correctPrimaryFamily {
+				return fmt.Errorf("the ClusterIP %s belongs to the wrong ip family", clusterIp)
+			}
+			return nil
+		}
 
-	runJobsAgainstService := func(svc *k8sv1.Service, namespace string, jobFactories ...func(host, port string) *batchv1.Job) {
-		serviceIPs := svc.Spec.ClusterIPs
-		for _, jobFactory := range jobFactories {
-			for ipOrderNum, ip := range serviceIPs {
-				assert.XFail(xfailError, func() {
-					servicePort := fmt.Sprint(svc.Spec.Ports[0].Port)
-					Expect(createAndWaitForJobToSucceed(jobFactory, namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
-				}, ipOrderNum > 0)
+		skipIfNotSupportedCluster := func(ipFamily ipFamily) {
+			if includesIpv4(ipFamily) {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			}
+			if inlcudesIpv6(ipFamily) {
+				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+			}
+			if isDualStack(ipFamily) {
+				checks.SkipIfVersionBelow("Dual stack service requires v1.20 and above", "1.20")
 			}
 		}
-	}
+
+		appendIpFamilyToExposeArgs := func(ipFamily ipFamily, vmiExposeArgs []string) []string {
+			if inlcudesIpv6(ipFamily) {
+				vmiExposeArgs = append(vmiExposeArgs, "--ip-family", string(ipFamily))
+			}
+			return vmiExposeArgs
+		}
+
+		createAndWaitForJobToSucceed := func(jobFactory func(host, port string) *batchv1.Job, namespace, ip, port, viaMessage string) error {
+			By(fmt.Sprintf("Starting a job which tries to reach the VMI via the %s", viaMessage))
+			job := jobFactory(ip, port)
+			job, err := virtClient.BatchV1().Jobs(namespace).Create(context.Background(), job, metav1.CreateOptions{})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+			By("Waiting for the job to report a successful connection attempt")
+			return tests.WaitForJobToSucceed(job, time.Duration(120)*time.Second)
+		}
+
+		executeVirtctlExposeCommand := func(ExposeArgs []string) error {
+		virtctl := clientcmd.NewRepeatableVirtctlCommand(ExposeArgs...)
+			return virtctl()
+		}
+
+		getService := func(namespace, serviceName string) (*k8sv1.Service, error) {
+			svc, err := virtClient.CoreV1().Services(namespace).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+
+			return svc, nil
+		}
+
+		runJobsAgainstService := func(svc *k8sv1.Service, namespace string, jobFactories ...func(host, port string) *batchv1.Job) {
+			serviceIPs := svc.Spec.ClusterIPs
+			for _, jobFactory := range jobFactories {
+				for ipOrderNum, ip := range serviceIPs {
+					assert.XFail(xfailError, func() {
+						servicePort := fmt.Sprint(svc.Spec.Ports[0].Port)
+						Expect(createAndWaitForJobToSucceed(jobFactory, namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
+					}, ipOrderNum > 0)
+				}
+			}
+		}
 
 	Context("Expose service on a VM", func() {
 		var tcpVM *v1.VirtualMachineInstance
@@ -172,263 +174,267 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			tests.GenerateHelloWorldServer(tcpVM, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 		})
 
-		Context("Expose ClusterIP service", func() {
-			const servicePort = "27017"
-			const serviceNamePrefix = "cluster-ip-vmi"
+			Context("Expose ClusterIP service", func() {
+				const servicePort = "27017"
+				const serviceNamePrefix = "cluster-ip-vmi"
 
-			var serviceName string
-			var vmiExposeArgs []string
+				var serviceName string
+				var vmiExposeArgs []string
 
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort(strconv.Itoa(testPort)))
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort(strconv.Itoa(testPort)))
+				})
+
+				DescribeTable("[label:masquerade_binding_connectivity]Should expose a Cluster IP service on a VMI and connect to it",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+
+						By(gettingValidatingClusterIP)
+						svc, err := getService(tcpVM.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
+						Expect(err).ToNot(HaveOccurred())
+
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, tcpVM.Namespace, tests.NewHelloWorldJobTCP)
+					},
+					Entry("[test_id:1531] over default IPv4 IP family", Labels{"test_id:1531"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
 			})
 
-			DescribeTable("[label:masquerade_binding_connectivity]Should expose a Cluster IP service on a VMI and connect to it", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+			Context("Expose ClusterIP service with string target-port", func() {
+				const servicePort = "27017"
+				const serviceNamePrefix = "cluster-ip-target-vmi"
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+				var serviceName string
+				var vmiExposeArgs []string
 
-				By(gettingValidatingClusterIP)
-				svc, err := getService(tcpVM.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
-				Expect(err).ToNot(HaveOccurred())
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort("http"))
+				})
 
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, tcpVM.Namespace, tests.NewHelloWorldJobTCP)
-			},
-				Entry("[test_id:1531] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
-		})
+				DescribeTable("Should expose a ClusterIP service and connect to the vm on port 80", func(ipFamily ipFamily) {
+					skipIfNotSupportedCluster(ipFamily)
+					vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
 
-		Context("Expose ClusterIP service with string target-port", func() {
-			const servicePort = "27017"
-			const serviceNamePrefix = "cluster-ip-target-vmi"
+					By("Exposing the service via virtctl command")
+					Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-			var serviceName string
-			var vmiExposeArgs []string
+					By("Waiting for kubernetes to create the relevant endpoint")
+					getEndpoint := func() error {
+						_, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
+						return err
+					}
+					Eventually(getEndpoint, 60, 1).Should(BeNil())
 
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort("http"))
+					endpoints, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(endpoints.Subsets).To(HaveLen(1))
+					endpoint := endpoints.Subsets[0]
+					Expect(endpoint.Ports).To(HaveLen(1))
+					Expect(endpoint.Ports[0].Port).To(Equal(int32(80)))
+
+					isDualStack := isDualStack(ipFamily)
+					numOfIps := 1
+					if isDualStack {
+						numOfIps = 2
+					}
+					assert.XFail(xfailError, func() {
+						Expect(endpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
+					}, isDualStack)
+				},
+					Entry("[test_id:1532] over default IPv4 IP family", Labels{"test_id:1532"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
 			})
 
-			DescribeTable("Should expose a ClusterIP service and connect to the vm on port 80", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+			Context("Expose ClusterIP service with ports on the vmi defined", func() {
+				const serviceNamePrefix = "cluster-ip-target-multiple-ports-vmi"
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+				var serviceName string
+				var vmiExposeArgs []string
 
-				By("Waiting for kubernetes to create the relevant endpoint")
-				getEndpoint := func() error {
-					_, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
-					return err
-				}
-				Eventually(getEndpoint, 60, 1).Should(BeNil())
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
+						libnet.WithServiceName(serviceName))
+				})
 
-				endpoints, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				DescribeTable("Should expose a ClusterIP service and connect to all ports defined on the vmi", func(ipFamily ipFamily) {
+					skipIfNotSupportedCluster(ipFamily)
+					vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
 
-				Expect(endpoints.Subsets).To(HaveLen(1))
-				endpoint := endpoints.Subsets[0]
-				Expect(endpoint.Ports).To(HaveLen(1))
-				Expect(endpoint.Ports[0].Port).To(Equal(int32(80)))
+					By("Exposing the service via virtctl command")
+					Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-				isDualStack := isDualStack(ipFamily)
-				numOfIps := 1
-				if isDualStack {
-					numOfIps = 2
-				}
-				assert.XFail(xfailError, func() {
-					Expect(endpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
-				}, isDualStack)
-			},
-				Entry("[test_id:1532] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
-		})
+					By("Waiting for kubernetes to create the relevant endpoint")
+					getEndpoint := func() error {
+						_, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
+						return err
+					}
+					Eventually(getEndpoint, 60, 1).Should(BeNil())
 
-		Context("Expose ClusterIP service with ports on the vmi defined", func() {
-			const serviceNamePrefix = "cluster-ip-target-multiple-ports-vmi"
+					endpoints, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
-			var serviceName string
-			var vmiExposeArgs []string
-
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
-					libnet.WithServiceName(serviceName))
+					Expect(endpoints.Subsets).To(HaveLen(1))
+					endpoint := endpoints.Subsets[0]
+					Expect(endpoint.Ports).To(HaveLen(4))
+					Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-1", Port: 80, Protocol: "TCP"}))
+					Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-2", Port: 1500, Protocol: "TCP"}))
+					Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-3", Port: 82, Protocol: "UDP"}))
+					Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-4", Port: 1500, Protocol: "UDP"}))
+				},
+					Entry("[test_id:1533] over default IPv4 IP family", Labels{"test_id:1533"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
 			})
 
-			DescribeTable("Should expose a ClusterIP service and connect to all ports defined on the vmi", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+			Context("Expose ClusterIP service with IPFamilyPolicy", func() {
+				const serviceNamePrefix = "cluster-ip-with-ip-family-policy"
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+				var serviceName string
+				var vmiExposeArgs []string
 
-				By("Waiting for kubernetes to create the relevant endpoint")
-				getEndpoint := func() error {
-					_, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
-					return err
-				}
-				Eventually(getEndpoint, 60, 1).Should(BeNil())
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
+						libnet.WithServiceName(serviceName))
+				})
 
-				endpoints, err := virtClient.CoreV1().Endpoints(util.NamespaceTestDefault).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				DescribeTable("Should expose a ClusterIP service with the correct IPFamilyPolicy", func(ipFamiyPolicy k8sv1.IPFamilyPolicyType) {
+					checks.SkipIfVersionBelow("IPFamilyPolicy property on a service requires v1.20 and above", "1.20")
 
-				Expect(endpoints.Subsets).To(HaveLen(1))
-				endpoint := endpoints.Subsets[0]
-				Expect(endpoint.Ports).To(HaveLen(4))
-				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-1", Port: 80, Protocol: "TCP"}))
-				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-2", Port: 1500, Protocol: "TCP"}))
-				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-3", Port: 82, Protocol: "UDP"}))
-				Expect(endpoint.Ports).To(ContainElement(k8sv1.EndpointPort{Name: "port-4", Port: 1500, Protocol: "UDP"}))
-			},
-				Entry("[test_id:1533] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
-		})
+					if ipFamiyPolicy == k8sv1.IPFamilyPolicyRequireDualStack {
+						libnet.SkipWhenNotDualStackCluster(virtClient)
+					}
 
-		Context("Expose ClusterIP service with IPFamilyPolicy", func() {
-			const serviceNamePrefix = "cluster-ip-with-ip-family-policy"
-
-			var serviceName string
-			var vmiExposeArgs []string
-
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
-					libnet.WithServiceName(serviceName))
-			})
-
-			DescribeTable("Should expose a ClusterIP service with the correct IPFamilyPolicy", func(ipFamiyPolicy k8sv1.IPFamilyPolicyType) {
-				checks.SkipIfVersionBelow("IPFamilyPolicy property on a service requires v1.20 and above", "1.20")
-
-				if ipFamiyPolicy == k8sv1.IPFamilyPolicyRequireDualStack {
-					libnet.SkipWhenNotDualStackCluster(virtClient)
-				}
-
-				calcNumOfClusterIPs := func() int {
-					switch ipFamiyPolicy {
-					case k8sv1.IPFamilyPolicySingleStack:
-						return 1
-					case k8sv1.IPFamilyPolicyPreferDualStack:
-						isClusterDualStack, err := cluster.DualStack(virtClient)
-						ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
-						if isClusterDualStack {
+					calcNumOfClusterIPs := func() int {
+						switch ipFamiyPolicy {
+						case k8sv1.IPFamilyPolicySingleStack:
+							return 1
+						case k8sv1.IPFamilyPolicyPreferDualStack:
+							isClusterDualStack, err := cluster.DualStack(virtClient)
+							ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
+							if isClusterDualStack {
+								return 2
+							}
+							return 1
+						case k8sv1.IPFamilyPolicyRequireDualStack:
 							return 2
 						}
-						return 1
-					case k8sv1.IPFamilyPolicyRequireDualStack:
-						return 2
+						return 0
 					}
-					return 0
-				}
 
-				vmiExposeArgs = append(vmiExposeArgs, "--ip-family-policy", string(ipFamiyPolicy))
+					vmiExposeArgs = append(vmiExposeArgs, "--ip-family-policy", string(ipFamiyPolicy))
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+					By("Exposing the service via virtctl command")
+					Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-				By("Getting the service")
-				svc, err := getService(tcpVM.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
+					By("Getting the service")
+					svc, err := getService(tcpVM.Namespace, serviceName)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("Validating the num of cluster ips")
-				Expect(svc.Spec.ClusterIPs).To(HaveLen(calcNumOfClusterIPs()))
-			},
-				Entry("over SingleStack IP family policy", k8sv1.IPFamilyPolicySingleStack),
-				Entry("over PreferDualStack IP family policy", k8sv1.IPFamilyPolicyPreferDualStack),
-				Entry("over RequireDualStack IP family policy", k8sv1.IPFamilyPolicyRequireDualStack),
-			)
-		})
-
-		Context("Expose NodePort service", func() {
-			const servicePort = "27017"
-			const serviceNamePrefix = "node-port-vmi"
-
-			var serviceName string
-			var vmiExposeArgs []string
-
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort(strconv.Itoa(testPort)),
-					libnet.WithType("NodePort"))
+					By("Validating the num of cluster ips")
+					Expect(svc.Spec.ClusterIPs).To(HaveLen(calcNumOfClusterIPs()))
+				},
+					Entry("over SingleStack IP family policy", k8sv1.IPFamilyPolicySingleStack),
+					Entry("over PreferDualStack IP family policy", k8sv1.IPFamilyPolicyPreferDualStack),
+					Entry("over RequireDualStack IP family policy", k8sv1.IPFamilyPolicyRequireDualStack),
+				)
 			})
 
-			DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+			Context("Expose NodePort service", func() {
+				const servicePort = "27017"
+				const serviceNamePrefix = "node-port-vmi"
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+				var serviceName string
+				var vmiExposeArgs []string
 
-				By("Getting the service")
-				svc, err := getService(tcpVM.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(tcpVM,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort(strconv.Itoa(testPort)),
+						libnet.WithType("NodePort"))
+				})
 
-				nodePort := svc.Spec.Ports[0].NodePort
-				Expect(nodePort).To(BeNumerically(">", 0))
+				DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
 
-				By("Getting the node IP from all nodes")
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(nodes.Items).ToNot(BeEmpty())
-				for _, node := range nodes.Items {
-					Expect(node.Status.Addresses).ToNot(BeEmpty())
-					nodeIP := node.Status.Addresses[0].Address
-					var ipv6NodeIP string
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-					if includesIpv4(ipFamily) {
-						By("Connecting to IPv4 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
-						}, ipFamily == dualIPv6Primary)
-					}
-					if inlcudesIpv6(ipFamily) {
-						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
-							virtClient,
-							libvmi.GetPodByVirtualMachineInstance(tcpVM, tcpVM.GetNamespace()),
-							node,
-							k8sv1.IPv6Protocol)
-						Expect(err).NotTo(HaveOccurred(), "must have been able to resolve an IP address from the node name")
-						Expect(ipv6NodeIP).NotTo(BeEmpty(), "must have been able to resolve the IPv6 address of the node")
+						By("Getting the service")
+						svc, err := getService(tcpVM.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
 
-						By("Connecting to IPv6 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
-						}, ipFamily == dualIPv4Primary)
-					}
-				}
-			},
-				Entry("[test_id:1534] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
+						nodePort := svc.Spec.Ports[0].NodePort
+						Expect(nodePort).To(BeNumerically(">", 0))
+
+						By("Getting the node IP from all nodes")
+						nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(nodes.Items).ToNot(BeEmpty())
+						for _, node := range nodes.Items {
+							Expect(node.Status.Addresses).ToNot(BeEmpty())
+							nodeIP := node.Status.Addresses[0].Address
+							var ipv6NodeIP string
+
+							if includesIpv4(ipFamily) {
+								By("Connecting to IPv4 node IP")
+								assert.XFail(xfailError, func() {
+									Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
+								}, ipFamily == dualIPv6Primary)
+							}
+							if inlcudesIpv6(ipFamily) {
+								ipv6NodeIP, err = resolveNodeIPAddrByFamily(
+									virtClient,
+									libvmi.GetPodByVirtualMachineInstance(tcpVM, tcpVM.GetNamespace()),
+									node,
+									k8sv1.IPv6Protocol)
+								Expect(err).NotTo(HaveOccurred(), "must have been able to resolve an IP address from the node name")
+								Expect(ipv6NodeIP).NotTo(BeEmpty(), "must have been able to resolve the IPv6 address of the node")
+
+								By("Connecting to IPv6 node IP")
+								assert.XFail(xfailError, func() {
+									Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
+								}, ipFamily == dualIPv4Primary)
+							}
+						}
+					},
+					Entry("[test_id:1534] over default IPv4 IP family", Labels{"test_id:1534"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
+			})
 		})
-	})
 
 	Context("Expose UDP service on a VMI", func() {
 		var udpVM *v1.VirtualMachineInstance
@@ -438,232 +444,238 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			tests.GenerateHelloWorldServer(udpVM, testPort, "udp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 		})
 
-		Context("Expose ClusterIP UDP service", func() {
-			const servicePort = "28017"
-			const serviceNamePrefix = "cluster-ip-udp-vmi"
+			Context("Expose ClusterIP UDP service", func() {
+				const servicePort = "28017"
+				const serviceNamePrefix = "cluster-ip-udp-vmi"
 
-			var serviceName string
-			var vmiExposeArgs []string
+				var serviceName string
+				var vmiExposeArgs []string
 
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(udpVM,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort(strconv.Itoa(testPort)),
-					libnet.WithProtocol("UDP"))
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(udpVM,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort(strconv.Itoa(testPort)),
+						libnet.WithProtocol("UDP"))
+				})
+
+				DescribeTable("[label:masquerade_binding_connectivity]Should expose a ClusterIP service on a VMI and connect to it",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+
+						By(gettingValidatingClusterIP)
+						svc, err := getService(udpVM.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
+						Expect(err).ToNot(HaveOccurred())
+
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
+					},
+					Entry("[test_id:1535] over default IPv4 IP family", Labels{"test_id:1535"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
 			})
 
-			DescribeTable("[label:masquerade_binding_connectivity]Should expose a ClusterIP service on a VMI and connect to it", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+			Context("Expose NodePort UDP service", func() {
+				const servicePort = "29017"
+				const serviceNamePrefix = "node-port-udp-vmi"
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+				var serviceName string
+				var vmiExposeArgs []string
 
-				By(gettingValidatingClusterIP)
-				svc, err := getService(udpVM.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
-				Expect(err).ToNot(HaveOccurred())
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmiExposeArgs = libnet.NewVMIExposeArgs(udpVM,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort(strconv.Itoa(testPort)),
+						libnet.WithType("NodePort"),
+						libnet.WithProtocol("UDP"))
+				})
 
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
-			},
-				Entry("[test_id:1535] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
+				DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+
+						By(gettingValidatingClusterIP)
+						svc, err := getService(udpVM.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
+						Expect(err).ToNot(HaveOccurred())
+
+						nodePort := svc.Spec.Ports[0].NodePort
+						Expect(nodePort).To(BeNumerically(">", 0))
+
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
+
+						By("Getting the node IP from all nodes")
+						nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(nodes.Items).ToNot(BeEmpty())
+						for _, node := range nodes.Items {
+							Expect(node.Status.Addresses).ToNot(BeEmpty())
+							nodeIP := node.Status.Addresses[0].Address
+
+							var ipv6NodeIP string
+							if inlcudesIpv6(ipFamily) {
+								ipv6NodeIP, err = resolveNodeIPAddrByFamily(
+									virtClient,
+									libvmi.GetPodByVirtualMachineInstance(udpVM, udpVM.GetNamespace()),
+									node,
+									k8sv1.IPv6Protocol)
+								Expect(err).NotTo(HaveOccurred(), "must have been able to resolve an IP address from the node name")
+								Expect(ipv6NodeIP).NotTo(BeEmpty(), "must have been able to resolve the IPv6 address of the node")
+							}
+
+							if includesIpv4(ipFamily) {
+								By("Connecting to IPv4 node IP")
+								assert.XFail(xfailError, func() {
+									Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
+								}, ipFamily == dualIPv6Primary)
+							}
+							if inlcudesIpv6(ipFamily) {
+								By("Connecting to IPv6 node IP")
+								assert.XFail(xfailError, func() {
+									Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
+								}, ipFamily == dualIPv4Primary)
+							}
+						}
+					},
+					Entry("[test_id:1536] over default IPv4 IP family", Labels{"test_id:1536"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
+			})
 		})
 
-		Context("Expose NodePort UDP service", func() {
-			const servicePort = "29017"
-			const serviceNamePrefix = "node-port-udp-vmi"
+		Context("Expose service on a VMI replica set", func() {
+			const numberOfVMs = 2
 
-			var serviceName string
-			var vmiExposeArgs []string
-
+			var vmrs *v1.VirtualMachineInstanceReplicaSet
 			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmiExposeArgs = libnet.NewVMIExposeArgs(udpVM,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort(strconv.Itoa(testPort)),
-					libnet.WithType("NodePort"),
-					libnet.WithProtocol("UDP"))
+				By("Creating a VMRS object with 2 replicas")
+				vmrs = tests.NewRandomReplicaSetFromVMI(newLabeledVMI("vmirs"), int32(numberOfVMs))
+				vmrs.Labels = map[string]string{"expose": "vmirs"}
+
+				By("Start the replica set")
+				vmrs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(vmrs)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking the number of ready replicas")
+				Eventually(func() int {
+					rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Get(vmrs.ObjectMeta.Name, k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return int(rs.Status.ReadyReplicas)
+				}, 120*time.Second, 1*time.Second).Should(Equal(numberOfVMs))
+
+				By("Add an 'hello world' server on each VMI in the replica set")
+				// TODO: add label to list options
+				// check size of list
+				// remove check for owner
+				vms, err := virtClient.VirtualMachineInstance(vmrs.ObjectMeta.Namespace).List(&k8smetav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, vm := range vms.Items {
+					if vm.OwnerReferences != nil {
+						tests.GenerateHelloWorldServer(&vm, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
+					}
+				}
 			})
 
-			DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmiExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmiExposeArgs)
+			Context("Expose ClusterIP service", func() {
+				const servicePort = "27017"
+				const serviceNamePrefix = "cluster-ip-vmirs"
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmiExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+				var serviceName string
+				var vmirsExposeArgs []string
 
-				By(gettingValidatingClusterIP)
-				svc, err := getService(udpVM.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
-				Expect(err).ToNot(HaveOccurred())
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmirsExposeArgs = libnet.NewVMIRSExposeArgs(vmrs,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort(strconv.Itoa(testPort)))
+				})
 
-				nodePort := svc.Spec.Ports[0].NodePort
-				Expect(nodePort).To(BeNumerically(">", 0))
+				DescribeTable("[label:masquerade_binding_connectivity]Should create a ClusterIP service on VMRS and connect to it",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmirsExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmirsExposeArgs)
 
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, udpVM.Namespace, tests.NewHelloWorldJobUDP)
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmirsExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-				By("Getting the node IP from all nodes")
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(nodes.Items).ToNot(BeEmpty())
-				for _, node := range nodes.Items {
-					Expect(node.Status.Addresses).ToNot(BeEmpty())
-					nodeIP := node.Status.Addresses[0].Address
+						By(gettingValidatingClusterIP)
+						svc, err := getService(vmrs.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
+						Expect(err).ToNot(HaveOccurred())
 
-					var ipv6NodeIP string
-					if inlcudesIpv6(ipFamily) {
-						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
-							virtClient,
-							libvmi.GetPodByVirtualMachineInstance(udpVM, udpVM.GetNamespace()),
-							node,
-							k8sv1.IPv6Protocol)
-						Expect(err).NotTo(HaveOccurred(), "must have been able to resolve an IP address from the node name")
-						Expect(ipv6NodeIP).NotTo(BeEmpty(), "must have been able to resolve the IPv6 address of the node")
-					}
-
-					if includesIpv4(ipFamily) {
-						By("Connecting to IPv4 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
-						}, ipFamily == dualIPv6Primary)
-					}
-					if inlcudesIpv6(ipFamily) {
-						By("Connecting to IPv6 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
-						}, ipFamily == dualIPv4Primary)
-					}
-				}
-			},
-				Entry("[test_id:1536] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
-		})
-	})
-
-	Context("Expose service on a VMI replica set", func() {
-		const numberOfVMs = 2
-
-		var vmrs *v1.VirtualMachineInstanceReplicaSet
-		BeforeEach(func() {
-			By("Creating a VMRS object with 2 replicas")
-			vmrs = tests.NewRandomReplicaSetFromVMI(newLabeledVMI("vmirs"), int32(numberOfVMs))
-			vmrs.Labels = map[string]string{"expose": "vmirs"}
-
-			By("Start the replica set")
-			vmrs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(vmrs)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Checking the number of ready replicas")
-			Eventually(func() int {
-				rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Get(vmrs.ObjectMeta.Name, k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return int(rs.Status.ReadyReplicas)
-			}, 120*time.Second, 1*time.Second).Should(Equal(numberOfVMs))
-
-			By("Add an 'hello world' server on each VMI in the replica set")
-			// TODO: add label to list options
-			// check size of list
-			// remove check for owner
-			vms, err := virtClient.VirtualMachineInstance(vmrs.ObjectMeta.Namespace).List(&k8smetav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			for _, vm := range vms.Items {
-				if vm.OwnerReferences != nil {
-					tests.GenerateHelloWorldServer(&vm, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
-				}
-			}
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, vmrs.Namespace, tests.NewHelloWorldJobTCP)
+					},
+					Entry("[test_id:1537] over default IPv4 IP family", Labels{"test_id:1537"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
+			})
 		})
 
-		Context("Expose ClusterIP service", func() {
+		Context("Expose a VM as a service.", func() {
 			const servicePort = "27017"
-			const serviceNamePrefix = "cluster-ip-vmirs"
+			const serviceNamePrefix = "cluster-ip-vm"
+			var vm *v1.VirtualMachine
 
-			var serviceName string
-			var vmirsExposeArgs []string
+			var vmExposeArgs []string
 
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmirsExposeArgs = libnet.NewVMIRSExposeArgs(vmrs,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort(strconv.Itoa(testPort)))
-			})
-
-			DescribeTable("[label:masquerade_binding_connectivity]Should create a ClusterIP service on VMRS and connect to it", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmirsExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmirsExposeArgs)
-
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmirsExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
-
-				By(gettingValidatingClusterIP)
-				svc, err := getService(vmrs.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
-				Expect(err).ToNot(HaveOccurred())
-
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vmrs.Namespace, tests.NewHelloWorldJobTCP)
-			},
-				Entry("[test_id:1537] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
-		})
-	})
-
-	Context("Expose a VM as a service.", func() {
-		const servicePort = "27017"
-		const serviceNamePrefix = "cluster-ip-vm"
-		var vm *v1.VirtualMachine
-
-		var vmExposeArgs []string
-
-		startVMIFromVMTemplate := func(virtClient kubecli.KubevirtClient, name string, namespace string) *v1.VirtualMachineInstance {
-			By("Calling the start command")
+			startVMIFromVMTemplate := func(virtClient kubecli.KubevirtClient, name string, namespace string) *v1.VirtualMachineInstance {
+				By("Calling the start command")
 			virtctl := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", namespace, name)
-			Expect(virtctl()).To(Succeed(), "should succeed starting a VMI via `virtctl start ...`")
+				Expect(virtctl()).To(Succeed(), "should succeed starting a VMI via `virtctl start ...`")
 
-			By("Getting the status of the VMI")
-			Eventually(func() bool {
-				vm, err := virtClient.VirtualMachine(namespace).Get(name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return vm.Status.Ready
-			}, 120*time.Second, 1*time.Second).Should(BeTrue())
+				By("Getting the status of the VMI")
+				Eventually(func() bool {
+					vm, err := virtClient.VirtualMachine(namespace).Get(name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return vm.Status.Ready
+				}, 120*time.Second, 1*time.Second).Should(BeTrue())
 
-			By("Getting the running VMI")
-			var vmi *v1.VirtualMachineInstance
-			Eventually(func() bool {
-				vmi, err = virtClient.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return vmi.Status.Phase == v1.Running
-			}, 120*time.Second, 1*time.Second).Should(BeTrue())
+				By("Getting the running VMI")
+				var vmi *v1.VirtualMachineInstance
+				Eventually(func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return vmi.Status.Phase == v1.Running
+				}, 120*time.Second, 1*time.Second).Should(BeTrue())
 
-			return vmi
-		}
+				return vmi
+			}
 
-		createStoppedVM := func(virtClient kubecli.KubevirtClient, namespace string) (*v1.VirtualMachine, error) {
-			By("Creating an VM object")
-			vm := tests.NewRandomVirtualMachine(newLabeledVMI("vm"), false)
+			createStoppedVM := func(virtClient kubecli.KubevirtClient, namespace string) (*v1.VirtualMachine, error) {
+				By("Creating an VM object")
+				vm := tests.NewRandomVirtualMachine(newLabeledVMI("vm"), false)
 
-			By("Creating the VM")
-			vm, err = virtClient.VirtualMachine(namespace).Create(vm)
-			return vm, err
-		}
+				By("Creating the VM")
+				vm, err = virtClient.VirtualMachine(namespace).Create(vm)
+				return vm, err
+			}
 
 		startVMWithServer := func(virtClient kubecli.KubevirtClient, protocol string, port int) *v1.VirtualMachineInstance {
 			By("Calling the start command on the stopped VM")
@@ -675,205 +687,211 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			return vmi
 		}
 
-		Context("Expose a VM as a ClusterIP service.", func() {
-			var serviceName string
+			Context("Expose a VM as a ClusterIP service.", func() {
+				var serviceName string
 
-			BeforeEach(func() {
-				vm, err = createStoppedVM(virtClient, util.NamespaceTestDefault)
-				Expect(err).NotTo(HaveOccurred(), "should create a stopped VM.")
-			})
+				BeforeEach(func() {
+					vm, err = createStoppedVM(virtClient, util.NamespaceTestDefault)
+					Expect(err).NotTo(HaveOccurred(), "should create a stopped VM.")
+				})
 
-			BeforeEach(func() {
-				serviceName = randomizeName(serviceNamePrefix)
-				vmExposeArgs = libnet.NewVMExposeArgs(vm,
-					libnet.WithPort(servicePort),
-					libnet.WithServiceName(serviceName),
-					libnet.WithTargetPort(strconv.Itoa(testPort)))
-			})
+				BeforeEach(func() {
+					serviceName = randomizeName(serviceNamePrefix)
+					vmExposeArgs = libnet.NewVMExposeArgs(vm,
+						libnet.WithPort(servicePort),
+						libnet.WithServiceName(serviceName),
+						libnet.WithTargetPort(strconv.Itoa(testPort)))
+				})
 
-			DescribeTable("[label:masquerade_binding_connectivity]Connect to ClusterIP service that was set when VM was offline.", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmExposeArgs)
+				DescribeTable("[label:masquerade_binding_connectivity]Connect to ClusterIP service that was set when VM was offline.",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmExposeArgs)
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-				vmi := startVMWithServer(virtClient, "tcp", testPort)
-				Expect(vmi).NotTo(BeNil(), shouldStartVM)
+						vmi := startVMWithServer(virtClient, "tcp", testPort)
+						Expect(vmi).NotTo(BeNil(), shouldStartVM)
 
-				// This TC also covers:
-				// [test_id:1795] Exposed VM (as a service) can be reconnected multiple times.
-				By(gettingValidatingClusterIP)
-				svc, err := getService(vm.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
-				Expect(err).ToNot(HaveOccurred())
+						// This TC also covers:
+						// [test_id:1795] Exposed VM (as a service) can be reconnected multiple times.
+						By(gettingValidatingClusterIP)
+						svc, err := getService(vm.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
+						Expect(err).ToNot(HaveOccurred())
 
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobHTTP)
-			},
-				Entry("[test_id:1538] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobHTTP)
+					},
+					Entry("[test_id:1538] over default IPv4 IP family", Labels{"test_id:1538"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
 
-			DescribeTable("[label:masquerade_binding_connectivity]Should verify the exposed service is functional before and after VM restart.", func(ipFamily ipFamily) {
-				skipIfNotSupportedCluster(ipFamily)
-				vmExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmExposeArgs)
+				DescribeTable("[label:masquerade_binding_connectivity]Should verify the exposed service is functional before and after VM restart.",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(ipFamily ipFamily) {
+						skipIfNotSupportedCluster(ipFamily)
+						vmExposeArgs = appendIpFamilyToExposeArgs(ipFamily, vmExposeArgs)
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-				vmi := startVMWithServer(virtClient, "tcp", testPort)
-				Expect(vmi).NotTo(BeNil(), shouldStartVM)
+						vmi := startVMWithServer(virtClient, "tcp", testPort)
+						Expect(vmi).NotTo(BeNil(), shouldStartVM)
 
-				vmObj := vm
+						vmObj := vm
 
-				By(gettingValidatingClusterIP)
-				svc, err := getService(vmObj.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
-				Expect(err).ToNot(HaveOccurred())
+						By(gettingValidatingClusterIP)
+						svc, err := getService(vmObj.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, ipFamily)
+						Expect(err).ToNot(HaveOccurred())
 
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
 
-				// Retrieve the current VMI UID, to be compared with the new UID after restart.
-				vmi, err = virtClient.VirtualMachineInstance(vmObj.Namespace).Get(vmObj.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				vmiUIdBeforeRestart := vmi.GetObjectMeta().GetUID()
+						// Retrieve the current VMI UID, to be compared with the new UID after restart.
+						vmi, err = virtClient.VirtualMachineInstance(vmObj.Namespace).Get(vmObj.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						vmiUIdBeforeRestart := vmi.GetObjectMeta().GetUID()
 
-				By("Restarting the running VM.")
+						By("Restarting the running VM.")
 				virtctl := clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", vmObj.Namespace, vmObj.Name)
-				err = virtctl()
-				Expect(err).ToNot(HaveOccurred())
+						err = virtctl()
+						Expect(err).ToNot(HaveOccurred())
 
-				By("Verifying the VMI is back up AFTER restart (in Running status with new UID).")
-				Eventually(func() bool {
-					vmi, err = virtClient.VirtualMachineInstance(vmObj.Namespace).Get(vmObj.Name, &k8smetav1.GetOptions{})
-					if errors.IsNotFound(err) {
-						return false
-					}
-					Expect(err).ToNot(HaveOccurred())
-					vmiUIdAfterRestart := vmi.GetObjectMeta().GetUID()
-					newUId := vmiUIdAfterRestart != vmiUIdBeforeRestart
-					return vmi.Status.Phase == v1.Running && newUId
-				}, 120*time.Second, 1*time.Second).Should(BeTrue())
+						By("Verifying the VMI is back up AFTER restart (in Running status with new UID).")
+						Eventually(func() bool {
+							vmi, err = virtClient.VirtualMachineInstance(vmObj.Namespace).Get(vmObj.Name, &k8smetav1.GetOptions{})
+							if errors.IsNotFound(err) {
+								return false
+							}
+							Expect(err).ToNot(HaveOccurred())
+							vmiUIdAfterRestart := vmi.GetObjectMeta().GetUID()
+							newUId := vmiUIdAfterRestart != vmiUIdBeforeRestart
+							return vmi.Status.Phase == v1.Running && newUId
+						}, 120*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Creating a TCP server on the VM.")
 				tests.GenerateHelloWorldServer(vmi, testPort, "tcp", libnet.WithAlpineConfig(console.LoginToAlpine), false)
 
-				By("Repeating the sequence as prior to restarting the VM: Connect to exposed ClusterIP service.")
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
-			},
-				Entry("[test_id:345] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
+						By("Repeating the sequence as prior to restarting the VM: Connect to exposed ClusterIP service.")
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, vmObj.Namespace, tests.NewHelloWorldJobTCP)
+					},
+					Entry("[test_id:345] over default IPv4 IP family", Labels{"test_id:345"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
 
-			DescribeTable("[label:masquerade_binding_connectivity]Should Verify an exposed service of a VM is not functional after VM deletion.", func(svcIpFamily ipFamily) {
-				skipIfNotSupportedCluster(svcIpFamily)
-				vmExposeArgs = appendIpFamilyToExposeArgs(svcIpFamily, vmExposeArgs)
+				DescribeTable("[label:masquerade_binding_connectivity]Should Verify an exposed service of a VM is not functional after VM deletion.",
+					Labels{"label:masquerade_binding_connectivity"},
+					func(svcIpFamily ipFamily) {
+						skipIfNotSupportedCluster(svcIpFamily)
+						vmExposeArgs = appendIpFamilyToExposeArgs(svcIpFamily, vmExposeArgs)
 
-				getPrimaryAndSecondaryAddr := func(ipv4Addr, ipv6Addr string) (string, string) {
-					var primaryAddr string
-					var secondaryAddr string
-					switch svcIpFamily {
-					case ipv4:
-						primaryAddr = ipv4Addr
-					case ipv6:
-						primaryAddr = ipv6Addr
-					case dualIPv4Primary:
-						primaryAddr = ipv4Addr
-						secondaryAddr = ipv6Addr
-					case dualIPv6Primary:
-						primaryAddr = ipv6Addr
-						secondaryAddr = ipv4Addr
-					}
-					return primaryAddr, secondaryAddr
-				}
+						getPrimaryAndSecondaryAddr := func(ipv4Addr, ipv6Addr string) (string, string) {
+							var primaryAddr string
+							var secondaryAddr string
+							switch svcIpFamily {
+							case ipv4:
+								primaryAddr = ipv4Addr
+							case ipv6:
+								primaryAddr = ipv6Addr
+							case dualIPv4Primary:
+								primaryAddr = ipv4Addr
+								secondaryAddr = ipv6Addr
+							case dualIPv6Primary:
+								primaryAddr = ipv6Addr
+								secondaryAddr = ipv4Addr
+							}
+							return primaryAddr, secondaryAddr
+						}
 
-				By("Exposing the service via virtctl command")
-				Expect(executeVirtctlExposeCommand(vmExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
+						By("Exposing the service via virtctl command")
+						Expect(executeVirtctlExposeCommand(vmExposeArgs)).To(Succeed(), shouldExposeServiceViaVirtctl)
 
-				vmi := startVMWithServer(virtClient, "tcp", testPort)
-				Expect(vmi).NotTo(BeNil(), shouldStartVM)
+						vmi := startVMWithServer(virtClient, "tcp", testPort)
+						Expect(vmi).NotTo(BeNil(), shouldStartVM)
 
-				By(gettingValidatingClusterIP)
-				svc, err := getService(vm.Namespace, serviceName)
-				Expect(err).ToNot(HaveOccurred())
-				err = validateClusterIp(svc.Spec.ClusterIP, svcIpFamily)
-				Expect(err).ToNot(HaveOccurred())
+						By(gettingValidatingClusterIP)
+						svc, err := getService(vm.Namespace, serviceName)
+						Expect(err).ToNot(HaveOccurred())
+						err = validateClusterIp(svc.Spec.ClusterIP, svcIpFamily)
+						Expect(err).ToNot(HaveOccurred())
 
-				By(iteratingClusterIPs)
-				runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobTCP)
+						By(iteratingClusterIPs)
+						runJobsAgainstService(svc, vm.Namespace, tests.NewHelloWorldJobTCP, tests.NewHelloWorldJobTCP)
 
-				By("Comparing the service's endpoints IP address to the VM pod IP address.")
-				// Get the IP address of the VM pod.
-				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				vmPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				vmPodIpv4Address := libnet.GetPodIpByFamily(vmPod, k8sv1.IPv4Protocol)
-				vmPodIpv6Address := libnet.GetPodIpByFamily(vmPod, k8sv1.IPv6Protocol)
+						By("Comparing the service's endpoints IP address to the VM pod IP address.")
+						// Get the IP address of the VM pod.
+						vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						vmPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						vmPodIpv4Address := libnet.GetPodIpByFamily(vmPod, k8sv1.IPv4Protocol)
+						vmPodIpv6Address := libnet.GetPodIpByFamily(vmPod, k8sv1.IPv6Protocol)
 
-				primaryVmPodAddr, secondaryVmPodAddr := getPrimaryAndSecondaryAddr(vmPodIpv4Address, vmPodIpv6Address)
+						primaryVmPodAddr, secondaryVmPodAddr := getPrimaryAndSecondaryAddr(vmPodIpv4Address, vmPodIpv6Address)
 
-				// Get the IP address of the service's endpoint.
-				endpointsName := serviceName
-				svcEndpoints, err := virtClient.CoreV1().Endpoints(vm.Namespace).Get(context.Background(), endpointsName, k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+						// Get the IP address of the service's endpoint.
+						endpointsName := serviceName
+						svcEndpoints, err := virtClient.CoreV1().Endpoints(vm.Namespace).Get(context.Background(), endpointsName, k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
 
-				// There should be one - and only one - subset for this endpoint,
-				// pointing to a single pod (the VMI's virt-launcher pod).
-				// This subset should hold a single IP address only - the VM's pod address.
-				Expect(svcEndpoints.Subsets).To(HaveLen(1))
+						// There should be one - and only one - subset for this endpoint,
+						// pointing to a single pod (the VMI's virt-launcher pod).
+						// This subset should hold a single IP address only - the VM's pod address.
+						Expect(svcEndpoints.Subsets).To(HaveLen(1))
 
-				numOfIps := 1
-				if secondaryVmPodAddr != "" {
-					numOfIps = 2
-				}
-				assert.XFail(xfailError, func() {
-					Expect(svcEndpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
-				}, secondaryVmPodAddr != "")
+						numOfIps := 1
+						if secondaryVmPodAddr != "" {
+							numOfIps = 2
+						}
+						assert.XFail(xfailError, func() {
+							Expect(svcEndpoints.Subsets[0].Addresses).To(HaveLen(numOfIps))
+						}, secondaryVmPodAddr != "")
 
-				endptSubsetIpAddress := svcEndpoints.Subsets[0].Addresses[0].IP
-				Eventually(endptSubsetIpAddress).Should(BeEquivalentTo(primaryVmPodAddr))
+						endptSubsetIpAddress := svcEndpoints.Subsets[0].Addresses[0].IP
+						Eventually(endptSubsetIpAddress).Should(BeEquivalentTo(primaryVmPodAddr))
 
-				if secondaryVmPodAddr != "" {
-					assert.XFail(xfailError, func() {
-						endptSubsetIpAddress := svcEndpoints.Subsets[0].Addresses[1].IP
-						Eventually(endptSubsetIpAddress).Should(BeEquivalentTo(secondaryVmPodAddr))
-					})
-				}
+						if secondaryVmPodAddr != "" {
+							assert.XFail(xfailError, func() {
+								endptSubsetIpAddress := svcEndpoints.Subsets[0].Addresses[1].IP
+								Eventually(endptSubsetIpAddress).Should(BeEquivalentTo(secondaryVmPodAddr))
+							})
+						}
 
-				By("Deleting the VM.")
-				Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &k8smetav1.DeleteOptions{})).To(Succeed())
-				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+						By("Deleting the VM.")
+						Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &k8smetav1.DeleteOptions{})).To(Succeed())
+						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 
-				By("Verifying the endpoints' single subset, which points to the VM's pod, is deleted once the VM was deleted.")
-				svcEndpoints, err = virtClient.CoreV1().Endpoints(vm.Namespace).Get(context.Background(), endpointsName, k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(svcEndpoints.Subsets).To(BeNil())
+						By("Verifying the endpoints' single subset, which points to the VM's pod, is deleted once the VM was deleted.")
+						svcEndpoints, err = virtClient.CoreV1().Endpoints(vm.Namespace).Get(context.Background(), endpointsName, k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(svcEndpoints.Subsets).To(BeNil())
 
-				By("Starting a job which tries to reach the VMI via the ClusterIP service.")
-				job := tests.NewHelloWorldJobTCP(svc.Spec.ClusterIP, servicePort)
-				job, err = virtClient.BatchV1().Jobs(vm.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+						By("Starting a job which tries to reach the VMI via the ClusterIP service.")
+						job := tests.NewHelloWorldJobTCP(svc.Spec.ClusterIP, servicePort)
+						job, err = virtClient.BatchV1().Jobs(vm.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred())
 
-				By("Waiting for the job to report a failed connection attempt.")
-				Expect(tests.WaitForJobToFail(job, 240*time.Second)).To(Succeed())
-			},
-				Entry("[test_id:343] over default IPv4 IP family", ipv4),
-				Entry(overIPv6Family, ipv6),
-				Entry(overDualStackIPv4, dualIPv4Primary),
-				Entry(overDualStackIPv6, dualIPv6Primary),
-			)
+						By("Waiting for the job to report a failed connection attempt.")
+						Expect(tests.WaitForJobToFail(job, 240*time.Second)).To(Succeed())
+					},
+					Entry("[test_id:343] over default IPv4 IP family", Labels{"test_id:343"}, ipv4),
+					Entry(overIPv6Family, ipv6),
+					Entry(overDualStackIPv4, dualIPv4Primary),
+					Entry(overDualStackIPv6, dualIPv6Primary),
+				)
+			})
 		})
 	})
-})
 
 func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {
 	for _, address := range nodeAddresses {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -141,7 +141,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		}
 
 		executeVirtctlExposeCommand := func(ExposeArgs []string) error {
-		virtctl := clientcmd.NewRepeatableVirtctlCommand(ExposeArgs...)
+			virtctl := clientcmd.NewRepeatableVirtctlCommand(ExposeArgs...)
 			return virtctl()
 		}
 
@@ -647,7 +647,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 			startVMIFromVMTemplate := func(virtClient kubecli.KubevirtClient, name string, namespace string) *v1.VirtualMachineInstance {
 				By("Calling the start command")
-			virtctl := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", namespace, name)
+				virtctl := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", namespace, name)
 				Expect(virtctl()).To(Succeed(), "should succeed starting a VMI via `virtctl start ...`")
 
 				By("Getting the status of the VMI")
@@ -761,7 +761,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						vmiUIdBeforeRestart := vmi.GetObjectMeta().GetUID()
 
 						By("Restarting the running VM.")
-				virtctl := clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", vmObj.Namespace, vmObj.Name)
+						virtctl := clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", vmObj.Namespace, vmObj.Name)
 						err = virtctl()
 						Expect(err).ToNot(HaveOccurred())
 

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -23,10 +23,22 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-network] "+text, body)
+func SIGDescribe(text string, args ...interface{}) bool {
+	for i := range args {
+		if labels, ok := args[i].(Labels); ok {
+			labels = append(labels, "sig-network")
+			args[i] = labels
+		}
+	}
+	return Describe("[sig-network] "+text, args)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-network] "+text, body)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	for i := range args {
+		if labels, ok := args[i].(Labels); ok {
+			labels = append(labels, "sig-network")
+			args[i] = labels
+		}
+	}
+	return FDescribe("[sig-network] "+text, args)
 }

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy",
-	Labels{"rfe_id:150", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+	Label("rfe_id:150", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 	func() {
 		var (
 			virtClient      kubecli.KubevirtClient
@@ -48,8 +48,8 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 			serverVMILabels = map[string]string{"type": "test"}
 		})
 
-	Context("when three alpine VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
-		var serverVMI, clientVMI *v1.VirtualMachineInstance
+		Context("when three alpine VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
+			var serverVMI, clientVMI *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
 				var err error
@@ -74,16 +74,16 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 					waitForNetworkPolicyDeletion(policy)
 				})
 
-				It("[test_id:1511] should fail to reach serverVMI from clientVMI", Labels{"test_id:1511"}, func() {
+				It("[test_id:1511] should fail to reach serverVMI from clientVMI", Label("test_id:1511"), func() {
 					By("Connect serverVMI from clientVMI")
 					assertPingFail(clientVMI, serverVMI)
 				})
 
-				It("[test_id:1512] should fail to reach clientVMI from serverVMI", Labels{"test_id:1512"}, func() {
+				It("[test_id:1512] should fail to reach clientVMI from serverVMI", Label("test_id:1512"), func() {
 					By("Connect clientVMI from serverVMI")
 					assertPingFail(serverVMI, clientVMI)
 				})
-				It("[test_id:369] should deny http traffic for ports 80/81 from clientVMI to serverVMI", Labels{"test_id:369"}, func() {
+				It("[test_id:369] should deny http traffic for ports 80/81 from clientVMI to serverVMI", Label("test_id:369"), func() {
 					assertHTTPPingFailed(clientVMI, serverVMI, 80)
 					assertHTTPPingFailed(clientVMI, serverVMI, 81)
 				})
@@ -122,7 +122,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 						assertIPsNotEmptyForVMI(clientVMI)
 					})
 
-					It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", Labels{"Conformance", "test_id:1513"}, func() {
+					It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", Label("Conformance", "test_id:1513"), func() {
 						assertPingSucceed(clientVMI, serverVMI)
 					})
 				})
@@ -137,7 +137,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 						assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 					})
 
-					It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", Labels{"Conformance", "test_id:1514"}, func() {
+					It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", Label("Conformance", "test_id:1514"), func() {
 						assertPingFail(clientVMIAlternativeNamespace, serverVMI)
 					})
 				})
@@ -178,7 +178,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 						assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 					})
 
-					It("[test_id:1515] should fail to reach serverVMI from clientVMIAlternativeNamespace", Labels{"test_id:1515"}, func() {
+					It("[test_id:1515] should fail to reach serverVMI from clientVMIAlternativeNamespace", Label("test_id:1515"), func() {
 						By("Connect serverVMI from clientVMIAlternativeNamespace")
 						assertPingFail(clientVMIAlternativeNamespace, serverVMI)
 					})
@@ -192,7 +192,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 						assertIPsNotEmptyForVMI(clientVMI)
 					})
 
-					It("[test_id:1515] should fail to reach serverVMI from clientVMI", Labels{"test_id:1515"}, func() {
+					It("[test_id:1515] should fail to reach serverVMI from clientVMI", Label("test_id:1515"), func() {
 						By("Connect serverVMI from clientVMIAlternativeNamespace")
 						assertPingFail(clientVMI, serverVMI)
 					})
@@ -207,7 +207,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 							assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
 						})
 
-						It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", Labels{"test_id:1517"}, func() {
+						It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", Label("test_id:1517"), func() {
 							By("Connect clientVMI from clientVMIAlternativeNamespace")
 							assertPingSucceed(clientVMIAlternativeNamespace, clientVMI)
 						})
@@ -241,7 +241,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				AfterEach(func() {
 					waitForNetworkPolicyDeletion(policy)
 				})
-				It("[test_id:2774] should allow http traffic for ports 80 and 81 from clientVMI to serverVMI", Labels{"test_id:2774"}, func() {
+				It("[test_id:2774] should allow http traffic for ports 80 and 81 from clientVMI to serverVMI", Label("test_id:2774"), func() {
 					assertHTTPPingSucceed(clientVMI, serverVMI, 80)
 					assertHTTPPingSucceed(clientVMI, serverVMI, 81)
 				})
@@ -270,7 +270,7 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 				AfterEach(func() {
 					waitForNetworkPolicyDeletion(policy)
 				})
-				It("[test_id:2775] should allow http traffic at port 80 and deny at port 81 from clientVMI to serverVMI", Labels{"test_id:2775"}, func() {
+				It("[test_id:2775] should allow http traffic at port 80 and deny at port 81 from clientVMI to serverVMI", Label("test_id:2775"), func() {
 					assertHTTPPingSucceed(clientVMI, serverVMI, 80)
 					assertHTTPPingFailed(clientVMI, serverVMI, 81)
 				})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					cleanupVMI(virtClient, vmi)
 				})
 
-				It("[test_id:4153]should report PodIP/s as its own on interface status", func() {
+				It("[test_id:4153]should report PodIP/s as its own on interface status", Labels{"test_id:4153"}, func() {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Consistently(func() error {
 						vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
@@ -174,7 +174,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					cleanupVMI(virtClient, vmi)
 				})
 
-				It("[Conformance] should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+				It("[Conformance] should report PodIP as its own on interface status", Labels{"Conformance"}, func() { AssertReportedIP(vmi) })
 			})
 		})
 	})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					cleanupVMI(virtClient, vmi)
 				})
 
-				It("[test_id:4153]should report PodIP/s as its own on interface status", Labels{"test_id:4153"}, func() {
+				It("[test_id:4153]should report PodIP/s as its own on interface status", Label("test_id:4153"), func() {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Consistently(func() error {
 						vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
@@ -174,7 +174,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					cleanupVMI(virtClient, vmi)
 				})
 
-				It("[Conformance] should report PodIP as its own on interface status", Labels{"Conformance"}, func() { AssertReportedIP(vmi) })
+				It("[Conformance] should report PodIP as its own on interface status", Label("Conformance"), func() { AssertReportedIP(vmi) })
 			})
 		})
 	})

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -26,7 +26,7 @@ const (
 	specifyingVMLivenessProbe  = "Specifying a VMI with a liveness probe"
 )
 
-var _ = SIGDescribe("[ref_id:1182]Probes", func() {
+var _ = SIGDescribe("[ref_id:1182]Probes", Labels{"ref_id:1182"}, func() {
 	var (
 		err           error
 		virtClient    kubecli.KubevirtClient
@@ -123,13 +123,13 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 120)
 			}
 		},
-			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv4", tcpProbe, corev1.IPv4Protocol, false, false),
-			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv6", tcpProbe, corev1.IPv6Protocol, false, false),
-			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv4", httpProbe, corev1.IPv4Protocol, false, false),
-			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv6", httpProbe, corev1.IPv6Protocol, false, false),
-			Entry("[test_id:TODO]with working Exec probe", createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true, false),
-			Entry("[test_id:6739]with GuestAgentPing", guestAgentPingProbe, blankIPFamily, true, false),
-			Entry("[test_id:6741]status change with guest-agent availability", guestAgentPingProbe, blankIPFamily, true, true),
+			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv4", Labels{"test_id:1202", "posneg:positive"}, tcpProbe, corev1.IPv4Protocol, false, false),
+			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv6", Labels{"test_id:1202", "posneg:positive"}, tcpProbe, corev1.IPv6Protocol, false, false),
+			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv4", Labels{"test_id:1200", "posneg:positive"}, httpProbe, corev1.IPv4Protocol, false, false),
+			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv6", Labels{"test_id:1200", "posneg:positive"}, httpProbe, corev1.IPv6Protocol, false, false),
+			Entry("[test_id:TODO]with working Exec probe", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true, false),
+			Entry("[test_id:6739]with GuestAgentPing", Labels{"test_id:6739"}, guestAgentPingProbe, blankIPFamily, true, false),
+			Entry("[test_id:6741]status change with guest-agent availability", Labels{"test_id:6741"}, guestAgentPingProbe, blankIPFamily, true, true),
 		)
 
 		DescribeTable("should fail", func(readinessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
@@ -143,10 +143,10 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				return getVMIConditions(virtClient, vmi)
 			}).ShouldNot(ContainElement(v1.VirtualMachineInstanceReady))
 		},
-			Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", tcpProbe, libvmi.NewAlpine),
-			Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", httpProbe, libvmi.NewAlpine),
-			Entry("[test_id:TODO]with working Exec probe and invalid command", createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
-			Entry("[test_id:TODO]with working Exec probe and infinitely running command", createExecProbe(period, initialSeconds, timeoutSeconds, "tail", "-f", "/dev/null"), libvmi.NewFedora),
+			Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", Labels{"test_id:1220", "posneg:negative"}, tcpProbe, libvmi.NewAlpine),
+			Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", Labels{"test_id:1219", "posneg:negative"}, httpProbe, libvmi.NewAlpine),
+			Entry("[test_id:TODO]with working Exec probe and invalid command", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
+			Entry("[test_id:TODO]with working Exec probe and infinitely running command", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "tail", "-f", "/dev/null"), libvmi.NewFedora),
 		)
 	})
 
@@ -200,11 +200,11 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				return vmi.IsFinal()
 			}, 120, 1).Should(Not(BeTrue()))
 		},
-			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv4", tcpProbe, corev1.IPv4Protocol, false),
-			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv6", tcpProbe, corev1.IPv6Protocol, false),
-			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv4", httpProbe, corev1.IPv4Protocol, false),
-			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv6", httpProbe, corev1.IPv6Protocol, false),
-			Entry("[test_id:TODO]with working Exec probe", createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true),
+			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv4", Labels{"test_id:1199", "posneg:positive"}, tcpProbe, corev1.IPv4Protocol, false),
+			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv6", Labels{"test_id:1199", "posneg:positive"}, tcpProbe, corev1.IPv6Protocol, false),
+			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv4", Labels{"test_id:1201", "posneg:positive"}, httpProbe, corev1.IPv4Protocol, false),
+			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv6", Labels{"test_id:1201", "posneg:positive"}, httpProbe, corev1.IPv6Protocol, false),
+			Entry("[test_id:TODO]with working Exec probe", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true),
 		)
 
 		DescribeTable("should fail the VMI", func(livenessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
@@ -220,9 +220,9 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				return vmi.IsFinal()
 			}, 120, 1).Should(BeTrue())
 		},
-			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", tcpProbe, libvmi.NewCirros),
-			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", httpProbe, libvmi.NewCirros),
-			Entry("[test_id:TODO]with working Exec probe and invalid command", createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
+			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", Labels{"test_id:1217", "posneg:negative"}, tcpProbe, libvmi.NewCirros),
+			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", Labels{"test_id:1218", "posneg:negative"}, httpProbe, libvmi.NewCirros),
+			Entry("[test_id:TODO]with working Exec probe and invalid command", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
 		)
 	})
 })

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -26,7 +26,7 @@ const (
 	specifyingVMLivenessProbe  = "Specifying a VMI with a liveness probe"
 )
 
-var _ = SIGDescribe("[ref_id:1182]Probes", Labels{"ref_id:1182"}, func() {
+var _ = SIGDescribe("[ref_id:1182]Probes", Label("ref_id:1182"), func() {
 	var (
 		err           error
 		virtClient    kubecli.KubevirtClient
@@ -123,13 +123,13 @@ var _ = SIGDescribe("[ref_id:1182]Probes", Labels{"ref_id:1182"}, func() {
 				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 120)
 			}
 		},
-			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv4", Labels{"test_id:1202", "posneg:positive"}, tcpProbe, corev1.IPv4Protocol, false, false),
-			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv6", Labels{"test_id:1202", "posneg:positive"}, tcpProbe, corev1.IPv6Protocol, false, false),
-			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv4", Labels{"test_id:1200", "posneg:positive"}, httpProbe, corev1.IPv4Protocol, false, false),
-			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv6", Labels{"test_id:1200", "posneg:positive"}, httpProbe, corev1.IPv6Protocol, false, false),
-			Entry("[test_id:TODO]with working Exec probe", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true, false),
-			Entry("[test_id:6739]with GuestAgentPing", Labels{"test_id:6739"}, guestAgentPingProbe, blankIPFamily, true, false),
-			Entry("[test_id:6741]status change with guest-agent availability", Labels{"test_id:6741"}, guestAgentPingProbe, blankIPFamily, true, true),
+			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv4", Label("test_id:1202", "posneg:positive"), tcpProbe, corev1.IPv4Protocol, false, false),
+			Entry("[test_id:1202][posneg:positive]with working TCP probe and tcp server on ipv6", Label("test_id:1202", "posneg:positive"), tcpProbe, corev1.IPv6Protocol, false, false),
+			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv4", Label("test_id:1200", "posneg:positive"), httpProbe, corev1.IPv4Protocol, false, false),
+			Entry("[test_id:1200][posneg:positive]with working HTTP probe and http server on ipv6", Label("test_id:1200", "posneg:positive"), httpProbe, corev1.IPv6Protocol, false, false),
+			Entry("[test_id:TODO]with working Exec probe", Label("test_id:TODO"), createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true, false),
+			Entry("[test_id:6739]with GuestAgentPing", Label("test_id:6739"), guestAgentPingProbe, blankIPFamily, true, false),
+			Entry("[test_id:6741]status change with guest-agent availability", Label("test_id:6741"), guestAgentPingProbe, blankIPFamily, true, true),
 		)
 
 		DescribeTable("should fail", func(readinessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
@@ -143,10 +143,10 @@ var _ = SIGDescribe("[ref_id:1182]Probes", Labels{"ref_id:1182"}, func() {
 				return getVMIConditions(virtClient, vmi)
 			}).ShouldNot(ContainElement(v1.VirtualMachineInstanceReady))
 		},
-			Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", Labels{"test_id:1220", "posneg:negative"}, tcpProbe, libvmi.NewAlpine),
-			Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", Labels{"test_id:1219", "posneg:negative"}, httpProbe, libvmi.NewAlpine),
-			Entry("[test_id:TODO]with working Exec probe and invalid command", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
-			Entry("[test_id:TODO]with working Exec probe and infinitely running command", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "tail", "-f", "/dev/null"), libvmi.NewFedora),
+			Entry("[test_id:1220][posneg:negative]with working TCP probe and no running server", Label("test_id:1220", "posneg:negative"), tcpProbe, libvmi.NewAlpine),
+			Entry("[test_id:1219][posneg:negative]with working HTTP probe and no running server", Label("test_id:1219", "posneg:negative"), httpProbe, libvmi.NewAlpine),
+			Entry("[test_id:TODO]with working Exec probe and invalid command", Label("test_id:TODO"), createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
+			Entry("[test_id:TODO]with working Exec probe and infinitely running command", Label("test_id:TODO"), createExecProbe(period, initialSeconds, timeoutSeconds, "tail", "-f", "/dev/null"), libvmi.NewFedora),
 		)
 	})
 
@@ -200,11 +200,11 @@ var _ = SIGDescribe("[ref_id:1182]Probes", Labels{"ref_id:1182"}, func() {
 				return vmi.IsFinal()
 			}, 120, 1).Should(Not(BeTrue()))
 		},
-			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv4", Labels{"test_id:1199", "posneg:positive"}, tcpProbe, corev1.IPv4Protocol, false),
-			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv6", Labels{"test_id:1199", "posneg:positive"}, tcpProbe, corev1.IPv6Protocol, false),
-			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv4", Labels{"test_id:1201", "posneg:positive"}, httpProbe, corev1.IPv4Protocol, false),
-			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv6", Labels{"test_id:1201", "posneg:positive"}, httpProbe, corev1.IPv6Protocol, false),
-			Entry("[test_id:TODO]with working Exec probe", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true),
+			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv4", Label("test_id:1199", "posneg:positive"), tcpProbe, corev1.IPv4Protocol, false),
+			Entry("[test_id:1199][posneg:positive]with working TCP probe and tcp server on ipv6", Label("test_id:1199", "posneg:positive"), tcpProbe, corev1.IPv6Protocol, false),
+			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv4", Label("test_id:1201", "posneg:positive"), httpProbe, corev1.IPv4Protocol, false),
+			Entry("[test_id:1201][posneg:positive]with working HTTP probe and http server on ipv6", Label("test_id:1201", "posneg:positive"), httpProbe, corev1.IPv6Protocol, false),
+			Entry("[test_id:TODO]with working Exec probe", Label("test_id:TODO"), createExecProbe(period, initialSeconds, timeoutSeconds, "uname", "-a"), blankIPFamily, true),
 		)
 
 		DescribeTable("should fail the VMI", func(livenessProbe *v1.Probe, vmiFactory func(opts ...libvmi.Option) *v1.VirtualMachineInstance) {
@@ -220,9 +220,9 @@ var _ = SIGDescribe("[ref_id:1182]Probes", Labels{"ref_id:1182"}, func() {
 				return vmi.IsFinal()
 			}, 120, 1).Should(BeTrue())
 		},
-			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", Labels{"test_id:1217", "posneg:negative"}, tcpProbe, libvmi.NewCirros),
-			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", Labels{"test_id:1218", "posneg:negative"}, httpProbe, libvmi.NewCirros),
-			Entry("[test_id:TODO]with working Exec probe and invalid command", Labels{"test_id:TODO"}, createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
+			Entry("[test_id:1217][posneg:negative]with working TCP probe and no running server", Label("test_id:1217", "posneg:negative"), tcpProbe, libvmi.NewCirros),
+			Entry("[test_id:1218][posneg:negative]with working HTTP probe and no running server", Label("test_id:1218", "posneg:negative"), httpProbe, libvmi.NewCirros),
+			Entry("[test_id:TODO]with working Exec probe and invalid command", Label("test_id:TODO"), createExecProbe(period, initialSeconds, timeoutSeconds, "exit", "1"), libvmi.NewFedora),
 		)
 	})
 })

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -183,14 +183,14 @@ var _ = SIGDescribe("Services", func() {
 				jobCleanup = nil
 			})
 
-			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", func() {
+			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", Labels{"test_id:1547"}, func() {
 				var err error
 
 				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort)
 				Expect(err).NotTo(HaveOccurred(), expectConnectivityToExposedService)
 			})
 
-			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", func() {
+			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", Labels{"test_id:1548"}, func() {
 				var err error
 
 				jobCleanup, err = assertNoConnectivityToService("wrongservice", inboundVMI.Namespace, servicePort)
@@ -217,7 +217,7 @@ var _ = SIGDescribe("Services", func() {
 				Expect(jobCleanup()).To(Succeed(), cleaningK8sv1ServiceShouldSucceed)
 			})
 
-			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", func() {
+			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", Labels{"test_id:1549"}, func() {
 				var err error
 				serviceHostnameWithSubdomain := fmt.Sprintf("%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain)
 
@@ -272,7 +272,7 @@ var _ = SIGDescribe("Services", func() {
 				Expect(cleanupService(inboundVMI.GetNamespace(), service.Name)).To(Succeed(), cleaningK8sv1ServiceShouldSucceed)
 			})
 
-			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
+			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", Labels{"Conformance"}, func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
 				By("setting up resources to expose the VMI via a service", func() {
 					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -183,14 +183,14 @@ var _ = SIGDescribe("Services", func() {
 				jobCleanup = nil
 			})
 
-			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", Labels{"test_id:1547"}, func() {
+			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", Label("test_id:1547"), func() {
 				var err error
 
 				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort)
 				Expect(err).NotTo(HaveOccurred(), expectConnectivityToExposedService)
 			})
 
-			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", Labels{"test_id:1548"}, func() {
+			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", Label("test_id:1548"), func() {
 				var err error
 
 				jobCleanup, err = assertNoConnectivityToService("wrongservice", inboundVMI.Namespace, servicePort)
@@ -217,7 +217,7 @@ var _ = SIGDescribe("Services", func() {
 				Expect(jobCleanup()).To(Succeed(), cleaningK8sv1ServiceShouldSucceed)
 			})
 
-			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", Labels{"test_id:1549"}, func() {
+			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", Label("test_id:1549"), func() {
 				var err error
 				serviceHostnameWithSubdomain := fmt.Sprintf("%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain)
 
@@ -272,7 +272,7 @@ var _ = SIGDescribe("Services", func() {
 				Expect(cleanupService(inboundVMI.GetNamespace(), service.Name)).To(Succeed(), cleaningK8sv1ServiceShouldSucceed)
 			})
 
-			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", Labels{"Conformance"}, func(ipFamily k8sv1.IPFamily) {
+			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", Label("Conformance"), func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
 				By("setting up resources to expose the VMI via a service", func() {
 					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -62,7 +62,7 @@ const (
 	sriovnetLinkEnabled = "sriov-linked"
 )
 
-var _ = Describe("[Serial]SRIOV", Label("Serial"), func() {
+var _ = Describe("[Serial]SRIOV", Label("Serial", "SRIOV"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -62,7 +62,7 @@ const (
 	sriovnetLinkEnabled = "sriov-linked"
 )
 
-var _ = Describe("[Serial]SRIOV", func() {
+var _ = Describe("[Serial]SRIOV", Label("Serial"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -351,7 +351,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				tests.CheckCloudInitMetaData(vmi, "openstack/latest/meta_data.json", string(buf))
 			})
 
-			It("[test_id:1754]should create a virtual machine with sriov interface", func() {
+			It("[test_id:1754]should create a virtual machine with sriov interface", Label("test_id:1754"), func() {
 				vmi := getSriovVmi([]string{sriovnet1}, defaultCloudInitNetworkData())
 				vmi = startVmi(vmi)
 				vmi = waitVmi(vmi)
@@ -369,7 +369,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				// it's hard to match them.
 			})
 
-			It("[test_id:1754]should create a virtual machine with sriov interface with all pci devices on the root bus", func() {
+			It("[test_id:1754]should create a virtual machine with sriov interface with all pci devices on the root bus", Label("test_id:1754"), func() {
 				vmi := getSriovVmi([]string{sriovnet1}, defaultCloudInitNetworkData())
 				vmi.Annotations = map[string]string{
 					v1.PlacePCIDevicesOnRootComplex: "true",
@@ -396,7 +396,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				Expect(rootPortController).To(BeEmpty(), "libvirt should not add additional buses to the root one")
 			})
 
-			It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", func() {
+			It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", Label("test_id:3959"), func() {
 				checks.SkipTestIfNoCPUManager()
 				// In addition to verifying that we can start a VMI with CPU pinning
 				// this also tests if we've correctly calculated the overhead for VFIO devices.
@@ -416,7 +416,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				By("checking virtual machine instance has two interfaces")
 				checkInterfacesInGuest(vmi, []string{"eth0", "eth1"})
 			})
-			It("[test_id:3985]should create a virtual machine with sriov interface with custom MAC address", func() {
+			It("[test_id:3985]should create a virtual machine with sriov interface with custom MAC address", Label("test_id:3985"), func() {
 				const mac = "de:ad:00:00:be:ef"
 				vmi := getSriovVmi([]string{sriovnet1}, defaultCloudInitNetworkData())
 				vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = mac
@@ -514,7 +514,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				Expect(createSriovNetworkAttachmentDefinition(sriovnet2, util.NamespaceTestDefault, sriovConfNAD)).To(Succeed(), shouldCreateNetwork)
 			})
 
-			It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
+			It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", Label("test_id:1755"), func() {
 				sriovNetworks := []string{sriovnet1, sriovnet2}
 				vmi := getSriovVmi(sriovNetworks, defaultCloudInitNetworkData())
 				vmi.Spec.Domain.Devices.Interfaces[1].PciAddress = "0000:06:00.0"
@@ -543,7 +543,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 					To(Succeed(), shouldCreateNetwork)
 			})
 
-			It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {
+			It("[test_id:3956]should connect to another machine with sriov interface over IPv4", Label("test_id:3956"), func() {
 				cidrA := "192.168.1.1/24"
 				cidrB := "192.168.1.2/24"
 				ipA, err := libnet.CidrToIP(cidrA)
@@ -562,7 +562,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				}, 15*time.Second, time.Second).Should(Succeed())
 			})
 
-			It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
+			It("[test_id:3957]should connect to another machine with sriov interface over IPv6", Label("test_id:3957"), func() {
 				vmi1CIDR := "fc00::1/64"
 				vmi2CIDR := "fc00::2/64"
 				vmi1IP, err := libnet.CidrToIP(vmi1CIDR)

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -76,7 +76,7 @@ const (
 	istioApiVersion   = "v1beta1"
 )
 
-var _ = SIGDescribe("[Serial] Istio", func() {
+var _ = SIGDescribe("[Serial] Istio", Labels{"Serial"}, func() {
 	var (
 		err        error
 		vmi        *v1.VirtualMachineInstance

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -76,7 +76,7 @@ const (
 	istioApiVersion   = "v1beta1"
 )
 
-var _ = SIGDescribe("[Serial] Istio", Labels{"Serial"}, func() {
+var _ = SIGDescribe("[Serial] Istio", Label("Serial"), func() {
 	var (
 		err        error
 		vmi        *v1.VirtualMachineInstance

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -43,7 +43,7 @@ import (
 )
 
 var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]",
-	Labels{"crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"},
+	Label("crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"),
 	func() {
 		var err error
 		var virtClient kubecli.KubevirtClient
@@ -58,10 +58,10 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 		})
 
 		Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance",
-			Labels{"crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("when virt-handler is responsive", func() {
-					It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", Labels{"Serial"}, func() {
+					It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", Label("Serial"), func() {
 						libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 						bridgeVMI := vmi
 						// Remove the masquerade interface to use the default bridge one

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -42,89 +42,93 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]", func() {
-	var err error
-	var virtClient kubecli.KubevirtClient
-	var vmi *v1.VirtualMachineInstance
+var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:component]",
+	Labels{"crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"},
+	func() {
+		var err error
+		var virtClient kubecli.KubevirtClient
+		var vmi *v1.VirtualMachineInstance
 
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
-		vmi = libvmi.NewAlpine()
-	})
-
-	Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
-		Context("when virt-handler is responsive", func() {
-			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-				bridgeVMI := vmi
-				// Remove the masquerade interface to use the default bridge one
-				bridgeVMI.Spec.Domain.Devices.Interfaces = nil
-				bridgeVMI.Spec.Networks = nil
-				v1.SetDefaults_NetworkInterface(bridgeVMI)
-				Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
-
-				By("starting a VMI with bridged network on a node")
-				bridgeVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(bridgeVMI)
-				Expect(err).To(BeNil(), "Should submit VMI successfully")
-
-				// Start a VirtualMachineInstance with bridged networking
-				nodeName := tests.WaitForSuccessfulVMIStart(bridgeVMI).Status.NodeName
-
-				verifyDummyNicForBridgeNetwork(bridgeVMI)
-
-				By("restarting kubelet")
-				pod := renderPkillAllPod("kubelet")
-				pod.Spec.NodeName = nodeName
-				_, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				By("starting another VMI on the same node, to verify kubelet is running again")
-				newVMI := libvmi.NewCirros()
-				newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
-				Eventually(func() error {
-					newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(newVMI)
-					Expect(err).To(BeNil())
-					return nil
-				}, 100, 10).Should(Succeed(), "Should be able to start a new VM")
-
-				By("checking if the VMI with bridged networking is still running, it will verify the CNI didn't cause the pod to be killed")
-				bridgeVMI = tests.WaitForSuccessfulVMIStart(bridgeVMI)
-			})
-
-			It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-				bridgeVMI := libvmi.NewCirros()
-				// Remove the masquerade interface to use the default bridge one
-				bridgeVMI.Spec.Domain.Devices.Interfaces = nil
-				bridgeVMI.Spec.Networks = nil
-				v1.SetDefaults_NetworkInterface(bridgeVMI)
-				Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
-
-				By("starting a VMI with bridged network on a node")
-				bridgeVMI = tests.RunVMI(bridgeVMI, 40)
-
-				// Start a VirtualMachineInstance with bridged networking
-				By("Waiting the VirtualMachineInstance start")
-				bridgeVMI = tests.WaitUntilVMIReady(bridgeVMI, console.LoginToCirros)
-				verifyDummyNicForBridgeNetwork(bridgeVMI)
-
-				vmIP := libnet.GetVmiPrimaryIpByFamily(bridgeVMI, k8sv1.IPv4Protocol)
-				dadCommand := fmt.Sprintf("sudo /usr/sbin/arping -D -I eth0 -c 2 %s | grep Received | cut -d ' ' -f 2\n", vmIP)
-
-				Expect(console.SafeExpectBatch(bridgeVMI, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-
-					&expect.BSnd{S: dadCommand},
-					&expect.BExp{R: "0"},
-				}, 600)).To(Succeed())
-			})
+			tests.BeforeTestCleanup()
+			vmi = libvmi.NewAlpine()
 		})
+
+		Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance",
+			Labels{"crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				Context("when virt-handler is responsive", func() {
+					It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", Labels{"Serial"}, func() {
+						libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+						bridgeVMI := vmi
+						// Remove the masquerade interface to use the default bridge one
+						bridgeVMI.Spec.Domain.Devices.Interfaces = nil
+						bridgeVMI.Spec.Networks = nil
+						v1.SetDefaults_NetworkInterface(bridgeVMI)
+						Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
+
+						By("starting a VMI with bridged network on a node")
+						bridgeVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(bridgeVMI)
+						Expect(err).To(BeNil(), "Should submit VMI successfully")
+
+						// Start a VirtualMachineInstance with bridged networking
+						nodeName := tests.WaitForSuccessfulVMIStart(bridgeVMI).Status.NodeName
+
+						verifyDummyNicForBridgeNetwork(bridgeVMI)
+
+						By("restarting kubelet")
+						pod := renderPkillAllPod("kubelet")
+						pod.Spec.NodeName = nodeName
+						_, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						By("starting another VMI on the same node, to verify kubelet is running again")
+						newVMI := libvmi.NewCirros()
+						newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+						Eventually(func() error {
+							newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(newVMI)
+							Expect(err).To(BeNil())
+							return nil
+						}, 100, 10).Should(Succeed(), "Should be able to start a new VM")
+
+						By("checking if the VMI with bridged networking is still running, it will verify the CNI didn't cause the pod to be killed")
+						bridgeVMI = tests.WaitForSuccessfulVMIStart(bridgeVMI)
+					})
+
+					It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", func() {
+						libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+						bridgeVMI := libvmi.NewCirros()
+						// Remove the masquerade interface to use the default bridge one
+						bridgeVMI.Spec.Domain.Devices.Interfaces = nil
+						bridgeVMI.Spec.Networks = nil
+						v1.SetDefaults_NetworkInterface(bridgeVMI)
+						Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
+
+						By("starting a VMI with bridged network on a node")
+						bridgeVMI = tests.RunVMI(bridgeVMI, 40)
+
+						// Start a VirtualMachineInstance with bridged networking
+						By("Waiting the VirtualMachineInstance start")
+						bridgeVMI = tests.WaitUntilVMIReady(bridgeVMI, console.LoginToCirros)
+						verifyDummyNicForBridgeNetwork(bridgeVMI)
+
+						vmIP := libnet.GetVmiPrimaryIpByFamily(bridgeVMI, k8sv1.IPv4Protocol)
+						dadCommand := fmt.Sprintf("sudo /usr/sbin/arping -D -I eth0 -c 2 %s | grep Received | cut -d ' ' -f 2\n", vmIP)
+
+						Expect(console.SafeExpectBatch(bridgeVMI, []expect.Batcher{
+							&expect.BSnd{S: "\n"},
+							&expect.BExp{R: console.PromptExpression},
+
+							&expect.BSnd{S: dadCommand},
+							&expect.BExp{R: "0"},
+						}, 600)).To(Succeed())
+					})
+				})
+			})
 	})
-})
 
 func renderPkillAllPod(processName string) *k8sv1.Pod {
 	return tests.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", processName})

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -85,7 +85,7 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
-var _ = SIGDescribe("[Serial]Multus", func() {
+var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -184,13 +184,15 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 		return tests.CreateVmiOnNode(vmi, nodeName)
 	}
 
-	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.", func() {
+	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.",
+		Labels{"rfe_id:694", "crit:medium", "vendor:cnv-qe@redhat.com"},
+			func() {
 		const ptpGateway = ptpSubnetIP1
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
 			BeforeEach(func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 			})
-			It("[test_id:1751]should create a virtual machine with one interface", func() {
+			It("[test_id:1751]should create a virtual machine with one interface", Labels{"test_id:1751"}, func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmi.NewAlpine()
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -204,10 +206,10 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
-				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
-			})
+					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
+				})
 
-			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
+			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", Labels{"test_id:1752"}, func() {
 				checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmi.NewAlpine()
@@ -222,48 +224,48 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
-				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
-			})
+					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
+				})
 
-			It("[test_id:1753]should create a virtual machine with two interfaces", func() {
-				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmi.NewCirros()
+				It("[test_id:1753]should create a virtual machine with two interfaces", Labels{"test_id:1753"}, func() {
+					By("checking virtual machine instance can ping using ptp cni plugin")
+					detachedVMI := libvmi.NewCirros()
 
-				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					defaultInterface,
-					{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-				detachedVMI.Spec.Networks = []v1.Network{
-					defaultNetwork,
-					{Name: "ptp", NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: ptpConf1},
-					}},
-				}
+					detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{
+						defaultInterface,
+						{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+					detachedVMI.Spec.Networks = []v1.Network{
+						defaultNetwork,
+						{Name: "ptp", NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{NetworkName: ptpConf1},
+						}},
+					}
 
 				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, console.LoginToCirros)
 
-				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
-				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: cmdCheck},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l\n"},
-					&expect.BExp{R: console.RetValue("1")},
-				}, 15)
-				Expect(err).ToNot(HaveOccurred())
+					cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
+					err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: cmdCheck},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l\n"},
+						&expect.BExp{R: console.RetValue("1")},
+					}, 15)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("checking virtual machine instance has two interfaces")
-				Expect(checkInterface(detachedVMI, "eth0")).To(Succeed())
-				Expect(checkInterface(detachedVMI, "eth1")).To(Succeed())
+					By("checking virtual machine instance has two interfaces")
+					Expect(checkInterface(detachedVMI, "eth0")).To(Succeed())
+					Expect(checkInterface(detachedVMI, "eth1")).To(Succeed())
 
-				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
+					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
+				})
 			})
-		})
 
 		Context("VirtualMachineInstance with multus network as default network", func() {
-			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", func() {
+			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", Labels{"test_id:1751"}, func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				detachedVMI := libvmi.NewAlpine()
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -279,46 +281,46 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
-				By("checking virtual machine instance can ping using ptp cni plugin")
-				Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
+					By("checking virtual machine instance can ping using ptp cni plugin")
+					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 
-				By("checking virtual machine instance only has one interface")
-				// lo0, eth0
-				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "ip link show | grep -c UP\n"},
-					&expect.BExp{R: "2"},
-				}, 15)
-				Expect(err).ToNot(HaveOccurred())
+					By("checking virtual machine instance only has one interface")
+					// lo0, eth0
+					err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "ip link show | grep -c UP\n"},
+						&expect.BExp{R: "2"},
+					}, 15)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("checking pod has only one interface")
-				// lo0, eth0-nic, k6t-eth0, vnet0
-				output := tests.RunCommandOnVmiPod(detachedVMI, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep -c UP"})
-				ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("4"))
+					By("checking pod has only one interface")
+					// lo0, eth0-nic, k6t-eth0, vnet0
+					output := tests.RunCommandOnVmiPod(detachedVMI, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep -c UP"})
+					ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("4"))
+				})
 			})
-		})
 
-		Context("VirtualMachineInstance with cni ptp plugin interface with custom MAC address", func() {
-			It("[test_id:1705]should configure valid custom MAC address on ptp interface when using tuning plugin", func() {
-				customMacAddress := "50:00:00:00:90:0d"
-				ptpInterface := v1.Interface{
-					Name: "ptp",
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Bridge: &v1.InterfaceBridge{},
-					},
-				}
-				ptpNetwork := v1.Network{
-					Name: "ptp",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{
-							NetworkName: ptpConf1,
+			Context("VirtualMachineInstance with cni ptp plugin interface with custom MAC address", func() {
+				It("[test_id:1705]should configure valid custom MAC address on ptp interface when using tuning plugin", Labels{"test_id:1705"}, func() {
+					customMacAddress := "50:00:00:00:90:0d"
+					ptpInterface := v1.Interface{
+						Name: "ptp",
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{},
 						},
-					},
-				}
+					}
+					ptpNetwork := v1.Network{
+						Name: "ptp",
+						NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{
+								NetworkName: ptpConf1,
+							},
+						},
+					}
 
-				interfaces := []v1.Interface{ptpInterface}
-				networks := []v1.Network{ptpNetwork}
+					interfaces := []v1.Interface{ptpInterface}
+					networks := []v1.Network{ptpNetwork}
 
 				By("Creating a VM with custom MAC address on its ptp interface.")
 				interfaces[0].MacAddress = customMacAddress
@@ -326,65 +328,65 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				vmiOne := createVMIOnNode(interfaces, networks)
 				tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 
-				By("Configuring static IP address to ptp interface.")
-				Expect(configInterface(vmiOne, "eth0", ptpSubnetIP1+ptpSubnetMask)).To(Succeed())
+					By("Configuring static IP address to ptp interface.")
+					Expect(configInterface(vmiOne, "eth0", ptpSubnetIP1+ptpSubnetMask)).To(Succeed())
 
-				By("Verifying the desired custom MAC is the one that was actually configured on the interface.")
-				ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
-				err = console.SafeExpectBatch(vmiOne, []expect.Batcher{
-					&expect.BSnd{S: ipLinkShow},
-					&expect.BExp{R: "1"},
-				}, 15)
-				Expect(err).ToNot(HaveOccurred())
+					By("Verifying the desired custom MAC is the one that was actually configured on the interface.")
+					ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
+					err = console.SafeExpectBatch(vmiOne, []expect.Batcher{
+						&expect.BSnd{S: ipLinkShow},
+						&expect.BExp{R: "1"},
+					}, 15)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, util.NamespaceTestDefault)
-				out, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					"compute",
-					[]string{"sh", "-c", "ip a"},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
+					By("Verifying the desired custom MAC is not configured inside the pod namespace.")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, util.NamespaceTestDefault)
+					out, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						vmiPod,
+						"compute",
+						[]string{"sh", "-c", "ip a"},
+					)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
+				})
 			})
-		})
 
-		Context("VirtualMachineInstance with Linux bridge plugin interface", func() {
-			getIfaceIPByNetworkName := func(vmiName, networkName string) (string, error) {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiName, &metav1.GetOptions{})
-				if err != nil {
-					return "", err
-				}
-
-				for _, iface := range vmi.Status.Interfaces {
-					if iface.Name == networkName {
-						return iface.IP, nil
+			Context("VirtualMachineInstance with Linux bridge plugin interface", func() {
+				getIfaceIPByNetworkName := func(vmiName, networkName string) (string, error) {
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiName, &metav1.GetOptions{})
+					if err != nil {
+						return "", err
 					}
+
+					for _, iface := range vmi.Status.Interfaces {
+						if iface.Name == networkName {
+							return iface.IP, nil
+						}
+					}
+
+					return "", fmt.Errorf("couldn't find iface %s on vmi %s", networkName, vmiName)
 				}
 
-				return "", fmt.Errorf("couldn't find iface %s on vmi %s", networkName, vmiName)
-			}
-
-			generateIPAMConfig := func(ipamType string, subnet string) string {
-				return fmt.Sprintf("\\\"type\\\": \\\"%s\\\", \\\"subnet\\\": \\\"%s\\\"", ipamType, subnet)
-			}
-
-			DescribeTable("should be able to ping between two vms", func(interfaces []v1.Interface, networks []v1.Network, ifaceName, staticIPVm1, staticIPVm2 string) {
-				if staticIPVm2 == "" || staticIPVm1 == "" {
-					ipam := generateIPAMConfig("host-local", ptpSubnet)
-					Expect(createBridgeNetworkAttachmentDefinition(util.NamespaceTestDefault, linuxBridgeVlan100WithIPAMNetwork, bridge10CNIType, bridge10Name, 0, ipam, bridge10MacSpoofCheck)).To(Succeed())
+				generateIPAMConfig := func(ipamType string, subnet string) string {
+					return fmt.Sprintf("\\\"type\\\": \\\"%s\\\", \\\"subnet\\\": \\\"%s\\\"", ipamType, subnet)
 				}
 
-				vmiOne := createVMIOnNode(interfaces, networks)
-				vmiTwo := createVMIOnNode(interfaces, networks)
+				DescribeTable("should be able to ping between two vms", func(interfaces []v1.Interface, networks []v1.Network, ifaceName, staticIPVm1, staticIPVm2 string) {
+					if staticIPVm2 == "" || staticIPVm1 == "" {
+						ipam := generateIPAMConfig("host-local", ptpSubnet)
+						Expect(createBridgeNetworkAttachmentDefinition(util.NamespaceTestDefault, linuxBridgeVlan100WithIPAMNetwork, bridge10CNIType, bridge10Name, 0, ipam, bridge10MacSpoofCheck)).To(Succeed())
+					}
 
-				tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
-				tests.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)
+					vmiOne := createVMIOnNode(interfaces, networks)
+					vmiTwo := createVMIOnNode(interfaces, networks)
 
-				Expect(configureAlpineInterfaceIP(vmiOne, ifaceName, staticIPVm1)).To(Succeed())
-				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
-				Expect(checkInterface(vmiOne, ifaceName)).To(Succeed())
+					tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
+					tests.WaitUntilVMIReady(vmiTwo, console.LoginToAlpine)
+
+					Expect(configureAlpineInterfaceIP(vmiOne, ifaceName, staticIPVm1)).To(Succeed())
+					By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
+					Expect(checkInterface(vmiOne, ifaceName)).To(Succeed())
 
 				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
 				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
@@ -392,279 +394,281 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				ipAddr := ""
 				if staticIPVm2 != "" {
 					ipAddr, err = libnet.CidrToIP(staticIPVm2)
-				} else {
-					const secondaryNetworkIndex = 1
-					ipAddr, err = getIfaceIPByNetworkName(vmiTwo.Name, networks[secondaryNetworkIndex].Name)
-				}
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ipAddr).ToNot(BeEmpty())
+					} else {
+						const secondaryNetworkIndex = 1
+						ipAddr, err = getIfaceIPByNetworkName(vmiTwo.Name, networks[secondaryNetworkIndex].Name)
+					}
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ipAddr).ToNot(BeEmpty())
 
-				By("ping between virtual machines")
-				Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
-			},
-				Entry("[test_id:1577]with secondary network only", []v1.Interface{linuxBridgeInterface}, []v1.Network{linuxBridgeNetwork}, "eth0", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
-				Entry("[test_id:1578]with default network and secondary network", []v1.Interface{defaultInterface, linuxBridgeInterface}, []v1.Network{defaultNetwork, linuxBridgeNetwork}, "eth1", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
-				Entry("with default network and secondary network with IPAM", []v1.Interface{defaultInterface, linuxBridgeInterfaceWithIPAM}, []v1.Network{defaultNetwork, linuxBridgeWithIPAMNetwork}, "eth1", "", ""),
-			)
-		})
-
-		Context("VirtualMachineInstance with Linux bridge CNI plugin interface and custom MAC address.", func() {
-			customMacAddress := "50:00:00:00:90:0d"
-			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
-				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
-				vmiTwo := libvmi.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithInterface(linuxBridgeInterface),
-					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ptpSubnetIP2+ptpSubnetMask), false))
-				vmiTwo = tests.CreateVmiOnNode(vmiTwo, nodes.Items[0].Name)
-
-				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
-				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
-				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
-				vmiOne := libvmi.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
-					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask), false))
-				vmiOne = tests.CreateVmiOnNode(vmiOne, nodes.Items[0].Name)
-
-				vmiOne = tests.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
-				tests.WaitAgentConnected(virtClient, vmiOne)
-
-				By("Verifying the desired custom MAC is the one that were actually configured on the interface.")
-				vmiIfaceStatusByName := libvmi.IndexInterfaceStatusByName(vmiOne)
-				Expect(vmiIfaceStatusByName).To(HaveKey(linuxBridgeInterfaceWithCustomMac.Name), "should set linux bridge interface with the custom MAC address at VMI Status")
-				Expect(vmiIfaceStatusByName[linuxBridgeInterfaceWithCustomMac.Name].MAC).To(Equal(customMacAddress), "should set linux bridge interface with the custom MAC address at VMI")
-
-				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, vmiOne.Namespace)
-				out, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					"compute",
-					[]string{"sh", "-c", "ip a"},
+					By("ping between virtual machines")
+					Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
+				},
+					Entry("[test_id:1577]with secondary network only", Labels{"test_id:1577"}, []v1.Interface{linuxBridgeInterface}, []v1.Network{linuxBridgeNetwork}, "eth0", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
+					Entry("[test_id:1578]with default network and secondary network", Labels{"test_id:1578"}, []v1.Interface{defaultInterface, linuxBridgeInterface}, []v1.Network{defaultNetwork, linuxBridgeNetwork}, "eth1", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
+					Entry("with default network and secondary network with IPAM", []v1.Interface{defaultInterface, linuxBridgeInterfaceWithIPAM}, []v1.Network{defaultNetwork, linuxBridgeWithIPAMNetwork}, "eth1", "", ""),
 				)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
-
-				By("Ping from the VM with the custom MAC to the other VM.")
-				tests.WaitUntilVMIReady(vmiTwo, console.LoginToFedora)
-				Expect(libnet.PingFromVMConsole(vmiOne, ptpSubnetIP2)).To(Succeed())
-			})
-		})
-
-		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
-			It("[test_id:1756]should report all interfaces in Status", func() {
-				interfaces := []v1.Interface{
-					defaultInterface,
-					linuxBridgeInterface,
-				}
-				networks := []v1.Network{
-					defaultNetwork,
-					linuxBridgeNetwork,
-				}
-
-				vmiOne := createVMIOnNode(interfaces, networks)
-
-				tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
-
-				updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiOne.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(updatedVmi.Status.Interfaces).To(HaveLen(2))
-				interfacesByName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)
-				for _, ifc := range updatedVmi.Status.Interfaces {
-					interfacesByName[ifc.Name] = ifc
-				}
-
-				for _, network := range networks {
-					ifc, is_present := interfacesByName[network.Name]
-					Expect(is_present).To(BeTrue())
-					Expect(ifc.MAC).To(Not(BeZero()))
-				}
-				Expect(interfacesByName[masqueradeIfaceName].MAC).To(Not(Equal(interfacesByName[linuxBridgeIfaceName].MAC)))
-				Expect(runSafeCommand(vmiOne, fmt.Sprintf("ip addr show eth0 | grep %s\n", interfacesByName["default"].MAC))).To(Succeed())
-				Expect(runSafeCommand(vmiOne, fmt.Sprintf("ip addr show eth1 | grep %s\n", interfacesByName[linuxBridgeIfaceName].MAC))).To(Succeed())
 			})
 
-			It("should have the correct MTU on the secondary interface with no dhcp server", func() {
-				getPodInterfaceMtu := func(vmi *v1.VirtualMachineInstance) string {
-					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-					output, err := tests.ExecuteCommandOnPod(
+			Context("VirtualMachineInstance with Linux bridge CNI plugin interface and custom MAC address.", func() {
+				customMacAddress := "50:00:00:00:90:0d"
+				It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", Labels{"test_id:676"}, func() {
+					By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
+					vmiTwo := libvmi.NewFedora(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithInterface(linuxBridgeInterface),
+						libvmi.WithNetwork(&linuxBridgeNetwork),
+						libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ptpSubnetIP2+ptpSubnetMask), false))
+					vmiTwo = tests.CreateVmiOnNode(vmiTwo, nodes.Items[0].Name)
+
+					By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
+					linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
+					linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
+					vmiOne := libvmi.NewFedora(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
+						libvmi.WithNetwork(&linuxBridgeNetwork),
+						libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask), false))
+					vmiOne = tests.CreateVmiOnNode(vmiOne, nodes.Items[0].Name)
+
+					vmiOne = tests.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
+					tests.WaitAgentConnected(virtClient, vmiOne)
+
+					By("Verifying the desired custom MAC is the one that were actually configured on the interface.")
+					vmiIfaceStatusByName := libvmi.IndexInterfaceStatusByName(vmiOne)
+					Expect(vmiIfaceStatusByName).To(HaveKey(linuxBridgeInterfaceWithCustomMac.Name), "should set linux bridge interface with the custom MAC address at VMI Status")
+					Expect(vmiIfaceStatusByName[linuxBridgeInterfaceWithCustomMac.Name].MAC).To(Equal(customMacAddress), "should set linux bridge interface with the custom MAC address at VMI")
+
+					By("Verifying the desired custom MAC is not configured inside the pod namespace.")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, vmiOne.Namespace)
+					out, err := tests.ExecuteCommandOnPod(
 						virtClient,
 						vmiPod,
 						"compute",
-						[]string{"cat", "/sys/class/net/net1/mtu"},
+						[]string{"sh", "-c", "ip a"},
 					)
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
 
-					return strings.TrimSuffix(output, "\n")
-				}
+					By("Ping from the VM with the custom MAC to the other VM.")
+					tests.WaitUntilVMIReady(vmiTwo, console.LoginToFedora)
+					Expect(libnet.PingFromVMConsole(vmiOne, ptpSubnetIP2)).To(Succeed())
+				})
+			})
 
-				getVmiInterfaceMtu := func(vmi *v1.VirtualMachineInstance) string {
-					res, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
-						&expect.BSnd{S: fmt.Sprintf("cat %s\n", "/sys/class/net/eth0/mtu")},
-						&expect.BExp{R: console.RetValue("[0-9]+")},
-					}, 15)
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
+				It("[test_id:1756]should report all interfaces in Status", Labels{"test_id:1756"}, func() {
+					interfaces := []v1.Interface{
+						defaultInterface,
+						linuxBridgeInterface,
+					}
+					networks := []v1.Network{
+						defaultNetwork,
+						linuxBridgeNetwork,
+					}
 
-					re := regexp.MustCompile("\r\n[0-9]+\r\n")
-					mtu := strings.TrimSpace(re.FindString(res[0].Match[0]))
-					return mtu
+					vmiOne := createVMIOnNode(interfaces, networks)
 
-				}
+					tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 
-				vmi := libvmi.NewFedora(
-					libvmi.WithInterface(linuxBridgeInterface),
-					libvmi.WithNetwork(&linuxBridgeNetwork),
-				)
+					updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiOne.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
+					Expect(updatedVmi.Status.Interfaces).To(HaveLen(2))
+					interfacesByName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)
+					for _, ifc := range updatedVmi.Status.Interfaces {
+						interfacesByName[ifc.Name] = ifc
+					}
 
-				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
-				Expect(getPodInterfaceMtu(vmi)).To(Equal(getVmiInterfaceMtu(vmi)))
+					for _, network := range networks {
+						ifc, is_present := interfacesByName[network.Name]
+						Expect(is_present).To(BeTrue())
+						Expect(ifc.MAC).To(Not(BeZero()))
+					}
+					Expect(interfacesByName[masqueradeIfaceName].MAC).To(Not(Equal(interfacesByName[linuxBridgeIfaceName].MAC)))
+					Expect(runSafeCommand(vmiOne, fmt.Sprintf("ip addr show eth0 | grep %s\n", interfacesByName["default"].MAC))).To(Succeed())
+					Expect(runSafeCommand(vmiOne, fmt.Sprintf("ip addr show eth1 | grep %s\n", interfacesByName[linuxBridgeIfaceName].MAC))).To(Succeed())
+				})
+
+				It("should have the correct MTU on the secondary interface with no dhcp server", func() {
+					getPodInterfaceMtu := func(vmi *v1.VirtualMachineInstance) string {
+						vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						output, err := tests.ExecuteCommandOnPod(
+							virtClient,
+							vmiPod,
+							"compute",
+							[]string{"cat", "/sys/class/net/net1/mtu"},
+						)
+						ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+						return strings.TrimSuffix(output, "\n")
+					}
+
+					getVmiInterfaceMtu := func(vmi *v1.VirtualMachineInstance) string {
+						res, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
+							&expect.BSnd{S: fmt.Sprintf("cat %s\n", "/sys/class/net/eth0/mtu")},
+							&expect.BExp{R: console.RetValue("[0-9]+")},
+						}, 15)
+						ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+						re := regexp.MustCompile("\r\n[0-9]+\r\n")
+						mtu := strings.TrimSpace(re.FindString(res[0].Match[0]))
+						return mtu
+
+					}
+
+					vmi := libvmi.NewFedora(
+						libvmi.WithInterface(linuxBridgeInterface),
+						libvmi.WithNetwork(&linuxBridgeNetwork),
+					)
+
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+
+					vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+					Expect(getPodInterfaceMtu(vmi)).To(Equal(getVmiInterfaceMtu(vmi)))
+				})
+			})
+
+			Context("VirtualMachineInstance with invalid MAC address", func() {
+
+				It("[test_id:1713]should failed to start with invalid MAC address", Labels{"test_id:1713"}, func() {
+					By("Start VMI")
+					linuxBridgeIfIdx := 1
+
+					vmi := libvmi.NewAlpine()
+					vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+						defaultInterface,
+						linuxBridgeInterface,
+					}
+					vmi.Spec.Domain.Devices.Interfaces[linuxBridgeIfIdx].MacAddress = "de:00c:00c:00:00:de:abc"
+
+					vmi.Spec.Networks = []v1.Network{
+						defaultNetwork,
+						linuxBridgeNetwork,
+					}
+
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(HaveOccurred())
+					testErr := err.(*errors.StatusError)
+					Expect(testErr.ErrStatus.Reason).To(BeEquivalentTo("Invalid"))
+				})
+			})
+
+			Context("Security", func() {
+				BeforeEach(func() {
+					const (
+						bridge11CNIType       = "cnv-bridge"
+						bridge11Name          = "br11"
+						bridge11MACSpoofCheck = true
+					)
+
+					Expect(createBridgeNetworkAttachmentDefinition(util.NamespaceTestDefault,
+						linuxBridgeWithMACSpoofCheckNetwork,
+						bridge11CNIType,
+						bridge11Name,
+						0,
+						"",
+						bridge11MACSpoofCheck)).To(Succeed())
+				})
+
+				It("Should allow outbound communication from VM under test - only if original MAC address is unchanged", func() {
+					const (
+						vmUnderTestIPAddress = "10.2.1.1"
+						targetVMIPAddress    = "10.2.1.2"
+						bridgeSubnetMask     = "/24"
+					)
+
+					initialMacAddress, err := tests.GenerateRandomMac()
+					Expect(err).NotTo(HaveOccurred())
+					initialMacAddressStr := initialMacAddress.String()
+
+					spoofedMacAddress, err := tests.GenerateRandomMac()
+					Expect(err).NotTo(HaveOccurred())
+					spoofedMacAddressStr := spoofedMacAddress.String()
+
+					linuxBridgeInterfaceWithMACSpoofCheck := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithMACSpoofCheckNetwork)
+
+					By("Creating a VM with custom MAC address on its Linux bridge CNI interface.")
+					linuxBridgeInterfaceWithCustomMac := linuxBridgeInterfaceWithMACSpoofCheck
+					libvmi.InterfaceWithMac(&linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
+
+					vmiUnderTest := libvmi.NewFedora(
+						libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
+						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
+						libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask), false))
+					vmiUnderTest = tests.CreateVmiOnNode(vmiUnderTest, nodes.Items[0].Name)
+
+					By("Creating a target VM with Linux bridge CNI network interface and default MAC address.")
+					targetVmi := libvmi.NewFedora(
+						libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
+						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
+						libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth0", targetVMIPAddress+bridgeSubnetMask), false))
+					targetVmi = tests.CreateVmiOnNode(targetVmi, nodes.Items[0].Name)
+
+					vmiUnderTest = tests.WaitUntilVMIReady(vmiUnderTest, console.LoginToFedora)
+					tests.WaitUntilVMIReady(targetVmi, console.LoginToFedora)
+
+					Expect(libnet.PingFromVMConsole(vmiUnderTest, targetVMIPAddress)).To(Succeed(), "Ping target IP with original MAC should succeed")
+
+					Expect(changeInterfaceMACAddress(vmiUnderTest, linuxBridgeInterfaceWithCustomMac.Name, spoofedMacAddressStr)).To(Succeed())
+					Expect(libnet.PingFromVMConsole(vmiUnderTest, targetVMIPAddress)).NotTo(Succeed(), "Ping target IP with modified MAC should fail")
+
+					Expect(changeInterfaceMACAddress(vmiUnderTest, linuxBridgeInterfaceWithCustomMac.Name, initialMacAddressStr)).To(Succeed())
+					Expect(libnet.PingFromVMConsole(vmiUnderTest, targetVMIPAddress)).To(Succeed(), "Ping target IP with restored original MAC should succeed")
+				})
 			})
 		})
 
-		Context("VirtualMachineInstance with invalid MAC address", func() {
+	Describe("[rfe_id:1758][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition",
+		Labels{"rfe_id:1758", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			Context("with qemu guest agent", func() {
 
-			It("[test_id:1713]should failed to start with invalid MAC address", func() {
-				By("Start VMI")
-				linuxBridgeIfIdx := 1
+				It("[test_id:1757] should report guest interfaces in VMI status", Labels{"test_id:1757"}, func() {
+					interfaces := []v1.Interface{
+						defaultInterface,
+						linuxBridgeInterface,
+					}
+					networks := []v1.Network{
+						defaultNetwork,
+						linuxBridgeNetwork,
+					}
 
-				vmi := libvmi.NewAlpine()
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					defaultInterface,
-					linuxBridgeInterface,
-				}
-				vmi.Spec.Domain.Devices.Interfaces[linuxBridgeIfIdx].MacAddress = "de:00c:00c:00:00:de:abc"
+					v4Mask := "/24"
+					ep1Ip := "1.0.0.10"
+					ep2Ip := "1.0.0.11"
+					ep1Cidr := ep1Ip + v4Mask
+					ep2Cidr := ep2Ip + v4Mask
 
-				vmi.Spec.Networks = []v1.Network{
-					defaultNetwork,
-					linuxBridgeNetwork,
-				}
+					v6Mask := "/64"
+					ep1IpV6 := "fe80::ce3d:82ff:fe52:24c0"
+					ep2IpV6 := "fe80::ce3d:82ff:fe52:24c1"
+					ep1CidrV6 := ep1IpV6 + v6Mask
+					ep2CidrV6 := ep2IpV6 + v6Mask
 
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(HaveOccurred())
-				testErr := err.(*errors.StatusError)
-				Expect(testErr.ErrStatus.Reason).To(BeEquivalentTo("Invalid"))
-			})
-		})
-
-		Context("Security", func() {
-			BeforeEach(func() {
-				const (
-					bridge11CNIType       = "cnv-bridge"
-					bridge11Name          = "br11"
-					bridge11MACSpoofCheck = true
-				)
-
-				Expect(createBridgeNetworkAttachmentDefinition(util.NamespaceTestDefault,
-					linuxBridgeWithMACSpoofCheckNetwork,
-					bridge11CNIType,
-					bridge11Name,
-					0,
-					"",
-					bridge11MACSpoofCheck)).To(Succeed())
-			})
-
-			It("Should allow outbound communication from VM under test - only if original MAC address is unchanged", func() {
-				const (
-					vmUnderTestIPAddress = "10.2.1.1"
-					targetVMIPAddress    = "10.2.1.2"
-					bridgeSubnetMask     = "/24"
-				)
-
-				initialMacAddress, err := tests.GenerateRandomMac()
-				Expect(err).NotTo(HaveOccurred())
-				initialMacAddressStr := initialMacAddress.String()
-
-				spoofedMacAddress, err := tests.GenerateRandomMac()
-				Expect(err).NotTo(HaveOccurred())
-				spoofedMacAddressStr := spoofedMacAddress.String()
-
-				linuxBridgeInterfaceWithMACSpoofCheck := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithMACSpoofCheckNetwork)
-
-				By("Creating a VM with custom MAC address on its Linux bridge CNI interface.")
-				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterfaceWithMACSpoofCheck
-				libvmi.InterfaceWithMac(&linuxBridgeInterfaceWithCustomMac, initialMacAddressStr)
-
-				vmiUnderTest := libvmi.NewFedora(
-					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
-					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask), false))
-				vmiUnderTest = tests.CreateVmiOnNode(vmiUnderTest, nodes.Items[0].Name)
-
-				By("Creating a target VM with Linux bridge CNI network interface and default MAC address.")
-				targetVmi := libvmi.NewFedora(
-					libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
-					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth0", targetVMIPAddress+bridgeSubnetMask), false))
-				targetVmi = tests.CreateVmiOnNode(targetVmi, nodes.Items[0].Name)
-
-				vmiUnderTest = tests.WaitUntilVMIReady(vmiUnderTest, console.LoginToFedora)
-				tests.WaitUntilVMIReady(targetVmi, console.LoginToFedora)
-
-				Expect(libnet.PingFromVMConsole(vmiUnderTest, targetVMIPAddress)).To(Succeed(), "Ping target IP with original MAC should succeed")
-
-				Expect(changeInterfaceMACAddress(vmiUnderTest, linuxBridgeInterfaceWithCustomMac.Name, spoofedMacAddressStr)).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmiUnderTest, targetVMIPAddress)).NotTo(Succeed(), "Ping target IP with modified MAC should fail")
-
-				Expect(changeInterfaceMACAddress(vmiUnderTest, linuxBridgeInterfaceWithCustomMac.Name, initialMacAddressStr)).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmiUnderTest, targetVMIPAddress)).To(Succeed(), "Ping target IP with restored original MAC should succeed")
-			})
-		})
-	})
-
-	Describe("[rfe_id:1758][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition", func() {
-		Context("with qemu guest agent", func() {
-
-			It("[test_id:1757] should report guest interfaces in VMI status", func() {
-				interfaces := []v1.Interface{
-					defaultInterface,
-					linuxBridgeInterface,
-				}
-				networks := []v1.Network{
-					defaultNetwork,
-					linuxBridgeNetwork,
-				}
-
-				v4Mask := "/24"
-				ep1Ip := "1.0.0.10"
-				ep2Ip := "1.0.0.11"
-				ep1Cidr := ep1Ip + v4Mask
-				ep2Cidr := ep2Ip + v4Mask
-
-				v6Mask := "/64"
-				ep1IpV6 := "fe80::ce3d:82ff:fe52:24c0"
-				ep2IpV6 := "fe80::ce3d:82ff:fe52:24c1"
-				ep1CidrV6 := ep1IpV6 + v6Mask
-				ep2CidrV6 := ep2IpV6 + v6Mask
-
-				userdata := fmt.Sprintf(`#!/bin/bash
+					userdata := fmt.Sprintf(`#!/bin/bash
                     ip link add ep1 type veth peer name ep2
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                     ip addr add %s dev ep1
                     ip addr add %s dev ep2
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
-				agentVMI := libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
+					agentVMI := libvmi.NewFedora(libvmi.WithCloudInitNoCloudUserData(userdata, false))
 
-				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
-				agentVMI.Spec.Networks = networks
-				agentVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
+					agentVMI.Spec.Domain.Devices.Interfaces = interfaces
+					agentVMI.Spec.Networks = networks
+					agentVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 
-				By("Starting a VirtualMachineInstance")
-				agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-				tests.WaitForSuccessfulVMIStart(agentVMI)
+					By("Starting a VirtualMachineInstance")
+					agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(agentVMI)
 
-				// Need to wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, agentVMI)
+					// Need to wait for cloud init to finish and start the agent inside the vmi.
+					tests.WaitAgentConnected(virtClient, agentVMI)
 
 				getOptions := &metav1.GetOptions{}
 				Eventually(func() []v1.VirtualMachineInstanceNetworkInterface {
@@ -675,32 +679,32 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 					return updatedVmi.Status.Interfaces
 				}, 420*time.Second, 4).Should(HaveLen(4), "Should have interfaces in vmi status")
 
-				updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
-				Expect(err).ToNot(HaveOccurred())
+					updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(updatedVmi.Status.Interfaces).To(HaveLen(4))
-				interfaceByIfcName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)
-				for _, ifc := range updatedVmi.Status.Interfaces {
-					interfaceByIfcName[ifc.InterfaceName] = ifc
-				}
-				Expect(interfaceByIfcName["eth0"].Name).To(Equal(masqueradeIfaceName))
-				Expect(interfaceByIfcName["eth0"].InterfaceName).To(Equal("eth0"))
+					Expect(updatedVmi.Status.Interfaces).To(HaveLen(4))
+					interfaceByIfcName := make(map[string]v1.VirtualMachineInstanceNetworkInterface)
+					for _, ifc := range updatedVmi.Status.Interfaces {
+						interfaceByIfcName[ifc.InterfaceName] = ifc
+					}
+					Expect(interfaceByIfcName["eth0"].Name).To(Equal(masqueradeIfaceName))
+					Expect(interfaceByIfcName["eth0"].InterfaceName).To(Equal("eth0"))
 
-				Expect(interfaceByIfcName["eth1"].Name).To(Equal(linuxBridgeIfaceName))
-				Expect(interfaceByIfcName["eth1"].InterfaceName).To(Equal("eth1"))
+					Expect(interfaceByIfcName["eth1"].Name).To(Equal(linuxBridgeIfaceName))
+					Expect(interfaceByIfcName["eth1"].InterfaceName).To(Equal("eth1"))
 
-				Expect(interfaceByIfcName["ep1"].Name).To(Equal(""))
-				Expect(interfaceByIfcName["ep1"].InterfaceName).To(Equal("ep1"))
-				Expect(interfaceByIfcName["ep1"].IP).To(Equal(ep1Ip))
-				Expect(interfaceByIfcName["ep1"].IPs).To(Equal([]string{ep1Ip, ep1IpV6}))
+					Expect(interfaceByIfcName["ep1"].Name).To(Equal(""))
+					Expect(interfaceByIfcName["ep1"].InterfaceName).To(Equal("ep1"))
+					Expect(interfaceByIfcName["ep1"].IP).To(Equal(ep1Ip))
+					Expect(interfaceByIfcName["ep1"].IPs).To(Equal([]string{ep1Ip, ep1IpV6}))
 
-				Expect(interfaceByIfcName["ep2"].Name).To(Equal(""))
-				Expect(interfaceByIfcName["ep2"].InterfaceName).To(Equal("ep2"))
-				Expect(interfaceByIfcName["ep2"].IP).To(Equal(ep2Ip))
-				Expect(interfaceByIfcName["ep2"].IPs).To(Equal([]string{ep2Ip, ep2IpV6}))
+					Expect(interfaceByIfcName["ep2"].Name).To(Equal(""))
+					Expect(interfaceByIfcName["ep2"].InterfaceName).To(Equal("ep2"))
+					Expect(interfaceByIfcName["ep2"].IP).To(Equal(ep2Ip))
+					Expect(interfaceByIfcName["ep2"].IPs).To(Equal([]string{ep2Ip, ep2IpV6}))
+				})
 			})
 		})
-	})
 })
 
 func changeInterfaceMACAddress(vmi *v1.VirtualMachineInstance, interfaceName string, newMACAddress string) error {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -85,7 +85,7 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
-var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
+var _ = SIGDescribe("[Serial]Multus", Label("Serial"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -185,49 +185,49 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 	}
 
 	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.",
-		Labels{"rfe_id:694", "crit:medium", "vendor:cnv-qe@redhat.com"},
-			func() {
-		const ptpGateway = ptpSubnetIP1
-		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
-			BeforeEach(func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-			})
-			It("[test_id:1751]should create a virtual machine with one interface", Labels{"test_id:1751"}, func() {
-				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmi.NewAlpine()
-				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-				detachedVMI.Spec.Networks = []v1.Network{
-					{Name: "ptp", NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: ptpConf1},
-					}},
-				}
+		Label("rfe_id:694", "crit:medium", "vendor:cnv-qe@redhat.com"),
+		func() {
+			const ptpGateway = ptpSubnetIP1
+			Context("VirtualMachineInstance with cni ptp plugin interface", func() {
+				BeforeEach(func() {
+					libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				})
+				It("[test_id:1751]should create a virtual machine with one interface", Label("test_id:1751"), func() {
+					By("checking virtual machine instance can ping using ptp cni plugin")
+					detachedVMI := libvmi.NewAlpine()
+					detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+					detachedVMI.Spec.Networks = []v1.Network{
+						{Name: "ptp", NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{NetworkName: ptpConf1},
+						}},
+					}
 
-				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
+					detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 				})
 
-			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", Labels{"test_id:1752"}, func() {
-				checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
-				By("checking virtual machine instance can ping using ptp cni plugin")
-				detachedVMI := libvmi.NewAlpine()
-				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-				detachedVMI.Spec.Networks = []v1.Network{
-					{Name: "ptp", NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: fmt.Sprintf("%s/%s", tests.NamespaceTestAlternative, ptpConf2)},
-					}},
-				}
+				It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", Label("test_id:1752"), func() {
+					checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
+					By("checking virtual machine instance can ping using ptp cni plugin")
+					detachedVMI := libvmi.NewAlpine()
+					detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+					detachedVMI.Spec.Networks = []v1.Network{
+						{Name: "ptp", NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{NetworkName: fmt.Sprintf("%s/%s", tests.NamespaceTestAlternative, ptpConf2)},
+						}},
+					}
 
-				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
+					detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
 				})
 
-				It("[test_id:1753]should create a virtual machine with two interfaces", Labels{"test_id:1753"}, func() {
+				It("[test_id:1753]should create a virtual machine with two interfaces", Label("test_id:1753"), func() {
 					By("checking virtual machine instance can ping using ptp cni plugin")
 					detachedVMI := libvmi.NewCirros()
 
@@ -241,9 +241,9 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 						}},
 					}
 
-				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, console.LoginToCirros)
+					detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitUntilVMIReady(detachedVMI, console.LoginToCirros)
 
 					cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
 					err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
@@ -264,22 +264,22 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 				})
 			})
 
-		Context("VirtualMachineInstance with multus network as default network", func() {
-			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", Labels{"test_id:1751"}, func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-				detachedVMI := libvmi.NewAlpine()
-				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
-				detachedVMI.Spec.Networks = []v1.Network{
-					{Name: "ptp", NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{
-							NetworkName: fmt.Sprintf("%s/%s", util.NamespaceTestDefault, ptpConf1),
-							Default:     true,
-						}}},
-				}
+			Context("VirtualMachineInstance with multus network as default network", func() {
+				It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", Label("test_id:1751"), func() {
+					libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+					detachedVMI := libvmi.NewAlpine()
+					detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+					detachedVMI.Spec.Networks = []v1.Network{
+						{Name: "ptp", NetworkSource: v1.NetworkSource{
+							Multus: &v1.MultusNetwork{
+								NetworkName: fmt.Sprintf("%s/%s", util.NamespaceTestDefault, ptpConf1),
+								Default:     true,
+							}}},
+					}
 
-				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
+					detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitUntilVMIReady(detachedVMI, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 					By("checking virtual machine instance can ping using ptp cni plugin")
 					Expect(libnet.PingFromVMConsole(detachedVMI, ptpGateway)).To(Succeed())
@@ -302,7 +302,7 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 			})
 
 			Context("VirtualMachineInstance with cni ptp plugin interface with custom MAC address", func() {
-				It("[test_id:1705]should configure valid custom MAC address on ptp interface when using tuning plugin", Labels{"test_id:1705"}, func() {
+				It("[test_id:1705]should configure valid custom MAC address on ptp interface when using tuning plugin", Label("test_id:1705"), func() {
 					customMacAddress := "50:00:00:00:90:0d"
 					ptpInterface := v1.Interface{
 						Name: "ptp",
@@ -322,11 +322,11 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 					interfaces := []v1.Interface{ptpInterface}
 					networks := []v1.Network{ptpNetwork}
 
-				By("Creating a VM with custom MAC address on its ptp interface.")
-				interfaces[0].MacAddress = customMacAddress
+					By("Creating a VM with custom MAC address on its ptp interface.")
+					interfaces[0].MacAddress = customMacAddress
 
-				vmiOne := createVMIOnNode(interfaces, networks)
-				tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
+					vmiOne := createVMIOnNode(interfaces, networks)
+					tests.WaitUntilVMIReady(vmiOne, console.LoginToAlpine)
 
 					By("Configuring static IP address to ptp interface.")
 					Expect(configInterface(vmiOne, "eth0", ptpSubnetIP1+ptpSubnetMask)).To(Succeed())
@@ -388,12 +388,12 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 					By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
 					Expect(checkInterface(vmiOne, ifaceName)).To(Succeed())
 
-				Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
-				By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
-				Expect(checkInterface(vmiTwo, ifaceName)).To(Succeed())
-				ipAddr := ""
-				if staticIPVm2 != "" {
-					ipAddr, err = libnet.CidrToIP(staticIPVm2)
+					Expect(configureAlpineInterfaceIP(vmiTwo, ifaceName, staticIPVm2)).To(Succeed())
+					By(fmt.Sprintf("checking virtual machine interface %s state", ifaceName))
+					Expect(checkInterface(vmiTwo, ifaceName)).To(Succeed())
+					ipAddr := ""
+					if staticIPVm2 != "" {
+						ipAddr, err = libnet.CidrToIP(staticIPVm2)
 					} else {
 						const secondaryNetworkIndex = 1
 						ipAddr, err = getIfaceIPByNetworkName(vmiTwo.Name, networks[secondaryNetworkIndex].Name)
@@ -404,15 +404,15 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 					By("ping between virtual machines")
 					Expect(libnet.PingFromVMConsole(vmiOne, ipAddr)).To(Succeed())
 				},
-					Entry("[test_id:1577]with secondary network only", Labels{"test_id:1577"}, []v1.Interface{linuxBridgeInterface}, []v1.Network{linuxBridgeNetwork}, "eth0", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
-					Entry("[test_id:1578]with default network and secondary network", Labels{"test_id:1578"}, []v1.Interface{defaultInterface, linuxBridgeInterface}, []v1.Network{defaultNetwork, linuxBridgeNetwork}, "eth1", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
+					Entry("[test_id:1577]with secondary network only", Label("test_id:1577"), []v1.Interface{linuxBridgeInterface}, []v1.Network{linuxBridgeNetwork}, "eth0", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
+					Entry("[test_id:1578]with default network and secondary network", Label("test_id:1578"), []v1.Interface{defaultInterface, linuxBridgeInterface}, []v1.Network{defaultNetwork, linuxBridgeNetwork}, "eth1", ptpSubnetIP1+ptpSubnetMask, ptpSubnetIP2+ptpSubnetMask),
 					Entry("with default network and secondary network with IPAM", []v1.Interface{defaultInterface, linuxBridgeInterfaceWithIPAM}, []v1.Network{defaultNetwork, linuxBridgeWithIPAMNetwork}, "eth1", "", ""),
 				)
 			})
 
 			Context("VirtualMachineInstance with Linux bridge CNI plugin interface and custom MAC address.", func() {
 				customMacAddress := "50:00:00:00:90:0d"
-				It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", Labels{"test_id:676"}, func() {
+				It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", Label("test_id:676"), func() {
 					By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
 					vmiTwo := libvmi.NewFedora(
 						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -459,7 +459,7 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 			})
 
 			Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
-				It("[test_id:1756]should report all interfaces in Status", Labels{"test_id:1756"}, func() {
+				It("[test_id:1756]should report all interfaces in Status", Label("test_id:1756"), func() {
 					interfaces := []v1.Interface{
 						defaultInterface,
 						linuxBridgeInterface,
@@ -534,7 +534,7 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 
 			Context("VirtualMachineInstance with invalid MAC address", func() {
 
-				It("[test_id:1713]should failed to start with invalid MAC address", Labels{"test_id:1713"}, func() {
+				It("[test_id:1713]should failed to start with invalid MAC address", Label("test_id:1713"), func() {
 					By("Start VMI")
 					linuxBridgeIfIdx := 1
 
@@ -623,11 +623,11 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 		})
 
 	Describe("[rfe_id:1758][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition",
-		Labels{"rfe_id:1758", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:1758", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			Context("with qemu guest agent", func() {
 
-				It("[test_id:1757] should report guest interfaces in VMI status", Labels{"test_id:1757"}, func() {
+				It("[test_id:1757] should report guest interfaces in VMI status", Label("test_id:1757"), func() {
 					interfaces := []v1.Interface{
 						defaultInterface,
 						linuxBridgeInterface,
@@ -670,14 +670,14 @@ var _ = SIGDescribe("[Serial]Multus", Labels{"Serial"}, func() {
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
 					tests.WaitAgentConnected(virtClient, agentVMI)
 
-				getOptions := &metav1.GetOptions{}
-				Eventually(func() []v1.VirtualMachineInstanceNetworkInterface {
-					updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
-					if err != nil {
-						return nil
-					}
-					return updatedVmi.Status.Interfaces
-				}, 420*time.Second, 4).Should(HaveLen(4), "Should have interfaces in vmi status")
+					getOptions := &metav1.GetOptions{}
+					Eventually(func() []v1.VirtualMachineInstanceNetworkInterface {
+						updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
+						if err != nil {
+							return nil
+						}
+						return updatedVmi.Status.Interfaces
+					}, 420*time.Second, 4).Should(HaveLen(4), "Should have interfaces in vmi status")
 
 					updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -138,13 +138,13 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					outboundVMI = runVMI(outboundVMI)
 				})
 
-			DescribeTable("should be able to reach", func(vmiRef **v1.VirtualMachineInstance) {
-				vmi := *vmiRef
-				if vmiHasCustomMacAddress(vmi) {
-					checks.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
-				}
-				vmi = runVMI(vmi)
-				addr := vmi.Status.Interfaces[0].IP
+				DescribeTable("should be able to reach", func(vmiRef **v1.VirtualMachineInstance) {
+					vmi := *vmiRef
+					if vmiHasCustomMacAddress(vmi) {
+						checks.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
+					}
+					vmi = runVMI(vmi)
+					addr := vmi.Status.Interfaces[0].IP
 
 					payloadSize := 0
 					ipHeaderSize := 28 // IPv4 specific
@@ -175,39 +175,39 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				By("checking eth0 MTU inside the VirtualMachineInstance")
 				Expect(console.LoginToCirros(outboundVMI)).To(Succeed())
 
-				addrShow := "ip address show eth0\n"
-				Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: addrShow},
-					&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
-					&expect.BSnd{S: tests.EchoLastReturnValue},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 180)).To(Succeed())
+					addrShow := "ip address show eth0\n"
+					Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: addrShow},
+						&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
+						&expect.BSnd{S: tests.EchoLastReturnValue},
+						&expect.BExp{R: console.RetValue("0")},
+					}, 180)).To(Succeed())
 
-				By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
-				// NOTE: VirtualMachineInstance is not directly accessible from inside the pod because
-				// we transferred its IP address under DHCP server control, so the
-				// only thing we can validate is connectivity between VMIs
-				//
-				// NOTE: cirros ping doesn't support -M do that could be used to
-				// validate end-to-end connectivity with Don't Fragment flag set
-				cmdCheck := fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
-				err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: cmdCheck},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: tests.EchoLastReturnValue},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 180)
-				Expect(err).ToNot(HaveOccurred())
-			},
-				Entry("[test_id:1539]the Inbound VirtualMachineInstance", &inboundVMI),
-				Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", &inboundVMIWithPodNetworkSet),
-				Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", &inboundVMIWithCustomMacAddress),
-			)
-		})
+					By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
+					// NOTE: VirtualMachineInstance is not directly accessible from inside the pod because
+					// we transferred its IP address under DHCP server control, so the
+					// only thing we can validate is connectivity between VMIs
+					//
+					// NOTE: cirros ping doesn't support -M do that could be used to
+					// validate end-to-end connectivity with Don't Fragment flag set
+					cmdCheck := fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
+					err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: cmdCheck},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: tests.EchoLastReturnValue},
+						&expect.BExp{R: console.RetValue("0")},
+					}, 180)
+					Expect(err).ToNot(HaveOccurred())
+				},
+					Entry("[test_id:1539]the Inbound VirtualMachineInstance", &inboundVMI),
+					Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", &inboundVMIWithPodNetworkSet),
+					Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", &inboundVMIWithCustomMacAddress),
+				)
+			})
 
 		Context("with propagated IP from a pod", func() {
 			BeforeEach(func() {
@@ -300,37 +300,37 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 		})
 
-	Context("VirtualMachineInstance with default settings", func() {
-		It("[test_id:1542]should be able to reach the internet", Labels{"test_id:1542"}, func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-			outboundVMI := libvmi.NewCirros()
-			outboundVMI = runVMI(outboundVMI)
-			tests.WaitUntilVMIReady(outboundVMI, console.LoginToCirros)
+		Context("VirtualMachineInstance with default settings", func() {
+			It("[test_id:1542]should be able to reach the internet", Labels{"test_id:1542"}, func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				outboundVMI := libvmi.NewCirros()
+				outboundVMI = runVMI(outboundVMI)
+				tests.WaitUntilVMIReady(outboundVMI, console.LoginToCirros)
 
-			By("checking the VirtualMachineInstance can fetch via HTTP")
-			err := console.SafeExpectBatch(outboundVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: tests.EchoLastReturnValue},
-				&expect.BExp{R: console.RetValue("0")},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
+				By("checking the VirtualMachineInstance can fetch via HTTP")
+				err := console.SafeExpectBatch(outboundVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: tests.EchoLastReturnValue},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with custom interface model", func() {
-		It("[test_id:1770]should expose the right device type to the guest", Labels{"test_id:1770"}, func() {
-			By("checking the device vendor in /sys/class")
-			// Create a machine with e1000 interface model
-			// Use alpine because cirros dhcp client starts prematurely before link is ready
-			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-			masqIface.Model = "e1000"
-			e1000VMI := libvmi.NewAlpine(
-				libvmi.WithInterface(masqIface),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
+		Context("VirtualMachineInstance with custom interface model", func() {
+			It("[test_id:1770]should expose the right device type to the guest", Labels{"test_id:1770"}, func() {
+				By("checking the device vendor in /sys/class")
+				// Create a machine with e1000 interface model
+				// Use alpine because cirros dhcp client starts prematurely before link is ready
+				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
+				masqIface.Model = "e1000"
+				e1000VMI := libvmi.NewAlpine(
+					libvmi.WithInterface(masqIface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
 
 				e1000VMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(e1000VMI)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -727,7 +727,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					)
 
 					It("[outside_connectivity]should be able to reach the outside world [IPv4]",
-						Label("outside_connectivity]should be able to reach the outside world [IPv4"),
+						Label("outside_connectivity"),
 						func() {
 							libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 							ipv4Address := "8.8.8.8"
@@ -787,7 +787,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					)
 
 					It("[outside_connectivity]should be able to reach the outside world [IPv6]",
-						Label("outside_connectivity]should be able to reach the outside world [IPv6"),
+						Label("outside_connectivity"),
 						func() {
 							libnet.SkipWhenClusterNotSupportIpv6(virtClient)
 							// Cluster nodes subnet (docker network gateway)

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -60,81 +60,83 @@ const (
 	catResolvConf       = "cat /etc/resolv.conf\n"
 )
 
-var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", func() {
+var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking",
+	Labels{"rfe_id:694", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+	func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
-	var currentConfiguration v1.KubeVirtConfiguration
+		var err error
+		var virtClient kubecli.KubevirtClient
+		var currentConfiguration v1.KubeVirtConfiguration
 
-	const (
-		testPort                   = 1500
-		LibvirtDirectMigrationPort = 49152
-		LibvirtBlockMigrationPort  = 49153
-	)
-
-	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		kv := util.GetCurrentKv(virtClient)
-		currentConfiguration = kv.Spec.Configuration
-	})
-
-	checkMacAddress := func(vmi *v1.VirtualMachineInstance, expectedMacAddress string) {
-		err := console.SafeExpectBatch(vmi, []expect.Batcher{
-			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: "cat /sys/class/net/eth0/address\n"},
-			&expect.BExp{R: expectedMacAddress},
-		}, 15)
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	checkNetworkVendor := func(vmi *v1.VirtualMachineInstance, expectedVendor string) {
-		err := console.SafeExpectBatch(vmi, []expect.Batcher{
-			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: "cat /sys/class/net/eth0/device/vendor\n"},
-			&expect.BExp{R: expectedVendor},
-		}, 15)
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
-		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0-nic/brport/learning"})
-		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
-	}
-
-	setBridgeEnabled := func(enable bool) {
-		if currentConfiguration.NetworkConfiguration == nil {
-			currentConfiguration.NetworkConfiguration = &v1.NetworkConfiguration{}
-		}
-
-		currentConfiguration.NetworkConfiguration.PermitBridgeInterfaceOnPodNetwork = pointer.BoolPtr(enable)
-		kv := tests.UpdateKubeVirtConfigValueAndWait(currentConfiguration)
-		currentConfiguration = kv.Spec.Configuration
-	}
-
-	Describe("Multiple virtual machines connectivity using bridge binding interface", func() {
-		var inboundVMI *v1.VirtualMachineInstance
-		var outboundVMI *v1.VirtualMachineInstance
-		var inboundVMIWithPodNetworkSet *v1.VirtualMachineInstance
-		var inboundVMIWithCustomMacAddress *v1.VirtualMachineInstance
+		const (
+			testPort                   = 1500
+			LibvirtDirectMigrationPort = 49152
+			LibvirtBlockMigrationPort  = 49153
+		)
 
 		BeforeEach(func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-		})
-		Context("with a test outbound VMI", func() {
-			BeforeEach(func() {
-				inboundVMI = libvmi.NewCirros()
-				outboundVMI = libvmi.NewCirros()
-				inboundVMIWithPodNetworkSet = vmiWithPodNetworkSet()
-				inboundVMIWithCustomMacAddress = vmiWithCustomMacAddress("de:ad:00:00:be:af")
+			tests.BeforeTestCleanup()
 
-				outboundVMI = runVMI(outboundVMI)
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
+
+			kv := util.GetCurrentKv(virtClient)
+			currentConfiguration = kv.Spec.Configuration
+		})
+
+		checkMacAddress := func(vmi *v1.VirtualMachineInstance, expectedMacAddress string) {
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "cat /sys/class/net/eth0/address\n"},
+				&expect.BExp{R: expectedMacAddress},
+			}, 15)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		checkNetworkVendor := func(vmi *v1.VirtualMachineInstance, expectedVendor string) {
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "cat /sys/class/net/eth0/device/vendor\n"},
+				&expect.BExp{R: expectedVendor},
+			}, 15)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
+			output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0-nic/brport/learning"})
+			ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
+		}
+
+		setBridgeEnabled := func(enable bool) {
+			if currentConfiguration.NetworkConfiguration == nil {
+				currentConfiguration.NetworkConfiguration = &v1.NetworkConfiguration{}
+			}
+
+			currentConfiguration.NetworkConfiguration.PermitBridgeInterfaceOnPodNetwork = pointer.BoolPtr(enable)
+			kv := tests.UpdateKubeVirtConfigValueAndWait(currentConfiguration)
+			currentConfiguration = kv.Spec.Configuration
+		}
+
+		Describe("Multiple virtual machines connectivity using bridge binding interface", func() {
+			var inboundVMI *v1.VirtualMachineInstance
+			var outboundVMI *v1.VirtualMachineInstance
+			var inboundVMIWithPodNetworkSet *v1.VirtualMachineInstance
+			var inboundVMIWithCustomMacAddress *v1.VirtualMachineInstance
+
+			BeforeEach(func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 			})
+			Context("with a test outbound VMI", func() {
+				BeforeEach(func() {
+					inboundVMI = libvmi.NewCirros()
+					outboundVMI = libvmi.NewCirros()
+					inboundVMIWithPodNetworkSet = vmiWithPodNetworkSet()
+					inboundVMIWithCustomMacAddress = vmiWithCustomMacAddress("de:ad:00:00:be:af")
+
+					outboundVMI = runVMI(outboundVMI)
+				})
 
 			DescribeTable("should be able to reach", func(vmiRef **v1.VirtualMachineInstance) {
 				vmi := *vmiRef
@@ -144,31 +146,31 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				vmi = runVMI(vmi)
 				addr := vmi.Status.Interfaces[0].IP
 
-				payloadSize := 0
-				ipHeaderSize := 28 // IPv4 specific
+					payloadSize := 0
+					ipHeaderSize := 28 // IPv4 specific
 
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(outboundVMI, util.NamespaceTestDefault)
-				var mtu int
-				for _, ifaceName := range []string{"k6t-eth0", "tap0"} {
-					By(fmt.Sprintf("checking %s MTU inside the pod", ifaceName))
-					output, err := tests.ExecuteCommandOnPod(
-						virtClient,
-						vmiPod,
-						"compute",
-						[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
-					)
-					log.Log.Infof("%s mtu is %v", ifaceName, output)
-					Expect(err).ToNot(HaveOccurred())
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(outboundVMI, util.NamespaceTestDefault)
+					var mtu int
+					for _, ifaceName := range []string{"k6t-eth0", "tap0"} {
+						By(fmt.Sprintf("checking %s MTU inside the pod", ifaceName))
+						output, err := tests.ExecuteCommandOnPod(
+							virtClient,
+							vmiPod,
+							"compute",
+							[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
+						)
+						log.Log.Infof("%s mtu is %v", ifaceName, output)
+						Expect(err).ToNot(HaveOccurred())
 
-					output = strings.TrimSuffix(output, "\n")
-					mtu, err = strconv.Atoi(output)
-					Expect(err).ToNot(HaveOccurred())
+						output = strings.TrimSuffix(output, "\n")
+						mtu, err = strconv.Atoi(output)
+						Expect(err).ToNot(HaveOccurred())
 
-					Expect(mtu > 1000).To(BeTrue())
+						Expect(mtu > 1000).To(BeTrue())
 
-					payloadSize = mtu - ipHeaderSize
-				}
-				expectedMtuString := fmt.Sprintf("mtu %d", mtu)
+						payloadSize = mtu - ipHeaderSize
+					}
+					expectedMtuString := fmt.Sprintf("mtu %d", mtu)
 
 				By("checking eth0 MTU inside the VirtualMachineInstance")
 				Expect(console.LoginToCirros(outboundVMI)).To(Succeed())
@@ -216,90 +218,90 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				tests.StartTCPServer(inboundVMI, testPort, console.LoginToCirros)
 			})
 
-			DescribeTable("should be able to reach", func(op v12.NodeSelectorOperator, hostNetwork bool) {
+				DescribeTable("should be able to reach", func(op v12.NodeSelectorOperator, hostNetwork bool) {
 
-				ip := inboundVMI.Status.Interfaces[0].IP
+					ip := inboundVMI.Status.Interfaces[0].IP
 
-				//TODO if node count 1, skip the nv12.NodeSelectorOpOut
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), v13.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(nodes.Items).ToNot(BeEmpty())
-				if len(nodes.Items) == 1 && op == v12.NodeSelectorOpNotIn {
-					Skip("Skip network test that requires multiple nodes when only one node is present.")
-				}
+					//TODO if node count 1, skip the nv12.NodeSelectorOpOut
+					nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), v13.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(nodes.Items).ToNot(BeEmpty())
+					if len(nodes.Items) == 1 && op == v12.NodeSelectorOpNotIn {
+						Skip("Skip network test that requires multiple nodes when only one node is present.")
+					}
 
-				job := tests.NewHelloWorldJobTCP(ip, strconv.Itoa(testPort))
-				job.Spec.Template.Spec.Affinity = &v12.Affinity{
-					NodeAffinity: &v12.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{
-							NodeSelectorTerms: []v12.NodeSelectorTerm{
-								{
-									MatchExpressions: []v12.NodeSelectorRequirement{
-										{Key: "kubernetes.io/hostname", Operator: op, Values: []string{inboundVMI.Status.NodeName}},
+					job := tests.NewHelloWorldJobTCP(ip, strconv.Itoa(testPort))
+					job.Spec.Template.Spec.Affinity = &v12.Affinity{
+						NodeAffinity: &v12.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{
+								NodeSelectorTerms: []v12.NodeSelectorTerm{
+									{
+										MatchExpressions: []v12.NodeSelectorRequirement{
+											{Key: "kubernetes.io/hostname", Operator: op, Values: []string{inboundVMI.Status.NodeName}},
+										},
 									},
 								},
 							},
 						},
-					},
-				}
-				job.Spec.Template.Spec.HostNetwork = hostNetwork
+					}
+					job.Spec.Template.Spec.HostNetwork = hostNetwork
 
-				job, err = virtClient.BatchV1().Jobs(inboundVMI.ObjectMeta.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
-			},
-				Entry("[test_id:1543]on the same node from Pod", v12.NodeSelectorOpIn, false),
-				Entry("[test_id:1544]on a different node from Pod", v12.NodeSelectorOpNotIn, false),
-				Entry("[test_id:1545]on the same node from Node", v12.NodeSelectorOpIn, true),
-				Entry("[test_id:1546]on a different node from Node", v12.NodeSelectorOpNotIn, true),
-			)
-		})
+					job, err = virtClient.BatchV1().Jobs(inboundVMI.ObjectMeta.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
+				},
+					Entry("[test_id:1543]on the same node from Pod", Labels{"test_id:1543"}, v12.NodeSelectorOpIn, false),
+					Entry("[test_id:1544]on a different node from Pod", Labels{"test_id:1544"}, v12.NodeSelectorOpNotIn, false),
+					Entry("[test_id:1545]on the same node from Node", Labels{"test_id:1545"}, v12.NodeSelectorOpIn, true),
+					Entry("[test_id:1546]on a different node from Node", Labels{"test_id:1546"}, v12.NodeSelectorOpNotIn, true),
+				)
+			})
 
 		Context("VirtualMachineInstance with default interface model", func() {
 			BeforeEach(func() {
 				inboundVMI = libvmi.NewAlpine()
 				outboundVMI = libvmi.NewAlpine()
 
-				inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
-				Expect(err).ToNot(HaveOccurred())
-				outboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(outboundVMI)
-				Expect(err).ToNot(HaveOccurred())
+					inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
+					Expect(err).ToNot(HaveOccurred())
+					outboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(outboundVMI)
+					Expect(err).ToNot(HaveOccurred())
 
 				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
 				outboundVMI = tests.WaitUntilVMIReady(outboundVMI, console.LoginToAlpine)
 			})
 
-			// Unless an explicit interface model is specified, the default interface model is virtio.
-			It("[test_id:1550]should expose the right device type to the guest", func() {
-				By("checking the device vendor in /sys/class")
+				// Unless an explicit interface model is specified, the default interface model is virtio.
+				It("[test_id:1550]should expose the right device type to the guest", Labels{"test_id:1550"}, func() {
+					By("checking the device vendor in /sys/class")
 
-				// Taken from https://wiki.osdev.org/Virtio#Technical_Details
-				virtio_vid := "0x1af4"
+					// Taken from https://wiki.osdev.org/Virtio#Technical_Details
+					virtio_vid := "0x1af4"
 
-				for _, networkVMI := range []*v1.VirtualMachineInstance{inboundVMI, outboundVMI} {
-					// as defined in https://vendev.org/pci/ven_1af4/
-					checkNetworkVendor(networkVMI, virtio_vid)
-				}
-			})
+					for _, networkVMI := range []*v1.VirtualMachineInstance{inboundVMI, outboundVMI} {
+						// as defined in https://vendev.org/pci/ven_1af4/
+						checkNetworkVendor(networkVMI, virtio_vid)
+					}
+				})
 
-			Context("VirtualMachineInstance with unsupported interface model", func() {
-				It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", func() {
-					// Create a virtual machine with an unsupported interface model
-					masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-					masqIface.Model = "gibberish"
-					customIfVMI := libvmi.NewAlpine(
-						libvmi.WithInterface(masqIface),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					)
-					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(customIfVMI)
-					Expect(err).To(HaveOccurred())
+				Context("VirtualMachineInstance with unsupported interface model", func() {
+					It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", Labels{"test_id:1551"}, func() {
+						// Create a virtual machine with an unsupported interface model
+						masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
+						masqIface.Model = "gibberish"
+						customIfVMI := libvmi.NewAlpine(
+							libvmi.WithInterface(masqIface),
+							libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						)
+						_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(customIfVMI)
+						Expect(err).To(HaveOccurred())
+					})
 				})
 			})
 		})
-	})
 
 	Context("VirtualMachineInstance with default settings", func() {
-		It("[test_id:1542]should be able to reach the internet", func() {
+		It("[test_id:1542]should be able to reach the internet", Labels{"test_id:1542"}, func() {
 			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 			outboundVMI := libvmi.NewCirros()
 			outboundVMI = runVMI(outboundVMI)
@@ -319,7 +321,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	})
 
 	Context("VirtualMachineInstance with custom interface model", func() {
-		It("[test_id:1770]should expose the right device type to the guest", func() {
+		It("[test_id:1770]should expose the right device type to the guest", Labels{"test_id:1770"}, func() {
 			By("checking the device vendor in /sys/class")
 			// Create a machine with e1000 interface model
 			// Use alpine because cirros dhcp client starts prematurely before link is ready
@@ -330,84 +332,84 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 
-			e1000VMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(e1000VMI)
-			Expect(err).ToNot(HaveOccurred())
+				e1000VMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(e1000VMI)
+				Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(e1000VMI, console.LoginToAlpine)
-			// as defined in https://vendev.org/pci/ven_8086/
-			checkNetworkVendor(e1000VMI, "0x8086")
+				tests.WaitUntilVMIReady(e1000VMI, console.LoginToAlpine)
+				// as defined in https://vendev.org/pci/ven_8086/
+				checkNetworkVendor(e1000VMI, "0x8086")
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with custom MAC address", func() {
-		It("[test_id:1771]should configure custom MAC address", func() {
-			By(checkingEth0MACAddr)
-			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-			masqIface.MacAddress = "de:ad:00:00:be:af"
-			deadbeafVMI := libvmi.NewAlpine(
-				libvmi.WithInterface(masqIface),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			deadbeafVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(deadbeafVMI)
-			Expect(err).ToNot(HaveOccurred())
+		Context("VirtualMachineInstance with custom MAC address", func() {
+			It("[test_id:1771]should configure custom MAC address", Labels{"test_id:1771"}, func() {
+				By(checkingEth0MACAddr)
+				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
+				masqIface.MacAddress = "de:ad:00:00:be:af"
+				deadbeafVMI := libvmi.NewAlpine(
+					libvmi.WithInterface(masqIface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				deadbeafVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(deadbeafVMI)
+				Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(deadbeafVMI, console.LoginToAlpine)
-			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
+				tests.WaitUntilVMIReady(deadbeafVMI, console.LoginToAlpine)
+				checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
-		It("[test_id:1772]should configure custom MAC address", func() {
-			By(checkingEth0MACAddr)
-			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-			masqIface.MacAddress = "BE-AF-00-00-DE-AD"
-			beafdeadVMI := libvmi.NewAlpine(
-				libvmi.WithInterface(masqIface),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			beafdeadVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(beafdeadVMI)
-			Expect(err).ToNot(HaveOccurred())
+		Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
+			It("[test_id:1772]should configure custom MAC address", Labels{"test_id:1772"}, func() {
+				By(checkingEth0MACAddr)
+				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
+				masqIface.MacAddress = "BE-AF-00-00-DE-AD"
+				beafdeadVMI := libvmi.NewAlpine(
+					libvmi.WithInterface(masqIface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				beafdeadVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(beafdeadVMI)
+				Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(beafdeadVMI, console.LoginToAlpine)
-			checkMacAddress(beafdeadVMI, "be:af:00:00:de:ad")
+				tests.WaitUntilVMIReady(beafdeadVMI, console.LoginToAlpine)
+				checkMacAddress(beafdeadVMI, "be:af:00:00:de:ad")
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with invalid MAC address", func() {
-		It("[test_id:700]should failed to start with invalid MAC address", func() {
-			By("Start VMI")
-			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
-			masqIface.MacAddress = "de:00c:00c:00:00:de:abc"
-			beafdeadVMI := libvmi.NewAlpine(
-				libvmi.WithInterface(masqIface),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(beafdeadVMI)
-			Expect(err).To(HaveOccurred())
-			testErr := err.(*errors.StatusError)
-			Expect(testErr.ErrStatus.Reason).To(BeEquivalentTo("Invalid"))
+		Context("VirtualMachineInstance with invalid MAC address", func() {
+			It("[test_id:700]should failed to start with invalid MAC address", Labels{"test_id:700"}, func() {
+				By("Start VMI")
+				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
+				masqIface.MacAddress = "de:00c:00c:00:00:de:abc"
+				beafdeadVMI := libvmi.NewAlpine(
+					libvmi.WithInterface(masqIface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(beafdeadVMI)
+				Expect(err).To(HaveOccurred())
+				testErr := err.(*errors.StatusError)
+				Expect(testErr.ErrStatus.Reason).To(BeEquivalentTo("Invalid"))
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
-		It("[test_id:1773]should configure custom MAC address", func() {
-			By(checkingEth0MACAddr)
-			slirpIface := libvmi.InterfaceDeviceWithSlirpBinding(libvmi.DefaultInterfaceName)
-			slirpIface.MacAddress = "de:ad:00:00:be:af"
-			deadbeafVMI := libvmi.NewAlpine(
-				libvmi.WithInterface(slirpIface),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			deadbeafVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(deadbeafVMI)
-			Expect(err).ToNot(HaveOccurred())
+		Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
+			It("[test_id:1773]should configure custom MAC address", Labels{"test_id:1773"}, func() {
+				By(checkingEth0MACAddr)
+				slirpIface := libvmi.InterfaceDeviceWithSlirpBinding(libvmi.DefaultInterfaceName)
+				slirpIface.MacAddress = "de:ad:00:00:be:af"
+				deadbeafVMI := libvmi.NewAlpine(
+					libvmi.WithInterface(slirpIface),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				deadbeafVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(deadbeafVMI)
+				Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(deadbeafVMI, console.LoginToAlpine)
-			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
+				tests.WaitUntilVMIReady(deadbeafVMI, console.LoginToAlpine)
+				checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
+			})
 		})
-	})
 
 	Context("VirtualMachineInstance with disabled automatic attachment of interfaces", func() {
-		It("[test_id:1774]should not configure any external interfaces", func() {
+		It("[test_id:1774]should not configure any external interfaces", Labels{"test_id:1774"}, func() {
 			By("checking loopback is the only guest interface")
 			autoAttach := false
 			detachedVMI := libvmi.NewAlpine()
@@ -420,68 +422,68 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(detachedVMI, console.LoginToAlpine)
 
-			err := console.SafeExpectBatch(detachedVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "ls /sys/class/net/ | wc -l\n"},
-				&expect.BExp{R: "1"},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
+				err := console.SafeExpectBatch(detachedVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "ls /sys/class/net/ | wc -l\n"},
+					&expect.BExp{R: "1"},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("[test_id:1775]should not request a tun device", Labels{"test_id:1775"}, func() {
+				By("Creating random VirtualMachineInstance")
+				autoAttach := false
+				vmi := libvmi.NewAlpine()
+				vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
+
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				waitUntilVMIReady(vmi, console.LoginToAlpine)
+
+				By("Checking that the pod did not request a tun device")
+				virtClient, err := kubecli.GetKubevirtClient()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Looking up pod using VMI's label")
+				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pods.Items).NotTo(BeEmpty())
+				pod := pods.Items[0]
+
+				foundContainer := false
+				for _, container := range pod.Spec.Containers {
+					if container.Name == "compute" {
+						foundContainer = true
+						_, ok := container.Resources.Requests[services.TunDevice]
+						Expect(ok).To(BeFalse())
+
+						_, ok = container.Resources.Limits[services.TunDevice]
+						Expect(ok).To(BeFalse())
+
+						caps := container.SecurityContext.Capabilities
+
+						Expect(caps.Add).To(Not(ContainElement(k8sv1.Capability("NET_ADMIN"))), "Compute container should not have NET_ADMIN capability")
+						Expect(caps.Drop).To(ContainElement(k8sv1.Capability("NET_RAW")), "Compute container should drop NET_RAW capability")
+					}
+				}
+
+				Expect(foundContainer).To(BeTrue(), "Did not find 'compute' container in pod")
+			})
 		})
 
-		It("[test_id:1775]should not request a tun device", func() {
-			By("Creating random VirtualMachineInstance")
-			autoAttach := false
-			vmi := libvmi.NewAlpine()
-			vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
-
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			waitUntilVMIReady(vmi, console.LoginToAlpine)
-
-			By("Checking that the pod did not request a tun device")
-			virtClient, err := kubecli.GetKubevirtClient()
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Looking up pod using VMI's label")
-			pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pods.Items).NotTo(BeEmpty())
-			pod := pods.Items[0]
-
-			foundContainer := false
-			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
-					foundContainer = true
-					_, ok := container.Resources.Requests[services.TunDevice]
-					Expect(ok).To(BeFalse())
-
-					_, ok = container.Resources.Limits[services.TunDevice]
-					Expect(ok).To(BeFalse())
-
-					caps := container.SecurityContext.Capabilities
-
-					Expect(caps.Add).To(Not(ContainElement(k8sv1.Capability("NET_ADMIN"))), "Compute container should not have NET_ADMIN capability")
-					Expect(caps.Drop).To(ContainElement(k8sv1.Capability("NET_RAW")), "Compute container should drop NET_RAW capability")
-				}
+		Context("VirtualMachineInstance with custom PCI address", func() {
+			checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
+				err := console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "grep INTERFACE /sys/bus/pci/devices/" + expectedPciAddress + "/*/net/eth0/uevent|awk -F= '{ print $2 }'\n"},
+					&expect.BExp{R: "eth0"},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
 			}
 
-			Expect(foundContainer).To(BeTrue(), "Did not find 'compute' container in pod")
-		})
-	})
-
-	Context("VirtualMachineInstance with custom PCI address", func() {
-		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
-			err := console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "grep INTERFACE /sys/bus/pci/devices/" + expectedPciAddress + "/*/net/eth0/uevent|awk -F= '{ print $2 }'\n"},
-				&expect.BExp{R: "eth0"},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
-		}
-
-		It("[test_id:1776]should configure custom Pci address", func() {
+		It("[test_id:1776]should configure custom Pci address", Labels{"test_id:1776"}, func() {
 			By("checking eth0 Pci address")
 			testVMI := libvmi.NewAlpine()
 			tests.AddExplicitPodNetworkInterface(testVMI)
@@ -494,69 +496,69 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 
-	Context("VirtualMachineInstance with learning disabled on pod interface", func() {
-		It("[test_id:1777]should disable learning on pod iface", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-			By("checking learning flag")
-			learningDisabledVMI := libvmi.NewAlpine()
-			learningDisabledVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(learningDisabledVMI)
-			Expect(err).ToNot(HaveOccurred())
+		Context("VirtualMachineInstance with learning disabled on pod interface", func() {
+			It("[test_id:1777]should disable learning on pod iface", Labels{"test_id:1777"}, func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				By("checking learning flag")
+				learningDisabledVMI := libvmi.NewAlpine()
+				learningDisabledVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(learningDisabledVMI)
+				Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(learningDisabledVMI, console.LoginToAlpine)
-			checkLearningState(learningDisabledVMI, "0")
+				tests.WaitUntilVMIReady(learningDisabledVMI, console.LoginToAlpine)
+				checkLearningState(learningDisabledVMI, "0")
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with dhcp options", func() {
-		It("[test_id:1778]should offer extra dhcp options to pod iface", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-			dhcpVMI := libvmi.NewFedora()
-			tests.AddExplicitPodNetworkInterface(dhcpVMI)
+		Context("VirtualMachineInstance with dhcp options", func() {
+			It("[test_id:1778]should offer extra dhcp options to pod iface", Labels{"test_id:1778"}, func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				dhcpVMI := libvmi.NewFedora()
+				tests.AddExplicitPodNetworkInterface(dhcpVMI)
 
-			dhcpVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
+				dhcpVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
 
-			// This IPv4 address tests backwards compatibility of the "DHCPOptions.NTPServers" field.
-			// The leading zero is intentional.
-			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
-			const NTPServerWithLeadingZeros = "0127.0.0.3"
+				// This IPv4 address tests backwards compatibility of the "DHCPOptions.NTPServers" field.
+				// The leading zero is intentional.
+				// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
+				const NTPServerWithLeadingZeros = "0127.0.0.3"
 
-			dhcpVMI.Spec.Domain.Devices.Interfaces[0].DHCPOptions = &v1.DHCPOptions{
-				BootFileName:   "config",
-				TFTPServerName: "tftp.kubevirt.io",
-				NTPServers:     []string{"127.0.0.1", "127.0.0.2", NTPServerWithLeadingZeros},
-				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "private.options.kubevirt.io"}},
-			}
+				dhcpVMI.Spec.Domain.Devices.Interfaces[0].DHCPOptions = &v1.DHCPOptions{
+					BootFileName:   "config",
+					TFTPServerName: "tftp.kubevirt.io",
+					NTPServers:     []string{"127.0.0.1", "127.0.0.2", NTPServerWithLeadingZeros},
+					PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "private.options.kubevirt.io"}},
+				}
 
-			dhcpVMI = tests.WaitUntilVMIReady(tests.RunVMI(dhcpVMI, 40), console.LoginToFedora)
+				dhcpVMI = tests.WaitUntilVMIReady(tests.RunVMI(dhcpVMI, 40), console.LoginToFedora)
 
-			err = console.SafeExpectBatch(dhcpVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "dhclient -1 -r -d eth0\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "dhclient -1 -sf /usr/bin/env --request-options subnet-mask,broadcast-address,time-offset,routers,domain-search,domain-name,domain-name-servers,host-name,nis-domain,nis-servers,ntp-servers,interface-mtu,tftp-server-name,bootfile-name eth0 | tee /dhcp-env\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "grep -q 'new_tftp_server_name=tftp.kubevirt.io' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-				&expect.BSnd{S: "grep -q 'new_bootfile_name=config' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-				&expect.BSnd{S: "grep -q 'new_ntp_servers=127.0.0.1 127.0.0.2 127.0.0.3' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-				&expect.BSnd{S: "grep -q 'new_unknown_240=private.options.kubevirt.io' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-			}, 15)
+				err = console.SafeExpectBatch(dhcpVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "dhclient -1 -r -d eth0\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "dhclient -1 -sf /usr/bin/env --request-options subnet-mask,broadcast-address,time-offset,routers,domain-search,domain-name,domain-name-servers,host-name,nis-domain,nis-servers,ntp-servers,interface-mtu,tftp-server-name,bootfile-name eth0 | tee /dhcp-env\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "grep -q 'new_tftp_server_name=tftp.kubevirt.io' /dhcp-env; echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+					&expect.BSnd{S: "grep -q 'new_bootfile_name=config' /dhcp-env; echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+					&expect.BSnd{S: "grep -q 'new_ntp_servers=127.0.0.1 127.0.0.2 127.0.0.3' /dhcp-env; echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+					&expect.BSnd{S: "grep -q 'new_unknown_240=private.options.kubevirt.io' /dhcp-env; echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 15)
 
-			Expect(err).ToNot(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
-	})
 
-	Context("VirtualMachineInstance with custom dns", func() {
-		It("[test_id:1779]should have custom resolv.conf", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-			userData := "#cloud-config\n"
-			dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData, false))
+		Context("VirtualMachineInstance with custom dns", func() {
+			It("[test_id:1779]should have custom resolv.conf", Labels{"test_id:1779"}, func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				userData := "#cloud-config\n"
+				dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData, false))
 
-			dnsVMI.Spec.DNSPolicy = "None"
+				dnsVMI.Spec.DNSPolicy = "None"
 
 			// This IPv4 address tests backwards compatibility of the "DNSConfig.Nameservers" field.
 			// The leading zero is intentional.
@@ -591,365 +593,371 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 
-	Context("VirtualMachineInstance with masquerade binding mechanism", func() {
-		masqueradeVMI := func(ports []v1.Port, ipv4NetworkCIDR string) *v1.VirtualMachineInstance {
-			net := v1.DefaultPodNetwork()
-			if ipv4NetworkCIDR != "" {
-				net.NetworkSource.Pod.VMNetworkCIDR = ipv4NetworkCIDR
-			}
-			return libvmi.NewCirros(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
-				libvmi.WithNetwork(net),
-			)
-		}
-
-		fedoraMasqueradeVMI := func(ports []v1.Port, ipv6NetworkCIDR string) (*v1.VirtualMachineInstance, error) {
-
-			networkData, err := libnet.NewNetworkData(
-				libnet.WithEthernet("eth0",
-					libnet.WithDHCP4Enabled(),
-					libnet.WithDHCP6Enabled(),
-				),
-			)
-			if err != nil {
-				return nil, err
+		Context("VirtualMachineInstance with masquerade binding mechanism", func() {
+			masqueradeVMI := func(ports []v1.Port, ipv4NetworkCIDR string) *v1.VirtualMachineInstance {
+				net := v1.DefaultPodNetwork()
+				if ipv4NetworkCIDR != "" {
+					net.NetworkSource.Pod.VMNetworkCIDR = ipv4NetworkCIDR
+				}
+				return libvmi.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+					libvmi.WithNetwork(net),
+				)
 			}
 
-			net := v1.DefaultPodNetwork()
-			net.Pod.VMIPv6NetworkCIDR = ipv6NetworkCIDR
-			vmi := libvmi.NewFedora(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
-				libvmi.WithNetwork(net),
-				libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
-			)
+			fedoraMasqueradeVMI := func(ports []v1.Port, ipv6NetworkCIDR string) (*v1.VirtualMachineInstance, error) {
 
-			return vmi, nil
-		}
+				networkData, err := libnet.NewNetworkData(
+					libnet.WithEthernet("eth0",
+						libnet.WithDHCP4Enabled(),
+						libnet.WithDHCP6Enabled(),
+					),
+				)
+				if err != nil {
+					return nil, err
+				}
 
-		configureIpv6 := func(vmi *v1.VirtualMachineInstance, networkCIDR string) error {
-			if networkCIDR == "" {
-				networkCIDR = api.DefaultVMIpv6CIDR
+				net := v1.DefaultPodNetwork()
+				net.Pod.VMIPv6NetworkCIDR = ipv6NetworkCIDR
+				vmi := libvmi.NewFedora(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+					libvmi.WithNetwork(net),
+					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+				)
+
+				return vmi, nil
 			}
 
-			err := console.RunCommand(vmi, "dhclient -6 eth0", 30*time.Second)
-			if err != nil {
-				return err
-			}
-			err = console.RunCommand(vmi, "ip -6 route add "+networkCIDR+" dev eth0", 5*time.Second)
-			if err != nil {
-				return err
-			}
-			gateway := gatewayIPFromCIDR(networkCIDR)
-			err = console.RunCommand(vmi, "ip -6 route add default via "+gateway, 5*time.Second)
-			if err != nil {
-				return err
-			}
-			return nil
-		}
+			configureIpv6 := func(vmi *v1.VirtualMachineInstance, networkCIDR string) error {
+				if networkCIDR == "" {
+					networkCIDR = api.DefaultVMIpv6CIDR
+				}
 
-		portsUsedByLiveMigration := func() []v1.Port {
-			return []v1.Port{
-				{Port: LibvirtDirectMigrationPort},
-				{Port: LibvirtBlockMigrationPort},
-			}
-		}
-
-		Context("[Conformance][test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", func() {
-			// This CIDR tests backwards compatibility of the "vmNetworkCIDR" field.
-			// The leading zero is intentional.
-			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
-			const cidrWithLeadingZeros = "10.10.010.0/24"
-
-			verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
-				serverIP := libnet.GetVmiPrimaryIpByFamily(serverVMI, ipFamily)
-				err := libnet.PingFromVMConsole(clientVMI, serverIP)
+				err := console.RunCommand(vmi, "dhclient -6 eth0", 30*time.Second)
 				if err != nil {
 					return err
 				}
-
-				By("Connecting from the client vm")
-				err = console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort, true), 30)
+				err = console.RunCommand(vmi, "ip -6 route add "+networkCIDR+" dev eth0", 5*time.Second)
 				if err != nil {
 					return err
 				}
-
-				By("Rejecting the connection from the client to unregistered port")
-				err = console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort+1, false), 30)
+				gateway := gatewayIPFromCIDR(networkCIDR)
+				err = console.RunCommand(vmi, "ip -6 route add default via "+gateway, 5*time.Second)
 				if err != nil {
 					return err
 				}
-
 				return nil
 			}
 
-			DescribeTable("ipv4", func(ports []v1.Port, tcpPort int, networkCIDR string) {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			portsUsedByLiveMigration := func() []v1.Port {
+				return []v1.Port{
+					{Port: LibvirtDirectMigrationPort},
+					{Port: LibvirtBlockMigrationPort},
+				}
+			}
 
-				var clientVMI *v1.VirtualMachineInstance
-				var serverVMI *v1.VirtualMachineInstance
+			Context("[Conformance][test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection",
+				Labels{"Conformance", "test_id:1780", "label:masquerade_binding_connectivity"},
+				func() {
+					// This CIDR tests backwards compatibility of the "vmNetworkCIDR" field.
+					// The leading zero is intentional.
+					// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
+					const cidrWithLeadingZeros = "10.10.010.0/24"
 
-				clientVMI = masqueradeVMI([]v1.Port{}, networkCIDR)
-				clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
-				Expect(err).ToNot(HaveOccurred())
-				clientVMI = tests.WaitUntilVMIReady(clientVMI, console.LoginToCirros)
+					verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
+						serverIP := libnet.GetVmiPrimaryIpByFamily(serverVMI, ipFamily)
+						err := libnet.PingFromVMConsole(clientVMI, serverIP)
+						if err != nil {
+							return err
+						}
 
-				serverVMI = masqueradeVMI(ports, networkCIDR)
+						By("Connecting from the client vm")
+						err = console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort, true), 30)
+						if err != nil {
+							return err
+						}
 
-				serverVMI.Labels = map[string]string{"expose": "server"}
-				serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
-				Expect(err).ToNot(HaveOccurred())
-				serverVMI = tests.WaitUntilVMIReady(serverVMI, console.LoginToCirros)
-				Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
-				Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
+						By("Rejecting the connection from the client to unregistered port")
+						err = console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort+1, false), 30)
+						if err != nil {
+							return err
+						}
+
+						return nil
+					}
+
+					DescribeTable("ipv4", func(ports []v1.Port, tcpPort int, networkCIDR string) {
+						libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+
+						var clientVMI *v1.VirtualMachineInstance
+						var serverVMI *v1.VirtualMachineInstance
+
+						clientVMI = masqueradeVMI([]v1.Port{}, networkCIDR)
+						clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
+						Expect(err).ToNot(HaveOccurred())
+						clientVMI = tests.WaitUntilVMIReady(clientVMI, console.LoginToCirros)
+
+						serverVMI = masqueradeVMI(ports, networkCIDR)
+
+						serverVMI.Labels = map[string]string{"expose": "server"}
+						serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
+						Expect(err).ToNot(HaveOccurred())
+						serverVMI = tests.WaitUntilVMIReady(serverVMI, console.LoginToCirros)
+						Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
+						Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
 				By("starting a tcp server")
 				tests.StartTCPServer(serverVMI, tcpPort, console.LoginToCirros)
 
-				if networkCIDR == "" {
-					networkCIDR = api.DefaultVMCIDR
+						if networkCIDR == "" {
+							networkCIDR = api.DefaultVMCIDR
+						}
+
+						By("Checking ping (IPv4) to gateway")
+						ipAddr := gatewayIPFromCIDR(networkCIDR)
+						Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
+
+						Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv4Protocol)).To(Succeed())
+					},
+						Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
+						Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
+						Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, ""),
+						Entry("with custom CIDR [IPv4]", []v1.Port{}, 8080, "10.10.10.0/24"),
+						Entry("with custom CIDR [IPv4] containing leading zeros", []v1.Port{}, 8080, cidrWithLeadingZeros),
+					)
+
+					It("[outside_connectivity]should be able to reach the outside world [IPv4]",
+						Labels{"outside_connectivity]should be able to reach the outside world [IPv4"},
+						func() {
+							libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+							ipv4Address := "8.8.8.8"
+							if flags.IPV4ConnectivityCheckAddress != "" {
+								ipv4Address = flags.IPV4ConnectivityCheckAddress
+							}
+							dns := "google.com"
+							if flags.ConnectivityCheckDNS != "" {
+								dns = flags.ConnectivityCheckDNS
+							}
+
+							vmi := masqueradeVMI([]v1.Port{}, "")
+							vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+							Expect(err).ToNot(HaveOccurred())
+							vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+							By("Checking ping (IPv4)")
+							Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
+							Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
+						})
+
+					DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {
+						libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+						var serverVMI *v1.VirtualMachineInstance
+						var clientVMI *v1.VirtualMachineInstance
+
+						clientVMI, err = fedoraMasqueradeVMI([]v1.Port{}, networkCIDR)
+						Expect(err).ToNot(HaveOccurred())
+						clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
+						Expect(err).ToNot(HaveOccurred())
+						clientVMI = tests.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
+
+						Expect(configureIpv6(clientVMI, networkCIDR)).To(Succeed(), "failed to configure ipv6 on client vmi")
+
+						serverVMI, err = fedoraMasqueradeVMI(ports, networkCIDR)
+						Expect(err).ToNot(HaveOccurred())
+
+						serverVMI.Labels = map[string]string{"expose": "server"}
+						serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
+						Expect(err).ToNot(HaveOccurred())
+						serverVMI = tests.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
+
+						Expect(configureIpv6(serverVMI, networkCIDR)).To(Succeed(), "failed to configure ipv6  on server vmi")
+
+						Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
+						Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
+
+						By("starting a http server")
+						tests.StartPythonHttpServer(serverVMI, tcpPort)
+
+						Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
+					},
+						Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
+						Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
+						Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, ""),
+						Entry("with custom CIDR [IPv6]", []v1.Port{}, 8080, "fd10:10:10::/120"),
+					)
+
+					It("[outside_connectivity]should be able to reach the outside world [IPv6]",
+						Labels{"outside_connectivity]should be able to reach the outside world [IPv6"},
+						func() {
+							libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+							// Cluster nodes subnet (docker network gateway)
+							// Docker network subnet cidr definition:
+							// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
+							ipv6Address := "2001:db8:1::1"
+							if flags.IPV6ConnectivityCheckAddress != "" {
+								ipv6Address = flags.IPV6ConnectivityCheckAddress
+							}
+
+							vmi, err := fedoraMasqueradeVMI([]v1.Port{}, "")
+							Expect(err).ToNot(HaveOccurred())
+							vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+							Expect(err).ToNot(HaveOccurred())
+							vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+							Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).To(Succeed(), "failed to configure ipv6 on vmi")
+
+							By("Checking ping (IPv6) from vmi to cluster nodes gateway")
+							Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
+						})
+				})
+
+			When("performing migration", func() {
+				var vmi *v1.VirtualMachineInstance
+
+				ping := func(ipAddr string) error {
+					return libnet.PingFromVMConsole(vmi, ipAddr, "-c 1", "-w 2")
 				}
 
-				By("Checking ping (IPv4) to gateway")
-				ipAddr := gatewayIPFromCIDR(networkCIDR)
-				Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
-
-				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv4Protocol)).To(Succeed())
-			},
-				Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
-				Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
-				Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, ""),
-				Entry("with custom CIDR [IPv4]", []v1.Port{}, 8080, "10.10.10.0/24"),
-				Entry("with custom CIDR [IPv4] containing leading zeros", []v1.Port{}, 8080, cidrWithLeadingZeros),
-			)
-
-			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-				ipv4Address := "8.8.8.8"
-				if flags.IPV4ConnectivityCheckAddress != "" {
-					ipv4Address = flags.IPV4ConnectivityCheckAddress
-				}
-				dns := "google.com"
-				if flags.ConnectivityCheckDNS != "" {
-					dns = flags.ConnectivityCheckDNS
-				}
-
-				vmi := masqueradeVMI([]v1.Port{}, "")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-
-				By("Checking ping (IPv4)")
-				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
-			})
-
-			DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {
-				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
-				var serverVMI *v1.VirtualMachineInstance
-				var clientVMI *v1.VirtualMachineInstance
-
-				clientVMI, err = fedoraMasqueradeVMI([]v1.Port{}, networkCIDR)
-				Expect(err).ToNot(HaveOccurred())
-				clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
-				Expect(err).ToNot(HaveOccurred())
-				clientVMI = tests.WaitUntilVMIReady(clientVMI, console.LoginToFedora)
-
-				Expect(configureIpv6(clientVMI, networkCIDR)).To(Succeed(), "failed to configure ipv6 on client vmi")
-
-				serverVMI, err = fedoraMasqueradeVMI(ports, networkCIDR)
-				Expect(err).ToNot(HaveOccurred())
-
-				serverVMI.Labels = map[string]string{"expose": "server"}
-				serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
-				Expect(err).ToNot(HaveOccurred())
-				serverVMI = tests.WaitUntilVMIReady(serverVMI, console.LoginToFedora)
-
-				Expect(configureIpv6(serverVMI, networkCIDR)).To(Succeed(), "failed to configure ipv6  on server vmi")
-
-				Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
-				Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
-
-				By("starting a http server")
-				tests.StartPythonHttpServer(serverVMI, tcpPort)
-
-				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
-			},
-				Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
-				Entry("with a specific port used by live migration", portsUsedByLiveMigration(), LibvirtDirectMigrationPort, ""),
-				Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, ""),
-				Entry("with custom CIDR [IPv6]", []v1.Port{}, 8080, "fd10:10:10::/120"),
-			)
-
-			It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
-				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
-				// Cluster nodes subnet (docker network gateway)
-				// Docker network subnet cidr definition:
-				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-				ipv6Address := "2001:db8:1::1"
-				if flags.IPV6ConnectivityCheckAddress != "" {
-					ipv6Address = flags.IPV6ConnectivityCheckAddress
-				}
-
-				vmi, err := fedoraMasqueradeVMI([]v1.Port{}, "")
-				Expect(err).ToNot(HaveOccurred())
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
-				Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).To(Succeed(), "failed to configure ipv6 on vmi")
-
-				By("Checking ping (IPv6) from vmi to cluster nodes gateway")
-				Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
-			})
-		})
-
-		When("performing migration", func() {
-			var vmi *v1.VirtualMachineInstance
-
-			ping := func(ipAddr string) error {
-				return libnet.PingFromVMConsole(vmi, ipAddr, "-c 1", "-w 2")
-			}
-
-			getVirtHandlerPod := func() (*k8sv1.Pod, error) {
-				node := vmi.Status.NodeName
-				pod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
-				if err != nil {
-					return nil, fmt.Errorf("failed to get virt-handler pod on node %s: %v", node, err)
-				}
-				return pod, nil
-			}
-
-			runMigrationAndExpectCompletion := func(migration *v1.VirtualMachineInstanceMigration, timeout int) {
-				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(func() error {
-					migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &v13.GetOptions{})
+				getVirtHandlerPod := func() (*k8sv1.Pod, error) {
+					node := vmi.Status.NodeName
+					pod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
 					if err != nil {
-						return err
+						return nil, fmt.Errorf("failed to get virt-handler pod on node %s: %v", node, err)
 					}
+					return pod, nil
+				}
 
-					Expect(migration.Status.Phase).ToNot(Equal(v1.MigrationFailed))
-
-					if migration.Status.Phase == v1.MigrationSucceeded {
-						return nil
-					}
-					return fmt.Errorf("Migration is in phase %s", migration.Status.Phase)
-
-				}, timeout, time.Second).Should(Succeed(), fmt.Sprintf("migration should succeed after %d s", timeout))
-			}
-
-			BeforeEach(func() {
-				checks.SkipIfMigrationIsNotPossible()
-			})
-
-			AfterEach(func() {
-				if vmi != nil {
-					By("Delete VMI")
-					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &v13.DeleteOptions{})).To(Succeed())
+				runMigrationAndExpectCompletion := func(migration *v1.VirtualMachineInstanceMigration, timeout int) {
+					migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration, &metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(func() error {
-						_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
-						return err
-					}, time.Minute, time.Second).Should(
-						SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())),
-						"The VMI should be gone within the given timeout",
-					)
+						migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &v13.GetOptions{})
+						if err != nil {
+							return err
+						}
+
+						Expect(migration.Status.Phase).ToNot(Equal(v1.MigrationFailed))
+
+						if migration.Status.Phase == v1.MigrationSucceeded {
+							return nil
+						}
+						return fmt.Errorf("Migration is in phase %s", migration.Status.Phase)
+
+					}, timeout, time.Second).Should(Succeed(), fmt.Sprintf("migration should succeed after %d s", timeout))
 				}
+
+				BeforeEach(func() {
+					checks.SkipIfMigrationIsNotPossible()
+				})
+
+				AfterEach(func() {
+					if vmi != nil {
+						By("Delete VMI")
+						Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &v13.DeleteOptions{})).To(Succeed())
+
+						Eventually(func() error {
+							_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
+							return err
+						}, time.Minute, time.Second).Should(
+							SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())),
+							"The VMI should be gone within the given timeout",
+						)
+					}
+				})
+
+				DescribeTable("[Conformance] preserves connectivity", Labels{"Conformance"}, func(ipFamily k8sv1.IPFamily, ports []v1.Port) {
+					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+
+					var err error
+					var loginMethod console.LoginToFunction
+
+					By("Create VMI")
+					if ipFamily == k8sv1.IPv4Protocol {
+						vmi = masqueradeVMI(ports, "")
+						loginMethod = console.LoginToCirros
+					} else {
+						vmi, err = fedoraMasqueradeVMI(ports, "")
+						Expect(err).ToNot(HaveOccurred(), "Error creating fedora masquerade vmi")
+						loginMethod = console.LoginToFedora
+					}
+
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					vmi = tests.WaitUntilVMIReady(vmi, loginMethod)
+
+					if ipFamily == k8sv1.IPv6Protocol {
+						err = configureIpv6(vmi, api.DefaultVMIpv6CIDR)
+						Expect(err).ToNot(HaveOccurred(), "failed to configure ipv6 on vmi")
+					}
+
+					virtHandlerPod, err := getVirtHandlerPod()
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Check connectivity")
+					podIP := libnet.GetPodIpByFamily(virtHandlerPod, ipFamily)
+					Expect(ping(podIP)).To(Succeed())
+
+					By("Execute migration")
+					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+					runMigrationAndExpectCompletion(migration, tests.MigrationWaitTime)
+
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Status.Phase).To(Equal(v1.Running))
+
+					Expect(ping(podIP)).To(Succeed())
+
+					By("Restarting the vmi")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "sudo reboot\n"},
+						&expect.BExp{R: "reboot: Restarting system"},
+					}, 10)).To(Succeed(), "failed to restart the vmi")
+					tests.WaitUntilVMIReady(vmi, loginMethod)
+					if ipFamily == k8sv1.IPv6Protocol {
+						Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).To(Succeed(), "failed to configure ipv6 on vmi after restart")
+					}
+					Expect(ping(podIP)).To(Succeed())
+				},
+					Entry("IPv4", k8sv1.IPv4Protocol, []v1.Port{}),
+					Entry("IPv4 with explicit ports used by live migration", k8sv1.IPv4Protocol, portsUsedByLiveMigration()),
+					Entry("IPv6", k8sv1.IPv6Protocol, []v1.Port{}),
+				)
 			})
 
-			DescribeTable("[Conformance] preserves connectivity", func(ipFamily k8sv1.IPFamily, ports []v1.Port) {
-				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+			Context("MTU verification", func() {
+				var vmi *v1.VirtualMachineInstance
+				var anotherVmi *v1.VirtualMachineInstance
 
-				var err error
-				var loginMethod console.LoginToFunction
+				getMtu := func(pod *k8sv1.Pod, ifaceName string) int {
+					output, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						pod,
+						"compute",
+						[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
+					)
+					ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-				By("Create VMI")
-				if ipFamily == k8sv1.IPv4Protocol {
-					vmi = masqueradeVMI(ports, "")
-					loginMethod = console.LoginToCirros
-				} else {
-					vmi, err = fedoraMasqueradeVMI(ports, "")
-					Expect(err).ToNot(HaveOccurred(), "Error creating fedora masquerade vmi")
-					loginMethod = console.LoginToFedora
+					output = strings.TrimSuffix(output, "\n")
+					mtu, err := strconv.Atoi(output)
+					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+					return mtu
 				}
 
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				vmi = tests.WaitUntilVMIReady(vmi, loginMethod)
+				BeforeEach(func() {
+					var err error
 
-				if ipFamily == k8sv1.IPv6Protocol {
-					err = configureIpv6(vmi, api.DefaultVMIpv6CIDR)
-					Expect(err).ToNot(HaveOccurred(), "failed to configure ipv6 on vmi")
-				}
+					By("Create masquerade VMI")
+					networkData, err := libnet.CreateDefaultCloudInitNetworkData()
+					Expect(err).NotTo(HaveOccurred())
 
-				virtHandlerPod, err := getVirtHandlerPod()
-				Expect(err).ToNot(HaveOccurred())
+					vmi = libvmi.NewFedora(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+					)
 
-				By("Check connectivity")
-				podIP := libnet.GetPodIpByFamily(virtHandlerPod, ipFamily)
-				Expect(ping(podIP)).To(Succeed())
-
-				By("Execute migration")
-				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				runMigrationAndExpectCompletion(migration, tests.MigrationWaitTime)
-
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Status.Phase).To(Equal(v1.Running))
-
-				Expect(ping(podIP)).To(Succeed())
-
-				By("Restarting the vmi")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo reboot\n"},
-					&expect.BExp{R: "reboot: Restarting system"},
-				}, 10)).To(Succeed(), "failed to restart the vmi")
-				tests.WaitUntilVMIReady(vmi, loginMethod)
-				if ipFamily == k8sv1.IPv6Protocol {
-					Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).To(Succeed(), "failed to configure ipv6 on vmi after restart")
-				}
-				Expect(ping(podIP)).To(Succeed())
-			},
-				Entry("IPv4", k8sv1.IPv4Protocol, []v1.Port{}),
-				Entry("IPv4 with explicit ports used by live migration", k8sv1.IPv4Protocol, portsUsedByLiveMigration()),
-				Entry("IPv6", k8sv1.IPv6Protocol, []v1.Port{}),
-			)
-		})
-
-		Context("MTU verification", func() {
-			var vmi *v1.VirtualMachineInstance
-			var anotherVmi *v1.VirtualMachineInstance
-
-			getMtu := func(pod *k8sv1.Pod, ifaceName string) int {
-				output, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					pod,
-					"compute",
-					[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
-				)
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-				output = strings.TrimSuffix(output, "\n")
-				mtu, err := strconv.Atoi(output)
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				return mtu
-			}
-
-			BeforeEach(func() {
-				var err error
-
-				By("Create masquerade VMI")
-				networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-				Expect(err).NotTo(HaveOccurred())
-
-				vmi = libvmi.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
-				)
-
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
 
 				By("Create another VMI")
 				anotherVmi = libvmi.NewAlpine(
@@ -962,83 +970,83 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				By("Wait for VMIs to be ready")
 				anotherVmi = tests.WaitUntilVMIReady(anotherVmi, libnet.WithAlpineConfig(console.LoginToAlpine))
 
-				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+					vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+				})
+
+				DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
+					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+
+					By("checking k6t-eth0 MTU inside the pod")
+					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+					bridgeMtu := getMtu(vmiPod, "k6t-eth0")
+					primaryIfaceMtu := getMtu(vmiPod, "eth0")
+
+					Expect(bridgeMtu).To(Equal(primaryIfaceMtu), "k6t-eth0 bridge mtu should equal eth0 interface mtu")
+
+					By("checking the tap device - tap0 - MTU inside the pod")
+					tapDeviceMTU := getMtu(vmiPod, "tap0")
+					Expect(tapDeviceMTU).To(Equal(primaryIfaceMtu), "tap0 mtu should equal eth0 interface mtu")
+
+					By("checking eth0 MTU inside the VirtualMachineInstance")
+					showMtu := "cat /sys/class/net/eth0/mtu\n"
+					err = console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: showMtu},
+						&expect.BExp{R: console.RetValue(strconv.Itoa(bridgeMtu))},
+					}, 180)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
+					icmpHeaderSize := 8
+					var ipHeaderSize int
+					if ipFamily == k8sv1.IPv4Protocol {
+						ipHeaderSize = 20
+					} else {
+						ipHeaderSize = 40
+					}
+					payloadSize := primaryIfaceMtu - ipHeaderSize - icmpHeaderSize
+					addr := libnet.GetVmiPrimaryIpByFamily(anotherVmi, ipFamily)
+					Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize), "-M do")).To(Succeed())
+
+					By("checking the VirtualMachineInstance cannot send bigger than MTU sized frames to another VirtualMachineInstance")
+					Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize+1), "-M do")).ToNot(Succeed())
+				},
+					Entry("IPv4", k8sv1.IPv4Protocol),
+					Entry("IPv6", k8sv1.IPv6Protocol),
+				)
 			})
+		})
 
-			DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
-				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+		Context("VirtualMachineInstance with TX offload disabled", func() {
+			It("[test_id:1781]should have tx checksumming disabled on interface serving dhcp", Labels{"test_id:1781"}, func() {
+				vmi := libvmi.NewAlpine()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
 
-				By("checking k6t-eth0 MTU inside the pod")
-				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				bridgeMtu := getMtu(vmiPod, "k6t-eth0")
-				primaryIfaceMtu := getMtu(vmiPod, "eth0")
-
-				Expect(bridgeMtu).To(Equal(primaryIfaceMtu), "k6t-eth0 bridge mtu should equal eth0 interface mtu")
-
-				By("checking the tap device - tap0 - MTU inside the pod")
-				tapDeviceMTU := getMtu(vmiPod, "tap0")
-				Expect(tapDeviceMTU).To(Equal(primaryIfaceMtu), "tap0 mtu should equal eth0 interface mtu")
-
-				By("checking eth0 MTU inside the VirtualMachineInstance")
-				showMtu := "cat /sys/class/net/eth0/mtu\n"
-				err = console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: showMtu},
-					&expect.BExp{R: console.RetValue(strconv.Itoa(bridgeMtu))},
-				}, 180)
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
+				tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
+				output := tests.RunCommandOnVmiPod(
+					vmi,
+					[]string{"/bin/bash", "-c", "/usr/sbin/ethtool -k k6t-eth0|grep tx-checksumming|awk '{ printf $2 }'"},
+				)
+				ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("off"))
+			})
+		})
 
-				By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
-				icmpHeaderSize := 8
-				var ipHeaderSize int
-				if ipFamily == k8sv1.IPv4Protocol {
-					ipHeaderSize = 20
-				} else {
-					ipHeaderSize = 40
-				}
-				payloadSize := primaryIfaceMtu - ipHeaderSize - icmpHeaderSize
-				addr := libnet.GetVmiPrimaryIpByFamily(anotherVmi, ipFamily)
-				Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize), "-M do")).To(Succeed())
+		Context("[Serial]vmi with default bridge interface on pod network", Labels{"Serial"}, func() {
+			BeforeEach(func() {
+				setBridgeEnabled(false)
+			})
+			AfterEach(func() {
+				setBridgeEnabled(true)
+			})
+			It("[test_id:2964]should reject VMIs with bridge interface when it's not permitted on pod network", Labels{"test_id:2964"}, func() {
+				vmi := libvmi.NewCirros()
 
-				By("checking the VirtualMachineInstance cannot send bigger than MTU sized frames to another VirtualMachineInstance")
-				Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize+1), "-M do")).ToNot(Succeed())
-			},
-				Entry("IPv4", k8sv1.IPv4Protocol),
-				Entry("IPv6", k8sv1.IPv6Protocol),
-			)
+				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err.Error()).To(ContainSubstring("Bridge interface is not enabled in kubevirt-config"))
+			})
 		})
 	})
-
-	Context("VirtualMachineInstance with TX offload disabled", func() {
-		It("[test_id:1781]should have tx checksumming disabled on interface serving dhcp", func() {
-			vmi := libvmi.NewAlpine()
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
-
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
-			output := tests.RunCommandOnVmiPod(
-				vmi,
-				[]string{"/bin/bash", "-c", "/usr/sbin/ethtool -k k6t-eth0|grep tx-checksumming|awk '{ printf $2 }'"},
-			)
-			ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("off"))
-		})
-	})
-
-	Context("[Serial]vmi with default bridge interface on pod network", func() {
-		BeforeEach(func() {
-			setBridgeEnabled(false)
-		})
-		AfterEach(func() {
-			setBridgeEnabled(true)
-		})
-		It("[test_id:2964]should reject VMIs with bridge interface when it's not permitted on pod network", func() {
-			vmi := libvmi.NewCirros()
-
-			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err.Error()).To(ContainSubstring("Bridge interface is not enabled in kubevirt-config"))
-		})
-	})
-})
 
 func waitUntilVMIReady(vmi *v1.VirtualMachineInstance, loginTo console.LoginToFunction) *v1.VirtualMachineInstance {
 	vmi = tests.WaitForSuccessfulVMIStart(vmi)

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -61,7 +61,7 @@ const (
 )
 
 var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking",
-	Labels{"rfe_id:694", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+	Label("rfe_id:694", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 	func() {
 
 		var err error
@@ -172,8 +172,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					}
 					expectedMtuString := fmt.Sprintf("mtu %d", mtu)
 
-				By("checking eth0 MTU inside the VirtualMachineInstance")
-				Expect(console.LoginToCirros(outboundVMI)).To(Succeed())
+					By("checking eth0 MTU inside the VirtualMachineInstance")
+					Expect(console.LoginToCirros(outboundVMI)).To(Succeed())
 
 					addrShow := "ip address show eth0\n"
 					Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
@@ -203,20 +203,20 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					}, 180)
 					Expect(err).ToNot(HaveOccurred())
 				},
-					Entry("[test_id:1539]the Inbound VirtualMachineInstance", &inboundVMI),
-					Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", &inboundVMIWithPodNetworkSet),
-					Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", &inboundVMIWithCustomMacAddress),
+					Entry("[test_id:1539]the Inbound VirtualMachineInstance", Label("test_id:1539"), &inboundVMI),
+					Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", Label("test_id:1540"), &inboundVMIWithPodNetworkSet),
+					Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", Label("test_id:1541"), &inboundVMIWithCustomMacAddress),
 				)
 			})
 
-		Context("with propagated IP from a pod", func() {
-			BeforeEach(func() {
-				inboundVMI = libvmi.NewCirros()
-				inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
-				Expect(err).ToNot(HaveOccurred())
-				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
-				tests.StartTCPServer(inboundVMI, testPort, console.LoginToCirros)
-			})
+			Context("with propagated IP from a pod", func() {
+				BeforeEach(func() {
+					inboundVMI = libvmi.NewCirros()
+					inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
+					Expect(err).ToNot(HaveOccurred())
+					inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
+					tests.StartTCPServer(inboundVMI, testPort, console.LoginToCirros)
+				})
 
 				DescribeTable("should be able to reach", func(op v12.NodeSelectorOperator, hostNetwork bool) {
 
@@ -250,29 +250,29 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					Expect(err).ToNot(HaveOccurred())
 					Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
 				},
-					Entry("[test_id:1543]on the same node from Pod", Labels{"test_id:1543"}, v12.NodeSelectorOpIn, false),
-					Entry("[test_id:1544]on a different node from Pod", Labels{"test_id:1544"}, v12.NodeSelectorOpNotIn, false),
-					Entry("[test_id:1545]on the same node from Node", Labels{"test_id:1545"}, v12.NodeSelectorOpIn, true),
-					Entry("[test_id:1546]on a different node from Node", Labels{"test_id:1546"}, v12.NodeSelectorOpNotIn, true),
+					Entry("[test_id:1543]on the same node from Pod", Label("test_id:1543"), v12.NodeSelectorOpIn, false),
+					Entry("[test_id:1544]on a different node from Pod", Label("test_id:1544"), v12.NodeSelectorOpNotIn, false),
+					Entry("[test_id:1545]on the same node from Node", Label("test_id:1545"), v12.NodeSelectorOpIn, true),
+					Entry("[test_id:1546]on a different node from Node", Label("test_id:1546"), v12.NodeSelectorOpNotIn, true),
 				)
 			})
 
-		Context("VirtualMachineInstance with default interface model", func() {
-			BeforeEach(func() {
-				inboundVMI = libvmi.NewAlpine()
-				outboundVMI = libvmi.NewAlpine()
+			Context("VirtualMachineInstance with default interface model", func() {
+				BeforeEach(func() {
+					inboundVMI = libvmi.NewAlpine()
+					outboundVMI = libvmi.NewAlpine()
 
 					inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
 					Expect(err).ToNot(HaveOccurred())
 					outboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(outboundVMI)
 					Expect(err).ToNot(HaveOccurred())
 
-				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
-				outboundVMI = tests.WaitUntilVMIReady(outboundVMI, console.LoginToAlpine)
-			})
+					inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
+					outboundVMI = tests.WaitUntilVMIReady(outboundVMI, console.LoginToAlpine)
+				})
 
 				// Unless an explicit interface model is specified, the default interface model is virtio.
-				It("[test_id:1550]should expose the right device type to the guest", Labels{"test_id:1550"}, func() {
+				It("[test_id:1550]should expose the right device type to the guest", Label("test_id:1550"), func() {
 					By("checking the device vendor in /sys/class")
 
 					// Taken from https://wiki.osdev.org/Virtio#Technical_Details
@@ -285,7 +285,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				})
 
 				Context("VirtualMachineInstance with unsupported interface model", func() {
-					It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", Labels{"test_id:1551"}, func() {
+					It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", Label("test_id:1551"), func() {
 						// Create a virtual machine with an unsupported interface model
 						masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 						masqIface.Model = "gibberish"
@@ -301,7 +301,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with default settings", func() {
-			It("[test_id:1542]should be able to reach the internet", Labels{"test_id:1542"}, func() {
+			It("[test_id:1542]should be able to reach the internet", Label("test_id:1542"), func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				outboundVMI := libvmi.NewCirros()
 				outboundVMI = runVMI(outboundVMI)
@@ -321,7 +321,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with custom interface model", func() {
-			It("[test_id:1770]should expose the right device type to the guest", Labels{"test_id:1770"}, func() {
+			It("[test_id:1770]should expose the right device type to the guest", Label("test_id:1770"), func() {
 				By("checking the device vendor in /sys/class")
 				// Create a machine with e1000 interface model
 				// Use alpine because cirros dhcp client starts prematurely before link is ready
@@ -342,7 +342,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with custom MAC address", func() {
-			It("[test_id:1771]should configure custom MAC address", Labels{"test_id:1771"}, func() {
+			It("[test_id:1771]should configure custom MAC address", Label("test_id:1771"), func() {
 				By(checkingEth0MACAddr)
 				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 				masqIface.MacAddress = "de:ad:00:00:be:af"
@@ -359,7 +359,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
-			It("[test_id:1772]should configure custom MAC address", Labels{"test_id:1772"}, func() {
+			It("[test_id:1772]should configure custom MAC address", Label("test_id:1772"), func() {
 				By(checkingEth0MACAddr)
 				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 				masqIface.MacAddress = "BE-AF-00-00-DE-AD"
@@ -376,7 +376,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with invalid MAC address", func() {
-			It("[test_id:700]should failed to start with invalid MAC address", Labels{"test_id:700"}, func() {
+			It("[test_id:700]should failed to start with invalid MAC address", Label("test_id:700"), func() {
 				By("Start VMI")
 				masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 				masqIface.MacAddress = "de:00c:00c:00:00:de:abc"
@@ -392,7 +392,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
-			It("[test_id:1773]should configure custom MAC address", Labels{"test_id:1773"}, func() {
+			It("[test_id:1773]should configure custom MAC address", Label("test_id:1773"), func() {
 				By(checkingEth0MACAddr)
 				slirpIface := libvmi.InterfaceDeviceWithSlirpBinding(libvmi.DefaultInterfaceName)
 				slirpIface.MacAddress = "de:ad:00:00:be:af"
@@ -408,19 +408,19 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 		})
 
-	Context("VirtualMachineInstance with disabled automatic attachment of interfaces", func() {
-		It("[test_id:1774]should not configure any external interfaces", Labels{"test_id:1774"}, func() {
-			By("checking loopback is the only guest interface")
-			autoAttach := false
-			detachedVMI := libvmi.NewAlpine()
-			// Remove the masquerade interface to use the default bridge one
-			detachedVMI.Spec.Domain.Devices.Interfaces = nil
-			detachedVMI.Spec.Networks = nil
-			detachedVMI.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
+		Context("VirtualMachineInstance with disabled automatic attachment of interfaces", func() {
+			It("[test_id:1774]should not configure any external interfaces", Label("test_id:1774"), func() {
+				By("checking loopback is the only guest interface")
+				autoAttach := false
+				detachedVMI := libvmi.NewAlpine()
+				// Remove the masquerade interface to use the default bridge one
+				detachedVMI.Spec.Domain.Devices.Interfaces = nil
+				detachedVMI.Spec.Networks = nil
+				detachedVMI.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
 
-			detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(detachedVMI, console.LoginToAlpine)
+				detachedVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(detachedVMI)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitUntilVMIReady(detachedVMI, console.LoginToAlpine)
 
 				err := console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
@@ -431,7 +431,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:1775]should not request a tun device", Labels{"test_id:1775"}, func() {
+			It("[test_id:1775]should not request a tun device", Label("test_id:1775"), func() {
 				By("Creating random VirtualMachineInstance")
 				autoAttach := false
 				vmi := libvmi.NewAlpine()
@@ -483,21 +483,21 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-		It("[test_id:1776]should configure custom Pci address", Labels{"test_id:1776"}, func() {
-			By("checking eth0 Pci address")
-			testVMI := libvmi.NewAlpine()
-			tests.AddExplicitPodNetworkInterface(testVMI)
-			testVMI.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:81:00.1"
-			testVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(testVMI)
-			Expect(err).ToNot(HaveOccurred())
+			It("[test_id:1776]should configure custom Pci address", Label("test_id:1776"), func() {
+				By("checking eth0 Pci address")
+				testVMI := libvmi.NewAlpine()
+				tests.AddExplicitPodNetworkInterface(testVMI)
+				testVMI.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:81:00.1"
+				testVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(testVMI)
+				Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(testVMI, console.LoginToAlpine)
-			checkPciAddress(testVMI, testVMI.Spec.Domain.Devices.Interfaces[0].PciAddress)
+				tests.WaitUntilVMIReady(testVMI, console.LoginToAlpine)
+				checkPciAddress(testVMI, testVMI.Spec.Domain.Devices.Interfaces[0].PciAddress)
+			})
 		})
-	})
 
 		Context("VirtualMachineInstance with learning disabled on pod interface", func() {
-			It("[test_id:1777]should disable learning on pod iface", Labels{"test_id:1777"}, func() {
+			It("[test_id:1777]should disable learning on pod iface", Label("test_id:1777"), func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				By("checking learning flag")
 				learningDisabledVMI := libvmi.NewAlpine()
@@ -510,7 +510,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with dhcp options", func() {
-			It("[test_id:1778]should offer extra dhcp options to pod iface", Labels{"test_id:1778"}, func() {
+			It("[test_id:1778]should offer extra dhcp options to pod iface", Label("test_id:1778"), func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				dhcpVMI := libvmi.NewFedora()
 				tests.AddExplicitPodNetworkInterface(dhcpVMI)
@@ -553,45 +553,45 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with custom dns", func() {
-			It("[test_id:1779]should have custom resolv.conf", Labels{"test_id:1779"}, func() {
+			It("[test_id:1779]should have custom resolv.conf", Label("test_id:1779"), func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				userData := "#cloud-config\n"
 				dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData, false))
 
 				dnsVMI.Spec.DNSPolicy = "None"
 
-			// This IPv4 address tests backwards compatibility of the "DNSConfig.Nameservers" field.
-			// The leading zero is intentional.
-			// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
-			const DNSNameserverWithLeadingZeros = "01.1.1.1"
-			dnsVMI.Spec.DNSConfig = &k8sv1.PodDNSConfig{
-				Nameservers: []string{"8.8.8.8", "4.2.2.1", DNSNameserverWithLeadingZeros},
-				Searches:    []string{"example.com"},
-			}
-			dnsVMI = tests.WaitUntilVMIReady(tests.RunVMI(dnsVMI, 40), console.LoginToCirros)
-			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: catResolvConf},
-				&expect.BExp{R: "search example.com"},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: catResolvConf},
-				&expect.BExp{R: "nameserver 8.8.8.8"},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: catResolvConf},
-				&expect.BExp{R: "nameserver 4.2.2.1"},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
-				&expect.BExp{R: "nameserver 1.1.1.1"},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
+				// This IPv4 address tests backwards compatibility of the "DNSConfig.Nameservers" field.
+				// The leading zero is intentional.
+				// For more details please see: https://github.com/kubevirt/kubevirt/issues/6498
+				const DNSNameserverWithLeadingZeros = "01.1.1.1"
+				dnsVMI.Spec.DNSConfig = &k8sv1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8", "4.2.2.1", DNSNameserverWithLeadingZeros},
+					Searches:    []string{"example.com"},
+				}
+				dnsVMI = tests.WaitUntilVMIReady(tests.RunVMI(dnsVMI, 40), console.LoginToCirros)
+				err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: catResolvConf},
+					&expect.BExp{R: "search example.com"},
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: catResolvConf},
+					&expect.BExp{R: "nameserver 8.8.8.8"},
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: catResolvConf},
+					&expect.BExp{R: "nameserver 4.2.2.1"},
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "cat /etc/resolv.conf\n"},
+					&expect.BExp{R: "nameserver 1.1.1.1"},
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
-	})
 
 		Context("VirtualMachineInstance with masquerade binding mechanism", func() {
 			masqueradeVMI := func(ports []v1.Port, ipv4NetworkCIDR string) *v1.VirtualMachineInstance {
@@ -657,7 +657,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			}
 
 			Context("[Conformance][test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection",
-				Labels{"Conformance", "test_id:1780", "label:masquerade_binding_connectivity"},
+				Label("Conformance", "test_id:1780", "label:masquerade_binding_connectivity"),
 				func() {
 					// This CIDR tests backwards compatibility of the "vmNetworkCIDR" field.
 					// The leading zero is intentional.
@@ -706,8 +706,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
 						Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
-				By("starting a tcp server")
-				tests.StartTCPServer(serverVMI, tcpPort, console.LoginToCirros)
+						By("starting a tcp server")
+						tests.StartTCPServer(serverVMI, tcpPort, console.LoginToCirros)
 
 						if networkCIDR == "" {
 							networkCIDR = api.DefaultVMCIDR
@@ -727,7 +727,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					)
 
 					It("[outside_connectivity]should be able to reach the outside world [IPv4]",
-						Labels{"outside_connectivity]should be able to reach the outside world [IPv4"},
+						Label("outside_connectivity]should be able to reach the outside world [IPv4"),
 						func() {
 							libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 							ipv4Address := "8.8.8.8"
@@ -787,7 +787,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					)
 
 					It("[outside_connectivity]should be able to reach the outside world [IPv6]",
-						Labels{"outside_connectivity]should be able to reach the outside world [IPv6"},
+						Label("outside_connectivity]should be able to reach the outside world [IPv6"),
 						func() {
 							libnet.SkipWhenClusterNotSupportIpv6(virtClient)
 							// Cluster nodes subnet (docker network gateway)
@@ -865,7 +865,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					}
 				})
 
-				DescribeTable("[Conformance] preserves connectivity", Labels{"Conformance"}, func(ipFamily k8sv1.IPFamily, ports []v1.Port) {
+				DescribeTable("[Conformance] preserves connectivity", Label("Conformance"), func(ipFamily k8sv1.IPFamily, ports []v1.Port) {
 					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
 
 					var err error
@@ -959,16 +959,16 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).ToNot(HaveOccurred())
 
-				By("Create another VMI")
-				anotherVmi = libvmi.NewAlpine(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				)
-				anotherVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(anotherVmi)
-				Expect(err).ToNot(HaveOccurred())
+					By("Create another VMI")
+					anotherVmi = libvmi.NewAlpine(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					)
+					anotherVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(anotherVmi)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("Wait for VMIs to be ready")
-				anotherVmi = tests.WaitUntilVMIReady(anotherVmi, libnet.WithAlpineConfig(console.LoginToAlpine))
+					By("Wait for VMIs to be ready")
+					anotherVmi = tests.WaitUntilVMIReady(anotherVmi, libnet.WithAlpineConfig(console.LoginToAlpine))
 
 					vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
 				})
@@ -1017,7 +1017,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 
 		Context("VirtualMachineInstance with TX offload disabled", func() {
-			It("[test_id:1781]should have tx checksumming disabled on interface serving dhcp", Labels{"test_id:1781"}, func() {
+			It("[test_id:1781]should have tx checksumming disabled on interface serving dhcp", Label("test_id:1781"), func() {
 				vmi := libvmi.NewAlpine()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
 
@@ -1032,14 +1032,14 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 		})
 
-		Context("[Serial]vmi with default bridge interface on pod network", Labels{"Serial"}, func() {
+		Context("[Serial]vmi with default bridge interface on pod network", Label("Serial"), func() {
 			BeforeEach(func() {
 				setBridgeEnabled(false)
 			})
 			AfterEach(func() {
 				setBridgeEnabled(true)
 			})
-			It("[test_id:2964]should reject VMIs with bridge interface when it's not permitted on pod network", Labels{"test_id:2964"}, func() {
+			It("[test_id:2964]should reject VMIs with bridge interface when it's not permitted on pod network", Label("test_id:2964"), func() {
 				vmi := libvmi.NewCirros()
 
 				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -159,7 +159,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
 		)
 
-		DescribeTable("[outside_connectivity]should be able to communicate with the outside world", Labels{"outside_connectivity"}, func(vmiRef **v1.VirtualMachineInstance) {
+		DescribeTable("[outside_connectivity]should be able to communicate with the outside world", Label("outside_connectivity"), func(vmiRef **v1.VirtualMachineInstance) {
 			vmi := *vmiRef
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -183,7 +183,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 		)
 	})
 
-	Context("[Serial]slirp is the default interface", Labels{"Serial"}, func() {
+	Context("[Serial]slirp is the default interface", Label("Serial"), func() {
 		BeforeEach(func() {
 			setSlirpEnabled(false)
 			setDefaultNetworkInterface("slirp")

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -159,7 +159,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
 		)
 
-		DescribeTable("[outside_connectivity]should be able to communicate with the outside world", func(vmiRef **v1.VirtualMachineInstance) {
+		DescribeTable("[outside_connectivity]should be able to communicate with the outside world", Labels{"outside_connectivity"}, func(vmiRef **v1.VirtualMachineInstance) {
 			vmi := *vmiRef
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -183,7 +183,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 		)
 	})
 
-	Context("[Serial]slirp is the default interface", func() {
+	Context("[Serial]slirp is the default interface", Labels{"Serial"}, func() {
 		BeforeEach(func() {
 			setSlirpEnabled(false)
 			setDefaultNetworkInterface("slirp")

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -14,7 +14,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute]NonRoot feature", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]NonRoot feature", Label("sig-compute"), func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error
@@ -46,10 +46,10 @@ var _ = Describe("[sig-compute]NonRoot feature", Labels{"sig-compute"}, func() {
 		Expect(err.Error()).To(And(ContainSubstring(feature), ContainSubstring("nonroot")))
 
 	},
-		Entry("[test_id:7127]VirtioFS", Labels{"test_id:7127"}, virtioFsVM, virtconfig.VirtIOFSGate, "VirtioFS"),
+		Entry("[test_id:7127]VirtioFS", Label("test_id:7127"), virtioFsVM, virtconfig.VirtIOFSGate, "VirtioFS"),
 	)
 
-	Context("[verify-nonroot] NonRoot feature", Labels{"verify-nonroot"}, func() {
+	Context("[verify-nonroot] NonRoot feature", Label("verify-nonroot"), func() {
 		It("Fails if can't be tested", func() {
 			Expect(checks.HasFeature(virtconfig.NonRoot)).To(BeTrue())
 

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -14,7 +14,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute]NonRoot feature", func() {
+var _ = Describe("[sig-compute]NonRoot feature", Labels{"sig-compute"}, func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error
@@ -46,10 +46,10 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 		Expect(err.Error()).To(And(ContainSubstring(feature), ContainSubstring("nonroot")))
 
 	},
-		Entry("[test_id:7127]VirtioFS", virtioFsVM, virtconfig.VirtIOFSGate, "VirtioFS"),
+		Entry("[test_id:7127]VirtioFS", Labels{"test_id:7127"}, virtioFsVM, virtconfig.VirtIOFSGate, "VirtioFS"),
 	)
 
-	Context("[verify-nonroot] NonRoot feature", func() {
+	Context("[verify-nonroot] NonRoot feature", Labels{"verify-nonroot"}, func() {
 		It("Fails if can't be tested", func() {
 			Expect(checks.HasFeature(virtconfig.NonRoot)).To(BeTrue())
 

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -1,167 +1,167 @@
 package numa
 
 import (
-	"bufio"
-	"fmt"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
+    "bufio"
+    "fmt"
+    "regexp"
+    "strconv"
+    "strings"
+    "time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+    k8sv1 "k8s.io/api/core/v1"
+    "k8s.io/apimachinery/pkg/api/resource"
 
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+    virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
-	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/console"
-	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/libvmi"
-	"kubevirt.io/kubevirt/tests/util"
+    v1 "kubevirt.io/api/core/v1"
+    "kubevirt.io/client-go/kubecli"
+    "kubevirt.io/kubevirt/tests"
+    "kubevirt.io/kubevirt/tests/console"
+    "kubevirt.io/kubevirt/tests/flags"
+    "kubevirt.io/kubevirt/tests/framework/checks"
+    "kubevirt.io/kubevirt/tests/libvmi"
+    "kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute][Serial]NUMA", func() {
+var _ = Describe("[sig-compute][Serial]NUMA", Labels{"sig-compute", "Serial"}, func() {
 
-	var virtClient kubecli.KubevirtClient
-	BeforeEach(func() {
-		checks.SkipTestIfNoCPUManager()
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
-	})
+    var virtClient kubecli.KubevirtClient
+    BeforeEach(func() {
+        checks.SkipTestIfNoCPUManager()
+        var err error
+        virtClient, err = kubecli.GetKubevirtClient()
+        Expect(err).ToNot(HaveOccurred())
+        tests.BeforeTestCleanup()
+    })
 
-	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", func() {
-		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
-		checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
-		var err error
-		cpuVMI := libvmi.NewCirros()
-		cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-		cpuVMI.Spec.Domain.CPU = &v1.CPU{
-			Cores:                 3,
-			DedicatedCPUPlacement: true,
-			NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
-		}
-		cpuVMI.Spec.Domain.Memory = &v1.Memory{
-			Hugepages: &v1.Hugepages{PageSize: "2Mi"},
-		}
+    It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", Labels{"test_id:7299"}, func() {
+        checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
+        checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
+        var err error
+        cpuVMI := libvmi.NewCirros()
+        cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
+        cpuVMI.Spec.Domain.CPU = &v1.CPU{
+            Cores:                 3,
+            DedicatedCPUPlacement: true,
+            NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
+        }
+        cpuVMI.Spec.Domain.Memory = &v1.Memory{
+            Hugepages: &v1.Hugepages{PageSize: "2Mi"},
+        }
 
-		By("Starting a VirtualMachineInstance")
-		cpuVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVMI)
-		Expect(err).ToNot(HaveOccurred())
-		cpuVMI = tests.WaitForSuccessfulVMIStart(cpuVMI)
-		By("Fetching the numa memory mapping")
-		handler, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(cpuVMI.Status.NodeName).Pod()
-		Expect(err).ToNot(HaveOccurred())
-		pid := getQEMUPID(virtClient, handler, cpuVMI)
+        By("Starting a VirtualMachineInstance")
+        cpuVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVMI)
+        Expect(err).ToNot(HaveOccurred())
+        cpuVMI = tests.WaitForSuccessfulVMIStart(cpuVMI)
+        By("Fetching the numa memory mapping")
+        handler, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(cpuVMI.Status.NodeName).Pod()
+        Expect(err).ToNot(HaveOccurred())
+        pid := getQEMUPID(virtClient, handler, cpuVMI)
 
-		By("Checking if the pinned numa memory chunks match the VMI memory size")
-		scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
-		rex := regexp.MustCompile(`bind:([0-9]+) .+memfd:.+N([0-9]+)=([0-9]+).+kernelpagesize_kB=([0-9]+)`)
-		mappings := map[int]mapping{}
-		for scanner.Scan() {
-			if findings := rex.FindStringSubmatch(scanner.Text()); findings != nil {
-				mappings[mustAtoi(findings[1])] = mapping{
-					BindNode:           mustAtoi(findings[1]),
-					AllocationNode:     mustAtoi(findings[2]),
-					Pages:              mustAtoi(findings[3]),
-					PageSizeAsQuantity: toKi(mustAtoi(findings[4])),
-					PageSize:           mustAtoi(findings[4]),
-				}
-			}
-		}
+        By("Checking if the pinned numa memory chunks match the VMI memory size")
+        scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
+        rex := regexp.MustCompile(`bind:([0-9]+) .+memfd:.+N([0-9]+)=([0-9]+).+kernelpagesize_kB=([0-9]+)`)
+        mappings := map[int]mapping{}
+        for scanner.Scan() {
+            if findings := rex.FindStringSubmatch(scanner.Text()); findings != nil {
+                mappings[mustAtoi(findings[1])] = mapping{
+                    BindNode:           mustAtoi(findings[1]),
+                    AllocationNode:     mustAtoi(findings[2]),
+                    Pages:              mustAtoi(findings[3]),
+                    PageSizeAsQuantity: toKi(mustAtoi(findings[4])),
+                    PageSize:           mustAtoi(findings[4]),
+                }
+            }
+        }
 
-		sum := 0
-		requestedPageSize := resource.MustParse(cpuVMI.Spec.Domain.Memory.Hugepages.PageSize)
-		requestedMemory := cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
-		for _, m := range mappings {
-			Expect(m.PageSizeAsQuantity.Equal(requestedPageSize)).To(BeTrue())
-			Expect(m.BindNode).To(Equal(m.AllocationNode))
-			sum += m.Pages
-		}
-		Expect(resource.MustParse(fmt.Sprintf("%dKi", sum*2048)).Equal(requestedMemory)).To(BeTrue())
+        sum := 0
+        requestedPageSize := resource.MustParse(cpuVMI.Spec.Domain.Memory.Hugepages.PageSize)
+        requestedMemory := cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
+        for _, m := range mappings {
+            Expect(m.PageSizeAsQuantity.Equal(requestedPageSize)).To(BeTrue())
+            Expect(m.BindNode).To(Equal(m.AllocationNode))
+            sum += m.Pages
+        }
+        Expect(resource.MustParse(fmt.Sprintf("%dKi", sum*2048)).Equal(requestedMemory)).To(BeTrue())
 
-		By("Fetching the domain XML")
-		domSpec, err := tests.GetRunningVMIDomainSpec(cpuVMI)
-		Expect(err).ToNot(HaveOccurred())
+        By("Fetching the domain XML")
+        domSpec, err := tests.GetRunningVMIDomainSpec(cpuVMI)
+        Expect(err).ToNot(HaveOccurred())
 
-		By("checking that we really deal with a domain with numa configured")
-		Expect(domSpec.CPU.NUMA.Cells).ToNot(BeEmpty())
+        By("checking that we really deal with a domain with numa configured")
+        Expect(domSpec.CPU.NUMA.Cells).ToNot(BeEmpty())
 
-		By("Checking if number of memory chunkgs matches the number of nodes on the VM")
-		Expect(mappings).To(HaveLen(len(domSpec.MemoryBacking.HugePages.HugePage)))
-		Expect(mappings).To(HaveLen(len(domSpec.CPU.NUMA.Cells)))
-		Expect(mappings).To(HaveLen(len(domSpec.NUMATune.MemNodes)))
+        By("Checking if number of memory chunkgs matches the number of nodes on the VM")
+        Expect(mappings).To(HaveLen(len(domSpec.MemoryBacking.HugePages.HugePage)))
+        Expect(mappings).To(HaveLen(len(domSpec.CPU.NUMA.Cells)))
+        Expect(mappings).To(HaveLen(len(domSpec.NUMATune.MemNodes)))
 
-		By("checking if the guest came up and is healthy")
-		Expect(console.LoginToCirros(cpuVMI)).To(Succeed())
-	})
+        By("checking if the guest came up and is healthy")
+        Expect(console.LoginToCirros(cpuVMI)).To(Succeed())
+    })
 
 })
 
 func getQEMUPID(virtClient kubecli.KubevirtClient, handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
-	var stdout, stderr string
-	// The retry is a desperate try to cope with URG in case that URG is not catches by the script
-	// since URG keep ps failing
-	Eventually(func() (err error) {
-		stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, handlerPod, "virt-handler",
-			[]string{
-				"/bin/bash",
-				"-c",
-				"trap '' URG && ps ax",
-			})
-		return err
-	}, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr)
+    var stdout, stderr string
+    // The retry is a desperate try to cope with URG in case that URG is not catches by the script
+    // since URG keep ps failing
+    Eventually(func() (err error) {
+        stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, handlerPod, "virt-handler",
+            []string{
+                "/bin/bash",
+                "-c",
+                "trap '' URG && ps ax",
+            })
+        return err
+    }, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr)
 
-	pid := ""
-	for _, str := range strings.Split(stdout, "\n") {
-		if !strings.Contains(str, fmt.Sprintf("-name guest=%s_%s", vmi.Namespace, vmi.Name)) {
-			continue
-		}
-		words := strings.Fields(str)
+    pid := ""
+    for _, str := range strings.Split(stdout, "\n") {
+        if !strings.Contains(str, fmt.Sprintf("-name guest=%s_%s", vmi.Namespace, vmi.Name)) {
+            continue
+        }
+        words := strings.Fields(str)
 
-		// verify it is numeric
-		_, err := strconv.Atoi(words[0])
-		Expect(err).ToNot(HaveOccurred(), "should have found pid for qemu that is numeric")
+        // verify it is numeric
+        _, err := strconv.Atoi(words[0])
+        Expect(err).ToNot(HaveOccurred(), "should have found pid for qemu that is numeric")
 
-		pid = words[0]
-		break
-	}
+        pid = words[0]
+        break
+    }
 
-	Expect(pid).ToNot(Equal(""), "qemu pid not found")
-	return pid
+    Expect(pid).ToNot(Equal(""), "qemu pid not found")
+    return pid
 }
 
 func getNUMAMapping(virtClient kubecli.KubevirtClient, pod *k8sv1.Pod, pid string) string {
-	stdout, stderr, err := tests.ExecuteCommandOnPodV2(virtClient, pod, "virt-handler",
-		[]string{
-			"/bin/bash",
-			"-c",
-			fmt.Sprintf("trap '' URG && cat /proc/%v/numa_maps", pid),
-		})
-	Expect(err).ToNot(HaveOccurred(), stderr)
-	return stdout
+    stdout, stderr, err := tests.ExecuteCommandOnPodV2(virtClient, pod, "virt-handler",
+        []string{
+            "/bin/bash",
+            "-c",
+            fmt.Sprintf("trap '' URG && cat /proc/%v/numa_maps", pid),
+        })
+    Expect(err).ToNot(HaveOccurred(), stderr)
+    return stdout
 }
 
 type mapping struct {
-	BindNode           int
-	AllocationNode     int
-	Pages              int
-	PageSizeAsQuantity resource.Quantity
-	PageSize           int
+    BindNode           int
+    AllocationNode     int
+    Pages              int
+    PageSizeAsQuantity resource.Quantity
+    PageSize           int
 }
 
 func mustAtoi(str string) int {
-	i, err := strconv.Atoi(str)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	return i
+    i, err := strconv.Atoi(str)
+    ExpectWithOffset(1, err).ToNot(HaveOccurred())
+    return i
 }
 
 func toKi(value int) resource.Quantity {
-	return resource.MustParse(fmt.Sprintf("%dKi", value))
+    return resource.MustParse(fmt.Sprintf("%dKi", value))
 }

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -25,7 +25,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute][Serial]NUMA", Labels{"sig-compute", "Serial"}, func() {
+var _ = Describe("[sig-compute][Serial]NUMA", Label("sig-compute", "Serial"), func() {
 
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
@@ -36,7 +36,7 @@ var _ = Describe("[sig-compute][Serial]NUMA", Labels{"sig-compute", "Serial"}, f
 		tests.BeforeTestCleanup()
 	})
 
-	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", Labels{"test_id:7299"}, func() {
+	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", Label("test_id:7299"), func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
 		checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
 		var err error

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -1,167 +1,167 @@
 package numa
 
 import (
-    "bufio"
-    "fmt"
-    "regexp"
-    "strconv"
-    "strings"
-    "time"
+	"bufio"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
-    k8sv1 "k8s.io/api/core/v1"
-    "k8s.io/apimachinery/pkg/api/resource"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
-    virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
-    v1 "kubevirt.io/api/core/v1"
-    "kubevirt.io/client-go/kubecli"
-    "kubevirt.io/kubevirt/tests"
-    "kubevirt.io/kubevirt/tests/console"
-    "kubevirt.io/kubevirt/tests/flags"
-    "kubevirt.io/kubevirt/tests/framework/checks"
-    "kubevirt.io/kubevirt/tests/libvmi"
-    "kubevirt.io/kubevirt/tests/util"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 var _ = Describe("[sig-compute][Serial]NUMA", Labels{"sig-compute", "Serial"}, func() {
 
-    var virtClient kubecli.KubevirtClient
-    BeforeEach(func() {
-        checks.SkipTestIfNoCPUManager()
-        var err error
-        virtClient, err = kubecli.GetKubevirtClient()
-        Expect(err).ToNot(HaveOccurred())
-        tests.BeforeTestCleanup()
-    })
+	var virtClient kubecli.KubevirtClient
+	BeforeEach(func() {
+		checks.SkipTestIfNoCPUManager()
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+		tests.BeforeTestCleanup()
+	})
 
-    It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", Labels{"test_id:7299"}, func() {
-        checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
-        checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
-        var err error
-        cpuVMI := libvmi.NewCirros()
-        cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-        cpuVMI.Spec.Domain.CPU = &v1.CPU{
-            Cores:                 3,
-            DedicatedCPUPlacement: true,
-            NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
-        }
-        cpuVMI.Spec.Domain.Memory = &v1.Memory{
-            Hugepages: &v1.Hugepages{PageSize: "2Mi"},
-        }
+	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", Labels{"test_id:7299"}, func() {
+		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
+		checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
+		var err error
+		cpuVMI := libvmi.NewCirros()
+		cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
+		cpuVMI.Spec.Domain.CPU = &v1.CPU{
+			Cores:                 3,
+			DedicatedCPUPlacement: true,
+			NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
+		}
+		cpuVMI.Spec.Domain.Memory = &v1.Memory{
+			Hugepages: &v1.Hugepages{PageSize: "2Mi"},
+		}
 
-        By("Starting a VirtualMachineInstance")
-        cpuVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVMI)
-        Expect(err).ToNot(HaveOccurred())
-        cpuVMI = tests.WaitForSuccessfulVMIStart(cpuVMI)
-        By("Fetching the numa memory mapping")
-        handler, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(cpuVMI.Status.NodeName).Pod()
-        Expect(err).ToNot(HaveOccurred())
-        pid := getQEMUPID(virtClient, handler, cpuVMI)
+		By("Starting a VirtualMachineInstance")
+		cpuVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVMI)
+		Expect(err).ToNot(HaveOccurred())
+		cpuVMI = tests.WaitForSuccessfulVMIStart(cpuVMI)
+		By("Fetching the numa memory mapping")
+		handler, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(cpuVMI.Status.NodeName).Pod()
+		Expect(err).ToNot(HaveOccurred())
+		pid := getQEMUPID(virtClient, handler, cpuVMI)
 
-        By("Checking if the pinned numa memory chunks match the VMI memory size")
-        scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
-        rex := regexp.MustCompile(`bind:([0-9]+) .+memfd:.+N([0-9]+)=([0-9]+).+kernelpagesize_kB=([0-9]+)`)
-        mappings := map[int]mapping{}
-        for scanner.Scan() {
-            if findings := rex.FindStringSubmatch(scanner.Text()); findings != nil {
-                mappings[mustAtoi(findings[1])] = mapping{
-                    BindNode:           mustAtoi(findings[1]),
-                    AllocationNode:     mustAtoi(findings[2]),
-                    Pages:              mustAtoi(findings[3]),
-                    PageSizeAsQuantity: toKi(mustAtoi(findings[4])),
-                    PageSize:           mustAtoi(findings[4]),
-                }
-            }
-        }
+		By("Checking if the pinned numa memory chunks match the VMI memory size")
+		scanner := bufio.NewScanner(strings.NewReader(getNUMAMapping(virtClient, handler, pid)))
+		rex := regexp.MustCompile(`bind:([0-9]+) .+memfd:.+N([0-9]+)=([0-9]+).+kernelpagesize_kB=([0-9]+)`)
+		mappings := map[int]mapping{}
+		for scanner.Scan() {
+			if findings := rex.FindStringSubmatch(scanner.Text()); findings != nil {
+				mappings[mustAtoi(findings[1])] = mapping{
+					BindNode:           mustAtoi(findings[1]),
+					AllocationNode:     mustAtoi(findings[2]),
+					Pages:              mustAtoi(findings[3]),
+					PageSizeAsQuantity: toKi(mustAtoi(findings[4])),
+					PageSize:           mustAtoi(findings[4]),
+				}
+			}
+		}
 
-        sum := 0
-        requestedPageSize := resource.MustParse(cpuVMI.Spec.Domain.Memory.Hugepages.PageSize)
-        requestedMemory := cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
-        for _, m := range mappings {
-            Expect(m.PageSizeAsQuantity.Equal(requestedPageSize)).To(BeTrue())
-            Expect(m.BindNode).To(Equal(m.AllocationNode))
-            sum += m.Pages
-        }
-        Expect(resource.MustParse(fmt.Sprintf("%dKi", sum*2048)).Equal(requestedMemory)).To(BeTrue())
+		sum := 0
+		requestedPageSize := resource.MustParse(cpuVMI.Spec.Domain.Memory.Hugepages.PageSize)
+		requestedMemory := cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
+		for _, m := range mappings {
+			Expect(m.PageSizeAsQuantity.Equal(requestedPageSize)).To(BeTrue())
+			Expect(m.BindNode).To(Equal(m.AllocationNode))
+			sum += m.Pages
+		}
+		Expect(resource.MustParse(fmt.Sprintf("%dKi", sum*2048)).Equal(requestedMemory)).To(BeTrue())
 
-        By("Fetching the domain XML")
-        domSpec, err := tests.GetRunningVMIDomainSpec(cpuVMI)
-        Expect(err).ToNot(HaveOccurred())
+		By("Fetching the domain XML")
+		domSpec, err := tests.GetRunningVMIDomainSpec(cpuVMI)
+		Expect(err).ToNot(HaveOccurred())
 
-        By("checking that we really deal with a domain with numa configured")
-        Expect(domSpec.CPU.NUMA.Cells).ToNot(BeEmpty())
+		By("checking that we really deal with a domain with numa configured")
+		Expect(domSpec.CPU.NUMA.Cells).ToNot(BeEmpty())
 
-        By("Checking if number of memory chunkgs matches the number of nodes on the VM")
-        Expect(mappings).To(HaveLen(len(domSpec.MemoryBacking.HugePages.HugePage)))
-        Expect(mappings).To(HaveLen(len(domSpec.CPU.NUMA.Cells)))
-        Expect(mappings).To(HaveLen(len(domSpec.NUMATune.MemNodes)))
+		By("Checking if number of memory chunkgs matches the number of nodes on the VM")
+		Expect(mappings).To(HaveLen(len(domSpec.MemoryBacking.HugePages.HugePage)))
+		Expect(mappings).To(HaveLen(len(domSpec.CPU.NUMA.Cells)))
+		Expect(mappings).To(HaveLen(len(domSpec.NUMATune.MemNodes)))
 
-        By("checking if the guest came up and is healthy")
-        Expect(console.LoginToCirros(cpuVMI)).To(Succeed())
-    })
+		By("checking if the guest came up and is healthy")
+		Expect(console.LoginToCirros(cpuVMI)).To(Succeed())
+	})
 
 })
 
 func getQEMUPID(virtClient kubecli.KubevirtClient, handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
-    var stdout, stderr string
-    // The retry is a desperate try to cope with URG in case that URG is not catches by the script
-    // since URG keep ps failing
-    Eventually(func() (err error) {
-        stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, handlerPod, "virt-handler",
-            []string{
-                "/bin/bash",
-                "-c",
-                "trap '' URG && ps ax",
-            })
-        return err
-    }, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr)
+	var stdout, stderr string
+	// The retry is a desperate try to cope with URG in case that URG is not catches by the script
+	// since URG keep ps failing
+	Eventually(func() (err error) {
+		stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, handlerPod, "virt-handler",
+			[]string{
+				"/bin/bash",
+				"-c",
+				"trap '' URG && ps ax",
+			})
+		return err
+	}, 3*time.Second, 500*time.Millisecond).Should(Succeed(), stderr)
 
-    pid := ""
-    for _, str := range strings.Split(stdout, "\n") {
-        if !strings.Contains(str, fmt.Sprintf("-name guest=%s_%s", vmi.Namespace, vmi.Name)) {
-            continue
-        }
-        words := strings.Fields(str)
+	pid := ""
+	for _, str := range strings.Split(stdout, "\n") {
+		if !strings.Contains(str, fmt.Sprintf("-name guest=%s_%s", vmi.Namespace, vmi.Name)) {
+			continue
+		}
+		words := strings.Fields(str)
 
-        // verify it is numeric
-        _, err := strconv.Atoi(words[0])
-        Expect(err).ToNot(HaveOccurred(), "should have found pid for qemu that is numeric")
+		// verify it is numeric
+		_, err := strconv.Atoi(words[0])
+		Expect(err).ToNot(HaveOccurred(), "should have found pid for qemu that is numeric")
 
-        pid = words[0]
-        break
-    }
+		pid = words[0]
+		break
+	}
 
-    Expect(pid).ToNot(Equal(""), "qemu pid not found")
-    return pid
+	Expect(pid).ToNot(Equal(""), "qemu pid not found")
+	return pid
 }
 
 func getNUMAMapping(virtClient kubecli.KubevirtClient, pod *k8sv1.Pod, pid string) string {
-    stdout, stderr, err := tests.ExecuteCommandOnPodV2(virtClient, pod, "virt-handler",
-        []string{
-            "/bin/bash",
-            "-c",
-            fmt.Sprintf("trap '' URG && cat /proc/%v/numa_maps", pid),
-        })
-    Expect(err).ToNot(HaveOccurred(), stderr)
-    return stdout
+	stdout, stderr, err := tests.ExecuteCommandOnPodV2(virtClient, pod, "virt-handler",
+		[]string{
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf("trap '' URG && cat /proc/%v/numa_maps", pid),
+		})
+	Expect(err).ToNot(HaveOccurred(), stderr)
+	return stdout
 }
 
 type mapping struct {
-    BindNode           int
-    AllocationNode     int
-    Pages              int
-    PageSizeAsQuantity resource.Quantity
-    PageSize           int
+	BindNode           int
+	AllocationNode     int
+	Pages              int
+	PageSizeAsQuantity resource.Quantity
+	PageSize           int
 }
 
 func mustAtoi(str string) int {
-    i, err := strconv.Atoi(str)
-    ExpectWithOffset(1, err).ToNot(HaveOccurred())
-    return i
+	i, err := strconv.Atoi(str)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return i
 }
 
 func toKi(value int) resource.Quantity {
-    return resource.MustParse(fmt.Sprintf("%dKi", value))
+	return resource.MustParse(fmt.Sprintf("%dKi", value))
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1550,12 +1550,12 @@ spec:
 					for _, vmYaml := range vmYamls {
 						By(fmt.Sprintf("Creating VM with %s api", vmYaml.vmName))
 						// NOTE: using kubectl to post yaml directly
-				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmYaml.yamlFile, "--cache-dir", oldClientCacheDir)
-				Expect(err).ToNot(HaveOccurred())
+						_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmYaml.yamlFile, "--cache-dir", oldClientCacheDir)
+						Expect(err).ToNot(HaveOccurred())
 
 						for _, vmSnapshot := range vmYaml.vmSnapshots {
 							By(fmt.Sprintf("Creating VM snapshot %s for vm %s", vmSnapshot.vmSnapshotName, vmYaml.vmName))
-					_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmSnapshot.yamlFile, "--cache-dir", oldClientCacheDir)
+							_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmSnapshot.yamlFile, "--cache-dir", oldClientCacheDir)
 							Expect(err).ToNot(HaveOccurred())
 						}
 
@@ -1563,7 +1563,7 @@ spec:
 						// NOTE: we are using virtctl explicitly here because we want to start the VM
 						// using the subresource endpoint in the same way virtctl performs this.
 						By("Starting VM with virtctl")
-			        	startCommand := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
 						Expect(startCommand()).To(Succeed())
 
 						By(fmt.Sprintf("Waiting for VM with %s api to become ready", vmYaml.apiVersion))
@@ -1651,7 +1651,7 @@ spec:
 				}, 60*time.Second, 1*time.Second).Should(BeNil())
 
 						By("Stopping VM with virtctl")
-				        stopFn := clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
+						stopFn := clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
 						Eventually(func() error {
 							return stopFn()
 						}, 30*time.Second, 1*time.Second).Should(BeNil())
@@ -1707,7 +1707,7 @@ spec:
 
 						By(fmt.Sprintf("Ensure vm %s can be restored from vmsnapshots", vmYaml.vmName))
 						for _, snapshot := range vmYaml.vmSnapshots {
-					        _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
+							_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
 							Expect(err).ToNot(HaveOccurred())
 							Eventually(func() bool {
 								r, err := virtClient.VirtualMachineRestore(util2.NamespaceTestDefault).Get(context.Background(), snapshot.restoreName, metav1.GetOptions{})
@@ -1719,7 +1719,7 @@ spec:
 						}
 
 						By(fmt.Sprintf("Deleting VM with %s api", vmYaml.apiVersion))
-				        _, _, err = clientcmd.RunCommand(k8sClient, "delete", "-f", vmYaml.yamlFile, "--cache-dir", newClientCacheDir)
+						_, _, err = clientcmd.RunCommand(k8sClient, "delete", "-f", vmYaml.yamlFile, "--cache-dir", newClientCacheDir)
 						Expect(err).ToNot(HaveOccurred())
 
 						By("Waiting for VM to be removed")

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -92,7 +92,7 @@ type vmYamlDefinition struct {
 	vmSnapshots   []vmSnapshotDef
 }
 
-var _ = Describe("[Serial][sig-operator]Operator", Labels{"Serial", "sig-operator"}, func() {
+var _ = Describe("[Serial][sig-operator]Operator", Label("Serial", "sig-operator"), func() {
 	var originalKv *v1.KubeVirt
 	var originalCDI *cdiv1.CDI
 	var originalOperatorVersion string
@@ -1090,14 +1090,14 @@ spec:
 		verifyOperatorWebhookCertificate()
 	})
 
-	It("[test_id:1746]should have created and available condition", Labels{"test_id:1746"}, func() {
+	It("[test_id:1746]should have created and available condition", Label("test_id:1746"), func() {
 		kv := util2.GetCurrentKv(virtClient)
 
 		By("verifying that created and available condition is present")
 		waitForKv(kv)
 	})
 
-	Describe("[Serial]should reconcile components", Labels{"Serial"}, func() {
+	Describe("[Serial]should reconcile components", Label("Serial"), func() {
 
 		deploymentName := "virt-controller"
 		daemonSetName := "virt-handler"
@@ -1286,7 +1286,7 @@ spec:
 				}),
 		)
 
-		It("[test_id:6309] checking updating service is reverted to original state", Labels{"test_id:6309"}, func() {
+		It("[test_id:6309] checking updating service is reverted to original state", Label("test_id:6309"), func() {
 			service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1317,9 +1317,9 @@ spec:
 	})
 
 	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should start a VM",
-		Labels{"rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
-			It("[test_id:3144]using virt-launcher with a shasum", Labels{"test_id:3144"}, func() {
+			It("[test_id:3144]using virt-launcher with a shasum", Label("test_id:3144"), func() {
 
 				if flags.SkipShasumCheck {
 					Skip("Cannot currently test shasums, skipping")
@@ -1342,7 +1342,7 @@ spec:
 			})
 		})
 
-	Describe("[test_id:6987]should apply component configuration", Labels{"test_id:6987"}, func() {
+	Describe("[test_id:6987]should apply component configuration", Label("test_id:6987"), func() {
 
 		It("test VirtualMachineInstancesPerNode", func() {
 			newVirtualMachineInstancesPerNode := 10
@@ -1373,7 +1373,7 @@ spec:
 		})
 	})
 
-	Describe("[test_id:4744]should apply component customization", Labels{"test_id:4744", "Serial"}, func() {
+	Describe("[test_id:4744]should apply component customization", Label("test_id:4744", "Serial"), func() {
 
 		It("test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"
@@ -1434,7 +1434,7 @@ spec:
 	})
 
 	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should update kubevirt",
-		Labels{"rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			runStrategyHalted := v1.RunStrategyHalted
 
@@ -1443,7 +1443,7 @@ spec:
 			// Updating KubeVirt to the target tested code
 			// Ensuring VM/VMI is still operational after the update from previous release.
 			DescribeTable("[release-blocker][test_id:3145]from previous release to target tested release",
-				Labels{"release-blocker", "test_id:3145"}, func(updateOperator bool) {
+				Label("release-blocker", "test_id:3145"), func(updateOperator bool) {
 					if !tests.HasCDI() {
 						Skip("Skip update test when CDI is not present")
 					}
@@ -1636,19 +1636,19 @@ spec:
 							}, 120*time.Second, 3*time.Second).Should(BeTrue())
 						}
 
-				By(fmt.Sprintf("Connecting to %s's console", vmYaml.vmName))
-				// This is in an eventually loop because it's possible for the
-				// subresource endpoint routing to fail temporarily right after a deployment
-				// completes while we wait for the kubernetes apiserver to detect our
-				// subresource api server is online and ready to serve requests.
-				Eventually(func() error {
-					vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					if err := console.LoginToCirros(vmi); err != nil {
-						return err
-					}
-					return nil
-				}, 60*time.Second, 1*time.Second).Should(BeNil())
+						By(fmt.Sprintf("Connecting to %s's console", vmYaml.vmName))
+						// This is in an eventually loop because it's possible for the
+						// subresource endpoint routing to fail temporarily right after a deployment
+						// completes while we wait for the kubernetes apiserver to detect our
+						// subresource api server is online and ready to serve requests.
+						Eventually(func() error {
+							vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							if err := console.LoginToCirros(vmi); err != nil {
+								return err
+							}
+							return nil
+						}, 60*time.Second, 1*time.Second).Should(BeNil())
 
 						By("Stopping VM with virtctl")
 						stopFn := clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
@@ -1753,9 +1753,9 @@ spec:
 		})
 
 	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management",
-		Labels{"rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
-			It("[test_id:3146]should be able to delete and re-create kubevirt install", Labels{"test_id:3146"}, func() {
+			It("[test_id:3146]should be able to delete and re-create kubevirt install", Label("test_id:3146"), func() {
 				allPodsAreReady(originalKv)
 				sanityCheckDeploymentsExist()
 
@@ -1797,9 +1797,9 @@ spec:
 			})
 
 			Describe("[rfe_id:3578][crit:high][vendor:cnv-qe@redhat.com][level:component] deleting with BlockUninstallIfWorkloadsExist",
-				Labels{"rfe_id:3578", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+				Label("rfe_id:3578", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 				func() {
-					It("[test_id:3683]should be blocked if a workload exists", Labels{"test_id:3683"}, func() {
+					It("[test_id:3683]should be blocked if a workload exists", Label("test_id:3683"), func() {
 						allPodsAreReady(originalKv)
 						sanityCheckDeploymentsExist()
 
@@ -1821,7 +1821,7 @@ spec:
 					})
 				})
 
-			It("[test_id:3148]should be able to create kubevirt install with custom image tag", Labels{"test_id:3148"}, func() {
+			It("[test_id:3148]should be able to create kubevirt install with custom image tag", Label("test_id:3148"), func() {
 
 				if flags.KubeVirtVersionTagAlt == "" {
 					Skip("Skip operator custom image tag test because alt tag is not present")
@@ -1860,7 +1860,7 @@ spec:
 			})
 
 			// this test ensures that we can deal with image prefixes in case they are not used for tests already
-			It("[test_id:3149]should be able to create kubevirt install with image prefix", Labels{"test_id:3149"}, func() {
+			It("[test_id:3149]should be able to create kubevirt install with image prefix", Label("test_id:3149"), func() {
 
 				if flags.ImagePrefixAlt == "" {
 					Skip("Skip operator imagePrefix test because imagePrefixAlt is not present")
@@ -1926,7 +1926,7 @@ spec:
 				allPodsAreReady(kv)
 			})
 
-			It("[test_id:3150]should be able to update kubevirt install with custom image tag", Labels{"test_id:3150"}, func() {
+			It("[test_id:3150]should be able to update kubevirt install with custom image tag", Label("test_id:3150"), func() {
 				if flags.KubeVirtVersionTagAlt == "" {
 					Skip("Skip operator custom image tag test because alt tag is not present")
 				}
@@ -1997,7 +1997,7 @@ spec:
 			// NOTE - this test verifies new operators can grab the leader election lease
 			// during operator updates. The only way the new infrastructure is deployed
 			// is if the update operator is capable of getting the lease.
-			It("[test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set", Labels{"test_id:3151"}, func() {
+			It("[test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set", Label("test_id:3151"), func() {
 
 				if flags.KubeVirtVersionTagAlt == "" {
 					Skip("Skip operator custom image tag test because alt tag is not present")
@@ -2035,7 +2035,7 @@ spec:
 				allPodsAreReady(kv)
 			})
 
-			It("[test_id:3152]should fail if KV object already exists", Labels{"test_id:3152"}, func() {
+			It("[test_id:3152]should fail if KV object already exists", Label("test_id:3152"), func() {
 
 				newKv := copyOriginalKv()
 				newKv.Name = "someother-kubevirt"
@@ -2068,13 +2068,13 @@ spec:
 				deleteAllKvAndWait(true)
 			})
 
-			It("[test_id:4612]should create non-namespaces resources without owner references", Labels{"test_id:4612"}, func() {
+			It("[test_id:4612]should create non-namespaces resources without owner references", Label("test_id:4612"), func() {
 				crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
 			})
 
-			It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", Labels{"test_id:4613"}, func() {
+			It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", Label("test_id:4613"), func() {
 				By("getting existing resource to reference")
 				cm, err := virtClient.CoreV1().ConfigMaps(originalKv.Namespace).Get(context.Background(), "kubevirt-ca", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2116,7 +2116,7 @@ spec:
 				Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
 			})
 
-			It("[test_id:5010]should be able to update product related labels of kubevirt install", Labels{"test_id:5010"}, func() {
+			It("[test_id:5010]should be able to update product related labels of kubevirt install", Label("test_id:5010"), func() {
 				productName := "kubevirt-test"
 				productVersion := "0.0.0"
 				productComponent := "kubevirt-component"
@@ -2149,7 +2149,7 @@ spec:
 			})
 
 			Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With OpenShift cluster",
-				Labels{"rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				Label("rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 				func() {
 
 					BeforeEach(func() {
@@ -2158,7 +2158,7 @@ spec:
 						}
 					})
 
-					It("[test_id:2910]Should have kubevirt SCCs created", Labels{"test_id:2910"}, func() {
+					It("[test_id:2910]Should have kubevirt SCCs created", Label("test_id:2910"), func() {
 						const OpenShiftSCCLabel = "openshift.io/scc"
 						var expectedSCCs, sccs []string
 
@@ -2206,7 +2206,7 @@ spec:
 		})
 
 	Describe("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]Dynamic feature detection",
-		Labels{"rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			var vm *v1.VirtualMachine
@@ -2227,11 +2227,11 @@ spec:
 				}
 			})
 
-		It("[test_id:3153]Ensure infra can handle dynamically detecting DataVolume Support", Labels{"test_id:3153"}, func() {
-			if !libstorage.HasDataVolumeCRD() {
-				Skip("Can't test DataVolume support when DataVolume CRD isn't present")
-			}
-			checks.SkipIfVersionBelow("Skipping dynamic cdi test in versions below 1.13 because crd garbage collection is broken", "1.13")
+			It("[test_id:3153]Ensure infra can handle dynamically detecting DataVolume Support", Label("test_id:3153"), func() {
+				if !libstorage.HasDataVolumeCRD() {
+					Skip("Can't test DataVolume support when DataVolume CRD isn't present")
+				}
+				checks.SkipIfVersionBelow("Skipping dynamic cdi test in versions below 1.13 because crd garbage collection is broken", "1.13")
 
 				// This tests starting infrastructure with and without the DataVolumes feature gate
 				vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util2.NamespaceTestDefault)
@@ -2287,7 +2287,7 @@ spec:
 		})
 
 	Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Disabled",
-		Labels{"rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			BeforeEach(func() {
@@ -2296,7 +2296,7 @@ spec:
 				}
 			})
 
-			It("[test_id:3154]Should not create RBAC Role or RoleBinding for ServiceMonitor", Labels{"test_id:3154"}, func() {
+			It("[test_id:3154]Should not create RBAC Role or RoleBinding for ServiceMonitor", Label("test_id:3154"), func() {
 				rbacClient := virtClient.RbacV1()
 
 				By("Checking that Role for ServiceMonitor doesn't exist")
@@ -2320,7 +2320,7 @@ spec:
 			}
 		})
 
-		It("[test_id:4614]Checks if the kubevirt PrometheusRule cr exists and verify it's spec", Labels{"test_id:4614"}, func() {
+		It("[test_id:4614]Checks if the kubevirt PrometheusRule cr exists and verify it's spec", Label("test_id:4614"), func() {
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			prometheusRule, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -2341,7 +2341,7 @@ spec:
 			}
 		})
 
-		It("[test_id:4615]Checks that we do not deploy a PrometheusRule cr when not needed", Labels{"test_id:4615"}, func() {
+		It("[test_id:4615]Checks that we do not deploy a PrometheusRule cr when not needed", Label("test_id:4615"), func() {
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			_, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
@@ -2349,7 +2349,7 @@ spec:
 	})
 
 	Context("[rfe_id:2937][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Enabled",
-		Labels{"rfe_id:2937", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2937", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			BeforeEach(func() {
@@ -2358,7 +2358,7 @@ spec:
 				}
 			})
 
-			It("[test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints", Labels{"test_id:2936"}, func() {
+			It("[test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints", Label("test_id:2936"), func() {
 				coreClient := virtClient.CoreV1()
 
 				// we don't know when the prometheus toolchain will pick up our config, so we retry plenty of times
@@ -2391,7 +2391,7 @@ spec:
 				}, 90*time.Second, 3*time.Second).Should(ContainSubstring(flags.KubeVirtInstallNamespace), "Prometheus should be monitoring KubeVirt")
 			})
 
-			It("[test_id:4616]Should patch our namespace labels with openshift.io/cluster-monitoring=true", Labels{"test_id:4616"}, func() {
+			It("[test_id:4616]Should patch our namespace labels with openshift.io/cluster-monitoring=true", Label("test_id:4616"), func() {
 				By("Inspecting the labels on our namespace")
 				namespace, err := virtClient.CoreV1().Namespaces().Get(context.Background(), flags.KubeVirtInstallNamespace, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2401,7 +2401,7 @@ spec:
 			})
 		})
 
-	It("[test_id:4617]should adopt previously unmanaged entities by updating its metadata", Labels{"test_id:4617"}, func() {
+	It("[test_id:4617]should adopt previously unmanaged entities by updating its metadata", Label("test_id:4617"), func() {
 		By("removing registration metadata")
 		patchData := []byte(fmt.Sprint(`[{ "op": "replace", "path": "/metadata/labels", "value": {} }]`))
 		_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Patch(context.Background(), components.VirtApiCertSecretName, types.JSONPatchType, patchData, metav1.PatchOptions{})
@@ -2436,8 +2436,8 @@ spec:
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 	})
 
-	Context("[rfe_id:4356]Node Placement", Labels{"rfe_id:4356"}, func() {
-		It("[test_id:4927]should dynamically update infra config", Labels{"test_id:4927"}, func() {
+	Context("[rfe_id:4356]Node Placement", Label("rfe_id:4356"), func() {
+		It("[test_id:4927]should dynamically update infra config", Label("test_id:4927"), func() {
 			// This label shouldn't exist, but this isn't harmful
 			// existing/running deployments will not be torn down until
 			// new ones are stood up (and the new ones will get stuck in scheduling)
@@ -2464,7 +2464,7 @@ spec:
 			patchKvInfra(nil, false, "")
 		})
 
-		It("[test_id:4928]should dynamically update workloads config", Labels{"test_id:4928"}, func() {
+		It("[test_id:4928]should dynamically update workloads config", Label("test_id:4928"), func() {
 			labelKey := "kubevirt-test"
 			labelValue := "test-label"
 			workloads := v1.ComponentConfig{
@@ -2516,7 +2516,7 @@ spec:
 			patchKvWorkloads(&incorrectWorkload, true, errMsg)
 		})
 
-		It("[test_id:8235]should check if kubevirt components have linux node selector", Labels{"test_id:8235"}, func() {
+		It("[test_id:8235]should check if kubevirt components have linux node selector", Label("test_id:8235"), func() {
 			By("Listing only kubevirt components")
 			labelReq, err := labels.NewRequirement("app.kubernetes.io/component", selection.In, []string{"kubevirt"})
 
@@ -2676,30 +2676,30 @@ spec:
 			}
 		})
 
-		It("[test_id:6257]should accept valid cert rotation parameters", Labels{"test_id:6257"}, func() {
+		It("[test_id:6257]should accept valid cert rotation parameters", Label("test_id:6257"), func() {
 			kv := copyOriginalKv()
 			patchKvCertConfig(kv.Name, certConfig)
 		})
 
-		It("[test_id:6258]should reject combining deprecated and new cert rotation parameters", Labels{"test_id:6258"}, func() {
+		It("[test_id:6258]should reject combining deprecated and new cert rotation parameters", Label("test_id:6258"), func() {
 			kv := copyOriginalKv()
 			certConfig.CAOverlapInterval = &metav1.Duration{Duration: 8 * time.Hour}
 			patchKvCertConfigExpectError(kv.Name, certConfig)
 		})
 
-		It("[test_id:6259]should reject CA expires before rotation", Labels{"test_id:6259"}, func() {
+		It("[test_id:6259]should reject CA expires before rotation", Label("test_id:6259"), func() {
 			kv := copyOriginalKv()
 			certConfig.CA.Duration = &metav1.Duration{Duration: 14 * time.Hour}
 			patchKvCertConfigExpectError(kv.Name, certConfig)
 		})
 
-		It("[test_id:6260]should reject Cert expires before rotation", Labels{"test_id:6260"}, func() {
+		It("[test_id:6260]should reject Cert expires before rotation", Label("test_id:6260"), func() {
 			kv := copyOriginalKv()
 			certConfig.Server.Duration = &metav1.Duration{Duration: 8 * time.Hour}
 			patchKvCertConfigExpectError(kv.Name, certConfig)
 		})
 
-		It("[test_id:6261]should reject Cert rotates after CA expires", Labels{"test_id:6261"}, func() {
+		It("[test_id:6261]should reject Cert rotates after CA expires", Label("test_id:6261"), func() {
 			kv := copyOriginalKv()
 			certConfig.Server.Duration = &metav1.Duration{Duration: 48 * time.Hour}
 			certConfig.Server.RenewBefore = &metav1.Duration{Duration: 36 * time.Hour}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1373,7 +1373,7 @@ spec:
 		})
 	})
 
-	Describe("[test_id:4744]should apply component customization", Label("test_id:4744", "Serial"), func() {
+	Describe("[test_id:4744][Serial]should apply component customization", Label("test_id:4744", "Serial"), func() {
 
 		It("test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -92,7 +92,7 @@ type vmYamlDefinition struct {
 	vmSnapshots   []vmSnapshotDef
 }
 
-var _ = Describe("[Serial][sig-operator]Operator", func() {
+var _ = Describe("[Serial][sig-operator]Operator", Labels{"Serial", "sig-operator"}, func() {
 	var originalKv *v1.KubeVirt
 	var originalCDI *cdiv1.CDI
 	var originalOperatorVersion string
@@ -1090,14 +1090,14 @@ spec:
 		verifyOperatorWebhookCertificate()
 	})
 
-	It("[test_id:1746]should have created and available condition", func() {
+	It("[test_id:1746]should have created and available condition", Labels{"test_id:1746"}, func() {
 		kv := util2.GetCurrentKv(virtClient)
 
 		By("verifying that created and available condition is present")
 		waitForKv(kv)
 	})
 
-	Describe("[Serial]should reconcile components", func() {
+	Describe("[Serial]should reconcile components", Labels{"Serial"}, func() {
 
 		deploymentName := "virt-controller"
 		daemonSetName := "virt-handler"
@@ -1286,7 +1286,7 @@ spec:
 				}),
 		)
 
-		It("[test_id:6309] checking updating service is reverted to original state", func() {
+		It("[test_id:6309] checking updating service is reverted to original state", Labels{"test_id:6309"}, func() {
 			service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1316,31 +1316,33 @@ spec:
 		})
 	})
 
-	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should start a VM", func() {
-		It("[test_id:3144]using virt-launcher with a shasum", func() {
+	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should start a VM",
+		Labels{"rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			It("[test_id:3144]using virt-launcher with a shasum", Labels{"test_id:3144"}, func() {
 
-			if flags.SkipShasumCheck {
-				Skip("Cannot currently test shasums, skipping")
-			}
+				if flags.SkipShasumCheck {
+					Skip("Cannot currently test shasums, skipping")
+				}
 
-			By("starting a VM")
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil())
-			tests.WaitForSuccessfulVMIStart(vmi)
+				By("starting a VM")
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+				Expect(err).To(BeNil())
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-			By("getting virt-launcher")
-			uid := vmi.GetObjectMeta().GetUID()
-			labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
-			pods, err := virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
-			Expect(err).ToNot(HaveOccurred(), "Should list pods")
-			Expect(pods.Items).To(HaveLen(1))
-			Expect(usesSha(pods.Items[0].Spec.Containers[0].Image)).To(BeTrue(), "launcher pod should use shasum")
+				By("getting virt-launcher")
+				uid := vmi.GetObjectMeta().GetUID()
+				labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
+				pods, err := virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+				Expect(err).ToNot(HaveOccurred(), "Should list pods")
+				Expect(pods.Items).To(HaveLen(1))
+				Expect(usesSha(pods.Items[0].Spec.Containers[0].Image)).To(BeTrue(), "launcher pod should use shasum")
 
+			})
 		})
-	})
 
-	Describe("[test_id:6987]should apply component configuration", func() {
+	Describe("[test_id:6987]should apply component configuration", Labels{"test_id:6987"}, func() {
 
 		It("test VirtualMachineInstancesPerNode", func() {
 			newVirtualMachineInstancesPerNode := 10
@@ -1371,7 +1373,7 @@ spec:
 		})
 	})
 
-	Describe("[test_id:4744][Serial]should apply component customization", func() {
+	Describe("[test_id:4744]should apply component customization", Labels{"test_id:4744", "Serial"}, func() {
 
 		It("test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"
@@ -1431,205 +1433,208 @@ spec:
 		})
 	})
 
-	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should update kubevirt", func() {
-		runStrategyHalted := v1.RunStrategyHalted
+	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should update kubevirt",
+		Labels{"rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			runStrategyHalted := v1.RunStrategyHalted
 
-		// This test is installing a previous release of KubeVirt
-		// running a VM/VMI using that previous release
-		// Updating KubeVirt to the target tested code
-		// Ensuring VM/VMI is still operational after the update from previous release.
-		DescribeTable("[release-blocker][test_id:3145]from previous release to target tested release", func(updateOperator bool) {
-			if !tests.HasCDI() {
-				Skip("Skip update test when CDI is not present")
-			}
+			// This test is installing a previous release of KubeVirt
+			// running a VM/VMI using that previous release
+			// Updating KubeVirt to the target tested code
+			// Ensuring VM/VMI is still operational after the update from previous release.
+			DescribeTable("[release-blocker][test_id:3145]from previous release to target tested release",
+				Labels{"release-blocker", "test_id:3145"}, func(updateOperator bool) {
+					if !tests.HasCDI() {
+						Skip("Skip update test when CDI is not present")
+					}
 
-			if updateOperator && flags.OperatorManifestPath == "" {
-				Skip("Skip operator update test when operator manifest path isn't configured")
-			}
+					if updateOperator && flags.OperatorManifestPath == "" {
+						Skip("Skip operator update test when operator manifest path isn't configured")
+					}
 
-			migratableVMIs := generateMigratableVMIs(2)
-			launcherSha := getVirtLauncherSha()
-			if !flags.SkipShasumCheck {
-				Expect(launcherSha).ToNot(Equal(""))
-			}
+					migratableVMIs := generateMigratableVMIs(2)
+					launcherSha := getVirtLauncherSha()
+					if !flags.SkipShasumCheck {
+						Expect(launcherSha).ToNot(Equal(""))
+					}
 
-			previousImageTag := flags.PreviousReleaseTag
-			previousImageRegistry := flags.PreviousReleaseRegistry
-			if previousImageTag == "" {
-				previousImageTag, err = tests.DetectLatestUpstreamOfficialTag()
-				Expect(err).ToNot(HaveOccurred())
-				By(fmt.Sprintf("By Using detected tag %s for previous kubevirt", previousImageTag))
-			} else {
-				By(fmt.Sprintf("By Using user defined tag %s for previous kubevirt", previousImageTag))
-			}
+					previousImageTag := flags.PreviousReleaseTag
+					previousImageRegistry := flags.PreviousReleaseRegistry
+					if previousImageTag == "" {
+						previousImageTag, err = tests.DetectLatestUpstreamOfficialTag()
+						Expect(err).ToNot(HaveOccurred())
+						By(fmt.Sprintf("By Using detected tag %s for previous kubevirt", previousImageTag))
+					} else {
+						By(fmt.Sprintf("By Using user defined tag %s for previous kubevirt", previousImageTag))
+					}
 
-			previousUtilityTag := flags.PreviousUtilityTag
-			previousUtilityRegistry := flags.PreviousUtilityRegistry
-			if previousUtilityTag == "" {
-				previousUtilityTag = previousImageTag
-				By(fmt.Sprintf("By Using detected tag %s for previous utility containers", previousUtilityTag))
-			} else {
-				By(fmt.Sprintf("By Using user defined tag %s for previous utility containers", previousUtilityTag))
-			}
+					previousUtilityTag := flags.PreviousUtilityTag
+					previousUtilityRegistry := flags.PreviousUtilityRegistry
+					if previousUtilityTag == "" {
+						previousUtilityTag = previousImageTag
+						By(fmt.Sprintf("By Using detected tag %s for previous utility containers", previousUtilityTag))
+					} else {
+						By(fmt.Sprintf("By Using user defined tag %s for previous utility containers", previousUtilityTag))
+					}
 
-			curVersion := originalKv.Status.ObservedKubeVirtVersion
-			curRegistry := originalKv.Status.ObservedKubeVirtRegistry
+					curVersion := originalKv.Status.ObservedKubeVirtVersion
+					curRegistry := originalKv.Status.ObservedKubeVirtRegistry
 
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
+					allPodsAreReady(originalKv)
+					sanityCheckDeploymentsExist()
 
-			// Delete current KubeVirt install so we can install previous release.
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
+					// Delete current KubeVirt install so we can install previous release.
+					By("Deleting KubeVirt object")
+					deleteAllKvAndWait(false)
 
-			By("Verifying all infra pods have terminated")
-			allPodsAreTerminated(originalKv)
+					By("Verifying all infra pods have terminated")
+					allPodsAreTerminated(originalKv)
 
-			By("Sanity Checking Deployments infrastructure is deleted")
-			sanityCheckDeploymentsDeleted()
+					By("Sanity Checking Deployments infrastructure is deleted")
+					sanityCheckDeploymentsDeleted()
 
-			if updateOperator {
-				By("Deleting virt-operator installation")
-				deleteOperator(flags.OperatorManifestPath)
+					if updateOperator {
+						By("Deleting virt-operator installation")
+						deleteOperator(flags.OperatorManifestPath)
 
-				By("Installing previous release of virt-operator")
-				manifestURL := tests.GetUpstreamReleaseAssetURL(previousImageTag, "kubevirt-operator.yaml")
-				installOperator(manifestURL)
-			}
+						By("Installing previous release of virt-operator")
+						manifestURL := tests.GetUpstreamReleaseAssetURL(previousImageTag, "kubevirt-operator.yaml")
+						installOperator(manifestURL)
+					}
 
-			// Install previous release of KubeVirt
-			By("Creating KubeVirt object")
-			kv := copyOriginalKv()
-			kv.Name = "kubevirt-release-install"
-			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate}
+					// Install previous release of KubeVirt
+					By("Creating KubeVirt object")
+					kv := copyOriginalKv()
+					kv.Name = "kubevirt-release-install"
+					kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate}
 
-			// If updating via the KubeVirt CR, explicitly specify the desired release.
-			if !updateOperator {
-				kv.Spec.ImageTag = previousImageTag
-				kv.Spec.ImageRegistry = previousImageRegistry
-			}
+					// If updating via the KubeVirt CR, explicitly specify the desired release.
+					if !updateOperator {
+						kv.Spec.ImageTag = previousImageTag
+						kv.Spec.ImageRegistry = previousImageRegistry
+					}
 
-			createKv(kv)
+					createKv(kv)
 
-			// Wait for previous release to come online
-			// wait 7 minutes because this test involves pulling containers
-			// over the internet related to the latest kubevirt release
-			By("Waiting for KV to stabilize")
-			waitForKvWithTimeout(kv, 420)
+					// Wait for previous release to come online
+					// wait 7 minutes because this test involves pulling containers
+					// over the internet related to the latest kubevirt release
+					By("Waiting for KV to stabilize")
+					waitForKvWithTimeout(kv, 420)
 
-			By("Verifying infrastructure is Ready")
-			allPodsAreReady(kv)
-			sanityCheckDeploymentsExist()
+					By("Verifying infrastructure is Ready")
+					allPodsAreReady(kv)
+					sanityCheckDeploymentsExist()
 
-			// kubectl API discovery cache only refreshes every 10 minutes
-			// Since we're likely dealing with api additions/removals here, we
-			// need to ensure we're using a different cache directory after
-			// the update from the previous release occurs.
-			oldClientCacheDir := filepath.Join(workDir, "oldclient")
-			err = os.MkdirAll(oldClientCacheDir, 0755)
-			Expect(err).ToNot(HaveOccurred())
-			newClientCacheDir := filepath.Join(workDir, "newclient")
-			err = os.MkdirAll(newClientCacheDir, 0755)
-			Expect(err).ToNot(HaveOccurred())
+					// kubectl API discovery cache only refreshes every 10 minutes
+					// Since we're likely dealing with api additions/removals here, we
+					// need to ensure we're using a different cache directory after
+					// the update from the previous release occurs.
+					oldClientCacheDir := filepath.Join(workDir, "oldclient")
+					err = os.MkdirAll(oldClientCacheDir, 0755)
+					Expect(err).ToNot(HaveOccurred())
+					newClientCacheDir := filepath.Join(workDir, "newclient")
+					err = os.MkdirAll(newClientCacheDir, 0755)
+					Expect(err).ToNot(HaveOccurred())
 
-			// Create VM on previous release using a specific API.
-			// NOTE: we are testing with yaml here and explicitly _NOT_ generating
-			// this vm using the latest api code. We want to guarrantee there are no
-			// surprises when it comes to backwards compatibility with previous
-			// virt apis.  As we progress our api from v1alpha3 -> v1 there
-			// needs to be a VM created for every api. This is how we will ensure
-			// our api remains upgradable and supportable from previous release.
+					// Create VM on previous release using a specific API.
+					// NOTE: we are testing with yaml here and explicitly _NOT_ generating
+					// this vm using the latest api code. We want to guarrantee there are no
+					// surprises when it comes to backwards compatibility with previous
+					// virt apis.  As we progress our api from v1alpha3 -> v1 there
+					// needs to be a VM created for every api. This is how we will ensure
+					// our api remains upgradable and supportable from previous release.
 
-			generatePreviousVersionVmYamls(previousUtilityRegistry, previousUtilityTag)
-			generatePreviousVersionVmsnapshotYamls()
-			for _, vmYaml := range vmYamls {
-				By(fmt.Sprintf("Creating VM with %s api", vmYaml.vmName))
-				// NOTE: using kubectl to post yaml directly
+					generatePreviousVersionVmYamls(previousUtilityRegistry, previousUtilityTag)
+					generatePreviousVersionVmsnapshotYamls()
+					for _, vmYaml := range vmYamls {
+						By(fmt.Sprintf("Creating VM with %s api", vmYaml.vmName))
+						// NOTE: using kubectl to post yaml directly
 				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmYaml.yamlFile, "--cache-dir", oldClientCacheDir)
 				Expect(err).ToNot(HaveOccurred())
 
-				for _, vmSnapshot := range vmYaml.vmSnapshots {
-					By(fmt.Sprintf("Creating VM snapshot %s for vm %s", vmSnapshot.vmSnapshotName, vmYaml.vmName))
+						for _, vmSnapshot := range vmYaml.vmSnapshots {
+							By(fmt.Sprintf("Creating VM snapshot %s for vm %s", vmSnapshot.vmSnapshotName, vmYaml.vmName))
 					_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmSnapshot.yamlFile, "--cache-dir", oldClientCacheDir)
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				// Use Current virtctl to start VM
-				// NOTE: we are using virtctl explicitly here because we want to start the VM
-				// using the subresource endpoint in the same way virtctl performs this.
-				By("Starting VM with virtctl")
-				startCommand := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
-				Expect(startCommand()).To(Succeed())
-
-				By(fmt.Sprintf("Waiting for VM with %s api to become ready", vmYaml.apiVersion))
-
-				Eventually(func() bool {
-					virtualMachine, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					if virtualMachine.Status.Ready {
-						return true
-					}
-					return false
-				}, 180*time.Second, 1*time.Second).Should(BeTrue())
-			}
-
-			By("Starting multiple migratable VMIs before performing update")
-			startAllVMIs(migratableVMIs)
-
-			// Update KubeVirt from the previous release to the testing target release.
-			if updateOperator {
-				By("Updating virt-operator installation")
-				installOperator(flags.OperatorManifestPath)
-			} else {
-				By("Updating KubeVirt object With current tag")
-				patchKvVersionAndRegistry(kv.Name, curVersion, curRegistry)
-			}
-
-			By("Wait for Updating Condition")
-			waitForUpdateCondition(kv)
-
-			By("Waiting for KV to stabilize")
-			waitForKvWithTimeout(kv, 420)
-
-			By("Verifying infrastructure Is Updated")
-			allPodsAreReady(kv)
-
-			// Verify console connectivity to VMI still works and stop VM
-			for _, vmYaml := range vmYamls {
-				By(fmt.Sprintf("Ensuring vm %s is ready and latest API annotation is set", vmYaml.apiVersion))
-				Eventually(func() bool {
-					// We are using our internal client here on purpose to ensure we can interact
-					// with previously created objects that may have been created using a different
-					// api version from the latest one our client uses.
-					virtualMachine, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					if !virtualMachine.Status.Ready {
-						return false
-					}
-
-					if !controller.ObservedLatestApiVersionAnnotation(virtualMachine) {
-						return false
-					}
-
-					return true
-				}, 180*time.Second, 1*time.Second).Should(BeTrue())
-
-				By(fmt.Sprintf("Ensure vm %s vmsnapshots exist and ready ", vmYaml.vmName))
-				for _, snapshot := range vmYaml.vmSnapshots {
-					Eventually(func() bool {
-						vmSnapshot, err := virtClient.VirtualMachineSnapshot(util2.NamespaceTestDefault).Get(context.Background(), snapshot.vmSnapshotName, metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						if !(vmSnapshot.Status != nil && vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse) {
-							return false
+							Expect(err).ToNot(HaveOccurred())
 						}
 
-						if vmSnapshot.Status.Phase != snapshotv1.Succeeded {
-							return false
-						}
+						// Use Current virtctl to start VM
+						// NOTE: we are using virtctl explicitly here because we want to start the VM
+						// using the subresource endpoint in the same way virtctl performs this.
+						By("Starting VM with virtctl")
+			        	startCommand := clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
+						Expect(startCommand()).To(Succeed())
 
-						return true
-					}, 120*time.Second, 3*time.Second).Should(BeTrue())
-				}
+						By(fmt.Sprintf("Waiting for VM with %s api to become ready", vmYaml.apiVersion))
+
+						Eventually(func() bool {
+							virtualMachine, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							if virtualMachine.Status.Ready {
+								return true
+							}
+							return false
+						}, 180*time.Second, 1*time.Second).Should(BeTrue())
+					}
+
+					By("Starting multiple migratable VMIs before performing update")
+					startAllVMIs(migratableVMIs)
+
+					// Update KubeVirt from the previous release to the testing target release.
+					if updateOperator {
+						By("Updating virt-operator installation")
+						installOperator(flags.OperatorManifestPath)
+					} else {
+						By("Updating KubeVirt object With current tag")
+						patchKvVersionAndRegistry(kv.Name, curVersion, curRegistry)
+					}
+
+					By("Wait for Updating Condition")
+					waitForUpdateCondition(kv)
+
+					By("Waiting for KV to stabilize")
+					waitForKvWithTimeout(kv, 420)
+
+					By("Verifying infrastructure Is Updated")
+					allPodsAreReady(kv)
+
+					// Verify console connectivity to VMI still works and stop VM
+					for _, vmYaml := range vmYamls {
+						By(fmt.Sprintf("Ensuring vm %s is ready and latest API annotation is set", vmYaml.apiVersion))
+						Eventually(func() bool {
+							// We are using our internal client here on purpose to ensure we can interact
+							// with previously created objects that may have been created using a different
+							// api version from the latest one our client uses.
+							virtualMachine, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							if !virtualMachine.Status.Ready {
+								return false
+							}
+
+							if !controller.ObservedLatestApiVersionAnnotation(virtualMachine) {
+								return false
+							}
+
+							return true
+						}, 180*time.Second, 1*time.Second).Should(BeTrue())
+
+						By(fmt.Sprintf("Ensure vm %s vmsnapshots exist and ready ", vmYaml.vmName))
+						for _, snapshot := range vmYaml.vmSnapshots {
+							Eventually(func() bool {
+								vmSnapshot, err := virtClient.VirtualMachineSnapshot(util2.NamespaceTestDefault).Get(context.Background(), snapshot.vmSnapshotName, metav1.GetOptions{})
+								Expect(err).ToNot(HaveOccurred())
+								if !(vmSnapshot.Status != nil && vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse) {
+									return false
+								}
+
+								if vmSnapshot.Status.Phase != snapshotv1.Succeeded {
+									return false
+								}
+
+								return true
+							}, 120*time.Second, 3*time.Second).Should(BeTrue())
+						}
 
 				By(fmt.Sprintf("Connecting to %s's console", vmYaml.vmName))
 				// This is in an eventually loop because it's possible for the
@@ -1645,657 +1650,667 @@ spec:
 					return nil
 				}, 60*time.Second, 1*time.Second).Should(BeNil())
 
-				By("Stopping VM with virtctl")
-				stopFn := clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
-				Eventually(func() error {
-					return stopFn()
-				}, 30*time.Second, 1*time.Second).Should(BeNil())
+						By("Stopping VM with virtctl")
+				        stopFn := clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util2.NamespaceTestDefault, vmYaml.vmName)
+						Eventually(func() error {
+							return stopFn()
+						}, 30*time.Second, 1*time.Second).Should(BeNil())
 
-				By("Waiting for VMI to stop")
-				Eventually(func() bool {
-					_, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					if err != nil && errors.IsNotFound(err) {
-						return true
-					} else if err != nil {
+						By("Waiting for VMI to stop")
+						Eventually(func() bool {
+							_, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							if err != nil && errors.IsNotFound(err) {
+								return true
+							} else if err != nil {
+								Expect(err).ToNot(HaveOccurred())
+							}
+							return false
+							// #3610 - this timeout needs to be reduced back to 60 seconds.
+							// there's an issue occurring after update where sometimes virt-launcher
+							// can't dial the event notify socket. This impacts the timing for when
+							// the vmi is shutdown. Once that is resolved, reduce the timeout
+						}, 160*time.Second, 1*time.Second).Should(BeTrue())
+
+						By("Ensuring we can Modify the VM Spec")
+						Eventually(func() error {
+							vm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							if err != nil {
+								return err
+							}
+
+							// by making a change to the VM, we ensure that writing the object is possible.
+							// This ensures VMs created previously before the update are still compatible with our validation webhooks
+							vm.Annotations["some-annotation"] = "some-val"
+							annotationBytes, err := json.Marshal(vm.Annotations)
+							Expect(err).ToNot(HaveOccurred())
+
+							ops := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations", "value": %s }]`, string(annotationBytes))
+							_, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte(ops), &metav1.PatchOptions{})
+							return err
+						}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+						// change run stategy to halted to be able to restore the vm
+						Eventually(func() bool {
+							vm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							if err != nil {
+								return false
+							}
+							vm.Spec.RunStrategy = &runStrategyHalted
+							_, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Update(vm)
+							if err != nil {
+								return false
+							}
+							updatedVM, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							return updatedVM.Spec.Running == nil && updatedVM.Spec.RunStrategy != nil && *updatedVM.Spec.RunStrategy == runStrategyHalted
+						}, 30*time.Second, 3*time.Second).Should(BeTrue())
+
+						By(fmt.Sprintf("Ensure vm %s can be restored from vmsnapshots", vmYaml.vmName))
+						for _, snapshot := range vmYaml.vmSnapshots {
+					        _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
+							Expect(err).ToNot(HaveOccurred())
+							Eventually(func() bool {
+								r, err := virtClient.VirtualMachineRestore(util2.NamespaceTestDefault).Get(context.Background(), snapshot.restoreName, metav1.GetOptions{})
+								if err != nil {
+									return false
+								}
+								return r.Status != nil && r.Status.Complete != nil && *r.Status.Complete
+							}, 180*time.Second, 3*time.Second).Should(BeTrue())
+						}
+
+						By(fmt.Sprintf("Deleting VM with %s api", vmYaml.apiVersion))
+				        _, _, err = clientcmd.RunCommand(k8sClient, "delete", "-f", vmYaml.yamlFile, "--cache-dir", newClientCacheDir)
 						Expect(err).ToNot(HaveOccurred())
-					}
-					return false
-					// #3610 - this timeout needs to be reduced back to 60 seconds.
-					// there's an issue occurring after update where sometimes virt-launcher
-					// can't dial the event notify socket. This impacts the timing for when
-					// the vmi is shutdown. Once that is resolved, reduce the timeout
-				}, 160*time.Second, 1*time.Second).Should(BeTrue())
 
-				By("Ensuring we can Modify the VM Spec")
+						By("Waiting for VM to be removed")
+						Eventually(func() bool {
+							_, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+							if err != nil && errors.IsNotFound(err) {
+								return true
+							}
+							return false
+						}, 90*time.Second, 1*time.Second).Should(BeTrue())
+					}
+
+					By("Verifying all migratable vmi workloads are updated via live migration")
+					verifyVMIsUpdated(migratableVMIs, launcherSha)
+
+					By("Verifying that a once migrated VMI after an update can be migrated again")
+					vmi := migratableVMIs[0]
+					migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(tests.NewRandomMigration(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
+
+					By("Deleting migratable VMIs")
+					deleteAllVMIs(migratableVMIs)
+
+					By("Deleting KubeVirt object")
+					deleteAllKvAndWait(false)
+				},
+				Entry("by patching KubeVirt CR", false),
+				Entry("by updating virt-operator", true),
+			)
+		})
+
+	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management",
+		Labels{"rfe_id:2291", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			It("[test_id:3146]should be able to delete and re-create kubevirt install", Labels{"test_id:3146"}, func() {
+				allPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
+
+				// This ensures that we can remove kubevirt while workloads are running
+				By("Starting some vmis")
+				vmis := generateMigratableVMIs(2)
+				startAllVMIs(vmis)
+
+				By("Deleting KubeVirt object")
+				deleteAllKvAndWait(false)
+
+				// this is just verifying some common known components do in fact get deleted.
+				By("Sanity Checking Deployments infrastructure is deleted")
+				sanityCheckDeploymentsDeleted()
+
+				By("ensuring that namespaces can be successfully created and deleted")
+				_, err := virtClient.CoreV1().Namespaces().Create(context.Background(), &k8sv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tests.NamespaceTestOperator}}, metav1.CreateOptions{})
+				if err != nil && !errors.IsAlreadyExists(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+				err = virtClient.CoreV1().Namespaces().Delete(context.Background(), tests.NamespaceTestOperator, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() bool {
+					_, err := virtClient.CoreV1().Namespaces().Get(context.Background(), tests.NamespaceTestOperator, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				}, 60*time.Second, 1*time.Second).Should(BeTrue())
+
+				By("Creating KubeVirt Object")
+				createKv(copyOriginalKv())
+
+				By("Creating KubeVirt Object Created and Ready Condition")
+				waitForKv(originalKv)
+
+				By("Verifying infrastructure is Ready")
+				allPodsAreReady(originalKv)
+				// We're just verifying that a few common components that
+				// should always exist get re-deployed.
+				sanityCheckDeploymentsExist()
+			})
+
+			Describe("[rfe_id:3578][crit:high][vendor:cnv-qe@redhat.com][level:component] deleting with BlockUninstallIfWorkloadsExist",
+				Labels{"rfe_id:3578", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+				func() {
+					It("[test_id:3683]should be blocked if a workload exists", Labels{"test_id:3683"}, func() {
+						allPodsAreReady(originalKv)
+						sanityCheckDeploymentsExist()
+
+						By("setting the right uninstall strategy")
+						kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
+						_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("creating a simple VMI")
+						_, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros)))
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Deleting KubeVirt object")
+						err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("there are still Virtual Machine Instances present"))
+					})
+				})
+
+			It("[test_id:3148]should be able to create kubevirt install with custom image tag", Labels{"test_id:3148"}, func() {
+
+				if flags.KubeVirtVersionTagAlt == "" {
+					Skip("Skip operator custom image tag test because alt tag is not present")
+				}
+
+				allPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
+
+				By("Deleting KubeVirt object")
+				deleteAllKvAndWait(false)
+
+				// this is just verifying some common known components do in fact get deleted.
+				By("Sanity Checking Deployments infrastructure is deleted")
+				sanityCheckDeploymentsDeleted()
+
+				By("Creating KubeVirt Object")
+				kv := copyOriginalKv()
+				kv.Name = "kubevirt-alt-install"
+				kv.Spec = v1.KubeVirtSpec{
+					ImageTag:      flags.KubeVirtVersionTagAlt,
+					ImageRegistry: flags.KubeVirtRepoPrefix,
+				}
+				createKv(kv)
+
+				By("Creating KubeVirt Object Created and Ready Condition")
+				waitForKv(kv)
+
+				By("Verifying infrastructure is Ready")
+				allPodsAreReady(kv)
+				// We're just verifying that a few common components that
+				// should always exist get re-deployed.
+				sanityCheckDeploymentsExist()
+
+				By("Deleting KubeVirt object")
+				deleteAllKvAndWait(false)
+			})
+
+			// this test ensures that we can deal with image prefixes in case they are not used for tests already
+			It("[test_id:3149]should be able to create kubevirt install with image prefix", Labels{"test_id:3149"}, func() {
+
+				if flags.ImagePrefixAlt == "" {
+					Skip("Skip operator imagePrefix test because imagePrefixAlt is not present")
+				}
+
+				kv := copyOriginalKv()
+
+				allPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
+
+				_, _, _, oldPrefix, _ := parseOperatorImage()
+
+				By("Update Operator using imagePrefixAlt")
+				patchOperator(&flags.ImagePrefixAlt, nil)
+
+				// should result in kubevirt cr entering updating state
+				By("Wait for Updating Condition")
+				waitForUpdateCondition(kv)
+
+				By("Waiting for KV to stabilize")
+				waitForKv(kv)
+
+				By("Verifying infrastructure Is Updated")
+				allPodsAreReady(kv)
+
+				By("Verifying deployments have prefix")
+				for _, name := range []string{"virt-operator", "virt-api", "virt-controller"} {
+					_, _, _, prefix, _ := parseDeployment(name)
+					Expect(prefix).To(Equal(flags.ImagePrefixAlt), fmt.Sprintf("%s should have correct image prefix", name))
+				}
+				_, _, _, prefix, _ := parseDaemonset("virt-handler")
+				Expect(prefix).To(Equal(flags.ImagePrefixAlt), "virt-handler should have correct image prefix")
+
+				By("Verifying VMs are working")
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+				Expect(err).ShouldNot(HaveOccurred(), "Create VMI successfully")
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				By("Verifying virt-launcher image is also prefixed")
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+				for _, container := range pod.Spec.Containers {
+					if container.Name == "compute" {
+						_, prefix, _ := parseImage("virt-launcher", container.Image)
+						Expect(prefix).To(Equal(flags.ImagePrefixAlt), "launcher image should have prefix")
+					}
+				}
+
+				By("Deleting VM")
+				err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred(), "Delete VMI successfully")
+
+				By("Restore Operator using original imagePrefix ")
+				patchOperator(&oldPrefix, nil)
+
+				By("Wait for Updating Condition")
+				waitForUpdateCondition(kv)
+
+				By("Waiting for KV to stabilize")
+				waitForKv(kv)
+
+				By("Verifying infrastructure Is Restored to original version")
+				allPodsAreReady(kv)
+			})
+
+			It("[test_id:3150]should be able to update kubevirt install with custom image tag", Labels{"test_id:3150"}, func() {
+				if flags.KubeVirtVersionTagAlt == "" {
+					Skip("Skip operator custom image tag test because alt tag is not present")
+				}
+
+				vmis := generateMigratableVMIs(2)
+				vmisNonMigratable := generateNonMigratableVMIs(2)
+
+				allPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
+
+				By("Deleting KubeVirt object")
+				deleteAllKvAndWait(false)
+
+				// this is just verifying some common known components do in fact get deleted.
+				By("Sanity Checking Deployments infrastructure is deleted")
+				sanityCheckDeploymentsDeleted()
+
+				By("Creating KubeVirt Object")
+				kv := copyOriginalKv()
+				kv.Name = "kubevirt-alt-install"
+				kv.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
+					PermitBridgeInterfaceOnPodNetwork: pointer.BoolPtr(true),
+				}
+				kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
+
+				createKv(kv)
+
+				By("Creating KubeVirt Object Created and Ready Condition")
+				waitForKv(kv)
+
+				By("Verifying infrastructure is Ready")
+				allPodsAreReady(kv)
+				// We're just verifying that a few common components that
+				// should always exist get re-deployed.
+				sanityCheckDeploymentsExist()
+
+				By("Starting multiple migratable VMIs before performing update")
+				startAllVMIs(vmis)
+				startAllVMIs(vmisNonMigratable)
+
+				By("Updating KubeVirtObject With Alt Tag")
+				patchKvVersion(kv.Name, flags.KubeVirtVersionTagAlt)
+
+				By("Wait for Updating Condition")
+				waitForUpdateCondition(kv)
+
+				By("Waiting for KV to stabilize")
+				waitForKv(kv)
+
+				By("Verifying infrastructure Is Updated")
+				allPodsAreReady(kv)
+
+				By("Verifying all non-migratable vmi workloads are shutdown")
+				verifyVMIsEvicted(vmisNonMigratable)
+
+				By("Verifying all migratable vmi workloads are updated via live migration")
+				verifyVMIsUpdated(vmis, flags.KubeVirtVersionTagAlt)
+
+				By("Deleting VMIs")
+				deleteAllVMIs(vmis)
+				deleteAllVMIs(vmisNonMigratable)
+
+				By("Deleting KubeVirt object")
+				deleteAllKvAndWait(false)
+
+			})
+
+			// NOTE - this test verifies new operators can grab the leader election lease
+			// during operator updates. The only way the new infrastructure is deployed
+			// is if the update operator is capable of getting the lease.
+			It("[test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set", Labels{"test_id:3151"}, func() {
+
+				if flags.KubeVirtVersionTagAlt == "" {
+					Skip("Skip operator custom image tag test because alt tag is not present")
+				}
+
+				kv := copyOriginalKv()
+
+				allPodsAreReady(originalKv)
+				sanityCheckDeploymentsExist()
+
+				By("Update Virt-Operator using  Alt Tag")
+				patchOperator(nil, &flags.KubeVirtVersionTagAlt)
+
+				// should result in kubevirt cr entering updating state
+				By("Wait for Updating Condition")
+				waitForUpdateCondition(kv)
+
+				By("Waiting for KV to stabilize")
+				waitForKv(kv)
+
+				By("Verifying infrastructure Is Updated")
+				allPodsAreReady(kv)
+
+				// by using the tag, we also test if resetting (in AfterEach) from tag to sha for the same "version" works
+				By("Restore Operator Version using original tag. ")
+				patchOperator(nil, &flags.KubeVirtVersionTag)
+
+				By("Wait for Updating Condition")
+				waitForUpdateCondition(kv)
+
+				By("Waiting for KV to stabilize")
+				waitForKv(kv)
+
+				By("Verifying infrastructure Is Restored to original version")
+				allPodsAreReady(kv)
+			})
+
+			It("[test_id:3152]should fail if KV object already exists", Labels{"test_id:3152"}, func() {
+
+				newKv := copyOriginalKv()
+				newKv.Name = "someother-kubevirt"
+
+				By("Creating another KubeVirt object")
+				createKv(newKv)
+				By("Waiting for duplicate KubeVirt object to fail")
 				Eventually(func() error {
-					vm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
+					kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(newKv.Name, &metav1.GetOptions{})
 					if err != nil {
 						return err
 					}
 
-					// by making a change to the VM, we ensure that writing the object is possible.
-					// This ensures VMs created previously before the update are still compatible with our validation webhooks
-					vm.Annotations["some-annotation"] = "some-val"
-					annotationBytes, err := json.Marshal(vm.Annotations)
-					Expect(err).ToNot(HaveOccurred())
-
-					ops := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations", "value": %s }]`, string(annotationBytes))
-					_, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte(ops), &metav1.PatchOptions{})
-					return err
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
-				// change run stategy to halted to be able to restore the vm
-				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					if err != nil {
-						return false
-					}
-					vm.Spec.RunStrategy = &runStrategyHalted
-					_, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Update(vm)
-					if err != nil {
-						return false
-					}
-					updatedVM, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return updatedVM.Spec.Running == nil && updatedVM.Spec.RunStrategy != nil && *updatedVM.Spec.RunStrategy == runStrategyHalted
-				}, 30*time.Second, 3*time.Second).Should(BeTrue())
-
-				By(fmt.Sprintf("Ensure vm %s can be restored from vmsnapshots", vmYaml.vmName))
-				for _, snapshot := range vmYaml.vmSnapshots {
-					_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", snapshot.restoreYamlFile, "--cache-dir", newClientCacheDir)
-					Expect(err).ToNot(HaveOccurred())
-					Eventually(func() bool {
-						r, err := virtClient.VirtualMachineRestore(util2.NamespaceTestDefault).Get(context.Background(), snapshot.restoreName, metav1.GetOptions{})
-						if err != nil {
-							return false
+					failed := false
+					for _, condition := range kv.Status.Conditions {
+						if condition.Type == v1.KubeVirtConditionSynchronized &&
+							condition.Status == k8sv1.ConditionFalse &&
+							condition.Reason == "ExistingDeployment" {
+							failed = true
 						}
-						return r.Status != nil && r.Status.Complete != nil && *r.Status.Complete
-					}, 180*time.Second, 3*time.Second).Should(BeTrue())
+					}
+
+					if !failed {
+						return fmt.Errorf("Waiting for sync failed condition")
+					}
+					return nil
+				}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+				By("Deleting duplicate KubeVirt Object")
+				deleteAllKvAndWait(true)
+			})
+
+			It("[test_id:4612]should create non-namespaces resources without owner references", Labels{"test_id:4612"}, func() {
+				crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
+			})
+
+			It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", Labels{"test_id:4613"}, func() {
+				By("getting existing resource to reference")
+				cm, err := virtClient.CoreV1().ConfigMaps(originalKv.Namespace).Get(context.Background(), "kubevirt-ca", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				ownerRef := []metav1.OwnerReference{
+					*metav1.NewControllerRef(&k8sv1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: cm.Name,
+							UID:  cm.UID,
+						},
+					}, schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap", Group: ""}),
 				}
 
-				By(fmt.Sprintf("Deleting VM with %s api", vmYaml.apiVersion))
-				_, _, err = clientcmd.RunCommand(k8sClient, "delete", "-f", vmYaml.yamlFile, "--cache-dir", newClientCacheDir)
+				By("adding an owner reference")
+				origCRD, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				crd := origCRD.DeepCopy()
+				crd.OwnerReferences = ownerRef
+				patch := patchCRD(origCRD, crd)
+				_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				By("verifying that the owner reference is there")
+				origCRD, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(origCRD.OwnerReferences).ToNot(BeEmpty())
+
+				By("changing the install version to force an update")
+				crd = origCRD.DeepCopy()
+				crd.Annotations[v1.InstallStrategyVersionAnnotation] = "outdated"
+				patch = patchCRD(origCRD, crd)
+				_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Waiting for VM to be removed")
-				Eventually(func() bool {
-					_, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
-					if err != nil && errors.IsNotFound(err) {
-						return true
-					}
-					return false
-				}, 90*time.Second, 1*time.Second).Should(BeTrue())
-			}
+				By("waiting until the owner reference disappears again")
+				Eventually(func() []metav1.OwnerReference {
+					crd, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return crd.OwnerReferences
+				}, 20*time.Second, 1*time.Second).Should(BeEmpty())
+				Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
+			})
 
-			By("Verifying all migratable vmi workloads are updated via live migration")
-			verifyVMIsUpdated(migratableVMIs, launcherSha)
-
-			By("Verifying that a once migrated VMI after an update can be migrated again")
-			vmi := migratableVMIs[0]
-			migration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(tests.NewRandomMigration(vmi.Name, vmi.Namespace), &metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisMigration(migration), 180).Should(HaveSucceeded())
-
-			By("Deleting migratable VMIs")
-			deleteAllVMIs(migratableVMIs)
-
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-		},
-			Entry("by patching KubeVirt CR", false),
-			Entry("by updating virt-operator", true),
-		)
-	})
-
-	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]infrastructure management", func() {
-		It("[test_id:3146]should be able to delete and re-create kubevirt install", func() {
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
-
-			// This ensures that we can remove kubevirt while workloads are running
-			By("Starting some vmis")
-			vmis := generateMigratableVMIs(2)
-			startAllVMIs(vmis)
-
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-
-			// this is just verifying some common known components do in fact get deleted.
-			By("Sanity Checking Deployments infrastructure is deleted")
-			sanityCheckDeploymentsDeleted()
-
-			By("ensuring that namespaces can be successfully created and deleted")
-			_, err := virtClient.CoreV1().Namespaces().Create(context.Background(), &k8sv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tests.NamespaceTestOperator}}, metav1.CreateOptions{})
-			if err != nil && !errors.IsAlreadyExists(err) {
-				Expect(err).ToNot(HaveOccurred())
-			}
-			err = virtClient.CoreV1().Namespaces().Delete(context.Background(), tests.NamespaceTestOperator, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(func() bool {
-				_, err := virtClient.CoreV1().Namespaces().Get(context.Background(), tests.NamespaceTestOperator, metav1.GetOptions{})
-				return errors.IsNotFound(err)
-			}, 60*time.Second, 1*time.Second).Should(BeTrue())
-
-			By("Creating KubeVirt Object")
-			createKv(copyOriginalKv())
-
-			By("Creating KubeVirt Object Created and Ready Condition")
-			waitForKv(originalKv)
-
-			By("Verifying infrastructure is Ready")
-			allPodsAreReady(originalKv)
-			// We're just verifying that a few common components that
-			// should always exist get re-deployed.
-			sanityCheckDeploymentsExist()
-		})
-
-		Describe("[rfe_id:3578][crit:high][vendor:cnv-qe@redhat.com][level:component] deleting with BlockUninstallIfWorkloadsExist", func() {
-			It("[test_id:3683]should be blocked if a workload exists", func() {
+			It("[test_id:5010]should be able to update product related labels of kubevirt install", Labels{"test_id:5010"}, func() {
+				productName := "kubevirt-test"
+				productVersion := "0.0.0"
+				productComponent := "kubevirt-component"
 				allPodsAreReady(originalKv)
 				sanityCheckDeploymentsExist()
 
-				By("setting the right uninstall strategy")
-				kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				kv.Spec.UninstallStrategy = v1.KubeVirtUninstallStrategyBlockUninstallIfWorkloadsExist
-				_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
-				Expect(err).ToNot(HaveOccurred())
+				kv := copyOriginalKv()
 
-				By("creating a simple VMI")
-				_, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros)))
-				Expect(err).ToNot(HaveOccurred())
+				By("Patching kubevirt resource with productName , productVersion  and productComponent")
+				patchKvProductNameVersionAndComponent(kv.Name, productName, productVersion, productComponent)
+
+				for _, deployment := range []string{"virt-api", "virt-controller"} {
+					By(fmt.Sprintf("Ensuring that the %s deployment is updated", deployment))
+					Eventually(func() bool {
+						dep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return dep.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dep.ObjectMeta.Labels[v1.AppPartOfLabel] == productName && dep.ObjectMeta.Labels[v1.AppComponentLabel] == productComponent
+					}, 240*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Expected labels to be updated for %s deployment", deployment))
+				}
+
+				By("Ensuring that the virt-handler daemonset is updated")
+				Eventually(func() bool {
+					dms, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return dms.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dms.ObjectMeta.Labels[v1.AppPartOfLabel] == productName && dms.ObjectMeta.Labels[v1.AppComponentLabel] == productComponent
+				}, 240*time.Second, 1*time.Second).Should(BeTrue(), "Expected labels to be updated for virt-handler daemonset")
 
 				By("Deleting KubeVirt object")
-				err = virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("there are still Virtual Machine Instances present"))
+				deleteAllKvAndWait(false)
 			})
+
+			Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With OpenShift cluster",
+				Labels{"rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				func() {
+
+					BeforeEach(func() {
+						if !checks.IsOpenShift() {
+							Skip("OpenShift operator tests should not be started on k8s")
+						}
+					})
+
+					It("[test_id:2910]Should have kubevirt SCCs created", Labels{"test_id:2910"}, func() {
+						const OpenShiftSCCLabel = "openshift.io/scc"
+						var expectedSCCs, sccs []string
+
+						By("Checking if kubevirt SCCs have been created")
+						secClient := virtClient.SecClient()
+						operatorSCCs := components.GetAllSCC(flags.KubeVirtInstallNamespace)
+						for _, scc := range operatorSCCs {
+							expectedSCCs = append(expectedSCCs, scc.GetName())
+						}
+
+						createdSCCs, err := secClient.SecurityContextConstraints().List(context.Background(), metav1.ListOptions{LabelSelector: controller.OperatorLabel})
+						Expect(err).NotTo(HaveOccurred())
+						for _, scc := range createdSCCs.Items {
+							sccs = append(sccs, scc.GetName())
+						}
+						Expect(sccs).To(ConsistOf(expectedSCCs))
+
+						By("Checking if virt-handler is assigned to kubevirt-handler SCC")
+						l, err := labels.Parse("kubevirt.io=virt-handler")
+						Expect(err).ToNot(HaveOccurred())
+
+						pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
+						Expect(err).ToNot(HaveOccurred(), "Should get virt-handler")
+						Expect(pods.Items).ToNot(BeEmpty())
+						Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
+							Equal("kubevirt-handler"), "Should virt-handler be assigned to kubevirt-handler SCC",
+						)
+
+						By("Checking if virt-launcher is assigned to kubevirt-controller SCC")
+						vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+						vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+						Expect(err).To(BeNil())
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						uid := vmi.GetObjectMeta().GetUID()
+						labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
+						pods, err = virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
+						Expect(err).ToNot(HaveOccurred(), "Should get virt-launcher")
+						Expect(pods.Items).To(HaveLen(1))
+						Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
+							Equal("kubevirt-controller"), "Should virt-launcher be assigned to kubevirt-controller SCC",
+						)
+					})
+				})
 		})
 
-		It("[test_id:3148]should be able to create kubevirt install with custom image tag", func() {
+	Describe("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]Dynamic feature detection",
+		Labels{"rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-			if flags.KubeVirtVersionTagAlt == "" {
-				Skip("Skip operator custom image tag test because alt tag is not present")
-			}
+			var vm *v1.VirtualMachine
 
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
+			AfterEach(func() {
 
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-
-			// this is just verifying some common known components do in fact get deleted.
-			By("Sanity Checking Deployments infrastructure is deleted")
-			sanityCheckDeploymentsDeleted()
-
-			By("Creating KubeVirt Object")
-			kv := copyOriginalKv()
-			kv.Name = "kubevirt-alt-install"
-			kv.Spec = v1.KubeVirtSpec{
-				ImageTag:      flags.KubeVirtVersionTagAlt,
-				ImageRegistry: flags.KubeVirtRepoPrefix,
-			}
-			createKv(kv)
-
-			By("Creating KubeVirt Object Created and Ready Condition")
-			waitForKv(kv)
-
-			By("Verifying infrastructure is Ready")
-			allPodsAreReady(kv)
-			// We're just verifying that a few common components that
-			// should always exist get re-deployed.
-			sanityCheckDeploymentsExist()
-
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-		})
-
-		// this test ensures that we can deal with image prefixes in case they are not used for tests already
-		It("[test_id:3149]should be able to create kubevirt install with image prefix", func() {
-
-			if flags.ImagePrefixAlt == "" {
-				Skip("Skip operator imagePrefix test because imagePrefixAlt is not present")
-			}
-
-			kv := copyOriginalKv()
-
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
-
-			_, _, _, oldPrefix, _ := parseOperatorImage()
-
-			By("Update Operator using imagePrefixAlt")
-			patchOperator(&flags.ImagePrefixAlt, nil)
-
-			// should result in kubevirt cr entering updating state
-			By("Wait for Updating Condition")
-			waitForUpdateCondition(kv)
-
-			By("Waiting for KV to stabilize")
-			waitForKv(kv)
-
-			By("Verifying infrastructure Is Updated")
-			allPodsAreReady(kv)
-
-			By("Verifying deployments have prefix")
-			for _, name := range []string{"virt-operator", "virt-api", "virt-controller"} {
-				_, _, _, prefix, _ := parseDeployment(name)
-				Expect(prefix).To(Equal(flags.ImagePrefixAlt), fmt.Sprintf("%s should have correct image prefix", name))
-			}
-			_, _, _, prefix, _ := parseDaemonset("virt-handler")
-			Expect(prefix).To(Equal(flags.ImagePrefixAlt), "virt-handler should have correct image prefix")
-
-			By("Verifying VMs are working")
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
-			Expect(err).ShouldNot(HaveOccurred(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("Verifying virt-launcher image is also prefixed")
-			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
-					_, prefix, _ := parseImage("virt-launcher", container.Image)
-					Expect(prefix).To(Equal(flags.ImagePrefixAlt), "launcher image should have prefix")
-				}
-			}
-
-			By("Deleting VM")
-			err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
-			Expect(err).ShouldNot(HaveOccurred(), "Delete VMI successfully")
-
-			By("Restore Operator using original imagePrefix ")
-			patchOperator(&oldPrefix, nil)
-
-			By("Wait for Updating Condition")
-			waitForUpdateCondition(kv)
-
-			By("Waiting for KV to stabilize")
-			waitForKv(kv)
-
-			By("Verifying infrastructure Is Restored to original version")
-			allPodsAreReady(kv)
-		})
-
-		It("[test_id:3150]should be able to update kubevirt install with custom image tag", func() {
-			if flags.KubeVirtVersionTagAlt == "" {
-				Skip("Skip operator custom image tag test because alt tag is not present")
-			}
-
-			vmis := generateMigratableVMIs(2)
-			vmisNonMigratable := generateNonMigratableVMIs(2)
-
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
-
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-
-			// this is just verifying some common known components do in fact get deleted.
-			By("Sanity Checking Deployments infrastructure is deleted")
-			sanityCheckDeploymentsDeleted()
-
-			By("Creating KubeVirt Object")
-			kv := copyOriginalKv()
-			kv.Name = "kubevirt-alt-install"
-			kv.Spec.Configuration.NetworkConfiguration = &v1.NetworkConfiguration{
-				PermitBridgeInterfaceOnPodNetwork: pointer.BoolPtr(true),
-			}
-			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
-
-			createKv(kv)
-
-			By("Creating KubeVirt Object Created and Ready Condition")
-			waitForKv(kv)
-
-			By("Verifying infrastructure is Ready")
-			allPodsAreReady(kv)
-			// We're just verifying that a few common components that
-			// should always exist get re-deployed.
-			sanityCheckDeploymentsExist()
-
-			By("Starting multiple migratable VMIs before performing update")
-			startAllVMIs(vmis)
-			startAllVMIs(vmisNonMigratable)
-
-			By("Updating KubeVirtObject With Alt Tag")
-			patchKvVersion(kv.Name, flags.KubeVirtVersionTagAlt)
-
-			By("Wait for Updating Condition")
-			waitForUpdateCondition(kv)
-
-			By("Waiting for KV to stabilize")
-			waitForKv(kv)
-
-			By("Verifying infrastructure Is Updated")
-			allPodsAreReady(kv)
-
-			By("Verifying all non-migratable vmi workloads are shutdown")
-			verifyVMIsEvicted(vmisNonMigratable)
-
-			By("Verifying all migratable vmi workloads are updated via live migration")
-			verifyVMIsUpdated(vmis, flags.KubeVirtVersionTagAlt)
-
-			By("Deleting VMIs")
-			deleteAllVMIs(vmis)
-			deleteAllVMIs(vmisNonMigratable)
-
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-
-		})
-
-		// NOTE - this test verifies new operators can grab the leader election lease
-		// during operator updates. The only way the new infrastructure is deployed
-		// is if the update operator is capable of getting the lease.
-		It("[test_id:3151]should be able to update kubevirt install when operator updates if no custom image tag is set", func() {
-
-			if flags.KubeVirtVersionTagAlt == "" {
-				Skip("Skip operator custom image tag test because alt tag is not present")
-			}
-
-			kv := copyOriginalKv()
-
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
-
-			By("Update Virt-Operator using  Alt Tag")
-			patchOperator(nil, &flags.KubeVirtVersionTagAlt)
-
-			// should result in kubevirt cr entering updating state
-			By("Wait for Updating Condition")
-			waitForUpdateCondition(kv)
-
-			By("Waiting for KV to stabilize")
-			waitForKv(kv)
-
-			By("Verifying infrastructure Is Updated")
-			allPodsAreReady(kv)
-
-			// by using the tag, we also test if resetting (in AfterEach) from tag to sha for the same "version" works
-			By("Restore Operator Version using original tag. ")
-			patchOperator(nil, &flags.KubeVirtVersionTag)
-
-			By("Wait for Updating Condition")
-			waitForUpdateCondition(kv)
-
-			By("Waiting for KV to stabilize")
-			waitForKv(kv)
-
-			By("Verifying infrastructure Is Restored to original version")
-			allPodsAreReady(kv)
-		})
-
-		It("[test_id:3152]should fail if KV object already exists", func() {
-
-			newKv := copyOriginalKv()
-			newKv.Name = "someother-kubevirt"
-
-			By("Creating another KubeVirt object")
-			createKv(newKv)
-			By("Waiting for duplicate KubeVirt object to fail")
-			Eventually(func() error {
-				kv, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Get(newKv.Name, &metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				failed := false
-				for _, condition := range kv.Status.Conditions {
-					if condition.Type == v1.KubeVirtConditionSynchronized &&
-						condition.Status == k8sv1.ConditionFalse &&
-						condition.Reason == "ExistingDeployment" {
-						failed = true
+				if vm != nil {
+					_, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					if err != nil && !errors.IsNotFound(err) {
+						Expect(err).ToNot(HaveOccurred())
 					}
-				}
 
-				if !failed {
-					return fmt.Errorf("Waiting for sync failed condition")
-				}
-				return nil
-			}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
-			By("Deleting duplicate KubeVirt Object")
-			deleteAllKvAndWait(true)
-		})
-
-		It("[test_id:4612]should create non-namespaces resources without owner references", func() {
-			crd, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
-		})
-
-		It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", func() {
-			By("getting existing resource to reference")
-			cm, err := virtClient.CoreV1().ConfigMaps(originalKv.Namespace).Get(context.Background(), "kubevirt-ca", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			ownerRef := []metav1.OwnerReference{
-				*metav1.NewControllerRef(&k8sv1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: cm.Name,
-						UID:  cm.UID,
-					},
-				}, schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap", Group: ""}),
-			}
-
-			By("adding an owner reference")
-			origCRD, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			crd := origCRD.DeepCopy()
-			crd.OwnerReferences = ownerRef
-			patch := patchCRD(origCRD, crd)
-			_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			By("verifying that the owner reference is there")
-			origCRD, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(origCRD.OwnerReferences).ToNot(BeEmpty())
-
-			By("changing the install version to force an update")
-			crd = origCRD.DeepCopy()
-			crd.Annotations[v1.InstallStrategyVersionAnnotation] = "outdated"
-			patch = patchCRD(origCRD, crd)
-			_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("waiting until the owner reference disappears again")
-			Eventually(func() []metav1.OwnerReference {
-				crd, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return crd.OwnerReferences
-			}, 20*time.Second, 1*time.Second).Should(BeEmpty())
-			Expect(crd.ObjectMeta.OwnerReferences).To(BeEmpty())
-		})
-
-		It("[test_id:5010]should be able to update product related labels of kubevirt install", func() {
-			productName := "kubevirt-test"
-			productVersion := "0.0.0"
-			productComponent := "kubevirt-component"
-			allPodsAreReady(originalKv)
-			sanityCheckDeploymentsExist()
-
-			kv := copyOriginalKv()
-
-			By("Patching kubevirt resource with productName , productVersion  and productComponent")
-			patchKvProductNameVersionAndComponent(kv.Name, productName, productVersion, productComponent)
-
-			for _, deployment := range []string{"virt-api", "virt-controller"} {
-				By(fmt.Sprintf("Ensuring that the %s deployment is updated", deployment))
-				Eventually(func() bool {
-					dep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deployment, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return dep.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dep.ObjectMeta.Labels[v1.AppPartOfLabel] == productName && dep.ObjectMeta.Labels[v1.AppComponentLabel] == productComponent
-				}, 240*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Expected labels to be updated for %s deployment", deployment))
-			}
-
-			By("Ensuring that the virt-handler daemonset is updated")
-			Eventually(func() bool {
-				dms, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return dms.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dms.ObjectMeta.Labels[v1.AppPartOfLabel] == productName && dms.ObjectMeta.Labels[v1.AppComponentLabel] == productComponent
-			}, 240*time.Second, 1*time.Second).Should(BeTrue(), "Expected labels to be updated for virt-handler daemonset")
-
-			By("Deleting KubeVirt object")
-			deleteAllKvAndWait(false)
-		})
-
-		Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With OpenShift cluster", func() {
-
-			BeforeEach(func() {
-				if !checks.IsOpenShift() {
-					Skip("OpenShift operator tests should not be started on k8s")
+					if vm != nil && vm.DeletionTimestamp == nil {
+						err = virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+					vm = nil
 				}
 			})
 
-			It("[test_id:2910]Should have kubevirt SCCs created", func() {
-				const OpenShiftSCCLabel = "openshift.io/scc"
-				var expectedSCCs, sccs []string
-
-				By("Checking if kubevirt SCCs have been created")
-				secClient := virtClient.SecClient()
-				operatorSCCs := components.GetAllSCC(flags.KubeVirtInstallNamespace)
-				for _, scc := range operatorSCCs {
-					expectedSCCs = append(expectedSCCs, scc.GetName())
-				}
-
-				createdSCCs, err := secClient.SecurityContextConstraints().List(context.Background(), metav1.ListOptions{LabelSelector: controller.OperatorLabel})
-				Expect(err).NotTo(HaveOccurred())
-				for _, scc := range createdSCCs.Items {
-					sccs = append(sccs, scc.GetName())
-				}
-				Expect(sccs).To(ConsistOf(expectedSCCs))
-
-				By("Checking if virt-handler is assigned to kubevirt-handler SCC")
-				l, err := labels.Parse("kubevirt.io=virt-handler")
-				Expect(err).ToNot(HaveOccurred())
-
-				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: l.String()})
-				Expect(err).ToNot(HaveOccurred(), "Should get virt-handler")
-				Expect(pods.Items).ToNot(BeEmpty())
-				Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
-					Equal("kubevirt-handler"), "Should virt-handler be assigned to kubevirt-handler SCC",
-				)
-
-				By("Checking if virt-launcher is assigned to kubevirt-controller SCC")
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-				vmi, err = virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(BeNil())
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				uid := vmi.GetObjectMeta().GetUID()
-				labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
-				pods, err = virtClient.CoreV1().Pods(util2.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
-				Expect(err).ToNot(HaveOccurred(), "Should get virt-launcher")
-				Expect(pods.Items).To(HaveLen(1))
-				Expect(pods.Items[0].Annotations[OpenShiftSCCLabel]).To(
-					Equal("kubevirt-controller"), "Should virt-launcher be assigned to kubevirt-controller SCC",
-				)
-			})
-		})
-	})
-
-	Describe("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]Dynamic feature detection", func() {
-
-		var vm *v1.VirtualMachine
-
-		AfterEach(func() {
-
-			if vm != nil {
-				_, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-				if err != nil && !errors.IsNotFound(err) {
-					Expect(err).ToNot(HaveOccurred())
-				}
-
-				if vm != nil && vm.DeletionTimestamp == nil {
-					err = virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
-				vm = nil
-			}
-		})
-
-		It("[test_id:3153]Ensure infra can handle dynamically detecting DataVolume Support", func() {
+		It("[test_id:3153]Ensure infra can handle dynamically detecting DataVolume Support", Labels{"test_id:3153"}, func() {
 			if !libstorage.HasDataVolumeCRD() {
 				Skip("Can't test DataVolume support when DataVolume CRD isn't present")
 			}
 			checks.SkipIfVersionBelow("Skipping dynamic cdi test in versions below 1.13 because crd garbage collection is broken", "1.13")
 
-			// This tests starting infrastructure with and without the DataVolumes feature gate
-			vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util2.NamespaceTestDefault)
-			running := false
-			vm.Spec.Running = &running
+				// This tests starting infrastructure with and without the DataVolumes feature gate
+				vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util2.NamespaceTestDefault)
+				running := false
+				vm.Spec.Running = &running
 
-			// Delete CDI object
-			By("Deleting CDI install")
-			Eventually(func() error {
-				cdi, err := virtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
-				if err != nil && errors.IsNotFound(err) {
-					// cdi is deleted
-					return nil
-				} else if err != nil {
-					return err
-				}
-
-				if cdi.DeletionTimestamp == nil {
-					err := virtClient.CdiClient().CdiV1beta1().CDIs().Delete(context.Background(), originalCDI.Name, metav1.DeleteOptions{})
-					if err != nil {
+				// Delete CDI object
+				By("Deleting CDI install")
+				Eventually(func() error {
+					cdi, err := virtClient.CdiClient().CdiV1beta1().CDIs().Get(context.Background(), originalCDI.Name, metav1.GetOptions{})
+					if err != nil && errors.IsNotFound(err) {
+						// cdi is deleted
+						return nil
+					} else if err != nil {
 						return err
 					}
+
+					if cdi.DeletionTimestamp == nil {
+						err := virtClient.CdiClient().CdiV1beta1().CDIs().Delete(context.Background(), originalCDI.Name, metav1.DeleteOptions{})
+						if err != nil {
+							return err
+						}
+					}
+
+					return fmt.Errorf("still waiting on cdi to delete")
+
+				}, 240*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+				// wait for virt-api and virt-controller to pick up the change that CDI no longer exists.
+				time.Sleep(30 * time.Second)
+
+				// Verify posting a VM with DataVolumeTemplate fails when DataVolumes
+				// feature gate is disabled
+				By("Expecting Error to Occur when posting VM with DataVolume")
+				_, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
+				Expect(err).To(HaveOccurred())
+
+				// Enable DataVolumes by reinstalling CDI
+				By("Enabling CDI install")
+				createCdi()
+
+				// wait for virt-api to pick up the change.
+				time.Sleep(30 * time.Second)
+
+				// Verify we can post a VM with DataVolumeTemplates successfully
+				By("Expecting Error to not occur when posting VM with DataVolume")
+				vm, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Expecting VM to start successfully")
+				tests.StartVirtualMachine(vm)
+			})
+		})
+
+	Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Disabled",
+		Labels{"rfe_id:2897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+
+			BeforeEach(func() {
+				if tests.ServiceMonitorEnabled() {
+					Skip("Test applies on when ServiceMonitor is not defined")
 				}
+			})
 
-				return fmt.Errorf("still waiting on cdi to delete")
+			It("[test_id:3154]Should not create RBAC Role or RoleBinding for ServiceMonitor", Labels{"test_id:3154"}, func() {
+				rbacClient := virtClient.RbacV1()
 
-			}, 240*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				By("Checking that Role for ServiceMonitor doesn't exist")
+				roleName := "kubevirt-service-monitor"
+				_, err := rbacClient.Roles(flags.KubeVirtInstallNamespace).Get(context.Background(), roleName, metav1.GetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue(), "Role 'kubevirt-service-monitor' should not have been created")
 
-			// wait for virt-api and virt-controller to pick up the change that CDI no longer exists.
-			time.Sleep(30 * time.Second)
-
-			// Verify posting a VM with DataVolumeTemplate fails when DataVolumes
-			// feature gate is disabled
-			By("Expecting Error to Occur when posting VM with DataVolume")
-			_, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
-			Expect(err).To(HaveOccurred())
-
-			// Enable DataVolumes by reinstalling CDI
-			By("Enabling CDI install")
-			createCdi()
-
-			// wait for virt-api to pick up the change.
-			time.Sleep(30 * time.Second)
-
-			// Verify we can post a VM with DataVolumeTemplates successfully
-			By("Expecting Error to not occur when posting VM with DataVolume")
-			vm, err = virtClient.VirtualMachine(util2.NamespaceTestDefault).Create(vm)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Expecting VM to start successfully")
-			tests.StartVirtualMachine(vm)
+				By("Checking that RoleBinding for ServiceMonitor doesn't exist")
+				_, err = rbacClient.RoleBindings(flags.KubeVirtInstallNamespace).Get(context.Background(), roleName, metav1.GetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue(), "RoleBinding 'kubevirt-service-monitor' should not have been created")
+			})
 		})
-	})
-
-	Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Disabled", func() {
-
-		BeforeEach(func() {
-			if tests.ServiceMonitorEnabled() {
-				Skip("Test applies on when ServiceMonitor is not defined")
-			}
-		})
-
-		It("[test_id:3154]Should not create RBAC Role or RoleBinding for ServiceMonitor", func() {
-			rbacClient := virtClient.RbacV1()
-
-			By("Checking that Role for ServiceMonitor doesn't exist")
-			roleName := "kubevirt-service-monitor"
-			_, err := rbacClient.Roles(flags.KubeVirtInstallNamespace).Get(context.Background(), roleName, metav1.GetOptions{})
-			Expect(err).To(HaveOccurred())
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "Role 'kubevirt-service-monitor' should not have been created")
-
-			By("Checking that RoleBinding for ServiceMonitor doesn't exist")
-			_, err = rbacClient.RoleBindings(flags.KubeVirtInstallNamespace).Get(context.Background(), roleName, metav1.GetOptions{})
-			Expect(err).To(HaveOccurred())
-			Expect(errors.IsNotFound(err)).To(BeTrue(), "RoleBinding 'kubevirt-service-monitor' should not have been created")
-		})
-	})
 
 	Context("With PrometheusRule Enabled", func() {
 
@@ -2305,7 +2320,7 @@ spec:
 			}
 		})
 
-		It("[test_id:4614]Checks if the kubevirt PrometheusRule cr exists and verify it's spec", func() {
+		It("[test_id:4614]Checks if the kubevirt PrometheusRule cr exists and verify it's spec", Labels{"test_id:4614"}, func() {
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			prometheusRule, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -2326,65 +2341,67 @@ spec:
 			}
 		})
 
-		It("[test_id:4615]Checks that we do not deploy a PrometheusRule cr when not needed", func() {
+		It("[test_id:4615]Checks that we do not deploy a PrometheusRule cr when not needed", Labels{"test_id:4615"}, func() {
 			monv1 := virtClient.PrometheusClient().MonitoringV1()
 			_, err := monv1.PrometheusRules(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	Context("[rfe_id:2937][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Enabled", func() {
+	Context("[rfe_id:2937][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Enabled",
+		Labels{"rfe_id:2937", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-		BeforeEach(func() {
-			if !tests.ServiceMonitorEnabled() {
-				Skip("Test requires ServiceMonitor to be valid")
-			}
-		})
-
-		It("[test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints", func() {
-			coreClient := virtClient.CoreV1()
-
-			// we don't know when the prometheus toolchain will pick up our config, so we retry plenty of times
-			// before to give up. TODO: there is a smarter way to wait?
-			Eventually(func() string {
-				By("Obtaining Prometheus' configuration data")
-				secret, err := coreClient.Secrets("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				data, ok := secret.Data["prometheus.yaml"]
-				// In new versions of prometheus-operator, the configuration file is compressed in the secret
-				if !ok {
-					data, ok = secret.Data["prometheus.yaml.gz"]
-					Expect(ok).To(BeTrue())
-
-					By("Decompressing Prometheus' configuration data")
-					gzreader, err := gzip.NewReader(bytes.NewReader(data))
-					Expect(err).ToNot(HaveOccurred())
-
-					decompressed, err := ioutil.ReadAll(gzreader)
-					Expect(err).ToNot(HaveOccurred())
-
-					data = decompressed
+			BeforeEach(func() {
+				if !tests.ServiceMonitorEnabled() {
+					Skip("Test requires ServiceMonitor to be valid")
 				}
+			})
 
-				Expect(data).ToNot(BeNil())
+			It("[test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints", Labels{"test_id:2936"}, func() {
+				coreClient := virtClient.CoreV1()
 
-				By("Verifying that Prometheus is watching KubeVirt")
-				return string(data)
-			}, 90*time.Second, 3*time.Second).Should(ContainSubstring(flags.KubeVirtInstallNamespace), "Prometheus should be monitoring KubeVirt")
+				// we don't know when the prometheus toolchain will pick up our config, so we retry plenty of times
+				// before to give up. TODO: there is a smarter way to wait?
+				Eventually(func() string {
+					By("Obtaining Prometheus' configuration data")
+					secret, err := coreClient.Secrets("openshift-monitoring").Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					data, ok := secret.Data["prometheus.yaml"]
+					// In new versions of prometheus-operator, the configuration file is compressed in the secret
+					if !ok {
+						data, ok = secret.Data["prometheus.yaml.gz"]
+						Expect(ok).To(BeTrue())
+
+						By("Decompressing Prometheus' configuration data")
+						gzreader, err := gzip.NewReader(bytes.NewReader(data))
+						Expect(err).ToNot(HaveOccurred())
+
+						decompressed, err := ioutil.ReadAll(gzreader)
+						Expect(err).ToNot(HaveOccurred())
+
+						data = decompressed
+					}
+
+					Expect(data).ToNot(BeNil())
+
+					By("Verifying that Prometheus is watching KubeVirt")
+					return string(data)
+				}, 90*time.Second, 3*time.Second).Should(ContainSubstring(flags.KubeVirtInstallNamespace), "Prometheus should be monitoring KubeVirt")
+			})
+
+			It("[test_id:4616]Should patch our namespace labels with openshift.io/cluster-monitoring=true", Labels{"test_id:4616"}, func() {
+				By("Inspecting the labels on our namespace")
+				namespace, err := virtClient.CoreV1().Namespaces().Get(context.Background(), flags.KubeVirtInstallNamespace, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				monitoringLabel, exists := namespace.ObjectMeta.Labels["openshift.io/cluster-monitoring"]
+				Expect(exists).To(BeTrue())
+				Expect(monitoringLabel).To(Equal("true"))
+			})
 		})
 
-		It("[test_id:4616]Should patch our namespace labels with openshift.io/cluster-monitoring=true", func() {
-			By("Inspecting the labels on our namespace")
-			namespace, err := virtClient.CoreV1().Namespaces().Get(context.Background(), flags.KubeVirtInstallNamespace, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			monitoringLabel, exists := namespace.ObjectMeta.Labels["openshift.io/cluster-monitoring"]
-			Expect(exists).To(BeTrue())
-			Expect(monitoringLabel).To(Equal("true"))
-		})
-	})
-
-	It("[test_id:4617]should adopt previously unmanaged entities by updating its metadata", func() {
+	It("[test_id:4617]should adopt previously unmanaged entities by updating its metadata", Labels{"test_id:4617"}, func() {
 		By("removing registration metadata")
 		patchData := []byte(fmt.Sprint(`[{ "op": "replace", "path": "/metadata/labels", "value": {} }]`))
 		_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Patch(context.Background(), components.VirtApiCertSecretName, types.JSONPatchType, patchData, metav1.PatchOptions{})
@@ -2419,8 +2436,8 @@ spec:
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 	})
 
-	Context("[rfe_id:4356]Node Placement", func() {
-		It("[test_id:4927]should dynamically update infra config", func() {
+	Context("[rfe_id:4356]Node Placement", Labels{"rfe_id:4356"}, func() {
+		It("[test_id:4927]should dynamically update infra config", Labels{"test_id:4927"}, func() {
 			// This label shouldn't exist, but this isn't harmful
 			// existing/running deployments will not be torn down until
 			// new ones are stood up (and the new ones will get stuck in scheduling)
@@ -2447,7 +2464,7 @@ spec:
 			patchKvInfra(nil, false, "")
 		})
 
-		It("[test_id:4928]should dynamically update workloads config", func() {
+		It("[test_id:4928]should dynamically update workloads config", Labels{"test_id:4928"}, func() {
 			labelKey := "kubevirt-test"
 			labelValue := "test-label"
 			workloads := v1.ComponentConfig{
@@ -2499,7 +2516,7 @@ spec:
 			patchKvWorkloads(&incorrectWorkload, true, errMsg)
 		})
 
-		It("[test_id:8235]should check if kubevirt components have linux node selector", func() {
+		It("[test_id:8235]should check if kubevirt components have linux node selector", Labels{"test_id:8235"}, func() {
 			By("Listing only kubevirt components")
 			labelReq, err := labels.NewRequirement("app.kubernetes.io/component", selection.In, []string{"kubevirt"})
 
@@ -2659,30 +2676,30 @@ spec:
 			}
 		})
 
-		It("[test_id:6257]should accept valid cert rotation parameters", func() {
+		It("[test_id:6257]should accept valid cert rotation parameters", Labels{"test_id:6257"}, func() {
 			kv := copyOriginalKv()
 			patchKvCertConfig(kv.Name, certConfig)
 		})
 
-		It("[test_id:6258]should reject combining deprecated and new cert rotation parameters", func() {
+		It("[test_id:6258]should reject combining deprecated and new cert rotation parameters", Labels{"test_id:6258"}, func() {
 			kv := copyOriginalKv()
 			certConfig.CAOverlapInterval = &metav1.Duration{Duration: 8 * time.Hour}
 			patchKvCertConfigExpectError(kv.Name, certConfig)
 		})
 
-		It("[test_id:6259]should reject CA expires before rotation", func() {
+		It("[test_id:6259]should reject CA expires before rotation", Labels{"test_id:6259"}, func() {
 			kv := copyOriginalKv()
 			certConfig.CA.Duration = &metav1.Duration{Duration: 14 * time.Hour}
 			patchKvCertConfigExpectError(kv.Name, certConfig)
 		})
 
-		It("[test_id:6260]should reject Cert expires before rotation", func() {
+		It("[test_id:6260]should reject Cert expires before rotation", Labels{"test_id:6260"}, func() {
 			kv := copyOriginalKv()
 			certConfig.Server.Duration = &metav1.Duration{Duration: 8 * time.Hour}
 			patchKvCertConfigExpectError(kv.Name, certConfig)
 		})
 
-		It("[test_id:6261]should reject Cert rotates after CA expires", func() {
+		It("[test_id:6261]should reject Cert rotates after CA expires", Labels{"test_id:6261"}, func() {
 			kv := copyOriginalKv()
 			certConfig.Server.Duration = &metav1.Duration{Duration: 48 * time.Hour}
 			certConfig.Server.RenewBefore = &metav1.Duration{Duration: 36 * time.Hour}

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -87,18 +87,18 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			When("paused via virtctl", func() {
 				It("[test_id:3079]should signal paused state with condition", Labels{"test_id:3079"}, func() {
 					runVMI()
-				    command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 				})
 
 				It("[test_id:3080]should signal unpaused state with removed condition", Labels{"test_id:3080"}, func() {
 					runVMI()
-				    command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-				    command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 				})
@@ -110,12 +110,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					for i := 0; i < 3; i++ {
 						By("Pausing VMI")
-					    command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+						command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 						Expect(command()).To(Succeed())
 						tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
 						By("Unpausing VMI")
-					    command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+						command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 						Expect(command()).To(Succeed())
 						tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 					}
@@ -144,7 +144,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						tests.RunVMIAndExpectLaunch(vmi, 90)
 
 						By("Pausing it")
-					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+						command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 						err := command()
 						Expect(err.Error()).To(ContainSubstring("Pausing VMIs with LivenessProbe is currently not supported"))
 					})
@@ -154,7 +154,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			When("paused via virtctl with --dry-run flag", func() {
 				It("[test_id:7671]should not paused", Labels{"test_id:7671"}, func() {
 					runVMI()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--dry-run", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--dry-run", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					By(fmt.Sprintf("Checking that VMI remains running"))
 					Consistently(func() bool {
@@ -173,11 +173,11 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			When("unpaused via virtctl with --dry-run flag", func() {
 				It("[test_id:7672]should not unpaused", Labels{"test_id:7672"}, func() {
 					runVMI()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--dry-run", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--dry-run", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 
 					By(fmt.Sprintf("Checking that VMI remains paused"))
@@ -242,55 +242,55 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				It("[test_id:3059]should signal paused state with condition", Labels{"test_id:3059"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 				})
 
 				It("[test_id:3081]should gracefully handle pausing the VM again", Labels{"test_id:3081"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					err := command()
 					Expect(err.Error()).To(ContainSubstring("VMI is already paused"))
 				})
 
 				It("[test_id:3088]should gracefully handle pausing the VMI again", Labels{"test_id:3088"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vm.Name)
 					err := command()
 					Expect(err.Error()).To(ContainSubstring("VMI is already paused"))
 				})
 
 				It("[test_id:3060]should signal unpaused state with removed condition", Labels{"test_id:3060"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMConditionRemovedOrFalse(virtClient, vm, v1.VirtualMachinePaused, 30)
 				})
 
 				It("[test_id:3082]should gracefully handle unpausing again", Labels{"test_id:3082"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMConditionRemovedOrFalse(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					err := command()
 					Expect(err.Error()).To(ContainSubstring("VMI is not paused"))
 				})
@@ -300,12 +300,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					runVM()
 
 					By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
 					By("Stopping the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 
 					By("Checking deletion of VMI")
@@ -332,12 +332,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					runVM()
 
 					By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
 					By("Starting the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", util.NamespaceTestDefault, vm.Name)
 					err = command()
 					Expect(err.Error()).To(ContainSubstring("VM is already running"))
 
@@ -353,12 +353,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					oldId := vmi.UID
 
 					By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
 					By("Restarting the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 
 					By("Checking deletion of VMI")
@@ -392,12 +392,12 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					runVM()
 
 					By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
 					By("Trying to migrate the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("migrate", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("migrate", "--namespace", util.NamespaceTestDefault, vm.Name)
 					err = command()
 					Expect(err.Error()).To(ContainSubstring("VM is paused"))
 
@@ -408,7 +408,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					runVM()
 
 					By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
@@ -422,7 +422,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					runVM()
 
 					By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
@@ -436,7 +436,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			When("paused via virtctl with --dry-run flag", func() {
 				It("[test_id:7673]should not paused", Labels{"test_id:7673"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--dry-run", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--dry-run", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					By(fmt.Sprintf("Checking that VM remains running"))
 					Consistently(func() bool {
@@ -455,11 +455,11 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			When("unpaused via virtctl with --dry-run flag", func() {
 				It("[test_id:7674]should not unpaused", Labels{"test_id:7674"}, func() {
 					runVM()
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
-				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--dry-run", "--namespace", util.NamespaceTestDefault, vm.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--dry-run", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 
 					By(fmt.Sprintf("Checking that VM remains paused"))
@@ -515,13 +515,13 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			It("[test_id:3090]should be less than uptime difference after pause", Labels{"test_id:3090"}, func() {
 				By("Pausing the VMI")
-			command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed(), "should successfully pause the vmi")
 				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 				time.Sleep(10 * time.Second) // sleep to increase uptime diff
 
 				By("Unpausing the VMI")
-			command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed(), "should successfully unpause tthe vmi")
 				tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -48,7 +48,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Pausing",
-	Labels{"rfe_id:3064", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:3064", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error
@@ -71,7 +71,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}
 
 			When("paused via API", func() {
-				It("[test_id:4597]should signal paused state with condition", Labels{"test_id:4597"}, func() {
+				It("[test_id:4597]should signal paused state with condition", Label("test_id:4597"), func() {
 					runVMI()
 
 					err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
@@ -85,14 +85,14 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("paused via virtctl", func() {
-				It("[test_id:3079]should signal paused state with condition", Labels{"test_id:3079"}, func() {
+				It("[test_id:3079]should signal paused state with condition", Label("test_id:3079"), func() {
 					runVMI()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 				})
 
-				It("[test_id:3080]should signal unpaused state with removed condition", Labels{"test_id:3080"}, func() {
+				It("[test_id:3080]should signal unpaused state with removed condition", Label("test_id:3080"), func() {
 					runVMI()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
@@ -105,7 +105,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("paused via virtctl multiple times", func() {
-				It("[test_id:3225]should signal unpaused state with removed condition at the end", Labels{"test_id:3225"}, func() {
+				It("[test_id:3225]should signal unpaused state with removed condition at the end", Label("test_id:3225"), func() {
 					runVMI()
 
 					for i := 0; i < 3; i++ {
@@ -124,7 +124,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			Context("with a LivenessProbe configured", func() {
 				When("paused via virtctl", func() {
-					It("[test_id:3224]should not be paused", Labels{"test_id:3224"}, func() {
+					It("[test_id:3224]should not be paused", Label("test_id:3224"), func() {
 						By("Launching a VMI with LivenessProbe")
 						vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 						// a random probe which will not fail immediately
@@ -152,7 +152,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("paused via virtctl with --dry-run flag", func() {
-				It("[test_id:7671]should not paused", Labels{"test_id:7671"}, func() {
+				It("[test_id:7671]should not paused", Label("test_id:7671"), func() {
 					runVMI()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--dry-run", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
@@ -171,7 +171,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("unpaused via virtctl with --dry-run flag", func() {
-				It("[test_id:7672]should not unpaused", Labels{"test_id:7672"}, func() {
+				It("[test_id:7672]should not unpaused", Label("test_id:7672"), func() {
 					runVMI()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
@@ -223,7 +223,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}
 
 			When("paused via API", func() {
-				It("[test_id:4598]should signal paused state with condition", Labels{"test_id:4598"}, func() {
+				It("[test_id:4598]should signal paused state with condition", Label("test_id:4598"), func() {
 
 					runVM()
 
@@ -240,14 +240,14 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			When("paused via virtctl", func() {
 
-				It("[test_id:3059]should signal paused state with condition", Labels{"test_id:3059"}, func() {
+				It("[test_id:3059]should signal paused state with condition", Label("test_id:3059"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 				})
 
-				It("[test_id:3081]should gracefully handle pausing the VM again", Labels{"test_id:3081"}, func() {
+				It("[test_id:3081]should gracefully handle pausing the VM again", Label("test_id:3081"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
@@ -258,7 +258,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err.Error()).To(ContainSubstring("VMI is already paused"))
 				})
 
-				It("[test_id:3088]should gracefully handle pausing the VMI again", Labels{"test_id:3088"}, func() {
+				It("[test_id:3088]should gracefully handle pausing the VMI again", Label("test_id:3088"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
@@ -269,7 +269,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err.Error()).To(ContainSubstring("VMI is already paused"))
 				})
 
-				It("[test_id:3060]should signal unpaused state with removed condition", Labels{"test_id:3060"}, func() {
+				It("[test_id:3060]should signal unpaused state with removed condition", Label("test_id:3060"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
@@ -280,7 +280,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					tests.WaitForVMConditionRemovedOrFalse(virtClient, vm, v1.VirtualMachinePaused, 30)
 				})
 
-				It("[test_id:3082]should gracefully handle unpausing again", Labels{"test_id:3082"}, func() {
+				It("[test_id:3082]should gracefully handle unpausing again", Label("test_id:3082"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
@@ -295,7 +295,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err.Error()).To(ContainSubstring("VMI is not paused"))
 				})
 
-				It("[test_id:3085]should be stopped successfully", Labels{"test_id:3085"}, func() {
+				It("[test_id:3085]should be stopped successfully", Label("test_id:3085"), func() {
 
 					runVM()
 
@@ -327,7 +327,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				})
 
-				It("[test_id:3229]should gracefully handle being started again", Labels{"test_id:3229"}, func() {
+				It("[test_id:3229]should gracefully handle being started again", Label("test_id:3229"), func() {
 
 					runVM()
 
@@ -343,7 +343,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				})
 
-				It("[test_id:3226]should be restarted successfully into unpaused state", Labels{"test_id:3226"}, func() {
+				It("[test_id:3226]should be restarted successfully into unpaused state", Label("test_id:3226"), func() {
 
 					runVM()
 
@@ -387,7 +387,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				})
 
-				It("[test_id:3086]should not be migrated", Labels{"test_id:3086"}, func() {
+				It("[test_id:3086]should not be migrated", Label("test_id:3086"), func() {
 
 					runVM()
 
@@ -403,7 +403,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				})
 
-				It("[test_id:3083]should connect to serial console", Labels{"test_id:3083"}, func() {
+				It("[test_id:3083]should connect to serial console", Label("test_id:3083"), func() {
 
 					runVM()
 
@@ -417,7 +417,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("[test_id:3084]should connect to vnc console", Labels{"test_id:3084"}, func() {
+				It("[test_id:3084]should connect to vnc console", Label("test_id:3084"), func() {
 
 					runVM()
 
@@ -434,7 +434,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("paused via virtctl with --dry-run flag", func() {
-				It("[test_id:7673]should not paused", Labels{"test_id:7673"}, func() {
+				It("[test_id:7673]should not paused", Label("test_id:7673"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--dry-run", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
@@ -453,7 +453,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			When("unpaused via virtctl with --dry-run flag", func() {
-				It("[test_id:7674]should not unpaused", Labels{"test_id:7674"}, func() {
+				It("[test_id:7674]should not unpaused", Label("test_id:7674"), func() {
 					runVM()
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", util.NamespaceTestDefault, vm.Name)
 					Expect(command()).To(Succeed())
@@ -513,7 +513,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				uptimeDiffBeforePausing = hostUptime() - grepGuestUptime(vmi)
 			})
 
-			It("[test_id:3090]should be less than uptime difference after pause", Labels{"test_id:3090"}, func() {
+			It("[test_id:3090]should be less than uptime difference after pause", Label("test_id:3090"), func() {
 				By("Pausing the VMI")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed(), "should successfully pause the vmi")

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -43,7 +43,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[sig-compute]VirtualMachinePool", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]VirtualMachinePool", Label("sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -127,15 +127,15 @@ var _ = Describe("[sig-compute]VirtualMachinePool", Labels{"sig-compute"}, func(
 		return createVirtualMachinePool(newPoolFromVMI(libvmi.NewCirros()))
 	}
 
-	DescribeTable("[Serial]pool should scale", Labels{"Serial"}, func(startScale int, stopScale int) {
+	DescribeTable("[Serial]pool should scale", Label("Serial"), func(startScale int, stopScale int) {
 		newPool := newVirtualMachinePool()
 		doScale(newPool.ObjectMeta.Name, int32(startScale))
 		doScale(newPool.ObjectMeta.Name, int32(stopScale))
 		doScale(newPool.ObjectMeta.Name, int32(0))
 
 	},
-		Entry("[QUARANTINE]to three, to two and then to zero replicas", Labels{"QUARANTINE"}, 3, 2),
-		Entry("[QUARANTINE]to five, to six and then to zero replicas", Labels{"QUARANTINE"}, 5, 6),
+		Entry("[QUARANTINE]to three, to two and then to zero replicas", Label("QUARANTINE"), 3, 2),
+		Entry("[QUARANTINE]to five, to six and then to zero replicas", Label("QUARANTINE"), 5, 6),
 	)
 
 	It("should be rejected on POST if spec is invalid", func() {

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -43,7 +43,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[sig-compute]VirtualMachinePool", func() {
+var _ = Describe("[sig-compute]VirtualMachinePool", Labels{"sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -127,15 +127,15 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		return createVirtualMachinePool(newPoolFromVMI(libvmi.NewCirros()))
 	}
 
-	DescribeTable("[Serial]pool should scale", func(startScale int, stopScale int) {
+	DescribeTable("[Serial]pool should scale", Labels{"Serial"}, func(startScale int, stopScale int) {
 		newPool := newVirtualMachinePool()
 		doScale(newPool.ObjectMeta.Name, int32(startScale))
 		doScale(newPool.ObjectMeta.Name, int32(stopScale))
 		doScale(newPool.ObjectMeta.Name, int32(0))
 
 	},
-		Entry("[QUARANTINE]to three, to two and then to zero replicas", 3, 2),
-		Entry("[QUARANTINE]to five, to six and then to zero replicas", 5, 6),
+		Entry("[QUARANTINE]to three, to two and then to zero replicas", Labels{"QUARANTINE"}, 3, 2),
+		Entry("[QUARANTINE]to five, to six and then to zero replicas", Labels{"QUARANTINE"}, 5, 6),
 	)
 
 	It("should be rejected on POST if spec is invalid", func() {

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute]PortForward", func() {
+var _ = Describe("[sig-compute]PortForward", Labels{"sig-compute"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute]PortForward", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]PortForward", Label("sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -61,7 +61,7 @@ func byConfiguringTheVMIForRealtime(vmi *v1.VirtualMachineInstance, realtimeMask
 	}
 }
 
-var _ = Describe("[sig-compute-realtime][Serial]Realtime", Labels{"sig-compute-realtime", "Serial"}, func() {
+var _ = Describe("[sig-compute-realtime][Serial]Realtime", Label("sig-compute-realtime", "Serial"), func() {
 
 	var (
 		vmi        *v1.VirtualMachineInstance

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -1,24 +1,24 @@
 package realtime
 
 import (
-	"strconv"
-	"strings"
+    "strconv"
+    "strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+    k8sv1 "k8s.io/api/core/v1"
+    "k8s.io/apimachinery/pkg/api/resource"
 
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/util"
+    v1 "kubevirt.io/api/core/v1"
+    "kubevirt.io/client-go/kubecli"
+    virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+    "kubevirt.io/kubevirt/tests"
+    "kubevirt.io/kubevirt/tests/console"
+    cd "kubevirt.io/kubevirt/tests/containerdisk"
+    "kubevirt.io/kubevirt/tests/framework/checks"
+    "kubevirt.io/kubevirt/tests/util"
 )
 
 const tuneAdminRealtimeCloudInitData = `#cloud-config
@@ -29,141 +29,141 @@ bootcmd:
 `
 
 var (
-	memoryRequest = resource.MustParse("512Mi")
+    memoryRequest = resource.MustParse("512Mi")
 )
 
 func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.KubevirtClient) {
-	By("Starting a VirtualMachineInstance")
-	var err error
-	vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-	Expect(err).ToNot(HaveOccurred())
-	tests.WaitForSuccessfulVMIStart(vmi)
+    By("Starting a VirtualMachineInstance")
+    var err error
+    vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+    Expect(err).ToNot(HaveOccurred())
+    tests.WaitForSuccessfulVMIStart(vmi)
 }
 
 func byConfiguringTheVMIForRealtime(vmi *v1.VirtualMachineInstance, realtimeMask string) {
-	vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
-		k8sv1.ResourceMemory: memoryRequest,
-		k8sv1.ResourceCPU:    resource.MustParse("2"),
-	}
-	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-		k8sv1.ResourceMemory: memoryRequest,
-		k8sv1.ResourceCPU:    resource.MustParse("2"),
-	}
-	vmi.Spec.Domain.CPU = &v1.CPU{
-		Model:                 "host-passthrough",
-		DedicatedCPUPlacement: true,
-		Realtime:              &v1.Realtime{Mask: realtimeMask},
-		NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
-	}
-	vmi.Spec.Domain.Memory = &v1.Memory{
-		Hugepages: &v1.Hugepages{PageSize: "2Mi"},
-		Guest:     &memoryRequest,
-	}
+    vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+        k8sv1.ResourceMemory: memoryRequest,
+        k8sv1.ResourceCPU:    resource.MustParse("2"),
+    }
+    vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+        k8sv1.ResourceMemory: memoryRequest,
+        k8sv1.ResourceCPU:    resource.MustParse("2"),
+    }
+    vmi.Spec.Domain.CPU = &v1.CPU{
+        Model:                 "host-passthrough",
+        DedicatedCPUPlacement: true,
+        Realtime:              &v1.Realtime{Mask: realtimeMask},
+        NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
+    }
+    vmi.Spec.Domain.Memory = &v1.Memory{
+        Hugepages: &v1.Hugepages{PageSize: "2Mi"},
+        Guest:     &memoryRequest,
+    }
 }
 
-var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
+var _ = Describe("[sig-compute-realtime][Serial]Realtime", Labels{"sig-compute-realtime", "Serial"}, func() {
 
-	var (
-		vmi        *v1.VirtualMachineInstance
-		virtClient kubecli.KubevirtClient
-	)
+    var (
+        vmi        *v1.VirtualMachineInstance
+        virtClient kubecli.KubevirtClient
+    )
 
-	BeforeEach(func() {
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
-		checks.SkipTestIfNoFeatureGate(virtconfig.CPUManager)
-		checks.SkipTestIfNotRealtimeCapable()
-		tests.BeforeTestCleanup()
+    BeforeEach(func() {
+        var err error
+        virtClient, err = kubecli.GetKubevirtClient()
+        Expect(err).ToNot(HaveOccurred())
+        checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
+        checks.SkipTestIfNoFeatureGate(virtconfig.CPUManager)
+        checks.SkipTestIfNotRealtimeCapable()
+        tests.BeforeTestCleanup()
 
-	})
+    })
 
-	It("should start the realtime VM when no mask is specified", func() {
-		vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
-		byConfiguringTheVMIForRealtime(vmi, "")
-		byStartingTheVMI(vmi, virtClient)
-		By("Validating VCPU scheduler placement information")
-		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-		psOutput, err := tests.ExecuteCommandOnPod(
-			virtClient,
-			pod,
-			"compute",
-			[]string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
-		Expect(slice).To(HaveLen(2))
-		for _, l := range slice {
-			Expect(parsePriority(l)).To(BeEquivalentTo(1))
-		}
-		By("Validating that the memory lock limits are higher than the memory requested")
-		psOutput, err = tests.ExecuteCommandOnPod(
-			virtClient,
-			pod,
-			"compute",
-			[]string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -u qemu -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		limits := strings.Split(strings.TrimSpace(psOutput), " ")
-		softLimit, err := strconv.ParseInt(limits[0], 10, 64)
-		Expect(err).ToNot(HaveOccurred())
-		hardLimit, err := strconv.ParseInt(limits[1], 10, 64)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(softLimit).To(Equal(hardLimit))
-		requested, canConvert := memoryRequest.AsInt64()
-		Expect(canConvert).To(BeTrue())
-		Expect(hardLimit).To(BeNumerically(">", requested))
-		By("checking if the guest is still running")
-		vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmi.Status.Phase).To(Equal(v1.Running))
-		Expect(console.LoginToFedora(vmi)).To(Succeed())
-	})
+    It("should start the realtime VM when no mask is specified", func() {
+        vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
+        byConfiguringTheVMIForRealtime(vmi, "")
+        byStartingTheVMI(vmi, virtClient)
+        By("Validating VCPU scheduler placement information")
+        pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+        psOutput, err := tests.ExecuteCommandOnPod(
+            virtClient,
+            pod,
+            "compute",
+            []string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+        )
+        Expect(err).ToNot(HaveOccurred())
+        slice := strings.Split(strings.TrimSpace(psOutput), "\n")
+        Expect(slice).To(HaveLen(2))
+        for _, l := range slice {
+            Expect(parsePriority(l)).To(BeEquivalentTo(1))
+        }
+        By("Validating that the memory lock limits are higher than the memory requested")
+        psOutput, err = tests.ExecuteCommandOnPod(
+            virtClient,
+            pod,
+            "compute",
+            []string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -u qemu -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
+        )
+        Expect(err).ToNot(HaveOccurred())
+        limits := strings.Split(strings.TrimSpace(psOutput), " ")
+        softLimit, err := strconv.ParseInt(limits[0], 10, 64)
+        Expect(err).ToNot(HaveOccurred())
+        hardLimit, err := strconv.ParseInt(limits[1], 10, 64)
+        Expect(err).ToNot(HaveOccurred())
+        Expect(softLimit).To(Equal(hardLimit))
+        requested, canConvert := memoryRequest.AsInt64()
+        Expect(canConvert).To(BeTrue())
+        Expect(hardLimit).To(BeNumerically(">", requested))
+        By("checking if the guest is still running")
+        vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
+        Expect(err).ToNot(HaveOccurred())
+        Expect(vmi.Status.Phase).To(Equal(v1.Running))
+        Expect(console.LoginToFedora(vmi)).To(Succeed())
+    })
 
-	It("should start the realtime VM when realtime mask is specified", func() {
-		vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
-		byConfiguringTheVMIForRealtime(vmi, "0-1,^1")
-		byStartingTheVMI(vmi, virtClient)
-		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-		By("Validating VCPU scheduler placement information")
-		psOutput, err := tests.ExecuteCommandOnPod(
-			virtClient,
-			pod,
-			"compute",
-			[]string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
-		Expect(slice).To(HaveLen(1))
-		Expect(parsePriority(slice[0])).To(BeEquivalentTo(1))
+    It("should start the realtime VM when realtime mask is specified", func() {
+        vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
+        byConfiguringTheVMIForRealtime(vmi, "0-1,^1")
+        byStartingTheVMI(vmi, virtClient)
+        pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+        By("Validating VCPU scheduler placement information")
+        psOutput, err := tests.ExecuteCommandOnPod(
+            virtClient,
+            pod,
+            "compute",
+            []string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+        )
+        Expect(err).ToNot(HaveOccurred())
+        slice := strings.Split(strings.TrimSpace(psOutput), "\n")
+        Expect(slice).To(HaveLen(1))
+        Expect(parsePriority(slice[0])).To(BeEquivalentTo(1))
 
-		By("Validating the VCPU mask matches the scheduler profile for all cores")
-		psOutput, err = tests.ExecuteCommandOnPod(
-			virtClient,
-			pod,
-			"compute",
-			[]string{tests.BinBash, "-c", "ps -cT -u qemu  |grep -i cpu |awk '{print $3\" \" $8}'"},
-		)
-		Expect(err).ToNot(HaveOccurred())
-		slice = strings.Split(strings.TrimSpace(psOutput), "\n")
-		Expect(slice).To(HaveLen(2))
-		Expect(slice[0]).To(Equal("FF 0/KVM"))
-		Expect(slice[1]).To(Equal("TS 1/KVM"))
+        By("Validating the VCPU mask matches the scheduler profile for all cores")
+        psOutput, err = tests.ExecuteCommandOnPod(
+            virtClient,
+            pod,
+            "compute",
+            []string{tests.BinBash, "-c", "ps -cT -u qemu  |grep -i cpu |awk '{print $3\" \" $8}'"},
+        )
+        Expect(err).ToNot(HaveOccurred())
+        slice = strings.Split(strings.TrimSpace(psOutput), "\n")
+        Expect(slice).To(HaveLen(2))
+        Expect(slice[0]).To(Equal("FF 0/KVM"))
+        Expect(slice[1]).To(Equal("TS 1/KVM"))
 
-		By("checking if the guest is still running")
-		vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmi.Status.Phase).To(Equal(v1.Running))
-		Expect(console.LoginToFedora(vmi)).To(Succeed())
-	})
+        By("checking if the guest is still running")
+        vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
+        Expect(err).ToNot(HaveOccurred())
+        Expect(vmi.Status.Phase).To(Equal(v1.Running))
+        Expect(console.LoginToFedora(vmi)).To(Succeed())
+    })
 
 })
 
 func parsePriority(psLine string) int64 {
-	s := strings.Split(psLine, " ")
-	Expect(s).To(HaveLen(1))
-	prio, err := strconv.ParseInt(s[0], 10, 8)
-	Expect(err).NotTo(HaveOccurred())
-	return prio
+    s := strings.Split(psLine, " ")
+    Expect(s).To(HaveLen(1))
+    prio, err := strconv.ParseInt(s[0], 10, 8)
+    Expect(err).NotTo(HaveOccurred())
+    return prio
 }

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -1,24 +1,24 @@
 package realtime
 
 import (
-    "strconv"
-    "strings"
+	"strconv"
+	"strings"
 
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
-    k8sv1 "k8s.io/api/core/v1"
-    "k8s.io/apimachinery/pkg/api/resource"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
-    k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-    v1 "kubevirt.io/api/core/v1"
-    "kubevirt.io/client-go/kubecli"
-    virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-    "kubevirt.io/kubevirt/tests"
-    "kubevirt.io/kubevirt/tests/console"
-    cd "kubevirt.io/kubevirt/tests/containerdisk"
-    "kubevirt.io/kubevirt/tests/framework/checks"
-    "kubevirt.io/kubevirt/tests/util"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 const tuneAdminRealtimeCloudInitData = `#cloud-config
@@ -29,141 +29,141 @@ bootcmd:
 `
 
 var (
-    memoryRequest = resource.MustParse("512Mi")
+	memoryRequest = resource.MustParse("512Mi")
 )
 
 func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.KubevirtClient) {
-    By("Starting a VirtualMachineInstance")
-    var err error
-    vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-    Expect(err).ToNot(HaveOccurred())
-    tests.WaitForSuccessfulVMIStart(vmi)
+	By("Starting a VirtualMachineInstance")
+	var err error
+	vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+	Expect(err).ToNot(HaveOccurred())
+	tests.WaitForSuccessfulVMIStart(vmi)
 }
 
 func byConfiguringTheVMIForRealtime(vmi *v1.VirtualMachineInstance, realtimeMask string) {
-    vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
-        k8sv1.ResourceMemory: memoryRequest,
-        k8sv1.ResourceCPU:    resource.MustParse("2"),
-    }
-    vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-        k8sv1.ResourceMemory: memoryRequest,
-        k8sv1.ResourceCPU:    resource.MustParse("2"),
-    }
-    vmi.Spec.Domain.CPU = &v1.CPU{
-        Model:                 "host-passthrough",
-        DedicatedCPUPlacement: true,
-        Realtime:              &v1.Realtime{Mask: realtimeMask},
-        NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
-    }
-    vmi.Spec.Domain.Memory = &v1.Memory{
-        Hugepages: &v1.Hugepages{PageSize: "2Mi"},
-        Guest:     &memoryRequest,
-    }
+	vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: memoryRequest,
+		k8sv1.ResourceCPU:    resource.MustParse("2"),
+	}
+	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: memoryRequest,
+		k8sv1.ResourceCPU:    resource.MustParse("2"),
+	}
+	vmi.Spec.Domain.CPU = &v1.CPU{
+		Model:                 "host-passthrough",
+		DedicatedCPUPlacement: true,
+		Realtime:              &v1.Realtime{Mask: realtimeMask},
+		NUMA:                  &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}},
+	}
+	vmi.Spec.Domain.Memory = &v1.Memory{
+		Hugepages: &v1.Hugepages{PageSize: "2Mi"},
+		Guest:     &memoryRequest,
+	}
 }
 
 var _ = Describe("[sig-compute-realtime][Serial]Realtime", Labels{"sig-compute-realtime", "Serial"}, func() {
 
-    var (
-        vmi        *v1.VirtualMachineInstance
-        virtClient kubecli.KubevirtClient
-    )
+	var (
+		vmi        *v1.VirtualMachineInstance
+		virtClient kubecli.KubevirtClient
+	)
 
-    BeforeEach(func() {
-        var err error
-        virtClient, err = kubecli.GetKubevirtClient()
-        Expect(err).ToNot(HaveOccurred())
-        checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
-        checks.SkipTestIfNoFeatureGate(virtconfig.CPUManager)
-        checks.SkipTestIfNotRealtimeCapable()
-        tests.BeforeTestCleanup()
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
+		checks.SkipTestIfNoFeatureGate(virtconfig.CPUManager)
+		checks.SkipTestIfNotRealtimeCapable()
+		tests.BeforeTestCleanup()
 
-    })
+	})
 
-    It("should start the realtime VM when no mask is specified", func() {
-        vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
-        byConfiguringTheVMIForRealtime(vmi, "")
-        byStartingTheVMI(vmi, virtClient)
-        By("Validating VCPU scheduler placement information")
-        pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-        psOutput, err := tests.ExecuteCommandOnPod(
-            virtClient,
-            pod,
-            "compute",
-            []string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
-        )
-        Expect(err).ToNot(HaveOccurred())
-        slice := strings.Split(strings.TrimSpace(psOutput), "\n")
-        Expect(slice).To(HaveLen(2))
-        for _, l := range slice {
-            Expect(parsePriority(l)).To(BeEquivalentTo(1))
-        }
-        By("Validating that the memory lock limits are higher than the memory requested")
-        psOutput, err = tests.ExecuteCommandOnPod(
-            virtClient,
-            pod,
-            "compute",
-            []string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -u qemu -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
-        )
-        Expect(err).ToNot(HaveOccurred())
-        limits := strings.Split(strings.TrimSpace(psOutput), " ")
-        softLimit, err := strconv.ParseInt(limits[0], 10, 64)
-        Expect(err).ToNot(HaveOccurred())
-        hardLimit, err := strconv.ParseInt(limits[1], 10, 64)
-        Expect(err).ToNot(HaveOccurred())
-        Expect(softLimit).To(Equal(hardLimit))
-        requested, canConvert := memoryRequest.AsInt64()
-        Expect(canConvert).To(BeTrue())
-        Expect(hardLimit).To(BeNumerically(">", requested))
-        By("checking if the guest is still running")
-        vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
-        Expect(err).ToNot(HaveOccurred())
-        Expect(vmi.Status.Phase).To(Equal(v1.Running))
-        Expect(console.LoginToFedora(vmi)).To(Succeed())
-    })
+	It("should start the realtime VM when no mask is specified", func() {
+		vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
+		byConfiguringTheVMIForRealtime(vmi, "")
+		byStartingTheVMI(vmi, virtClient)
+		By("Validating VCPU scheduler placement information")
+		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+		psOutput, err := tests.ExecuteCommandOnPod(
+			virtClient,
+			pod,
+			"compute",
+			[]string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
+		Expect(slice).To(HaveLen(2))
+		for _, l := range slice {
+			Expect(parsePriority(l)).To(BeEquivalentTo(1))
+		}
+		By("Validating that the memory lock limits are higher than the memory requested")
+		psOutput, err = tests.ExecuteCommandOnPod(
+			virtClient,
+			pod,
+			"compute",
+			[]string{tests.BinBash, "-c", "grep 'locked memory' /proc/$(ps -u qemu -o pid --noheader|xargs)/limits |tr -s ' '| awk '{print $4\" \"$5}'"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		limits := strings.Split(strings.TrimSpace(psOutput), " ")
+		softLimit, err := strconv.ParseInt(limits[0], 10, 64)
+		Expect(err).ToNot(HaveOccurred())
+		hardLimit, err := strconv.ParseInt(limits[1], 10, 64)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(softLimit).To(Equal(hardLimit))
+		requested, canConvert := memoryRequest.AsInt64()
+		Expect(canConvert).To(BeTrue())
+		Expect(hardLimit).To(BeNumerically(">", requested))
+		By("checking if the guest is still running")
+		vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi.Status.Phase).To(Equal(v1.Running))
+		Expect(console.LoginToFedora(vmi)).To(Succeed())
+	})
 
-    It("should start the realtime VM when realtime mask is specified", func() {
-        vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
-        byConfiguringTheVMIForRealtime(vmi, "0-1,^1")
-        byStartingTheVMI(vmi, virtClient)
-        pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-        By("Validating VCPU scheduler placement information")
-        psOutput, err := tests.ExecuteCommandOnPod(
-            virtClient,
-            pod,
-            "compute",
-            []string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
-        )
-        Expect(err).ToNot(HaveOccurred())
-        slice := strings.Split(strings.TrimSpace(psOutput), "\n")
-        Expect(slice).To(HaveLen(1))
-        Expect(parsePriority(slice[0])).To(BeEquivalentTo(1))
+	It("should start the realtime VM when realtime mask is specified", func() {
+		vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraRealtime), tuneAdminRealtimeCloudInitData)
+		byConfiguringTheVMIForRealtime(vmi, "0-1,^1")
+		byStartingTheVMI(vmi, virtClient)
+		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+		By("Validating VCPU scheduler placement information")
+		psOutput, err := tests.ExecuteCommandOnPod(
+			virtClient,
+			pod,
+			"compute",
+			[]string{tests.BinBash, "-c", "ps -u qemu -L -o policy,rtprio,psr|grep FF| awk '{print $2}'"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		slice := strings.Split(strings.TrimSpace(psOutput), "\n")
+		Expect(slice).To(HaveLen(1))
+		Expect(parsePriority(slice[0])).To(BeEquivalentTo(1))
 
-        By("Validating the VCPU mask matches the scheduler profile for all cores")
-        psOutput, err = tests.ExecuteCommandOnPod(
-            virtClient,
-            pod,
-            "compute",
-            []string{tests.BinBash, "-c", "ps -cT -u qemu  |grep -i cpu |awk '{print $3\" \" $8}'"},
-        )
-        Expect(err).ToNot(HaveOccurred())
-        slice = strings.Split(strings.TrimSpace(psOutput), "\n")
-        Expect(slice).To(HaveLen(2))
-        Expect(slice[0]).To(Equal("FF 0/KVM"))
-        Expect(slice[1]).To(Equal("TS 1/KVM"))
+		By("Validating the VCPU mask matches the scheduler profile for all cores")
+		psOutput, err = tests.ExecuteCommandOnPod(
+			virtClient,
+			pod,
+			"compute",
+			[]string{tests.BinBash, "-c", "ps -cT -u qemu  |grep -i cpu |awk '{print $3\" \" $8}'"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		slice = strings.Split(strings.TrimSpace(psOutput), "\n")
+		Expect(slice).To(HaveLen(2))
+		Expect(slice[0]).To(Equal("FF 0/KVM"))
+		Expect(slice[1]).To(Equal("TS 1/KVM"))
 
-        By("checking if the guest is still running")
-        vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
-        Expect(err).ToNot(HaveOccurred())
-        Expect(vmi.Status.Phase).To(Equal(v1.Running))
-        Expect(console.LoginToFedora(vmi)).To(Succeed())
-    })
+		By("checking if the guest is still running")
+		vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &k8smetav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi.Status.Phase).To(Equal(v1.Running))
+		Expect(console.LoginToFedora(vmi)).To(Succeed())
+	})
 
 })
 
 func parsePriority(psLine string) int64 {
-    s := strings.Split(psLine, " ")
-    Expect(s).To(HaveLen(1))
-    prio, err := strconv.ParseInt(s[0], 10, 8)
-    Expect(err).NotTo(HaveOccurred())
-    return prio
+	s := strings.Split(psLine, " ")
+	Expect(s).To(HaveLen(1))
+	prio, err := strconv.ParseInt(s[0], 10, 8)
+	Expect(err).NotTo(HaveOccurred())
+	return prio
 }

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -411,7 +411,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			vmis, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmis.Items).Should(HaveLen(2))
-	})
+		})
 
 		It("should replace a VMI immediately when a virt-launcher pod gets deleted", func() {
 			By("Creating new replica set")
@@ -475,7 +475,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			newRS := newReplicaSet()
 			doScale(newRS.ObjectMeta.Name, 2)
 
-		    result, _, _ := clientcmd.RunCommand(k8sClient, "get", "virtualmachineinstancereplicaset")
+			result, _, _ := clientcmd.RunCommand(k8sClient, "get", "virtualmachineinstancereplicaset")
 			Expect(result).ToNot(BeNil())
 			resultFields := strings.Fields(result)
 			expectedHeader := []string{"NAME", "DESIRED", "CURRENT", "READY", "AGE"}

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -50,431 +50,439 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachineInstanceReplicaSet", func() {
-	var err error
-	var virtClient kubecli.KubevirtClient
+var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachineInstanceReplicaSet",
+	Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	func() {
+		var err error
+		var virtClient kubecli.KubevirtClient
 
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
-	})
-
-	doScale := func(name string, scale int32) {
-
-		By(fmt.Sprintf("Scaling to %d", scale))
-		rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Patch(name, types.JSONPatchType, []byte(fmt.Sprintf("[{ \"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": %v }]", scale)))
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking the number of replicas")
-		Eventually(func() int32 {
-			rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return rs.Status.Replicas
-		}, 90*time.Second, time.Second).Should(Equal(int32(scale)))
-
-		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(tests.NotDeleted(vmis)).To(HaveLen(int(scale)))
-	}
-
-	doScaleWithHPA := func(name string, min int32, max int32, expected int32) {
-
-		// Status updates can conflict with our desire to change the spec
-		By(fmt.Sprintf("Scaling to %d", min))
-		hpa := &autov1.HorizontalPodAutoscaler{
-			ObjectMeta: v12.ObjectMeta{
-				Name: name,
-			},
-			Spec: autov1.HorizontalPodAutoscalerSpec{
-				ScaleTargetRef: autov1.CrossVersionObjectReference{
-					Name:       name,
-					Kind:       v1.VirtualMachineInstanceReplicaSetGroupVersionKind.Kind,
-					APIVersion: v1.VirtualMachineInstanceReplicaSetGroupVersionKind.GroupVersion().String(),
-				},
-				MinReplicas: &min,
-				MaxReplicas: max,
-			},
-		}
-		_, err := virtClient.AutoscalingV1().HorizontalPodAutoscalers(util.NamespaceTestDefault).Create(context.Background(), hpa, v12.CreateOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		var s *autov1.Scale
-		By("Checking the number of replicas")
-		EventuallyWithOffset(1, func() int32 {
-			s, err = virtClient.ReplicaSet(util.NamespaceTestDefault).GetScale(name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return s.Status.Replicas
-		}, 90*time.Second, time.Second).Should(Equal(int32(expected)))
-
-		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		ExpectWithOffset(1, tests.NotDeleted(vmis)).To(HaveLen(int(min)))
-		err = virtClient.AutoscalingV1().HorizontalPodAutoscalers(util.NamespaceTestDefault).Delete(context.Background(), name, v12.DeleteOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	}
-
-	newReplicaSetWithTemplate := func(template *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceReplicaSet {
-		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(0))
-		newRS, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(newRS)
-		Expect(err).ToNot(HaveOccurred())
-		return newRS
-	}
-
-	newReplicaSet := func() *v1.VirtualMachineInstanceReplicaSet {
-		By("Create a new VirtualMachineInstance replica set")
-		template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-		return newReplicaSetWithTemplate(template)
-	}
-
-	DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale", func(startScale int, stopScale int) {
-		newRS := newReplicaSet()
-		doScale(newRS.ObjectMeta.Name, int32(startScale))
-		doScale(newRS.ObjectMeta.Name, int32(stopScale))
-		doScale(newRS.ObjectMeta.Name, int32(0))
-
-	},
-		Entry("[test_id:1405]to three, to two and then to zero replicas", 3, 2),
-		Entry("[test_id:1406]to five, to six and then to zero replicas", 5, 6),
-	)
-
-	DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with scale subresource", func(startScale int, stopScale int) {
-		newRS := newReplicaSet()
-		libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(startScale))
-		libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(stopScale))
-		libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(0))
-	},
-		Entry("[test_id:1407]to three, to two and then to zero replicas", 3, 2),
-		Entry("[test_id:1408]to five, to six and then to zero replicas", 5, 6),
-	)
-
-	DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with the horizontal pod autoscaler", func(startScale int, stopScale int) {
-		checks.SkipIfVersionBelow("HPA only works with CRs with multiple versions starting from 1.13", "1.13")
-		template := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(1))
-		newRS, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(newRS)
-		Expect(err).ToNot(HaveOccurred())
-		doScaleWithHPA(newRS.ObjectMeta.Name, int32(startScale), int32(startScale), int32(startScale))
-		doScaleWithHPA(newRS.ObjectMeta.Name, int32(stopScale), int32(stopScale), int32(stopScale))
-		doScaleWithHPA(newRS.ObjectMeta.Name, int32(1), int32(1), int32(1))
-
-	},
-		Entry("[test_id:1409]to three, to two and then to one replicas", 3, 2),
-		Entry("[test_id:1410]to five, to six and then to one replicas", 5, 6),
-	)
-
-	It("[test_id:1411]should be rejected on POST if spec is invalid", func() {
-		newRS := newReplicaSet()
-		newRS.TypeMeta = v12.TypeMeta{
-			APIVersion: v1.StorageGroupVersion.String(),
-			Kind:       "VirtualMachineInstanceReplicaSet",
-		}
-
-		jsonBytes, err := json.Marshal(newRS)
-		Expect(err).To(BeNil())
-
-		// change the name of a required field (like domain) so validation will fail
-		jsonString := strings.Replace(string(jsonBytes), "domain", "not-a-domain", -1)
-
-		result := virtClient.RestClient().Post().Resource("virtualmachineinstancereplicasets").Namespace(util.NamespaceTestDefault).Body([]byte(jsonString)).SetHeader("Content-Type", "application/json").Do(context.Background())
-
-		// Verify validation failed.
-		statusCode := 0
-		result.StatusCode(&statusCode)
-		Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
-
-	})
-	It("[test_id:1412]should reject POST if validation webhoook deems the spec is invalid", func() {
-		newRS := newReplicaSet()
-		newRS.TypeMeta = v12.TypeMeta{
-			APIVersion: v1.GroupVersion.String(),
-			Kind:       "VirtualMachineInstanceReplicaSet",
-		}
-
-		// Add a disk that doesn't map to a volume.
-		// This should get rejected which tells us the webhook validator is working.
-		newRS.Spec.Template.Spec.Domain.Devices.Disks = append(newRS.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: "testdisk",
+			tests.BeforeTestCleanup()
 		})
 
-		result := virtClient.RestClient().Post().Resource("virtualmachineinstancereplicasets").Namespace(util.NamespaceTestDefault).Body(newRS).Do(context.Background())
+		doScale := func(name string, scale int32) {
 
-		// Verify validation failed.
-		statusCode := 0
-		result.StatusCode(&statusCode)
-		Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
-
-		reviewResponse := &v12.Status{}
-		body, _ := result.Raw()
-		err = json.Unmarshal(body, reviewResponse)
-		Expect(err).To(BeNil())
-
-		Expect(reviewResponse.Details.Causes).To(HaveLen(1))
-		Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].name"))
-	})
-	It("[test_id:1413]should update readyReplicas once VMIs are up", func() {
-		newRS := newReplicaSet()
-		doScale(newRS.ObjectMeta.Name, 2)
-
-		By("checking the number of ready replicas in the returned yaml")
-		Eventually(func() int {
-			rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+			By(fmt.Sprintf("Scaling to %d", scale))
+			rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Patch(name, types.JSONPatchType, []byte(fmt.Sprintf("[{ \"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": %v }]", scale)))
 			Expect(err).ToNot(HaveOccurred())
-			return int(rs.Status.ReadyReplicas)
-		}, 120*time.Second, 1*time.Second).Should(Equal(2))
-	})
 
-	It("[test_id:1414]should return the correct data when using server-side printing", func() {
-		checks.SkipIfVersionBelow("server-side printing is only enabled by default from 1.11 on", "1.11")
-		newRS := newReplicaSet()
-		doScale(newRS.ObjectMeta.Name, 2)
+			By("Checking the number of replicas")
+			Eventually(func() int32 {
+				rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return rs.Status.Replicas
+			}, 90*time.Second, time.Second).Should(Equal(int32(scale)))
 
-		By("waiting until all VMIs are ready")
-		Eventually(func() int {
-			rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return int(rs.Status.ReadyReplicas)
-		}, 120*time.Second, 1*time.Second).Should(Equal(2))
-
-		By("checking the output of server-side table printing")
-		rawTable, err := virtClient.RestClient().Get().
-			RequestURI(fmt.Sprintf("/apis/kubevirt.io/%s/namespaces/%s/virtualmachineinstancereplicasets/%s", v1.ApiLatestVersion, util.NamespaceTestDefault, newRS.ObjectMeta.Name)).
-			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io, application/json").
-			DoRaw(context.Background())
-
-		Expect(err).ToNot(HaveOccurred())
-		table := &v1beta1.Table{}
-		Expect(json.Unmarshal(rawTable, table)).To(Succeed())
-		Expect(table.ColumnDefinitions[0].Name).To(Equal("Name"))
-		Expect(table.ColumnDefinitions[0].Type).To(Equal("string"))
-		Expect(table.ColumnDefinitions[1].Name).To(Equal("Desired"))
-		Expect(table.ColumnDefinitions[1].Type).To(Equal("integer"))
-		Expect(table.ColumnDefinitions[2].Name).To(Equal("Current"))
-		Expect(table.ColumnDefinitions[2].Type).To(Equal("integer"))
-		Expect(table.ColumnDefinitions[3].Name).To(Equal("Ready"))
-		Expect(table.ColumnDefinitions[3].Type).To(Equal("integer"))
-		Expect(table.ColumnDefinitions[4].Name).To(Equal("Age"))
-		Expect(table.ColumnDefinitions[4].Type).To(Equal("date"))
-		Expect(table.Rows[0].Cells[0].(string)).To(Equal(newRS.ObjectMeta.Name))
-		Expect(table.Rows[0].Cells[1]).To(BeNumerically("==", 2))
-		Expect(table.Rows[0].Cells[2]).To(BeNumerically("==", 2))
-		Expect(table.Rows[0].Cells[3]).To(BeNumerically("==", 2))
-	})
-
-	It("[test_id:1415]should remove VMIs once they are marked for deletion", func() {
-		newRS := newReplicaSet()
-		// Create a replicaset with two replicas
-		doScale(newRS.ObjectMeta.Name, 2)
-		// Delete it
-		By("Deleting the VirtualMachineInstance replica set")
-		Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Delete(newRS.ObjectMeta.Name, &v12.DeleteOptions{})).To(Succeed())
-		// Wait until VMIs are gone
-		By("Waiting until all VMIs are gone")
-		Eventually(func() int {
-			vmis, err := virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return len(vmis.Items)
-		}, 120*time.Second, 1*time.Second).Should(BeZero())
-	})
-
-	It("[test_id:1416]should remove owner references on the VirtualMachineInstance if it is orphan deleted", func() {
-		newRS := newReplicaSet()
-		// Create a replicaset with two replicas
-		doScale(newRS.ObjectMeta.Name, 2)
-
-		// Check for owner reference
-		vmis, err := virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
-		Expect(vmis.Items).To(HaveLen(2))
-		Expect(err).ToNot(HaveOccurred())
-		for _, vmi := range vmis.Items {
-			Expect(vmi.OwnerReferences).ToNot(BeEmpty())
-		}
-
-		// Delete it
-		By("Deleting the VirtualMachineInstance replica set with the 'orphan' deletion strategy")
-		orphanPolicy := v12.DeletePropagationOrphan
-		Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).
-			Delete(newRS.ObjectMeta.Name, &v12.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
-		// Wait until the replica set is deleted
-		By("Waiting until the replica set got deleted")
-		Eventually(func() bool {
-			_, err := virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
-			if errors.IsNotFound(err) {
-				return true
-			}
-			return false
-		}, 60*time.Second, 1*time.Second).Should(BeTrue())
-
-		By("Checking if two VMIs are orphaned and still exist")
-		vmis, err = virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
-		Expect(vmis.Items).To(HaveLen(2))
-
-		By("Checking a VirtualMachineInstance owner references")
-		for _, vmi := range vmis.Items {
-			Expect(vmi.OwnerReferences).To(BeEmpty())
-		}
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("[test_id:1417]should not scale when paused and scale when resume", func() {
-		rs := newReplicaSet()
-		// pause controller
-		By("Pausing the replicaset")
-		_, err := virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"add\", \"path\": \"/spec/paused\", \"value\": true }]"))
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(func() v1.VirtualMachineInstanceReplicaSetConditionType {
-			rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if len(rs.Status.Conditions) > 0 {
-				return rs.Status.Conditions[0].Type
-			}
-			return ""
-		}, 10*time.Second, 1*time.Second).Should(Equal(v1.VirtualMachineInstanceReplicaSetReplicaPaused))
-
-		// set new replica count while still being paused
-		By("Updating the number of replicas")
-		rs.Spec.Replicas = tests.NewInt32(2)
-		_, err = virtClient.ReplicaSet(rs.ObjectMeta.Namespace).Update(rs)
-		Expect(err).ToNot(HaveOccurred())
-
-		// make sure that we don't scale up
-		By("Checking that the replicaset do not scale while it is paused")
-		Consistently(func() int32 {
-			rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			// Make sure that no failure happened, so that ensure that we don't scale because we are paused
-			Expect(rs.Status.Conditions).To(HaveLen(1))
-			return rs.Status.Replicas
-		}, 3*time.Second, 1*time.Second).Should(Equal(int32(0)))
-
-		// resume controller
-		By("Resuming the replicaset")
-		_, err = virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"replace\", \"path\": \"/spec/paused\", \"value\": false }]"))
-		Expect(err).ToNot(HaveOccurred())
-
-		// Paused condition should disappear
-		By("Checking that the pause condition disappeared from the replicaset")
-		Eventually(func() int {
-			rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return len(rs.Status.Conditions)
-		}, 10*time.Second, 1*time.Second).Should(Equal(0))
-
-		// Replicas should be created
-		By("Checking that the missing replicas are now created")
-		Eventually(func() int32 {
-			rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			return rs.Status.Replicas
-		}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))
-	})
-
-	It("[test_id:1418]should replace finished VMIs", func() {
-		By("Creating new replica set")
-		rs := newReplicaSet()
-		doScale(rs.ObjectMeta.Name, int32(2))
-
-		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmis.Items).ToNot(BeEmpty())
-
-		vmi := vmis.Items[0]
-		pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(&vmi))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(pods.Items).To(HaveLen(1))
-		pod := pods.Items[0]
-
-		By("Deleting one of the RS VMS pods")
-		err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Delete(context.Background(), pod.Name, v12.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Checking that the VM disappeared")
-		Eventually(func() bool {
-			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &v12.GetOptions{})
-			if errors.IsNotFound(err) {
-				return true
-			}
-			return false
-		}, 120*time.Second, time.Second).Should(BeTrue())
-
-		By("Checking number of RS VM's to see that we got a replacement")
-		vmis, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmis.Items).Should(HaveLen(2))
-	})
-
-	It("should replace a VMI immediately when a virt-launcher pod gets deleted", func() {
-		By("Creating new replica set")
-		template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-		var gracePeriod int64 = 200
-		template.Spec.TerminationGracePeriodSeconds = &gracePeriod
-		rs := newReplicaSetWithTemplate(template)
-
-		// ensure that the shutdown will take as long as possible
-
-		doScale(rs.ObjectMeta.Name, int32(2))
-
-		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmis.Items).ToNot(BeEmpty())
-
-		By("Waiting until the VMIs are running")
-		Eventually(func() int {
 			vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return len(tests.Running(vmis))
-		}, 40*time.Second, time.Second).Should(Equal(2))
+			Expect(tests.NotDeleted(vmis)).To(HaveLen(int(scale)))
+		}
 
-		vmi := &vmis.Items[0]
-		pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(pods.Items).To(HaveLen(1))
-		pod := pods.Items[0]
+		doScaleWithHPA := func(name string, min int32, max int32, expected int32) {
 
-		By("Deleting one of the RS VMS pods, which will take some time to really stop the VMI")
-		err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Delete(context.Background(), pod.Name, v12.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
+			// Status updates can conflict with our desire to change the spec
+			By(fmt.Sprintf("Scaling to %d", min))
+			hpa := &autov1.HorizontalPodAutoscaler{
+				ObjectMeta: v12.ObjectMeta{
+					Name: name,
+				},
+				Spec: autov1.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autov1.CrossVersionObjectReference{
+						Name:       name,
+						Kind:       v1.VirtualMachineInstanceReplicaSetGroupVersionKind.Kind,
+						APIVersion: v1.VirtualMachineInstanceReplicaSetGroupVersionKind.GroupVersion().String(),
+					},
+					MinReplicas: &min,
+					MaxReplicas: max,
+				},
+			}
+			_, err := virtClient.AutoscalingV1().HorizontalPodAutoscalers(util.NamespaceTestDefault).Create(context.Background(), hpa, v12.CreateOptions{})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-		By("Checking that then number of VMIs increases to three")
-		Expect(err).ToNot(HaveOccurred())
-		Eventually(func() int {
+			var s *autov1.Scale
+			By("Checking the number of replicas")
+			EventuallyWithOffset(1, func() int32 {
+				s, err = virtClient.ReplicaSet(util.NamespaceTestDefault).GetScale(name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return s.Status.Replicas
+			}, 90*time.Second, time.Second).Should(Equal(int32(expected)))
+
+			vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, tests.NotDeleted(vmis)).To(HaveLen(int(min)))
+			err = virtClient.AutoscalingV1().HorizontalPodAutoscalers(util.NamespaceTestDefault).Delete(context.Background(), name, v12.DeleteOptions{})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		}
+
+		newReplicaSetWithTemplate := func(template *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceReplicaSet {
+			newRS := tests.NewRandomReplicaSetFromVMI(template, int32(0))
+			newRS, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(newRS)
+			Expect(err).ToNot(HaveOccurred())
+			return newRS
+		}
+
+		newReplicaSet := func() *v1.VirtualMachineInstanceReplicaSet {
+			By("Create a new VirtualMachineInstance replica set")
+			template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			return newReplicaSetWithTemplate(template)
+		}
+
+		DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale",
+			Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func(startScale int, stopScale int) {
+				newRS := newReplicaSet()
+				doScale(newRS.ObjectMeta.Name, int32(startScale))
+				doScale(newRS.ObjectMeta.Name, int32(stopScale))
+				doScale(newRS.ObjectMeta.Name, int32(0))
+
+			},
+			Entry("[test_id:1405]to three, to two and then to zero replicas", Labels{"test_id:1405"}, 3, 2),
+			Entry("[test_id:1406]to five, to six and then to zero replicas", Labels{"test_id:1406"}, 5, 6),
+		)
+
+		DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with scale subresource",
+			Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func(startScale int, stopScale int) {
+				newRS := newReplicaSet()
+				libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(startScale))
+				libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(stopScale))
+				libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(0))
+			},
+			Entry("[test_id:1407]to three, to two and then to zero replicas", Labels{"test_id:1407"}, 3, 2),
+			Entry("[test_id:1408]to five, to six and then to zero replicas", Labels{"test_id:1408"}, 5, 6),
+		)
+
+		DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with the horizontal pod autoscaler",
+			Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func(startScale int, stopScale int) {
+				checks.SkipIfVersionBelow("HPA only works with CRs with multiple versions starting from 1.13", "1.13")
+				template := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				newRS := tests.NewRandomReplicaSetFromVMI(template, int32(1))
+				newRS, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(newRS)
+				Expect(err).ToNot(HaveOccurred())
+				doScaleWithHPA(newRS.ObjectMeta.Name, int32(startScale), int32(startScale), int32(startScale))
+				doScaleWithHPA(newRS.ObjectMeta.Name, int32(stopScale), int32(stopScale), int32(stopScale))
+				doScaleWithHPA(newRS.ObjectMeta.Name, int32(1), int32(1), int32(1))
+
+			},
+			Entry("[test_id:1409]to three, to two and then to one replicas", Labels{"test_id:1409"}, 3, 2),
+			Entry("[test_id:1410]to five, to six and then to one replicas", Labels{"test_id:1410"}, 5, 6),
+		)
+
+		It("[test_id:1411]should be rejected on POST if spec is invalid", Labels{"test_id:1411"}, func() {
+			newRS := newReplicaSet()
+			newRS.TypeMeta = v12.TypeMeta{
+				APIVersion: v1.StorageGroupVersion.String(),
+				Kind:       "VirtualMachineInstanceReplicaSet",
+			}
+
+			jsonBytes, err := json.Marshal(newRS)
+			Expect(err).To(BeNil())
+
+			// change the name of a required field (like domain) so validation will fail
+			jsonString := strings.Replace(string(jsonBytes), "domain", "not-a-domain", -1)
+
+			result := virtClient.RestClient().Post().Resource("virtualmachineinstancereplicasets").Namespace(util.NamespaceTestDefault).Body([]byte(jsonString)).SetHeader("Content-Type", "application/json").Do(context.Background())
+
+			// Verify validation failed.
+			statusCode := 0
+			result.StatusCode(&statusCode)
+			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+
+		})
+		It("[test_id:1412]should reject POST if validation webhoook deems the spec is invalid", Labels{"test_id:1412"}, func() {
+			newRS := newReplicaSet()
+			newRS.TypeMeta = v12.TypeMeta{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       "VirtualMachineInstanceReplicaSet",
+			}
+
+			// Add a disk that doesn't map to a volume.
+			// This should get rejected which tells us the webhook validator is working.
+			newRS.Spec.Template.Spec.Domain.Devices.Disks = append(newRS.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk",
+			})
+
+			result := virtClient.RestClient().Post().Resource("virtualmachineinstancereplicasets").Namespace(util.NamespaceTestDefault).Body(newRS).Do(context.Background())
+
+			// Verify validation failed.
+			statusCode := 0
+			result.StatusCode(&statusCode)
+			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+
+			reviewResponse := &v12.Status{}
+			body, _ := result.Raw()
+			err = json.Unmarshal(body, reviewResponse)
+			Expect(err).To(BeNil())
+
+			Expect(reviewResponse.Details.Causes).To(HaveLen(1))
+			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].name"))
+		})
+		It("[test_id:1413]should update readyReplicas once VMIs are up", Labels{"test_id:1413"}, func() {
+			newRS := newReplicaSet()
+			doScale(newRS.ObjectMeta.Name, 2)
+
+			By("checking the number of ready replicas in the returned yaml")
+			Eventually(func() int {
+				rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return int(rs.Status.ReadyReplicas)
+			}, 120*time.Second, 1*time.Second).Should(Equal(2))
+		})
+
+		It("[test_id:1414]should return the correct data when using server-side printing", Labels{"test_id:1414"}, func() {
+			checks.SkipIfVersionBelow("server-side printing is only enabled by default from 1.11 on", "1.11")
+			newRS := newReplicaSet()
+			doScale(newRS.ObjectMeta.Name, 2)
+
+			By("waiting until all VMIs are ready")
+			Eventually(func() int {
+				rs, err := virtClient.ReplicaSet(util.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return int(rs.Status.ReadyReplicas)
+			}, 120*time.Second, 1*time.Second).Should(Equal(2))
+
+			By("checking the output of server-side table printing")
+			rawTable, err := virtClient.RestClient().Get().
+				RequestURI(fmt.Sprintf("/apis/kubevirt.io/%s/namespaces/%s/virtualmachineinstancereplicasets/%s", v1.ApiLatestVersion, util.NamespaceTestDefault, newRS.ObjectMeta.Name)).
+				SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io, application/json").
+				DoRaw(context.Background())
+
+			Expect(err).ToNot(HaveOccurred())
+			table := &v1beta1.Table{}
+			Expect(json.Unmarshal(rawTable, table)).To(Succeed())
+			Expect(table.ColumnDefinitions[0].Name).To(Equal("Name"))
+			Expect(table.ColumnDefinitions[0].Type).To(Equal("string"))
+			Expect(table.ColumnDefinitions[1].Name).To(Equal("Desired"))
+			Expect(table.ColumnDefinitions[1].Type).To(Equal("integer"))
+			Expect(table.ColumnDefinitions[2].Name).To(Equal("Current"))
+			Expect(table.ColumnDefinitions[2].Type).To(Equal("integer"))
+			Expect(table.ColumnDefinitions[3].Name).To(Equal("Ready"))
+			Expect(table.ColumnDefinitions[3].Type).To(Equal("integer"))
+			Expect(table.ColumnDefinitions[4].Name).To(Equal("Age"))
+			Expect(table.ColumnDefinitions[4].Type).To(Equal("date"))
+			Expect(table.Rows[0].Cells[0].(string)).To(Equal(newRS.ObjectMeta.Name))
+			Expect(table.Rows[0].Cells[1]).To(BeNumerically("==", 2))
+			Expect(table.Rows[0].Cells[2]).To(BeNumerically("==", 2))
+			Expect(table.Rows[0].Cells[3]).To(BeNumerically("==", 2))
+		})
+
+		It("[test_id:1415]should remove VMIs once they are marked for deletion", Labels{"test_id:1415"}, func() {
+			newRS := newReplicaSet()
+			// Create a replicaset with two replicas
+			doScale(newRS.ObjectMeta.Name, 2)
+			// Delete it
+			By("Deleting the VirtualMachineInstance replica set")
+			Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Delete(newRS.ObjectMeta.Name, &v12.DeleteOptions{})).To(Succeed())
+			// Wait until VMIs are gone
+			By("Waiting until all VMIs are gone")
+			Eventually(func() int {
+				vmis, err := virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return len(vmis.Items)
+			}, 120*time.Second, 1*time.Second).Should(BeZero())
+		})
+
+		It("[test_id:1416]should remove owner references on the VirtualMachineInstance if it is orphan deleted", Labels{"test_id:1416"}, func() {
+			newRS := newReplicaSet()
+			// Create a replicaset with two replicas
+			doScale(newRS.ObjectMeta.Name, 2)
+
+			// Check for owner reference
+			vmis, err := virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
+			Expect(vmis.Items).To(HaveLen(2))
+			Expect(err).ToNot(HaveOccurred())
+			for _, vmi := range vmis.Items {
+				Expect(vmi.OwnerReferences).ToNot(BeEmpty())
+			}
+
+			// Delete it
+			By("Deleting the VirtualMachineInstance replica set with the 'orphan' deletion strategy")
+			orphanPolicy := v12.DeletePropagationOrphan
+			Expect(virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).
+				Delete(newRS.ObjectMeta.Name, &v12.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
+			// Wait until the replica set is deleted
+			By("Waiting until the replica set got deleted")
+			Eventually(func() bool {
+				_, err := virtClient.ReplicaSet(newRS.ObjectMeta.Namespace).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+				if errors.IsNotFound(err) {
+					return true
+				}
+				return false
+			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+
+			By("Checking if two VMIs are orphaned and still exist")
+			vmis, err = virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
+			Expect(vmis.Items).To(HaveLen(2))
+
+			By("Checking a VirtualMachineInstance owner references")
+			for _, vmi := range vmis.Items {
+				Expect(vmi.OwnerReferences).To(BeEmpty())
+			}
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("[test_id:1417]should not scale when paused and scale when resume", Labels{"test_id:1417"}, func() {
+			rs := newReplicaSet()
+			// pause controller
+			By("Pausing the replicaset")
+			_, err := virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"add\", \"path\": \"/spec/paused\", \"value\": true }]"))
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() v1.VirtualMachineInstanceReplicaSetConditionType {
+				rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if len(rs.Status.Conditions) > 0 {
+					return rs.Status.Conditions[0].Type
+				}
+				return ""
+			}, 10*time.Second, 1*time.Second).Should(Equal(v1.VirtualMachineInstanceReplicaSetReplicaPaused))
+
+			// set new replica count while still being paused
+			By("Updating the number of replicas")
+			rs.Spec.Replicas = tests.NewInt32(2)
+			_, err = virtClient.ReplicaSet(rs.ObjectMeta.Namespace).Update(rs)
+			Expect(err).ToNot(HaveOccurred())
+
+			// make sure that we don't scale up
+			By("Checking that the replicaset do not scale while it is paused")
+			Consistently(func() int32 {
+				rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				// Make sure that no failure happened, so that ensure that we don't scale because we are paused
+				Expect(rs.Status.Conditions).To(HaveLen(1))
+				return rs.Status.Replicas
+			}, 3*time.Second, 1*time.Second).Should(Equal(int32(0)))
+
+			// resume controller
+			By("Resuming the replicaset")
+			_, err = virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"replace\", \"path\": \"/spec/paused\", \"value\": false }]"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Paused condition should disappear
+			By("Checking that the pause condition disappeared from the replicaset")
+			Eventually(func() int {
+				rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return len(rs.Status.Conditions)
+			}, 10*time.Second, 1*time.Second).Should(Equal(0))
+
+			// Replicas should be created
+			By("Checking that the missing replicas are now created")
+			Eventually(func() int32 {
+				rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return rs.Status.Replicas
+			}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))
+		})
+
+		It("[test_id:1418]should replace finished VMIs", Labels{"test_id:1418"}, func() {
+			By("Creating new replica set")
+			rs := newReplicaSet()
+			doScale(rs.ObjectMeta.Name, int32(2))
+
+			vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmis.Items).ToNot(BeEmpty())
+
+			vmi := vmis.Items[0]
+			pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(&vmi))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods.Items).To(HaveLen(1))
+			pod := pods.Items[0]
+
+			By("Deleting one of the RS VMS pods")
+			err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Delete(context.Background(), pod.Name, v12.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking that the VM disappeared")
+			Eventually(func() bool {
+				_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &v12.GetOptions{})
+				if errors.IsNotFound(err) {
+					return true
+				}
+				return false
+			}, 120*time.Second, time.Second).Should(BeTrue())
+
+			By("Checking number of RS VM's to see that we got a replacement")
 			vmis, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return len(vmis.Items)
-		}, 20*time.Second, time.Second).Should(Equal(3))
-
-		By("Checking that the shutting donw VMI is still running, reporting the pod deletion and being marked for deletion")
-		vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &v12.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmi.Status.Phase).To(Equal(v1.Running))
-		Expect(controller.NewVirtualMachineInstanceConditionManager().
-			HasConditionWithStatusAndReason(
-				vmi,
-				v1.VirtualMachineInstanceConditionType(v13.PodReady),
-				v13.ConditionFalse,
-				v1.PodTerminatingReason,
-			),
-		).To(BeTrue())
-		Expect(vmi.DeletionTimestamp).ToNot(BeNil())
+			Expect(vmis.Items).Should(HaveLen(2))
 	})
 
-	It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", func() {
-		k8sClient := clientcmd.GetK8sCmdClient()
-		clientcmd.SkipIfNoCmd(k8sClient)
+		It("should replace a VMI immediately when a virt-launcher pod gets deleted", func() {
+			By("Creating new replica set")
+			template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			var gracePeriod int64 = 200
+			template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+			rs := newReplicaSetWithTemplate(template)
 
-		newRS := newReplicaSet()
-		doScale(newRS.ObjectMeta.Name, 2)
+			// ensure that the shutdown will take as long as possible
 
-		result, _, _ := clientcmd.RunCommand(k8sClient, "get", "virtualmachineinstancereplicaset")
-		Expect(result).ToNot(BeNil())
-		resultFields := strings.Fields(result)
-		expectedHeader := []string{"NAME", "DESIRED", "CURRENT", "READY", "AGE"}
-		columnHeaders := resultFields[:len(expectedHeader)]
-		// Verify the generated header is same as expected
-		Expect(columnHeaders).To(Equal(expectedHeader))
-		// Name will be there in all the cases, so verify name
-		Expect(resultFields[len(expectedHeader)]).To(Equal(newRS.Name))
+			doScale(rs.ObjectMeta.Name, int32(2))
+
+			vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmis.Items).ToNot(BeEmpty())
+
+			By("Waiting until the VMIs are running")
+			Eventually(func() int {
+				vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return len(tests.Running(vmis))
+			}, 40*time.Second, time.Second).Should(Equal(2))
+
+			vmi := &vmis.Items[0]
+			pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods.Items).To(HaveLen(1))
+			pod := pods.Items[0]
+
+			By("Deleting one of the RS VMS pods, which will take some time to really stop the VMI")
+			err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Delete(context.Background(), pod.Name, v12.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking that then number of VMIs increases to three")
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() int {
+				vmis, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v12.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return len(vmis.Items)
+			}, 20*time.Second, time.Second).Should(Equal(3))
+
+			By("Checking that the shutting donw VMI is still running, reporting the pod deletion and being marked for deletion")
+			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &v12.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmi.Status.Phase).To(Equal(v1.Running))
+			Expect(controller.NewVirtualMachineInstanceConditionManager().
+				HasConditionWithStatusAndReason(
+					vmi,
+					v1.VirtualMachineInstanceConditionType(v13.PodReady),
+					v13.ConditionFalse,
+					v1.PodTerminatingReason,
+				),
+			).To(BeTrue())
+			Expect(vmi.DeletionTimestamp).ToNot(BeNil())
+		})
+
+		It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", Labels{"test_id:4121"}, func() {
+			k8sClient := clientcmd.GetK8sCmdClient()
+			clientcmd.SkipIfNoCmd(k8sClient)
+
+			newRS := newReplicaSet()
+			doScale(newRS.ObjectMeta.Name, 2)
+
+		    result, _, _ := clientcmd.RunCommand(k8sClient, "get", "virtualmachineinstancereplicaset")
+			Expect(result).ToNot(BeNil())
+			resultFields := strings.Fields(result)
+			expectedHeader := []string{"NAME", "DESIRED", "CURRENT", "READY", "AGE"}
+			columnHeaders := resultFields[:len(expectedHeader)]
+			// Verify the generated header is same as expected
+			Expect(columnHeaders).To(Equal(expectedHeader))
+			// Name will be there in all the cases, so verify name
+			Expect(resultFields[len(expectedHeader)]).To(Equal(newRS.Name))
+		})
 	})
-})

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -51,7 +51,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachineInstanceReplicaSet",
-	Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 		var err error
 		var virtClient kubecli.KubevirtClient
@@ -131,7 +131,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		}
 
 		DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale",
-			Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func(startScale int, stopScale int) {
 				newRS := newReplicaSet()
 				doScale(newRS.ObjectMeta.Name, int32(startScale))
@@ -139,24 +139,24 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				doScale(newRS.ObjectMeta.Name, int32(0))
 
 			},
-			Entry("[test_id:1405]to three, to two and then to zero replicas", Labels{"test_id:1405"}, 3, 2),
-			Entry("[test_id:1406]to five, to six and then to zero replicas", Labels{"test_id:1406"}, 5, 6),
+			Entry("[test_id:1405]to three, to two and then to zero replicas", Label("test_id:1405"), 3, 2),
+			Entry("[test_id:1406]to five, to six and then to zero replicas", Label("test_id:1406"), 5, 6),
 		)
 
 		DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with scale subresource",
-			Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func(startScale int, stopScale int) {
 				newRS := newReplicaSet()
 				libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(startScale))
 				libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(stopScale))
 				libreplicaset.DoScaleWithScaleSubresource(virtClient, newRS.ObjectMeta.Name, int32(0))
 			},
-			Entry("[test_id:1407]to three, to two and then to zero replicas", Labels{"test_id:1407"}, 3, 2),
-			Entry("[test_id:1408]to five, to six and then to zero replicas", Labels{"test_id:1408"}, 5, 6),
+			Entry("[test_id:1407]to three, to two and then to zero replicas", Label("test_id:1407"), 3, 2),
+			Entry("[test_id:1408]to five, to six and then to zero replicas", Label("test_id:1408"), 5, 6),
 		)
 
 		DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale with the horizontal pod autoscaler",
-			Labels{"rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:588", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func(startScale int, stopScale int) {
 				checks.SkipIfVersionBelow("HPA only works with CRs with multiple versions starting from 1.13", "1.13")
 				template := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
@@ -168,11 +168,11 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				doScaleWithHPA(newRS.ObjectMeta.Name, int32(1), int32(1), int32(1))
 
 			},
-			Entry("[test_id:1409]to three, to two and then to one replicas", Labels{"test_id:1409"}, 3, 2),
-			Entry("[test_id:1410]to five, to six and then to one replicas", Labels{"test_id:1410"}, 5, 6),
+			Entry("[test_id:1409]to three, to two and then to one replicas", Label("test_id:1409"), 3, 2),
+			Entry("[test_id:1410]to five, to six and then to one replicas", Label("test_id:1410"), 5, 6),
 		)
 
-		It("[test_id:1411]should be rejected on POST if spec is invalid", Labels{"test_id:1411"}, func() {
+		It("[test_id:1411]should be rejected on POST if spec is invalid", Label("test_id:1411"), func() {
 			newRS := newReplicaSet()
 			newRS.TypeMeta = v12.TypeMeta{
 				APIVersion: v1.StorageGroupVersion.String(),
@@ -193,7 +193,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
 		})
-		It("[test_id:1412]should reject POST if validation webhoook deems the spec is invalid", Labels{"test_id:1412"}, func() {
+		It("[test_id:1412]should reject POST if validation webhoook deems the spec is invalid", Label("test_id:1412"), func() {
 			newRS := newReplicaSet()
 			newRS.TypeMeta = v12.TypeMeta{
 				APIVersion: v1.GroupVersion.String(),
@@ -221,7 +221,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(reviewResponse.Details.Causes).To(HaveLen(1))
 			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].name"))
 		})
-		It("[test_id:1413]should update readyReplicas once VMIs are up", Labels{"test_id:1413"}, func() {
+		It("[test_id:1413]should update readyReplicas once VMIs are up", Label("test_id:1413"), func() {
 			newRS := newReplicaSet()
 			doScale(newRS.ObjectMeta.Name, 2)
 
@@ -233,7 +233,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			}, 120*time.Second, 1*time.Second).Should(Equal(2))
 		})
 
-		It("[test_id:1414]should return the correct data when using server-side printing", Labels{"test_id:1414"}, func() {
+		It("[test_id:1414]should return the correct data when using server-side printing", Label("test_id:1414"), func() {
 			checks.SkipIfVersionBelow("server-side printing is only enabled by default from 1.11 on", "1.11")
 			newRS := newReplicaSet()
 			doScale(newRS.ObjectMeta.Name, 2)
@@ -270,7 +270,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(table.Rows[0].Cells[3]).To(BeNumerically("==", 2))
 		})
 
-		It("[test_id:1415]should remove VMIs once they are marked for deletion", Labels{"test_id:1415"}, func() {
+		It("[test_id:1415]should remove VMIs once they are marked for deletion", Label("test_id:1415"), func() {
 			newRS := newReplicaSet()
 			// Create a replicaset with two replicas
 			doScale(newRS.ObjectMeta.Name, 2)
@@ -286,7 +286,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			}, 120*time.Second, 1*time.Second).Should(BeZero())
 		})
 
-		It("[test_id:1416]should remove owner references on the VirtualMachineInstance if it is orphan deleted", Labels{"test_id:1416"}, func() {
+		It("[test_id:1416]should remove owner references on the VirtualMachineInstance if it is orphan deleted", Label("test_id:1416"), func() {
 			newRS := newReplicaSet()
 			// Create a replicaset with two replicas
 			doScale(newRS.ObjectMeta.Name, 2)
@@ -325,7 +325,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:1417]should not scale when paused and scale when resume", Labels{"test_id:1417"}, func() {
+		It("[test_id:1417]should not scale when paused and scale when resume", Label("test_id:1417"), func() {
 			rs := newReplicaSet()
 			// pause controller
 			By("Pausing the replicaset")
@@ -379,7 +379,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))
 		})
 
-		It("[test_id:1418]should replace finished VMIs", Labels{"test_id:1418"}, func() {
+		It("[test_id:1418]should replace finished VMIs", Label("test_id:1418"), func() {
 			By("Creating new replica set")
 			rs := newReplicaSet()
 			doScale(rs.ObjectMeta.Name, int32(2))
@@ -468,7 +468,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(vmi.DeletionTimestamp).ToNot(BeNil())
 		})
 
-		It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", Labels{"test_id:4121"}, func() {
+		It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", Label("test_id:4121"), func() {
 			k8sClient := clientcmd.GetK8sCmdClient()
 			clientcmd.SkipIfNoCmd(k8sClient)
 

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -14,7 +14,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute] virt-api scaling", func() {
+var _ = Describe("[sig-compute] virt-api scaling", Label("sig-compute"), func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]SecurityFeatures", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -77,7 +77,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-
 				vmi.Spec.Networks = []v1.Network{}
 			})
 
-			It("[test_id:2953]Ensure virt-launcher pod securityContext type is correctly set", Labels{"test_id:2953"}, func() {
+			It("[test_id:2953]Ensure virt-launcher pod securityContext type is correctly set", Label("test_id:2953"), func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -89,7 +89,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-
 				Expect(vmiPod.Spec.SecurityContext.SELinuxOptions).To(Equal(&k8sv1.SELinuxOptions{Type: "container_t"}))
 			})
 
-			It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", Labels{"test_id:2895"}, func() {
+			It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", Label("test_id:2895"), func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -107,7 +107,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-
 				Expect(*container.SecurityContext.Privileged).To(BeFalse())
 			})
 
-			It("[test_id:4297]Make sure qemu processes are MCS constrained", Labels{"test_id:4297"}, func() {
+			It("[test_id:4297]Make sure qemu processes are MCS constrained", Label("test_id:4297"), func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -140,7 +140,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-
 
 		Context("With selinuxLauncherType defined as spc_t", func() {
 
-			It("[test_id:3787]Should honor custom SELinux type for virt-launcher", Labels{"test_id:3787"}, func() {
+			It("[test_id:3787]Should honor custom SELinux type for virt-launcher", Label("test_id:3787"), func() {
 				config := kubevirtConfiguration.DeepCopy()
 				superPrivilegedType := "spc_t"
 				config.SELinuxLauncherType = superPrivilegedType
@@ -170,7 +170,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-
 
 		Context("With selinuxLauncherType defined as virt_launcher.process", func() {
 
-			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", Labels{"test_id:4298"}, func() {
+			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", Label("test_id:4298"), func() {
 				config := kubevirtConfiguration.DeepCopy()
 				launcherType := "virt_launcher.process"
 				config.SELinuxLauncherType = launcherType
@@ -217,7 +217,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-
 		var container k8sv1.Container
 		var vmi *v1.VirtualMachineInstance
 
-		It("[test_id:4300]has precisely the documented extra capabilities relative to a regular user pod", Labels{"test_id:4300"}, func() {
+		It("[test_id:4300]has precisely the documented extra capabilities relative to a regular user pod", Label("test_id:4300"), func() {
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 			By("Starting a New VMI")

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
+var _ = Describe("[Serial][sig-compute]SecurityFeatures", Labels{"Serial", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -77,7 +77,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				vmi.Spec.Networks = []v1.Network{}
 			})
 
-			It("[test_id:2953]Ensure virt-launcher pod securityContext type is correctly set", func() {
+			It("[test_id:2953]Ensure virt-launcher pod securityContext type is correctly set", Labels{"test_id:2953"}, func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -89,7 +89,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				Expect(vmiPod.Spec.SecurityContext.SELinuxOptions).To(Equal(&k8sv1.SELinuxOptions{Type: "container_t"}))
 			})
 
-			It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", func() {
+			It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", Labels{"test_id:2895"}, func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -107,7 +107,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				Expect(*container.SecurityContext.Privileged).To(BeFalse())
 			})
 
-			It("[test_id:4297]Make sure qemu processes are MCS constrained", func() {
+			It("[test_id:4297]Make sure qemu processes are MCS constrained", Labels{"test_id:4297"}, func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -140,7 +140,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 
 		Context("With selinuxLauncherType defined as spc_t", func() {
 
-			It("[test_id:3787]Should honor custom SELinux type for virt-launcher", func() {
+			It("[test_id:3787]Should honor custom SELinux type for virt-launcher", Labels{"test_id:3787"}, func() {
 				config := kubevirtConfiguration.DeepCopy()
 				superPrivilegedType := "spc_t"
 				config.SELinuxLauncherType = superPrivilegedType
@@ -170,7 +170,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 
 		Context("With selinuxLauncherType defined as virt_launcher.process", func() {
 
-			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", func() {
+			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", Labels{"test_id:4298"}, func() {
 				config := kubevirtConfiguration.DeepCopy()
 				launcherType := "virt_launcher.process"
 				config.SELinuxLauncherType = launcherType
@@ -217,7 +217,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 		var container k8sv1.Container
 		var vmi *v1.VirtualMachineInstance
 
-		It("[test_id:4300]has precisely the documented extra capabilities relative to a regular user pod", func() {
+		It("[test_id:4300]has precisely the documented extra capabilities relative to a regular user pod", Labels{"test_id:4300"}, func() {
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 			By("Starting a New VMI")

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -114,7 +114,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 					tests.WaitAgentConnected(virtClient, vmi)
 
-				    command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 
 					waitForVMIRebooted(vmi, console.LoginToFedora)
@@ -128,7 +128,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					Expect(console.LoginToCirros(vmi)).To(Succeed())
 					tests.WaitAgentDisconnected(virtClient, vmi)
 
-				    command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 
 					waitForVMIRebooted(vmi, console.LoginToCirros)
@@ -142,7 +142,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					Expect(console.LoginToCirros(vmi)).To(Succeed())
 					tests.WaitAgentDisconnected(virtClient, vmi)
 
-				command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 					err := command()
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("VMI neither have the agent connected nor the ACPI feature enabled"))
@@ -154,22 +154,22 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(), vmiLaunchTimeout)
 					tests.WaitAgentConnected(virtClient, vmi)
 
-				    command := clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_PAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command := clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_PAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-				    command = clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 					err := command()
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("VMI is paused"))
 
-				    command = clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_UNPAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_UNPAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 					tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
 					tests.WaitAgentConnected(virtClient, vmi)
 
-				    command = clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
+					command = clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 					Expect(command()).To(Succeed())
 
 					waitForVMIRebooted(vmi, console.LoginToFedora)

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -64,7 +64,7 @@ func withoutACPI() libvmi.Option {
 const vmiLaunchTimeout = 360
 
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Soft reboot",
-	Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -20,1095 +20,1095 @@
 package storage
 
 import (
-    "context"
-    "fmt"
-    "math"
-    "strings"
-    "time"
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
 
-    expect "github.com/google/goexpect"
-    storagev1 "k8s.io/api/storage/v1"
+	expect "github.com/google/goexpect"
+	storagev1 "k8s.io/api/storage/v1"
 
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
-    k8sv1 "k8s.io/api/core/v1"
-    rbacv1 "k8s.io/api/rbac/v1"
-    "k8s.io/apimachinery/pkg/api/resource"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/util/rand"
-    "k8s.io/utils/pointer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/pointer"
 
-    v1 "kubevirt.io/api/core/v1"
-    "kubevirt.io/client-go/kubecli"
-    cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-    virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-    "kubevirt.io/kubevirt/tests"
-    "kubevirt.io/kubevirt/tests/clientcmd"
-    "kubevirt.io/kubevirt/tests/console"
-    cd "kubevirt.io/kubevirt/tests/containerdisk"
-    "kubevirt.io/kubevirt/tests/flags"
-    "kubevirt.io/kubevirt/tests/framework/checks"
-    . "kubevirt.io/kubevirt/tests/framework/matcher"
-    "kubevirt.io/kubevirt/tests/libstorage"
-    "kubevirt.io/kubevirt/tests/util"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/console"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libstorage"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 const (
-    checkingVMInstanceConsoleExpectedOut = "Checking that the VirtualMachineInstance console has expected output"
-    deletingDataVolume                   = "Deleting the DataVolume"
-    creatingVMInvalidDataVolume          = "Creating a VM with an invalid DataVolume"
-    creatingVMDataVolumeTemplateEntry    = "Creating VM with DataVolumeTemplate entry with k8s client binary"
-    verifyingDataVolumeSuccess           = "Verifying DataVolume succeeded and is created with VM owner reference"
-    verifyingPVCCreated                  = "Verifying PVC is created"
-    verifyingVMICreated                  = "Verifying VMI is created with VM owner reference"
-    syncName                             = "sync\n"
+	checkingVMInstanceConsoleExpectedOut = "Checking that the VirtualMachineInstance console has expected output"
+	deletingDataVolume                   = "Deleting the DataVolume"
+	creatingVMInvalidDataVolume          = "Creating a VM with an invalid DataVolume"
+	creatingVMDataVolumeTemplateEntry    = "Creating VM with DataVolumeTemplate entry with k8s client binary"
+	verifyingDataVolumeSuccess           = "Verifying DataVolume succeeded and is created with VM owner reference"
+	verifyingPVCCreated                  = "Verifying PVC is created"
+	verifyingVMICreated                  = "Verifying VMI is created with VM owner reference"
+	syncName                             = "sync\n"
 )
 
 const InvalidDataVolumeUrl = "docker://127.0.0.1/invalid:latest"
 
 var _ = SIGDescribe("DataVolume Integration", func() {
 
-    var virtClient kubecli.KubevirtClient
-    var err error
-
-    BeforeEach(func() {
-        virtClient, err = kubecli.GetKubevirtClient()
-        util.PanicOnError(err)
-
-        tests.BeforeTestCleanup()
-        if !tests.HasCDI() {
-            Skip("Skip DataVolume tests when CDI is not present")
-        }
-    })
-
-    Context("[storage-req]PVC expansion", Label("storage-req"), func() {
-        DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
-            checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
-            if !tests.HasCDI() {
-                Skip("Skip DataVolume tests when CDI is not present")
-            }
-            var sc string
-            exists := false
-            if volumeMode == k8sv1.PersistentVolumeBlock {
-                sc, exists = libstorage.GetRWOBlockStorageClass()
-                if !exists {
-                    Skip("Skip test when Block storage is not present")
-                }
-            } else {
-                sc, exists = libstorage.GetRWOFileSystemStorageClass()
-                if !exists {
-                    Skip("Skip test when Filesystem storage is not present")
-                }
-            }
-            volumeExpansionAllowed := tests.VolumeExpansionAllowed(sc)
-            if !volumeExpansionAllowed {
-                Skip("Skip when volume expansion storage class not available")
-            }
-            vmi, dataVolume := tests.NewRandomVirtualMachineInstanceWithDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce, volumeMode)
-            tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
-            vmi = tests.RunVMIAndExpectLaunch(vmi, 500)
-
-            By("Expecting the VirtualMachineInstance console")
-            Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-            pvc, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
-            Expect(err).ToNot(HaveOccurred())
-
-            By("Expanding PVC")
-            pvc.Spec.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("2Gi")
-            _, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
-            Expect(err).ToNot(HaveOccurred())
-
-            By("Waiting for notification about size change")
-            Eventually(func() error {
-                err := console.SafeExpectBatch(vmi, []expect.Batcher{
-                    &expect.BSnd{S: "\n"},
-                    &expect.BExp{R: console.PromptExpression},
-                    &expect.BSnd{S: "dmesg |grep 'new size'\n"},
-                    &expect.BExp{R: console.PromptExpression},
-                    &expect.BSnd{S: "dmesg |grep -c 'new size: [34]'\n"},
-                    &expect.BExp{R: "1"},
-                }, 10)
-                return err
-            }, 360).Should(BeNil())
-
-            Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-                &expect.BSnd{S: "sudo /sbin/resize-filesystem /dev/root /run/resize.rootfs /dev/console && echo $?\n"},
-                &expect.BExp{R: "0"},
-            }, 30)).To(Succeed(), "failed to resize root")
-
-            By("Writing a 1.5G file after expansion, should succeed")
-            Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-                &expect.BSnd{S: "\n"},
-                &expect.BExp{R: console.PromptExpression},
-                &expect.BSnd{S: "dd if=/dev/zero of=largefile count=1500 bs=1M; echo $?\n"},
-                &expect.BExp{R: "0"},
-            }, 360)).To(Succeed(), "can use more space after expansion and resize")
-        },
-            Entry("with Block PVC", k8sv1.PersistentVolumeBlock),
-            Entry("with Filesystem PVC", k8sv1.PersistentVolumeFilesystem),
-        )
-    })
-
-    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source",
-        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
-        func() {
-
-            Context("[Serial]without fsgroup support", Label("Serial"), func() {
-                size := "1Gi"
-
-                It("should succesfully start", func() {
-                    // Create DV and alter permission of disk.img
-                    url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-                    dv := libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
-                    tests.SetDataVolumeForceBindAnnotation(dv)
-                    dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
-                    _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-                    Expect(err).To(BeNil())
-                    var pvc *k8sv1.PersistentVolumeClaim
-                    Eventually(func() *k8sv1.PersistentVolumeClaim {
-                        pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-                        if err != nil {
-                            return nil
-                        }
-                        return pvc
-                    }, 30*time.Second).Should(Not(BeNil()))
-                    By("waiting for the dv import to pvc to finish")
-                    Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
-                    tests.ChangeImgFilePermissionsToNonQEMU(pvc)
-
-                    vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
-
-                    By("Starting the VirtualMachineInstance")
-                    vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
-
-                    By(checkingVMInstanceConsoleExpectedOut)
-                    Expect(console.LoginToAlpine(vmi)).To(Succeed())
-                })
-            })
-
-            Context("Alpine import", func() {
-                BeforeEach(func() {
-                    cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-                    Expect(cdis.Items).To(HaveLen(1))
-                    hasWaitForFirstConsumerGate := false
-                    for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
-                        if feature == "HonorWaitForFirstConsumer" {
-                            hasWaitForFirstConsumerGate = true
-                            break
-                        }
-                    }
-                    if !hasWaitForFirstConsumerGate {
-                        Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
-                    }
-                })
-
-                It("[test_id:3189]should be successfully started and stopped multiple times", Label("test_id:3189"), func() {
-
-                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-
-                    _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-                    Expect(err).To(BeNil())
-
-                    // This will only work on storage with binding mode WaitForFirstConsumer,
-                    if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-                        Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
-                    }
-                    num := 2
-                    By("Starting and stopping the VirtualMachineInstance a number of times")
-                    for i := 1; i <= num; i++ {
-                        vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-                        // Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
-                        // after being restarted multiple times
-                        if i == num {
-                            By(checkingVMInstanceConsoleExpectedOut)
-                            Expect(console.LoginToAlpine(vmi)).To(Succeed())
-                        }
-
-                        err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-                        Expect(err).To(BeNil())
-                        tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-                    }
-                    err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-                    Expect(err).To(BeNil())
-                })
-
-                It("[test_id:6686]should successfully start multiple concurrent VMIs", Label("test_id:6686"), func() {
-
-                    numVmis := 5
-                    vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
-                    dvs := make([]*cdiv1.DataVolume, 0, numVmis)
-
-                    for idx := 0; idx < numVmis; idx++ {
-                        dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-                        vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-                        vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-
-                        _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-                        Expect(err).To(BeNil())
-
-                        vmi = tests.RunVMI(vmi, 60)
-                        vmis = append(vmis, vmi)
-                        dvs = append(dvs, dataVolume)
-                    }
-
-                    for idx := 0; idx < numVmis; idx++ {
-                        tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
-                        By(checkingVMInstanceConsoleExpectedOut)
-                        Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
-
-                        err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
-                        Expect(err).To(BeNil())
-                        err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
-                        Expect(err).To(BeNil())
-                    }
-                })
-
-                It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", Label("test_id:5252"), func() {
-                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-                    vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
-
-                    _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-                    Expect(err).To(BeNil())
-                    // This will only work on storage with binding mode WaitForFirstConsumer,
-                    if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-                        Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
-                    }
-                    // with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
-                    // import and start
-                    vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-
-                    By(checkingVMInstanceConsoleExpectedOut)
-                    Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-                    err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-                    Expect(err).To(BeNil())
-                    tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-
-                    err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-                    Expect(err).To(BeNil())
-                })
-
-                It("should accurately report DataVolume provisioning", func() {
-                    sc, exists := libstorage.GetSnapshotStorageClass()
-                    if !exists {
-                        Skip("no snapshot storage class configured")
-                    }
-
-                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(
-                        cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
-                        util.NamespaceTestDefault,
-                        sc,
-                        k8sv1.ReadWriteOnce,
-                        k8sv1.PersistentVolumeFilesystem,
-                    )
-                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-                    vm := tests.NewRandomVirtualMachine(vmi, false)
-
-                    _, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-                    defer func() {
-                        err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }()
-
-                    Eventually(func() bool {
-                        vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                        return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-                    }, 180*time.Second, 2*time.Second).Should(BeTrue())
-
-                    _, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-                    defer func() {
-                        err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }()
-
-                    Eventually(func() bool {
-                        vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                        return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
-                    }, 180*time.Second, 1*time.Second).Should(BeTrue())
-
-                    Eventually(func() bool {
-                        vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                        return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-                    }, 180*time.Second, 2*time.Second).Should(BeTrue())
-                })
-            })
-
-            Context("with a PVC from a Datavolume", func() {
-                var storageClass *storagev1.StorageClass
-                BeforeEach(func() {
-                    // ensure that we always use a storage class which binds immediately,
-                    // otherwise we will never see a PVC appear for the datavolume
-                    bindMode := storagev1.VolumeBindingImmediate
-                    storageClass = &storagev1.StorageClass{
-                        ObjectMeta: metav1.ObjectMeta{
-                            GenerateName: "fake",
-                        },
-                        Provisioner:       "afakeone",
-                        VolumeBindingMode: &bindMode,
-                    }
-                    storageClass, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-                })
-                AfterEach(func() {
-                    if storageClass != nil && storageClass.Name != "" {
-                        err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }
-                })
-
-                It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", Label("test_id:4643"), func() {
-
-                    dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-                    _, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-                    Expect(err).To(BeNil())
-
-                    defer func(dv *cdiv1.DataVolume) {
-                        By(deletingDataVolume)
-                        ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-                    }(dv)
-
-                    Eventually(func() (*k8sv1.PersistentVolumeClaim, error) {
-                        return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-                    }, 30).Should(Not(BeNil()))
-
-                    vmi := tests.NewRandomVMI()
-
-                    diskName := "disk0"
-                    bus := "virtio"
-                    vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-                        Name: diskName,
-                        DiskDevice: v1.DiskDevice{
-                            Disk: &v1.DiskTarget{
-                                Bus: bus,
-                            },
-                        },
-                    })
-                    vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-                        Name: diskName,
-                        VolumeSource: v1.VolumeSource{
-                            PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-                                ClaimName: dv.ObjectMeta.Name,
-                            }},
-                        },
-                    })
-
-                    vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-
-                    vm := tests.NewRandomVirtualMachine(vmi, true)
-                    dvt := &v1.DataVolumeTemplateSpec{
-                        ObjectMeta: dv.ObjectMeta,
-                        Spec:       dv.Spec,
-                    }
-                    vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
-                    _, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-                })
-                It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself",
-                    Label("Serial", "test_id:4644"),
-                    func() {
-                        dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-                        _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-                        Expect(err).To(BeNil())
-
-                        defer func(dv *cdiv1.DataVolume) {
-                            By(deletingDataVolume)
-                            ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-                        }(dv)
-                        Eventually(func() error {
-                            _, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-                            return err
-                        }, 30*time.Second, 1*time.Second).Should(BeNil())
-
-                        vmi := tests.NewRandomVMI()
-
-                        diskName := "disk0"
-                        bus := "virtio"
-                        vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-                            Name: diskName,
-                            DiskDevice: v1.DiskDevice{
-                                Disk: &v1.DiskTarget{
-                                    Bus: bus,
-                                },
-                            },
-                        })
-                        vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-                            Name: diskName,
-                            VolumeSource: v1.VolumeSource{
-                                PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-                                    ClaimName: dv.ObjectMeta.Name,
-                                }},
-                            },
-                        })
-
-                        vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-
-                        vm := tests.NewRandomVirtualMachine(vmi, true)
-                        _, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-                        Expect(err).ShouldNot(HaveOccurred())
-
-                        Eventually(func() bool {
-                            vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-                            Expect(err).ToNot(HaveOccurred())
-
-                            return vm.Status.Created
-                        }, 30*time.Second, 1*time.Second).Should(Equal(false))
-                    })
-            })
-        })
-
-    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume",
-        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
-        func() {
-            Context("using DataVolume with invalid URL", func() {
-                deleteDataVolume := func(dv *cdiv1.DataVolume) {
-                    By(deletingDataVolume)
-                    ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-                }
-
-                It("shold be possible to stop VM if datavolume is crashing", func() {
-                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-                    vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
-                    vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
-                        {
-                            ObjectMeta: dataVolume.ObjectMeta,
-                            Spec:       dataVolume.Spec,
-                        },
-                    }
-
-                    By(creatingVMInvalidDataVolume)
-                    vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-
-                    By("Waiting for DV to start crashing")
-                    Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.ImportInProgress))
-
-                    By("Stop VM")
-                    tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
-                })
-
-                It("[test_id:3190]should correctly handle invalid DataVolumes", Label("test_id:3190"), func() {
-                    // Don't actually create the DataVolume since it's invalid.
-                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-                    //  Add the invalid DataVolume to a VMI
-                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-                    // Create a VM for this VMI
-                    vm := tests.NewRandomVirtualMachine(vmi, true)
-
-                    By(creatingVMInvalidDataVolume)
-                    vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-
-                    By("Waiting for VMI to be created")
-                    Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
-                })
-                It("[test_id:3190]should correctly handle eventually consistent DataVolumes", Label("test_id:3190"), func() {
-                    realRegistryName := flags.KubeVirtUtilityRepoPrefix
-                    realRegistryPort := ""
-                    if strings.Contains(flags.KubeVirtUtilityRepoPrefix, ":") {
-                        realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
-                        realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
-                    }
-                    if realRegistryPort == "" {
-                        Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
-                    }
-
-                    fakeRegistryName := "fakeregistry"
-                    fakeRegistryWithPort := fakeRegistryName
-                    if realRegistryPort != "" {
-                        fakeRegistryWithPort = fmt.Sprintf("%s:%s", fakeRegistryName, realRegistryPort)
-                    }
-
-                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlFromRegistryForContainerDisk(fakeRegistryWithPort, cd.ContainerDiskCirros),
-                        util.NamespaceTestDefault,
-                        k8sv1.ReadWriteOnce,
-                    )
-                    defer deleteDataVolume(dataVolume)
-
-                    By("Creating DataVolume with invalid URL")
-                    dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-                    Expect(err).To(BeNil())
-
-                    By(creatingVMInvalidDataVolume)
-                    //  Add the invalid DataVolume to a VMI
-                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-                    // Create a VM for this VMI
-                    vm := tests.NewRandomVirtualMachine(vmi, true)
-                    vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-
-                    Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
-
-                    By("Creating a service which makes the registry reachable")
-                    virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
-                        ObjectMeta: metav1.ObjectMeta{
-                            Name: fakeRegistryName,
-                        },
-                        Spec: k8sv1.ServiceSpec{
-                            Type:         k8sv1.ServiceTypeExternalName,
-                            ExternalName: realRegistryName,
-                        },
-                    }, metav1.CreateOptions{})
-
-                    By("Wait for DataVolume to complete")
-                    Eventually(ThisDV(dataVolume), 160).Should(HaveSucceeded())
-
-                    By("Waiting for VMI to be created")
-                    Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
-                })
-            })
-        })
-
-    Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl",
-        Label("rfe_id:896", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
-        func() {
-            var vm *v1.VirtualMachine
-            var err error
-            var vmJson string
-            var dataVolumeName string
-            var pvcName string
-
-            k8sClient := clientcmd.GetK8sCmdClient()
-
-            BeforeEach(func() {
-                running := true
-
-                vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-                vm.Spec.Running = &running
-
-                dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
-                pvcName = dataVolumeName
-
-                vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
-                Expect(err).ToNot(HaveOccurred())
-            })
-
-            It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", Label("test_id:836"), func() {
-                By(creatingVMDataVolumeTemplateEntry)
-                _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-                Expect(err).ToNot(HaveOccurred())
-
-                By(verifyingDataVolumeSuccess)
-                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-                By(verifyingPVCCreated)
-                Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-                By(verifyingVMICreated)
-                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-            })
-
-            It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", Label("test_id:837"), func() {
-                By(creatingVMDataVolumeTemplateEntry)
-                _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-                Expect(err).ToNot(HaveOccurred())
-
-                By(verifyingDataVolumeSuccess)
-                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-                By(verifyingPVCCreated)
-                Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-                By(verifyingVMICreated)
-                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-
-                By("Deleting VM with cascade=true")
-                _, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
-                Expect(err).ToNot(HaveOccurred())
-
-                By("Waiting for the VM to be deleted")
-                Eventually(ThisVM(vm), 100).Should(BeGone())
-
-                By("Waiting for the VMI to be deleted")
-                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
-
-                By("Waiting for the DataVolume to be deleted")
-                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
-
-                By("Waiting for the PVC to be deleted")
-                Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
-            })
-
-            It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", Label("test_id:838"), func() {
-                By(creatingVMDataVolumeTemplateEntry)
-                _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-                Expect(err).ToNot(HaveOccurred())
-
-                By(verifyingDataVolumeSuccess)
-                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-                By(verifyingPVCCreated)
-                Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-                By(verifyingVMICreated)
-                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-
-                By("Deleting VM with cascade=false")
-                _, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
-                Expect(err).ToNot(HaveOccurred())
-
-                By("Waiting for the VM to be deleted")
-                Eventually(ThisVM(vm), 100).Should(BeGone())
-
-                By("Verifying DataVolume still exists with owner references removed")
-                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), Not(BeOwned())))
-
-                By("Verifying VMI still exists with owner references removed")
-                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(And(BeRunning(), Not(BeOwned())))
-            })
-
-        })
-
-    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume",
-        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
-        func() {
-            Context("using Alpine http import", func() {
-                It("a DataVolume with preallocation shouldn't have discard=unmap", func() {
-                    var vm *v1.VirtualMachine
-                    vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-                    preallocation := true
-                    vm.Spec.DataVolumeTemplates[0].Spec.Preallocation = &preallocation
-
-                    vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-
-                    vm = tests.StartVirtualMachine(vm)
-                    vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-
-                    domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-                    Expect(err).ToNot(HaveOccurred())
-                    Expect(domXml).ToNot(ContainSubstring("discard='unmap'"))
-                    vm = tests.StopVirtualMachine(vm)
-                    Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})).To(Succeed())
-                })
-
-                DescribeTable("[test_id:3191]should be successfully started and stopped multiple times", Label("test_id:3191"), func(isHTTP bool) {
-                    var vm *v1.VirtualMachine
-                    if isHTTP {
-                        vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-                    } else {
-                        url := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
-                        vm = tests.NewRandomVMWithDataVolume(url, util.NamespaceTestDefault)
-                    }
-                    vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-                    num := 2
-                    By("Starting and stopping the VirtualMachine number of times")
-                    for i := 0; i < num; i++ {
-                        By(fmt.Sprintf("Doing run: %d", i))
-                        vm = tests.StartVirtualMachine(vm)
-                        // Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
-                        // after being restarted multiple times
-                        if i == num {
-                            By(checkingVMInstanceConsoleExpectedOut)
-                            vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-                            Expect(err).ToNot(HaveOccurred())
-                            Expect(console.LoginToAlpine(vmi)).To(Succeed())
-                        }
-                        vm = tests.StopVirtualMachine(vm)
-                    }
-                },
-
-                    Entry("with http import", true),
-                    Entry("with registry import", false),
-                )
-
-                It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", Label("test_id:3192"), func() {
-                    vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-                    vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-                    Expect(err).ToNot(HaveOccurred())
-
-                    // Check for owner reference
-                    Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
-
-                    // Delete the VM with orphan Propagation
-                    orphanPolicy := metav1.DeletePropagationOrphan
-                    Expect(virtClient.VirtualMachine(vm.Namespace).
-                        Delete(vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
-
-                    // Wait for the owner reference to disappear
-                    Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
-                })
-            })
-        })
-
-    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking",
-        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
-        func() {
-            Context("using Alpine import/clone", func() {
-                var dataVolume *cdiv1.DataVolume
-                var createdVirtualMachine *v1.VirtualMachine
-                var cloneRole *rbacv1.Role
-                var cloneRoleBinding *rbacv1.RoleBinding
-                var storageClass string
-                var vm *v1.VirtualMachine
-
-                BeforeEach(func() {
-                    var exists bool
-                    storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
-                    if !exists {
-                        Skip("Skip test when RWOFileSystem storage class is not present")
-                    }
-                    var err error
-                    dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-                    tests.SetDataVolumeForceBindAnnotation(dv)
-                    dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-                    Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
-
-                    vm = tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, util.NamespaceTestDefault)
-                    const volumeName = "sa"
-                    saVol := v1.Volume{
-                        Name: volumeName,
-                        VolumeSource: v1.VolumeSource{
-                            ServiceAccount: &v1.ServiceAccountVolumeSource{
-                                ServiceAccountName: tests.AdminServiceAccountName,
-                            },
-                        },
-                    }
-                    vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.StringPtr(storageClass)
-                    vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
-                    vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
-                })
-
-                AfterEach(func() {
-                    if cloneRole != nil {
-                        err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }
-
-                    if cloneRoleBinding != nil {
-                        err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }
-
-                    if createdVirtualMachine != nil {
-                        err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }
-                })
-
-                createVmSuccess := func() {
-                    // sometimes it takes a bit for permission to actually be applied so eventually
-                    Eventually(func() bool {
-                        _, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-                        if err != nil {
-                            fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
-                            return false
-                        }
-                        return true
-                    }, 90*time.Second, 1*time.Second).Should(BeTrue())
-
-                    createdVirtualMachine = vm
-
-                    // start vm and check dv clone succeeded
-                    createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
-                    targetDVName := vm.Spec.DataVolumeTemplates[0].Name
-                    Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
-                }
-
-                It("should resolve DataVolume sourceRef", func() {
-                    // convert DV to use datasource
-                    dvt := &vm.Spec.DataVolumeTemplates[0]
-                    ds := &cdiv1.DataSource{
-                        ObjectMeta: metav1.ObjectMeta{
-                            Name: "ds-" + rand.String(12),
-                        },
-                        Spec: cdiv1.DataSourceSpec{
-                            Source: cdiv1.DataSourceSource{
-                                PVC: dvt.Spec.Source.PVC,
-                            },
-                        },
-                    }
-                    ds, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-
-                    defer func() {
-                        err := virtClient.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
-                        Expect(err).ToNot(HaveOccurred())
-                    }()
-
-                    dvt.Spec.Source = nil
-                    dvt.Spec.SourceRef = &cdiv1.DataVolumeSourceRef{
-                        Kind: "DataSource",
-                        Name: ds.Name,
-                    }
-
-                    cloneRole, cloneRoleBinding = addClonePermission(
-                        virtClient,
-                        explicitCloneRole,
-                        tests.AdminServiceAccountName,
-                        util.NamespaceTestDefault,
-                        tests.NamespaceTestAlternative,
-                    )
-
-                    createVmSuccess()
-
-                    dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.TODO(), dvt.Name, metav1.GetOptions{})
-                    Expect(err).ToNot(HaveOccurred())
-                    Expect(dv.Spec.SourceRef).To(BeNil())
-                    Expect(dv.Spec.Source.PVC.Namespace).To(Equal(ds.Spec.Source.PVC.Namespace))
-                    Expect(dv.Spec.Source.PVC.Name).To(Equal(ds.Spec.Source.PVC.Name))
-                })
-
-                DescribeTable("[storage-req] deny then allow clone request", Label("storage-req"), func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
-                    _, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-                    Expect(err).To(HaveOccurred())
-                    Expect(err.Error()).To(ContainSubstring("Authorization failed, message is:"))
-
-                    saName := tests.AdminServiceAccountName
-                    saNamespace := util.NamespaceTestDefault
-
-                    if allServiceAccounts {
-                        saName = ""
-                        saNamespace = ""
-                    } else if allServiceAccountsInNamespace {
-                        saName = ""
-                    }
-
-                    // add permission
-                    cloneRole, cloneRoleBinding = addClonePermission(virtClient, role, saName, saNamespace, tests.NamespaceTestAlternative)
-
-                    createVmSuccess()
-
-                    // stop vm
-                    createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
-                },
-                    Entry("[test_id:3193]with explicit role", Label("test_id:3193"), explicitCloneRole, false, false),
-                    Entry("[test_id:3194]with implicit role", Label("test_id:3194"), implicitCloneRole, false, false),
-                    Entry("[test_id:5253]with explicit role (all namespaces)", Label("test_id:5253"), explicitCloneRole, true, false),
-                    Entry("[test_id:5254]with explicit role (one namespace)", Label("test_id:5254"), explicitCloneRole, false, true),
-                )
-            })
-        })
-
-    Context("Fedora VMI tests", func() {
-        imageSizeEqual := func(a, b int64) bool {
-            // Our OCS image size method probe is very precise and can show a few
-            // bytes of difference.
-            // A VM cannot do sub-512 byte accesses anyway, so such small size
-            // differences are practically equal.
-            if math.Abs((float64)(a-b)) >= 512 {
-                By(fmt.Sprintf("Image sizes not equal, %d - %d >= 512", a, b))
-                return false
-            } else {
-                return true
-            }
-        }
-        getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
-            var imageSize int64
-            var unused string
-            pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-            lsOutput, err := tests.ExecuteCommandOnPod(
-                virtClient,
-                pod,
-                "compute",
-                []string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
-            )
-            Expect(err).ToNot(HaveOccurred())
-            fmt.Sscanf(lsOutput, "%d %s", &imageSize, &unused)
-            return imageSize
-        }
-
-        noop := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-            return dv
-        }
-        addPreallocationTrue := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-            preallocation := true
-            dv.Spec.Preallocation = &preallocation
-            return dv
-        }
-        addPreallocationFalse := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-            preallocation := false
-            dv.Spec.Preallocation = &preallocation
-            return dv
-        }
-        addThickProvisionedTrueAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-            dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "true"}
-            return dv
-        }
-        addThickProvisionedFalseAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-            dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
-            return dv
-        }
-        DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img",
-            Label("rfe_id:5070", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
-            func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
-                dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-                dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
-                dataVolume = dvChange(dataVolume)
-                preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
-
-                vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-                vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-                vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
-                tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
-
-                _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-                Expect(err).ToNot(HaveOccurred())
-
-                vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-
-                By("Expecting the VirtualMachineInstance console")
-                Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-                imageSizeAfterBoot := getImageSize(vmi, dataVolume)
-                By(fmt.Sprintf("image size after boot is %d", imageSizeAfterBoot))
-
-                By("Filling out disk space")
-                Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-                    &expect.BSnd{S: "\n"},
-                    &expect.BExp{R: console.PromptExpression},
-                    &expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
-                    &expect.BExp{R: console.PromptExpression},
-                    &expect.BSnd{S: syncName},
-                    &expect.BExp{R: console.PromptExpression},
-                }, 360)).To(Succeed(), "should write a large file")
-
-                if preallocated {
-                    // Preallocation means no changes to disk size
-                    Eventually(imageSizeEqual(getImageSize(vmi, dataVolume), imageSizeAfterBoot), 120*time.Second).Should(BeTrue())
-                } else {
-                    Eventually(getImageSize(vmi, dataVolume), 120*time.Second).Should(BeNumerically(">", imageSizeAfterBoot))
-                }
-
-                imageSizeBeforeTrim := getImageSize(vmi, dataVolume)
-                By(fmt.Sprintf("image size before trim is %d", imageSizeBeforeTrim))
-
-                By("Writing a small file so that we detect a disk space usage change.")
-                By("Deleting large file and trimming disk")
-                Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-                    // Write a small file so that we'll have an increase in image size if trim is unsupported.
-                    &expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
-                    &expect.BExp{R: console.PromptExpression},
-                    &expect.BSnd{S: syncName},
-                    &expect.BExp{R: console.PromptExpression},
-                    &expect.BSnd{S: "rm -f largefile\n"},
-                    &expect.BExp{R: console.PromptExpression},
-                }, 60)).To(Succeed(), "should trim within the VM")
-
-                Eventually(func() bool {
-                    By("Running trim")
-                    err := console.SafeExpectBatch(vmi, []expect.Batcher{
-                        &expect.BSnd{S: "sudo fstrim -v /\n"},
-                        &expect.BExp{R: console.PromptExpression},
-                        &expect.BSnd{S: syncName},
-                        &expect.BExp{R: console.PromptExpression},
-                    }, 60)
-                    Expect(err).ToNot(HaveOccurred())
-
-                    currentImageSize := getImageSize(vmi, dataVolume)
-                    if expectSmaller {
-                        // Trim should make the space usage go down
-                        By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-                        return currentImageSize < imageSizeBeforeTrim
-                    } else if preallocated {
-                        By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-                        return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
-
-                    } else {
-                        By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-                        return currentImageSize > imageSizeBeforeTrim
-                    }
-                }, 120*time.Second).Should(BeTrue())
-
-                err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
-                Expect(err).To(BeNil())
-            },
-            Entry("[test_id:5894]by default, fstrim will make the image smaller", Label("test_id:5894"), noop, true),
-            Entry("[test_id:5898]with preallocation true, fstrim has no effect", Label("test_id:5898"), addPreallocationTrue, false),
-            Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", Label("test_id:5897"), addPreallocationFalse, true),
-            Entry("[test_id:5899]with thick provision true, fstrim has no effect", Label("test_id:5899"), addThickProvisionedTrueAnnotation, false),
-            Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", Label("test_id:5896"), addThickProvisionedFalseAnnotation, true),
-        )
-    })
+	var virtClient kubecli.KubevirtClient
+	var err error
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+
+		tests.BeforeTestCleanup()
+		if !tests.HasCDI() {
+			Skip("Skip DataVolume tests when CDI is not present")
+		}
+	})
+
+	Context("[storage-req]PVC expansion", Label("storage-req"), func() {
+		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
+			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
+			if !tests.HasCDI() {
+				Skip("Skip DataVolume tests when CDI is not present")
+			}
+			var sc string
+			exists := false
+			if volumeMode == k8sv1.PersistentVolumeBlock {
+				sc, exists = libstorage.GetRWOBlockStorageClass()
+				if !exists {
+					Skip("Skip test when Block storage is not present")
+				}
+			} else {
+				sc, exists = libstorage.GetRWOFileSystemStorageClass()
+				if !exists {
+					Skip("Skip test when Filesystem storage is not present")
+				}
+			}
+			volumeExpansionAllowed := tests.VolumeExpansionAllowed(sc)
+			if !volumeExpansionAllowed {
+				Skip("Skip when volume expansion storage class not available")
+			}
+			vmi, dataVolume := tests.NewRandomVirtualMachineInstanceWithDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce, volumeMode)
+			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 500)
+
+			By("Expecting the VirtualMachineInstance console")
+			Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Expanding PVC")
+			pvc.Spec.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("2Gi")
+			_, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for notification about size change")
+			Eventually(func() error {
+				err := console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "dmesg |grep 'new size'\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "dmesg |grep -c 'new size: [34]'\n"},
+					&expect.BExp{R: "1"},
+				}, 10)
+				return err
+			}, 360).Should(BeNil())
+
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "sudo /sbin/resize-filesystem /dev/root /run/resize.rootfs /dev/console && echo $?\n"},
+				&expect.BExp{R: "0"},
+			}, 30)).To(Succeed(), "failed to resize root")
+
+			By("Writing a 1.5G file after expansion, should succeed")
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "dd if=/dev/zero of=largefile count=1500 bs=1M; echo $?\n"},
+				&expect.BExp{R: "0"},
+			}, 360)).To(Succeed(), "can use more space after expansion and resize")
+		},
+			Entry("with Block PVC", k8sv1.PersistentVolumeBlock),
+			Entry("with Filesystem PVC", k8sv1.PersistentVolumeFilesystem),
+		)
+	})
+
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source",
+		Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+		func() {
+
+			Context("[Serial]without fsgroup support", Label("Serial"), func() {
+				size := "1Gi"
+
+				It("should succesfully start", func() {
+					// Create DV and alter permission of disk.img
+					url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
+					dv := libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
+					tests.SetDataVolumeForceBindAnnotation(dv)
+					dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
+					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+					var pvc *k8sv1.PersistentVolumeClaim
+					Eventually(func() *k8sv1.PersistentVolumeClaim {
+						pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+						if err != nil {
+							return nil
+						}
+						return pvc
+					}, 30*time.Second).Should(Not(BeNil()))
+					By("waiting for the dv import to pvc to finish")
+					Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
+					tests.ChangeImgFilePermissionsToNonQEMU(pvc)
+
+					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
+
+					By("Starting the VirtualMachineInstance")
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+
+					By(checkingVMInstanceConsoleExpectedOut)
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				})
+			})
+
+			Context("Alpine import", func() {
+				BeforeEach(func() {
+					cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cdis.Items).To(HaveLen(1))
+					hasWaitForFirstConsumerGate := false
+					for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
+						if feature == "HonorWaitForFirstConsumer" {
+							hasWaitForFirstConsumerGate = true
+							break
+						}
+					}
+					if !hasWaitForFirstConsumerGate {
+						Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
+					}
+				})
+
+				It("[test_id:3189]should be successfully started and stopped multiple times", Label("test_id:3189"), func() {
+
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+
+					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+
+					// This will only work on storage with binding mode WaitForFirstConsumer,
+					if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
+						Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
+					}
+					num := 2
+					By("Starting and stopping the VirtualMachineInstance a number of times")
+					for i := 1; i <= num; i++ {
+						vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+						// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
+						// after being restarted multiple times
+						if i == num {
+							By(checkingVMInstanceConsoleExpectedOut)
+							Expect(console.LoginToAlpine(vmi)).To(Succeed())
+						}
+
+						err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+						Expect(err).To(BeNil())
+						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					}
+					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+				})
+
+				It("[test_id:6686]should successfully start multiple concurrent VMIs", Label("test_id:6686"), func() {
+
+					numVmis := 5
+					vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
+					dvs := make([]*cdiv1.DataVolume, 0, numVmis)
+
+					for idx := 0; idx < numVmis; idx++ {
+						dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+						vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+						vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
+
+						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+						Expect(err).To(BeNil())
+
+						vmi = tests.RunVMI(vmi, 60)
+						vmis = append(vmis, vmi)
+						dvs = append(dvs, dataVolume)
+					}
+
+					for idx := 0; idx < numVmis; idx++ {
+						tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
+						By(checkingVMInstanceConsoleExpectedOut)
+						Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
+
+						err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
+						Expect(err).To(BeNil())
+						err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
+						Expect(err).To(BeNil())
+					}
+				})
+
+				It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", Label("test_id:5252"), func() {
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
+
+					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+					// This will only work on storage with binding mode WaitForFirstConsumer,
+					if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
+						Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
+					}
+					// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
+					// import and start
+					vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+
+					By(checkingVMInstanceConsoleExpectedOut)
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+
+					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+				})
+
+				It("should accurately report DataVolume provisioning", func() {
+					sc, exists := libstorage.GetSnapshotStorageClass()
+					if !exists {
+						Skip("no snapshot storage class configured")
+					}
+
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(
+						cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
+						util.NamespaceTestDefault,
+						sc,
+						k8sv1.ReadWriteOnce,
+						k8sv1.PersistentVolumeFilesystem,
+					)
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					vm := tests.NewRandomVirtualMachine(vmi, false)
+
+					_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+					defer func() {
+						err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}()
+
+					Eventually(func() bool {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
+					}, 180*time.Second, 2*time.Second).Should(BeTrue())
+
+					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					defer func() {
+						err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}()
+
+					Eventually(func() bool {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
+					}, 180*time.Second, 1*time.Second).Should(BeTrue())
+
+					Eventually(func() bool {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
+					}, 180*time.Second, 2*time.Second).Should(BeTrue())
+				})
+			})
+
+			Context("with a PVC from a Datavolume", func() {
+				var storageClass *storagev1.StorageClass
+				BeforeEach(func() {
+					// ensure that we always use a storage class which binds immediately,
+					// otherwise we will never see a PVC appear for the datavolume
+					bindMode := storagev1.VolumeBindingImmediate
+					storageClass = &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "fake",
+						},
+						Provisioner:       "afakeone",
+						VolumeBindingMode: &bindMode,
+					}
+					storageClass, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				})
+				AfterEach(func() {
+					if storageClass != nil && storageClass.Name != "" {
+						err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+
+				It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", Label("test_id:4643"), func() {
+
+					dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+
+					defer func(dv *cdiv1.DataVolume) {
+						By(deletingDataVolume)
+						ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+					}(dv)
+
+					Eventually(func() (*k8sv1.PersistentVolumeClaim, error) {
+						return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+					}, 30).Should(Not(BeNil()))
+
+					vmi := tests.NewRandomVMI()
+
+					diskName := "disk0"
+					bus := "virtio"
+					vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+						Name: diskName,
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{
+								Bus: bus,
+							},
+						},
+					})
+					vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+						Name: diskName,
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: dv.ObjectMeta.Name,
+							}},
+						},
+					})
+
+					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+					dvt := &v1.DataVolumeTemplateSpec{
+						ObjectMeta: dv.ObjectMeta,
+						Spec:       dv.Spec,
+					}
+					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
+					_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself",
+					Label("Serial", "test_id:4644"),
+					func() {
+						dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+						Expect(err).To(BeNil())
+
+						defer func(dv *cdiv1.DataVolume) {
+							By(deletingDataVolume)
+							ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+						}(dv)
+						Eventually(func() error {
+							_, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+							return err
+						}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+						vmi := tests.NewRandomVMI()
+
+						diskName := "disk0"
+						bus := "virtio"
+						vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+							Name: diskName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: bus,
+								},
+							},
+						})
+						vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+							Name: diskName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: dv.ObjectMeta.Name,
+								}},
+							},
+						})
+
+						vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+
+						vm := tests.NewRandomVirtualMachine(vmi, true)
+						_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+						Expect(err).ShouldNot(HaveOccurred())
+
+						Eventually(func() bool {
+							vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+
+							return vm.Status.Created
+						}, 30*time.Second, 1*time.Second).Should(Equal(false))
+					})
+			})
+		})
+
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume",
+		Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+		func() {
+			Context("using DataVolume with invalid URL", func() {
+				deleteDataVolume := func(dv *cdiv1.DataVolume) {
+					By(deletingDataVolume)
+					ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+				}
+
+				It("shold be possible to stop VM if datavolume is crashing", func() {
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
+					vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
+						{
+							ObjectMeta: dataVolume.ObjectMeta,
+							Spec:       dataVolume.Spec,
+						},
+					}
+
+					By(creatingVMInvalidDataVolume)
+					vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for DV to start crashing")
+					Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.ImportInProgress))
+
+					By("Stop VM")
+					tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
+				})
+
+				It("[test_id:3190]should correctly handle invalid DataVolumes", Label("test_id:3190"), func() {
+					// Don't actually create the DataVolume since it's invalid.
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					//  Add the invalid DataVolume to a VMI
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					// Create a VM for this VMI
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+
+					By(creatingVMInvalidDataVolume)
+					vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for VMI to be created")
+					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+				})
+				It("[test_id:3190]should correctly handle eventually consistent DataVolumes", Label("test_id:3190"), func() {
+					realRegistryName := flags.KubeVirtUtilityRepoPrefix
+					realRegistryPort := ""
+					if strings.Contains(flags.KubeVirtUtilityRepoPrefix, ":") {
+						realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
+						realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
+					}
+					if realRegistryPort == "" {
+						Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
+					}
+
+					fakeRegistryName := "fakeregistry"
+					fakeRegistryWithPort := fakeRegistryName
+					if realRegistryPort != "" {
+						fakeRegistryWithPort = fmt.Sprintf("%s:%s", fakeRegistryName, realRegistryPort)
+					}
+
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlFromRegistryForContainerDisk(fakeRegistryWithPort, cd.ContainerDiskCirros),
+						util.NamespaceTestDefault,
+						k8sv1.ReadWriteOnce,
+					)
+					defer deleteDataVolume(dataVolume)
+
+					By("Creating DataVolume with invalid URL")
+					dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+
+					By(creatingVMInvalidDataVolume)
+					//  Add the invalid DataVolume to a VMI
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					// Create a VM for this VMI
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+					vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+
+					By("Creating a service which makes the registry reachable")
+					virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeRegistryName,
+						},
+						Spec: k8sv1.ServiceSpec{
+							Type:         k8sv1.ServiceTypeExternalName,
+							ExternalName: realRegistryName,
+						},
+					}, metav1.CreateOptions{})
+
+					By("Wait for DataVolume to complete")
+					Eventually(ThisDV(dataVolume), 160).Should(HaveSucceeded())
+
+					By("Waiting for VMI to be created")
+					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
+				})
+			})
+		})
+
+	Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl",
+		Label("rfe_id:896", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+		func() {
+			var vm *v1.VirtualMachine
+			var err error
+			var vmJson string
+			var dataVolumeName string
+			var pvcName string
+
+			k8sClient := clientcmd.GetK8sCmdClient()
+
+			BeforeEach(func() {
+				running := true
+
+				vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+				vm.Spec.Running = &running
+
+				dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
+				pvcName = dataVolumeName
+
+				vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", Label("test_id:836"), func() {
+				By(creatingVMDataVolumeTemplateEntry)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
+
+				By(verifyingDataVolumeSuccess)
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+				By(verifyingPVCCreated)
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+				By(verifyingVMICreated)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+			})
+
+			It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", Label("test_id:837"), func() {
+				By(creatingVMDataVolumeTemplateEntry)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
+
+				By(verifyingDataVolumeSuccess)
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+				By(verifyingPVCCreated)
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+				By(verifyingVMICreated)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+
+				By("Deleting VM with cascade=true")
+				_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for the VM to be deleted")
+				Eventually(ThisVM(vm), 100).Should(BeGone())
+
+				By("Waiting for the VMI to be deleted")
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
+
+				By("Waiting for the DataVolume to be deleted")
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
+
+				By("Waiting for the PVC to be deleted")
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
+			})
+
+			It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", Label("test_id:838"), func() {
+				By(creatingVMDataVolumeTemplateEntry)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
+
+				By(verifyingDataVolumeSuccess)
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+				By(verifyingPVCCreated)
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+				By(verifyingVMICreated)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+
+				By("Deleting VM with cascade=false")
+				_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for the VM to be deleted")
+				Eventually(ThisVM(vm), 100).Should(BeGone())
+
+				By("Verifying DataVolume still exists with owner references removed")
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), Not(BeOwned())))
+
+				By("Verifying VMI still exists with owner references removed")
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(And(BeRunning(), Not(BeOwned())))
+			})
+
+		})
+
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume",
+		Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+		func() {
+			Context("using Alpine http import", func() {
+				It("a DataVolume with preallocation shouldn't have discard=unmap", func() {
+					var vm *v1.VirtualMachine
+					vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+					preallocation := true
+					vm.Spec.DataVolumeTemplates[0].Spec.Preallocation = &preallocation
+
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					vm = tests.StartVirtualMachine(vm)
+					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).ToNot(ContainSubstring("discard='unmap'"))
+					vm = tests.StopVirtualMachine(vm)
+					Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})).To(Succeed())
+				})
+
+				DescribeTable("[test_id:3191]should be successfully started and stopped multiple times", Label("test_id:3191"), func(isHTTP bool) {
+					var vm *v1.VirtualMachine
+					if isHTTP {
+						vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+					} else {
+						url := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
+						vm = tests.NewRandomVMWithDataVolume(url, util.NamespaceTestDefault)
+					}
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+					num := 2
+					By("Starting and stopping the VirtualMachine number of times")
+					for i := 0; i < num; i++ {
+						By(fmt.Sprintf("Doing run: %d", i))
+						vm = tests.StartVirtualMachine(vm)
+						// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
+						// after being restarted multiple times
+						if i == num {
+							By(checkingVMInstanceConsoleExpectedOut)
+							vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(console.LoginToAlpine(vmi)).To(Succeed())
+						}
+						vm = tests.StopVirtualMachine(vm)
+					}
+				},
+
+					Entry("with http import", true),
+					Entry("with registry import", false),
+				)
+
+				It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", Label("test_id:3192"), func() {
+					vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Check for owner reference
+					Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
+
+					// Delete the VM with orphan Propagation
+					orphanPolicy := metav1.DeletePropagationOrphan
+					Expect(virtClient.VirtualMachine(vm.Namespace).
+						Delete(vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
+
+					// Wait for the owner reference to disappear
+					Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
+				})
+			})
+		})
+
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking",
+		Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+		func() {
+			Context("using Alpine import/clone", func() {
+				var dataVolume *cdiv1.DataVolume
+				var createdVirtualMachine *v1.VirtualMachine
+				var cloneRole *rbacv1.Role
+				var cloneRoleBinding *rbacv1.RoleBinding
+				var storageClass string
+				var vm *v1.VirtualMachine
+
+				BeforeEach(func() {
+					var exists bool
+					storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
+					if !exists {
+						Skip("Skip test when RWOFileSystem storage class is not present")
+					}
+					var err error
+					dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+					tests.SetDataVolumeForceBindAnnotation(dv)
+					dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
+
+					vm = tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, util.NamespaceTestDefault)
+					const volumeName = "sa"
+					saVol := v1.Volume{
+						Name: volumeName,
+						VolumeSource: v1.VolumeSource{
+							ServiceAccount: &v1.ServiceAccountVolumeSource{
+								ServiceAccountName: tests.AdminServiceAccountName,
+							},
+						},
+					}
+					vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.StringPtr(storageClass)
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
+					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
+				})
+
+				AfterEach(func() {
+					if cloneRole != nil {
+						err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					if cloneRoleBinding != nil {
+						err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					if createdVirtualMachine != nil {
+						err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+
+				createVmSuccess := func() {
+					// sometimes it takes a bit for permission to actually be applied so eventually
+					Eventually(func() bool {
+						_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+						if err != nil {
+							fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
+							return false
+						}
+						return true
+					}, 90*time.Second, 1*time.Second).Should(BeTrue())
+
+					createdVirtualMachine = vm
+
+					// start vm and check dv clone succeeded
+					createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
+					targetDVName := vm.Spec.DataVolumeTemplates[0].Name
+					Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
+				}
+
+				It("should resolve DataVolume sourceRef", func() {
+					// convert DV to use datasource
+					dvt := &vm.Spec.DataVolumeTemplates[0]
+					ds := &cdiv1.DataSource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ds-" + rand.String(12),
+						},
+						Spec: cdiv1.DataSourceSpec{
+							Source: cdiv1.DataSourceSource{
+								PVC: dvt.Spec.Source.PVC,
+							},
+						},
+					}
+					ds, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					defer func() {
+						err := virtClient.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}()
+
+					dvt.Spec.Source = nil
+					dvt.Spec.SourceRef = &cdiv1.DataVolumeSourceRef{
+						Kind: "DataSource",
+						Name: ds.Name,
+					}
+
+					cloneRole, cloneRoleBinding = addClonePermission(
+						virtClient,
+						explicitCloneRole,
+						tests.AdminServiceAccountName,
+						util.NamespaceTestDefault,
+						tests.NamespaceTestAlternative,
+					)
+
+					createVmSuccess()
+
+					dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.TODO(), dvt.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dv.Spec.SourceRef).To(BeNil())
+					Expect(dv.Spec.Source.PVC.Namespace).To(Equal(ds.Spec.Source.PVC.Namespace))
+					Expect(dv.Spec.Source.PVC.Name).To(Equal(ds.Spec.Source.PVC.Name))
+				})
+
+				DescribeTable("[storage-req] deny then allow clone request", Label("storage-req"), func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
+					_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Authorization failed, message is:"))
+
+					saName := tests.AdminServiceAccountName
+					saNamespace := util.NamespaceTestDefault
+
+					if allServiceAccounts {
+						saName = ""
+						saNamespace = ""
+					} else if allServiceAccountsInNamespace {
+						saName = ""
+					}
+
+					// add permission
+					cloneRole, cloneRoleBinding = addClonePermission(virtClient, role, saName, saNamespace, tests.NamespaceTestAlternative)
+
+					createVmSuccess()
+
+					// stop vm
+					createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
+				},
+					Entry("[test_id:3193]with explicit role", Label("test_id:3193"), explicitCloneRole, false, false),
+					Entry("[test_id:3194]with implicit role", Label("test_id:3194"), implicitCloneRole, false, false),
+					Entry("[test_id:5253]with explicit role (all namespaces)", Label("test_id:5253"), explicitCloneRole, true, false),
+					Entry("[test_id:5254]with explicit role (one namespace)", Label("test_id:5254"), explicitCloneRole, false, true),
+				)
+			})
+		})
+
+	Context("Fedora VMI tests", func() {
+		imageSizeEqual := func(a, b int64) bool {
+			// Our OCS image size method probe is very precise and can show a few
+			// bytes of difference.
+			// A VM cannot do sub-512 byte accesses anyway, so such small size
+			// differences are practically equal.
+			if math.Abs((float64)(a-b)) >= 512 {
+				By(fmt.Sprintf("Image sizes not equal, %d - %d >= 512", a, b))
+				return false
+			} else {
+				return true
+			}
+		}
+		getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
+			var imageSize int64
+			var unused string
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+			lsOutput, err := tests.ExecuteCommandOnPod(
+				virtClient,
+				pod,
+				"compute",
+				[]string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Sscanf(lsOutput, "%d %s", &imageSize, &unused)
+			return imageSize
+		}
+
+		noop := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+			return dv
+		}
+		addPreallocationTrue := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+			preallocation := true
+			dv.Spec.Preallocation = &preallocation
+			return dv
+		}
+		addPreallocationFalse := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+			preallocation := false
+			dv.Spec.Preallocation = &preallocation
+			return dv
+		}
+		addThickProvisionedTrueAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "true"}
+			return dv
+		}
+		addThickProvisionedFalseAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
+			return dv
+		}
+		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img",
+			Label("rfe_id:5070", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
+			func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
+				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
+				dataVolume = dvChange(dataVolume)
+				preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
+
+				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+				vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
+
+				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				imageSizeAfterBoot := getImageSize(vmi, dataVolume)
+				By(fmt.Sprintf("image size after boot is %d", imageSizeAfterBoot))
+
+				By("Filling out disk space")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: syncName},
+					&expect.BExp{R: console.PromptExpression},
+				}, 360)).To(Succeed(), "should write a large file")
+
+				if preallocated {
+					// Preallocation means no changes to disk size
+					Eventually(imageSizeEqual(getImageSize(vmi, dataVolume), imageSizeAfterBoot), 120*time.Second).Should(BeTrue())
+				} else {
+					Eventually(getImageSize(vmi, dataVolume), 120*time.Second).Should(BeNumerically(">", imageSizeAfterBoot))
+				}
+
+				imageSizeBeforeTrim := getImageSize(vmi, dataVolume)
+				By(fmt.Sprintf("image size before trim is %d", imageSizeBeforeTrim))
+
+				By("Writing a small file so that we detect a disk space usage change.")
+				By("Deleting large file and trimming disk")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					// Write a small file so that we'll have an increase in image size if trim is unsupported.
+					&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: syncName},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "rm -f largefile\n"},
+					&expect.BExp{R: console.PromptExpression},
+				}, 60)).To(Succeed(), "should trim within the VM")
+
+				Eventually(func() bool {
+					By("Running trim")
+					err := console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "sudo fstrim -v /\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: syncName},
+						&expect.BExp{R: console.PromptExpression},
+					}, 60)
+					Expect(err).ToNot(HaveOccurred())
+
+					currentImageSize := getImageSize(vmi, dataVolume)
+					if expectSmaller {
+						// Trim should make the space usage go down
+						By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+						return currentImageSize < imageSizeBeforeTrim
+					} else if preallocated {
+						By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+						return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
+
+					} else {
+						By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+						return currentImageSize > imageSizeBeforeTrim
+					}
+				}, 120*time.Second).Should(BeTrue())
+
+				err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			},
+			Entry("[test_id:5894]by default, fstrim will make the image smaller", Label("test_id:5894"), noop, true),
+			Entry("[test_id:5898]with preallocation true, fstrim has no effect", Label("test_id:5898"), addPreallocationTrue, false),
+			Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", Label("test_id:5897"), addPreallocationFalse, true),
+			Entry("[test_id:5899]with thick provision true, fstrim has no effect", Label("test_id:5899"), addThickProvisionedTrueAnnotation, false),
+			Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", Label("test_id:5896"), addThickProvisionedFalseAnnotation, true),
+		)
+	})
 })
 
 var explicitCloneRole = &rbacv1.Role{
-    ObjectMeta: metav1.ObjectMeta{
-        Name: "explicit-clone-role",
-    },
-    Rules: []rbacv1.PolicyRule{
-        {
-            APIGroups: []string{
-                "cdi.kubevirt.io",
-            },
-            Resources: []string{
-                "datavolumes/source",
-            },
-            Verbs: []string{
-                "create",
-            },
-        },
-    },
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "explicit-clone-role",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"cdi.kubevirt.io",
+			},
+			Resources: []string{
+				"datavolumes/source",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
+	},
 }
 
 var implicitCloneRole = &rbacv1.Role{
-    ObjectMeta: metav1.ObjectMeta{
-        Name: "implicit-clone-role",
-    },
-    Rules: []rbacv1.PolicyRule{
-        {
-            APIGroups: []string{
-                "",
-            },
-            Resources: []string{
-                "pods",
-            },
-            Verbs: []string{
-                "create",
-            },
-        },
-    },
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "implicit-clone-role",
+	},
+	Rules: []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"pods",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
+	},
 }
 
 func addClonePermission(client kubecli.KubevirtClient, role *rbacv1.Role, sa, saNamespace, targetNamesace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
-    role, err := client.RbacV1().Roles(targetNamesace).Create(context.Background(), role, metav1.CreateOptions{})
-    Expect(err).ToNot(HaveOccurred())
+	role, err := client.RbacV1().Roles(targetNamesace).Create(context.Background(), role, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
 
-    rb := &rbacv1.RoleBinding{
-        ObjectMeta: metav1.ObjectMeta{
-            Name: role.Name,
-        },
-        RoleRef: rbacv1.RoleRef{
-            Kind:     "Role",
-            Name:     role.Name,
-            APIGroup: "rbac.authorization.k8s.io",
-        },
-    }
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: role.Name,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     role.Name,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
 
-    if sa != "" {
-        rb.Subjects = []rbacv1.Subject{
-            {
-                Kind:      "ServiceAccount",
-                Name:      sa,
-                Namespace: saNamespace,
-            },
-        }
-    } else {
-        g := "system:serviceaccounts"
-        if saNamespace != "" {
-            g += ":" + saNamespace
-        }
-        rb.Subjects = []rbacv1.Subject{
-            {
-                Kind:     "Group",
-                Name:     g,
-                APIGroup: "rbac.authorization.k8s.io",
-            },
-        }
-    }
+	if sa != "" {
+		rb.Subjects = []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      sa,
+				Namespace: saNamespace,
+			},
+		}
+	} else {
+		g := "system:serviceaccounts"
+		if saNamespace != "" {
+			g += ":" + saNamespace
+		}
+		rb.Subjects = []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				Name:     g,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		}
+	}
 
-    rb, err = client.RbacV1().RoleBindings(targetNamesace).Create(context.Background(), rb, metav1.CreateOptions{})
-    Expect(err).ToNot(HaveOccurred())
+	rb, err = client.RbacV1().RoleBindings(targetNamesace).Create(context.Background(), rb, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
 
-    return role, rb
+	return role, rb
 }

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -81,7 +81,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		}
 	})
 
-	Context("[storage-req]PVC expansion", func() {
+	Context("[storage-req]PVC expansion", Labels{"storage-req"}, func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
 			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
 			if !tests.HasCDI() {
@@ -150,9 +150,11 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		)
 	})
 
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source", func() {
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source",
+		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
+		func() {
 
-		Context("[Serial]without fsgroup support", func() {
+		Context("[Serial]without fsgroup support", Labels{"Serial"}, func() {
 			size := "1Gi"
 
 			It("should succesfully start", func() {
@@ -175,40 +177,40 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
 				tests.ChangeImgFilePermissionsToNonQEMU(pvc)
 
-				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
+					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
 
-				By("Starting the VirtualMachineInstance")
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+					By("Starting the VirtualMachineInstance")
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
 
-				By(checkingVMInstanceConsoleExpectedOut)
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By(checkingVMInstanceConsoleExpectedOut)
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				})
 			})
-		})
 
-		Context("Alpine import", func() {
-			BeforeEach(func() {
-				cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cdis.Items).To(HaveLen(1))
-				hasWaitForFirstConsumerGate := false
-				for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
-					if feature == "HonorWaitForFirstConsumer" {
-						hasWaitForFirstConsumerGate = true
-						break
+			Context("Alpine import", func() {
+				BeforeEach(func() {
+					cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(cdis.Items).To(HaveLen(1))
+					hasWaitForFirstConsumerGate := false
+					for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
+						if feature == "HonorWaitForFirstConsumer" {
+							hasWaitForFirstConsumerGate = true
+							break
+						}
 					}
-				}
-				if !hasWaitForFirstConsumerGate {
-					Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
-				}
-			})
+					if !hasWaitForFirstConsumerGate {
+						Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
+					}
+				})
 
-			It("[test_id:3189]should be successfully started and stopped multiple times", func() {
+				It("[test_id:3189]should be successfully started and stopped multiple times", Labels{"test_id:3189"}, func() {
 
 				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
+					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
 
 				// This will only work on storage with binding mode WaitForFirstConsumer,
 				if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
@@ -225,48 +227,48 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 						Expect(console.LoginToAlpine(vmi)).To(Succeed())
 					}
 
-					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+						err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+						Expect(err).To(BeNil())
+						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					}
+					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
 					Expect(err).To(BeNil())
-					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-				}
-				err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-				Expect(err).To(BeNil())
-			})
+				})
 
-			It("[test_id:6686]should successfully start multiple concurrent VMIs", func() {
+				It("[test_id:6686]should successfully start multiple concurrent VMIs", Labels{"test_id:6686"}, func() {
 
-				numVmis := 5
-				vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
-				dvs := make([]*cdiv1.DataVolume, 0, numVmis)
+					numVmis := 5
+					vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
+					dvs := make([]*cdiv1.DataVolume, 0, numVmis)
 
 				for idx := 0; idx < numVmis; idx++ {
 					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
 
-					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
+						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+						Expect(err).To(BeNil())
 
-					vmi = tests.RunVMI(vmi, 60)
-					vmis = append(vmis, vmi)
-					dvs = append(dvs, dataVolume)
-				}
+						vmi = tests.RunVMI(vmi, 60)
+						vmis = append(vmis, vmi)
+						dvs = append(dvs, dataVolume)
+					}
 
-				for idx := 0; idx < numVmis; idx++ {
-					tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
-					By(checkingVMInstanceConsoleExpectedOut)
-					Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
+					for idx := 0; idx < numVmis; idx++ {
+						tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
+						By(checkingVMInstanceConsoleExpectedOut)
+						Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
 
-					err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
-					Expect(err).To(BeNil())
-					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
-					Expect(err).To(BeNil())
-				}
-			})
+						err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
+						Expect(err).To(BeNil())
+						err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
+						Expect(err).To(BeNil())
+					}
+				})
 
-			It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", func() {
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-				vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
+				It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", Labels{"test_id:5252"}, func() {
+					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
@@ -278,605 +280,615 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				// import and start
 				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 
-				By(checkingVMInstanceConsoleExpectedOut)
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By(checkingVMInstanceConsoleExpectedOut)
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-				Expect(err).To(BeNil())
-				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 
-				err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-				Expect(err).To(BeNil())
-			})
+					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+				})
 
-			It("should accurately report DataVolume provisioning", func() {
+				It("should accurately report DataVolume provisioning", func() {
 				sc, exists := libstorage.GetSnapshotStorageClass()
-				if !exists {
-					Skip("no snapshot storage class configured")
-				}
+					if !exists {
+						Skip("no snapshot storage class configured")
+					}
 
 				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(
-					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
-					util.NamespaceTestDefault,
-					sc,
-					k8sv1.ReadWriteOnce,
-					k8sv1.PersistentVolumeFilesystem,
-				)
-				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-				vm := tests.NewRandomVirtualMachine(vmi, false)
+						cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
+						util.NamespaceTestDefault,
+						sc,
+						k8sv1.ReadWriteOnce,
+						k8sv1.PersistentVolumeFilesystem,
+					)
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					vm := tests.NewRandomVirtualMachine(vmi, false)
 
-				_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-				defer func() {
-					err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+					_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
 					Expect(err).ToNot(HaveOccurred())
-				}()
+					defer func() {
+						err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}()
 
-				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-				}, 180*time.Second, 2*time.Second).Should(BeTrue())
+					Eventually(func() bool {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
+					}, 180*time.Second, 2*time.Second).Should(BeTrue())
 
-				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				defer func() {
-					err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
-				}()
+					defer func() {
+						err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}()
 
-				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
-				}, 180*time.Second, 1*time.Second).Should(BeTrue())
+					Eventually(func() bool {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
+					}, 180*time.Second, 1*time.Second).Should(BeTrue())
 
-				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					Eventually(func() bool {
+						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
+					}, 180*time.Second, 2*time.Second).Should(BeTrue())
+				})
+			})
+
+			Context("with a PVC from a Datavolume", func() {
+				var storageClass *storagev1.StorageClass
+				BeforeEach(func() {
+					// ensure that we always use a storage class which binds immediately,
+					// otherwise we will never see a PVC appear for the datavolume
+					bindMode := storagev1.VolumeBindingImmediate
+					storageClass = &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "fake",
+						},
+						Provisioner:       "afakeone",
+						VolumeBindingMode: &bindMode,
+					}
+					storageClass, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-				}, 180*time.Second, 2*time.Second).Should(BeTrue())
+				})
+				AfterEach(func() {
+					if storageClass != nil && storageClass.Name != "" {
+						err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+
+				It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", Labels{"test_id:4643"}, func() {
+
+				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+
+					defer func(dv *cdiv1.DataVolume) {
+						By(deletingDataVolume)
+						ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+					}(dv)
+
+					Eventually(func() (*k8sv1.PersistentVolumeClaim, error) {
+						return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+					}, 30).Should(Not(BeNil()))
+
+					vmi := tests.NewRandomVMI()
+
+					diskName := "disk0"
+					bus := "virtio"
+					vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+						Name: diskName,
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{
+								Bus: bus,
+							},
+						},
+					})
+					vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+						Name: diskName,
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: dv.ObjectMeta.Name,
+							}},
+						},
+					})
+
+					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+					dvt := &v1.DataVolumeTemplateSpec{
+						ObjectMeta: dv.ObjectMeta,
+						Spec:       dv.Spec,
+					}
+					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
+					_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself",
+					Labels{"Serial", "test_id:4644"},
+					func() {
+						dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+						Expect(err).To(BeNil())
+
+						defer func(dv *cdiv1.DataVolume) {
+							By(deletingDataVolume)
+							ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+						}(dv)
+						Eventually(func() error {
+							_, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+							return err
+						}, 30*time.Second, 1*time.Second).Should(BeNil())
+
+						vmi := tests.NewRandomVMI()
+
+						diskName := "disk0"
+						bus := "virtio"
+						vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+							Name: diskName,
+							DiskDevice: v1.DiskDevice{
+								Disk: &v1.DiskTarget{
+									Bus: bus,
+								},
+							},
+						})
+						vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+							Name: diskName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: dv.ObjectMeta.Name,
+								}},
+							},
+						})
+
+						vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+
+						vm := tests.NewRandomVirtualMachine(vmi, true)
+						_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+						Expect(err).ShouldNot(HaveOccurred())
+
+						Eventually(func() bool {
+							vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+
+							return vm.Status.Created
+						}, 30*time.Second, 1*time.Second).Should(Equal(false))
+					})
 			})
 		})
 
-		Context("with a PVC from a Datavolume", func() {
-			var storageClass *storagev1.StorageClass
-			BeforeEach(func() {
-				// ensure that we always use a storage class which binds immediately,
-				// otherwise we will never see a PVC appear for the datavolume
-				bindMode := storagev1.VolumeBindingImmediate
-				storageClass = &storagev1.StorageClass{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "fake",
-					},
-					Provisioner:       "afakeone",
-					VolumeBindingMode: &bindMode,
-				}
-				storageClass, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-			})
-			AfterEach(func() {
-				if storageClass != nil && storageClass.Name != "" {
-					err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
-			})
-
-			It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", func() {
-
-				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-
-				defer func(dv *cdiv1.DataVolume) {
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume",
+		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
+		func() {
+			Context("using DataVolume with invalid URL", func() {
+				deleteDataVolume := func(dv *cdiv1.DataVolume) {
 					By(deletingDataVolume)
 					ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-				}(dv)
-
-				Eventually(func() (*k8sv1.PersistentVolumeClaim, error) {
-					return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-				}, 30).Should(Not(BeNil()))
-
-				vmi := tests.NewRandomVMI()
-
-				diskName := "disk0"
-				bus := "virtio"
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-					Name: diskName,
-					DiskDevice: v1.DiskDevice{
-						Disk: &v1.DiskTarget{
-							Bus: bus,
-						},
-					},
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: diskName,
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-							ClaimName: dv.ObjectMeta.Name,
-						}},
-					},
-				})
-
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-
-				vm := tests.NewRandomVirtualMachine(vmi, true)
-				dvt := &v1.DataVolumeTemplateSpec{
-					ObjectMeta: dv.ObjectMeta,
-					Spec:       dv.Spec,
 				}
-				vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
-				_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-			})
-			It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself", func() {
-				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
 
-				defer func(dv *cdiv1.DataVolume) {
-					By(deletingDataVolume)
-					ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-				}(dv)
-				Eventually(func() error {
-					_, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-					return err
-				}, 30*time.Second, 1*time.Second).Should(BeNil())
-
-				vmi := tests.NewRandomVMI()
-
-				diskName := "disk0"
-				bus := "virtio"
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-					Name: diskName,
-					DiskDevice: v1.DiskDevice{
-						Disk: &v1.DiskTarget{
-							Bus: bus,
+				It("shold be possible to stop VM if datavolume is crashing", func() {
+				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
+					vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
+						{
+							ObjectMeta: dataVolume.ObjectMeta,
+							Spec:       dataVolume.Spec,
 						},
-					},
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: diskName,
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-							ClaimName: dv.ObjectMeta.Name,
-						}},
-					},
-				})
+					}
 
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-
-				vm := tests.NewRandomVirtualMachine(vmi, true)
-				_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Eventually(func() bool {
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					By(creatingVMInvalidDataVolume)
+					vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
 					Expect(err).ToNot(HaveOccurred())
 
-					return vm.Status.Created
-				}, 30*time.Second, 1*time.Second).Should(Equal(false))
-			})
-		})
-	})
+					By("Waiting for DV to start crashing")
+					Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.ImportInProgress))
 
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume", func() {
-		Context("using DataVolume with invalid URL", func() {
-			deleteDataVolume := func(dv *cdiv1.DataVolume) {
-				By(deletingDataVolume)
-				ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-			}
+					By("Stop VM")
+					tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
+				})
 
-			It("shold be possible to stop VM if datavolume is crashing", func() {
+				It("[test_id:3190]should correctly handle invalid DataVolumes", Labels{"test_id:3190"}, func() {
+					// Don't actually create the DataVolume since it's invalid.
 				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
-				vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
-					{
-						ObjectMeta: dataVolume.ObjectMeta,
-						Spec:       dataVolume.Spec,
-					},
-				}
+					//  Add the invalid DataVolume to a VMI
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					// Create a VM for this VMI
+					vm := tests.NewRandomVirtualMachine(vmi, true)
 
-				By(creatingVMInvalidDataVolume)
-				vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
+					By(creatingVMInvalidDataVolume)
+					vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
 
-				By("Waiting for DV to start crashing")
-				Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.ImportInProgress))
+					By("Waiting for VMI to be created")
+					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+				})
+				It("[test_id:3190]should correctly handle eventually consistent DataVolumes", Labels{"test_id:3190"}, func() {
+					realRegistryName := flags.KubeVirtUtilityRepoPrefix
+					realRegistryPort := ""
+					if strings.Contains(flags.KubeVirtUtilityRepoPrefix, ":") {
+						realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
+						realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
+					}
+					if realRegistryPort == "" {
+						Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
+					}
 
-				By("Stop VM")
-				tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
-			})
-
-			It("[test_id:3190]should correctly handle invalid DataVolumes", func() {
-				// Don't actually create the DataVolume since it's invalid.
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-				//  Add the invalid DataVolume to a VMI
-				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-				// Create a VM for this VMI
-				vm := tests.NewRandomVirtualMachine(vmi, true)
-
-				By(creatingVMInvalidDataVolume)
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Waiting for VMI to be created")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
-			})
-			It("[test_id:3190]should correctly handle eventually consistent DataVolumes", func() {
-				realRegistryName := flags.KubeVirtUtilityRepoPrefix
-				realRegistryPort := ""
-				if strings.Contains(flags.KubeVirtUtilityRepoPrefix, ":") {
-					realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
-					realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
-				}
-				if realRegistryPort == "" {
-					Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
-				}
-
-				fakeRegistryName := "fakeregistry"
-				fakeRegistryWithPort := fakeRegistryName
-				if realRegistryPort != "" {
-					fakeRegistryWithPort = fmt.Sprintf("%s:%s", fakeRegistryName, realRegistryPort)
-				}
+					fakeRegistryName := "fakeregistry"
+					fakeRegistryWithPort := fakeRegistryName
+					if realRegistryPort != "" {
+						fakeRegistryWithPort = fmt.Sprintf("%s:%s", fakeRegistryName, realRegistryPort)
+					}
 
 				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlFromRegistryForContainerDisk(fakeRegistryWithPort, cd.ContainerDiskCirros),
-					util.NamespaceTestDefault,
-					k8sv1.ReadWriteOnce,
-				)
-				defer deleteDataVolume(dataVolume)
+						util.NamespaceTestDefault,
+						k8sv1.ReadWriteOnce,
+					)
+					defer deleteDataVolume(dataVolume)
 
-				By("Creating DataVolume with invalid URL")
-				dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
+					By("Creating DataVolume with invalid URL")
+					dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
 
-				By(creatingVMInvalidDataVolume)
-				//  Add the invalid DataVolume to a VMI
-				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-				// Create a VM for this VMI
-				vm := tests.NewRandomVirtualMachine(vmi, true)
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
+					By(creatingVMInvalidDataVolume)
+					//  Add the invalid DataVolume to a VMI
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					// Create a VM for this VMI
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+					vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
 
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
 
-				By("Creating a service which makes the registry reachable")
-				virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fakeRegistryName,
-					},
-					Spec: k8sv1.ServiceSpec{
-						Type:         k8sv1.ServiceTypeExternalName,
-						ExternalName: realRegistryName,
-					},
-				}, metav1.CreateOptions{})
+					By("Creating a service which makes the registry reachable")
+					virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fakeRegistryName,
+						},
+						Spec: k8sv1.ServiceSpec{
+							Type:         k8sv1.ServiceTypeExternalName,
+							ExternalName: realRegistryName,
+						},
+					}, metav1.CreateOptions{})
 
-				By("Wait for DataVolume to complete")
-				Eventually(ThisDV(dataVolume), 160).Should(HaveSucceeded())
+					By("Wait for DataVolume to complete")
+					Eventually(ThisDV(dataVolume), 160).Should(HaveSucceeded())
 
-				By("Waiting for VMI to be created")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
+					By("Waiting for VMI to be created")
+					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
+				})
 			})
 		})
-	})
 
-	Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl", func() {
-		var vm *v1.VirtualMachine
-		var err error
-		var vmJson string
-		var dataVolumeName string
-		var pvcName string
+	Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl",
+		Labels{"rfe_id:896", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
+		func() {
+			var vm *v1.VirtualMachine
+			var err error
+			var vmJson string
+			var dataVolumeName string
+			var pvcName string
 
 		k8sClient := clientcmd.GetK8sCmdClient()
 
-		BeforeEach(func() {
-			running := true
-
-			vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-			vm.Spec.Running = &running
-
-			dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
-			pvcName = dataVolumeName
-
-			vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", func() {
-			By(creatingVMDataVolumeTemplateEntry)
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-			Expect(err).ToNot(HaveOccurred())
-
-			By(verifyingDataVolumeSuccess)
-			Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-			By(verifyingPVCCreated)
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-			By(verifyingVMICreated)
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-		})
-
-		It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", func() {
-			By(creatingVMDataVolumeTemplateEntry)
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-			Expect(err).ToNot(HaveOccurred())
-
-			By(verifyingDataVolumeSuccess)
-			Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-			By(verifyingPVCCreated)
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-			By(verifyingVMICreated)
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-
-			By("Deleting VM with cascade=true")
-			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Waiting for the VM to be deleted")
-			Eventually(ThisVM(vm), 100).Should(BeGone())
-
-			By("Waiting for the VMI to be deleted")
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
-
-			By("Waiting for the DataVolume to be deleted")
-			Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
-
-			By("Waiting for the PVC to be deleted")
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
-		})
-
-		It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", func() {
-			By(creatingVMDataVolumeTemplateEntry)
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-			Expect(err).ToNot(HaveOccurred())
-
-			By(verifyingDataVolumeSuccess)
-			Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-			By(verifyingPVCCreated)
-			Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-			By(verifyingVMICreated)
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-
-			By("Deleting VM with cascade=false")
-			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Waiting for the VM to be deleted")
-			Eventually(ThisVM(vm), 100).Should(BeGone())
-
-			By("Verifying DataVolume still exists with owner references removed")
-			Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), Not(BeOwned())))
-
-			By("Verifying VMI still exists with owner references removed")
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(And(BeRunning(), Not(BeOwned())))
-		})
-
-	})
-
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume", func() {
-		Context("using Alpine http import", func() {
-			It("a DataVolume with preallocation shouldn't have discard=unmap", func() {
-				var vm *v1.VirtualMachine
-				vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-				preallocation := true
-				vm.Spec.DataVolumeTemplates[0].Spec.Preallocation = &preallocation
-
-				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-
-				vm = tests.StartVirtualMachine(vm)
-				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).ToNot(ContainSubstring("discard='unmap'"))
-				vm = tests.StopVirtualMachine(vm)
-				Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})).To(Succeed())
-			})
-
-			DescribeTable("[test_id:3191]should be successfully started and stopped multiple times", func(isHTTP bool) {
-				var vm *v1.VirtualMachine
-				if isHTTP {
-					vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-				} else {
-					url := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
-					vm = tests.NewRandomVMWithDataVolume(url, util.NamespaceTestDefault)
-				}
-				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-				num := 2
-				By("Starting and stopping the VirtualMachine number of times")
-				for i := 0; i < num; i++ {
-					By(fmt.Sprintf("Doing run: %d", i))
-					vm = tests.StartVirtualMachine(vm)
-					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
-					// after being restarted multiple times
-					if i == num {
-						By(checkingVMInstanceConsoleExpectedOut)
-						vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						Expect(console.LoginToAlpine(vmi)).To(Succeed())
-					}
-					vm = tests.StopVirtualMachine(vm)
-				}
-			},
-
-				Entry("with http import", true),
-				Entry("with registry import", false),
-			)
-
-			It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", func() {
-				vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check for owner reference
-				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
-
-				// Delete the VM with orphan Propagation
-				orphanPolicy := metav1.DeletePropagationOrphan
-				Expect(virtClient.VirtualMachine(vm.Namespace).
-					Delete(vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
-
-				// Wait for the owner reference to disappear
-				Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
-			})
-		})
-	})
-
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking", func() {
-		Context("using Alpine import/clone", func() {
-			var dataVolume *cdiv1.DataVolume
-			var createdVirtualMachine *v1.VirtualMachine
-			var cloneRole *rbacv1.Role
-			var cloneRoleBinding *rbacv1.RoleBinding
-			var storageClass string
-			var vm *v1.VirtualMachine
-
 			BeforeEach(func() {
-				var exists bool
-				storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when RWOFileSystem storage class is not present")
-				}
-				var err error
-				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-				tests.SetDataVolumeForceBindAnnotation(dv)
-				dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+				running := true
+
+				vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+				vm.Spec.Running = &running
+
+				dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
+				pvcName = dataVolumeName
+
+				vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
 				Expect(err).ToNot(HaveOccurred())
-				Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
-
-				vm = tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, util.NamespaceTestDefault)
-				const volumeName = "sa"
-				saVol := v1.Volume{
-					Name: volumeName,
-					VolumeSource: v1.VolumeSource{
-						ServiceAccount: &v1.ServiceAccountVolumeSource{
-							ServiceAccountName: tests.AdminServiceAccountName,
-						},
-					},
-				}
-				vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.StringPtr(storageClass)
-				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
-				vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
 			})
 
-			AfterEach(func() {
-				if cloneRole != nil {
-					err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
+			It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", Labels{"test_id:836"}, func() {
+				By(creatingVMDataVolumeTemplateEntry)
+			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
 
-				if cloneRoleBinding != nil {
-					err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
+				By(verifyingDataVolumeSuccess)
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
 
-				if createdVirtualMachine != nil {
-					err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}
+				By(verifyingPVCCreated)
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+				By(verifyingVMICreated)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
 			})
 
-			createVmSuccess := func() {
-				// sometimes it takes a bit for permission to actually be applied so eventually
-				Eventually(func() bool {
-					_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-					if err != nil {
-						fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
-						return false
+			It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", Labels{"test_id:837"}, func() {
+				By(creatingVMDataVolumeTemplateEntry)
+			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
+
+				By(verifyingDataVolumeSuccess)
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+				By(verifyingPVCCreated)
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+				By(verifyingVMICreated)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+
+				By("Deleting VM with cascade=true")
+			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for the VM to be deleted")
+				Eventually(ThisVM(vm), 100).Should(BeGone())
+
+				By("Waiting for the VMI to be deleted")
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
+
+				By("Waiting for the DataVolume to be deleted")
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
+
+				By("Waiting for the PVC to be deleted")
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
+			})
+
+			It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", Labels{"test_id:838"}, func() {
+				By(creatingVMDataVolumeTemplateEntry)
+			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				Expect(err).ToNot(HaveOccurred())
+
+				By(verifyingDataVolumeSuccess)
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+				By(verifyingPVCCreated)
+				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+				By(verifyingVMICreated)
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+
+				By("Deleting VM with cascade=false")
+			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for the VM to be deleted")
+				Eventually(ThisVM(vm), 100).Should(BeGone())
+
+				By("Verifying DataVolume still exists with owner references removed")
+				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), Not(BeOwned())))
+
+				By("Verifying VMI still exists with owner references removed")
+				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(And(BeRunning(), Not(BeOwned())))
+			})
+
+		})
+
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume",
+		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
+		func() {
+			Context("using Alpine http import", func() {
+				It("a DataVolume with preallocation shouldn't have discard=unmap", func() {
+					var vm *v1.VirtualMachine
+					vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+					preallocation := true
+					vm.Spec.DataVolumeTemplates[0].Spec.Preallocation = &preallocation
+
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					vm = tests.StartVirtualMachine(vm)
+					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).ToNot(ContainSubstring("discard='unmap'"))
+					vm = tests.StopVirtualMachine(vm)
+					Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})).To(Succeed())
+				})
+
+				DescribeTable("[test_id:3191]should be successfully started and stopped multiple times", Labels{"test_id:3191"}, func(isHTTP bool) {
+					var vm *v1.VirtualMachine
+					if isHTTP {
+						vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+					} else {
+						url := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
+						vm = tests.NewRandomVMWithDataVolume(url, util.NamespaceTestDefault)
 					}
-					return true
-				}, 90*time.Second, 1*time.Second).Should(BeTrue())
-
-				createdVirtualMachine = vm
-
-				// start vm and check dv clone succeeded
-				createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
-				targetDVName := vm.Spec.DataVolumeTemplates[0].Name
-				Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
-			}
-
-			It("should resolve DataVolume sourceRef", func() {
-				// convert DV to use datasource
-				dvt := &vm.Spec.DataVolumeTemplates[0]
-				ds := &cdiv1.DataSource{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "ds-" + rand.String(12),
-					},
-					Spec: cdiv1.DataSourceSpec{
-						Source: cdiv1.DataSourceSource{
-							PVC: dvt.Spec.Source.PVC,
-						},
-					},
-				}
-				ds, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				defer func() {
-					err := virtClient.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 					Expect(err).ToNot(HaveOccurred())
-				}()
+					num := 2
+					By("Starting and stopping the VirtualMachine number of times")
+					for i := 0; i < num; i++ {
+						By(fmt.Sprintf("Doing run: %d", i))
+						vm = tests.StartVirtualMachine(vm)
+						// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
+						// after being restarted multiple times
+						if i == num {
+							By(checkingVMInstanceConsoleExpectedOut)
+							vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
+							Expect(console.LoginToAlpine(vmi)).To(Succeed())
+						}
+						vm = tests.StopVirtualMachine(vm)
+					}
+				},
 
-				dvt.Spec.Source = nil
-				dvt.Spec.SourceRef = &cdiv1.DataVolumeSourceRef{
-					Kind: "DataSource",
-					Name: ds.Name,
-				}
-
-				cloneRole, cloneRoleBinding = addClonePermission(
-					virtClient,
-					explicitCloneRole,
-					tests.AdminServiceAccountName,
-					util.NamespaceTestDefault,
-					tests.NamespaceTestAlternative,
+					Entry("with http import", true),
+					Entry("with registry import", false),
 				)
 
-				createVmSuccess()
+				It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", Labels{"test_id:3192"}, func() {
+					vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
 
-				dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.TODO(), dvt.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(dv.Spec.SourceRef).To(BeNil())
-				Expect(dv.Spec.Source.PVC.Namespace).To(Equal(ds.Spec.Source.PVC.Namespace))
-				Expect(dv.Spec.Source.PVC.Name).To(Equal(ds.Spec.Source.PVC.Name))
+					// Check for owner reference
+					Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
+
+					// Delete the VM with orphan Propagation
+					orphanPolicy := metav1.DeletePropagationOrphan
+					Expect(virtClient.VirtualMachine(vm.Namespace).
+						Delete(vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
+
+					// Wait for the owner reference to disappear
+					Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
+				})
 			})
+		})
 
-			DescribeTable("[storage-req] deny then allow clone request", func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
-				_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Authorization failed, message is:"))
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking",
+		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
+		func() {
+			Context("using Alpine import/clone", func() {
+				var dataVolume *cdiv1.DataVolume
+				var createdVirtualMachine *v1.VirtualMachine
+				var cloneRole *rbacv1.Role
+				var cloneRoleBinding *rbacv1.RoleBinding
+				var storageClass string
+				var vm *v1.VirtualMachine
 
-				saName := tests.AdminServiceAccountName
-				saNamespace := util.NamespaceTestDefault
+				BeforeEach(func() {
+					var exists bool
+				storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
+					if !exists {
+						Skip("Skip test when RWOFileSystem storage class is not present")
+					}
+					var err error
+				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+					tests.SetDataVolumeForceBindAnnotation(dv)
+					dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
 
-				if allServiceAccounts {
-					saName = ""
-					saNamespace = ""
-				} else if allServiceAccountsInNamespace {
-					saName = ""
+					vm = tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, util.NamespaceTestDefault)
+					const volumeName = "sa"
+					saVol := v1.Volume{
+						Name: volumeName,
+						VolumeSource: v1.VolumeSource{
+							ServiceAccount: &v1.ServiceAccountVolumeSource{
+								ServiceAccountName: tests.AdminServiceAccountName,
+							},
+						},
+					}
+					vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.StringPtr(storageClass)
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
+					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
+				})
+
+				AfterEach(func() {
+					if cloneRole != nil {
+						err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					if cloneRoleBinding != nil {
+						err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					if createdVirtualMachine != nil {
+						err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
+
+				createVmSuccess := func() {
+					// sometimes it takes a bit for permission to actually be applied so eventually
+					Eventually(func() bool {
+						_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+						if err != nil {
+							fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
+							return false
+						}
+						return true
+					}, 90*time.Second, 1*time.Second).Should(BeTrue())
+
+					createdVirtualMachine = vm
+
+					// start vm and check dv clone succeeded
+					createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
+					targetDVName := vm.Spec.DataVolumeTemplates[0].Name
+					Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
 				}
 
-				// add permission
-				cloneRole, cloneRoleBinding = addClonePermission(virtClient, role, saName, saNamespace, tests.NamespaceTestAlternative)
+				It("should resolve DataVolume sourceRef", func() {
+					// convert DV to use datasource
+					dvt := &vm.Spec.DataVolumeTemplates[0]
+					ds := &cdiv1.DataSource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ds-" + rand.String(12),
+						},
+						Spec: cdiv1.DataSourceSpec{
+							Source: cdiv1.DataSourceSource{
+								PVC: dvt.Spec.Source.PVC,
+							},
+						},
+					}
+					ds, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
-				createVmSuccess()
+					defer func() {
+						err := virtClient.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					}()
 
-				// stop vm
-				createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
-			},
-				Entry("[test_id:3193]with explicit role", explicitCloneRole, false, false),
-				Entry("[test_id:3194]with implicit role", implicitCloneRole, false, false),
-				Entry("[test_id:5253]with explicit role (all namespaces)", explicitCloneRole, true, false),
-				Entry("[test_id:5254]with explicit role (one namespace)", explicitCloneRole, false, true),
-			)
+					dvt.Spec.Source = nil
+					dvt.Spec.SourceRef = &cdiv1.DataVolumeSourceRef{
+						Kind: "DataSource",
+						Name: ds.Name,
+					}
+
+					cloneRole, cloneRoleBinding = addClonePermission(
+						virtClient,
+						explicitCloneRole,
+						tests.AdminServiceAccountName,
+						util.NamespaceTestDefault,
+						tests.NamespaceTestAlternative,
+					)
+
+					createVmSuccess()
+
+					dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.TODO(), dvt.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dv.Spec.SourceRef).To(BeNil())
+					Expect(dv.Spec.Source.PVC.Namespace).To(Equal(ds.Spec.Source.PVC.Namespace))
+					Expect(dv.Spec.Source.PVC.Name).To(Equal(ds.Spec.Source.PVC.Name))
+				})
+
+				DescribeTable("[storage-req] deny then allow clone request", Labels{"storage-req"}, func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
+					_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Authorization failed, message is:"))
+
+					saName := tests.AdminServiceAccountName
+					saNamespace := util.NamespaceTestDefault
+
+					if allServiceAccounts {
+						saName = ""
+						saNamespace = ""
+					} else if allServiceAccountsInNamespace {
+						saName = ""
+					}
+
+					// add permission
+					cloneRole, cloneRoleBinding = addClonePermission(virtClient, role, saName, saNamespace, tests.NamespaceTestAlternative)
+
+					createVmSuccess()
+
+					// stop vm
+					createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
+				},
+					Entry("[test_id:3193]with explicit role", Labels{"test_id:3193"}, explicitCloneRole, false, false),
+					Entry("[test_id:3194]with implicit role", Labels{"test_id:3194"}, implicitCloneRole, false, false),
+					Entry("[test_id:5253]with explicit role (all namespaces)", Labels{"test_id:5253"}, explicitCloneRole, true, false),
+					Entry("[test_id:5254]with explicit role (one namespace)", Labels{"test_id:5254"}, explicitCloneRole, false, true),
+				)
+			})
 		})
-	})
 
 	Context("Fedora VMI tests", func() {
 		imageSizeEqual := func(a, b int64) bool {
@@ -927,93 +939,95 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
 			return dv
 		}
-		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
-			dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-			dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
-			dataVolume = dvChange(dataVolume)
-			preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
+		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img",
+			Labels{"rfe_id:5070", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
+				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
+				dataVolume = dvChange(dataVolume)
+				preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
 
-			vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-			vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
-			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
+				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+				vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
 
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-			vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 
-			By("Expecting the VirtualMachineInstance console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-			imageSizeAfterBoot := getImageSize(vmi, dataVolume)
-			By(fmt.Sprintf("image size after boot is %d", imageSizeAfterBoot))
+				imageSizeAfterBoot := getImageSize(vmi, dataVolume)
+				By(fmt.Sprintf("image size after boot is %d", imageSizeAfterBoot))
 
-			By("Filling out disk space")
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: syncName},
-				&expect.BExp{R: console.PromptExpression},
-			}, 360)).To(Succeed(), "should write a large file")
-
-			if preallocated {
-				// Preallocation means no changes to disk size
-				Eventually(imageSizeEqual(getImageSize(vmi, dataVolume), imageSizeAfterBoot), 120*time.Second).Should(BeTrue())
-			} else {
-				Eventually(getImageSize(vmi, dataVolume), 120*time.Second).Should(BeNumerically(">", imageSizeAfterBoot))
-			}
-
-			imageSizeBeforeTrim := getImageSize(vmi, dataVolume)
-			By(fmt.Sprintf("image size before trim is %d", imageSizeBeforeTrim))
-
-			By("Writing a small file so that we detect a disk space usage change.")
-			By("Deleting large file and trimming disk")
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				// Write a small file so that we'll have an increase in image size if trim is unsupported.
-				&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: syncName},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "rm -f largefile\n"},
-				&expect.BExp{R: console.PromptExpression},
-			}, 60)).To(Succeed(), "should trim within the VM")
-
-			Eventually(func() bool {
-				By("Running trim")
-				err := console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo fstrim -v /\n"},
+				By("Filling out disk space")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: syncName},
 					&expect.BExp{R: console.PromptExpression},
-				}, 60)
-				Expect(err).ToNot(HaveOccurred())
+				}, 360)).To(Succeed(), "should write a large file")
 
-				currentImageSize := getImageSize(vmi, dataVolume)
-				if expectSmaller {
-					// Trim should make the space usage go down
-					By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-					return currentImageSize < imageSizeBeforeTrim
-				} else if preallocated {
-					By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-					return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
-
+				if preallocated {
+					// Preallocation means no changes to disk size
+					Eventually(imageSizeEqual(getImageSize(vmi, dataVolume), imageSizeAfterBoot), 120*time.Second).Should(BeTrue())
 				} else {
-					By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-					return currentImageSize > imageSizeBeforeTrim
+					Eventually(getImageSize(vmi, dataVolume), 120*time.Second).Should(BeNumerically(">", imageSizeAfterBoot))
 				}
-			}, 120*time.Second).Should(BeTrue())
 
-			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
-			Expect(err).To(BeNil())
-		},
-			Entry("[test_id:5894]by default, fstrim will make the image smaller", noop, true),
-			Entry("[test_id:5898]with preallocation true, fstrim has no effect", addPreallocationTrue, false),
-			Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", addPreallocationFalse, true),
-			Entry("[test_id:5899]with thick provision true, fstrim has no effect", addThickProvisionedTrueAnnotation, false),
-			Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", addThickProvisionedFalseAnnotation, true),
+				imageSizeBeforeTrim := getImageSize(vmi, dataVolume)
+				By(fmt.Sprintf("image size before trim is %d", imageSizeBeforeTrim))
+
+				By("Writing a small file so that we detect a disk space usage change.")
+				By("Deleting large file and trimming disk")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					// Write a small file so that we'll have an increase in image size if trim is unsupported.
+					&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: syncName},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "rm -f largefile\n"},
+					&expect.BExp{R: console.PromptExpression},
+				}, 60)).To(Succeed(), "should trim within the VM")
+
+				Eventually(func() bool {
+					By("Running trim")
+					err := console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "sudo fstrim -v /\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: syncName},
+						&expect.BExp{R: console.PromptExpression},
+					}, 60)
+					Expect(err).ToNot(HaveOccurred())
+
+					currentImageSize := getImageSize(vmi, dataVolume)
+					if expectSmaller {
+						// Trim should make the space usage go down
+						By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+						return currentImageSize < imageSizeBeforeTrim
+					} else if preallocated {
+						By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+						return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
+
+					} else {
+						By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+						return currentImageSize > imageSizeBeforeTrim
+					}
+				}, 120*time.Second).Should(BeTrue())
+
+				err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			},
+			Entry("[test_id:5894]by default, fstrim will make the image smaller", Labels{"test_id:5894"}, noop, true),
+			Entry("[test_id:5898]with preallocation true, fstrim has no effect", Labels{"test_id:5898"}, addPreallocationTrue, false),
+			Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", Labels{"test_id:5897"}, addPreallocationFalse, true),
+			Entry("[test_id:5899]with thick provision true, fstrim has no effect", Labels{"test_id:5899"}, addThickProvisionedTrueAnnotation, false),
+			Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", Labels{"test_id:5896"}, addThickProvisionedFalseAnnotation, true),
 		)
 	})
 })

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -154,28 +154,28 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
 		func() {
 
-		Context("[Serial]without fsgroup support", Labels{"Serial"}, func() {
-			size := "1Gi"
+			Context("[Serial]without fsgroup support", Labels{"Serial"}, func() {
+				size := "1Gi"
 
-			It("should succesfully start", func() {
-				// Create DV and alter permission of disk.img
-				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-				dv := libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
-				tests.SetDataVolumeForceBindAnnotation(dv)
-				dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				var pvc *k8sv1.PersistentVolumeClaim
-				Eventually(func() *k8sv1.PersistentVolumeClaim {
-					pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-					if err != nil {
-						return nil
-					}
-					return pvc
-				}, 30*time.Second).Should(Not(BeNil()))
-				By("waiting for the dv import to pvc to finish")
-				Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
-				tests.ChangeImgFilePermissionsToNonQEMU(pvc)
+				It("should succesfully start", func() {
+					// Create DV and alter permission of disk.img
+					url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
+					dv := libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
+					tests.SetDataVolumeForceBindAnnotation(dv)
+					dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
+					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+					var pvc *k8sv1.PersistentVolumeClaim
+					Eventually(func() *k8sv1.PersistentVolumeClaim {
+						pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+						if err != nil {
+							return nil
+						}
+						return pvc
+					}, 30*time.Second).Should(Not(BeNil()))
+					By("waiting for the dv import to pvc to finish")
+					Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
+					tests.ChangeImgFilePermissionsToNonQEMU(pvc)
 
 					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
 
@@ -212,20 +212,20 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 					Expect(err).To(BeNil())
 
-				// This will only work on storage with binding mode WaitForFirstConsumer,
-				if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-					Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
-				}
-				num := 2
-				By("Starting and stopping the VirtualMachineInstance a number of times")
-				for i := 1; i <= num; i++ {
-					vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-					// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
-					// after being restarted multiple times
-					if i == num {
-						By(checkingVMInstanceConsoleExpectedOut)
-						Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					// This will only work on storage with binding mode WaitForFirstConsumer,
+					if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
+						Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 					}
+					num := 2
+					By("Starting and stopping the VirtualMachineInstance a number of times")
+					for i := 1; i <= num; i++ {
+						vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+						// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
+						// after being restarted multiple times
+						if i == num {
+							By(checkingVMInstanceConsoleExpectedOut)
+							Expect(console.LoginToAlpine(vmi)).To(Succeed())
+						}
 
 						err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 						Expect(err).To(BeNil())
@@ -241,10 +241,10 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
 					dvs := make([]*cdiv1.DataVolume, 0, numVmis)
 
-				for idx := 0; idx < numVmis; idx++ {
+					for idx := 0; idx < numVmis; idx++ {
 					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
+						vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+						vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
 
 						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 						Expect(err).To(BeNil())
@@ -270,15 +270,15 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 					vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				// This will only work on storage with binding mode WaitForFirstConsumer,
+					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+					// This will only work on storage with binding mode WaitForFirstConsumer,
 				if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-					Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
-				}
-				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
-				// import and start
-				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+						Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
+					}
+					// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
+					// import and start
+					vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 
 					By(checkingVMInstanceConsoleExpectedOut)
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -575,7 +575,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			var dataVolumeName string
 			var pvcName string
 
-		k8sClient := clientcmd.GetK8sCmdClient()
+			k8sClient := clientcmd.GetK8sCmdClient()
 
 			BeforeEach(func() {
 				running := true
@@ -592,7 +592,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", Labels{"test_id:836"}, func() {
 				By(creatingVMDataVolumeTemplateEntry)
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By(verifyingDataVolumeSuccess)
@@ -607,7 +607,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", Labels{"test_id:837"}, func() {
 				By(creatingVMDataVolumeTemplateEntry)
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By(verifyingDataVolumeSuccess)
@@ -620,7 +620,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
 
 				By("Deleting VM with cascade=true")
-			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
+				_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for the VM to be deleted")
@@ -638,7 +638,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", Labels{"test_id:838"}, func() {
 				By(creatingVMDataVolumeTemplateEntry)
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By(verifyingDataVolumeSuccess)
@@ -651,7 +651,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
 
 				By("Deleting VM with cascade=false")
-			_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
+				_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for the VM to be deleted")

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -20,1095 +20,1095 @@
 package storage
 
 import (
-	"context"
-	"fmt"
-	"math"
-	"strings"
-	"time"
+    "context"
+    "fmt"
+    "math"
+    "strings"
+    "time"
 
-	expect "github.com/google/goexpect"
-	storagev1 "k8s.io/api/storage/v1"
+    expect "github.com/google/goexpect"
+    storagev1 "k8s.io/api/storage/v1"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
+    k8sv1 "k8s.io/api/core/v1"
+    rbacv1 "k8s.io/api/rbac/v1"
+    "k8s.io/apimachinery/pkg/api/resource"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/util/rand"
+    "k8s.io/utils/pointer"
 
-	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/clientcmd"
-	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
-	"kubevirt.io/kubevirt/tests/flags"
-	"kubevirt.io/kubevirt/tests/framework/checks"
-	. "kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libstorage"
-	"kubevirt.io/kubevirt/tests/util"
+    v1 "kubevirt.io/api/core/v1"
+    "kubevirt.io/client-go/kubecli"
+    cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+    virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+    "kubevirt.io/kubevirt/tests"
+    "kubevirt.io/kubevirt/tests/clientcmd"
+    "kubevirt.io/kubevirt/tests/console"
+    cd "kubevirt.io/kubevirt/tests/containerdisk"
+    "kubevirt.io/kubevirt/tests/flags"
+    "kubevirt.io/kubevirt/tests/framework/checks"
+    . "kubevirt.io/kubevirt/tests/framework/matcher"
+    "kubevirt.io/kubevirt/tests/libstorage"
+    "kubevirt.io/kubevirt/tests/util"
 )
 
 const (
-	checkingVMInstanceConsoleExpectedOut = "Checking that the VirtualMachineInstance console has expected output"
-	deletingDataVolume                   = "Deleting the DataVolume"
-	creatingVMInvalidDataVolume          = "Creating a VM with an invalid DataVolume"
-	creatingVMDataVolumeTemplateEntry    = "Creating VM with DataVolumeTemplate entry with k8s client binary"
-	verifyingDataVolumeSuccess           = "Verifying DataVolume succeeded and is created with VM owner reference"
-	verifyingPVCCreated                  = "Verifying PVC is created"
-	verifyingVMICreated                  = "Verifying VMI is created with VM owner reference"
-	syncName                             = "sync\n"
+    checkingVMInstanceConsoleExpectedOut = "Checking that the VirtualMachineInstance console has expected output"
+    deletingDataVolume                   = "Deleting the DataVolume"
+    creatingVMInvalidDataVolume          = "Creating a VM with an invalid DataVolume"
+    creatingVMDataVolumeTemplateEntry    = "Creating VM with DataVolumeTemplate entry with k8s client binary"
+    verifyingDataVolumeSuccess           = "Verifying DataVolume succeeded and is created with VM owner reference"
+    verifyingPVCCreated                  = "Verifying PVC is created"
+    verifyingVMICreated                  = "Verifying VMI is created with VM owner reference"
+    syncName                             = "sync\n"
 )
 
 const InvalidDataVolumeUrl = "docker://127.0.0.1/invalid:latest"
 
 var _ = SIGDescribe("DataVolume Integration", func() {
 
-	var virtClient kubecli.KubevirtClient
-	var err error
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-		if !tests.HasCDI() {
-			Skip("Skip DataVolume tests when CDI is not present")
-		}
-	})
-
-	Context("[storage-req]PVC expansion", Labels{"storage-req"}, func() {
-		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
-			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
-			if !tests.HasCDI() {
-				Skip("Skip DataVolume tests when CDI is not present")
-			}
-			var sc string
-			exists := false
-			if volumeMode == k8sv1.PersistentVolumeBlock {
-				sc, exists = libstorage.GetRWOBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
-			} else {
-				sc, exists = libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
-			}
-			volumeExpansionAllowed := tests.VolumeExpansionAllowed(sc)
-			if !volumeExpansionAllowed {
-				Skip("Skip when volume expansion storage class not available")
-			}
-			vmi, dataVolume := tests.NewRandomVirtualMachineInstanceWithDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce, volumeMode)
-			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 500)
-
-			By("Expecting the VirtualMachineInstance console")
-			Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-			pvc, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Expanding PVC")
-			pvc.Spec.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("2Gi")
-			_, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Waiting for notification about size change")
-			Eventually(func() error {
-				err := console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "dmesg |grep 'new size'\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "dmesg |grep -c 'new size: [34]'\n"},
-					&expect.BExp{R: "1"},
-				}, 10)
-				return err
-			}, 360).Should(BeNil())
-
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "sudo /sbin/resize-filesystem /dev/root /run/resize.rootfs /dev/console && echo $?\n"},
-				&expect.BExp{R: "0"},
-			}, 30)).To(Succeed(), "failed to resize root")
-
-			By("Writing a 1.5G file after expansion, should succeed")
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "dd if=/dev/zero of=largefile count=1500 bs=1M; echo $?\n"},
-				&expect.BExp{R: "0"},
-			}, 360)).To(Succeed(), "can use more space after expansion and resize")
-		},
-			Entry("with Block PVC", k8sv1.PersistentVolumeBlock),
-			Entry("with Filesystem PVC", k8sv1.PersistentVolumeFilesystem),
-		)
-	})
-
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source",
-		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
-		func() {
-
-			Context("[Serial]without fsgroup support", Labels{"Serial"}, func() {
-				size := "1Gi"
-
-				It("should succesfully start", func() {
-					// Create DV and alter permission of disk.img
-					url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-					dv := libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
-					tests.SetDataVolumeForceBindAnnotation(dv)
-					dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
-					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-					var pvc *k8sv1.PersistentVolumeClaim
-					Eventually(func() *k8sv1.PersistentVolumeClaim {
-						pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-						if err != nil {
-							return nil
-						}
-						return pvc
-					}, 30*time.Second).Should(Not(BeNil()))
-					By("waiting for the dv import to pvc to finish")
-					Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
-					tests.ChangeImgFilePermissionsToNonQEMU(pvc)
-
-					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
-
-					By("Starting the VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
-
-					By(checkingVMInstanceConsoleExpectedOut)
-					Expect(console.LoginToAlpine(vmi)).To(Succeed())
-				})
-			})
-
-			Context("Alpine import", func() {
-				BeforeEach(func() {
-					cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(cdis.Items).To(HaveLen(1))
-					hasWaitForFirstConsumerGate := false
-					for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
-						if feature == "HonorWaitForFirstConsumer" {
-							hasWaitForFirstConsumerGate = true
-							break
-						}
-					}
-					if !hasWaitForFirstConsumerGate {
-						Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
-					}
-				})
-
-				It("[test_id:3189]should be successfully started and stopped multiple times", Labels{"test_id:3189"}, func() {
-
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-
-					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-
-					// This will only work on storage with binding mode WaitForFirstConsumer,
-					if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-						Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
-					}
-					num := 2
-					By("Starting and stopping the VirtualMachineInstance a number of times")
-					for i := 1; i <= num; i++ {
-						vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-						// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
-						// after being restarted multiple times
-						if i == num {
-							By(checkingVMInstanceConsoleExpectedOut)
-							Expect(console.LoginToAlpine(vmi)).To(Succeed())
-						}
-
-						err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-						Expect(err).To(BeNil())
-						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-					}
-					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-					Expect(err).To(BeNil())
-				})
-
-				It("[test_id:6686]should successfully start multiple concurrent VMIs", Labels{"test_id:6686"}, func() {
-
-					numVmis := 5
-					vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
-					dvs := make([]*cdiv1.DataVolume, 0, numVmis)
-
-					for idx := 0; idx < numVmis; idx++ {
-					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-						vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-						vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-
-						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-						Expect(err).To(BeNil())
-
-						vmi = tests.RunVMI(vmi, 60)
-						vmis = append(vmis, vmi)
-						dvs = append(dvs, dataVolume)
-					}
-
-					for idx := 0; idx < numVmis; idx++ {
-						tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
-						By(checkingVMInstanceConsoleExpectedOut)
-						Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
-
-						err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
-						Expect(err).To(BeNil())
-						err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
-						Expect(err).To(BeNil())
-					}
-				})
-
-				It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", Labels{"test_id:5252"}, func() {
-					dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
-
-					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-					// This will only work on storage with binding mode WaitForFirstConsumer,
-				if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
-						Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
-					}
-					// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
-					// import and start
-					vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-
-					By(checkingVMInstanceConsoleExpectedOut)
-					Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-					Expect(err).To(BeNil())
-					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-
-					err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-					Expect(err).To(BeNil())
-				})
-
-				It("should accurately report DataVolume provisioning", func() {
-				sc, exists := libstorage.GetSnapshotStorageClass()
-					if !exists {
-						Skip("no snapshot storage class configured")
-					}
-
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(
-						cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
-						util.NamespaceTestDefault,
-						sc,
-						k8sv1.ReadWriteOnce,
-						k8sv1.PersistentVolumeFilesystem,
-					)
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-					vm := tests.NewRandomVirtualMachine(vmi, false)
-
-					_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-					defer func() {
-						err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}()
-
-					Eventually(func() bool {
-						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-					}, 180*time.Second, 2*time.Second).Should(BeTrue())
-
-					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					defer func() {
-						err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}()
-
-					Eventually(func() bool {
-						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
-					}, 180*time.Second, 1*time.Second).Should(BeTrue())
-
-					Eventually(func() bool {
-						vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
-						return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-					}, 180*time.Second, 2*time.Second).Should(BeTrue())
-				})
-			})
-
-			Context("with a PVC from a Datavolume", func() {
-				var storageClass *storagev1.StorageClass
-				BeforeEach(func() {
-					// ensure that we always use a storage class which binds immediately,
-					// otherwise we will never see a PVC appear for the datavolume
-					bindMode := storagev1.VolumeBindingImmediate
-					storageClass = &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							GenerateName: "fake",
-						},
-						Provisioner:       "afakeone",
-						VolumeBindingMode: &bindMode,
-					}
-					storageClass, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				})
-				AfterEach(func() {
-					if storageClass != nil && storageClass.Name != "" {
-						err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}
-				})
-
-				It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", Labels{"test_id:4643"}, func() {
-
-				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-					_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-
-					defer func(dv *cdiv1.DataVolume) {
-						By(deletingDataVolume)
-						ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-					}(dv)
-
-					Eventually(func() (*k8sv1.PersistentVolumeClaim, error) {
-						return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-					}, 30).Should(Not(BeNil()))
-
-					vmi := tests.NewRandomVMI()
-
-					diskName := "disk0"
-					bus := "virtio"
-					vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-						Name: diskName,
-						DiskDevice: v1.DiskDevice{
-							Disk: &v1.DiskTarget{
-								Bus: bus,
-							},
-						},
-					})
-					vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-						Name: diskName,
-						VolumeSource: v1.VolumeSource{
-							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-								ClaimName: dv.ObjectMeta.Name,
-							}},
-						},
-					})
-
-					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-
-					vm := tests.NewRandomVirtualMachine(vmi, true)
-					dvt := &v1.DataVolumeTemplateSpec{
-						ObjectMeta: dv.ObjectMeta,
-						Spec:       dv.Spec,
-					}
-					vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
-					_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself",
-					Labels{"Serial", "test_id:4644"},
-					func() {
-						dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-						_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-						Expect(err).To(BeNil())
-
-						defer func(dv *cdiv1.DataVolume) {
-							By(deletingDataVolume)
-							ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-						}(dv)
-						Eventually(func() error {
-							_, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-							return err
-						}, 30*time.Second, 1*time.Second).Should(BeNil())
-
-						vmi := tests.NewRandomVMI()
-
-						diskName := "disk0"
-						bus := "virtio"
-						vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-							Name: diskName,
-							DiskDevice: v1.DiskDevice{
-								Disk: &v1.DiskTarget{
-									Bus: bus,
-								},
-							},
-						})
-						vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-							Name: diskName,
-							VolumeSource: v1.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-									ClaimName: dv.ObjectMeta.Name,
-								}},
-							},
-						})
-
-						vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-
-						vm := tests.NewRandomVirtualMachine(vmi, true)
-						_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-						Expect(err).ShouldNot(HaveOccurred())
-
-						Eventually(func() bool {
-							vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-							Expect(err).ToNot(HaveOccurred())
-
-							return vm.Status.Created
-						}, 30*time.Second, 1*time.Second).Should(Equal(false))
-					})
-			})
-		})
-
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume",
-		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
-		func() {
-			Context("using DataVolume with invalid URL", func() {
-				deleteDataVolume := func(dv *cdiv1.DataVolume) {
-					By(deletingDataVolume)
-					ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-				}
-
-				It("shold be possible to stop VM if datavolume is crashing", func() {
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
-					vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
-						{
-							ObjectMeta: dataVolume.ObjectMeta,
-							Spec:       dataVolume.Spec,
-						},
-					}
-
-					By(creatingVMInvalidDataVolume)
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					By("Waiting for DV to start crashing")
-					Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.ImportInProgress))
-
-					By("Stop VM")
-					tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
-				})
-
-				It("[test_id:3190]should correctly handle invalid DataVolumes", Labels{"test_id:3190"}, func() {
-					// Don't actually create the DataVolume since it's invalid.
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					//  Add the invalid DataVolume to a VMI
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-					// Create a VM for this VMI
-					vm := tests.NewRandomVirtualMachine(vmi, true)
-
-					By(creatingVMInvalidDataVolume)
-					vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					By("Waiting for VMI to be created")
-					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
-				})
-				It("[test_id:3190]should correctly handle eventually consistent DataVolumes", Labels{"test_id:3190"}, func() {
-					realRegistryName := flags.KubeVirtUtilityRepoPrefix
-					realRegistryPort := ""
-					if strings.Contains(flags.KubeVirtUtilityRepoPrefix, ":") {
-						realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
-						realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
-					}
-					if realRegistryPort == "" {
-						Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
-					}
-
-					fakeRegistryName := "fakeregistry"
-					fakeRegistryWithPort := fakeRegistryName
-					if realRegistryPort != "" {
-						fakeRegistryWithPort = fmt.Sprintf("%s:%s", fakeRegistryName, realRegistryPort)
-					}
-
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlFromRegistryForContainerDisk(fakeRegistryWithPort, cd.ContainerDiskCirros),
-						util.NamespaceTestDefault,
-						k8sv1.ReadWriteOnce,
-					)
-					defer deleteDataVolume(dataVolume)
-
-					By("Creating DataVolume with invalid URL")
-					dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-
-					By(creatingVMInvalidDataVolume)
-					//  Add the invalid DataVolume to a VMI
-					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-					// Create a VM for this VMI
-					vm := tests.NewRandomVirtualMachine(vmi, true)
-					vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
-
-					By("Creating a service which makes the registry reachable")
-					virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: fakeRegistryName,
-						},
-						Spec: k8sv1.ServiceSpec{
-							Type:         k8sv1.ServiceTypeExternalName,
-							ExternalName: realRegistryName,
-						},
-					}, metav1.CreateOptions{})
-
-					By("Wait for DataVolume to complete")
-					Eventually(ThisDV(dataVolume), 160).Should(HaveSucceeded())
-
-					By("Waiting for VMI to be created")
-					Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
-				})
-			})
-		})
-
-	Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl",
-		Labels{"rfe_id:896", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
-		func() {
-			var vm *v1.VirtualMachine
-			var err error
-			var vmJson string
-			var dataVolumeName string
-			var pvcName string
-
-			k8sClient := clientcmd.GetK8sCmdClient()
-
-			BeforeEach(func() {
-				running := true
-
-				vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-				vm.Spec.Running = &running
-
-				dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
-				pvcName = dataVolumeName
-
-				vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", Labels{"test_id:836"}, func() {
-				By(creatingVMDataVolumeTemplateEntry)
-				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-				Expect(err).ToNot(HaveOccurred())
-
-				By(verifyingDataVolumeSuccess)
-				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-				By(verifyingPVCCreated)
-				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-				By(verifyingVMICreated)
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-			})
-
-			It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", Labels{"test_id:837"}, func() {
-				By(creatingVMDataVolumeTemplateEntry)
-				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-				Expect(err).ToNot(HaveOccurred())
-
-				By(verifyingDataVolumeSuccess)
-				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-				By(verifyingPVCCreated)
-				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-				By(verifyingVMICreated)
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-
-				By("Deleting VM with cascade=true")
-				_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Waiting for the VM to be deleted")
-				Eventually(ThisVM(vm), 100).Should(BeGone())
-
-				By("Waiting for the VMI to be deleted")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
-
-				By("Waiting for the DataVolume to be deleted")
-				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
-
-				By("Waiting for the PVC to be deleted")
-				Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
-			})
-
-			It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", Labels{"test_id:838"}, func() {
-				By(creatingVMDataVolumeTemplateEntry)
-				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
-				Expect(err).ToNot(HaveOccurred())
-
-				By(verifyingDataVolumeSuccess)
-				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
-
-				By(verifyingPVCCreated)
-				Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
-
-				By(verifyingVMICreated)
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
-
-				By("Deleting VM with cascade=false")
-				_, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Waiting for the VM to be deleted")
-				Eventually(ThisVM(vm), 100).Should(BeGone())
-
-				By("Verifying DataVolume still exists with owner references removed")
-				Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), Not(BeOwned())))
-
-				By("Verifying VMI still exists with owner references removed")
-				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(And(BeRunning(), Not(BeOwned())))
-			})
-
-		})
-
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume",
-		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
-		func() {
-			Context("using Alpine http import", func() {
-				It("a DataVolume with preallocation shouldn't have discard=unmap", func() {
-					var vm *v1.VirtualMachine
-					vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-					preallocation := true
-					vm.Spec.DataVolumeTemplates[0].Spec.Preallocation = &preallocation
-
-					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					vm = tests.StartVirtualMachine(vm)
-					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(domXml).ToNot(ContainSubstring("discard='unmap'"))
-					vm = tests.StopVirtualMachine(vm)
-					Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})).To(Succeed())
-				})
-
-				DescribeTable("[test_id:3191]should be successfully started and stopped multiple times", Labels{"test_id:3191"}, func(isHTTP bool) {
-					var vm *v1.VirtualMachine
-					if isHTTP {
-						vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-					} else {
-						url := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
-						vm = tests.NewRandomVMWithDataVolume(url, util.NamespaceTestDefault)
-					}
-					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-					num := 2
-					By("Starting and stopping the VirtualMachine number of times")
-					for i := 0; i < num; i++ {
-						By(fmt.Sprintf("Doing run: %d", i))
-						vm = tests.StartVirtualMachine(vm)
-						// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
-						// after being restarted multiple times
-						if i == num {
-							By(checkingVMInstanceConsoleExpectedOut)
-							vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-							Expect(err).ToNot(HaveOccurred())
-							Expect(console.LoginToAlpine(vmi)).To(Succeed())
-						}
-						vm = tests.StopVirtualMachine(vm)
-					}
-				},
-
-					Entry("with http import", true),
-					Entry("with registry import", false),
-				)
-
-				It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", Labels{"test_id:3192"}, func() {
-					vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
-					vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Check for owner reference
-					Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
-
-					// Delete the VM with orphan Propagation
-					orphanPolicy := metav1.DeletePropagationOrphan
-					Expect(virtClient.VirtualMachine(vm.Namespace).
-						Delete(vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
-
-					// Wait for the owner reference to disappear
-					Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
-				})
-			})
-		})
-
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking",
-		Labels{"rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"},
-		func() {
-			Context("using Alpine import/clone", func() {
-				var dataVolume *cdiv1.DataVolume
-				var createdVirtualMachine *v1.VirtualMachine
-				var cloneRole *rbacv1.Role
-				var cloneRoleBinding *rbacv1.RoleBinding
-				var storageClass string
-				var vm *v1.VirtualMachine
-
-				BeforeEach(func() {
-					var exists bool
-				storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
-					if !exists {
-						Skip("Skip test when RWOFileSystem storage class is not present")
-					}
-					var err error
-				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-					tests.SetDataVolumeForceBindAnnotation(dv)
-					dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
-
-					vm = tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, util.NamespaceTestDefault)
-					const volumeName = "sa"
-					saVol := v1.Volume{
-						Name: volumeName,
-						VolumeSource: v1.VolumeSource{
-							ServiceAccount: &v1.ServiceAccountVolumeSource{
-								ServiceAccountName: tests.AdminServiceAccountName,
-							},
-						},
-					}
-					vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.StringPtr(storageClass)
-					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
-					vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
-				})
-
-				AfterEach(func() {
-					if cloneRole != nil {
-						err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}
-
-					if cloneRoleBinding != nil {
-						err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}
-
-					if createdVirtualMachine != nil {
-						err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}
-				})
-
-				createVmSuccess := func() {
-					// sometimes it takes a bit for permission to actually be applied so eventually
-					Eventually(func() bool {
-						_, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
-						if err != nil {
-							fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
-							return false
-						}
-						return true
-					}, 90*time.Second, 1*time.Second).Should(BeTrue())
-
-					createdVirtualMachine = vm
-
-					// start vm and check dv clone succeeded
-					createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
-					targetDVName := vm.Spec.DataVolumeTemplates[0].Name
-					Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
-				}
-
-				It("should resolve DataVolume sourceRef", func() {
-					// convert DV to use datasource
-					dvt := &vm.Spec.DataVolumeTemplates[0]
-					ds := &cdiv1.DataSource{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "ds-" + rand.String(12),
-						},
-						Spec: cdiv1.DataSourceSpec{
-							Source: cdiv1.DataSourceSource{
-								PVC: dvt.Spec.Source.PVC,
-							},
-						},
-					}
-					ds, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					defer func() {
-						err := virtClient.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
-						Expect(err).ToNot(HaveOccurred())
-					}()
-
-					dvt.Spec.Source = nil
-					dvt.Spec.SourceRef = &cdiv1.DataVolumeSourceRef{
-						Kind: "DataSource",
-						Name: ds.Name,
-					}
-
-					cloneRole, cloneRoleBinding = addClonePermission(
-						virtClient,
-						explicitCloneRole,
-						tests.AdminServiceAccountName,
-						util.NamespaceTestDefault,
-						tests.NamespaceTestAlternative,
-					)
-
-					createVmSuccess()
-
-					dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.TODO(), dvt.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(dv.Spec.SourceRef).To(BeNil())
-					Expect(dv.Spec.Source.PVC.Namespace).To(Equal(ds.Spec.Source.PVC.Namespace))
-					Expect(dv.Spec.Source.PVC.Name).To(Equal(ds.Spec.Source.PVC.Name))
-				})
-
-				DescribeTable("[storage-req] deny then allow clone request", Labels{"storage-req"}, func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
-					_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("Authorization failed, message is:"))
-
-					saName := tests.AdminServiceAccountName
-					saNamespace := util.NamespaceTestDefault
-
-					if allServiceAccounts {
-						saName = ""
-						saNamespace = ""
-					} else if allServiceAccountsInNamespace {
-						saName = ""
-					}
-
-					// add permission
-					cloneRole, cloneRoleBinding = addClonePermission(virtClient, role, saName, saNamespace, tests.NamespaceTestAlternative)
-
-					createVmSuccess()
-
-					// stop vm
-					createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
-				},
-					Entry("[test_id:3193]with explicit role", Labels{"test_id:3193"}, explicitCloneRole, false, false),
-					Entry("[test_id:3194]with implicit role", Labels{"test_id:3194"}, implicitCloneRole, false, false),
-					Entry("[test_id:5253]with explicit role (all namespaces)", Labels{"test_id:5253"}, explicitCloneRole, true, false),
-					Entry("[test_id:5254]with explicit role (one namespace)", Labels{"test_id:5254"}, explicitCloneRole, false, true),
-				)
-			})
-		})
-
-	Context("Fedora VMI tests", func() {
-		imageSizeEqual := func(a, b int64) bool {
-			// Our OCS image size method probe is very precise and can show a few
-			// bytes of difference.
-			// A VM cannot do sub-512 byte accesses anyway, so such small size
-			// differences are practically equal.
-			if math.Abs((float64)(a-b)) >= 512 {
-				By(fmt.Sprintf("Image sizes not equal, %d - %d >= 512", a, b))
-				return false
-			} else {
-				return true
-			}
-		}
-		getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
-			var imageSize int64
-			var unused string
-			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-			lsOutput, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				pod,
-				"compute",
-				[]string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			fmt.Sscanf(lsOutput, "%d %s", &imageSize, &unused)
-			return imageSize
-		}
-
-		noop := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			return dv
-		}
-		addPreallocationTrue := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			preallocation := true
-			dv.Spec.Preallocation = &preallocation
-			return dv
-		}
-		addPreallocationFalse := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			preallocation := false
-			dv.Spec.Preallocation = &preallocation
-			return dv
-		}
-		addThickProvisionedTrueAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "true"}
-			return dv
-		}
-		addThickProvisionedFalseAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
-			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
-			return dv
-		}
-		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img",
-			Labels{"rfe_id:5070", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
-			func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
-				dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-				dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
-				dataVolume = dvChange(dataVolume)
-				preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
-
-				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-				vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
-				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
-
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-				imageSizeAfterBoot := getImageSize(vmi, dataVolume)
-				By(fmt.Sprintf("image size after boot is %d", imageSizeAfterBoot))
-
-				By("Filling out disk space")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: syncName},
-					&expect.BExp{R: console.PromptExpression},
-				}, 360)).To(Succeed(), "should write a large file")
-
-				if preallocated {
-					// Preallocation means no changes to disk size
-					Eventually(imageSizeEqual(getImageSize(vmi, dataVolume), imageSizeAfterBoot), 120*time.Second).Should(BeTrue())
-				} else {
-					Eventually(getImageSize(vmi, dataVolume), 120*time.Second).Should(BeNumerically(">", imageSizeAfterBoot))
-				}
-
-				imageSizeBeforeTrim := getImageSize(vmi, dataVolume)
-				By(fmt.Sprintf("image size before trim is %d", imageSizeBeforeTrim))
-
-				By("Writing a small file so that we detect a disk space usage change.")
-				By("Deleting large file and trimming disk")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					// Write a small file so that we'll have an increase in image size if trim is unsupported.
-					&expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: syncName},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "rm -f largefile\n"},
-					&expect.BExp{R: console.PromptExpression},
-				}, 60)).To(Succeed(), "should trim within the VM")
-
-				Eventually(func() bool {
-					By("Running trim")
-					err := console.SafeExpectBatch(vmi, []expect.Batcher{
-						&expect.BSnd{S: "sudo fstrim -v /\n"},
-						&expect.BExp{R: console.PromptExpression},
-						&expect.BSnd{S: syncName},
-						&expect.BExp{R: console.PromptExpression},
-					}, 60)
-					Expect(err).ToNot(HaveOccurred())
-
-					currentImageSize := getImageSize(vmi, dataVolume)
-					if expectSmaller {
-						// Trim should make the space usage go down
-						By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-						return currentImageSize < imageSizeBeforeTrim
-					} else if preallocated {
-						By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-						return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
-
-					} else {
-						By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
-						return currentImageSize > imageSizeBeforeTrim
-					}
-				}, 120*time.Second).Should(BeTrue())
-
-				err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
-				Expect(err).To(BeNil())
-			},
-			Entry("[test_id:5894]by default, fstrim will make the image smaller", Labels{"test_id:5894"}, noop, true),
-			Entry("[test_id:5898]with preallocation true, fstrim has no effect", Labels{"test_id:5898"}, addPreallocationTrue, false),
-			Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", Labels{"test_id:5897"}, addPreallocationFalse, true),
-			Entry("[test_id:5899]with thick provision true, fstrim has no effect", Labels{"test_id:5899"}, addThickProvisionedTrueAnnotation, false),
-			Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", Labels{"test_id:5896"}, addThickProvisionedFalseAnnotation, true),
-		)
-	})
+    var virtClient kubecli.KubevirtClient
+    var err error
+
+    BeforeEach(func() {
+        virtClient, err = kubecli.GetKubevirtClient()
+        util.PanicOnError(err)
+
+        tests.BeforeTestCleanup()
+        if !tests.HasCDI() {
+            Skip("Skip DataVolume tests when CDI is not present")
+        }
+    })
+
+    Context("[storage-req]PVC expansion", Label("storage-req"), func() {
+        DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
+            checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
+            if !tests.HasCDI() {
+                Skip("Skip DataVolume tests when CDI is not present")
+            }
+            var sc string
+            exists := false
+            if volumeMode == k8sv1.PersistentVolumeBlock {
+                sc, exists = libstorage.GetRWOBlockStorageClass()
+                if !exists {
+                    Skip("Skip test when Block storage is not present")
+                }
+            } else {
+                sc, exists = libstorage.GetRWOFileSystemStorageClass()
+                if !exists {
+                    Skip("Skip test when Filesystem storage is not present")
+                }
+            }
+            volumeExpansionAllowed := tests.VolumeExpansionAllowed(sc)
+            if !volumeExpansionAllowed {
+                Skip("Skip when volume expansion storage class not available")
+            }
+            vmi, dataVolume := tests.NewRandomVirtualMachineInstanceWithDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce, volumeMode)
+            tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+            vmi = tests.RunVMIAndExpectLaunch(vmi, 500)
+
+            By("Expecting the VirtualMachineInstance console")
+            Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+            pvc, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Get(context.Background(), dataVolume.Name, metav1.GetOptions{})
+            Expect(err).ToNot(HaveOccurred())
+
+            By("Expanding PVC")
+            pvc.Spec.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("2Gi")
+            _, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
+            Expect(err).ToNot(HaveOccurred())
+
+            By("Waiting for notification about size change")
+            Eventually(func() error {
+                err := console.SafeExpectBatch(vmi, []expect.Batcher{
+                    &expect.BSnd{S: "\n"},
+                    &expect.BExp{R: console.PromptExpression},
+                    &expect.BSnd{S: "dmesg |grep 'new size'\n"},
+                    &expect.BExp{R: console.PromptExpression},
+                    &expect.BSnd{S: "dmesg |grep -c 'new size: [34]'\n"},
+                    &expect.BExp{R: "1"},
+                }, 10)
+                return err
+            }, 360).Should(BeNil())
+
+            Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+                &expect.BSnd{S: "sudo /sbin/resize-filesystem /dev/root /run/resize.rootfs /dev/console && echo $?\n"},
+                &expect.BExp{R: "0"},
+            }, 30)).To(Succeed(), "failed to resize root")
+
+            By("Writing a 1.5G file after expansion, should succeed")
+            Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+                &expect.BSnd{S: "\n"},
+                &expect.BExp{R: console.PromptExpression},
+                &expect.BSnd{S: "dd if=/dev/zero of=largefile count=1500 bs=1M; echo $?\n"},
+                &expect.BExp{R: "0"},
+            }, 360)).To(Succeed(), "can use more space after expansion and resize")
+        },
+            Entry("with Block PVC", k8sv1.PersistentVolumeBlock),
+            Entry("with Filesystem PVC", k8sv1.PersistentVolumeFilesystem),
+        )
+    })
+
+    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source",
+        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+        func() {
+
+            Context("[Serial]without fsgroup support", Label("Serial"), func() {
+                size := "1Gi"
+
+                It("should succesfully start", func() {
+                    // Create DV and alter permission of disk.img
+                    url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
+                    dv := libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
+                    tests.SetDataVolumeForceBindAnnotation(dv)
+                    dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
+                    _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+                    Expect(err).To(BeNil())
+                    var pvc *k8sv1.PersistentVolumeClaim
+                    Eventually(func() *k8sv1.PersistentVolumeClaim {
+                        pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+                        if err != nil {
+                            return nil
+                        }
+                        return pvc
+                    }, 30*time.Second).Should(Not(BeNil()))
+                    By("waiting for the dv import to pvc to finish")
+                    Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
+                    tests.ChangeImgFilePermissionsToNonQEMU(pvc)
+
+                    vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
+
+                    By("Starting the VirtualMachineInstance")
+                    vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
+
+                    By(checkingVMInstanceConsoleExpectedOut)
+                    Expect(console.LoginToAlpine(vmi)).To(Succeed())
+                })
+            })
+
+            Context("Alpine import", func() {
+                BeforeEach(func() {
+                    cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+                    Expect(cdis.Items).To(HaveLen(1))
+                    hasWaitForFirstConsumerGate := false
+                    for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
+                        if feature == "HonorWaitForFirstConsumer" {
+                            hasWaitForFirstConsumerGate = true
+                            break
+                        }
+                    }
+                    if !hasWaitForFirstConsumerGate {
+                        Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
+                    }
+                })
+
+                It("[test_id:3189]should be successfully started and stopped multiple times", Label("test_id:3189"), func() {
+
+                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+
+                    _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+                    Expect(err).To(BeNil())
+
+                    // This will only work on storage with binding mode WaitForFirstConsumer,
+                    if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
+                        Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
+                    }
+                    num := 2
+                    By("Starting and stopping the VirtualMachineInstance a number of times")
+                    for i := 1; i <= num; i++ {
+                        vmi := tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+                        // Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
+                        // after being restarted multiple times
+                        if i == num {
+                            By(checkingVMInstanceConsoleExpectedOut)
+                            Expect(console.LoginToAlpine(vmi)).To(Succeed())
+                        }
+
+                        err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+                        Expect(err).To(BeNil())
+                        tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+                    }
+                    err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+                    Expect(err).To(BeNil())
+                })
+
+                It("[test_id:6686]should successfully start multiple concurrent VMIs", Label("test_id:6686"), func() {
+
+                    numVmis := 5
+                    vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
+                    dvs := make([]*cdiv1.DataVolume, 0, numVmis)
+
+                    for idx := 0; idx < numVmis; idx++ {
+                        dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+                        vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+                        vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
+
+                        _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+                        Expect(err).To(BeNil())
+
+                        vmi = tests.RunVMI(vmi, 60)
+                        vmis = append(vmis, vmi)
+                        dvs = append(dvs, dataVolume)
+                    }
+
+                    for idx := 0; idx < numVmis; idx++ {
+                        tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
+                        By(checkingVMInstanceConsoleExpectedOut)
+                        Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
+
+                        err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
+                        Expect(err).To(BeNil())
+                        err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
+                        Expect(err).To(BeNil())
+                    }
+                })
+
+                It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", Label("test_id:5252"), func() {
+                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+                    vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
+
+                    _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+                    Expect(err).To(BeNil())
+                    // This will only work on storage with binding mode WaitForFirstConsumer,
+                    if tests.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
+                        Eventually(ThisDV(dataVolume), 40).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
+                    }
+                    // with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
+                    // import and start
+                    vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+
+                    By(checkingVMInstanceConsoleExpectedOut)
+                    Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+                    err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+                    Expect(err).To(BeNil())
+                    tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+
+                    err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+                    Expect(err).To(BeNil())
+                })
+
+                It("should accurately report DataVolume provisioning", func() {
+                    sc, exists := libstorage.GetSnapshotStorageClass()
+                    if !exists {
+                        Skip("no snapshot storage class configured")
+                    }
+
+                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(
+                        cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
+                        util.NamespaceTestDefault,
+                        sc,
+                        k8sv1.ReadWriteOnce,
+                        k8sv1.PersistentVolumeFilesystem,
+                    )
+                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+                    vm := tests.NewRandomVirtualMachine(vmi, false)
+
+                    _, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+                    defer func() {
+                        err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }()
+
+                    Eventually(func() bool {
+                        vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                        return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
+                    }, 180*time.Second, 2*time.Second).Should(BeTrue())
+
+                    _, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+                    defer func() {
+                        err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }()
+
+                    Eventually(func() bool {
+                        vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                        return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
+                    }, 180*time.Second, 1*time.Second).Should(BeTrue())
+
+                    Eventually(func() bool {
+                        vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                        return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
+                    }, 180*time.Second, 2*time.Second).Should(BeTrue())
+                })
+            })
+
+            Context("with a PVC from a Datavolume", func() {
+                var storageClass *storagev1.StorageClass
+                BeforeEach(func() {
+                    // ensure that we always use a storage class which binds immediately,
+                    // otherwise we will never see a PVC appear for the datavolume
+                    bindMode := storagev1.VolumeBindingImmediate
+                    storageClass = &storagev1.StorageClass{
+                        ObjectMeta: metav1.ObjectMeta{
+                            GenerateName: "fake",
+                        },
+                        Provisioner:       "afakeone",
+                        VolumeBindingMode: &bindMode,
+                    }
+                    storageClass, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+                })
+                AfterEach(func() {
+                    if storageClass != nil && storageClass.Name != "" {
+                        err := virtClient.StorageV1().StorageClasses().Delete(context.Background(), storageClass.Name, metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }
+                })
+
+                It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", Label("test_id:4643"), func() {
+
+                    dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+                    _, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+                    Expect(err).To(BeNil())
+
+                    defer func(dv *cdiv1.DataVolume) {
+                        By(deletingDataVolume)
+                        ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+                    }(dv)
+
+                    Eventually(func() (*k8sv1.PersistentVolumeClaim, error) {
+                        return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+                    }, 30).Should(Not(BeNil()))
+
+                    vmi := tests.NewRandomVMI()
+
+                    diskName := "disk0"
+                    bus := "virtio"
+                    vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+                        Name: diskName,
+                        DiskDevice: v1.DiskDevice{
+                            Disk: &v1.DiskTarget{
+                                Bus: bus,
+                            },
+                        },
+                    })
+                    vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+                        Name: diskName,
+                        VolumeSource: v1.VolumeSource{
+                            PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+                                ClaimName: dv.ObjectMeta.Name,
+                            }},
+                        },
+                    })
+
+                    vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+
+                    vm := tests.NewRandomVirtualMachine(vmi, true)
+                    dvt := &v1.DataVolumeTemplateSpec{
+                        ObjectMeta: dv.ObjectMeta,
+                        Spec:       dv.Spec,
+                    }
+                    vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
+                    _, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+                })
+                It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself",
+                    Label("Serial", "test_id:4644"),
+                    func() {
+                        dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+                        _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+                        Expect(err).To(BeNil())
+
+                        defer func(dv *cdiv1.DataVolume) {
+                            By(deletingDataVolume)
+                            ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+                        }(dv)
+                        Eventually(func() error {
+                            _, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+                            return err
+                        }, 30*time.Second, 1*time.Second).Should(BeNil())
+
+                        vmi := tests.NewRandomVMI()
+
+                        diskName := "disk0"
+                        bus := "virtio"
+                        vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+                            Name: diskName,
+                            DiskDevice: v1.DiskDevice{
+                                Disk: &v1.DiskTarget{
+                                    Bus: bus,
+                                },
+                            },
+                        })
+                        vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+                            Name: diskName,
+                            VolumeSource: v1.VolumeSource{
+                                PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+                                    ClaimName: dv.ObjectMeta.Name,
+                                }},
+                            },
+                        })
+
+                        vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+
+                        vm := tests.NewRandomVirtualMachine(vmi, true)
+                        _, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+                        Expect(err).ShouldNot(HaveOccurred())
+
+                        Eventually(func() bool {
+                            vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+                            Expect(err).ToNot(HaveOccurred())
+
+                            return vm.Status.Created
+                        }, 30*time.Second, 1*time.Second).Should(Equal(false))
+                    })
+            })
+        })
+
+    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume",
+        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+        func() {
+            Context("using DataVolume with invalid URL", func() {
+                deleteDataVolume := func(dv *cdiv1.DataVolume) {
+                    By(deletingDataVolume)
+                    ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
+                }
+
+                It("shold be possible to stop VM if datavolume is crashing", func() {
+                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+                    vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
+                    vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
+                        {
+                            ObjectMeta: dataVolume.ObjectMeta,
+                            Spec:       dataVolume.Spec,
+                        },
+                    }
+
+                    By(creatingVMInvalidDataVolume)
+                    vm, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+
+                    By("Waiting for DV to start crashing")
+                    Eventually(ThisDV(dataVolume), 60).Should(BeInPhase(cdiv1.ImportInProgress))
+
+                    By("Stop VM")
+                    tests.StopVirtualMachineWithTimeout(vm, time.Second*30)
+                })
+
+                It("[test_id:3190]should correctly handle invalid DataVolumes", Label("test_id:3190"), func() {
+                    // Don't actually create the DataVolume since it's invalid.
+                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+                    //  Add the invalid DataVolume to a VMI
+                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+                    // Create a VM for this VMI
+                    vm := tests.NewRandomVirtualMachine(vmi, true)
+
+                    By(creatingVMInvalidDataVolume)
+                    vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+
+                    By("Waiting for VMI to be created")
+                    Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+                })
+                It("[test_id:3190]should correctly handle eventually consistent DataVolumes", Label("test_id:3190"), func() {
+                    realRegistryName := flags.KubeVirtUtilityRepoPrefix
+                    realRegistryPort := ""
+                    if strings.Contains(flags.KubeVirtUtilityRepoPrefix, ":") {
+                        realRegistryName = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[0]
+                        realRegistryPort = strings.Split(flags.KubeVirtUtilityRepoPrefix, ":")[1]
+                    }
+                    if realRegistryPort == "" {
+                        Skip("Skip when no port, CDI will always try to reach dockerhub/fakeregistry instead of just fakeregistry")
+                    }
+
+                    fakeRegistryName := "fakeregistry"
+                    fakeRegistryWithPort := fakeRegistryName
+                    if realRegistryPort != "" {
+                        fakeRegistryWithPort = fmt.Sprintf("%s:%s", fakeRegistryName, realRegistryPort)
+                    }
+
+                    dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlFromRegistryForContainerDisk(fakeRegistryWithPort, cd.ContainerDiskCirros),
+                        util.NamespaceTestDefault,
+                        k8sv1.ReadWriteOnce,
+                    )
+                    defer deleteDataVolume(dataVolume)
+
+                    By("Creating DataVolume with invalid URL")
+                    dataVolume, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+                    Expect(err).To(BeNil())
+
+                    By(creatingVMInvalidDataVolume)
+                    //  Add the invalid DataVolume to a VMI
+                    vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+                    // Create a VM for this VMI
+                    vm := tests.NewRandomVirtualMachine(vmi, true)
+                    vm, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+
+                    Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
+
+                    By("Creating a service which makes the registry reachable")
+                    virtClient.CoreV1().Services(vm.Namespace).Create(context.Background(), &k8sv1.Service{
+                        ObjectMeta: metav1.ObjectMeta{
+                            Name: fakeRegistryName,
+                        },
+                        Spec: k8sv1.ServiceSpec{
+                            Type:         k8sv1.ServiceTypeExternalName,
+                            ExternalName: realRegistryName,
+                        },
+                    }, metav1.CreateOptions{})
+
+                    By("Wait for DataVolume to complete")
+                    Eventually(ThisDV(dataVolume), 160).Should(HaveSucceeded())
+
+                    By("Waiting for VMI to be created")
+                    Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Running))
+                })
+            })
+        })
+
+    Describe("[rfe_id:896][crit:high][vendor:cnv-qe@redhat.com][level:system] with oc/kubectl",
+        Label("rfe_id:896", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+        func() {
+            var vm *v1.VirtualMachine
+            var err error
+            var vmJson string
+            var dataVolumeName string
+            var pvcName string
+
+            k8sClient := clientcmd.GetK8sCmdClient()
+
+            BeforeEach(func() {
+                running := true
+
+                vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+                vm.Spec.Running = &running
+
+                dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
+                pvcName = dataVolumeName
+
+                vmJson, err = tests.GenerateVMJson(vm, GinkgoT().TempDir())
+                Expect(err).ToNot(HaveOccurred())
+            })
+
+            It("[test_id:836] Creating a VM with DataVolumeTemplates should succeed.", Label("test_id:836"), func() {
+                By(creatingVMDataVolumeTemplateEntry)
+                _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+                Expect(err).ToNot(HaveOccurred())
+
+                By(verifyingDataVolumeSuccess)
+                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+                By(verifyingPVCCreated)
+                Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+                By(verifyingVMICreated)
+                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+            })
+
+            It("[test_id:837]deleting VM with cascade=true should automatically delete DataVolumes and VMI owned by VM.", Label("test_id:837"), func() {
+                By(creatingVMDataVolumeTemplateEntry)
+                _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+                Expect(err).ToNot(HaveOccurred())
+
+                By(verifyingDataVolumeSuccess)
+                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+                By(verifyingPVCCreated)
+                Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+                By(verifyingVMICreated)
+                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+
+                By("Deleting VM with cascade=true")
+                _, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=true")
+                Expect(err).ToNot(HaveOccurred())
+
+                By("Waiting for the VM to be deleted")
+                Eventually(ThisVM(vm), 100).Should(BeGone())
+
+                By("Waiting for the VMI to be deleted")
+                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeGone())
+
+                By("Waiting for the DataVolume to be deleted")
+                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(BeGone())
+
+                By("Waiting for the PVC to be deleted")
+                Eventually(ThisPVCWith(vm.Namespace, pvcName), 100).Should(BeGone())
+            })
+
+            It("[test_id:838]deleting VM with cascade=false should orphan DataVolumes and VMI owned by VM.", Label("test_id:838"), func() {
+                By(creatingVMDataVolumeTemplateEntry)
+                _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+                Expect(err).ToNot(HaveOccurred())
+
+                By(verifyingDataVolumeSuccess)
+                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), BeOwned()))
+
+                By(verifyingPVCCreated)
+                Eventually(ThisPVCWith(vm.Namespace, pvcName), 160).Should(Exist())
+
+                By(verifyingVMICreated)
+                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 160).Should(And(BeRunning(), BeOwned()))
+
+                By("Deleting VM with cascade=false")
+                _, _, err = clientcmd.RunCommand("kubectl", "delete", "vm", vm.Name, "--cascade=false")
+                Expect(err).ToNot(HaveOccurred())
+
+                By("Waiting for the VM to be deleted")
+                Eventually(ThisVM(vm), 100).Should(BeGone())
+
+                By("Verifying DataVolume still exists with owner references removed")
+                Eventually(ThisDVWith(vm.Namespace, dataVolumeName), 100).Should(And(HaveSucceeded(), Not(BeOwned())))
+
+                By("Verifying VMI still exists with owner references removed")
+                Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(And(BeRunning(), Not(BeOwned())))
+            })
+
+        })
+
+    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume",
+        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+        func() {
+            Context("using Alpine http import", func() {
+                It("a DataVolume with preallocation shouldn't have discard=unmap", func() {
+                    var vm *v1.VirtualMachine
+                    vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+                    preallocation := true
+                    vm.Spec.DataVolumeTemplates[0].Spec.Preallocation = &preallocation
+
+                    vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+
+                    vm = tests.StartVirtualMachine(vm)
+                    vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+
+                    domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+                    Expect(err).ToNot(HaveOccurred())
+                    Expect(domXml).ToNot(ContainSubstring("discard='unmap'"))
+                    vm = tests.StopVirtualMachine(vm)
+                    Expect(virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})).To(Succeed())
+                })
+
+                DescribeTable("[test_id:3191]should be successfully started and stopped multiple times", Label("test_id:3191"), func(isHTTP bool) {
+                    var vm *v1.VirtualMachine
+                    if isHTTP {
+                        vm = tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+                    } else {
+                        url := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
+                        vm = tests.NewRandomVMWithDataVolume(url, util.NamespaceTestDefault)
+                    }
+                    vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+                    num := 2
+                    By("Starting and stopping the VirtualMachine number of times")
+                    for i := 0; i < num; i++ {
+                        By(fmt.Sprintf("Doing run: %d", i))
+                        vm = tests.StartVirtualMachine(vm)
+                        // Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
+                        // after being restarted multiple times
+                        if i == num {
+                            By(checkingVMInstanceConsoleExpectedOut)
+                            vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+                            Expect(err).ToNot(HaveOccurred())
+                            Expect(console.LoginToAlpine(vmi)).To(Succeed())
+                        }
+                        vm = tests.StopVirtualMachine(vm)
+                    }
+                },
+
+                    Entry("with http import", true),
+                    Entry("with registry import", false),
+                )
+
+                It("[test_id:3192]should remove owner references on DataVolume if VM is orphan deleted.", Label("test_id:3192"), func() {
+                    vm := tests.NewRandomVMWithDataVolume(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault)
+                    vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+                    Expect(err).ToNot(HaveOccurred())
+
+                    // Check for owner reference
+                    Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(BeOwned())
+
+                    // Delete the VM with orphan Propagation
+                    orphanPolicy := metav1.DeletePropagationOrphan
+                    Expect(virtClient.VirtualMachine(vm.Namespace).
+                        Delete(vm.Name, &metav1.DeleteOptions{PropagationPolicy: &orphanPolicy})).To(Succeed())
+
+                    // Wait for the owner reference to disappear
+                    Eventually(ThisDVWith(vm.Namespace, vm.Spec.DataVolumeTemplates[0].Name), 100).Should(Not(BeOwned()))
+                })
+            })
+        })
+
+    Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] DataVolume clone permission checking",
+        Label("rfe_id:3188", "crit:high", "vendor:cnv-qe@redhat.com", "level:system"),
+        func() {
+            Context("using Alpine import/clone", func() {
+                var dataVolume *cdiv1.DataVolume
+                var createdVirtualMachine *v1.VirtualMachine
+                var cloneRole *rbacv1.Role
+                var cloneRoleBinding *rbacv1.RoleBinding
+                var storageClass string
+                var vm *v1.VirtualMachine
+
+                BeforeEach(func() {
+                    var exists bool
+                    storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
+                    if !exists {
+                        Skip("Skip test when RWOFileSystem storage class is not present")
+                    }
+                    var err error
+                    dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), tests.NamespaceTestAlternative, storageClass, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+                    tests.SetDataVolumeForceBindAnnotation(dv)
+                    dataVolume, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+                    Eventually(ThisDV(dataVolume), 90).Should(HaveSucceeded())
+
+                    vm = tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, util.NamespaceTestDefault)
+                    const volumeName = "sa"
+                    saVol := v1.Volume{
+                        Name: volumeName,
+                        VolumeSource: v1.VolumeSource{
+                            ServiceAccount: &v1.ServiceAccountVolumeSource{
+                                ServiceAccountName: tests.AdminServiceAccountName,
+                            },
+                        },
+                    }
+                    vm.Spec.DataVolumeTemplates[0].Spec.PVC.StorageClassName = pointer.StringPtr(storageClass)
+                    vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, saVol)
+                    vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{Name: volumeName})
+                })
+
+                AfterEach(func() {
+                    if cloneRole != nil {
+                        err := virtClient.RbacV1().Roles(cloneRole.Namespace).Delete(context.Background(), cloneRole.Name, metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }
+
+                    if cloneRoleBinding != nil {
+                        err := virtClient.RbacV1().RoleBindings(cloneRoleBinding.Namespace).Delete(context.Background(), cloneRoleBinding.Name, metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }
+
+                    if createdVirtualMachine != nil {
+                        err := virtClient.VirtualMachine(createdVirtualMachine.Namespace).Delete(createdVirtualMachine.Name, &metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }
+                })
+
+                createVmSuccess := func() {
+                    // sometimes it takes a bit for permission to actually be applied so eventually
+                    Eventually(func() bool {
+                        _, err = virtClient.VirtualMachine(vm.Namespace).Create(vm)
+                        if err != nil {
+                            fmt.Printf("command should have succeeded maybe new permissions not applied yet\nerror\n%s\n", err)
+                            return false
+                        }
+                        return true
+                    }, 90*time.Second, 1*time.Second).Should(BeTrue())
+
+                    createdVirtualMachine = vm
+
+                    // start vm and check dv clone succeeded
+                    createdVirtualMachine = tests.StartVirtualMachine(createdVirtualMachine)
+                    targetDVName := vm.Spec.DataVolumeTemplates[0].Name
+                    Eventually(ThisDVWith(createdVirtualMachine.Namespace, targetDVName), 90).Should(HaveSucceeded())
+                }
+
+                It("should resolve DataVolume sourceRef", func() {
+                    // convert DV to use datasource
+                    dvt := &vm.Spec.DataVolumeTemplates[0]
+                    ds := &cdiv1.DataSource{
+                        ObjectMeta: metav1.ObjectMeta{
+                            Name: "ds-" + rand.String(12),
+                        },
+                        Spec: cdiv1.DataSourceSpec{
+                            Source: cdiv1.DataSourceSource{
+                                PVC: dvt.Spec.Source.PVC,
+                            },
+                        },
+                    }
+                    ds, err := virtClient.CdiClient().CdiV1beta1().DataSources(vm.Namespace).Create(context.TODO(), ds, metav1.CreateOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+
+                    defer func() {
+                        err := virtClient.CdiClient().CdiV1beta1().DataSources(ds.Namespace).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
+                        Expect(err).ToNot(HaveOccurred())
+                    }()
+
+                    dvt.Spec.Source = nil
+                    dvt.Spec.SourceRef = &cdiv1.DataVolumeSourceRef{
+                        Kind: "DataSource",
+                        Name: ds.Name,
+                    }
+
+                    cloneRole, cloneRoleBinding = addClonePermission(
+                        virtClient,
+                        explicitCloneRole,
+                        tests.AdminServiceAccountName,
+                        util.NamespaceTestDefault,
+                        tests.NamespaceTestAlternative,
+                    )
+
+                    createVmSuccess()
+
+                    dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.TODO(), dvt.Name, metav1.GetOptions{})
+                    Expect(err).ToNot(HaveOccurred())
+                    Expect(dv.Spec.SourceRef).To(BeNil())
+                    Expect(dv.Spec.Source.PVC.Namespace).To(Equal(ds.Spec.Source.PVC.Namespace))
+                    Expect(dv.Spec.Source.PVC.Name).To(Equal(ds.Spec.Source.PVC.Name))
+                })
+
+                DescribeTable("[storage-req] deny then allow clone request", Label("storage-req"), func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
+                    _, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+                    Expect(err).To(HaveOccurred())
+                    Expect(err.Error()).To(ContainSubstring("Authorization failed, message is:"))
+
+                    saName := tests.AdminServiceAccountName
+                    saNamespace := util.NamespaceTestDefault
+
+                    if allServiceAccounts {
+                        saName = ""
+                        saNamespace = ""
+                    } else if allServiceAccountsInNamespace {
+                        saName = ""
+                    }
+
+                    // add permission
+                    cloneRole, cloneRoleBinding = addClonePermission(virtClient, role, saName, saNamespace, tests.NamespaceTestAlternative)
+
+                    createVmSuccess()
+
+                    // stop vm
+                    createdVirtualMachine = tests.StopVirtualMachine(createdVirtualMachine)
+                },
+                    Entry("[test_id:3193]with explicit role", Label("test_id:3193"), explicitCloneRole, false, false),
+                    Entry("[test_id:3194]with implicit role", Label("test_id:3194"), implicitCloneRole, false, false),
+                    Entry("[test_id:5253]with explicit role (all namespaces)", Label("test_id:5253"), explicitCloneRole, true, false),
+                    Entry("[test_id:5254]with explicit role (one namespace)", Label("test_id:5254"), explicitCloneRole, false, true),
+                )
+            })
+        })
+
+    Context("Fedora VMI tests", func() {
+        imageSizeEqual := func(a, b int64) bool {
+            // Our OCS image size method probe is very precise and can show a few
+            // bytes of difference.
+            // A VM cannot do sub-512 byte accesses anyway, so such small size
+            // differences are practically equal.
+            if math.Abs((float64)(a-b)) >= 512 {
+                By(fmt.Sprintf("Image sizes not equal, %d - %d >= 512", a, b))
+                return false
+            } else {
+                return true
+            }
+        }
+        getImageSize := func(vmi *v1.VirtualMachineInstance, dv *cdiv1.DataVolume) int64 {
+            var imageSize int64
+            var unused string
+            pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+            lsOutput, err := tests.ExecuteCommandOnPod(
+                virtClient,
+                pod,
+                "compute",
+                []string{"ls", "-s", "/var/run/kubevirt-private/vmi-disks/disk0/disk.img"},
+            )
+            Expect(err).ToNot(HaveOccurred())
+            fmt.Sscanf(lsOutput, "%d %s", &imageSize, &unused)
+            return imageSize
+        }
+
+        noop := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+            return dv
+        }
+        addPreallocationTrue := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+            preallocation := true
+            dv.Spec.Preallocation = &preallocation
+            return dv
+        }
+        addPreallocationFalse := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+            preallocation := false
+            dv.Spec.Preallocation = &preallocation
+            return dv
+        }
+        addThickProvisionedTrueAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+            dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "true"}
+            return dv
+        }
+        addThickProvisionedFalseAnnotation := func(dv *cdiv1.DataVolume) *cdiv1.DataVolume {
+            dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
+            return dv
+        }
+        DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img",
+            Label("rfe_id:5070", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
+            func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
+                dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+                dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse(cd.FedoraVolumeSize)
+                dataVolume = dvChange(dataVolume)
+                preallocated := dataVolume.Spec.Preallocation != nil && *dataVolume.Spec.Preallocation
+
+                vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+                vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+                vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = "scsi"
+                tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
+
+                _, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+                Expect(err).ToNot(HaveOccurred())
+
+                vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
+
+                By("Expecting the VirtualMachineInstance console")
+                Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+                imageSizeAfterBoot := getImageSize(vmi, dataVolume)
+                By(fmt.Sprintf("image size after boot is %d", imageSizeAfterBoot))
+
+                By("Filling out disk space")
+                Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+                    &expect.BSnd{S: "\n"},
+                    &expect.BExp{R: console.PromptExpression},
+                    &expect.BSnd{S: "dd if=/dev/urandom of=largefile bs=1M count=300 2> /dev/null\n"},
+                    &expect.BExp{R: console.PromptExpression},
+                    &expect.BSnd{S: syncName},
+                    &expect.BExp{R: console.PromptExpression},
+                }, 360)).To(Succeed(), "should write a large file")
+
+                if preallocated {
+                    // Preallocation means no changes to disk size
+                    Eventually(imageSizeEqual(getImageSize(vmi, dataVolume), imageSizeAfterBoot), 120*time.Second).Should(BeTrue())
+                } else {
+                    Eventually(getImageSize(vmi, dataVolume), 120*time.Second).Should(BeNumerically(">", imageSizeAfterBoot))
+                }
+
+                imageSizeBeforeTrim := getImageSize(vmi, dataVolume)
+                By(fmt.Sprintf("image size before trim is %d", imageSizeBeforeTrim))
+
+                By("Writing a small file so that we detect a disk space usage change.")
+                By("Deleting large file and trimming disk")
+                Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+                    // Write a small file so that we'll have an increase in image size if trim is unsupported.
+                    &expect.BSnd{S: "dd if=/dev/urandom of=smallfile bs=1M count=50 2> /dev/null\n"},
+                    &expect.BExp{R: console.PromptExpression},
+                    &expect.BSnd{S: syncName},
+                    &expect.BExp{R: console.PromptExpression},
+                    &expect.BSnd{S: "rm -f largefile\n"},
+                    &expect.BExp{R: console.PromptExpression},
+                }, 60)).To(Succeed(), "should trim within the VM")
+
+                Eventually(func() bool {
+                    By("Running trim")
+                    err := console.SafeExpectBatch(vmi, []expect.Batcher{
+                        &expect.BSnd{S: "sudo fstrim -v /\n"},
+                        &expect.BExp{R: console.PromptExpression},
+                        &expect.BSnd{S: syncName},
+                        &expect.BExp{R: console.PromptExpression},
+                    }, 60)
+                    Expect(err).ToNot(HaveOccurred())
+
+                    currentImageSize := getImageSize(vmi, dataVolume)
+                    if expectSmaller {
+                        // Trim should make the space usage go down
+                        By(fmt.Sprintf("We expect disk usage to go down from the use of trim.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+                        return currentImageSize < imageSizeBeforeTrim
+                    } else if preallocated {
+                        By(fmt.Sprintf("Trim shouldn't do anything, and preallocation should mean no change to disk usage.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+                        return imageSizeEqual(currentImageSize, imageSizeBeforeTrim)
+
+                    } else {
+                        By(fmt.Sprintf("Trim shouldn't do anything, but we expect size usage to go up, because we wrote another small file.\nIt is currently %d and was previously %d", currentImageSize, imageSizeBeforeTrim))
+                        return currentImageSize > imageSizeBeforeTrim
+                    }
+                }, 120*time.Second).Should(BeTrue())
+
+                err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+                Expect(err).To(BeNil())
+            },
+            Entry("[test_id:5894]by default, fstrim will make the image smaller", Label("test_id:5894"), noop, true),
+            Entry("[test_id:5898]with preallocation true, fstrim has no effect", Label("test_id:5898"), addPreallocationTrue, false),
+            Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", Label("test_id:5897"), addPreallocationFalse, true),
+            Entry("[test_id:5899]with thick provision true, fstrim has no effect", Label("test_id:5899"), addThickProvisionedTrueAnnotation, false),
+            Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", Label("test_id:5896"), addThickProvisionedFalseAnnotation, true),
+        )
+    })
 })
 
 var explicitCloneRole = &rbacv1.Role{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "explicit-clone-role",
-	},
-	Rules: []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{
-				"cdi.kubevirt.io",
-			},
-			Resources: []string{
-				"datavolumes/source",
-			},
-			Verbs: []string{
-				"create",
-			},
-		},
-	},
+    ObjectMeta: metav1.ObjectMeta{
+        Name: "explicit-clone-role",
+    },
+    Rules: []rbacv1.PolicyRule{
+        {
+            APIGroups: []string{
+                "cdi.kubevirt.io",
+            },
+            Resources: []string{
+                "datavolumes/source",
+            },
+            Verbs: []string{
+                "create",
+            },
+        },
+    },
 }
 
 var implicitCloneRole = &rbacv1.Role{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "implicit-clone-role",
-	},
-	Rules: []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{
-				"",
-			},
-			Resources: []string{
-				"pods",
-			},
-			Verbs: []string{
-				"create",
-			},
-		},
-	},
+    ObjectMeta: metav1.ObjectMeta{
+        Name: "implicit-clone-role",
+    },
+    Rules: []rbacv1.PolicyRule{
+        {
+            APIGroups: []string{
+                "",
+            },
+            Resources: []string{
+                "pods",
+            },
+            Verbs: []string{
+                "create",
+            },
+        },
+    },
 }
 
 func addClonePermission(client kubecli.KubevirtClient, role *rbacv1.Role, sa, saNamespace, targetNamesace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
-	role, err := client.RbacV1().Roles(targetNamesace).Create(context.Background(), role, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+    role, err := client.RbacV1().Roles(targetNamesace).Create(context.Background(), role, metav1.CreateOptions{})
+    Expect(err).ToNot(HaveOccurred())
 
-	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: role.Name,
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "Role",
-			Name:     role.Name,
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	}
+    rb := &rbacv1.RoleBinding{
+        ObjectMeta: metav1.ObjectMeta{
+            Name: role.Name,
+        },
+        RoleRef: rbacv1.RoleRef{
+            Kind:     "Role",
+            Name:     role.Name,
+            APIGroup: "rbac.authorization.k8s.io",
+        },
+    }
 
-	if sa != "" {
-		rb.Subjects = []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      sa,
-				Namespace: saNamespace,
-			},
-		}
-	} else {
-		g := "system:serviceaccounts"
-		if saNamespace != "" {
-			g += ":" + saNamespace
-		}
-		rb.Subjects = []rbacv1.Subject{
-			{
-				Kind:     "Group",
-				Name:     g,
-				APIGroup: "rbac.authorization.k8s.io",
-			},
-		}
-	}
+    if sa != "" {
+        rb.Subjects = []rbacv1.Subject{
+            {
+                Kind:      "ServiceAccount",
+                Name:      sa,
+                Namespace: saNamespace,
+            },
+        }
+    } else {
+        g := "system:serviceaccounts"
+        if saNamespace != "" {
+            g += ":" + saNamespace
+        }
+        rb.Subjects = []rbacv1.Subject{
+            {
+                Kind:     "Group",
+                Name:     g,
+                APIGroup: "rbac.authorization.k8s.io",
+            },
+        }
+    }
 
-	rb, err = client.RbacV1().RoleBindings(targetNamesace).Create(context.Background(), rb, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+    rb, err = client.RbacV1().RoleBindings(targetNamesace).Create(context.Background(), rb, metav1.CreateOptions{})
+    Expect(err).ToNot(HaveOccurred())
 
-	return role, rb
+    return role, rb
 }

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -42,7 +42,7 @@ const (
 	diskName   = "disk0"
 )
 
-var _ = SIGDescribe("[Serial]K8s IO events", Labels{"Serial"}, func() {
+var _ = SIGDescribe("[Serial]K8s IO events", Label("Serial"), func() {
 	var (
 		nodeName   string
 		virtClient kubecli.KubevirtClient
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[Serial]K8s IO events", Labels{"Serial"}, func() {
 		err := virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
-	It("[test_id:6225]Should catch the IO error event", Labels{"test_id:6225"}, func() {
+	It("[test_id:6225]Should catch the IO error event", Label("test_id:6225"), func() {
 		By("Creating VMI with faulty disk")
 		vmi := tests.NewRandomVMIWithPVC(pvc.Name)
 		Eventually(func() error {

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -42,7 +42,7 @@ const (
 	diskName   = "disk0"
 )
 
-var _ = SIGDescribe("[Serial]K8s IO events", func() {
+var _ = SIGDescribe("[Serial]K8s IO events", Labels{"Serial"}, func() {
 	var (
 		nodeName   string
 		virtClient kubecli.KubevirtClient
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[Serial]K8s IO events", func() {
 		err := virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
-	It("[test_id:6225]Should catch the IO error event", func() {
+	It("[test_id:6225]Should catch the IO error event", Labels{"test_id:6225"}, func() {
 		By("Creating VMI with faulty disk")
 		vmi := tests.NewRandomVMIWithPVC(pvc.Name)
 		Eventually(func() error {

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -23,10 +23,22 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-storage] "+text, body)
+func SIGDescribe(text string, args ...interface{}) bool {
+	for i := range args {
+		if labels, ok := args[i].(Labels); ok {
+			labels = append(labels, "sig-storage")
+			args[i] = labels
+		}
+	}
+	return Describe("[sig-storage] "+text, args)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-storage] "+text, body)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	for i := range args {
+		if labels, ok := args[i].(Labels); ok {
+			labels = append(labels, "sig-storage")
+			args[i] = labels
+		}
+	}
+	return FDescribe("[sig-storage] "+text, args)
 }

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -154,7 +154,7 @@ var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Labels{"rfe_id:6364", "Seria
 				pvcClaim = "pvc-fail-to-run-twice"
 				createPVCFilesystem(pvcClaim)
 				runGuestfsOnPVC(pvcClaim)
-			guestfsCmd := clientcmd.NewVirtctlCommand("guestfs",
+				guestfsCmd := clientcmd.NewVirtctlCommand("guestfs",
 					pvcClaim,
 					"--namespace", util.NamespaceTestDefault)
 				Expect(guestfsCmd.Execute()).To(HaveOccurred())

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -34,7 +34,7 @@ func (f *fakeAttacher) closeChannel() {
 	f.done <- true
 }
 
-var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Labels{"rfe_id:6364", "Serial"}, func() {
+var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Label("rfe_id:6364", "Serial"), func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		pvcClaim   string
@@ -127,7 +127,7 @@ var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Labels{"rfe_id:6364", "Seria
 		})
 
 		It("[posneg:positive][test_id:6480]Should successfully run guestfs command on a filesystem-based PVC",
-			Labels{"posneg:positive", "test_id:6480"},
+			Label("posneg:positive", "test_id:6480"),
 			func() {
 				f := createFakeAttacher()
 				defer f.closeChannel()
@@ -147,7 +147,7 @@ var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Labels{"rfe_id:6364", "Seria
 			})
 
 		It("[posneg:negative][test_id:6480]Should fail to run the guestfs command on a PVC in use",
-			Labels{"posneg:negative", "test_id:6480"},
+			Label("posneg:negative", "test_id:6480"),
 			func() {
 				f := createFakeAttacher()
 				defer f.closeChannel()
@@ -161,7 +161,7 @@ var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Labels{"rfe_id:6364", "Seria
 			})
 
 		It("[posneg:positive][test_id:6479]Should successfully run guestfs command on a block-based PVC",
-			Labels{"posneg:positive", "test_id:6479"},
+			Label("posneg:positive", "test_id:6479"),
 			func() {
 				f := createFakeAttacher()
 				defer f.closeChannel()

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -34,7 +34,7 @@ func (f *fakeAttacher) closeChannel() {
 	f.done <- true
 }
 
-var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
+var _ = SIGDescribe("[rfe_id:6364][Serial]Guestfs", Labels{"rfe_id:6364", "Serial"}, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		pvcClaim   string
@@ -126,51 +126,57 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 
 		})
 
-		It("[posneg:positive][test_id:6480]Should successfully run guestfs command on a filesystem-based PVC", func() {
-			f := createFakeAttacher()
-			defer f.closeChannel()
-			pvcClaim = "pvc-fs"
-			podName := libguestsTools + pvcClaim
-			createPVCFilesystem(pvcClaim)
-			runGuestfsOnPVC(pvcClaim)
-			stdout, stderr, err := execCommandLibguestfsPod(podName, []string{"qemu-img", "create", "/disk/disk.img", "500M"})
-			Expect(stderr).To(Equal(""))
-			Expect(stdout).To(ContainSubstring("Formatting"))
-			Expect(err).ToNot(HaveOccurred())
-			stdout, stderr, err = execCommandLibguestfsPod(podName, []string{"guestfish", "-a", "/disk/disk.img", "run"})
-			Expect(stderr).To(Equal(""))
-			Expect(stdout).To(Equal(""))
-			Expect(err).ToNot(HaveOccurred())
+		It("[posneg:positive][test_id:6480]Should successfully run guestfs command on a filesystem-based PVC",
+			Labels{"posneg:positive", "test_id:6480"},
+			func() {
+				f := createFakeAttacher()
+				defer f.closeChannel()
+				pvcClaim = "pvc-fs"
+				podName := libguestsTools + pvcClaim
+				createPVCFilesystem(pvcClaim)
+				runGuestfsOnPVC(pvcClaim)
+				stdout, stderr, err := execCommandLibguestfsPod(podName, []string{"qemu-img", "create", "/disk/disk.img", "500M"})
+				Expect(stderr).To(Equal(""))
+				Expect(stdout).To(ContainSubstring("Formatting"))
+				Expect(err).ToNot(HaveOccurred())
+				stdout, stderr, err = execCommandLibguestfsPod(podName, []string{"guestfish", "-a", "/disk/disk.img", "run"})
+				Expect(stderr).To(Equal(""))
+				Expect(stdout).To(Equal(""))
+				Expect(err).ToNot(HaveOccurred())
 
-		})
+			})
 
-		It("[posneg:negative][test_id:6480]Should fail to run the guestfs command on a PVC in use", func() {
-			f := createFakeAttacher()
-			defer f.closeChannel()
-			pvcClaim = "pvc-fail-to-run-twice"
-			createPVCFilesystem(pvcClaim)
-			runGuestfsOnPVC(pvcClaim)
+		It("[posneg:negative][test_id:6480]Should fail to run the guestfs command on a PVC in use",
+			Labels{"posneg:negative", "test_id:6480"},
+			func() {
+				f := createFakeAttacher()
+				defer f.closeChannel()
+				pvcClaim = "pvc-fail-to-run-twice"
+				createPVCFilesystem(pvcClaim)
+				runGuestfsOnPVC(pvcClaim)
 			guestfsCmd := clientcmd.NewVirtctlCommand("guestfs",
-				pvcClaim,
-				"--namespace", util.NamespaceTestDefault)
-			Expect(guestfsCmd.Execute()).To(HaveOccurred())
-		})
+					pvcClaim,
+					"--namespace", util.NamespaceTestDefault)
+				Expect(guestfsCmd.Execute()).To(HaveOccurred())
+			})
 
-		It("[posneg:positive][test_id:6479]Should successfully run guestfs command on a block-based PVC", func() {
-			f := createFakeAttacher()
-			defer f.closeChannel()
+		It("[posneg:positive][test_id:6479]Should successfully run guestfs command on a block-based PVC",
+			Labels{"posneg:positive", "test_id:6479"},
+			func() {
+				f := createFakeAttacher()
+				defer f.closeChannel()
 
-			pvcClaim = "pvc-block"
-			podName := libguestsTools + pvcClaim
-			size, _ := resource.ParseQuantity("500Mi")
-			tests.CreateBlockPVC(virtClient, pvcClaim, size)
-			runGuestfsOnPVC(pvcClaim)
-			stdout, stderr, err := execCommandLibguestfsPod(podName, []string{"guestfish", "-a", "/dev/vda", "run"})
-			Expect(stderr).To(Equal(""))
-			Expect(stdout).To(Equal(""))
-			Expect(err).ToNot(HaveOccurred())
+				pvcClaim = "pvc-block"
+				podName := libguestsTools + pvcClaim
+				size, _ := resource.ParseQuantity("500Mi")
+				tests.CreateBlockPVC(virtClient, pvcClaim, size)
+				runGuestfsOnPVC(pvcClaim)
+				stdout, stderr, err := execCommandLibguestfsPod(podName, []string{"guestfish", "-a", "/dev/vda", "run"})
+				Expect(stderr).To(Equal(""))
+				Expect(stdout).To(Equal(""))
+				Expect(err).ToNot(HaveOccurred())
 
-		})
+			})
 
 	})
 })

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -584,7 +584,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 	})
 
-	Context("[storage-req]", func() {
+	Context("[storage-req]", Labels{"storage-req"}, func() {
 		Context("Online VM", func() {
 			var (
 				vm *v1.VirtualMachine
@@ -791,7 +791,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			},
 				Entry("with VMs", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeFilesystem, false),
 				Entry("with VMIs", addDVVolumeVMI, removeVolumeVMI, corev1.PersistentVolumeFilesystem, true),
-				Entry("[Serial] with VMs and block", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
+				Entry("[Serial] with VMs and block", Labels{"Serial"}, addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
 			)
 
 			It("should permanently add hotplug volume when added to VM, but still unpluggable after restart", func() {
@@ -1224,7 +1224,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			}
 		},
 			Entry("with default", false),
-			Entry("[test_id:7803]with dry-run", true),
+			Entry("[test_id:7803]with dry-run", Labels{"test_id:7803"}, true),
 		)
 
 		DescribeTable("should remove volume according to options", func(dryRun bool) {
@@ -1265,7 +1265,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			}
 		},
 			Entry("with default", false),
-			Entry("[test_id:7829]with dry-run", true),
+			Entry("[test_id:7829]with dry-run", Labels{"test_id:7829"}, true),
 		)
 	})
 })

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -584,7 +584,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 	})
 
-	Context("[storage-req]", Labels{"storage-req"}, func() {
+	Context("[storage-req]", Label("storage-req"), func() {
 		Context("Online VM", func() {
 			var (
 				vm *v1.VirtualMachine
@@ -791,7 +791,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			},
 				Entry("with VMs", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeFilesystem, false),
 				Entry("with VMIs", addDVVolumeVMI, removeVolumeVMI, corev1.PersistentVolumeFilesystem, true),
-				Entry("[Serial] with VMs and block", Labels{"Serial"}, addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
+				Entry("[Serial] with VMs and block", Label("Serial"), addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
 			)
 
 			It("should permanently add hotplug volume when added to VM, but still unpluggable after restart", func() {
@@ -1224,7 +1224,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			}
 		},
 			Entry("with default", false),
-			Entry("[test_id:7803]with dry-run", Labels{"test_id:7803"}, true),
+			Entry("[test_id:7803]with dry-run", Label("test_id:7803"), true),
 		)
 
 		DescribeTable("should remove volume according to options", func(dryRun bool) {
@@ -1265,7 +1265,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			}
 		},
 			Entry("with default", false),
-			Entry("[test_id:7829]with dry-run", Labels{"test_id:7829"}, true),
+			Entry("[test_id:7829]with dry-run", Label("test_id:7829"), true),
 		)
 	})
 })

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -39,7 +39,7 @@ const (
 	insecure             = "--insecure"
 )
 
-var _ = SIGDescribe("[Serial]ImageUpload", Labels{"Serial"}, func() {
+var _ = SIGDescribe("[Serial]ImageUpload", Label("Serial"), func() {
 	var kubectlCmd *exec.Cmd
 
 	pvcSize := "100Mi"
@@ -142,8 +142,8 @@ var _ = SIGDescribe("[Serial]ImageUpload", Labels{"Serial"}, func() {
 		Expect(*pvc.Spec.StorageClassName).To(Equal(storageClass))
 	}
 
-	Context("[storage-req] Upload an image and start a VMI with PVC", Labels{"storage-req"}, func() {
-		DescribeTable("[test_id:4621] Should succeed", Labels{"test_id:4621"}, func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
+	Context("[storage-req] Upload an image and start a VMI with PVC", Label("storage-req"), func() {
+		DescribeTable("[test_id:4621] Should succeed", Label("test_id:4621"), func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := libstorage.GetRWOBlockStorageClass()
 			if !exists {
 				Skip("Skip test when RWOBlock storage class is not present")

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -39,7 +39,7 @@ const (
 	insecure             = "--insecure"
 )
 
-var _ = SIGDescribe("[Serial]ImageUpload", func() {
+var _ = SIGDescribe("[Serial]ImageUpload", Labels{"Serial"}, func() {
 	var kubectlCmd *exec.Cmd
 
 	pvcSize := "100Mi"
@@ -142,8 +142,8 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 		Expect(*pvc.Spec.StorageClassName).To(Equal(storageClass))
 	}
 
-	Context("[storage-req] Upload an image and start a VMI with PVC", func() {
-		DescribeTable("[test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
+	Context("[storage-req] Upload an image and start a VMI with PVC", Labels{"storage-req"}, func() {
+		DescribeTable("[test_id:4621] Should succeed", Labels{"test_id:4621"}, func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := libstorage.GetRWOBlockStorageClass()
 			if !exists {
 				Skip("Skip test when RWOBlock storage class is not present")

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -41,7 +41,7 @@ const (
 	creatingSnapshot          = "creating snapshot"
 )
 
-var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, func() {
+var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Label("Serial"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -208,7 +208,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 		})
 
 		Context("and no snapshot", func() {
-			It("[test_id:5255]should reject restore", Labels{"test_id:5255"}, func() {
+			It("[test_id:5255]should reject restore", Label("test_id:5255"), func() {
 				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 				restore := createRestoreDef(vm, "foobar")
@@ -265,7 +265,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				}
 			})
 
-			It("[test_id:5256]should successfully restore", Labels{"test_id:5256"}, func() {
+			It("[test_id:5256]should successfully restore", Label("test_id:5256"), func() {
 				var origSpec *v1.VirtualMachineSpec
 
 				Eventually(func() bool {
@@ -306,7 +306,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				deleteRestore(restore)
 			})
 
-			It("[test_id:5257]should reject restore if VM running", Labels{"test_id:5257"}, func() {
+			It("[test_id:5257]should reject restore if VM running", Label("test_id:5257"), func() {
 				patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -318,7 +318,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachine %q is not stopped", vm.Name)))
 			})
 
-			It("[test_id:5258]should reject restore if another in progress", Labels{"test_id:5258"}, func() {
+			It("[test_id:5258]should reject restore if another in progress", Label("test_id:5258"), func() {
 				fp := admissionregistrationv1.Fail
 				sideEffectNone := admissionregistrationv1.SideEffectClassNone
 				whPath := "/foobar"
@@ -398,7 +398,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 		})
 	})
 
-	Context("[storage-req]", Labels{"storage-req"}, func() {
+	Context("[storage-req]", Label("storage-req"), func() {
 		Context("With a more complicated VM", func() {
 			var (
 				vm                   *v1.VirtualMachine
@@ -583,7 +583,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 			}
 
-			It("[test_id:5259]should restore a vm multiple from the same snapshot", Labels{"test_id:5259"}, func() {
+			It("[test_id:5259]should restore a vm multiple from the same snapshot", Label("test_id:5259"), func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -612,7 +612,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				}
 			})
 
-			It("[test_id:5260]should restore a vm that boots from a datavolumetemplate", Labels{"test_id:5260"}, func() {
+			It("[test_id:5260]should restore a vm that boots from a datavolumetemplate", Label("test_id:5260"), func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -630,7 +630,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 
-			It("[test_id:5261]should restore a vm that boots from a datavolume (not template)", Labels{"test_id:5261"}, func() {
+			It("[test_id:5261]should restore a vm that boots from a datavolume (not template)", Label("test_id:5261"), func() {
 				vm = tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -677,7 +677,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				}
 			})
 
-			It("[test_id:5262]should restore a vm that boots from a PVC", Labels{"test_id:5262"}, func() {
+			It("[test_id:5262]should restore a vm that boots from a PVC", Label("test_id:5262"), func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				pvc := &corev1.PersistentVolumeClaim{
@@ -730,7 +730,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				}
 			})
 
-			It("[test_id:5263]should restore a vm with containerdisk and blank datavolume", Labels{"test_id:5263"}, func() {
+			It("[test_id:5263]should restore a vm with containerdisk and blank datavolume", Label("test_id:5263"), func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(
@@ -882,7 +882,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				deleteRestore(restore)
 			})
 
-			It("[test_id:6053]should restore a vm from an online snapshot", Labels{"test_id:6053"}, func() {
+			It("[test_id:6053]should restore a vm from an online snapshot", Label("test_id:6053"), func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -894,7 +894,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 
 			})
 
-			It("[test_id:6766]should restore a vm from an online snapshot with guest agent", Labels{"test_id:6766"}, func() {
+			It("[test_id:6766]should restore a vm from an online snapshot with guest agent", Label("test_id:6766"), func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.NewRandomFedoraVMIWithGuestAgent()
@@ -947,7 +947,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 
 			})
 
-			It("[test_id:6836]should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", Labels{"test_id:6836"}, func() {
+			It("[test_id:6836]should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", Label("test_id:6836"), func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
 					util.NamespaceTestDefault,
@@ -1014,7 +1014,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, fun
 				Expect(vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(initialMemory))
 			})
 
-			It("[test_id:7425]should restore vm with hot plug disks", Labels{"test_id:7425"}, func() {
+			It("[test_id:7425]should restore vm with hot plug disks", Label("test_id:7425"), func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
 					util.NamespaceTestDefault,

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -41,7 +41,7 @@ const (
 	creatingSnapshot          = "creating snapshot"
 )
 
-var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
+var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Labels{"Serial"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -208,7 +208,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 		})
 
 		Context("and no snapshot", func() {
-			It("[test_id:5255]should reject restore", func() {
+			It("[test_id:5255]should reject restore", Labels{"test_id:5255"}, func() {
 				vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 				restore := createRestoreDef(vm, "foobar")
@@ -265,7 +265,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}
 			})
 
-			It("[test_id:5256]should successfully restore", func() {
+			It("[test_id:5256]should successfully restore", Labels{"test_id:5256"}, func() {
 				var origSpec *v1.VirtualMachineSpec
 
 				Eventually(func() bool {
@@ -306,7 +306,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				deleteRestore(restore)
 			})
 
-			It("[test_id:5257]should reject restore if VM running", func() {
+			It("[test_id:5257]should reject restore if VM running", Labels{"test_id:5257"}, func() {
 				patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -318,7 +318,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("VirtualMachine %q is not stopped", vm.Name)))
 			})
 
-			It("[test_id:5258]should reject restore if another in progress", func() {
+			It("[test_id:5258]should reject restore if another in progress", Labels{"test_id:5258"}, func() {
 				fp := admissionregistrationv1.Fail
 				sideEffectNone := admissionregistrationv1.SideEffectClassNone
 				whPath := "/foobar"
@@ -398,7 +398,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 		})
 	})
 
-	Context("[storage-req]", func() {
+	Context("[storage-req]", Labels{"storage-req"}, func() {
 		Context("With a more complicated VM", func() {
 			var (
 				vm                   *v1.VirtualMachine
@@ -583,7 +583,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 			}
 
-			It("[test_id:5259]should restore a vm multiple from the same snapshot", func() {
+			It("[test_id:5259]should restore a vm multiple from the same snapshot", Labels{"test_id:5259"}, func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -612,7 +612,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}
 			})
 
-			It("[test_id:5260]should restore a vm that boots from a datavolumetemplate", func() {
+			It("[test_id:5260]should restore a vm that boots from a datavolumetemplate", Labels{"test_id:5260"}, func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -630,7 +630,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 
-			It("[test_id:5261]should restore a vm that boots from a datavolume (not template)", func() {
+			It("[test_id:5261]should restore a vm that boots from a datavolume (not template)", Labels{"test_id:5261"}, func() {
 				vm = tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -677,7 +677,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}
 			})
 
-			It("[test_id:5262]should restore a vm that boots from a PVC", func() {
+			It("[test_id:5262]should restore a vm that boots from a PVC", Labels{"test_id:5262"}, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				pvc := &corev1.PersistentVolumeClaim{
@@ -730,7 +730,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}
 			})
 
-			It("[test_id:5263]should restore a vm with containerdisk and blank datavolume", func() {
+			It("[test_id:5263]should restore a vm with containerdisk and blank datavolume", Labels{"test_id:5263"}, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(
@@ -882,7 +882,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				deleteRestore(restore)
 			})
 
-			It("[test_id:6053]should restore a vm from an online snapshot", func() {
+			It("[test_id:6053]should restore a vm from an online snapshot", Labels{"test_id:6053"}, func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
@@ -894,7 +894,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 			})
 
-			It("[test_id:6766]should restore a vm from an online snapshot with guest agent", func() {
+			It("[test_id:6766]should restore a vm from an online snapshot with guest agent", Labels{"test_id:6766"}, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.NewRandomFedoraVMIWithGuestAgent()
@@ -947,7 +947,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 
 			})
 
-			It("[test_id:6836]should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", func() {
+			It("[test_id:6836]should restore an online vm snapshot that boots from a datavolumetemplate with guest agent", Labels{"test_id:6836"}, func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
 					util.NamespaceTestDefault,
@@ -1014,7 +1014,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(initialMemory))
 			})
 
-			It("[test_id:7425]should restore vm with hot plug disks", func() {
+			It("[test_id:7425]should restore vm with hot plug disks", Labels{"test_id:7425"}, func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
 					util.NamespaceTestDefault,

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -39,7 +39,7 @@ const (
 	operationComplete        = "Operation complete"
 )
 
-var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, func() {
+var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Label("Serial"), func() {
 
 	var (
 		err        error
@@ -220,11 +220,11 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 			}
 		}
 
-		It("[test_id:4609]should successfully create a snapshot", Labels{"test_id:4609"}, func() {
+		It("[test_id:4609]should successfully create a snapshot", Label("test_id:4609"), func() {
 			createAndVerifyVMSnapshot(vm)
 		})
 
-		It("[test_id:4610]create a snapshot when VM is running should succeed", Labels{"test_id:4610"}, func() {
+		It("[test_id:4610]create a snapshot when VM is running should succeed", Label("test_id:4610"), func() {
 			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 		})
 	})
 
-	Context("[storage-req]", Labels{"storage-req"}, func() {
+	Context("[storage-req]", Label("storage-req"), func() {
 		var (
 			snapshotStorageClass string
 		)
@@ -363,7 +363,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				return err
 			}
 
-			It("[test_id:6767]with volumes and guest agent available", Labels{"test_id:6767"}, func() {
+			It("[test_id:6767]with volumes and guest agent available", Label("test_id:6767"), func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
@@ -442,7 +442,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				checkContentSourceAndMemory(vm.DeepCopy(), contentName, initialMemory)
 			})
 
-			It("[test_id:6768]with volumes and no guest agent available", Labels{"test_id:6768"}, func() {
+			It("[test_id:6768]with volumes and no guest agent available", Label("test_id:6768"), func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi := tests.NewRandomFedoraVMI()
@@ -504,7 +504,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				checkOnlineSnapshotExpectedContentSource(vm.DeepCopy(), contentName, true)
 			})
 
-			It("[test_id:6769]without volumes with guest agent available", Labels{"test_id:6769"}, func() {
+			It("[test_id:6769]without volumes with guest agent available", Label("test_id:6769"), func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Namespace = util.NamespaceTestDefault
 				vm = tests.NewRandomVirtualMachine(vmi, false)
@@ -527,7 +527,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				checkOnlineSnapshotExpectedContentSource(vm.DeepCopy(), contentName, false)
 			})
 
-			It("[test_id:6837]delete snapshot after freeze, expect vm unfreeze", Labels{"test_id:6837"}, func() {
+			It("[test_id:6837]delete snapshot after freeze, expect vm unfreeze", Label("test_id:6837"), func() {
 				var vmi *v1.VirtualMachineInstance
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
@@ -558,7 +558,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:6949]should unfreeze vm if snapshot fails when deadline exceeded", Labels{"test_id:6949"}, func() {
+			It("[test_id:6949]should unfreeze vm if snapshot fails when deadline exceeded", Label("test_id:6949"), func() {
 				var vmi *v1.VirtualMachineInstance
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
@@ -607,7 +607,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:7472]should succeed online snapshot with hot plug disk", Labels{"test_id:7472"}, func() {
+			It("[test_id:7472]should succeed online snapshot with hot plug disk", Label("test_id:7472"), func() {
 				var vmi *v1.VirtualMachineInstance
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
@@ -769,7 +769,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				}
 			})
 
-			It("[test_id:4611]should successfully create a snapshot", Labels{"test_id:4611"}, func() {
+			It("[test_id:4611]should successfully create a snapshot", Label("test_id:4611"), func() {
 				snapshot = newSnapshot()
 
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
@@ -981,7 +981,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				Expect(*snapshot.Status.ReadyToUse).To(BeTrue())
 			})
 
-			It("[test_id:6952]snapshot change phase to in progress and succeeded and then should not fail", Labels{"test_id:6952"}, func() {
+			It("[test_id:6952]snapshot change phase to in progress and succeeded and then should not fail", Label("test_id:6952"), func() {
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
 				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: time.Minute}
@@ -1040,7 +1040,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, fu
 				Expect(snapshot.Status.Phase).To(Equal(snapshotv1.Succeeded))
 			})
 
-			It("[test_id:6838]snapshot should fail when deadline exceeded due to volume snapshots failure", Labels{"test_id:6838"}, func() {
+			It("[test_id:6838]snapshot should fail when deadline exceeded due to volume snapshots failure", Label("test_id:6838"), func() {
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
 				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: 40 * time.Second}

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -39,7 +39,7 @@ const (
 	operationComplete        = "Operation complete"
 )
 
-var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
+var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Labels{"Serial"}, func() {
 
 	var (
 		err        error
@@ -220,11 +220,11 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 			}
 		}
 
-		It("[test_id:4609]should successfully create a snapshot", func() {
+		It("[test_id:4609]should successfully create a snapshot", Labels{"test_id:4609"}, func() {
 			createAndVerifyVMSnapshot(vm)
 		})
 
-		It("[test_id:4610]create a snapshot when VM is running should succeed", func() {
+		It("[test_id:4610]create a snapshot when VM is running should succeed", Labels{"test_id:4610"}, func() {
 			patch := []byte("[{ \"op\": \"replace\", \"path\": \"/spec/running\", \"value\": true }]")
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, patch, &metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -250,7 +250,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 		})
 	})
 
-	Context("[storage-req]", func() {
+	Context("[storage-req]", Labels{"storage-req"}, func() {
 		var (
 			snapshotStorageClass string
 		)
@@ -363,7 +363,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				return err
 			}
 
-			It("[test_id:6767]with volumes and guest agent available", func() {
+			It("[test_id:6767]with volumes and guest agent available", Labels{"test_id:6767"}, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
@@ -442,7 +442,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				checkContentSourceAndMemory(vm.DeepCopy(), contentName, initialMemory)
 			})
 
-			It("[test_id:6768]with volumes and no guest agent available", func() {
+			It("[test_id:6768]with volumes and no guest agent available", Labels{"test_id:6768"}, func() {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
 				vmi := tests.NewRandomFedoraVMI()
@@ -504,7 +504,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				checkOnlineSnapshotExpectedContentSource(vm.DeepCopy(), contentName, true)
 			})
 
-			It("[test_id:6769]without volumes with guest agent available", func() {
+			It("[test_id:6769]without volumes with guest agent available", Labels{"test_id:6769"}, func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Namespace = util.NamespaceTestDefault
 				vm = tests.NewRandomVirtualMachine(vmi, false)
@@ -527,7 +527,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				checkOnlineSnapshotExpectedContentSource(vm.DeepCopy(), contentName, false)
 			})
 
-			It("[test_id:6837]delete snapshot after freeze, expect vm unfreeze", func() {
+			It("[test_id:6837]delete snapshot after freeze, expect vm unfreeze", Labels{"test_id:6837"}, func() {
 				var vmi *v1.VirtualMachineInstance
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
@@ -558,7 +558,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:6949]should unfreeze vm if snapshot fails when deadline exceeded", func() {
+			It("[test_id:6949]should unfreeze vm if snapshot fails when deadline exceeded", Labels{"test_id:6949"}, func() {
 				var vmi *v1.VirtualMachineInstance
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
@@ -607,7 +607,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:7472]should succeed online snapshot with hot plug disk", func() {
+			It("[test_id:7472]should succeed online snapshot with hot plug disk", Labels{"test_id:7472"}, func() {
 				var vmi *v1.VirtualMachineInstance
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
@@ -769,7 +769,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				}
 			})
 
-			It("[test_id:4611]should successfully create a snapshot", func() {
+			It("[test_id:4611]should successfully create a snapshot", Labels{"test_id:4611"}, func() {
 				snapshot = newSnapshot()
 
 				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
@@ -981,7 +981,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				Expect(*snapshot.Status.ReadyToUse).To(BeTrue())
 			})
 
-			It("[test_id:6952]snapshot change phase to in progress and succeeded and then should not fail", func() {
+			It("[test_id:6952]snapshot change phase to in progress and succeeded and then should not fail", Labels{"test_id:6952"}, func() {
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
 				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: time.Minute}
@@ -1040,7 +1040,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 				Expect(snapshot.Status.Phase).To(Equal(snapshotv1.Succeeded))
 			})
 
-			It("[test_id:6838]snapshot should fail when deadline exceeded due to volume snapshots failure", func() {
+			It("[test_id:6838]snapshot should fail when deadline exceeded due to volume snapshots failure", Labels{"test_id:6838"}, func() {
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
 				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: 40 * time.Second}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -245,7 +245,7 @@ var _ = SIGDescribe("Storage", func() {
 		})
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]with Alpine PVC",
-			Labels{"rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 
 				Context("should be successfully", func() {
@@ -282,11 +282,11 @@ var _ = SIGDescribe("Storage", func() {
 						By(checkingVMInstanceConsoleOut)
 						Expect(console.LoginToAlpine(vmi)).To(Succeed())
 					},
-						Entry("[test_id:3130]with Disk PVC", Labels{"test_id:3130"}, tests.NewRandomVMIWithPVC, "", nil, true),
-						Entry("[test_id:3131]with CDRom PVC", Labels{"test_id:3131"}, tests.NewRandomVMIWithCDRom, "", nil, true),
-						Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", Labels{"test_id:4618"}, tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
-						Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", Labels{"Serial"}, tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
-						Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", Labels{"Serial"}, tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
+						Entry("[test_id:3130]with Disk PVC", Label("test_id:3130"), tests.NewRandomVMIWithPVC, "", nil, true),
+						Entry("[test_id:3131]with CDRom PVC", Label("test_id:3131"), tests.NewRandomVMIWithCDRom, "", nil, true),
+						Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", Label("test_id:4618"), tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
+						Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", Label("Serial"), tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
+						Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", Label("Serial"), tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
 					)
 				})
 
@@ -310,16 +310,16 @@ var _ = SIGDescribe("Storage", func() {
 						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 					}
 				},
-					Entry("[test_id:3132]with Disk PVC", Labels{"test_id:3132"}, tests.NewRandomVMIWithPVC),
-					Entry("[test_id:3133]with CDRom PVC", Labels{"test_id:3133"}, tests.NewRandomVMIWithCDRom),
+					Entry("[test_id:3132]with Disk PVC", Label("test_id:3132"), tests.NewRandomVMIWithPVC),
+					Entry("[test_id:3133]with CDRom PVC", Label("test_id:3133"), tests.NewRandomVMIWithCDRom),
 				)
 			})
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With an emptyDisk defined",
-			Labels{"rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
-				It("[test_id:3134]should create a writeable emptyDisk with the right capacity", Labels{"test_id:3134"}, func() {
+				It("[test_id:3134]should create a writeable emptyDisk with the right capacity", Label("test_id:3134"), func() {
 
 					// Start the VirtualMachineInstance with the empty disk attached
 					vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
@@ -341,7 +341,7 @@ var _ = SIGDescribe("Storage", func() {
 					})
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					By("Checking that /dev/vdc has a capacity of 1G, aligned to 4k")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -361,43 +361,43 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With an emptyDisk defined and a specified serial number",
-			Labels{"rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
-				It("[test_id:3135]should create a writeable emptyDisk with the specified serial number", Labels{"test_id:3135"}, func() {
+				It("[test_id:3135]should create a writeable emptyDisk with the specified serial number", Label("test_id:3135"), func() {
 
-				// Start the VirtualMachineInstance with the empty disk attached
-				vmi = libvmi.NewAlpine(
-					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				)
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
-					Name:   "emptydisk1",
-					Serial: diskSerial,
-					DiskDevice: virtv1.DiskDevice{
-						Disk: &virtv1.DiskTarget{
-							Bus: "virtio",
+					// Start the VirtualMachineInstance with the empty disk attached
+					vmi = libvmi.NewAlpine(
+						libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					)
+					vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
+						Name:   "emptydisk1",
+						Serial: diskSerial,
+						DiskDevice: virtv1.DiskDevice{
+							Disk: &virtv1.DiskTarget{
+								Bus: "virtio",
+							},
 						},
-					},
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
-					Name: "emptydisk1",
-					VolumeSource: virtv1.VolumeSource{
-						EmptyDisk: &virtv1.EmptyDiskSource{
-							Capacity: resource.MustParse("1Gi"),
+					})
+					vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
+						Name: "emptydisk1",
+						VolumeSource: virtv1.VolumeSource{
+							EmptyDisk: &virtv1.EmptyDiskSource{
+								Capacity: resource.MustParse("1Gi"),
+							},
 						},
-					},
+					})
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+
+					Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
+
+					By("Checking for the specified serial number")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "find /sys -type f -regex \".*/block/.*/serial\" | xargs cat\n"},
+						&expect.BExp{R: diskSerial},
+					}, 10)).To(Succeed())
 				})
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
-
-				Expect(libnet.WithAlpineConfig(console.LoginToAlpine)(vmi)).To(Succeed())
-
-				By("Checking for the specified serial number")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "find /sys -type f -regex \".*/block/.*/serial\" | xargs cat\n"},
-					&expect.BExp{R: diskSerial},
-				}, 10)).To(Succeed())
-			})
 
 			})
 		Context("VirtIO-FS with an empty PVC", func() {
@@ -525,7 +525,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ephemeral alpine PVC",
-			Labels{"rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var isRunOnKindInfra bool
 				BeforeEach(func() {
@@ -581,14 +581,14 @@ var _ = SIGDescribe("Storage", func() {
 						By(checkingVMInstanceConsoleOut)
 						Expect(console.LoginToAlpine(vmi)).To(Succeed())
 					},
-						Entry("[test_id:3136]with Ephemeral PVC", Labels{"test_id:3136"}, tests.NewRandomVMIWithEphemeralPVC, "", nil),
-						Entry("[test_id:4619]with Ephemeral PVC from NFS using ipv4 address of the NFS pod", Labels{"test_id:4619"}, tests.NewRandomVMIWithEphemeralPVC, "nfs", k8sv1.IPv4Protocol),
+						Entry("[test_id:3136]with Ephemeral PVC", Label("test_id:3136"), tests.NewRandomVMIWithEphemeralPVC, "", nil),
+						Entry("[test_id:4619]with Ephemeral PVC from NFS using ipv4 address of the NFS pod", Label("test_id:4619"), tests.NewRandomVMIWithEphemeralPVC, "nfs", k8sv1.IPv4Protocol),
 						Entry("with Ephemeral PVC from NFS using ipv6 address of the NFS pod", tests.NewRandomVMIWithEphemeralPVC, "nfs", k8sv1.IPv6Protocol),
 					)
 				})
 
 				// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
-				It("[test_id:3137]should not persist data", Labels{"test_id:3137"}, func() {
+				It("[test_id:3137]should not persist data", Label("test_id:3137"), func() {
 					vmi = tests.NewRandomVMIWithEphemeralPVC(tests.DiskAlpineHostPath)
 
 					By("Starting the VirtualMachineInstance")
@@ -645,7 +645,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With VirtualMachineInstance with two PVCs",
-			Labels{"rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:3106", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					// Setup second PVC to use in this context
@@ -654,7 +654,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 
 				// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
-				It("[test_id:3138]should start vmi multiple times", Labels{"test_id:3138"}, func() {
+				It("[test_id:3138]should start vmi multiple times", Label("test_id:3138"), func() {
 					vmi = tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 					tests.AddPVCDisk(vmi, "disk1", "virtio", tests.DiskCustomHostPath)
 
@@ -682,8 +682,8 @@ var _ = SIGDescribe("Storage", func() {
 				})
 			})
 
-		Context("[Serial]With feature gates disabled for", Labels{"Serial"}, func() {
-			It("[test_id:4620]HostDisk, it should fail to start a VMI", Labels{"test_id:4620"}, func() {
+		Context("[Serial]With feature gates disabled for", Label("Serial"), func() {
+			It("[test_id:4620]HostDisk, it should fail to start a VMI", Label("test_id:4620"), func() {
 				tests.DisableFeatureGate(virtconfig.HostDiskGate)
 				vmi = tests.NewRandomVMIWithHostDisk("somepath", virtv1.HostDiskExistsOrCreate, "")
 				virtClient, err := kubecli.GetKubevirtClient()
@@ -708,7 +708,7 @@ var _ = SIGDescribe("Storage", func() {
 		})
 
 		Context("[rfe_id:2298][crit:medium][vendor:cnv-qe@redhat.com][level:component] With HostDisk and PVC initialization",
-			Labels{"rfe_id:2298", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:2298", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 
 				BeforeEach(func() {
@@ -768,11 +768,11 @@ var _ = SIGDescribe("Storage", func() {
 							Expect(err).ToNot(HaveOccurred())
 							Expect(output).To(ContainSubstring(hostdisk.GetMountedHostDiskPath(hostDiskName, diskPath)))
 						},
-							Entry("[test_id:851]with virtio driver", Labels{"test_id:851"}, "virtio"),
-							Entry("[test_id:3057]with sata driver", Labels{"test_id:3057"}, "sata"),
+							Entry("[test_id:851]with virtio driver", Label("test_id:851"), "virtio"),
+							Entry("[test_id:3057]with sata driver", Label("test_id:3057"), "sata"),
 						)
 
-						It("[test_id:3107]should start with multiple hostdisks in the same directory", Labels{"test_id:3107"}, func() {
+						It("[test_id:3107]should start with multiple hostdisks in the same directory", Label("test_id:3107"), func() {
 							By(startingVMInstance)
 							// do not choose a specific node to run the test
 							vmi = tests.NewRandomVMIWithHostDisk(diskPath, virtv1.HostDiskExistsOrCreate, "")
@@ -825,7 +825,7 @@ var _ = SIGDescribe("Storage", func() {
 							Eventually(getStatus, 30, 1).Should(Equal(k8sv1.PodSucceeded))
 						})
 
-						It("[test_id:2306]Should use existing disk image and start", Labels{"test_id:2306"}, func() {
+						It("[test_id:2306]Should use existing disk image and start", Label("test_id:2306"), func() {
 							By(startingVMInstance)
 							vmi = tests.NewRandomVMIWithHostDisk(diskPath, virtv1.HostDiskExists, nodeName)
 							tests.RunVMIAndExpectLaunch(vmi, 30)
@@ -842,7 +842,7 @@ var _ = SIGDescribe("Storage", func() {
 							Expect(output).To(ContainSubstring(diskName))
 						})
 
-						It("[test_id:847]Should fail with a capacity option", Labels{"test_id:847"}, func() {
+						It("[test_id:847]Should fail with a capacity option", Label("test_id:847"), func() {
 							By(startingVMInstance)
 							vmi = tests.NewRandomVMIWithHostDisk(diskPath, virtv1.HostDiskExists, nodeName)
 							for i, volume := range vmi.Spec.Volumes {
@@ -857,7 +857,7 @@ var _ = SIGDescribe("Storage", func() {
 					})
 
 					Context("With unknown hostDisk type", func() {
-						It("[test_id:852]Should fail to start VMI", Labels{"test_id:852"}, func() {
+						It("[test_id:852]Should fail to start VMI", Label("test_id:852"), func() {
 							By(startingVMInstance)
 							vmi = tests.NewRandomVMIWithHostDisk("/data/unknown.img", "unknown", "")
 							_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -900,7 +900,7 @@ var _ = SIGDescribe("Storage", func() {
 					})
 
 					// Not a candidate for NFS testing because multiple VMIs are started
-					It("[test_id:868] Should initialize an empty PVC by creating a disk.img", Labels{"test_id:868"}, func() {
+					It("[test_id:868] Should initialize an empty PVC by creating a disk.img", Label("test_id:868"), func() {
 						for _, pvc := range pvcs {
 							By(startingVMInstance)
 							vmi = tests.NewRandomVMIWithPVC(fmt.Sprintf("disk-%s", pvc))
@@ -991,7 +991,7 @@ var _ = SIGDescribe("Storage", func() {
 
 					// Not a candidate for NFS test due to usage of host disk
 					It("[Serial][test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration",
-						Labels{"Serial", "test_id:3108"},
+						Label("Serial", "test_id:3108"),
 						func() {
 
 							configureToleration(10)
@@ -1011,7 +1011,7 @@ var _ = SIGDescribe("Storage", func() {
 
 					// Not a candidate for NFS test due to usage of host disk
 					It("[Serial][test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration",
-						Labels{"Serial", "test_id:3109"},
+						Label("Serial", "test_id:3109"),
 						func() {
 
 							configureToleration(30)
@@ -1033,13 +1033,13 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 		Context("[rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component][storage-req] With Cirros BlockMode PVC",
-			Labels{"rfe_id:2288", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "storage-req"},
+			Label("rfe_id:2288", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "storage-req"),
 			func() {
 				var dataVolume *cdiv1.DataVolume
 
 				BeforeEach(func() {
 					// create a new PV and PVC (PVs can't be reused)
-				dataVolume = libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					dataVolume = libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
 					_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -1053,7 +1053,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 
 				// Not a candidate for NFS because local volumes are used in test
-				It("[test_id:1015]should be successfully started", Labels{"test_id:1015"}, func() {
+				It("[test_id:1015]should be successfully started", Label("test_id:1015"), func() {
 					// Start the VirtualMachineInstance with the PVC attached
 					vmi = tests.NewRandomVMIWithPVC(dataVolume.Name)
 					// Without userdata the hostname isn't set correctly and the login expecter fails...
@@ -1061,16 +1061,16 @@ var _ = SIGDescribe("Storage", func() {
 
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				By(checkingVMInstanceConsoleOut)
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					By(checkingVMInstanceConsoleOut)
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
+				})
 			})
-		})
 
 		Context("[storage-req][rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component]With Alpine block volume PVC",
-			Labels{"storage-req", "rfe_id:2288", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("storage-req", "rfe_id:2288", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 
-				It("[test_id:3139]should be successfully started", Labels{"test_id:3139"}, func() {
+				It("[test_id:3139]should be successfully started", Label("test_id:3139"), func() {
 					By("Create a VMIWithPVC")
 					// Start the VirtualMachineInstance with the PVC attached
 					vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
@@ -1083,10 +1083,10 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 		Context("[rfe_id:2288][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component] With not existing PVC",
-			Labels{"rfe_id:2288", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:2288", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				// Not a candidate for NFS because the PVC in question doesn't actually exist
-				It("[test_id:1040] should get unschedulable condition", Labels{"test_id:1040"}, func() {
+				It("[test_id:1040] should get unschedulable condition", Label("test_id:1040"), func() {
 					// Start the VirtualMachineInstance
 					pvcName := "nonExistingPVC"
 					vmi = tests.NewRandomVMIWithPVC(pvcName)
@@ -1186,7 +1186,7 @@ var _ = SIGDescribe("Storage", func() {
 
 		})
 
-		Context("[storage-req] With a volumeMode block backed ephemeral disk", Labels{"storage-req"}, func() {
+		Context("[storage-req] With a volumeMode block backed ephemeral disk", Label("storage-req"), func() {
 			var dataVolume *cdiv1.DataVolume
 
 			BeforeEach(func() {

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Subresource Api", Label("sig-compute"), func() {
 
 	var err error
 	var virtCli kubecli.KubevirtClient
@@ -56,7 +56,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 	})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization",
-		Labels{"rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			var resource string
 			BeforeEach(func() {
@@ -67,39 +67,39 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 			})
 
 			Context("with correct permissions", func() {
-				It("[test_id:3170]should be allowed to access subresource endpoint", Labels{"test_id:3170"}, func() {
+				It("[test_id:3170]should be allowed to access subresource endpoint", Label("test_id:3170"), func() {
 					testClientJob(virtCli, true, resource)
 				})
 			})
 			Context("Without permissions", func() {
-				It("[test_id:3171]should not be able to access subresource endpoint", Labels{"test_id:3171"}, func() {
+				It("[test_id:3171]should not be able to access subresource endpoint", Label("test_id:3171"), func() {
 					testClientJob(virtCli, false, resource)
 				})
 			})
 		})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization For Version Command",
-		Labels{"rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			resource := "version"
 
 			Context("with authenticated user", func() {
-				It("[test_id:3172]should be allowed to access subresource version endpoint", Labels{"test_id:3172"}, func() {
+				It("[test_id:3172]should be allowed to access subresource version endpoint", Label("test_id:3172"), func() {
 					testClientJob(virtCli, true, resource)
 				})
 			})
 			Context("Without permissions", func() {
-				It("[test_id:3173]should be able to access subresource version endpoint", Labels{"test_id:3173"}, func() {
+				It("[test_id:3173]should be able to access subresource version endpoint", Label("test_id:3173"), func() {
 					testClientJob(virtCli, false, resource)
 				})
 			})
 		})
 
 	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource",
-		Labels{"rfe_id:1177", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:1177", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			Context("with a restart endpoint", func() {
-				It("[test_id:1304] should restart a VM", Labels{"test_id:1304"}, func() {
+				It("[test_id:1304] should restart a VM", Label("test_id:1304"), func() {
 					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 					Expect(err).NotTo(HaveOccurred())
@@ -121,7 +121,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 					}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
 				})
 
-				It("[test_id:1305][posneg:negative] should return an error when VM is not running", Labels{"test_id:1305", "posneg:negative"}, func() {
+				It("[test_id:1305][posneg:negative] should return an error when VM is not running", Label("test_id:1305", "posneg:negative"), func() {
 					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 					Expect(err).NotTo(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", Labels{"test_id:2265", "posneg:negative"}, func() {
+				It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", Label("test_id:2265", "posneg:negative"), func() {
 					vmi := tests.NewRandomVMI()
 					tests.RunVMIAndExpectLaunch(vmi, 60)
 
@@ -140,7 +140,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 			})
 
 			Context("With manual RunStrategy", func() {
-				It("[test_id:3174]Should not restart when VM is not running", Labels{"test_id:3174"}, func() {
+				It("[test_id:3174]Should not restart when VM is not running", Label("test_id:3174"), func() {
 					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 					vm.Spec.RunStrategy = &manual
 					vm.Spec.Running = nil
@@ -154,7 +154,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("[test_id:3175]Should restart when VM is running", Labels{"test_id:3175"}, func() {
+				It("[test_id:3175]Should restart when VM is running", Label("test_id:3175"), func() {
 					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 					vm.Spec.RunStrategy = &manual
 					vm.Spec.Running = nil
@@ -194,7 +194,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 			})
 
 			Context("With RunStrategy RerunOnFailure", func() {
-				It("[test_id:3176]Should restart the VM", Labels{"test_id:3176"}, func() {
+				It("[test_id:3176]Should restart the VM", Label("test_id:3176"), func() {
 					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 					vm.Spec.RunStrategy = &restartOnError
 					vm.Spec.Running = nil
@@ -231,9 +231,9 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 		})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources",
-		Labels{"rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
-			It("[test_id:3177]should be aggregated into the apiserver openapi spec", Labels{"test_id:3177"}, func() {
+			It("[test_id:3177]should be aggregated into the apiserver openapi spec", Label("test_id:3177"), func() {
 				Eventually(func() string {
 					spec, err := virtCli.RestClient().Get().AbsPath("/openapi/v2").DoRaw(context.Background())
 					Expect(err).ToNot(HaveOccurred())
@@ -265,14 +265,14 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 180)
 			})
 
-			It("[test_id:7476]Freeze without guest agent", Labels{"test_id:7476"}, func() {
+			It("[test_id:7476]Freeze without guest agent", Label("test_id:7476"), func() {
 				expectedErr := "Internal error occurred"
 				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(expectedErr))
 			})
 
-			It("[test_id:7477]Unfreeze without guest agent", Labels{"test_id:7477"}, func() {
+			It("[test_id:7477]Unfreeze without guest agent", Label("test_id:7477"), func() {
 				expectedErr := "Internal error occurred"
 				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
 				Expect(err).ToNot(BeNil())
@@ -310,7 +310,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 				}, 30*time.Second, 2*time.Second).Should(BeTrue())
 			}
 
-			It("[test_id:7479]Freeze Unfreeze should succeed", Labels{"test_id:7479"}, func() {
+			It("[test_id:7479]Freeze Unfreeze should succeed", Label("test_id:7479"), func() {
 				By("Freezing VMI")
 				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 				Expect(err).ToNot(HaveOccurred())
@@ -324,7 +324,7 @@ var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 				waitVMIFSFreezeStatus("")
 			})
 
-			It("[test_id:7480]Multi Freeze Unfreeze calls should succeed", Labels{"test_id:7480"}, func() {
+			It("[test_id:7480]Multi Freeze Unfreeze calls should succeed", Label("test_id:7480"), func() {
 				for i := 0; i < 5; i++ {
 					By("Freezing VMI")
 					err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-var _ = Describe("[sig-compute]Subresource Api", func() {
+var _ = Describe("[sig-compute]Subresource Api", Labels{"sig-compute"}, func() {
 
 	var err error
 	var virtCli kubecli.KubevirtClient
@@ -55,185 +55,193 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 		tests.BeforeTestCleanup()
 	})
 
-	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization", func() {
-		var resource string
-		BeforeEach(func() {
-			vm := tests.NewRandomVMWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			resource = vm.Name
-			vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		Context("with correct permissions", func() {
-			It("[test_id:3170]should be allowed to access subresource endpoint", func() {
-				testClientJob(virtCli, true, resource)
-			})
-		})
-		Context("Without permissions", func() {
-			It("[test_id:3171]should not be able to access subresource endpoint", func() {
-				testClientJob(virtCli, false, resource)
-			})
-		})
-	})
-
-	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization For Version Command", func() {
-		resource := "version"
-
-		Context("with authenticated user", func() {
-			It("[test_id:3172]should be allowed to access subresource version endpoint", func() {
-				testClientJob(virtCli, true, resource)
-			})
-		})
-		Context("Without permissions", func() {
-			It("[test_id:3173]should be able to access subresource version endpoint", func() {
-				testClientJob(virtCli, false, resource)
-			})
-		})
-	})
-
-	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource", func() {
-		Context("with a restart endpoint", func() {
-			It("[test_id:1304] should restart a VM", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).NotTo(HaveOccurred())
-
-				tests.StartVirtualMachine(vm)
-				vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(vmi.Status.Phase).To(Equal(v1.Running))
-
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					if err != nil || vmi.UID == newVMI.UID {
-						return v1.VmPhaseUnset
-					}
-					return newVMI.Status.Phase
-				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
-			})
-
-			It("[test_id:1305][posneg:negative] should return an error when VM is not running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
-				Expect(err).To(HaveOccurred())
-			})
-
-			It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", func() {
-				vmi := tests.NewRandomVMI()
-				tests.RunVMIAndExpectLaunch(vmi, 60)
-
-				err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("With manual RunStrategy", func() {
-			It("[test_id:3174]Should not restart when VM is not running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm.Spec.RunStrategy = &manual
-				vm.Spec.Running = nil
-
-				By("Creating VM")
+	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization",
+		Labels{"rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			var resource string
+			BeforeEach(func() {
+				vm := tests.NewRandomVMWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				resource = vm.Name
 				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
-
-				By("Trying to start VM via Restart subresource")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
-				Expect(err).To(HaveOccurred())
 			})
 
-			It("[test_id:3175]Should restart when VM is running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm.Spec.RunStrategy = &manual
-				vm.Spec.Running = nil
-
-				By("Creating VM")
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Starting VM via Start subresource")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Start(vm.Name, &v1.StartOptions{Paused: false})
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Waiting for VMI to start")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					if err != nil {
-						return v1.VmPhaseUnset
-					}
-					return newVMI.Status.Phase
-				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
-
-				vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				By("Restarting VM")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					if err != nil || vmi.UID == newVMI.UID {
-						return v1.VmPhaseUnset
-					}
-					return newVMI.Status.Phase
-				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+			Context("with correct permissions", func() {
+				It("[test_id:3170]should be allowed to access subresource endpoint", Labels{"test_id:3170"}, func() {
+					testClientJob(virtCli, true, resource)
+				})
+			})
+			Context("Without permissions", func() {
+				It("[test_id:3171]should not be able to access subresource endpoint", Labels{"test_id:3171"}, func() {
+					testClientJob(virtCli, false, resource)
+				})
 			})
 		})
 
-		Context("With RunStrategy RerunOnFailure", func() {
-			It("[test_id:3176]Should restart the VM", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
-				vm.Spec.RunStrategy = &restartOnError
-				vm.Spec.Running = nil
+	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization For Version Command",
+		Labels{"rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			resource := "version"
 
-				By("Creating VM")
-				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Waiting for VMI to start")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					if err != nil {
-						return v1.VmPhaseUnset
-					}
-					return newVMI.Status.Phase
-				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
-
-				vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				By("Restarting VM")
-				err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					if err != nil || vmi.UID == newVMI.UID {
-						return v1.VmPhaseUnset
-					}
-					return newVMI.Status.Phase
-				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+			Context("with authenticated user", func() {
+				It("[test_id:3172]should be allowed to access subresource version endpoint", Labels{"test_id:3172"}, func() {
+					testClientJob(virtCli, true, resource)
+				})
+			})
+			Context("Without permissions", func() {
+				It("[test_id:3173]should be able to access subresource version endpoint", Labels{"test_id:3173"}, func() {
+					testClientJob(virtCli, false, resource)
+				})
 			})
 		})
-	})
 
-	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources", func() {
-		It("[test_id:3177]should be aggregated into the apiserver openapi spec", func() {
-			Eventually(func() string {
-				spec, err := virtCli.RestClient().Get().AbsPath("/openapi/v2").DoRaw(context.Background())
-				Expect(err).ToNot(HaveOccurred())
-				return string(spec)
-				// The first item in the SubresourceGroupVersions array is the preferred version
-			}, 60*time.Second, 1*time.Second).Should(ContainSubstring("subresources.kubevirt.io/" + v1.SubresourceGroupVersions[0].Version))
+	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource",
+		Labels{"rfe_id:1177", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			Context("with a restart endpoint", func() {
+				It("[test_id:1304] should restart a VM", Labels{"test_id:1304"}, func() {
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).NotTo(HaveOccurred())
+
+					tests.StartVirtualMachine(vm)
+					vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vmi.Status.Phase).To(Equal(v1.Running))
+
+					err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+						if err != nil || vmi.UID == newVMI.UID {
+							return v1.VmPhaseUnset
+						}
+						return newVMI.Status.Phase
+					}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+				})
+
+				It("[test_id:1305][posneg:negative] should return an error when VM is not running", Labels{"test_id:1305", "posneg:negative"}, func() {
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", Labels{"test_id:2265", "posneg:negative"}, func() {
+					vmi := tests.NewRandomVMI()
+					tests.RunVMIAndExpectLaunch(vmi, 60)
+
+					err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("With manual RunStrategy", func() {
+				It("[test_id:3174]Should not restart when VM is not running", Labels{"test_id:3174"}, func() {
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+					vm.Spec.RunStrategy = &manual
+					vm.Spec.Running = nil
+
+					By("Creating VM")
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Trying to start VM via Restart subresource")
+					err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("[test_id:3175]Should restart when VM is running", Labels{"test_id:3175"}, func() {
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+					vm.Spec.RunStrategy = &manual
+					vm.Spec.Running = nil
+
+					By("Creating VM")
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Starting VM via Start subresource")
+					err = virtCli.VirtualMachine(util.NamespaceTestDefault).Start(vm.Name, &v1.StartOptions{Paused: false})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for VMI to start")
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+						if err != nil {
+							return v1.VmPhaseUnset
+						}
+						return newVMI.Status.Phase
+					}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+
+					vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Restarting VM")
+					err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+						if err != nil || vmi.UID == newVMI.UID {
+							return v1.VmPhaseUnset
+						}
+						return newVMI.Status.Phase
+					}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+				})
+			})
+
+			Context("With RunStrategy RerunOnFailure", func() {
+				It("[test_id:3176]Should restart the VM", Labels{"test_id:3176"}, func() {
+					vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+					vm.Spec.RunStrategy = &restartOnError
+					vm.Spec.Running = nil
+
+					By("Creating VM")
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for VMI to start")
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+						if err != nil {
+							return v1.VmPhaseUnset
+						}
+						return newVMI.Status.Phase
+					}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+
+					vmi, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Restarting VM")
+					err = virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vm.Name, &v1.RestartOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						newVMI, err := virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+						if err != nil || vmi.UID == newVMI.UID {
+							return v1.VmPhaseUnset
+						}
+						return newVMI.Status.Phase
+					}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+				})
+			})
 		})
-	})
+
+	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources",
+		Labels{"rfe_id:1195", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			It("[test_id:3177]should be aggregated into the apiserver openapi spec", Labels{"test_id:3177"}, func() {
+				Eventually(func() string {
+					spec, err := virtCli.RestClient().Get().AbsPath("/openapi/v2").DoRaw(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+					return string(spec)
+					// The first item in the SubresourceGroupVersions array is the preferred version
+				}, 60*time.Second, 1*time.Second).Should(ContainSubstring("subresources.kubevirt.io/" + v1.SubresourceGroupVersions[0].Version))
+			})
+		})
 
 	Describe("VirtualMachineInstance subresource", func() {
 		Context("Freeze Unfreeze should fail", func() {
@@ -257,14 +265,14 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 180)
 			})
 
-			It("[test_id:7476]Freeze without guest agent", func() {
+			It("[test_id:7476]Freeze without guest agent", Labels{"test_id:7476"}, func() {
 				expectedErr := "Internal error occurred"
 				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring(expectedErr))
 			})
 
-			It("[test_id:7477]Unfreeze without guest agent", func() {
+			It("[test_id:7477]Unfreeze without guest agent", Labels{"test_id:7477"}, func() {
 				expectedErr := "Internal error occurred"
 				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Unfreeze(vm.Name)
 				Expect(err).ToNot(BeNil())
@@ -302,7 +310,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				}, 30*time.Second, 2*time.Second).Should(BeTrue())
 			}
 
-			It("[test_id:7479]Freeze Unfreeze should succeed", func() {
+			It("[test_id:7479]Freeze Unfreeze should succeed", Labels{"test_id:7479"}, func() {
 				By("Freezing VMI")
 				err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)
 				Expect(err).ToNot(HaveOccurred())
@@ -316,7 +324,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				waitVMIFSFreezeStatus("")
 			})
 
-			It("[test_id:7480]Multi Freeze Unfreeze calls should succeed", func() {
+			It("[test_id:7480]Multi Freeze Unfreeze calls should succeed", Labels{"test_id:7480"}, func() {
 				for i := 0; i < 5; i++ {
 					By("Freezing VMI")
 					err = virtCli.VirtualMachineInstance(util.NamespaceTestDefault).Freeze(vm.Name, 0)

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -61,7 +61,7 @@ const (
 	bytesInKib          = 1024
 )
 
-var _ = Describe("[Serial][sig-compute]SwapTest", func() {
+var _ = Describe("[Serial][sig-compute]SwapTest", Label("Serial][sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -61,7 +61,7 @@ const (
 	bytesInKib          = 1024
 )
 
-var _ = Describe("[Serial][sig-compute]SwapTest", Label("Serial][sig-compute"), func() {
+var _ = Describe("[Serial][sig-compute]SwapTest", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -286,7 +286,7 @@ const (
 	windowsSysprepedVMIPassword = "Gauranga"
 )
 
-var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", Labels{"Serial", "Sysprep", "sig-compute"}, func() {
+var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", Label("Serial", "Sysprep", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -306,7 +306,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
-	Context("[ref_id:5105]should create the Admin user as specified in the Autounattend.xml", Labels{"ref_id:5105"}, func() {
+	Context("[ref_id:5105]should create the Admin user as specified in the Autounattend.xml", Label("ref_id:5105"), func() {
 		var winrmcliPod *k8sv1.Pod
 		var cli []string
 		var output string
@@ -349,7 +349,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 			}
 		})
 
-		It("[test_id:5843]Should run echo command on machine using the credentials specified in the Autounattend.xml file", Labels{"test_id:5843"}, func() {
+		It("[test_id:5843]Should run echo command on machine using the credentials specified in the Autounattend.xml file", Label("test_id:5843"), func() {
 			command := append(cli, "echo works")
 			Eventually(func() error {
 				fmt.Printf("Running \"%s\" command via winrm-cli\n", command)

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -286,7 +286,7 @@ const (
 	windowsSysprepedVMIPassword = "Gauranga"
 )
 
-var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", func() {
+var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", Labels{"Serial", "Sysprep", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -306,7 +306,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
-	Context("[ref_id:5105]should create the Admin user as specified in the Autounattend.xml", func() {
+	Context("[ref_id:5105]should create the Admin user as specified in the Autounattend.xml", Labels{"ref_id:5105"}, func() {
 		var winrmcliPod *k8sv1.Pod
 		var cli []string
 		var output string
@@ -349,7 +349,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 			}
 		})
 
-		It("[test_id:5843]Should run echo command on machine using the credentials specified in the Autounattend.xml file", func() {
+		It("[test_id:5843]Should run echo command on machine using the credentials specified in the Autounattend.xml file", Labels{"test_id:5843"}, func() {
 			command := append(cli, "echo works")
 			Eventually(func() error {
 				fmt.Printf("Running \"%s\" command via winrm-cli\n", command)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -52,7 +52,7 @@ const (
 	defaultMemory     = "2Gi"
 )
 
-var _ = Describe("[Serial][sig-compute]Templates", func() {
+var _ = Describe("[Serial][sig-compute]Templates", Labels{"Serial", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -241,14 +241,14 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 		}
 
 		AssertTemplateTestSuccess := func() {
-			It("[test_id:3292]should succeed to create VirtualMachine via oc command", AssertVMCreationSuccess())
-			It("[test_id:3293]should fail to delete VirtualMachine via oc command", AssertVMDeletionFailure())
+			It("[test_id:3292]should succeed to create VirtualMachine via oc command", Labels{"test_id:3292"}, AssertVMCreationSuccess())
+			It("[test_id:3293]should fail to delete VirtualMachine via oc command", Labels{"test_id:3293"}, AssertVMDeletionFailure())
 
 			When("the VirtualMachine was created", func() {
 				BeforeEach(AssertVMCreationSuccess())
-				It("[test_id:3294]should succeed to start the VirtualMachine via oc command", AssertVMStartSuccess("oc"))
-				It("[test_id:3295]should succeed to delete VirtualMachine via oc command", AssertVMDeletionSuccess())
-				It("[test_id:3308]should fail to create the same VirtualMachine via oc command", AssertVMCreationFailure())
+				It("[test_id:3294]should succeed to start the VirtualMachine via oc command", Labels{"test_id:3294"}, AssertVMStartSuccess("oc"))
+				It("[test_id:3295]should succeed to delete VirtualMachine via oc command", Labels{"test_id:3295"}, AssertVMDeletionSuccess())
+				It("[test_id:3308]should fail to create the same VirtualMachine via oc command", Labels{"test_id:3308"}, AssertVMCreationFailure())
 			})
 		}
 
@@ -264,14 +264,16 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 			AssertTemplateTestSuccess()
 		})
 
-		Context("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]with RHEL Template", func() {
-			BeforeEach(func() {
-				checks.SkipIfNoRhelImage(virtClient)
-				tests.CreatePVC(tests.OSRhel, "15Gi", libstorage.Config.StorageClassRhel, true)
-				AssertTemplateSetupSuccess(vmsgen.GetTestTemplateRHEL7(), nil)()
-			})
+		Context("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]with RHEL Template",
+			Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				BeforeEach(func() {
+					checks.SkipIfNoRhelImage(virtClient)
+					tests.CreatePVC(tests.OSRhel, "15Gi", libstorage.Config.StorageClassRhel, true)
+					AssertTemplateSetupSuccess(vmsgen.GetTestTemplateRHEL7(), nil)()
+				})
 
-			AssertTemplateTestSuccess()
-		})
+				AssertTemplateTestSuccess()
+			})
 	})
 })

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -52,7 +52,7 @@ const (
 	defaultMemory     = "2Gi"
 )
 
-var _ = Describe("[Serial][sig-compute]Templates", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]Templates", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -241,14 +241,14 @@ var _ = Describe("[Serial][sig-compute]Templates", Labels{"Serial", "sig-compute
 		}
 
 		AssertTemplateTestSuccess := func() {
-			It("[test_id:3292]should succeed to create VirtualMachine via oc command", Labels{"test_id:3292"}, AssertVMCreationSuccess())
-			It("[test_id:3293]should fail to delete VirtualMachine via oc command", Labels{"test_id:3293"}, AssertVMDeletionFailure())
+			It("[test_id:3292]should succeed to create VirtualMachine via oc command", Label("test_id:3292"), AssertVMCreationSuccess())
+			It("[test_id:3293]should fail to delete VirtualMachine via oc command", Label("test_id:3293"), AssertVMDeletionFailure())
 
 			When("the VirtualMachine was created", func() {
 				BeforeEach(AssertVMCreationSuccess())
-				It("[test_id:3294]should succeed to start the VirtualMachine via oc command", Labels{"test_id:3294"}, AssertVMStartSuccess("oc"))
-				It("[test_id:3295]should succeed to delete VirtualMachine via oc command", Labels{"test_id:3295"}, AssertVMDeletionSuccess())
-				It("[test_id:3308]should fail to create the same VirtualMachine via oc command", Labels{"test_id:3308"}, AssertVMCreationFailure())
+				It("[test_id:3294]should succeed to start the VirtualMachine via oc command", Label("test_id:3294"), AssertVMStartSuccess("oc"))
+				It("[test_id:3295]should succeed to delete VirtualMachine via oc command", Label("test_id:3295"), AssertVMDeletionSuccess())
+				It("[test_id:3308]should fail to create the same VirtualMachine via oc command", Label("test_id:3308"), AssertVMCreationFailure())
 			})
 		}
 
@@ -265,7 +265,7 @@ var _ = Describe("[Serial][sig-compute]Templates", Labels{"Serial", "sig-compute
 		})
 
 		Context("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]with RHEL Template",
-			Labels{"rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					checks.SkipIfNoRhelImage(virtClient)

--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -51,7 +51,7 @@ var helloMessageRemote = []byte{
 }
 
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] USB Redirection",
-	Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"}, func() {
+	Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"), func() {
 
 		var err error
 		var virtClient kubecli.KubevirtClient
@@ -64,7 +64,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance without usbredir support",
-			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 
 				var vmi *v1.VirtualMachineInstance
@@ -82,7 +82,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			})
 
 		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with usbredir support",
-			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 
 				var vmi *v1.VirtualMachineInstance

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -32,7 +32,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[sig-compute]Version", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Version", Label("sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -45,7 +45,7 @@ var _ = Describe("[sig-compute]Version", Labels{"sig-compute"}, func() {
 	})
 
 	Describe("Check that version parameters where loaded by ldflags in build time", func() {
-		It("[test_id:555]Should return a good version information struct", Labels{"test_id:555"}, func() {
+		It("[test_id:555]Should return a good version information struct", Label("test_id:555"), func() {
 			info, err := virtClient.ServerVersion().Get()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(info.Compiler).To(Equal(runtime.Compiler))

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -32,7 +32,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[sig-compute]Version", func() {
+var _ = Describe("[sig-compute]Version", Labels{"sig-compute"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -45,7 +45,7 @@ var _ = Describe("[sig-compute]Version", func() {
 	})
 
 	Describe("Check that version parameters where loaded by ldflags in build time", func() {
-		It("[test_id:555]Should return a good version information struct", func() {
+		It("[test_id:555]Should return a good version information struct", Labels{"test_id:555"}, func() {
 			info, err := virtClient.ServerVersion().Get()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(info.Compiler).To(Equal(runtime.Compiler))

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -53,7 +53,7 @@ const (
 )
 
 var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience",
-	Labels{"Serial", "ref_id:2717", "sig-compute"},
+	Label("Serial", "ref_id:2717", "sig-compute"),
 	func() {
 
 		var err error
@@ -197,9 +197,9 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 					}
 				}
 			},
-				Entry("[test_id:2830]last eviction should fail for multi-replica virt-controller pods", Labels{"test_id:2830"},
+				Entry("[test_id:2830]last eviction should fail for multi-replica virt-controller pods", Label("test_id:2830"),
 					"virt-controller", multiReplica, "no error occurred on evict of last virt-controller pod"),
-				Entry("[test_id:2799]last eviction should fail for multi-replica virt-api pods", Labels{"test_id:2799"},
+				Entry("[test_id:2799]last eviction should fail for multi-replica virt-api pods", Label("test_id:2799"),
 					"virt-api", multiReplica, "no error occurred on evict of last virt-api pod"),
 				Entry("eviction of single-replica virt-controller pod should succeed",
 					"virt-controller", singleReplica, "error occurred on eviction of single-replica virt-controller pod"),
@@ -212,7 +212,7 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 
 			When("control plane pods are running", func() {
 
-				It("[test_id:2806]virt-controller and virt-api pods have a pod disruption budget", Labels{"test_id:2806"}, func() {
+				It("[test_id:2806]virt-controller and virt-api pods have a pod disruption budget", Label("test_id:2806"), func() {
 					// Single replica deployments do not create PDBs
 					checks.SkipIfSingleReplica(virtCli)
 

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -52,263 +52,265 @@ const (
 	singleReplica = false
 )
 
-var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience", func() {
+var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience",
+	Labels{"Serial", "ref_id:2717", "sig-compute"},
+	func() {
 
-	var err error
-	var virtCli kubecli.KubevirtClient
+		var err error
+		var virtCli kubecli.KubevirtClient
 
-	RegisterFailHandler(Fail)
+		RegisterFailHandler(Fail)
 
-	controlPlaneDeploymentNames := []string{"virt-api", "virt-controller"}
-
-	BeforeEach(func() {
-		virtCli, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	Context("pod eviction", func() {
-		var nodeList []k8sv1.Node
-
-		getRunningReadyPods := func(podList *k8sv1.PodList, podNames []string, nodeNames ...string) (pods []*k8sv1.Pod) {
-			pods = make([]*k8sv1.Pod, 0)
-			for _, pod := range podList.Items {
-				if pod.Status.Phase != k8sv1.PodRunning {
-					continue
-				}
-				podReady := tests.PodReady(&pod)
-				if podReady != k8sv1.ConditionTrue {
-					continue
-				}
-				for _, podName := range podNames {
-					if strings.HasPrefix(pod.Name, podName) {
-						if len(nodeNames) > 0 {
-							for _, nodeName := range nodeNames {
-								if pod.Spec.NodeName == nodeName {
-									deepCopy := pod.DeepCopy()
-									pods = append(pods, deepCopy)
-								}
-							}
-						} else {
-							deepCopy := pod.DeepCopy()
-							pods = append(pods, deepCopy)
-						}
-					}
-				}
-			}
-			return
-		}
-
-		getPodList := func() (podList *k8sv1.PodList, err error) {
-			podList, err = virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
-			return
-		}
-
-		waitForDeploymentsToStabilize := func() (bool, error) {
-			deploymentsClient := virtCli.AppsV1().Deployments(flags.KubeVirtInstallNamespace)
-			for _, deploymentName := range controlPlaneDeploymentNames {
-				deployment, err := deploymentsClient.Get(context.Background(), deploymentName, metav1.GetOptions{})
-				if err != nil {
-					return false, err
-				}
-
-				if !(deployment.Status.UpdatedReplicas == *(deployment.Spec.Replicas) &&
-					deployment.Status.Replicas == *(deployment.Spec.Replicas) &&
-					deployment.Status.AvailableReplicas == *(deployment.Spec.Replicas)) {
-					return false, err
-				}
-			}
-			return true, nil
-		}
-
-		eventuallyWithTimeout := func(f func() (bool, error)) {
-			Eventually(f,
-				DefaultStabilizationTimeoutInSeconds, DefaultPollIntervalInSeconds,
-			).Should(BeTrue())
-		}
-
-		setNodeUnschedulable := func(nodeName string) {
-			Eventually(func() error {
-				selectedNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				selectedNode.Spec.Unschedulable = true
-				if _, err = virtCli.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{}); err != nil {
-					return err
-				}
-				return nil
-			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
-		}
-
-		setNodeSchedulable := func(nodeName string) {
-			Eventually(func() error {
-				selectedNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				selectedNode.Spec.Unschedulable = false
-				if _, err = virtCli.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{}); err != nil {
-					return err
-				}
-				return nil
-			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
-		}
+		controlPlaneDeploymentNames := []string{"virt-api", "virt-controller"}
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-
-			nodeList = util.GetAllSchedulableNodes(virtCli).Items
-			for _, node := range nodeList {
-				setNodeUnschedulable(node.Name)
-			}
-			eventuallyWithTimeout(waitForDeploymentsToStabilize)
-		})
-
-		AfterEach(func() {
-			for _, node := range nodeList {
-				setNodeSchedulable(node.Name)
-			}
-			eventuallyWithTimeout(waitForDeploymentsToStabilize)
-		})
-
-		DescribeTable("evicting pods of control plane", func(podName string, isMultiReplica bool, msg string) {
-			if isMultiReplica {
-				checks.SkipIfSingleReplica(virtCli)
-			} else {
-				checks.SkipIfMultiReplica(virtCli)
-			}
-			By(fmt.Sprintf("Try to evict all pods %s\n", podName))
-			podList, err := getPodList()
+			virtCli, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
-			runningPods := getRunningReadyPods(podList, []string{podName})
-			Expect(len(runningPods)).ToNot(Equal(0))
-			for index, pod := range runningPods {
-				err = virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).EvictV1beta1(context.Background(), &v1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
-				if index == len(runningPods)-1 {
-					if isMultiReplica {
-						Expect(err).To(HaveOccurred(), msg)
-					} else {
-						Expect(err).ToNot(HaveOccurred(), msg)
+		})
+
+		Context("pod eviction", func() {
+			var nodeList []k8sv1.Node
+
+			getRunningReadyPods := func(podList *k8sv1.PodList, podNames []string, nodeNames ...string) (pods []*k8sv1.Pod) {
+				pods = make([]*k8sv1.Pod, 0)
+				for _, pod := range podList.Items {
+					if pod.Status.Phase != k8sv1.PodRunning {
+						continue
 					}
-				} else {
-					Expect(err).ToNot(HaveOccurred())
+					podReady := tests.PodReady(&pod)
+					if podReady != k8sv1.ConditionTrue {
+						continue
+					}
+					for _, podName := range podNames {
+						if strings.HasPrefix(pod.Name, podName) {
+							if len(nodeNames) > 0 {
+								for _, nodeName := range nodeNames {
+									if pod.Spec.NodeName == nodeName {
+										deepCopy := pod.DeepCopy()
+										pods = append(pods, deepCopy)
+									}
+								}
+							} else {
+								deepCopy := pod.DeepCopy()
+								pods = append(pods, deepCopy)
+							}
+						}
+					}
 				}
+				return
 			}
-		},
-			Entry("[test_id:2830]last eviction should fail for multi-replica virt-controller pods",
-				"virt-controller", multiReplica, "no error occurred on evict of last virt-controller pod"),
-			Entry("[test_id:2799]last eviction should fail for multi-replica virt-api pods",
-				"virt-api", multiReplica, "no error occurred on evict of last virt-api pod"),
-			Entry("eviction of single-replica virt-controller pod should succeed",
-				"virt-controller", singleReplica, "error occurred on eviction of single-replica virt-controller pod"),
-			Entry("eviction of multi-replica virt-api pod should succeed",
-				"virt-api", singleReplica, "error occurred on eviction of single-replica virt-api pod"),
-		)
-	})
 
-	Context("control plane components check", func() {
+			getPodList := func() (podList *k8sv1.PodList, err error) {
+				podList, err = virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+				return
+			}
 
-		When("control plane pods are running", func() {
-
-			It("[test_id:2806]virt-controller and virt-api pods have a pod disruption budget", func() {
-				// Single replica deployments do not create PDBs
-				checks.SkipIfSingleReplica(virtCli)
-
+			waitForDeploymentsToStabilize := func() (bool, error) {
 				deploymentsClient := virtCli.AppsV1().Deployments(flags.KubeVirtInstallNamespace)
-				By("check deployments")
-				deployments, err := deploymentsClient.List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, expectedDeployment := range controlPlaneDeploymentNames {
-					found := false
-					for _, deployment := range deployments.Items {
-						if deployment.Name != expectedDeployment {
-							continue
-						}
-						found = true
-						break
+				for _, deploymentName := range controlPlaneDeploymentNames {
+					deployment, err := deploymentsClient.Get(context.Background(), deploymentName, metav1.GetOptions{})
+					if err != nil {
+						return false, err
 					}
-					if !found {
-						Fail(fmt.Sprintf("deployment %s not found", expectedDeployment))
-					}
-				}
 
-				By("check pod disruption budgets exist")
-				podDisruptionBudgetList, err := virtCli.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, controlPlaneDeploymentName := range controlPlaneDeploymentNames {
-					pdbName := controlPlaneDeploymentName + "-pdb"
-					found := false
-					for _, pdb := range podDisruptionBudgetList.Items {
-						if pdb.Name != pdbName {
-							continue
-						}
-						found = true
-						break
-					}
-					if !found {
-						Fail(fmt.Sprintf("pod disruption budget %s not found for control plane pod %s", pdbName, controlPlaneDeploymentName))
+					if !(deployment.Status.UpdatedReplicas == *(deployment.Spec.Replicas) &&
+						deployment.Status.Replicas == *(deployment.Spec.Replicas) &&
+						deployment.Status.AvailableReplicas == *(deployment.Spec.Replicas)) {
+						return false, err
 					}
 				}
+				return true, nil
+			}
+
+			eventuallyWithTimeout := func(f func() (bool, error)) {
+				Eventually(f,
+					DefaultStabilizationTimeoutInSeconds, DefaultPollIntervalInSeconds,
+				).Should(BeTrue())
+			}
+
+			setNodeUnschedulable := func(nodeName string) {
+				Eventually(func() error {
+					selectedNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					selectedNode.Spec.Unschedulable = true
+					if _, err = virtCli.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{}); err != nil {
+						return err
+					}
+					return nil
+				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+			}
+
+			setNodeSchedulable := func(nodeName string) {
+				Eventually(func() error {
+					selectedNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					selectedNode.Spec.Unschedulable = false
+					if _, err = virtCli.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{}); err != nil {
+						return err
+					}
+					return nil
+				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+			}
+
+			BeforeEach(func() {
+				tests.BeforeTestCleanup()
+
+				nodeList = util.GetAllSchedulableNodes(virtCli).Items
+				for _, node := range nodeList {
+					setNodeUnschedulable(node.Name)
+				}
+				eventuallyWithTimeout(waitForDeploymentsToStabilize)
 			})
 
+			AfterEach(func() {
+				for _, node := range nodeList {
+					setNodeSchedulable(node.Name)
+				}
+				eventuallyWithTimeout(waitForDeploymentsToStabilize)
+			})
+
+			DescribeTable("evicting pods of control plane", func(podName string, isMultiReplica bool, msg string) {
+				if isMultiReplica {
+					checks.SkipIfSingleReplica(virtCli)
+				} else {
+					checks.SkipIfMultiReplica(virtCli)
+				}
+				By(fmt.Sprintf("Try to evict all pods %s\n", podName))
+				podList, err := getPodList()
+				Expect(err).ToNot(HaveOccurred())
+				runningPods := getRunningReadyPods(podList, []string{podName})
+				Expect(len(runningPods)).ToNot(Equal(0))
+				for index, pod := range runningPods {
+					err = virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).EvictV1beta1(context.Background(), &v1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
+					if index == len(runningPods)-1 {
+						if isMultiReplica {
+							Expect(err).To(HaveOccurred(), msg)
+						} else {
+							Expect(err).ToNot(HaveOccurred(), msg)
+						}
+					} else {
+						Expect(err).ToNot(HaveOccurred())
+					}
+				}
+			},
+				Entry("[test_id:2830]last eviction should fail for multi-replica virt-controller pods", Labels{"test_id:2830"},
+					"virt-controller", multiReplica, "no error occurred on evict of last virt-controller pod"),
+				Entry("[test_id:2799]last eviction should fail for multi-replica virt-api pods", Labels{"test_id:2799"},
+					"virt-api", multiReplica, "no error occurred on evict of last virt-api pod"),
+				Entry("eviction of single-replica virt-controller pod should succeed",
+					"virt-controller", singleReplica, "error occurred on eviction of single-replica virt-controller pod"),
+				Entry("eviction of multi-replica virt-api pod should succeed",
+					"virt-api", singleReplica, "error occurred on eviction of single-replica virt-api pod"),
+			)
 		})
 
-		When("Control plane pods temporarily lose connection to Kubernetes API", func() {
-			// virt-handler is the only component that has the tools to add blackhole routes for testing healthz. Ideally we would test all component healthz endpoints.
-			componentName := "virt-handler"
+		Context("control plane components check", func() {
 
-			getVirtHandler := func() *v1.DaemonSet {
-				daemonSet, err := virtCli.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), componentName, metav1.GetOptions{})
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-				return daemonSet
-			}
+			When("control plane pods are running", func() {
 
-			readyFunc := func() int32 {
-				return getVirtHandler().Status.NumberReady
-			}
+				It("[test_id:2806]virt-controller and virt-api pods have a pod disruption budget", Labels{"test_id:2806"}, func() {
+					// Single replica deployments do not create PDBs
+					checks.SkipIfSingleReplica(virtCli)
 
-			blackHolePodFunc := func(addOrDel string) {
-				pods, err := virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("kubevirt.io=%s", componentName)})
-				Expect(err).NotTo(HaveOccurred())
+					deploymentsClient := virtCli.AppsV1().Deployments(flags.KubeVirtInstallNamespace)
+					By("check deployments")
+					deployments, err := deploymentsClient.List(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, expectedDeployment := range controlPlaneDeploymentNames {
+						found := false
+						for _, deployment := range deployments.Items {
+							if deployment.Name != expectedDeployment {
+								continue
+							}
+							found = true
+							break
+						}
+						if !found {
+							Fail(fmt.Sprintf("deployment %s not found", expectedDeployment))
+						}
+					}
 
-				serviceIp, err := tests.GetKubernetesApiServiceIp(virtCli)
-				Expect(err).NotTo(HaveOccurred())
+					By("check pod disruption budgets exist")
+					podDisruptionBudgetList, err := virtCli.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, controlPlaneDeploymentName := range controlPlaneDeploymentNames {
+						pdbName := controlPlaneDeploymentName + "-pdb"
+						found := false
+						for _, pdb := range podDisruptionBudgetList.Items {
+							if pdb.Name != pdbName {
+								continue
+							}
+							found = true
+							break
+						}
+						if !found {
+							Fail(fmt.Sprintf("pod disruption budget %s not found for control plane pod %s", pdbName, controlPlaneDeploymentName))
+						}
+					}
+				})
 
-				for _, pod := range pods.Items {
-					_, err = tests.ExecuteCommandOnPod(virtCli, &pod, componentName, []string{"ip", "route", addOrDel, "blackhole", serviceIp})
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}
-
-			It("should fail health checks when connectivity is lost, and recover when connectivity is regained", func() {
-				desiredDeamonsSetCount := getVirtHandler().Status.DesiredNumberScheduled
-
-				By("ensuring we have ready pods")
-				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically(">", 0))
-
-				By("blocking connection to API on pods")
-				blackHolePodFunc("add")
-
-				By("ensuring we no longer have a ready pod")
-				Eventually(readyFunc, 120*time.Second, time.Second).Should(BeNumerically("==", 0))
-
-				By("removing blockage to API")
-				blackHolePodFunc("del")
-
-				By("ensuring we now have a ready virt-handler daemonset")
-				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically("==", desiredDeamonsSetCount))
-
-				By("changing a setting and ensuring that the config update watcher eventually resumes and picks it up")
-				migrationBandwidth := resource.MustParse("1Mi")
-				kv := util.GetCurrentKv(virtCli)
-				kv.Spec.Configuration.MigrationConfiguration = &k6sv1.MigrationConfiguration{
-					BandwidthPerMigration: &migrationBandwidth,
-				}
-				kv = tests.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
-				tests.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", kv.ResourceVersion, tests.ExpectResourceVersionToBeLessEqualThanConfigVersion, 60*time.Second)
 			})
+
+			When("Control plane pods temporarily lose connection to Kubernetes API", func() {
+				// virt-handler is the only component that has the tools to add blackhole routes for testing healthz. Ideally we would test all component healthz endpoints.
+				componentName := "virt-handler"
+
+				getVirtHandler := func() *v1.DaemonSet {
+					daemonSet, err := virtCli.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), componentName, metav1.GetOptions{})
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
+					return daemonSet
+				}
+
+				readyFunc := func() int32 {
+					return getVirtHandler().Status.NumberReady
+				}
+
+				blackHolePodFunc := func(addOrDel string) {
+					pods, err := virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("kubevirt.io=%s", componentName)})
+					Expect(err).NotTo(HaveOccurred())
+
+					serviceIp, err := tests.GetKubernetesApiServiceIp(virtCli)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, pod := range pods.Items {
+						_, err = tests.ExecuteCommandOnPod(virtCli, &pod, componentName, []string{"ip", "route", addOrDel, "blackhole", serviceIp})
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+
+				It("should fail health checks when connectivity is lost, and recover when connectivity is regained", func() {
+					desiredDeamonsSetCount := getVirtHandler().Status.DesiredNumberScheduled
+
+					By("ensuring we have ready pods")
+					Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically(">", 0))
+
+					By("blocking connection to API on pods")
+					blackHolePodFunc("add")
+
+					By("ensuring we no longer have a ready pod")
+					Eventually(readyFunc, 120*time.Second, time.Second).Should(BeNumerically("==", 0))
+
+					By("removing blockage to API")
+					blackHolePodFunc("del")
+
+					By("ensuring we now have a ready virt-handler daemonset")
+					Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically("==", desiredDeamonsSetCount))
+
+					By("changing a setting and ensuring that the config update watcher eventually resumes and picks it up")
+					migrationBandwidth := resource.MustParse("1Mi")
+					kv := util.GetCurrentKv(virtCli)
+					kv.Spec.Configuration.MigrationConfiguration = &k6sv1.MigrationConfiguration{
+						BandwidthPerMigration: &migrationBandwidth,
+					}
+					kv = tests.UpdateKubeVirtConfigValue(kv.Spec.Configuration)
+					tests.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", kv.ResourceVersion, tests.ExpectResourceVersionToBeLessEqualThanConfigVersion, 60*time.Second)
+				})
+			})
+
 		})
 
 	})
-
-})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -891,7 +891,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					newVM := newVirtualMachine(false)
 
 					By("Invoking virtctl start")
-				    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name)
+					startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name)
 					Expect(startCommand()).To(Succeed())
 
 					By("Getting the status of the VM")
@@ -926,7 +926,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 					By("Invoking virtctl stop")
-				    stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", newVM.Namespace, newVM.Name)
+					stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", newVM.Namespace, newVM.Name)
 					Expect(stopCommand()).To(Succeed())
 
 					By("Ensuring VM is not running")
@@ -954,7 +954,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					newVM := newVirtualMachine(false)
 
 					By("Invoking virtctl start")
-				    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name, "--paused")
+					startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name, "--paused")
 					Expect(startCommand()).To(Succeed())
 
 					By("Getting the status of the VM")
@@ -989,7 +989,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					oldVMIUuid := newVM.ObjectMeta.UID
 
 					By("Invoking virtctl --force restart")
-				    forceRestart := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", newVM.Namespace, "--force", newVM.Name, "--grace-period=0")
+					forceRestart := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", newVM.Namespace, "--force", newVM.Name, "--grace-period=0")
 					err = forceRestart()
 					Expect(err).ToNot(HaveOccurred())
 
@@ -1060,7 +1060,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					go terminatationGracePeriodUpdated(stopCn, lw.ResultChan(), updated)
 
 					By("Invoking virtctl --force stop")
-				    forceStop := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, newVM.Name, "--namespace", newVM.Namespace, "--force", "--grace-period=0")
+					forceStop := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, newVM.Name, "--namespace", newVM.Namespace, "--force", "--grace-period=0")
 					Expect(forceStop()).ToNot(HaveOccurred())
 
 					By("Ensuring the VirtualMachineInstance is removed")
@@ -1087,7 +1087,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 						By("Invoking virtctl stop")
-					    stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						Expect(stopCommand()).To(Succeed())
 
 						By("Ensuring the VirtualMachineInstance is removed")
@@ -1121,7 +1121,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						currentUUID := virtualMachine.UID
 
 						By("Invoking virtctl restart")
-					    restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						Expect(restartCommand()).To(Succeed())
 
 						By("Ensuring the VirtualMachineInstance is restarted")
@@ -1212,7 +1212,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 						By("Invoking virtctl migrate")
-					    migrateCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_MIGRATE, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						migrateCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_MIGRATE, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						Expect(migrateCommand()).To(Succeed())
 
 						By("Ensuring the VirtualMachineInstance is migrated")
@@ -1239,7 +1239,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 						By("Invoking virtctl migrate with dry-run option")
-					    migrateCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_MIGRATE, "--dry-run", "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						migrateCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_MIGRATE, "--dry-run", "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						Expect(migrateCommand()).To(Succeed())
 
 						By("Check that no migration was actually created")
@@ -1255,7 +1255,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						By("creating a VM with RunStrategyRerunOnFailure")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
-					    stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 
 						By("Waiting for VM to be ready")
 						Eventually(func() bool {
@@ -1275,19 +1275,19 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							return err
 						}, 240*time.Second, 1*time.Second).Should(HaveOccurred())
 
-					newVM, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
-					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyHalted))
-					By("Ensuring stateChangeRequests list is cleared")
-					Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
-				})
+						newVM, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
+						Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyHalted))
+						By("Ensuring stateChangeRequests list is cleared")
+						Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
+					})
 
 					It("[test_id:2187] should restart a running VM", Labels{"test_id:2187"}, func() {
 						By("creating a VM with RunStrategyRerunOnFailure")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
-					    restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 
 						By("Waiting for VM to be ready")
 						Eventually(func() bool {
@@ -1367,7 +1367,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						// At this point, explicitly test that a start command will delete an existing
 						// VMI in the Succeeded phase.
 						By("Invoking virtctl start")
-					    restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = restartCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1392,7 +1392,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						By("creating a VM with RunStrategyHalted")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyHalted)
 
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = startCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1403,14 +1403,14 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							return virtualMachine.Status.Ready
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
-					newVM, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
-					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyAlways))
-					By("Ensuring stateChangeRequests list is cleared")
-					Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
+						newVM, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
+						Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyAlways))
+						By("Ensuring stateChangeRequests list is cleared")
+						Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
+					})
 				})
-			})
 
 				Context("Using RunStrategyOnce", func() {
 					It("[Serial] Should leave a failed VMI", Labels{"Serial"}, func() {
@@ -1500,7 +1500,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = startCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1511,19 +1511,19 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							return virtualMachine.Status.Ready
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
-					newVM, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
-					Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyManual))
-					By("Ensuring stateChangeRequests list is cleared")
-					Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
-				})
+						newVM, err := virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
+						Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyManual))
+						By("Ensuring stateChangeRequests list is cleared")
+						Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
+					})
 
 					It("[test_id:2189] should stop", Labels{"test_id:2189"}, func() {
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = startCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1534,7 +1534,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							return virtualMachine.Status.Ready
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
-					    stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = stopCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1563,7 +1563,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
 						By("Invoking virtctl start")
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name, "--paused")
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name, "--paused")
 						Expect(startCommand()).To(Succeed())
 
 						By("Getting the status of the VM")
@@ -1587,9 +1587,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
-					    stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
-					    restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						stopCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 
 						By("Invoking virtctl restart should fail")
 						err = restartCommand()
@@ -1680,7 +1680,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = startCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1713,7 +1713,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						// At this point, explicitly test that a start command will delete an existing
 						// VMI in the Succeeded phase.
 						By("Invoking virtctl start")
-					    restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
+						restartCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 						err = restartCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1748,7 +1748,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(err).ToNot(HaveOccurred())
 
 						By("Starting the VMI with virtctl")
-					    startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name)
+						startCommand := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name)
 						err = startCommand()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1804,8 +1804,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			var vmRunningRe *regexp.Regexp
 
 			BeforeEach(func() {
-			    k8sClient = clientcmd.GetK8sCmdClient()
-			    clientcmd.SkipIfNoCmd(k8sClient)
+				k8sClient = clientcmd.GetK8sCmdClient()
+				clientcmd.SkipIfNoCmd(k8sClient)
 				workDir = GinkgoT().TempDir()
 
 				// By default "." does not match newline: "Phase" and "Running" only match if on same line.
@@ -1820,7 +1820,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
 
 				By("Creating VM with DataVolumeTemplate entry with k8s client binary")
-			    _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying VM is created")
@@ -1829,7 +1829,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(newVM.Name).To(Equal(vm.Name), "New VM was not created")
 
 				By("Creating the VM again")
-			    _, stdErr, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, stdErr, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).To(HaveOccurred())
 
 				Expect(strings.HasPrefix(stdErr, "Error from server (AlreadyExists): error when creating")).To(BeTrue(), "command should error when creating VM second time")
@@ -1845,14 +1845,14 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
 
 				By("Creating VM using k8s client binary")
-			    _, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to start")
 				waitForVMIStart(virtClient, vmi)
 
 				By("Listing running pods")
-			    stdout, _, err := clientcmd.RunCommand(k8sClient, "get", "pods")
+				stdout, _, err := clientcmd.RunCommand(k8sClient, "get", "pods")
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Ensuring pod is running")
@@ -1863,7 +1863,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(podRunningRe.FindString(stdout)).ToNot(Equal(""), "Pod is not Running")
 
 				By("Checking that VM is running")
-			stdout, _, err = clientcmd.RunCommand(k8sClient, "describe", "vmis", vm.GetName())
+				stdout, _, err = clientcmd.RunCommand(k8sClient, "describe", "vmis", vm.GetName())
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
@@ -1880,11 +1880,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err).ToNot(HaveOccurred(), "Cannot generate VM's manifest")
 
 				By("Creating VM using k8s client binary")
-			_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Invoking virtctl start")
-			virtctl := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", thisVm.Namespace, thisVm.Name)
+				virtctl := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", thisVm.Namespace, thisVm.Name)
 				err = virtctl()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1892,13 +1892,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				waitForVMIStart(virtClient, vmi)
 
 				By("Checking that VM is running")
-			stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", thisVm.GetName())
+				stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", thisVm.GetName())
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
 
 				By("Deleting VM using k8s client binary")
-			_, _, err = clientcmd.RunCommand(k8sClient, "delete", "vm", thisVm.GetName())
+				_, _, err = clientcmd.RunCommand(k8sClient, "delete", "vm", thisVm.GetName())
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying the VM gets deleted")
@@ -1918,11 +1918,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred(), "Cannot generate VM's manifest")
 
 					By("Creating VM using k8s client binary")
-				_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+					_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Invoking virtctl start with dry-run option")
-				virtctl := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", thisVm.Namespace, "--dry-run", thisVm.Name)
+					virtctl := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", thisVm.Namespace, "--dry-run", thisVm.Name)
 					err = virtctl()
 					Expect(err).ToNot(HaveOccurred())
 
@@ -1939,7 +1939,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred(), "Cannot generate VM's manifest")
 
 					By("Creating VM using k8s client binary")
-				_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+					_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Waiting for VMI to start")
@@ -1958,12 +1958,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						args = append(args, flags...)
 					}
 					By("Invoking virtctl stop with dry-run option")
-				virtctl := clientcmd.NewRepeatableVirtctlCommand(args...)
+					virtctl := clientcmd.NewRepeatableVirtctlCommand(args...)
 					err = virtctl()
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Checking that VM is still running")
-				stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", thisVm.GetName())
+					stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", thisVm.GetName())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
 
@@ -1996,7 +1996,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred(), "Cannot generate VM's manifest")
 
 					By("Creating VM using k8s client binary")
-				_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+					_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Waiting for VMI to start")
@@ -2009,7 +2009,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					VMIUuid := currentVmi.ObjectMeta.UID
 
 					By("Invoking virtctl restart with dry-run option")
-				virtctl := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", thisVm.Namespace, "--dry-run", thisVm.Name)
+					virtctl := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", thisVm.Namespace, "--dry-run", thisVm.Name)
 					err = virtctl()
 					Expect(err).ToNot(HaveOccurred())
 
@@ -2021,7 +2021,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(newVMI.ObjectMeta.DeletionTimestamp).To(BeNil())
 
 					By("Checking that VM is running")
-				stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", thisVm.GetName())
+					stdout, _, err := clientcmd.RunCommand(k8sClient, "describe", "vmis", thisVm.GetName())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
 				})
@@ -2035,21 +2035,21 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err).ToNot(HaveOccurred(), "Cannot generate VM's manifest")
 
 				By("Creating VM using k8s client binary")
-			_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err := clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to start")
 				waitForVMIStart(virtClient, vmi)
 
 				By("Deleting VM using k8s client binary")
-			_, _, err = clientcmd.RunCommand(k8sClient, "delete", "vm", thisVm.GetName())
+				_, _, err = clientcmd.RunCommand(k8sClient, "delete", "vm", thisVm.GetName())
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying the VM gets deleted")
 				waitForResourceDeletion(k8sClient, "vms", thisVm.GetName())
 
 				By("Creating same VM using k8s client binary and same manifest")
-			_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
+				_, _, err = clientcmd.RunCommand(k8sClient, "create", "-f", vmJson)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to start")
@@ -2060,7 +2060,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				vmi := tests.NewRandomVMWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 				By("Creating VM with DataVolumeTemplate entry with k8s client binary")
-			_, stdErr, err := clientcmd.RunCommand(k8sClient, "delete", "vm", vmi.Name)
+				_, stdErr, err := clientcmd.RunCommand(k8sClient, "delete", "vm", vmi.Name)
 				Expect(err).To(HaveOccurred())
 				Expect(strings.HasPrefix(stdErr, "Error from server (NotFound): virtualmachines.kubevirt.io")).To(BeTrue(), "should fail when deleting non existent VM")
 			})
@@ -2075,22 +2075,22 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Context("should succeed with right rights", func() {
 					BeforeEach(func() {
 						// kubectl doesn't have "adm" subcommand -- only oc does
-					clientcmd.SkipIfNoCmd("oc")
+						clientcmd.SkipIfNoCmd("oc")
 						By("Ensuring the cluster has new test serviceaccount")
-					stdOut, stdErr, err := clientcmd.RunCommand(k8sClient, "create", "user", testUser)
+						stdOut, stdErr, err := clientcmd.RunCommand(k8sClient, "create", "user", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 
 						By("Ensuring user has the admin rights for the test namespace project")
 						// This simulates the ordinary user as an admin in this project
-					stdOut, stdErr, err = clientcmd.RunCommand(k8sClient, "adm", "policy", "add-role-to-user", "admin", testUser, "--namespace", util.NamespaceTestDefault)
+						stdOut, stdErr, err = clientcmd.RunCommand(k8sClient, "adm", "policy", "add-role-to-user", "admin", testUser, "--namespace", util.NamespaceTestDefault)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
 					AfterEach(func() {
-					stdOut, stdErr, err := clientcmd.RunCommand(k8sClient, "adm", "policy", "remove-role-from-user", "admin", testUser, "--namespace", util.NamespaceTestDefault)
+						stdOut, stdErr, err := clientcmd.RunCommand(k8sClient, "adm", "policy", "remove-role-from-user", "admin", testUser, "--namespace", util.NamespaceTestDefault)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 
-					stdOut, stdErr, err = clientcmd.RunCommand(k8sClient, "delete", "user", testUser)
+						stdOut, stdErr, err = clientcmd.RunCommand(k8sClient, "delete", "user", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
@@ -2102,7 +2102,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
 
 						By("Checking VM creation permission using k8s client binary")
-					stdOut, _, err := clientcmd.RunCommand(k8sClient, "auth", "can-i", "create", "vms", "--as", testUser)
+						stdOut, _, err := clientcmd.RunCommand(k8sClient, "auth", "can-i", "create", "vms", "--as", testUser)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(strings.TrimSpace(stdOut)).To(Equal("yes"))
 					})
@@ -2111,12 +2111,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Context("should fail without right rights", func() {
 					BeforeEach(func() {
 						By("Ensuring the cluster has new test serviceaccount")
-					stdOut, stdErr, err := clientcmd.RunCommandWithNS(util.NamespaceTestDefault, k8sClient, "create", "serviceaccount", testUser)
+						stdOut, stdErr, err := clientcmd.RunCommandWithNS(util.NamespaceTestDefault, k8sClient, "create", "serviceaccount", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
 					AfterEach(func() {
-					stdOut, stdErr, err := clientcmd.RunCommandWithNS(util.NamespaceTestDefault, k8sClient, "delete", "serviceaccount", testUser)
+						stdOut, stdErr, err := clientcmd.RunCommandWithNS(util.NamespaceTestDefault, k8sClient, "delete", "serviceaccount", testUser)
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
@@ -2128,7 +2128,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
 
 						By("Checking VM creation permission using k8s client binary")
-					stdOut, _, err := clientcmd.RunCommand(k8sClient, "auth", "can-i", "create", "vms", "--as", testUser)
+						stdOut, _, err := clientcmd.RunCommand(k8sClient, "auth", "can-i", "create", "vms", "--as", testUser)
 						// non-zero exit code
 						Expect(err).To(HaveOccurred())
 						Expect(err.Error()).To(ContainSubstring("exit status 1"))
@@ -2234,7 +2234,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 1*time.Minute, 5*time.Second).Should(BeNil())
 
 				By("Invoking virtctl stop while in a crash loop")
-			stopCmd := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, newVM.Name, "--namespace", newVM.Namespace)
+				stopCmd := clientcmd.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, newVM.Name, "--namespace", newVM.Namespace)
 				Expect(stopCmd()).ToNot(HaveOccurred())
 
 				By("Waiting on crash loop status to be removed.")

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -60,7 +60,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachine",
-	Labels{"rfe_id:1177", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:1177", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error
@@ -78,7 +78,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		Context("An invalid VirtualMachine given", func() {
 
-			It("[test_id:1518]should be rejected on POST", Labels{"test_id:1518"}, func() {
+			It("[test_id:1518]should be rejected on POST", Label("test_id:1518"), func() {
 				vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 				template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
 				newVM := tests.NewRandomVirtualMachine(template, false)
@@ -99,7 +99,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
 			})
-			It("[test_id:1519]should reject POST if validation webhoook deems the spec is invalid", Labels{"test_id:1519"}, func() {
+			It("[test_id:1519]should reject POST if validation webhoook deems the spec is invalid", Label("test_id:1519"), func() {
 				vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 				template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
 				// Add a disk that doesn't map to a volume.
@@ -126,7 +126,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 		})
 
-		Context("[Serial]A mutated VirtualMachine given", Labels{"Serial"}, func() {
+		Context("[Serial]A mutated VirtualMachine given", Label("Serial"), func() {
 
 			var testingMachineType string = "pc-q35-2.7"
 
@@ -151,7 +151,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				return newVM
 			}
 
-			It("[test_id:3312]should set the default MachineType when created without explicit value", Labels{"test_id:3312"}, func() {
+			It("[test_id:3312]should set the default MachineType when created without explicit value", Label("test_id:3312"), func() {
 				By("Creating VirtualMachine")
 				template, _ := newVirtualMachineInstanceWithContainerDisk()
 				template.Spec.Domain.Machine = nil
@@ -163,7 +163,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(createdVM.Spec.Template.Spec.Domain.Machine.Type).To(Equal(testingMachineType))
 			})
 
-			It("[test_id:3311]should keep the supplied MachineType when created", Labels{"test_id:3311"}, func() {
+			It("[test_id:3311]should keep the supplied MachineType when created", Label("test_id:3311"), func() {
 				By("Creating VirtualMachine")
 				explicitMachineType := "pc-q35-3.0"
 				template, _ := newVirtualMachineInstanceWithContainerDisk()
@@ -352,7 +352,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Entry("float type", "2.2", "2222222.2"),
 			)
 
-			It("[test_id:3161]should carry annotations to VMI", Labels{"test_id:3161"}, func() {
+			It("[test_id:3161]should carry annotations to VMI", Label("test_id:3161"), func() {
 				annotations := map[string]string{
 					"testannotation": "test",
 				}
@@ -380,7 +380,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 300*time.Second, 1*time.Second).Should(HaveKeyWithValue("testannotation", "test"), "VM should start normally.")
 			})
 
-			It("[test_id:3162]should ignore kubernetes and kubevirt annotations to VMI", Labels{"test_id:3162"}, func() {
+			It("[test_id:3162]should ignore kubernetes and kubevirt annotations to VMI", Label("test_id:3162"), func() {
 				annotations := map[string]string{
 					"kubevirt.io/test":   "test",
 					"kubernetes.io/test": "test",
@@ -411,7 +411,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(vmi.Annotations).ShouldNot(HaveKey("kubernetes.io/test"), "kubernetes internal annotations should be ignored")
 			})
 
-			DescribeTable("[test_id:1520]should update VirtualMachine once VMIs are up", Labels{"test_id:1520"}, func(createTemplate vmiBuilder) {
+			DescribeTable("[test_id:1520]should update VirtualMachine once VMIs are up", Label("test_id:1520"), func(createTemplate vmiBuilder) {
 				template, dv := createTemplate()
 				defer deleteDataVolume(dv)
 				newVM := createVirtualMachine(true, template)
@@ -422,11 +422,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 300*time.Second, 1*time.Second).Should(BeTrue())
 			},
 				Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-				Entry("[Serial][storage-req]with Filesystem Disk", Labels{"Serial", "storage-req"}, newVirtualMachineInstanceWithFileDisk),
-				Entry("[Serial][storage-req]with Block Disk", Labels{"Serial", "storage-req"}, newVirtualMachineInstanceWithBlockDisk),
+				Entry("[Serial][storage-req]with Filesystem Disk", Label("Serial", "storage-req"), newVirtualMachineInstanceWithFileDisk),
+				Entry("[Serial][storage-req]with Block Disk", Label("Serial", "storage-req"), newVirtualMachineInstanceWithBlockDisk),
 			)
 
-			DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", Labels{"test_id:1521"}, func(createTemplate vmiBuilder) {
+			DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", Label("test_id:1521"), func(createTemplate vmiBuilder) {
 				template, dv := createTemplate()
 				defer deleteDataVolume(dv)
 				newVM := createVirtualMachine(true, template)
@@ -440,11 +440,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 300*time.Second, 2*time.Second).Should(BeZero(), "The VirtualMachineInstance did not disappear")
 			},
 				Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-				Entry("[Serial][storage-req]with Filesystem Disk", Labels{"Serial", "storage-req"}, newVirtualMachineInstanceWithFileDisk),
-				Entry("[Serial][storage-req]with Block Disk", Labels{"Serial", "storage-req"}, newVirtualMachineInstanceWithBlockDisk),
+				Entry("[Serial][storage-req]with Filesystem Disk", Label("Serial", "storage-req"), newVirtualMachineInstanceWithFileDisk),
+				Entry("[Serial][storage-req]with Block Disk", Label("Serial", "storage-req"), newVirtualMachineInstanceWithBlockDisk),
 			)
 
-			It("[test_id:1522]should remove owner references on the VirtualMachineInstance if it is orphan deleted", Labels{"test_id:1522"}, func() {
+			It("[test_id:1522]should remove owner references on the VirtualMachineInstance if it is orphan deleted", Label("test_id:1522"), func() {
 				newVM := newVirtualMachine(true)
 
 				By("Getting owner references")
@@ -476,7 +476,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:1523]should recreate VirtualMachineInstance if it gets deleted", Labels{"test_id:1523"}, func() {
+			It("[test_id:1523]should recreate VirtualMachineInstance if it gets deleted", Label("test_id:1523"), func() {
 				newVM := startVM(newVirtualMachine(false))
 
 				currentVMI, err := virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
@@ -496,7 +496,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 240*time.Second, 1*time.Second).Should(BeTrue())
 			})
 
-			It("[test_id:1524]should recreate VirtualMachineInstance if the VirtualMachineInstance's pod gets deleted", Labels{"test_id:1524"}, func() {
+			It("[test_id:1524]should recreate VirtualMachineInstance if the VirtualMachineInstance's pod gets deleted", Label("test_id:1524"), func() {
 				var firstVMI *v1.VirtualMachineInstance
 				var curVMI *v1.VirtualMachineInstance
 				var err error
@@ -556,7 +556,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(pod.Name).ToNot(Equal(firstPod.Name))
 			})
 
-			DescribeTable("[test_id:1525]should stop VirtualMachineInstance if running set to false", Labels{"test_id:1525"}, func(createTemplate vmiBuilder) {
+			DescribeTable("[test_id:1525]should stop VirtualMachineInstance if running set to false", Label("test_id:1525"), func(createTemplate vmiBuilder) {
 				template, dv := createTemplate()
 				defer deleteDataVolume(dv)
 				vm := createVirtualMachine(false, template)
@@ -564,11 +564,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				stopVM(vm)
 			},
 				Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-				Entry("[Serial][storage-req]with Filesystem Disk", Labels{"Serial", "storage-req"}, newVirtualMachineInstanceWithFileDisk),
-				Entry("[Serial][storage-req]with Block Disk", Labels{"Serial", "storage-req"}, newVirtualMachineInstanceWithBlockDisk),
+				Entry("[Serial][storage-req]with Filesystem Disk", Label("Serial", "storage-req"), newVirtualMachineInstanceWithFileDisk),
+				Entry("[Serial][storage-req]with Block Disk", Label("Serial", "storage-req"), newVirtualMachineInstanceWithBlockDisk),
 			)
 
-			It("[test_id:1526]should start and stop VirtualMachineInstance multiple times", Labels{"test_id:1526"}, func() {
+			It("[test_id:1526]should start and stop VirtualMachineInstance multiple times", Label("test_id:1526"), func() {
 				vm := newVirtualMachine(false)
 				// Start and stop VirtualMachineInstance multiple times
 				for i := 0; i < 5; i++ {
@@ -578,7 +578,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}
 			})
 
-			It("[test_id:1527]should not update the VirtualMachineInstance spec if Running", Labels{"test_id:1527"}, func() {
+			It("[test_id:1527]should not update the VirtualMachineInstance spec if Running", Label("test_id:1527"), func() {
 				newVM := newVirtualMachine(true)
 
 				Eventually(func() bool {
@@ -619,7 +619,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(vmiMemory.Cmp(*vmMemory)).To(Equal(0))
 			})
 
-			It("[test_id:1528]should survive guest shutdown, multiple times", Labels{"test_id:1528"}, func() {
+			It("[test_id:1528]should survive guest shutdown, multiple times", Label("test_id:1528"), func() {
 				By("Creating new VM, not running")
 				newVM := newVirtualMachine(false)
 				newVM = startVM(newVM)
@@ -636,8 +636,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						return vmi.Status.Phase == v1.Running
 					}, 240*time.Second, 1*time.Second).Should(BeTrue())
 
-				By("Obtaining the serial console")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					By("Obtaining the serial console")
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					By("Guest shutdown")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -750,7 +750,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(vmRevision.Spec).To(Equal(vmCpy.Spec))
 			})
 
-			It("[test_id:4645]should set the Ready condition on VM", Labels{"test_id:4645"}, func() {
+			It("[test_id:4645]should set the Ready condition on VM", Label("test_id:4645"), func() {
 				vm := newVirtualMachine(false)
 
 				vmReadyConditionStatus := func() k8sv1.ConditionStatus {
@@ -793,21 +793,21 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Eventually(vmPrintableStatus, 300*time.Second, 1*time.Second).
 					Should(Equal(v1.VirtualMachineStatusUnschedulable))
 			},
-				Entry("[test_id:6867]with unsatisfiable resource requirements", Labels{"test_id:6867"}, func(vmi *v1.VirtualMachineInstance) {
+				Entry("[test_id:6867]with unsatisfiable resource requirements", Label("test_id:6867"), func(vmi *v1.VirtualMachineInstance) {
 					vmi.Spec.Domain.Resources.Requests = corev1.ResourceList{
 						// This may stop working sometime around 2040
 						corev1.ResourceMemory: resource.MustParse("1Ei"),
 						corev1.ResourceCPU:    resource.MustParse("1M"),
 					}
 				}),
-				Entry("[test_id:6868]with unsatisfiable scheduling constraints", Labels{"test_id:6868"}, func(vmi *v1.VirtualMachineInstance) {
+				Entry("[test_id:6868]with unsatisfiable scheduling constraints", Label("test_id:6868"), func(vmi *v1.VirtualMachineInstance) {
 					vmi.Spec.NodeSelector = map[string]string{
 						"node-label": "that-doesnt-exist",
 					}
 				}),
 			)
 
-			It("[test_id:6869]should report an error status when image pull error occurs", Labels{"test_id:6869"}, func() {
+			It("[test_id:6869]should report an error status when image pull error occurs", Label("test_id:6869"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk("no-such-image")
 
 				vm := createVirtualMachine(true, vmi)
@@ -856,9 +856,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				),
 			)
 
-			It("[test_id:7679]should report an error status when data volume error occurs", Labels{"test_id:7679"}, func() {
+			It("[test_id:7679]should report an error status when data volume error occurs", Label("test_id:7679"), func() {
 				By("Verifying that required StorageClass is configured")
-			storageClassName := libstorage.Config.StorageRWOFileSystem
+				storageClassName := libstorage.Config.StorageRWOFileSystem
 
 				_, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), storageClassName, metav1.GetOptions{})
 				if errors.IsNotFound(err) {
@@ -886,7 +886,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			Context("Using virtctl interface", func() {
-				It("[test_id:1529]should start a VirtualMachineInstance once", Labels{"test_id:1529"}, func() {
+				It("[test_id:1529]should start a VirtualMachineInstance once", Label("test_id:1529"), func() {
 					By("getting a VM")
 					newVM := newVirtualMachine(false)
 
@@ -914,7 +914,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err.Error()).To(Equal(fmt.Sprintf(`Error starting VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is already running`, newVM.Name)))
 				})
 
-				It("[test_id:1530]should stop a VirtualMachineInstance once", Labels{"test_id:1530"}, func() {
+				It("[test_id:1530]should stop a VirtualMachineInstance once", Label("test_id:1530"), func() {
 					By("getting a VM")
 					newVM := newVirtualMachine(true)
 
@@ -949,7 +949,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err.Error()).To(Equal(fmt.Sprintf(`Error stopping VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is not running`, newVM.Name)))
 				})
 
-				It("[test_id:6310]should start a VirtualMachineInstance in paused state", Labels{"test_id:6310"}, func() {
+				It("[test_id:6310]should start a VirtualMachineInstance in paused state", Label("test_id:6310"), func() {
 					By("getting a VM")
 					newVM := newVirtualMachine(false)
 
@@ -974,7 +974,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					}, 240*time.Second, 1*time.Second).Should(BeTrue())
 				})
 
-				It("[test_id:3007]Should force restart a VM with terminationGracePeriodSeconds>0", Labels{"test_id:3007"}, func() {
+				It("[test_id:3007]Should force restart a VM with terminationGracePeriodSeconds>0", Label("test_id:3007"), func() {
 
 					By("getting a VM with high TerminationGracePeriod")
 					newVMI := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
@@ -1075,7 +1075,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				Context("Using RunStrategyAlways", func() {
-					It("[test_id:3163]should stop a running VM", Labels{"test_id:3163"}, func() {
+					It("[test_id:3163]should stop a running VM", Label("test_id:3163"), func() {
 						By("creating a VM with RunStrategyAlways")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyAlways)
 
@@ -1102,9 +1102,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(newVM.Spec.RunStrategy).ToNot(BeNil())
 						Expect(*newVM.Spec.RunStrategy).To(Equal(v1.RunStrategyHalted))
 						Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
-				})
+					})
 
-					It("[test_id:3164]should restart a running VM", Labels{"test_id:3164"}, func() {
+					It("[test_id:3164]should restart a running VM", Label("test_id:3164"), func() {
 						By("creating a VM with RunStrategyAlways")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyAlways)
 
@@ -1153,7 +1153,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							"New VMI was created, but StateChangeRequest was never cleared")
 					})
 
-					It("[test_id:3165]should restart a succeeded VMI", Labels{"test_id:3165"}, func() {
+					It("[test_id:3165]should restart a succeeded VMI", Label("test_id:3165"), func() {
 						By("creating a VM with RunStategyRunning")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyAlways)
 
@@ -1167,7 +1167,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 
-					Expect(console.LoginToCirros(vmi)).To(Succeed())
+						Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 						By("Issuing a poweroff command from inside VM")
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1196,7 +1196,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					})
 
-					It("[test_id:4119]should migrate a running VM", Labels{"test_id:4119"}, func() {
+					It("[test_id:4119]should migrate a running VM", Label("test_id:4119"), func() {
 						nodes := util.GetAllSchedulableNodes(virtClient)
 						if len(nodes.Items) < 2 {
 							Skip("Migration tests require at least 2 nodes")
@@ -1223,7 +1223,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}, 240*time.Second, 1*time.Second).Should(BeTrue())
 					})
 
-					It("[test_id:7743]should not migrate a running vm if dry-run option is passed", Labels{"test_id:7743"}, func() {
+					It("[test_id:7743]should not migrate a running vm if dry-run option is passed", Label("test_id:7743"), func() {
 						nodes := util.GetAllSchedulableNodes(virtClient)
 						if len(nodes.Items) < 2 {
 							Skip("Migration tests require at least 2 nodes")
@@ -1251,7 +1251,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				Context("Using RunStrategyRerunOnFailure", func() {
-					It("[test_id:2186] should stop a running VM", Labels{"test_id:2186"}, func() {
+					It("[test_id:2186] should stop a running VM", Label("test_id:2186"), func() {
 						By("creating a VM with RunStrategyRerunOnFailure")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
@@ -1283,7 +1283,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
 					})
 
-					It("[test_id:2187] should restart a running VM", Labels{"test_id:2187"}, func() {
+					It("[test_id:2187] should restart a running VM", Label("test_id:2187"), func() {
 						By("creating a VM with RunStrategyRerunOnFailure")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
@@ -1335,7 +1335,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							"New VMI was created, but StateChangeRequest was never cleared")
 					})
 
-					It("[test_id:2188] should not remove a succeeded VMI", Labels{"test_id:2188"}, func() {
+					It("[test_id:2188] should not remove a succeeded VMI", Label("test_id:2188"), func() {
 						By("creating a VM with RunStrategyRerunOnFailure")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyRerunOnFailure)
 
@@ -1348,7 +1348,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 
-					Expect(console.LoginToCirros(vmi)).To(Succeed())
+						Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 						By("Issuing a poweroff command from inside VM")
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1388,7 +1388,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				Context("Using RunStrategyHalted", func() {
-					It("[test_id:2037] should start a stopped VM", Labels{"test_id:2037"}, func() {
+					It("[test_id:2037] should start a stopped VM", Label("test_id:2037"), func() {
 						By("creating a VM with RunStrategyHalted")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyHalted)
 
@@ -1413,7 +1413,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				Context("Using RunStrategyOnce", func() {
-					It("[Serial] Should leave a failed VMI", Labels{"Serial"}, func() {
+					It("[Serial] Should leave a failed VMI", Label("Serial"), func() {
 						By("creating a VM with RunStrategyOnce")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyOnce)
 
@@ -1463,9 +1463,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							return virtualMachine.Status.Ready
 						}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
-					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(console.LoginToCirros(vmi)).To(Succeed())
+						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 						By("Issuing a poweroff command from inside VM")
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1496,7 +1496,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				Context("Using RunStrategyManual", func() {
-					It("[test_id:2036] should start", Labels{"test_id:2036"}, func() {
+					It("[test_id:2036] should start", Label("test_id:2036"), func() {
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
@@ -1519,7 +1519,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(newVM.Status.StateChangeRequests).To(BeEmpty())
 					})
 
-					It("[test_id:2189] should stop", Labels{"test_id:2189"}, func() {
+					It("[test_id:2189] should stop", Label("test_id:2189"), func() {
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
@@ -1558,7 +1558,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}, 30*time.Second, time.Second).Should(BeTrue())
 					})
 
-					It("[test_id:6311]should start in paused state", Labels{"test_id:6311"}, func() {
+					It("[test_id:6311]should start in paused state", Label("test_id:6311"), func() {
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
@@ -1583,7 +1583,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						}, 240*time.Second, 1*time.Second).Should(BeTrue())
 					})
 
-					It("[test_id:2035] should restart", Labels{"test_id:2035"}, func() {
+					It("[test_id:2035] should restart", Label("test_id:2035"), func() {
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
@@ -1676,7 +1676,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							"New VMI was created, but StateChangeRequest was never cleared")
 					})
 
-					It("[test_id:2190] should not remove a succeeded VMI", Labels{"test_id:2190"}, func() {
+					It("[test_id:2190] should not remove a succeeded VMI", Label("test_id:2190"), func() {
 						By("creating a VM with RunStrategyManual")
 						virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)
 
@@ -1694,7 +1694,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 
-					Expect(console.LoginToCirros(vmi)).To(Succeed())
+						Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 						By("Issuing a poweroff command from inside VM")
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1786,14 +1786,14 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 							Eventually(Expect(launcherPod.Status.Phase).To(Equal(k8sv1.PodFailed)), 160*time.Second, 1*time.Second).Should(BeTrue())
 						}
 					},
-						Entry("[test_id:7164]VMI launcher pod should fail", Labels{"test_id:7164"}, "false"),
-						Entry("[test_id:6993]VMI launcher pod compute container should keep running", Labels{"test_id:6993"}, "true"),
+						Entry("[test_id:7164]VMI launcher pod should fail", Label("test_id:7164"), "false"),
+						Entry("[test_id:6993]VMI launcher pod compute container should keep running", Label("test_id:6993"), "true"),
 					)
 				})
 			})
 		})
 
-		Context("[rfe_id:273]with oc/kubectl", Labels{"rfe_id:273"}, func() {
+		Context("[rfe_id:273]with oc/kubectl", Label("rfe_id:273"), func() {
 			var vmi *v1.VirtualMachineInstance
 			var err error
 			var vmJson string
@@ -1812,7 +1812,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				vmRunningRe = regexp.MustCompile("Phase.*Running")
 			})
 
-			It("[test_id:243][posneg:negative]should create VM only once", Labels{"test_id:243", "posneg:negative"}, func() {
+			It("[test_id:243][posneg:negative]should create VM only once", Label("test_id:243", "posneg:negative"), func() {
 				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vm := tests.NewRandomVirtualMachine(vmi, true)
 
@@ -1835,7 +1835,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(strings.HasPrefix(stdErr, "Error from server (AlreadyExists): error when creating")).To(BeTrue(), "command should error when creating VM second time")
 			})
 
-			DescribeTable("[release-blocker][test_id:299]should create VM via command line using all supported API versions", Labels{"release-blocker", "test_id:299"}, func(version string) {
+			DescribeTable("[release-blocker][test_id:299]should create VM via command line using all supported API versions", Label("release-blocker", "test_id:299"), func(version string) {
 				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vm := tests.NewRandomVirtualMachine(vmi, true)
 
@@ -1872,7 +1872,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Entry("with v1alpha3 api", "kubevirt.io/v1alpha3"),
 			)
 
-			It("[test_id:264]should create and delete via command line", Labels{"test_id:264"}, func() {
+			It("[test_id:264]should create and delete via command line", Label("test_id:264"), func() {
 				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				thisVm := tests.NewRandomVirtualMachine(vmi, false)
 
@@ -1910,7 +1910,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			Context("should not change anything if dry-run option is passed", func() {
-				It("[test_id:7530]in start command", Labels{"test_id:7530"}, func() {
+				It("[test_id:7530]in start command", Label("test_id:7530"), func() {
 					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					thisVm := tests.NewRandomVirtualMachine(vmi, false)
 
@@ -1985,10 +1985,10 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				},
 
 					Entry("[test_id:7529]with no other flags"),
-					Entry("[test_id:7604]with grace period", Labels{"test_id:7604"}, "--grace-period=10", "--force"),
+					Entry("[test_id:7604]with grace period", Label("test_id:7604"), "--grace-period=10", "--force"),
 				)
 
-				It("[test_id:7528]in restart command", Labels{"test_id:7528"}, func() {
+				It("[test_id:7528]in restart command", Label("test_id:7528"), func() {
 					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					thisVm := tests.NewRandomVirtualMachine(vmi, true)
 
@@ -2027,7 +2027,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 			})
 
-			It("[test_id:232]should create same manifest twice via command line", Labels{"test_id:232"}, func() {
+			It("[test_id:232]should create same manifest twice via command line", Label("test_id:232"), func() {
 				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				thisVm := tests.NewRandomVirtualMachine(vmi, true)
 
@@ -2056,7 +2056,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				waitForVMIStart(virtClient, vmi)
 			})
 
-			It("[test_id:233][posneg:negative]should fail when deleting nonexistent VM", Labels{"test_id:233", "posneg:negative"}, func() {
+			It("[test_id:233][posneg:negative]should fail when deleting nonexistent VM", Label("test_id:233", "posneg:negative"), func() {
 				vmi := tests.NewRandomVMWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 				By("Creating VM with DataVolumeTemplate entry with k8s client binary")
@@ -2094,7 +2094,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
-					It("[test_id:2839]should create VM via command line", Labels{"test_id:2839"}, func() {
+					It("[test_id:2839]should create VM via command line", Label("test_id:2839"), func() {
 						vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 						vm := tests.NewRandomVirtualMachine(vmi, true)
 
@@ -2120,7 +2120,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 					})
 
-					It("[test_id:2914]should create VM via command line", Labels{"test_id:2914"}, func() {
+					It("[test_id:2914]should create VM via command line", Label("test_id:2914"), func() {
 						vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 						vm := tests.NewRandomVirtualMachine(vmi, true)
 

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -42,7 +42,7 @@ import (
 
 const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
 
-var _ = Describe("[sig-compute]CloudInitHookSidecars", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]CloudInitHookSidecars", Label("sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -102,13 +102,13 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", Labels{"sig-compute"}, fu
 
 	Describe("VMI definition", func() {
 		Context("with CloudInit hook sidecar", func() {
-			It("[test_id:3167]should successfully start with hook sidecar annotation", Labels{"test_id:3167"}, func() {
+			It("[test_id:3167]should successfully start with hook sidecar annotation", Label("test_id:3167"), func() {
 				By("Starting a VMI")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:3168]should call Collect and PreCloudInitIso on the hook sidecar", Labels{"test_id:3168"}, func() {
+			It("[test_id:3168]should call Collect and PreCloudInitIso on the hook sidecar", Label("test_id:3168"), func() {
 				By("Getting hook-sidecar logs")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", Labels{"sig-compute"}, fu
 					Should(ContainSubstring("Hook's PreCloudInitIso callback method has been called"))
 			})
 
-			It("[test_id:3169]should have cloud-init user-data from sidecar", Labels{"test_id:3169"}, func() {
+			It("[test_id:3169]should have cloud-init user-data from sidecar", Label("test_id:3169"), func() {
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -42,7 +42,7 @@ import (
 
 const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
 
-var _ = Describe("[sig-compute]CloudInitHookSidecars", func() {
+var _ = Describe("[sig-compute]CloudInitHookSidecars", Labels{"sig-compute"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -102,13 +102,13 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", func() {
 
 	Describe("VMI definition", func() {
 		Context("with CloudInit hook sidecar", func() {
-			It("[test_id:3167]should successfully start with hook sidecar annotation", func() {
+			It("[test_id:3167]should successfully start with hook sidecar annotation", Labels{"test_id:3167"}, func() {
 				By("Starting a VMI")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:3168]should call Collect and PreCloudInitIso on the hook sidecar", func() {
+			It("[test_id:3168]should call Collect and PreCloudInitIso on the hook sidecar", Labels{"test_id:3168"}, func() {
 				By("Getting hook-sidecar logs")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", func() {
 					Should(ContainSubstring("Hook's PreCloudInitIso callback method has been called"))
 			})
 
-			It("[test_id:3169]should have cloud-init user-data from sidecar", func() {
+			It("[test_id:3169]should have cloud-init user-data from sidecar", Labels{"test_id:3169"}, func() {
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -56,351 +56,355 @@ const (
 	testUserData     = "#cloud-config"
 )
 
-var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]CloudInit UserData", func() {
+var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]CloudInit UserData",
+	Labels{"rfe_id:151", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
+		var err error
+		var virtClient kubecli.KubevirtClient
 
-	var (
-		LaunchVMI                 func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
-		VerifyUserDataVMI         func(*v1.VirtualMachineInstance, []expect.Batcher, time.Duration)
-		MountCloudInitNoCloud     func(*v1.VirtualMachineInstance)
-		MountCloudInitConfigDrive func(*v1.VirtualMachineInstance)
-		CheckCloudInitFile        func(*v1.VirtualMachineInstance, string, string)
-		CheckCloudInitIsoSize     func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType)
-	)
+		var (
+			LaunchVMI                 func(*v1.VirtualMachineInstance) *v1.VirtualMachineInstance
+			VerifyUserDataVMI         func(*v1.VirtualMachineInstance, []expect.Batcher, time.Duration)
+			MountCloudInitNoCloud     func(*v1.VirtualMachineInstance)
+			MountCloudInitConfigDrive func(*v1.VirtualMachineInstance)
+			CheckCloudInitFile        func(*v1.VirtualMachineInstance, string, string)
+			CheckCloudInitIsoSize     func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType)
+		)
 
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
+			tests.BeforeTestCleanup()
 
-		// from default virt-launcher flag: do we need to make this configurable in some cases?
-		cloudinit.SetLocalDirectoryOnly("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
-		MountCloudInitNoCloud = tests.MountCloudInitFunc("cidata")
-		MountCloudInitConfigDrive = tests.MountCloudInitFunc("config-2")
-	})
+			// from default virt-launcher flag: do we need to make this configurable in some cases?
+			cloudinit.SetLocalDirectoryOnly("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
+			MountCloudInitNoCloud = tests.MountCloudInitFunc("cidata")
+			MountCloudInitConfigDrive = tests.MountCloudInitFunc("config-2")
+		})
 
-	LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
-		By("Starting a VirtualMachineInstance")
-		obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
-		Expect(err).To(BeNil())
+		LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+			By("Starting a VirtualMachineInstance")
+			obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
+			Expect(err).To(BeNil())
 
-		By("Waiting the VirtualMachineInstance start")
-		vmi, ok := obj.(*v1.VirtualMachineInstance)
-		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-		Expect(tests.WaitForSuccessfulVMIStart(obj).Status.NodeName).ToNot(BeEmpty())
-		return vmi
-	}
+			By("Waiting the VirtualMachineInstance start")
+			vmi, ok := obj.(*v1.VirtualMachineInstance)
+			Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
+			Expect(tests.WaitForSuccessfulVMIStart(obj).Status.NodeName).ToNot(BeEmpty())
+			return vmi
+		}
 
-	VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
-		By("Checking that the VirtualMachineInstance serial console output equals to expected one")
-		Expect(console.SafeExpectBatch(vmi, commands, int(timeout.Seconds()))).To(Succeed())
-	}
+		VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
+			By("Checking that the VirtualMachineInstance serial console output equals to expected one")
+			Expect(console.SafeExpectBatch(vmi, commands, int(timeout.Seconds()))).To(Succeed())
+		}
 
-	CheckCloudInitFile = func(vmi *v1.VirtualMachineInstance, testFile, testData string) {
-		cmdCheck := "cat " + filepath.Join("/mnt", testFile) + "\n"
-		err := console.SafeExpectBatch(vmi, []expect.Batcher{
-			&expect.BSnd{S: "sudo su -\n"},
-			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: cmdCheck},
-			&expect.BExp{R: testData},
-		}, 15)
-		Expect(err).ToNot(HaveOccurred())
-	}
+		CheckCloudInitFile = func(vmi *v1.VirtualMachineInstance, testFile, testData string) {
+			cmdCheck := "cat " + filepath.Join("/mnt", testFile) + "\n"
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "sudo su -\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: cmdCheck},
+				&expect.BExp{R: testData},
+			}, 15)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
-	CheckCloudInitIsoSize = func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType) {
-		pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-		path := cloudinit.GetIsoFilePath(source, vmi.Name, vmi.Namespace)
+		CheckCloudInitIsoSize = func(vmi *v1.VirtualMachineInstance, source cloudinit.DataSourceType) {
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			path := cloudinit.GetIsoFilePath(source, vmi.Name, vmi.Namespace)
 
-		By(fmt.Sprintf("Checking cloud init ISO at '%s' is 4k-block fs compatible", path))
-		cmdCheck := []string{"stat", "--printf='%s'", path}
+			By(fmt.Sprintf("Checking cloud init ISO at '%s' is 4k-block fs compatible", path))
+			cmdCheck := []string{"stat", "--printf='%s'", path}
 
-		out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
-		Expect(err).NotTo(HaveOccurred())
-		size, err := strconv.Atoi(strings.Trim(out, "'"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(size % 4096).To(Equal(0))
-	}
+			out, err := tests.ExecuteCommandOnPod(virtClient, pod, "compute", cmdCheck)
+			Expect(err).NotTo(HaveOccurred())
+			size, err := strconv.Atoi(strings.Trim(out, "'"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(size % 4096).To(Equal(0))
+		}
 
-	Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
-		Context("with cloudInitNoCloud userDataBase64 source", func() {
-			It("[test_id:1615]should have cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
+		Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance",
+			Labels{"rfe_id:151", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				Context("with cloudInitNoCloud userDataBase64 source", func() {
+					It("[test_id:1615]should have cloud-init data", Labels{"test_id:1615"}, func() {
+						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-				LaunchVMI(vmi)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
-			})
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+						LaunchVMI(vmi)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+						VerifyUserDataVMI(vmi, []expect.Batcher{
+							&expect.BSnd{S: "\n"},
+							&expect.BExp{R: expectedUserData},
+						}, time.Second*120)
+					})
 
-			Context("with injected ssh-key", func() {
-				It("[test_id:1616]should have ssh-key under authorized keys", func() {
-					userData := fmt.Sprintf(
-						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
-						fedoraPassword,
-						sshAuthorizedKey,
-					)
-					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userData)
+					Context("with injected ssh-key", func() {
+						It("[test_id:1616]should have ssh-key under authorized keys", Labels{"test_id:1616"}, func() {
+							userData := fmt.Sprintf(
+								"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
+								fedoraPassword,
+								sshAuthorizedKey,
+							)
+							vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userData)
 
+							LaunchVMI(vmi)
+							CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+							VerifyUserDataVMI(vmi, []expect.Batcher{
+								&expect.BSnd{S: "\n"},
+								&expect.BExp{R: "login:"},
+								&expect.BSnd{S: "fedora\n"},
+								&expect.BExp{R: "Password:"},
+								&expect.BSnd{S: fedoraPassword + "\n"},
+								&expect.BExp{R: console.PromptExpression},
+								&expect.BSnd{S: "cat /home/fedora/.ssh/authorized_keys\n"},
+								&expect.BExp{R: "test-ssh-key"},
+							}, time.Second*300)
+						})
+					})
+				})
+
+				Context("with cloudInitConfigDrive userDataBase64 source", func() {
+					It("[test_id:3178]should have cloud-init data", Labels{"test_id:3178"}, func() {
+						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
+
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+						LaunchVMI(vmi)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+						VerifyUserDataVMI(vmi, []expect.Batcher{
+							&expect.BSnd{S: "\n"},
+							&expect.BExp{R: expectedUserData},
+						}, time.Second*120)
+					})
+
+					Context("with injected ssh-key", func() {
+						It("[test_id:3178]should have ssh-key under authorized keys", Labels{"test_id:3178"}, func() {
+							userData := fmt.Sprintf(
+								"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
+								fedoraPassword,
+								sshAuthorizedKey,
+							)
+							vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userData)
+
+							LaunchVMI(vmi)
+							CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+							VerifyUserDataVMI(vmi, []expect.Batcher{
+								&expect.BSnd{S: "\n"},
+								&expect.BExp{R: "login:"},
+								&expect.BSnd{S: "fedora\n"},
+								&expect.BExp{R: "Password:"},
+								&expect.BSnd{S: fedoraPassword + "\n"},
+								&expect.BExp{R: console.PromptExpression},
+								&expect.BSnd{S: "cat /home/fedora/.ssh/authorized_keys\n"},
+								&expect.BExp{R: "test-ssh-key"},
+							}, time.Second*300)
+						})
+					})
+				})
+
+				Context("with cloudInitNoCloud userData source", func() {
+					It("[test_id:1617]should process provided cloud-init data", Labels{"test_id:1617"}, func() {
+						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+
+						vmi = LaunchVMI(vmi)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+						By("executing a user-data script")
+						VerifyUserDataVMI(vmi, []expect.Batcher{
+							&expect.BSnd{S: "\n"},
+							&expect.BExp{R: expectedUserData},
+						}, time.Second*120)
+
+				By("applying the hostname from meta-data")
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+							&expect.BSnd{S: "hostname\n"},
+							&expect.BExp{R: dns.SanitizeHostname(vmi)},
+						}, 10)).To(Succeed())
+					})
+				})
+
+				Context("with cloudInitConfigDrive userData source", func() {
+					It("[test_id:3180]should process provided cloud-init data", Labels{"test_id:3180"}, func() {
+						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+
+						vmi = LaunchVMI(vmi)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+						By("executing a user-data script")
+						VerifyUserDataVMI(vmi, []expect.Batcher{
+							&expect.BSnd{S: "\n"},
+							&expect.BExp{R: expectedUserData},
+						}, time.Second*120)
+
+				By("applying the hostname from meta-data")
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+							&expect.BSnd{S: "hostname\n"},
+							&expect.BExp{R: dns.SanitizeHostname(vmi)},
+						}, 10)).To(Succeed())
+					})
+				})
+
+				It("[test_id:1618]should take user-data from k8s secret", Labels{"test_id:1618"}, func() {
+					userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
+					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "")
+
+					idx := 0
+					for i, volume := range vmi.Spec.Volumes {
+						if volume.CloudInitNoCloud == nil {
+							continue
+						}
+						idx = i
+
+						secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
+						spec := volume.CloudInitNoCloud
+						spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
+
+						// Store userdata as k8s secret
+						By("Creating a user-data secret")
+						secret := kubev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      secretID,
+								Namespace: vmi.Namespace,
+								Labels: map[string]string{
+									tests.SecretLabel: secretID,
+								},
+							},
+							Type: "Opaque",
+							Data: map[string][]byte{
+								"userdata": []byte(userData), // The client encrypts the secret for us
+							},
+						}
+						_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+						Expect(err).To(BeNil())
+						break
+					}
 					LaunchVMI(vmi)
 					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 					VerifyUserDataVMI(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
-						&expect.BExp{R: "login:"},
-						&expect.BSnd{S: "fedora\n"},
-						&expect.BExp{R: "Password:"},
-						&expect.BSnd{S: fedoraPassword + "\n"},
-						&expect.BExp{R: console.PromptExpression},
-						&expect.BSnd{S: "cat /home/fedora/.ssh/authorized_keys\n"},
-						&expect.BExp{R: "test-ssh-key"},
-					}, time.Second*300)
+						&expect.BExp{R: expectedUserData},
+					}, time.Second*120)
+
+					// Expect that the secret is not present on the vmi itself
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserData).To(BeEmpty())
+					Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserDataBase64).To(BeEmpty())
 				})
-			})
-		})
-
-		Context("with cloudInitConfigDrive userDataBase64 source", func() {
-			It("[test_id:3178]should have cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-				LaunchVMI(vmi)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
-			})
-
-			Context("with injected ssh-key", func() {
-				It("[test_id:3178]should have ssh-key under authorized keys", func() {
-					userData := fmt.Sprintf(
-						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
-						fedoraPassword,
-						sshAuthorizedKey,
-					)
-					vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userData)
-
-					LaunchVMI(vmi)
-					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-					VerifyUserDataVMI(vmi, []expect.Batcher{
-						&expect.BSnd{S: "\n"},
-						&expect.BExp{R: "login:"},
-						&expect.BSnd{S: "fedora\n"},
-						&expect.BExp{R: "Password:"},
-						&expect.BSnd{S: fedoraPassword + "\n"},
-						&expect.BExp{R: console.PromptExpression},
-						&expect.BSnd{S: "cat /home/fedora/.ssh/authorized_keys\n"},
-						&expect.BExp{R: "test-ssh-key"},
-					}, time.Second*300)
-				})
-			})
-		})
-
-		Context("with cloudInitNoCloud userData source", func() {
-			It("[test_id:1617]should process provided cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-
-				vmi = LaunchVMI(vmi)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-				By("executing a user-data script")
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
-
-				By("applying the hostname from meta-data")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "hostname\n"},
-					&expect.BExp{R: dns.SanitizeHostname(vmi)},
-				}, 10)).To(Succeed())
-			})
-		})
-
-		Context("with cloudInitConfigDrive userData source", func() {
-			It("[test_id:3180]should process provided cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-
-				vmi = LaunchVMI(vmi)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-				By("executing a user-data script")
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
-
-				By("applying the hostname from meta-data")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "hostname\n"},
-					&expect.BExp{R: dns.SanitizeHostname(vmi)},
-				}, 10)).To(Succeed())
-			})
-		})
-
-		It("[test_id:1618]should take user-data from k8s secret", func() {
-			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "")
-
-			idx := 0
-			for i, volume := range vmi.Spec.Volumes {
-				if volume.CloudInitNoCloud == nil {
-					continue
-				}
-				idx = i
-
-				secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
-				spec := volume.CloudInitNoCloud
-				spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
-
-				// Store userdata as k8s secret
-				By("Creating a user-data secret")
-				secret := kubev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      secretID,
-						Namespace: vmi.Namespace,
-						Labels: map[string]string{
-							tests.SecretLabel: secretID,
-						},
-					},
-					Type: "Opaque",
-					Data: map[string][]byte{
-						"userdata": []byte(userData), // The client encrypts the secret for us
-					},
-				}
-				_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				break
-			}
-			LaunchVMI(vmi)
-			CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-			VerifyUserDataVMI(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: expectedUserData},
-			}, time.Second*120)
-
-			// Expect that the secret is not present on the vmi itself
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserData).To(BeEmpty())
-			Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserDataBase64).To(BeEmpty())
-		})
 
 		Context("with cloudInitNoCloud networkData", func() {
-			It("[test_id:3181]should have cloud-init network-config with NetworkData source", func() {
+			It("[test_id:3181]should have cloud-init network-config with NetworkData source", Labels{"test_id:3181"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
-				By("mouting cloudinit iso")
-				MountCloudInitNoCloud(vmi)
+						By("mouting cloudinit iso")
+						MountCloudInitNoCloud(vmi)
 
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "network-config", testNetworkData)
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "network-config", testNetworkData)
 
 			})
-			It("[test_id:3182]should have cloud-init network-config with NetworkDataBase64 source", func() {
+			It("[test_id:3182]should have cloud-init network-config with NetworkDataBase64 source", Labels{"test_id:3182"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
-				By("mouting cloudinit iso")
-				MountCloudInitNoCloud(vmi)
+						By("mouting cloudinit iso")
+						MountCloudInitNoCloud(vmi)
 
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "network-config", testNetworkData)
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "network-config", testNetworkData)
 
-			})
-			It("[test_id:3183]should have cloud-init network-config from k8s secret", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
+					})
+					It("[test_id:3183]should have cloud-init network-config from k8s secret", Labels{"test_id:3183"}, func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
 
-				idx := 0
-				for i, volume := range vmi.Spec.Volumes {
-					if volume.CloudInitNoCloud == nil {
-						continue
-					}
-					idx = i
+						idx := 0
+						for i, volume := range vmi.Spec.Volumes {
+							if volume.CloudInitNoCloud == nil {
+								continue
+							}
+							idx = i
 
-					secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
-					spec := volume.CloudInitNoCloud
-					spec.NetworkDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
+							secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
+							spec := volume.CloudInitNoCloud
+							spec.NetworkDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
 
-					// Store cloudinit data as k8s secret
-					By("Creating a secret with network data")
-					secret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      secretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								tests.SecretLabel: secretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							"networkdata": []byte(testNetworkData),
-						},
-					}
-					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
+							// Store cloudinit data as k8s secret
+							By("Creating a secret with network data")
+							secret := kubev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      secretID,
+									Namespace: vmi.Namespace,
+									Labels: map[string]string{
+										tests.SecretLabel: secretID,
+									},
+								},
+								Type: "Opaque",
+								Data: map[string][]byte{
+									// The client encrypts the secret for us
+									"networkdata": []byte(testNetworkData),
+								},
+							}
+							_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+							Expect(err).To(BeNil())
 
-					break
-				}
-
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-
-				By("mouting cloudinit iso")
-				MountCloudInitNoCloud(vmi)
-
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "network-config", testNetworkData)
-
-				// Expect that the secret is not present on the vmi itself
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserData).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserDataBase64).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.NetworkData).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.NetworkDataBase64).To(BeEmpty())
-			})
-
-		})
-
-		Context("with cloudInitConfigDrive networkData", func() {
-			It("[test_id:3184]should have cloud-init network-config with NetworkData source", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
+							break
+						}
 
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
-				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+						By("mouting cloudinit iso")
+						MountCloudInitNoCloud(vmi)
+
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "network-config", testNetworkData)
+
+						// Expect that the secret is not present on the vmi itself
+						vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserData).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserDataBase64).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.NetworkData).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.NetworkDataBase64).To(BeEmpty())
+					})
+
+				})
+
+				Context("with cloudInitConfigDrive networkData", func() {
+					It("[test_id:3184]should have cloud-init network-config with NetworkData source", Labels{"test_id:3184"}, func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
+
+				LaunchVMI(vmi)
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+
+						By("mouting cloudinit iso")
+						MountCloudInitConfigDrive(vmi)
 
 				By("checking cloudinit network-config")
 				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
 			})
-			It("[test_id:4622]should have cloud-init meta_data with tagged devices", func() {
+			It("[test_id:4622]should have cloud-init meta_data with tagged devices", Labels{"test_id:4622"}, func() {
 				testFlavor := "testFlavor"
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
@@ -414,199 +418,199 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
+						domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+						Expect(err).ToNot(HaveOccurred())
 
-				domSpec := &api.DomainSpec{}
-				Expect(xml.Unmarshal([]byte(domXml), domSpec)).To(Succeed())
-				nic := domSpec.Devices.Interfaces[0]
-				address := nic.Address
-				pciAddrStr := fmt.Sprintf("%s:%s:%s.%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
-				deviceData := []cloudinit.DeviceData{
-					{
-						Type:    cloudinit.NICMetadataType,
-						Bus:     nic.Address.Type,
-						Address: pciAddrStr,
-						MAC:     nic.MAC.MAC,
-						Tags:    []string{"specialNet"},
-					},
-				}
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+						domSpec := &api.DomainSpec{}
+						Expect(xml.Unmarshal([]byte(domXml), domSpec)).To(Succeed())
+						nic := domSpec.Devices.Interfaces[0]
+						address := nic.Address
+						pciAddrStr := fmt.Sprintf("%s:%s:%s.%s", address.Domain[2:], address.Bus[2:], address.Slot[2:], address.Function[2:])
+						deviceData := []cloudinit.DeviceData{
+							{
+								Type:    cloudinit.NICMetadataType,
+								Bus:     nic.Address.Type,
+								Address: pciAddrStr,
+								MAC:     nic.MAC.MAC,
+								Tags:    []string{"specialNet"},
+							},
+						}
+						vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
 
-				metadataStruct := cloudinit.ConfigDriveMetadata{
-					InstanceID:   fmt.Sprintf("%s.%s", vmi.Name, vmi.Namespace),
-					InstanceType: testFlavor,
-					Hostname:     dns.SanitizeHostname(vmi),
-					UUID:         string(vmi.UID),
-					Devices:      &deviceData,
-				}
+						metadataStruct := cloudinit.ConfigDriveMetadata{
+							InstanceID:   fmt.Sprintf("%s.%s", vmi.Name, vmi.Namespace),
+							InstanceType: testFlavor,
+							Hostname:     dns.SanitizeHostname(vmi),
+							UUID:         string(vmi.UID),
+							Devices:      &deviceData,
+						}
 
-				buf, err := json.Marshal(metadataStruct)
-				Expect(err).To(BeNil())
-				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+						buf, err := json.Marshal(metadataStruct)
+						Expect(err).To(BeNil())
+						By("mouting cloudinit iso")
+						MountCloudInitConfigDrive(vmi)
 
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
 
 				By("checking cloudinit meta-data")
 				tests.CheckCloudInitMetaData(vmi, "openstack/latest/meta_data.json", string(buf))
 			})
-			It("[test_id:3185]should have cloud-init network-config with NetworkDataBase64 source", func() {
+			It("[test_id:3185]should have cloud-init network-config with NetworkDataBase64 source", Labels{"test_id:3185"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+						By("mouting cloudinit iso")
+						MountCloudInitConfigDrive(vmi)
 
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
 
-			})
-			It("[test_id:3186]should have cloud-init network-config from k8s secret", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
+					})
+					It("[test_id:3186]should have cloud-init network-config from k8s secret", Labels{"test_id:3186"}, func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
 
-				idx := 0
-				for i, volume := range vmi.Spec.Volumes {
-					if volume.CloudInitConfigDrive == nil {
-						continue
-					}
-					idx = i
+						idx := 0
+						for i, volume := range vmi.Spec.Volumes {
+							if volume.CloudInitConfigDrive == nil {
+								continue
+							}
+							idx = i
 
-					secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
-					spec := volume.CloudInitConfigDrive
-					spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
-					spec.NetworkDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
+							secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
+							spec := volume.CloudInitConfigDrive
+							spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
+							spec.NetworkDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
 
-					// Store cloudinit data as k8s secret
-					By("Creating a secret with user and network data")
-					secret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      secretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								tests.SecretLabel: secretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							"networkdata": []byte(testNetworkData),
-						},
-					}
-					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
+							// Store cloudinit data as k8s secret
+							By("Creating a secret with user and network data")
+							secret := kubev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      secretID,
+									Namespace: vmi.Namespace,
+									Labels: map[string]string{
+										tests.SecretLabel: secretID,
+									},
+								},
+								Type: "Opaque",
+								Data: map[string][]byte{
+									// The client encrypts the secret for us
+									"networkdata": []byte(testNetworkData),
+								},
+							}
+							_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+							Expect(err).To(BeNil())
 
-					break
-				}
-
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-
-				By("mouting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
-
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
-
-				// Expect that the secret is not present on the vmi itself
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkData).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkDataBase64).To(BeEmpty())
-			})
-
-			DescribeTable("[test_id:3187]should have cloud-init userdata and network-config from separate k8s secrets", func(userDataLabel string, networkDataLabel string) {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
-
-				idx := 0
-				for i, volume := range vmi.Spec.Volumes {
-					if volume.CloudInitConfigDrive == nil {
-						continue
-					}
-					idx = i
-
-					uSecretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
-					spec := volume.CloudInitConfigDrive
-					spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: uSecretID}
-
-					nSecretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
-					spec.NetworkDataSecretRef = &kubev1.LocalObjectReference{Name: nSecretID}
-
-					// Store cloudinit data as k8s secret
-					By("Creating a secret with userdata")
-					uSecret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      uSecretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								tests.SecretLabel: uSecretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							userDataLabel: []byte(testUserData),
-						},
-					}
-					By("Creating a secret with network data")
-					nSecret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      nSecretID,
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								tests.SecretLabel: nSecretID,
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							// The client encrypts the secret for us
-							networkDataLabel: []byte(testNetworkData),
-						},
-					}
-					_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &uSecret, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-
-					_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &nSecret, metav1.CreateOptions{})
-					Expect(err).To(BeNil())
-
-					break
-				}
+							break
+						}
 
 				LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
-				By("mounting cloudinit iso")
-				MountCloudInitConfigDrive(vmi)
+						By("mouting cloudinit iso")
+						MountCloudInitConfigDrive(vmi)
 
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
 
-				By("checking cloudinit user-data")
-				CheckCloudInitFile(vmi, "openstack/latest/user_data", testUserData)
+						// Expect that the secret is not present on the vmi itself
+						vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkData).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkDataBase64).To(BeEmpty())
+					})
 
-				// Expect that the secret is not present on the vmi itself
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.UserData).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.UserDataBase64).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkData).To(BeEmpty())
-				Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkDataBase64).To(BeEmpty())
-			},
-				Entry("with lowercase labels", "userdata", "networkdata"),
-				Entry("with camelCase labels", "userData", "networkData"),
-			)
-		})
+					DescribeTable("[test_id:3187]should have cloud-init userdata and network-config from separate k8s secrets", Labels{"test_id:3187"}, func(userDataLabel string, networkDataLabel string) {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
 
+						idx := 0
+						for i, volume := range vmi.Spec.Volumes {
+							if volume.CloudInitConfigDrive == nil {
+								continue
+							}
+							idx = i
+
+							uSecretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
+							spec := volume.CloudInitConfigDrive
+							spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: uSecretID}
+
+							nSecretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
+							spec.NetworkDataSecretRef = &kubev1.LocalObjectReference{Name: nSecretID}
+
+							// Store cloudinit data as k8s secret
+							By("Creating a secret with userdata")
+							uSecret := kubev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      uSecretID,
+									Namespace: vmi.Namespace,
+									Labels: map[string]string{
+										tests.SecretLabel: uSecretID,
+									},
+								},
+								Type: "Opaque",
+								Data: map[string][]byte{
+									// The client encrypts the secret for us
+									userDataLabel: []byte(testUserData),
+								},
+							}
+							By("Creating a secret with network data")
+							nSecret := kubev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      nSecretID,
+									Namespace: vmi.Namespace,
+									Labels: map[string]string{
+										tests.SecretLabel: nSecretID,
+									},
+								},
+								Type: "Opaque",
+								Data: map[string][]byte{
+									// The client encrypts the secret for us
+									networkDataLabel: []byte(testNetworkData),
+								},
+							}
+							_, err := virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &uSecret, metav1.CreateOptions{})
+							Expect(err).To(BeNil())
+
+							_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &nSecret, metav1.CreateOptions{})
+							Expect(err).To(BeNil())
+
+							break
+						}
+
+				LaunchVMI(vmi)
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+
+						By("mounting cloudinit iso")
+						MountCloudInitConfigDrive(vmi)
+
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+
+						By("checking cloudinit user-data")
+						CheckCloudInitFile(vmi, "openstack/latest/user_data", testUserData)
+
+						// Expect that the secret is not present on the vmi itself
+						vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.UserData).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.UserDataBase64).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkData).To(BeEmpty())
+						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkDataBase64).To(BeEmpty())
+					},
+						Entry("with lowercase labels", "userdata", "networkdata"),
+						Entry("with camelCase labels", "userData", "networkData"),
+					)
+				})
+
+			})
 	})
-})

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -57,7 +57,7 @@ const (
 )
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]CloudInit UserData",
-	Labels{"rfe_id:151", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:151", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error
@@ -126,10 +126,10 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		}
 
 		Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance",
-			Labels{"rfe_id:151", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:151", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with cloudInitNoCloud userDataBase64 source", func() {
-					It("[test_id:1615]should have cloud-init data", Labels{"test_id:1615"}, func() {
+					It("[test_id:1615]should have cloud-init data", Label("test_id:1615"), func() {
 						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
@@ -142,7 +142,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					})
 
 					Context("with injected ssh-key", func() {
-						It("[test_id:1616]should have ssh-key under authorized keys", Labels{"test_id:1616"}, func() {
+						It("[test_id:1616]should have ssh-key under authorized keys", Label("test_id:1616"), func() {
 							userData := fmt.Sprintf(
 								"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 								fedoraPassword,
@@ -167,7 +167,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				})
 
 				Context("with cloudInitConfigDrive userDataBase64 source", func() {
-					It("[test_id:3178]should have cloud-init data", Labels{"test_id:3178"}, func() {
+					It("[test_id:3178]should have cloud-init data", Label("test_id:3178"), func() {
 						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
@@ -180,7 +180,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					})
 
 					Context("with injected ssh-key", func() {
-						It("[test_id:3178]should have ssh-key under authorized keys", Labels{"test_id:3178"}, func() {
+						It("[test_id:3178]should have ssh-key under authorized keys", Label("test_id:3178"), func() {
 							userData := fmt.Sprintf(
 								"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 								fedoraPassword,
@@ -205,7 +205,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				})
 
 				Context("with cloudInitNoCloud userData source", func() {
-					It("[test_id:1617]should process provided cloud-init data", Labels{"test_id:1617"}, func() {
+					It("[test_id:1617]should process provided cloud-init data", Label("test_id:1617"), func() {
 						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 
@@ -217,8 +217,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							&expect.BExp{R: expectedUserData},
 						}, time.Second*120)
 
-				By("applying the hostname from meta-data")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+						By("applying the hostname from meta-data")
+						Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 							&expect.BSnd{S: "hostname\n"},
@@ -228,7 +228,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				})
 
 				Context("with cloudInitConfigDrive userData source", func() {
-					It("[test_id:3180]should process provided cloud-init data", Labels{"test_id:3180"}, func() {
+					It("[test_id:3180]should process provided cloud-init data", Label("test_id:3180"), func() {
 						userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
 
@@ -240,8 +240,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							&expect.BExp{R: expectedUserData},
 						}, time.Second*120)
 
-				By("applying the hostname from meta-data")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+						By("applying the hostname from meta-data")
+						Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 						Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 							&expect.BSnd{S: "hostname\n"},
@@ -250,7 +250,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					})
 				})
 
-				It("[test_id:1618]should take user-data from k8s secret", Labels{"test_id:1618"}, func() {
+				It("[test_id:1618]should take user-data from k8s secret", Label("test_id:1618"), func() {
 					userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "")
 
@@ -298,27 +298,12 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					Expect(vmi.Spec.Volumes[idx].CloudInitNoCloud.UserDataBase64).To(BeEmpty())
 				})
 
-		Context("with cloudInitNoCloud networkData", func() {
-			It("[test_id:3181]should have cloud-init network-config with NetworkData source", Labels{"test_id:3181"}, func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-
-						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-
-						By("mouting cloudinit iso")
-						MountCloudInitNoCloud(vmi)
-
-						By("checking cloudinit network-config")
-						CheckCloudInitFile(vmi, "network-config", testNetworkData)
-
-			})
-			It("[test_id:3182]should have cloud-init network-config with NetworkDataBase64 source", Labels{"test_id:3182"}, func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				Context("with cloudInitNoCloud networkData", func() {
+					It("[test_id:3181]should have cloud-init network-config with NetworkData source", Label("test_id:3181"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -329,7 +314,22 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						CheckCloudInitFile(vmi, "network-config", testNetworkData)
 
 					})
-					It("[test_id:3183]should have cloud-init network-config from k8s secret", Labels{"test_id:3183"}, func() {
+					It("[test_id:3182]should have cloud-init network-config with NetworkDataBase64 source", Label("test_id:3182"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+
+						By("mouting cloudinit iso")
+						MountCloudInitNoCloud(vmi)
+
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "network-config", testNetworkData)
+
+					})
+					It("[test_id:3183]should have cloud-init network-config from k8s secret", Label("test_id:3183"), func() {
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
 
@@ -366,8 +366,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							break
 						}
 
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
 
@@ -389,34 +389,34 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				})
 
 				Context("with cloudInitConfigDrive networkData", func() {
-					It("[test_id:3184]should have cloud-init network-config with NetworkData source", Labels{"test_id:3184"}, func() {
+					It("[test_id:3184]should have cloud-init network-config with NetworkData source", Label("test_id:3184"), func() {
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
 
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 						By("mouting cloudinit iso")
 						MountCloudInitConfigDrive(vmi)
 
-				By("checking cloudinit network-config")
-				CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
-			})
-			It("[test_id:4622]should have cloud-init meta_data with tagged devices", Labels{"test_id:4622"}, func() {
-				testFlavor := "testFlavor"
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", Tag: "specialNet", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}}
-				vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-				if vmi.Annotations == nil {
-					vmi.Annotations = make(map[string]string)
-				}
-				vmi.Annotations[v1.FlavorAnnotation] = testFlavor
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+						By("checking cloudinit network-config")
+						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
+					})
+					It("[test_id:4622]should have cloud-init meta_data with tagged devices", Label("test_id:4622"), func() {
+						testFlavor := "testFlavor"
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, false)
+						vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", Tag: "specialNet", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}}
+						vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+						if vmi.Annotations == nil {
+							vmi.Annotations = make(map[string]string)
+						}
+						vmi.Annotations[v1.FlavorAnnotation] = testFlavor
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 						domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 						Expect(err).ToNot(HaveOccurred())
@@ -454,14 +454,14 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						By("checking cloudinit network-config")
 						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
 
-				By("checking cloudinit meta-data")
-				tests.CheckCloudInitMetaData(vmi, "openstack/latest/meta_data.json", string(buf))
-			})
-			It("[test_id:3185]should have cloud-init network-config with NetworkDataBase64 source", Labels{"test_id:3185"}, func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						By("checking cloudinit meta-data")
+						tests.CheckCloudInitMetaData(vmi, "openstack/latest/meta_data.json", string(buf))
+					})
+					It("[test_id:3185]should have cloud-init network-config with NetworkDataBase64 source", Label("test_id:3185"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
+							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", testNetworkData, true)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 						By("mouting cloudinit iso")
@@ -471,7 +471,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						CheckCloudInitFile(vmi, "openstack/latest/network_data.json", testNetworkData)
 
 					})
-					It("[test_id:3186]should have cloud-init network-config from k8s secret", Labels{"test_id:3186"}, func() {
+					It("[test_id:3186]should have cloud-init network-config from k8s secret", Label("test_id:3186"), func() {
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
 
@@ -509,8 +509,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							break
 						}
 
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -527,7 +527,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						Expect(vmi.Spec.Volumes[idx].CloudInitConfigDrive.NetworkDataBase64).To(BeEmpty())
 					})
 
-					DescribeTable("[test_id:3187]should have cloud-init userdata and network-config from separate k8s secrets", Labels{"test_id:3187"}, func(userDataLabel string, networkDataLabel string) {
+					DescribeTable("[test_id:3187]should have cloud-init userdata and network-config from separate k8s secrets", Label("test_id:3187"), func(userDataLabel string, networkDataLabel string) {
 						vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 							cd.ContainerDiskFor(cd.ContainerDiskCirros), "", "", false)
 
@@ -585,8 +585,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							break
 						}
 
-				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						LaunchVMI(vmi)
+						tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 						CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -239,15 +239,15 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				})
 
-			It("[test_id:1659]should report 3 cpu cores under guest OS", Labels{"test_id:1659"}, func() {
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 3,
-				}
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("100M"),
-					},
-				}
+				It("[test_id:1659]should report 3 cpu cores under guest OS", Labels{"test_id:1659"}, func() {
+					vmi.Spec.Domain.CPU = &v1.CPU{
+						Cores: 3,
+					}
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("100M"),
+						},
+					}
 
 					By("Starting a VirtualMachineInstance")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -263,21 +263,21 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 						&expect.BExp{R: console.RetValue("3")},
 					}, 15)).To(Succeed(), "should report number of cores")
 
-				By("Checking the requested amount of memory allocated for a guest")
-				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("100M"))
+					By("Checking the requested amount of memory allocated for a guest")
+					Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("100M"))
 
-				readyPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				var computeContainer *kubev1.Container
-				for _, container := range readyPod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainer = &container
-						break
+					readyPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					var computeContainer *kubev1.Container
+					for _, container := range readyPod.Spec.Containers {
+						if container.Name == "compute" {
+							computeContainer = &container
+							break
+						}
 					}
-				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
-				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(296)))
+					if computeContainer == nil {
+						util.PanicOnError(fmt.Errorf("could not find the compute container"))
+					}
+					Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(296)))
 
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -609,10 +609,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("225")},
-				}, 10)).To(Succeed())
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
+						&expect.BExp{R: console.RetValue("225")},
+					}, 10)).To(Succeed())
 
 				})
 			})
@@ -630,10 +630,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("225")},
-				}, 10)).To(Succeed())
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
+						&expect.BExp{R: console.RetValue("225")},
+					}, 10)).To(Succeed())
 
 				})
 			})
@@ -1170,19 +1170,19 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 							vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(hugepagesVmi.Name, &metav1.GetOptions{})
 							Expect(err).ToNot(HaveOccurred())
 
-						for _, cond := range vmi.Status.Conditions {
-							if cond.Type == v1.VirtualMachineInstanceConditionType(kubev1.PodScheduled) && cond.Status == kubev1.ConditionFalse {
-								vmiCondition = cond
-								return true
+							for _, cond := range vmi.Status.Conditions {
+								if cond.Type == v1.VirtualMachineInstanceConditionType(kubev1.PodScheduled) && cond.Status == kubev1.ConditionFalse {
+									vmiCondition = cond
+									return true
+								}
 							}
-						}
-						return false
-					}, 30*time.Second, time.Second).Should(BeTrue())
-					Expect(vmiCondition.Message).To(ContainSubstring("Insufficient hugepages-3Mi"))
-					Expect(vmiCondition.Reason).To(Equal("Unschedulable"))
+							return false
+						}, 30*time.Second, time.Second).Should(BeTrue())
+						Expect(vmiCondition.Message).To(ContainSubstring("Insufficient hugepages-3Mi"))
+						Expect(vmiCondition.Reason).To(Equal("Unschedulable"))
+					})
 				})
 			})
-		})
 
 		Context("[rfe_id:893][crit:medium][vendor:cnv-qe@redhat.com][level:component]with rng",
 			Labels{"rfe_id:893", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
@@ -1414,22 +1414,22 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				It("[test_id:4627]should return the whole data when agent is present", Labels{"test_id:4627"}, func() {
 					agentVMI := prepareAgentVM()
 
-				By("Expecting the Guest VM information")
-				Eventually(func() bool {
-					guestInfo, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
-					if err != nil {
-						// invalid request, retry
-						return false
-					}
+					By("Expecting the Guest VM information")
+					Eventually(func() bool {
+						guestInfo, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
+						if err != nil {
+							// invalid request, retry
+							return false
+						}
 
-					return guestInfo.Hostname != "" &&
-						guestInfo.Timezone != "" &&
-						guestInfo.GAVersion != "" &&
-						guestInfo.OS.Name != "" &&
-						len(guestInfo.FSInfo.Filesystems) > 0
+						return guestInfo.Hostname != "" &&
+							guestInfo.Timezone != "" &&
+							guestInfo.GAVersion != "" &&
+							guestInfo.OS.Name != "" &&
+							len(guestInfo.FSInfo.Filesystems) > 0
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in subresource")
-			})
+					}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in subresource")
+				})
 
 				It("[test_id:4628]should not return the whole data when agent is not present", Labels{"test_id:4628"}, func() {
 					agentVMI := prepareAgentVM()
@@ -1458,34 +1458,34 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 					Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 
-				By("Expecting the Guest VM information")
-				Eventually(func() bool {
-					userList, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).UserList(agentVMI.Name)
-					if err != nil {
-						// invalid request, retry
-						return false
-					}
+					By("Expecting the Guest VM information")
+					Eventually(func() bool {
+						userList, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).UserList(agentVMI.Name)
+						if err != nil {
+							// invalid request, retry
+							return false
+						}
 
-					return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
+						return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have fedora users")
-			})
+					}, 240*time.Second, 2).Should(BeTrue(), "Should have fedora users")
+				})
 
 				It("[test_id:4630]should return filesystem list", Labels{"test_id:4630"}, func() {
 					agentVMI := prepareAgentVM()
 
-				By("Expecting the Guest VM information")
-				Eventually(func() bool {
-					fsList, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).FilesystemList(agentVMI.Name)
-					if err != nil {
-						// invalid request, retry
-						return false
-					}
+					By("Expecting the Guest VM information")
+					Eventually(func() bool {
+						fsList, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).FilesystemList(agentVMI.Name)
+						if err != nil {
+							// invalid request, retry
+							return false
+						}
 
-					return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != ""
+						return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != ""
 
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have some filesystem")
-			})
+					}, 240*time.Second, 2).Should(BeTrue(), "Should have some filesystem")
+				})
 
 			})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -65,7 +65,7 @@ import (
 
 type VMICreationFuncWithEFI func() *v1.VirtualMachineInstance
 
-var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Configurations", Label("sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -105,7 +105,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 	})
 
 	Context("with all devices on the root PCI bus", func() {
-		It("[test_id:4623]should start run the guest as usual", Labels{"test_id:4623"}, func() {
+		It("[test_id:4623]should start run the guest as usual", Label("test_id:4623"), func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			vmi.Annotations = map[string]string{
 				v1.PlacePCIDevicesOnRootComplex: "true",
@@ -128,7 +128,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 	})
 
 	Context("when requesting virtio-transitional models", func() {
-		It("[test_id:6957]should start and run the guest", Labels{"test_id:6957"}, func() {
+		It("[test_id:6957]should start and run the guest", Label("test_id:6957"), func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
@@ -143,10 +143,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 	})
 
 	Context("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]for CPU and memory limits should",
-		Labels{"rfe_id:897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
-			It("[test_id:3110]lead to get the burstable QOS class assigned when limit and requests differ", Labels{"test_id:3110"}, func() {
+			It("[test_id:3110]lead to get the burstable QOS class assigned when limit and requests differ", Label("test_id:3110"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
@@ -161,7 +161,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSBurstable))
 			})
 
-			It("[test_id:3111]lead to get the guaranteed QOS class assigned when limit and requests are identical", Labels{"test_id:3111"}, func() {
+			It("[test_id:3111]lead to get the guaranteed QOS class assigned when limit and requests are identical", Label("test_id:3111"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				By("specifying identical limits and requests")
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
@@ -190,7 +190,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSGuaranteed))
 			})
 
-			It("[test_id:3112]lead to get the guaranteed QOS class assigned when only limits are set", Labels{"test_id:3112"}, func() {
+			It("[test_id:3112]lead to get the guaranteed QOS class assigned when only limits are set", Label("test_id:3112"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				By("specifying identical limits and requests")
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
@@ -225,7 +225,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 	Describe("VirtualMachineInstance definition", func() {
 		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores",
-			Labels{"Serial", "rfe_id:2065", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("Serial", "rfe_id:2065", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var availableNumberOfCPUs int
 				var vmi *v1.VirtualMachineInstance
@@ -239,7 +239,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				})
 
-				It("[test_id:1659]should report 3 cpu cores under guest OS", Labels{"test_id:1659"}, func() {
+				It("[test_id:1659]should report 3 cpu cores under guest OS", Label("test_id:1659"), func() {
 					vmi.Spec.Domain.CPU = &v1.CPU{
 						Cores: 3,
 					}
@@ -281,7 +281,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 					Expect(err).ToNot(HaveOccurred())
 				})
-				It("[test_id:4624]should set a correct memory units", Labels{"test_id:4624"}, func() {
+				It("[test_id:4624]should set a correct memory units", Label("test_id:4624"), func() {
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
 							kubev1.ResourceMemory: resource.MustParse("64Mi"),
@@ -300,7 +300,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(domXml).To(ContainSubstring(expectedMemoryXMLStr))
 				})
 
-				It("[test_id:1660]should report 3 sockets under guest OS", Labels{"test_id:1660"}, func() {
+				It("[test_id:1660]should report 3 sockets under guest OS", Label("test_id:1660"), func() {
 					vmi.Spec.Domain.CPU = &v1.CPU{
 						Sockets: 3,
 						Cores:   2,
@@ -326,7 +326,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report number of sockets")
 				})
 
-				It("[test_id:1661]should report 2 sockets from spec.domain.resources.requests under guest OS ", Labels{"test_id:1661"}, func() {
+				It("[test_id:1661]should report 2 sockets from spec.domain.resources.requests under guest OS ", Label("test_id:1661"), func() {
 					vmi.Spec.Domain.CPU = nil
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
@@ -350,7 +350,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report number of sockets")
 				})
 
-				It("[test_id:1662]should report 2 sockets from spec.domain.resources.limits under guest OS ", Labels{"test_id:1662"}, func() {
+				It("[test_id:1662]should report 2 sockets from spec.domain.resources.limits under guest OS ", Label("test_id:1662"), func() {
 					vmi.Spec.Domain.CPU = nil
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
@@ -376,7 +376,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report number of sockets")
 				})
 
-				It("[test_id:1663]should report 4 vCPUs under guest OS", Labels{"test_id:1663"}, func() {
+				It("[test_id:1663]should report 4 vCPUs under guest OS", Label("test_id:1663"), func() {
 					vmi.Spec.Domain.CPU = &v1.CPU{
 						Threads: 2,
 						Sockets: 2,
@@ -403,7 +403,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report number of threads")
 				})
 
-				It("[Serial][test_id:1664]should map cores to virtio block queues", Labels{"Serial", "test_id:1664"}, func() {
+				It("[Serial][test_id:1664]should map cores to virtio block queues", Label("Serial", "test_id:1664"), func() {
 					_true := true
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
@@ -423,7 +423,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(domXml).To(ContainSubstring("queues='3'"))
 				})
 
-				It("[test_id:1665]should map cores to virtio net queues", Labels{"test_id:1665"}, func() {
+				It("[test_id:1665]should map cores to virtio net queues", Label("test_id:1665"), func() {
 					if tests.ShouldAllowEmulation(virtClient) {
 						Skip("Software emulation should not be enabled for this test to run")
 					}
@@ -452,7 +452,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(domXml).ToNot(ContainSubstring("cache='none' queues='3'"))
 				})
 
-				It("[test_id:1667]should not enforce explicitly rejected virtio block queues without cores", Labels{"test_id:1667"}, func() {
+				It("[test_id:1667]should not enforce explicitly rejected virtio block queues without cores", Label("test_id:1667"), func() {
 					_false := false
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
@@ -473,9 +473,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with no memory requested",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
-				It("[test_id:3113]should failed to the VMI creation", Labels{"test_id:3113"}, func() {
+				It("[test_id:3113]should failed to the VMI creation", Label("test_id:3113"), func() {
 					vmi := tests.NewRandomVMI()
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
 					By("Starting a VirtualMachineInstance")
@@ -485,7 +485,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied",
-			Labels{"Serial", "rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("Serial", "rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					kv := util.GetCurrentKv(virtClient)
@@ -495,7 +495,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					tests.UpdateKubeVirtConfigValueAndWait(config)
 				})
 
-				It("[test_id:3114]should set requested amount of memory according to the specified virtual memory", Labels{"test_id:3114"}, func() {
+				It("[test_id:3114]should set requested amount of memory according to the specified virtual memory", Label("test_id:3114"), func() {
 					vmi := tests.NewRandomVMI()
 					guestMemory := resource.MustParse("4096M")
 					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
@@ -506,7 +506,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("with BIOS bootloader method and no disk", func() {
-			It("[test_id:5265]should find no bootable device by default", Labels{"test_id:5265"}, func() {
+			It("[test_id:5265]should find no bootable device by default", Label("test_id:5265"), func() {
 				By("Creating a VMI with no disk and an explicit network interface")
 				vmi := tests.NewRandomVMI()
 				tests.AddExplicitPodNetworkInterface(vmi)
@@ -532,7 +532,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				// The expecter *should* have error-ed since the network interface is not marked bootable
 			})
 
-			It("[test_id:5266]should boot to NIC rom if a boot order was set on a network interface", Labels{"test_id:5266"}, func() {
+			It("[test_id:5266]should boot to NIC rom if a boot order was set on a network interface", Label("test_id:5266"), func() {
 				By("Creating a VMI with no disk and an explicit network interface")
 				vmi := tests.NewRandomVMI()
 				tests.AddExplicitPodNetworkInterface(vmi)
@@ -560,7 +560,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 		})
 
 		DescribeTable("[rfe_id:2262][crit:medium][vendor:cnv-qe@redhat.com][level:component]with EFI bootloader method",
-			Labels{"rfe_id:2262", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:2262", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func(vmiNew VMICreationFuncWithEFI, loginTo console.LoginToFunction, msg string, fileName string) {
 				vmi := vmiNew()
 				By("Starting a VirtualMachineInstance")
@@ -589,14 +589,14 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(domXml).To(MatchRegexp(fileName))
 				}
 			},
-			Entry("[Serial][test_id:1668]should use EFI without secure boot", Labels{"Serial", "test_id:1668"}, tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
-			Entry("[Serial][test_id:4437]should enable EFI secure boot", Labels{"Serial", "test_id:4437"}, tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
+			Entry("[Serial][test_id:1668]should use EFI without secure boot", Label("Serial", "test_id:1668"), tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
+			Entry("[Serial][test_id:4437]should enable EFI secure boot", Label("Serial", "test_id:4437"), tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
 		)
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
-				It("[test_id:1669]should show the requested guest memory inside the VMI", Labels{"test_id:1669"}, func() {
+				It("[test_id:1669]should show the requested guest memory inside the VMI", Label("test_id:1669"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					guestMemory := resource.MustParse("256Mi")
 					vmi.Spec.Domain.Memory = &v1.Memory{
@@ -607,7 +607,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(vmi)
 
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
@@ -618,8 +618,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging memory limit from memory request and no guest memory",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
-				It("[test_id:3115]should show the memory limit inside the VMI", Labels{"test_id:3115"}, func() {
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"), func() {
+				It("[test_id:3115]should show the memory limit inside the VMI", Label("test_id:3115"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					vmi.Spec.Domain.Resources.Limits = kubev1.ResourceList{
 						kubev1.ResourceMemory: resource.MustParse("256Mi"),
@@ -628,7 +628,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(vmi)
 
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
@@ -638,7 +638,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				})
 			})
 
-		Context("[rfe_id:989]test cpu_allocation_ratio", Labels{"rfe_id:989"}, func() {
+		Context("[rfe_id:989]test cpu_allocation_ratio", Label("rfe_id:989"), func() {
 			It("virt-launchers pod cpu requests should be proportional to the number of vCPUs", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				guestMemory := resource.MustParse("256Mi")
@@ -672,9 +672,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 		})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with support memory over commitment",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
-				It("[test_id:755]should show the requested memory different than guest memory", Labels{"test_id:755"}, func() {
+				It("[test_id:755]should show the requested memory different than guest memory", Label("test_id:755"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					guestMemory := resource.MustParse("256Mi")
 					vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
@@ -686,7 +686,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(vmi)
 
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
@@ -710,7 +710,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test",
-			Labels{"rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var vmi *v1.VirtualMachineInstance
 
@@ -724,17 +724,17 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					tests.WaitForSuccessfulVMIStart(vmi)
 				})
 
-				It("[test_id:730]Check OverCommit VM Created and Started", Labels{"test_id:730"}, func() {
+				It("[test_id:730]Check OverCommit VM Created and Started", Label("test_id:730"), func() {
 					overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(overcommitVmi)
 				})
-				It("[test_id:731]Check OverCommit status on VMI", Labels{"test_id:731"}, func() {
+				It("[test_id:731]Check OverCommit status on VMI", Label("test_id:731"), func() {
 					overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(overcommitVmi.Spec.Domain.Resources.OvercommitGuestOverhead).To(BeTrue())
 				})
-				It("[test_id:732]Check Free memory on the VMI", Labels{"test_id:732"}, func() {
+				It("[test_id:732]Check Free memory on the VMI", Label("test_id:732"), func() {
 					By("Expecting console")
 					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
@@ -747,9 +747,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:3078][crit:medium][vendor:cnv-qe@redhat.com][level:component]with usb controller",
-			Labels{"rfe_id:3078", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:3078", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
-				It("[test_id:3117]should start the VMI with usb controller when usb device is present", Labels{"test_id:3117"}, func() {
+				It("[test_id:3117]should start the VMI with usb controller when usb device is present", Label("test_id:3117"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 						{
@@ -773,7 +773,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report number of usb")
 				})
 
-				It("[test_id:3117]should start the VMI with usb controller when input device doesn't have bus", Labels{"test_id:3117"}, func() {
+				It("[test_id:3117]should start the VMI with usb controller when input device doesn't have bus", Label("test_id:3117"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 						{
@@ -796,7 +796,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report number of usb")
 				})
 
-				It("[test_id:3118]should start the VMI without usb controller", Labels{"test_id:3118"}, func() {
+				It("[test_id:3118]should start the VMI without usb controller", Label("test_id:3118"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					By("Starting a VirtualMachineInstance")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -816,8 +816,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:3077][crit:medium][vendor:cnv-qe@redhat.com][level:component]with input devices",
-			Labels{"rfe_id:3077", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
-				It("[test_id:2642]should failed to start the VMI with wrong type of input device", Labels{"test_id:2642"}, func() {
+			Label("rfe_id:3077", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"), func() {
+				It("[test_id:2642]should failed to start the VMI with wrong type of input device", Label("test_id:2642"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 						{
@@ -831,7 +831,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).To(HaveOccurred(), "should not start vmi")
 				})
 
-				It("[test_id:3074]should failed to start the VMI with wrong bus of input device", Labels{"test_id:3074"}, func() {
+				It("[test_id:3074]should failed to start the VMI with wrong bus of input device", Label("test_id:3074"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 						{
@@ -845,7 +845,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).To(HaveOccurred(), "should not start vmi")
 				})
 
-				It("[test_id:3072]should start the VMI with tablet input device with virtio bus", Labels{"test_id:3072"}, func() {
+				It("[test_id:3072]should start the VMI with tablet input device with virtio bus", Label("test_id:3072"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 						{
@@ -869,7 +869,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 60)).To(Succeed(), "should report input device")
 				})
 
-				It("[test_id:3073]should start the VMI with tablet input device with usb bus", Labels{"test_id:3073"}, func() {
+				It("[test_id:3073]should start the VMI with tablet input device with usb bus", Label("test_id:3073"), func() {
 					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 						{
@@ -895,10 +895,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace memory limits lower than VMI required memory",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var vmi *v1.VirtualMachineInstance
-				It("[test_id:1670]should failed to start the VMI", Labels{"test_id:1670"}, func() {
+				It("[test_id:1670]should failed to start the VMI", Label("test_id:1670"), func() {
 					// create a namespace default limit
 					limitRangeObj := kubev1.LimitRange{
 
@@ -934,10 +934,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace cpu limits lower than VMI required cpu",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var vmi *v1.VirtualMachineInstance
-				It("[test_id:3119]should fail to start the VMI", Labels{"test_id:3119"}, func() {
+				It("[test_id:3119]should fail to start the VMI", Label("test_id:3119"), func() {
 					// create a namespace default limit
 					limitRangeObj := kubev1.LimitRange{
 
@@ -974,10 +974,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace limits higher than VMI requests",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var vmi *v1.VirtualMachineInstance
-				It("[test_id:3120]should start the VMI with the right default settings from namespace limits", Labels{"test_id:3120"}, func() {
+				It("[test_id:3120]should start the VMI with the right default settings from namespace limits", Label("test_id:3120"), func() {
 					// create a namespace default limit
 					limitRangeObj := kubev1.LimitRange{
 
@@ -1027,7 +1027,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with hugepages",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var hugepagesVmi *v1.VirtualMachineInstance
 
@@ -1138,13 +1138,13 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					By("Checking that the VM memory equals to a number of consumed hugepages")
 					Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
 				},
-					Entry("[Serial][test_id:1671]hugepages-2Mi", Labels{"Serial", "test_id:1671"}, "2Mi", "64Mi", "None"),
-					Entry("[Serial][test_id:1672]hugepages-1Gi", Labels{"Serial", "test_id:1672"}, "1Gi", "1Gi", "None"),
-					Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", Labels{"Serial", "test_id:1672"}, "2Mi", "70Mi", "64Mi"),
+					Entry("[Serial][test_id:1671]hugepages-2Mi", Label("Serial", "test_id:1671"), "2Mi", "64Mi", "None"),
+					Entry("[Serial][test_id:1672]hugepages-1Gi", Label("Serial", "test_id:1672"), "1Gi", "1Gi", "None"),
+					Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", Label("Serial", "test_id:1672"), "2Mi", "70Mi", "64Mi"),
 				)
 
 				Context("with unsupported page size", func() {
-					It("[test_id:1673]should failed to schedule the pod", Labels{"test_id:1673"}, func() {
+					It("[test_id:1673]should failed to schedule the pod", Label("test_id:1673"), func() {
 						nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1185,7 +1185,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:893][crit:medium][vendor:cnv-qe@redhat.com][level:component]with rng",
-			Labels{"rfe_id:893", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:893", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var rngVmi *v1.VirtualMachineInstance
 
@@ -1193,7 +1193,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					rngVmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				})
 
-				It("[test_id:1674]should have the virtio rng device present when present", Labels{"test_id:1674"}, func() {
+				It("[test_id:1674]should have the virtio rng device present when present", Label("test_id:1674"), func() {
 					rngVmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 
 					By("Starting a VirtualMachineInstance")
@@ -1211,7 +1211,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 400)).To(Succeed())
 				})
 
-				It("[test_id:1675]should not have the virtio rng device when not present", Labels{"test_id:1675"}, func() {
+				It("[test_id:1675]should not have the virtio rng device when not present", Label("test_id:1675"), func() {
 					By("Starting a VirtualMachineInstance")
 					rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
 					Expect(err).ToNot(HaveOccurred())
@@ -1229,7 +1229,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var agentVMI *v1.VirtualMachineInstance
 
@@ -1260,7 +1260,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					return agentVMI
 				}
 
-				It("[test_id:1676]should have attached a guest agent channel by default", Labels{"test_id:1676"}, func() {
+				It("[test_id:1676]should have attached a guest agent channel by default", Label("test_id:1676"), func() {
 
 					agentVMI = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					By("Starting a VirtualMachineInstance")
@@ -1282,7 +1282,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(domXML).To(ContainSubstring("<alias name='channel0'/>"), "Should have guest channel present")
 				})
 
-				It("[test_id:1677]VMI condition should signal agent presence", Labels{"test_id:1677"}, func() {
+				It("[test_id:1677]VMI condition should signal agent presence", Label("test_id:1677"), func() {
 					agentVMI := prepareAgentVM()
 					getOptions := metav1.GetOptions{}
 
@@ -1297,7 +1297,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 				})
 
-				It("[test_id:4625]should remove condition when agent is off", Labels{"test_id:4625"}, func() {
+				It("[test_id:4625]should remove condition when agent is off", Label("test_id:4625"), func() {
 					agentVMI := prepareAgentVM()
 					getOptions := metav1.GetOptions{}
 
@@ -1323,7 +1323,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 						"Agent condition should be gone")
 				})
 
-				Context("[Serial]with cluster config changes", Labels{"Serial"}, func() {
+				Context("[Serial]with cluster config changes", Label("Serial"), func() {
 					BeforeEach(func() {
 						kv := util.GetCurrentKv(virtClient)
 
@@ -1332,7 +1332,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 						tests.UpdateKubeVirtConfigValueAndWait(config)
 					})
 
-					It("[test_id:5267]VMI condition should signal unsupported agent presence", Labels{"test_id:5267"}, func() {
+					It("[test_id:5267]VMI condition should signal unsupported agent presence", Label("test_id:5267"), func() {
 						agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-shutdown")
 						By("Starting a VirtualMachineInstance")
 						agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
@@ -1356,7 +1356,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 					})
 
-					It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", Labels{"test_id:6958"}, func() {
+					It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", Label("test_id:6958"), func() {
 						agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-exec,guest-set-password")
 						By("Starting a VirtualMachineInstance")
 						agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
@@ -1392,7 +1392,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					})
 				})
 
-				It("[test_id:4626]should have guestosinfo in status when agent is present", Labels{"test_id:4626"}, func() {
+				It("[test_id:4626]should have guestosinfo in status when agent is present", Label("test_id:4626"), func() {
 					agentVMI := prepareAgentVM()
 					getOptions := metav1.GetOptions{}
 					var updatedVmi *v1.VirtualMachineInstance
@@ -1411,7 +1411,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
 				})
 
-				It("[test_id:4627]should return the whole data when agent is present", Labels{"test_id:4627"}, func() {
+				It("[test_id:4627]should return the whole data when agent is present", Label("test_id:4627"), func() {
 					agentVMI := prepareAgentVM()
 
 					By("Expecting the Guest VM information")
@@ -1431,7 +1431,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in subresource")
 				})
 
-				It("[test_id:4628]should not return the whole data when agent is not present", Labels{"test_id:4628"}, func() {
+				It("[test_id:4628]should not return the whole data when agent is not present", Label("test_id:4628"), func() {
 					agentVMI := prepareAgentVM()
 
 					By("Expecting the VirtualMachineInstance console")
@@ -1453,7 +1453,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 240*time.Second, 2).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
 				})
 
-				It("[test_id:4629]should return user list", Labels{"test_id:4629"}, func() {
+				It("[test_id:4629]should return user list", Label("test_id:4629"), func() {
 					agentVMI := prepareAgentVM()
 
 					Expect(console.LoginToFedora(agentVMI)).To(Succeed())
@@ -1471,7 +1471,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 240*time.Second, 2).Should(BeTrue(), "Should have fedora users")
 				})
 
-				It("[test_id:4630]should return filesystem list", Labels{"test_id:4630"}, func() {
+				It("[test_id:4630]should return filesystem list", Label("test_id:4630"), func() {
 					agentVMI := prepareAgentVM()
 
 					By("Expecting the Guest VM information")
@@ -1490,7 +1490,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with serial-number",
-			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				var snVmi *v1.VirtualMachineInstance
 
@@ -1498,7 +1498,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					snVmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				})
 
-				It("[test_id:3121]should have serial-number set when present", Labels{"test_id:3121"}, func() {
+				It("[test_id:3121]should have serial-number set when present", Label("test_id:3121"), func() {
 					snVmi.Spec.Domain.Firmware = &v1.Firmware{Serial: "4b2f5496-f3a3-460b-a375-168223f68845"}
 
 					By("Starting a VirtualMachineInstance")
@@ -1518,7 +1518,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(domXML).To(ContainSubstring("<entry name='serial'>4b2f5496-f3a3-460b-a375-168223f68845</entry>"), "Should have serial-number present")
 				})
 
-				It("[test_id:3122]should not have serial-number set when not present", Labels{"test_id:3122"}, func() {
+				It("[test_id:3122]should not have serial-number set when not present", Label("test_id:3122"), func() {
 					By("Starting a VirtualMachineInstance")
 					snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
 					Expect(err).ToNot(HaveOccurred())
@@ -1538,7 +1538,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 		Context("with TSC timer", func() {
-			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", Labels{"test_id:6843"}, func() {
+			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", Label("test_id:6843"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{
@@ -1583,7 +1583,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 		Context("with Clock and timezone", func() {
 
-			It("[sig-compute][test_id:5268]guest should see timezone", Labels{"sig-compute", "test_id:5268"}, func() {
+			It("[sig-compute][test_id:5268]guest should see timezone", Label("sig-compute", "test_id:5268"), func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				timezone := "America/New_York"
 				tz := v1.ClockOffsetTimezone(timezone)
@@ -1627,7 +1627,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				vmi = tests.NewRandomVMI()
 			})
 
-			It("[test_id:6960]should reject disk with missing volume", Labels{"test_id:6960"}, func() {
+			It("[test_id:6960]should reject disk with missing volume", Label("test_id:6960"), func() {
 				const diskName = "testdisk"
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: diskName,
@@ -1638,7 +1638,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(err.Error()).To(ContainSubstring(expectedErrMessage))
 			})
 
-			It("[test_id:6961]should reject volume with missing disk / file system", Labels{"test_id:6961"}, func() {
+			It("[test_id:6961]should reject volume with missing disk / file system", Label("test_id:6961"), func() {
 				const volumeName = "testvolume"
 				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 					Name: volumeName,
@@ -1654,7 +1654,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 		})
 
-		Context("[Serial]using defaultRuntimeClass configuration", Labels{"Serial"}, func() {
+		Context("[Serial]using defaultRuntimeClass configuration", Label("Serial"), func() {
 			runtimeClassName := "custom-runtime-class"
 
 			BeforeEach(func() {
@@ -1701,7 +1701,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 	})
 
 	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU spec",
-		Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			var cpuVmi *v1.VirtualMachineInstance
 			var nodes *k8sv1.NodeList
@@ -1735,9 +1735,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 
 			Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model defined",
-				Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 				func() {
-					It("[test_id:1678]should report defined CPU model", Labels{"test_id:1678"}, func() {
+					It("[test_id:1678]should report defined CPU model", Label("test_id:1678"), func() {
 						supportedCPUs := tests.GetSupportedCPUModels(*nodes)
 						Expect(supportedCPUs).ToNot(BeEmpty())
 						cpuVmi.Spec.Domain.CPU = &v1.CPU{
@@ -1750,8 +1750,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 						Expect(err).ToNot(HaveOccurred())
 						tests.WaitForSuccessfulVMIStart(cpuVmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+						By("Expecting the VirtualMachineInstance console")
+						Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 						By("Checking the CPU model under the guest OS")
 						Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -1762,9 +1762,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				})
 
 			Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model equals to passthrough",
-				Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 				func() {
-					It("[test_id:1679]should report exactly the same model as node CPU", Labels{"test_id:1679"}, func() {
+					It("[test_id:1679]should report exactly the same model as node CPU", Label("test_id:1679"), func() {
 						cpuVmi.Spec.Domain.CPU = &v1.CPU{
 							Model: "host-passthrough",
 						}
@@ -1779,8 +1779,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 						niceName := parseCPUNiceName(output)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+						By("Expecting the VirtualMachineInstance console")
+						Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 						By("Checking the CPU model under the guest OS")
 						Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -1791,9 +1791,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				})
 
 			Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model not defined",
-				Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 				func() {
-					It("[test_id:1680]should report CPU model from libvirt capabilities", Labels{"test_id:1680"}, func() {
+					It("[test_id:1680]should report CPU model from libvirt capabilities", Label("test_id:1680"), func() {
 						By("Starting a VirtualMachineInstance")
 						cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 						Expect(err).ToNot(HaveOccurred())
@@ -1803,8 +1803,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 						niceName := parseCPUNiceName(output)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+						By("Expecting the VirtualMachineInstance console")
+						Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 						By("Checking the CPU model under the guest OS")
 						console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -1815,7 +1815,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				})
 
 			Context("when CPU features defined", func() {
-				It("[test_id:3123]should start a Virtual Machine with matching features", Labels{"test_id:3123"}, func() {
+				It("[test_id:3123]should start a Virtual Machine with matching features", Label("test_id:3123"), func() {
 					supportedCPUFeatures := tests.GetSupportedCPUFeatures(*nodes)
 					Expect(supportedCPUFeatures).ToNot(BeEmpty())
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
@@ -1831,14 +1831,14 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(cpuVmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+				})
 			})
 		})
-	})
 
 	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings",
-		Labels{"Serial", "rfe_id:2869", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("Serial", "rfe_id:2869", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			BeforeEach(func() {
 				kv := util.GetCurrentKv(virtClient)
@@ -1848,7 +1848,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 			})
 
-			It("[test_id:3124]should set machine type from VMI spec", Labels{"test_id:3124"}, func() {
+			It("[test_id:3124]should set machine type from VMI spec", Label("test_id:3124"), func() {
 				vmi := tests.NewRandomVMI()
 				vmi.Spec.Domain.Machine = &v1.Machine{Type: "pc"}
 				tests.RunVMIAndExpectLaunch(vmi, 30)
@@ -1858,7 +1858,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
 			})
 
-			It("[test_id:3125]should allow creating VM without Machine defined", Labels{"test_id:3125"}, func() {
+			It("[test_id:3125]should allow creating VM without Machine defined", Label("test_id:3125"), func() {
 				vmi := tests.NewRandomVMI()
 				vmi.Spec.Domain.Machine = nil
 				tests.RunVMIAndExpectLaunch(vmi, 30)
@@ -1868,7 +1868,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
 			})
 
-			It("[test_id:6964]should allow creating VM defined with Machine with an empty Type", Labels{"test_id:6964"}, func() {
+			It("[test_id:6964]should allow creating VM defined with Machine with an empty Type", Label("test_id:6964"), func() {
 				// This is needed to provide backward compatibility since our example VMIs used to be defined in this way
 				vmi := tests.NewRandomVMI()
 				vmi.Spec.Domain.Machine = &v1.Machine{Type: ""}
@@ -1879,7 +1879,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
 			})
 
-			It("[Serial][test_id:3126]should set machine type from kubevirt-config", Labels{"Serial", "test_id:3126"}, func() {
+			It("[Serial][test_id:3126]should set machine type from kubevirt-config", Label("Serial", "test_id:3126"), func() {
 				kv := util.GetCurrentKv(virtClient)
 
 				config := kv.Spec.Configuration
@@ -1897,7 +1897,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 		})
 
 	Context("with a custom scheduler", func() {
-		It("[test_id:4631]should set the custom scheduler on the pod", Labels{"test_id:4631"}, func() {
+		It("[test_id:4631]should set the custom scheduler on the pod", Label("test_id:4631"), func() {
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.SchedulerName = "my-custom-scheduler"
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
@@ -1907,10 +1907,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 	})
 
 	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU request settings",
-		Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
-			It("[test_id:3127]should set CPU request from VMI spec", Labels{"test_id:3127"}, func() {
+			It("[test_id:3127]should set CPU request from VMI spec", Label("test_id:3127"), func() {
 				vmi := tests.NewRandomVMI()
 				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceCPU] = resource.MustParse("500m")
 				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
@@ -1921,7 +1921,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(cpuRequest.String()).To(Equal("500m"))
 			})
 
-			It("[test_id:3128]should set CPU request when it is not provided", Labels{"test_id:3128"}, func() {
+			It("[test_id:3128]should set CPU request when it is not provided", Label("test_id:3128"), func() {
 				vmi := tests.NewRandomVMI()
 				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
@@ -1931,7 +1931,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(cpuRequest.String()).To(Equal("100m"))
 			})
 
-			It("[Serial][test_id:3129]should set CPU request from kubevirt-config", Labels{"Serial", "test_id:3129"}, func() {
+			It("[Serial][test_id:3129]should set CPU request from kubevirt-config", Label("Serial", "test_id:3129"), func() {
 				kv := util.GetCurrentKv(virtClient)
 
 				config := kv.Spec.Configuration
@@ -1950,7 +1950,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 		})
 
 	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC",
-		Labels{"Serial", "rfe_id:904", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "storage-req"},
+		Label("Serial", "rfe_id:904", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "storage-req"),
 		func() {
 			var dataVolume *cdiv1.DataVolume
 
@@ -1959,7 +1959,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
 				}
 				// create a new PV and PVC (PVs can't be reused)
-			dataVolume = libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume = libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1972,7 +1972,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:1681]should set appropriate cache modes", Labels{"test_id:1681"}, func() {
+			It("[test_id:1681]should set appropriate cache modes", Label("test_id:1681"), func() {
 				vmi := tests.NewRandomVMI()
 
 				By("adding disks to a VMI")
@@ -2029,7 +2029,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 			})
 
-			It("[test_id:5360]should set appropriate IO modes", Labels{"test_id:5360"}, func() {
+			It("[test_id:5360]should set appropriate IO modes", Label("test_id:5360"), func() {
 				vmi := tests.NewRandomVMI()
 
 				By("adding disks to a VMI")
@@ -2089,7 +2089,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 	Context("Block size configuration set", func() {
 
-		It("[test_id:6965][storage-req]Should set BlockIO when using custom block sizes", Labels{"test_id:6965", "storage-req"}, func() {
+		It("[test_id:6965][storage-req]Should set BlockIO when using custom block sizes", Label("test_id:6965", "storage-req"), func() {
 			By("creating a block volume")
 			dataVolume := libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
@@ -2127,10 +2127,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 		})
 
 		It("[test_id:6966][storage-req]Should set BlockIO when set to match volume block sizes on block devices",
-			Labels{"test_id:6966", "storage-req"},
+			Label("test_id:6966", "storage-req"),
 			func() {
 				By("creating a block volume")
-			dataVolume := libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume := libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -2162,7 +2162,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(disks[0].BlockIO.PhysicalBlockSize).To(expectedDiskSizes)
 			})
 
-		It("[test_id:6967]Should set BlockIO when set to match volume block sizes on files", Labels{"test_id:6967"}, func() {
+		It("[test_id:6967]Should set BlockIO when set to match volume block sizes on files", Label("test_id:6967"), func() {
 			if !checks.HasFeature(virtconfig.HostDiskGate) {
 				Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
 			}
@@ -2214,7 +2214,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 	})
 
 	Context("[rfe_id:898][crit:medium][vendor:cnv-qe@redhat.com][level:component]New VirtualMachineInstance with all supported drives",
-		Labels{"rfe_id:898", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:898", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			var vmi *v1.VirtualMachineInstance
@@ -2239,12 +2239,12 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			It("[test_id:1682]should have all the device nodes", Labels{"test_id:1682"}, func() {
+			It("[test_id:1682]should have all the device nodes", Label("test_id:1682"), func() {
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)
 
-			Expect(console.LoginToCirros(vmi)).To(Succeed())
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// keep the ordering!
@@ -2255,7 +2255,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				}, 10)).To(Succeed())
 			})
 
-			It("[test_id:3906]should configure custom Pci address", Labels{"test_id:3906"}, func() {
+			It("[test_id:3906]should configure custom Pci address", Label("test_id:3906"), func() {
 				By("checking disk1 Pci address")
 				vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = "0000:00:10.0"
 				vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
@@ -2266,7 +2266,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
 			})
 
-			It("[test_id:1020]should not create the VM with wrong PCI address", Labels{"test_id:1020"}, func() {
+			It("[test_id:1020]should not create the VM with wrong PCI address", Label("test_id:1020"), func() {
 				By("setting disk1 Pci address")
 
 				wrongPciAddress := "0000:04:10.0"
@@ -2294,7 +2294,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			})
 		})
 	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning",
-		Labels{"rfe_id:897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			var nodes *kubev1.NodeList
 
@@ -2324,9 +2324,9 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				}
 			})
 
-			Context("[Serial]with cpu pinning enabled", Labels{"Serial"}, func() {
+			Context("[Serial]with cpu pinning enabled", Label("Serial"), func() {
 
-				It("[test_id:1684]should set the cpumanager label to false when it's not running", Labels{"test_id:1684"}, func() {
+				It("[test_id:1684]should set the cpumanager label to false when it's not running", Label("test_id:1684"), func() {
 
 					By("adding a cpumanger=true label to a node")
 					nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
@@ -2346,7 +2346,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 						return n.Labels[v1.CPUManager]
 					}, 3*time.Minute, 2*time.Second).Should(Equal("false"))
 				})
-				It("[test_id:1685]non master node should have a cpumanager label", Labels{"test_id:1685"}, func() {
+				It("[test_id:1685]non master node should have a cpumanager label", Label("test_id:1685"), func() {
 					cpuManagerEnabled := false
 					for idx := 1; idx < len(nodes.Items); idx++ {
 						labels := nodes.Items[idx].GetLabels()
@@ -2358,7 +2358,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}
 					Expect(cpuManagerEnabled).To(BeTrue())
 				})
-				It("[test_id:991]should be scheduled on a node with running cpu manager", Labels{"test_id:991"}, func() {
+				It("[test_id:991]should be scheduled on a node with running cpu manager", Label("test_id:991"), func() {
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
 						Cores:                 2,
@@ -2402,8 +2402,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 					Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores)))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 					By("Checking the number of CPU cores under guest OS")
 					Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -2416,7 +2416,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
 					Expect(domXML).To(ContainSubstring("<hint-dedicated state='on'/>"), "should container the hint-dedicated feature")
 				})
-				It("[test_id:4632]should be able to start a vm with guest memory different from requested and keep guaranteed qos", Labels{"test_id:4632"}, func() {
+				It("[test_id:4632]should be able to start a vm with guest memory different from requested and keep guaranteed qos", Label("test_id:4632"), func() {
 					Skip("Skip test till issue https://github.com/kubevirt/kubevirt/issues/3910 is fixed")
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
@@ -2450,8 +2450,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					podQos := readyPod.Status.QOSClass
 					Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
 
-				//-------------------------------------------------------------------
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+					//-------------------------------------------------------------------
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
@@ -2471,7 +2471,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					By("Checking if pod memory usage is > 80Mi")
 					Expect(m > 83886080).To(BeTrue(), "83886080 B = 80 Mi")
 				})
-				It("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", Labels{"test_id:4023"}, func() {
+				It("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", Label("test_id:4023"), func() {
 
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
@@ -2518,8 +2518,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					// 1 additioan pcpus should be allocated on the pod for the emulation threads
 					Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores) + 1))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 					By("Checking the number of CPU cores under guest OS")
 					Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -2528,7 +2528,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 15)).To(Succeed())
 				})
 
-				It("[test_id:4024]should fail the vmi creation if IsolateEmulatorThread requested without dedicated cpus", Labels{"test_id:4024"}, func() {
+				It("[test_id:4024]should fail the vmi creation if IsolateEmulatorThread requested without dedicated cpus", Label("test_id:4024"), func() {
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
 						Cores:                 2,
@@ -2540,7 +2540,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("[test_id:802]should configure correct number of vcpus with requests.cpus", Labels{"test_id:802"}, func() {
+				It("[test_id:802]should configure correct number of vcpus with requests.cpus", Label("test_id:802"), func() {
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
 						DedicatedCPUPlacement: true,
@@ -2553,8 +2553,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
 					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
 					By("Checking the number of CPU cores under guest OS")
 					Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
@@ -2563,7 +2563,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					}, 15)).To(Succeed())
 				})
 
-				It("[test_id:1688]should fail the vmi creation if the requested resources are inconsistent", Labels{"test_id:1688"}, func() {
+				It("[test_id:1688]should fail the vmi creation if the requested resources are inconsistent", Label("test_id:1688"), func() {
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
 						Cores:                 2,
@@ -2576,7 +2576,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 					Expect(err).To(HaveOccurred())
 				})
-				It("[test_id:1689]should fail the vmi creation if cpu is not an integer", Labels{"test_id:1689"}, func() {
+				It("[test_id:1689]should fail the vmi creation if cpu is not an integer", Label("test_id:1689"), func() {
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
 						DedicatedCPUPlacement: true,
@@ -2588,7 +2588,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 					Expect(err).To(HaveOccurred())
 				})
-				It("[test_id:1690]should fail the vmi creation if Guaranteed QOS cannot be set", Labels{"test_id:1690"}, func() {
+				It("[test_id:1690]should fail the vmi creation if Guaranteed QOS cannot be set", Label("test_id:1690"), func() {
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
 						DedicatedCPUPlacement: true,
@@ -2603,7 +2603,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
 					Expect(err).To(HaveOccurred())
 				})
-				It("[test_id:830]should start a vm with no cpu pinning after a vm with cpu pinning on same node", Labels{"test_id:830"}, func() {
+				It("[test_id:830]should start a vm with no cpu pinning after a vm with cpu pinning on same node", Label("test_id:830"), func() {
 					Vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 					cpuVmi.Spec.Domain.CPU = &v1.CPU{
@@ -2623,12 +2623,12 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					By("Starting a VirtualMachineInstance without dedicated cpus")
 					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(Vmi)
 					Expect(err).ToNot(HaveOccurred())
-				node = tests.WaitForSuccessfulVMIStart(Vmi).Status.NodeName
+					node = tests.WaitForSuccessfulVMIStart(Vmi).Status.NodeName
 					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
 				})
 			})
 
-			Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", Labels{"Serial"}, func() {
+			Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", Label("Serial"), func() {
 
 				var cpuvmi, vmi *v1.VirtualMachineInstance
 				var node string
@@ -2664,7 +2664,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
 				})
 
-				It("[test_id:829]should start a vm with no cpu pinning after a vm with cpu pinning on same node", Labels{"test_id:829"}, func() {
+				It("[test_id:829]should start a vm with no cpu pinning after a vm with cpu pinning on same node", Label("test_id:829"), func() {
 
 					By("Starting a VirtualMachineInstance with dedicated cpus")
 					cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
@@ -2673,8 +2673,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
 					Expect(node1).To(Equal(node))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
 
 					By("Starting a VirtualMachineInstance without dedicated cpus")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -2683,11 +2683,11 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
 					Expect(node2).To(Equal(node))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-			})
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
+				})
 
-				It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", Labels{"test_id:832"}, func() {
+				It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", Label("test_id:832"), func() {
 
 					By("Starting a VirtualMachineInstance without dedicated cpus")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -2696,27 +2696,27 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 					Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
 					Expect(node2).To(Equal(node))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				By("Starting a VirtualMachineInstance with dedicated cpus")
-				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
-				Expect(err).ToNot(HaveOccurred())
-				node1 := tests.WaitForSuccessfulVMIStart(cpuvmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
-				Expect(node1).To(Equal(node))
+					By("Starting a VirtualMachineInstance with dedicated cpus")
+					cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
+					Expect(err).ToNot(HaveOccurred())
+					node1 := tests.WaitForSuccessfulVMIStart(cpuvmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
+					Expect(node1).To(Equal(node))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
+				})
 			})
 		})
-	})
 
 	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check Chassis value",
-		Labels{"rfe_id:2926", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2926", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
-			It("[Serial][test_id:2927]Test Chassis value in a newly created VM", Labels{"Serial", "test_id:2927"}, func() {
+			It("[Serial][test_id:2927]Test Chassis value in a newly created VM", Label("Serial", "test_id:2927"), func() {
 				vmi := tests.NewRandomFedoraVMIWithDmidecode()
 				vmi.Spec.Domain.Chassis = &v1.Chassis{
 					Asset: "Test-123",
@@ -2732,8 +2732,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
 
-			By("Expecting console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
+				By("Expecting console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Check value in VM with dmidecode")
 				// Check on the VM, if expected values are there with dmidecode
@@ -2745,7 +2745,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 		})
 
 	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values",
-		Labels{"Serial", "rfe_id:2926", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("Serial", "rfe_id:2926", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 
 			var vmi *v1.VirtualMachineInstance
@@ -2754,7 +2754,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				vmi = tests.NewRandomFedoraVMIWithDmidecode()
 			})
 
-			It("[test_id:2751]test default SMBios", Labels{"test_id:2751"}, func() {
+			It("[test_id:2751]test default SMBios", Label("test_id:2751"), func() {
 				kv := util.GetCurrentKv(virtClient)
 
 				config := kv.Spec.Configuration
@@ -2775,8 +2775,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(domXml).To(ContainSubstring("<entry name='product'>None</entry>"))
 				Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
 
-			By("Expecting console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
+				By("Expecting console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Check values in dmidecode")
 				// Check on the VM, if expected values are there with dmidecode
@@ -2790,7 +2790,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				}, 1)).To(Succeed())
 			})
 
-			It("[test_id:2752]test custom SMBios values", Labels{"test_id:2752"}, func() {
+			It("[test_id:2752]test custom SMBios values", Label("test_id:2752"), func() {
 				kv := util.GetCurrentKv(virtClient)
 				config := kv.Spec.Configuration
 				// Set a custom test SMBios
@@ -2811,8 +2811,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(domXml).To(ContainSubstring("<entry name='sku'>1.0</entry>"))
 				Expect(domXml).To(ContainSubstring("<entry name='version'>1.0</entry>"))
 
-			By("Expecting console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
+				By("Expecting console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Check values in dmidecode")
 
@@ -2847,10 +2847,10 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 				Expect(err.Error()).To(ContainSubstring(errMsg))
 			}
 		},
-			Entry("[test_id:3777] Should be accepted when using sata", Labels{"test_id:3777"}, "sata", ""),
-			Entry("[test_id:3809] Should be accepted when using scsi", Labels{"test_id:3809"}, "scsi", ""),
-			Entry("[test_id:3776] Should be rejected when using virtio", Labels{"test_id:3776"}, "virtio", "Bus type virtio is invalid"),
-			Entry("[test_id:3808] Should be rejected when using ide", Labels{"test_id:3808"}, "ide", "IDE bus is not supported"),
+			Entry("[test_id:3777] Should be accepted when using sata", Label("test_id:3777"), "sata", ""),
+			Entry("[test_id:3809] Should be accepted when using scsi", Label("test_id:3809"), "scsi", ""),
+			Entry("[test_id:3776] Should be rejected when using virtio", Label("test_id:3776"), "virtio", "Bus type virtio is invalid"),
+			Entry("[test_id:3808] Should be rejected when using ide", Label("test_id:3808"), "ide", "IDE bus is not supported"),
 		)
 	})
 
@@ -2931,8 +2931,8 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		},
-			Entry("[test_id:5269]across all available PCI root bus slots", Labels{"test_id:5269"}, 2, numOfSlotsToTest, false),
-			Entry("[test_id:5270]across all available PCI functions of a single slot", Labels{"test_id:5270"}, 0, numOfFuncsToTest, true),
+			Entry("[test_id:5269]across all available PCI root bus slots", Label("test_id:5269"), 2, numOfSlotsToTest, false),
+			Entry("[test_id:5270]across all available PCI functions of a single slot", Label("test_id:5270"), 0, numOfFuncsToTest, true),
 		)
 	})
 
@@ -2947,7 +2947,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			vmi = tests.NewRandomFedoraVMIWithVirtWhatCpuidHelper()
 		})
 
-		It("[test_id:5271]test cpuid hidden", Labels{"test_id:5271"}, func() {
+		It("[test_id:5271]test cpuid hidden", Label("test_id:5271"), func() {
 			vmi.Spec.Domain.Features = &v1.Features{
 				KVM: &v1.FeatureKVM{Hidden: true},
 			}
@@ -2974,7 +2974,7 @@ var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 			}, 2*time.Second)).To(Succeed())
 		})
 
-		It("[test_id:5272]test cpuid default", Labels{"test_id:5272"}, func() {
+		It("[test_id:5272]test cpuid default", Label("test_id:5272"), func() {
 			By("Starting a VirtualMachineInstance")
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -65,7 +65,7 @@ import (
 
 type VMICreationFuncWithEFI func() *v1.VirtualMachineInstance
 
-var _ = Describe("[sig-compute]Configurations", func() {
+var _ = Describe("[sig-compute]Configurations", Labels{"sig-compute"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -105,7 +105,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	})
 
 	Context("with all devices on the root PCI bus", func() {
-		It("[test_id:4623]should start run the guest as usual", func() {
+		It("[test_id:4623]should start run the guest as usual", Labels{"test_id:4623"}, func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			vmi.Annotations = map[string]string{
 				v1.PlacePCIDevicesOnRootComplex: "true",
@@ -128,7 +128,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	})
 
 	Context("when requesting virtio-transitional models", func() {
-		It("[test_id:6957]should start and run the guest", func() {
+		It("[test_id:6957]should start and run the guest", Labels{"test_id:6957"}, func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
@@ -142,100 +142,104 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]for CPU and memory limits should", func() {
+	Context("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]for CPU and memory limits should",
+		Labels{"rfe_id:897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-		It("[test_id:3110]lead to get the burstable QOS class assigned when limit and requests differ", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
+			It("[test_id:3110]lead to get the burstable QOS class assigned when limit and requests differ", Labels{"test_id:3110"}, func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
-			Eventually(func() kubev1.PodQOSClass {
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.IsFinal()).To(BeFalse())
-				if vmi.Status.QOSClass == nil {
-					return ""
-				}
-				return *vmi.Status.QOSClass
-			}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSBurstable))
-		})
-
-		It("[test_id:3111]lead to get the guaranteed QOS class assigned when limit and requests are identical", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			By("specifying identical limits and requests")
-			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-				Requests: kubev1.ResourceList{
-					kubev1.ResourceCPU:    resource.MustParse("1"),
-					kubev1.ResourceMemory: resource.MustParse("64M"),
-				},
-				Limits: kubev1.ResourceList{
-					kubev1.ResourceCPU:    resource.MustParse("1"),
-					kubev1.ResourceMemory: resource.MustParse("64M"),
-				},
-			}
-
-			By("adding a sidecar to ensure it gets limits assigned too")
-			vmi.ObjectMeta.Annotations = RenderSidecar(kubevirt_hooks_v1alpha2.Version)
-			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
-
-			Eventually(func() kubev1.PodQOSClass {
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.IsFinal()).To(BeFalse())
-				if vmi.Status.QOSClass == nil {
-					return ""
-				}
-				return *vmi.Status.QOSClass
-			}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSGuaranteed))
-		})
-
-		It("[test_id:3112]lead to get the guaranteed QOS class assigned when only limits are set", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			By("specifying identical limits and requests")
-			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-				Requests: kubev1.ResourceList{},
-				Limits: kubev1.ResourceList{
-					kubev1.ResourceCPU:    resource.MustParse("1"),
-					kubev1.ResourceMemory: resource.MustParse("64M"),
-				},
-			}
-
-			By("adding a sidecar to ensure it gets limits assigned too")
-			vmi.ObjectMeta.Annotations = RenderSidecar(kubevirt_hooks_v1alpha2.Version)
-			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
-
-			Eventually(func() kubev1.PodQOSClass {
-				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.IsFinal()).To(BeFalse())
-				if vmi.Status.QOSClass == nil {
-					return ""
-				}
-				return *vmi.Status.QOSClass
-			}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSGuaranteed))
-
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(vmi.Spec.Domain.Resources.Requests.Cpu().Cmp(*vmi.Spec.Domain.Resources.Limits.Cpu())).To(BeZero())
-			Expect(vmi.Spec.Domain.Resources.Requests.Memory().Cmp(*vmi.Spec.Domain.Resources.Limits.Memory())).To(BeZero())
-		})
-
-	})
-
-	Describe("VirtualMachineInstance definition", func() {
-		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", func() {
-			var availableNumberOfCPUs int
-			var vmi *v1.VirtualMachineInstance
-
-			BeforeEach(func() {
-				availableNumberOfCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
-
-				requiredNumberOfCpus := 3
-				Expect(availableNumberOfCPUs).ToNot(BeNumerically("<", requiredNumberOfCpus),
-					fmt.Sprintf("Test requires %d cpus, but only %d available!", requiredNumberOfCpus, availableNumberOfCPUs))
-				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				Eventually(func() kubev1.PodQOSClass {
+					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.IsFinal()).To(BeFalse())
+					if vmi.Status.QOSClass == nil {
+						return ""
+					}
+					return *vmi.Status.QOSClass
+				}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSBurstable))
 			})
 
-			It("[test_id:1659]should report 3 cpu cores under guest OS", func() {
+			It("[test_id:3111]lead to get the guaranteed QOS class assigned when limit and requests are identical", Labels{"test_id:3111"}, func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				By("specifying identical limits and requests")
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceCPU:    resource.MustParse("1"),
+						kubev1.ResourceMemory: resource.MustParse("64M"),
+					},
+					Limits: kubev1.ResourceList{
+						kubev1.ResourceCPU:    resource.MustParse("1"),
+						kubev1.ResourceMemory: resource.MustParse("64M"),
+					},
+				}
+
+				By("adding a sidecar to ensure it gets limits assigned too")
+				vmi.ObjectMeta.Annotations = RenderSidecar(kubevirt_hooks_v1alpha2.Version)
+				vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
+
+				Eventually(func() kubev1.PodQOSClass {
+					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.IsFinal()).To(BeFalse())
+					if vmi.Status.QOSClass == nil {
+						return ""
+					}
+					return *vmi.Status.QOSClass
+				}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSGuaranteed))
+			})
+
+			It("[test_id:3112]lead to get the guaranteed QOS class assigned when only limits are set", Labels{"test_id:3112"}, func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				By("specifying identical limits and requests")
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{},
+					Limits: kubev1.ResourceList{
+						kubev1.ResourceCPU:    resource.MustParse("1"),
+						kubev1.ResourceMemory: resource.MustParse("64M"),
+					},
+				}
+
+				By("adding a sidecar to ensure it gets limits assigned too")
+				vmi.ObjectMeta.Annotations = RenderSidecar(kubevirt_hooks_v1alpha2.Version)
+				vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
+
+				Eventually(func() kubev1.PodQOSClass {
+					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.IsFinal()).To(BeFalse())
+					if vmi.Status.QOSClass == nil {
+						return ""
+					}
+					return *vmi.Status.QOSClass
+				}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSGuaranteed))
+
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi.Spec.Domain.Resources.Requests.Cpu().Cmp(*vmi.Spec.Domain.Resources.Limits.Cpu())).To(BeZero())
+				Expect(vmi.Spec.Domain.Resources.Requests.Memory().Cmp(*vmi.Spec.Domain.Resources.Limits.Memory())).To(BeZero())
+			})
+
+		})
+
+	Describe("VirtualMachineInstance definition", func() {
+		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores",
+			Labels{"Serial", "rfe_id:2065", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var availableNumberOfCPUs int
+				var vmi *v1.VirtualMachineInstance
+
+				BeforeEach(func() {
+					availableNumberOfCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+
+					requiredNumberOfCpus := 3
+					Expect(availableNumberOfCPUs).ToNot(BeNumerically("<", requiredNumberOfCpus),
+						fmt.Sprintf("Test requires %d cpus, but only %d available!", requiredNumberOfCpus, availableNumberOfCPUs))
+					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				})
+
+			It("[test_id:1659]should report 3 cpu cores under guest OS", Labels{"test_id:1659"}, func() {
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Cores: 3,
 				}
@@ -245,19 +249,19 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					},
 				}
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				By("Checking the number of CPU cores under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: console.RetValue("3")},
-				}, 15)).To(Succeed(), "should report number of cores")
+					By("Checking the number of CPU cores under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
+						&expect.BExp{R: console.RetValue("3")},
+					}, 15)).To(Succeed(), "should report number of cores")
 
 				By("Checking the requested amount of memory allocated for a guest")
 				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("100M"))
@@ -275,230 +279,234 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}
 				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(296)))
 
-				Expect(err).ToNot(HaveOccurred())
-			})
-			It("[test_id:4624]should set a correct memory units", func() {
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64Mi"),
-					},
-				}
-				expectedMemoryInKiB := 64 * 1024
-				expectedMemoryXMLStr := fmt.Sprintf("unit='KiB'>%d", expectedMemoryInKiB)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("[test_id:4624]should set a correct memory units", Labels{"test_id:4624"}, func() {
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+					}
+					expectedMemoryInKiB := 64 * 1024
+					expectedMemoryXMLStr := fmt.Sprintf("unit='KiB'>%d", expectedMemoryInKiB)
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(ContainSubstring(expectedMemoryXMLStr))
-			})
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).To(ContainSubstring(expectedMemoryXMLStr))
+				})
 
-			It("[test_id:1660]should report 3 sockets under guest OS", func() {
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Sockets: 3,
-					Cores:   2,
-				}
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("120M"),
-					},
-				}
+				It("[test_id:1660]should report 3 sockets under guest OS", Labels{"test_id:1660"}, func() {
+					vmi.Spec.Domain.CPU = &v1.CPU{
+						Sockets: 3,
+						Cores:   2,
+					}
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("120M"),
+						},
+					}
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				By("Checking the number of sockets under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
-					&expect.BExp{R: console.RetValue("3")},
-				}, 60)).To(Succeed(), "should report number of sockets")
-			})
+					By("Checking the number of sockets under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
+						&expect.BExp{R: console.RetValue("3")},
+					}, 60)).To(Succeed(), "should report number of sockets")
+				})
 
-			It("[test_id:1661]should report 2 sockets from spec.domain.resources.requests under guest OS ", func() {
-				vmi.Spec.Domain.CPU = nil
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("1200m"),
-						kubev1.ResourceMemory: resource.MustParse("100M"),
-					},
-				}
+				It("[test_id:1661]should report 2 sockets from spec.domain.resources.requests under guest OS ", Labels{"test_id:1661"}, func() {
+					vmi.Spec.Domain.CPU = nil
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceCPU:    resource.MustParse("1200m"),
+							kubev1.ResourceMemory: resource.MustParse("100M"),
+						},
+					}
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				By("Checking the number of sockets under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
-					&expect.BExp{R: console.RetValue("2")},
-				}, 60)).To(Succeed(), "should report number of sockets")
-			})
+					By("Checking the number of sockets under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
+						&expect.BExp{R: console.RetValue("2")},
+					}, 60)).To(Succeed(), "should report number of sockets")
+				})
 
-			It("[test_id:1662]should report 2 sockets from spec.domain.resources.limits under guest OS ", func() {
-				vmi.Spec.Domain.CPU = nil
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("100M"),
-					},
-					Limits: kubev1.ResourceList{
-						kubev1.ResourceCPU: resource.MustParse("1200m"),
-					},
-				}
+				It("[test_id:1662]should report 2 sockets from spec.domain.resources.limits under guest OS ", Labels{"test_id:1662"}, func() {
+					vmi.Spec.Domain.CPU = nil
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("100M"),
+						},
+						Limits: kubev1.ResourceList{
+							kubev1.ResourceCPU: resource.MustParse("1200m"),
+						},
+					}
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				By("Checking the number of sockets under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
-					&expect.BExp{R: console.RetValue("2")},
-				}, 60)).To(Succeed(), "should report number of sockets")
-			})
+					By("Checking the number of sockets under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
+						&expect.BExp{R: console.RetValue("2")},
+					}, 60)).To(Succeed(), "should report number of sockets")
+				})
 
-			It("[test_id:1663]should report 4 vCPUs under guest OS", func() {
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Threads: 2,
-					Sockets: 2,
-					Cores:   1,
-				}
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("128M"),
-					},
-				}
+				It("[test_id:1663]should report 4 vCPUs under guest OS", Labels{"test_id:1663"}, func() {
+					vmi.Spec.Domain.CPU = &v1.CPU{
+						Threads: 2,
+						Sockets: 2,
+						Cores:   1,
+					}
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("128M"),
+						},
+					}
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				By("Checking the number of vCPUs under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: console.RetValue("4")},
-				}, 60)).To(Succeed(), "should report number of threads")
-			})
+					By("Checking the number of vCPUs under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
+						&expect.BExp{R: console.RetValue("4")},
+					}, 60)).To(Succeed(), "should report number of threads")
+				})
 
-			It("[Serial][test_id:1664]should map cores to virtio block queues", func() {
-				_true := true
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-						kubev1.ResourceCPU:    resource.MustParse("3"),
-					},
-				}
-				vmi.Spec.Domain.Devices.BlockMultiQueue = &_true
+				It("[Serial][test_id:1664]should map cores to virtio block queues", Labels{"Serial", "test_id:1664"}, func() {
+					_true := true
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("64M"),
+							kubev1.ResourceCPU:    resource.MustParse("3"),
+						},
+					}
+					vmi.Spec.Domain.Devices.BlockMultiQueue = &_true
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(ContainSubstring("queues='3'"))
-			})
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).To(ContainSubstring("queues='3'"))
+				})
 
-			It("[test_id:1665]should map cores to virtio net queues", func() {
-				if tests.ShouldAllowEmulation(virtClient) {
-					Skip("Software emulation should not be enabled for this test to run")
-				}
+				It("[test_id:1665]should map cores to virtio net queues", Labels{"test_id:1665"}, func() {
+					if tests.ShouldAllowEmulation(virtClient) {
+						Skip("Software emulation should not be enabled for this test to run")
+					}
 
-				_true := true
-				_false := false
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-						kubev1.ResourceCPU:    resource.MustParse("3"),
-					},
-				}
+					_true := true
+					_false := false
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("64M"),
+							kubev1.ResourceCPU:    resource.MustParse("3"),
+						},
+					}
 
-				vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
-				vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
+					vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
+					vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(ContainSubstring("driver name='vhost' queues='3'"))
-				// make sure that there are not block queues configured
-				Expect(domXml).ToNot(ContainSubstring("cache='none' queues='3'"))
-			})
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).To(ContainSubstring("driver name='vhost' queues='3'"))
+					// make sure that there are not block queues configured
+					Expect(domXml).ToNot(ContainSubstring("cache='none' queues='3'"))
+				})
 
-			It("[test_id:1667]should not enforce explicitly rejected virtio block queues without cores", func() {
-				_false := false
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
-				vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
+				It("[test_id:1667]should not enforce explicitly rejected virtio block queues without cores", Labels{"test_id:1667"}, func() {
+					_false := false
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("64M"),
+						},
+					}
+					vmi.Spec.Domain.Devices.BlockMultiQueue = &_false
 
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).ToNot(ContainSubstring("queues='"))
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with no memory requested", func() {
-			It("[test_id:3113]should failed to the VMI creation", func() {
-				vmi := tests.NewRandomVMI()
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
-				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", func() {
-			BeforeEach(func() {
-				kv := util.GetCurrentKv(virtClient)
-
-				config := kv.Spec.Configuration
-				config.DeveloperConfiguration.MemoryOvercommit = 200
-				tests.UpdateKubeVirtConfigValueAndWait(config)
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).ToNot(ContainSubstring("queues='"))
+				})
 			})
 
-			It("[test_id:3114]should set requested amount of memory according to the specified virtual memory", func() {
-				vmi := tests.NewRandomVMI()
-				guestMemory := resource.MustParse("4096M")
-				vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
-				runningVMI := tests.RunVMI(vmi, 30)
-				Expect(runningVMI.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with no memory requested",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				It("[test_id:3113]should failed to the VMI creation", Labels{"test_id:3113"}, func() {
+					vmi := tests.NewRandomVMI()
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
+					By("Starting a VirtualMachineInstance")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(HaveOccurred())
+				})
 			})
-		})
+
+		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied",
+			Labels{"Serial", "rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				BeforeEach(func() {
+					kv := util.GetCurrentKv(virtClient)
+
+					config := kv.Spec.Configuration
+					config.DeveloperConfiguration.MemoryOvercommit = 200
+					tests.UpdateKubeVirtConfigValueAndWait(config)
+				})
+
+				It("[test_id:3114]should set requested amount of memory according to the specified virtual memory", Labels{"test_id:3114"}, func() {
+					vmi := tests.NewRandomVMI()
+					guestMemory := resource.MustParse("4096M")
+					vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
+					runningVMI := tests.RunVMI(vmi, 30)
+					Expect(runningVMI.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("2048M"))
+				})
+			})
 
 		Context("with BIOS bootloader method and no disk", func() {
-			It("[test_id:5265]should find no bootable device by default", func() {
+			It("[test_id:5265]should find no bootable device by default", Labels{"test_id:5265"}, func() {
 				By("Creating a VMI with no disk and an explicit network interface")
 				vmi := tests.NewRandomVMI()
 				tests.AddExplicitPodNetworkInterface(vmi)
@@ -524,7 +532,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				// The expecter *should* have error-ed since the network interface is not marked bootable
 			})
 
-			It("[test_id:5266]should boot to NIC rom if a boot order was set on a network interface", func() {
+			It("[test_id:5266]should boot to NIC rom if a boot order was set on a network interface", Labels{"test_id:5266"}, func() {
 				By("Creating a VMI with no disk and an explicit network interface")
 				vmi := tests.NewRandomVMI()
 				tests.AddExplicitPodNetworkInterface(vmi)
@@ -551,69 +559,53 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		DescribeTable("[rfe_id:2262][crit:medium][vendor:cnv-qe@redhat.com][level:component]with EFI bootloader method", func(vmiNew VMICreationFuncWithEFI, loginTo console.LoginToFunction, msg string, fileName string) {
-			vmi := vmiNew()
-			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			wp := tests.WarningsPolicy{FailOnWarnings: false}
-			tests.WaitForVMIStartOrFailed(vmi, 180, wp)
-			vmiMeta, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-			switch vmiMeta.Status.Phase {
-			case v1.Failed:
-				// This Error is expected to be handled
-				By("Getting virt-launcher logs")
-				logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
-				Eventually(logs,
-					30*time.Second,
-					500*time.Millisecond).
-					Should(ContainSubstring("EFI OVMF rom missing"))
-			default:
-				tests.WaitUntilVMIReady(vmi, loginTo)
-				By(msg)
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+		DescribeTable("[rfe_id:2262][crit:medium][vendor:cnv-qe@redhat.com][level:component]with EFI bootloader method",
+			Labels{"rfe_id:2262", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func(vmiNew VMICreationFuncWithEFI, loginTo console.LoginToFunction, msg string, fileName string) {
+				vmi := vmiNew()
+				By("Starting a VirtualMachineInstance")
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(MatchRegexp(fileName))
-			}
-		},
-			Entry("[Serial][test_id:1668]should use EFI without secure boot", tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
-			Entry("[Serial][test_id:4437]should enable EFI secure boot", tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
+
+				wp := tests.WarningsPolicy{FailOnWarnings: false}
+				tests.WaitForVMIStartOrFailed(vmi, 180, wp)
+				vmiMeta, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+				switch vmiMeta.Status.Phase {
+				case v1.Failed:
+					// This Error is expected to be handled
+					By("Getting virt-launcher logs")
+					logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
+					Eventually(logs,
+						30*time.Second,
+						500*time.Millisecond).
+						Should(ContainSubstring("EFI OVMF rom missing"))
+				default:
+					tests.WaitUntilVMIReady(vmi, loginTo)
+					By(msg)
+					domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(domXml).To(MatchRegexp(fileName))
+				}
+			},
+			Entry("[Serial][test_id:1668]should use EFI without secure boot", Labels{"Serial", "test_id:1668"}, tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
+			Entry("[Serial][test_id:4437]should enable EFI secure boot", Labels{"Serial", "test_id:4437"}, tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
 		)
 
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {
-			It("[test_id:1669]should show the requested guest memory inside the VMI", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				guestMemory := resource.MustParse("256Mi")
-				vmi.Spec.Domain.Memory = &v1.Memory{
-					Guest: &guestMemory,
-				}
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				It("[test_id:1669]should show the requested guest memory inside the VMI", Labels{"test_id:1669"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					guestMemory := resource.MustParse("256Mi")
+					vmi.Spec.Domain.Memory = &v1.Memory{
+						Guest: &guestMemory,
+					}
 
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("225")},
-				}, 10)).To(Succeed())
-
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging memory limit from memory request and no guest memory", func() {
-			It("[test_id:3115]should show the memory limit inside the VMI", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.Resources.Limits = kubev1.ResourceList{
-					kubev1.ResourceMemory: resource.MustParse("256Mi"),
-				}
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
@@ -622,10 +614,31 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					&expect.BExp{R: console.RetValue("225")},
 				}, 10)).To(Succeed())
 
+				})
 			})
-		})
 
-		Context("[rfe_id:989]test cpu_allocation_ratio", func() {
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging memory limit from memory request and no guest memory",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
+				It("[test_id:3115]should show the memory limit inside the VMI", Labels{"test_id:3115"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					vmi.Spec.Domain.Resources.Limits = kubev1.ResourceList{
+						kubev1.ResourceMemory: resource.MustParse("256Mi"),
+					}
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
+					&expect.BExp{R: console.RetValue("225")},
+				}, 10)).To(Succeed())
+
+				})
+			})
+
+		Context("[rfe_id:989]test cpu_allocation_ratio", Labels{"rfe_id:989"}, func() {
 			It("virt-launchers pod cpu requests should be proportional to the number of vCPUs", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				guestMemory := resource.MustParse("256Mi")
@@ -658,489 +671,504 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		})
 
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with support memory over commitment", func() {
-			It("[test_id:755]should show the requested memory different than guest memory", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				guestMemory := resource.MustParse("256Mi")
-				vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
-				vmi.Spec.Domain.Memory = &v1.Memory{
-					Guest: &guestMemory,
-				}
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with support memory over commitment",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				It("[test_id:755]should show the requested memory different than guest memory", Labels{"test_id:755"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					guestMemory := resource.MustParse("256Mi")
+					vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+					vmi.Spec.Domain.Memory = &v1.Memory{
+						Guest: &guestMemory,
+					}
 
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
-					&expect.BExp{R: console.RetValue("pass")},
-					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=100k\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 15)).To(Succeed())
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
+						&expect.BExp{R: console.RetValue("pass")},
+						&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=100k\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+					}, 15)).To(Succeed())
 
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				podMemoryUsage, err := getPodMemoryUsage(pod)
-				Expect(err).ToNot(HaveOccurred())
-				By("Converting pod memory usage")
-				m, err := strconv.Atoi(strings.Trim(podMemoryUsage, "\n"))
-				Expect(err).ToNot(HaveOccurred())
-				By("Checking if pod memory usage is > 64Mi")
-				Expect(m > 67108864).To(BeTrue(), "67108864 B = 64 Mi")
+					pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					podMemoryUsage, err := getPodMemoryUsage(pod)
+					Expect(err).ToNot(HaveOccurred())
+					By("Converting pod memory usage")
+					m, err := strconv.Atoi(strings.Trim(podMemoryUsage, "\n"))
+					Expect(err).ToNot(HaveOccurred())
+					By("Checking if pod memory usage is > 64Mi")
+					Expect(m > 67108864).To(BeTrue(), "67108864 B = 64 Mi")
+				})
+
 			})
 
-		})
+		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test",
+			Labels{"rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var vmi *v1.VirtualMachineInstance
 
-		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test", func() {
-			var vmi *v1.VirtualMachineInstance
+				BeforeEach(func() {
+					vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("128M")
+					vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
 
-			BeforeEach(func() {
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("128M")
-				vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(vmi)
+				})
 
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(vmi)
+				It("[test_id:730]Check OverCommit VM Created and Started", Labels{"test_id:730"}, func() {
+					overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(overcommitVmi)
+				})
+				It("[test_id:731]Check OverCommit status on VMI", Labels{"test_id:731"}, func() {
+					overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(overcommitVmi.Spec.Domain.Resources.OvercommitGuestOverhead).To(BeTrue())
+				})
+				It("[test_id:732]Check Free memory on the VMI", Labels{"test_id:732"}, func() {
+					By("Expecting console")
+					Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+					// Check on the VM, if the Free memory is roughly what we expected
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 90 ] && echo 'pass'\n"},
+						&expect.BExp{R: console.RetValue("pass")},
+					}, 15)).To(Succeed())
+				})
 			})
 
-			It("[test_id:730]Check OverCommit VM Created and Started", func() {
-				overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(overcommitVmi)
-			})
-			It("[test_id:731]Check OverCommit status on VMI", func() {
-				overcommitVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(overcommitVmi.Spec.Domain.Resources.OvercommitGuestOverhead).To(BeTrue())
-			})
-			It("[test_id:732]Check Free memory on the VMI", func() {
-				By("Expecting console")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+		Context("[rfe_id:3078][crit:medium][vendor:cnv-qe@redhat.com][level:component]with usb controller",
+			Labels{"rfe_id:3078", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				It("[test_id:3117]should start the VMI with usb controller when usb device is present", Labels{"test_id:3117"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+						{
+							Name: "tablet0",
+							Type: "tablet",
+							Bus:  "usb",
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				// Check on the VM, if the Free memory is roughly what we expected
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 90 ] && echo 'pass'\n"},
-					&expect.BExp{R: console.RetValue("pass")},
-				}, 15)).To(Succeed())
-			})
-		})
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-		Context("[rfe_id:3078][crit:medium][vendor:cnv-qe@redhat.com][level:component]with usb controller", func() {
-			It("[test_id:3117]should start the VMI with usb controller when usb device is present", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
-					{
-						Name: "tablet0",
-						Type: "tablet",
-						Bus:  "usb",
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Checking the number of usb under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
+						&expect.BExp{R: console.RetValue("2")},
+					}, 60)).To(Succeed(), "should report number of usb")
+				})
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				It("[test_id:3117]should start the VMI with usb controller when input device doesn't have bus", Labels{"test_id:3117"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+						{
+							Name: "tablet0",
+							Type: "tablet",
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Checking the number of usb under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
-					&expect.BExp{R: console.RetValue("2")},
-				}, 60)).To(Succeed(), "should report number of usb")
-			})
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-			It("[test_id:3117]should start the VMI with usb controller when input device doesn't have bus", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
-					{
-						Name: "tablet0",
-						Type: "tablet",
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+					By("Checking the number of usb under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
+						&expect.BExp{R: console.RetValue("2")},
+					}, 60)).To(Succeed(), "should report number of usb")
+				})
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				It("[test_id:3118]should start the VMI without usb controller", Labels{"test_id:3118"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
 
-				By("Checking the number of usb under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
-					&expect.BExp{R: console.RetValue("2")},
-				}, 60)).To(Succeed(), "should report number of usb")
-			})
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-			It("[test_id:3118]should start the VMI without usb controller", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-				By("Checking the number of usb under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* 2>/dev/null | wc -l\n"},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 60)).To(Succeed(), "should report number of usb")
-			})
-		})
-
-		Context("[rfe_id:3077][crit:medium][vendor:cnv-qe@redhat.com][level:component]with input devices", func() {
-			It("[test_id:2642]should failed to start the VMI with wrong type of input device", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
-					{
-						Name: "tablet0",
-						Type: "keyboard",
-						Bus:  "virtio",
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(HaveOccurred(), "should not start vmi")
+					By("Checking the number of usb under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* 2>/dev/null | wc -l\n"},
+						&expect.BExp{R: console.RetValue("0")},
+					}, 60)).To(Succeed(), "should report number of usb")
+				})
 			})
 
-			It("[test_id:3074]should failed to start the VMI with wrong bus of input device", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
-					{
-						Name: "tablet0",
-						Type: "tablet",
-						Bus:  "ps2",
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(HaveOccurred(), "should not start vmi")
+		Context("[rfe_id:3077][crit:medium][vendor:cnv-qe@redhat.com][level:component]with input devices",
+			Labels{"rfe_id:3077", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"}, func() {
+				It("[test_id:2642]should failed to start the VMI with wrong type of input device", Labels{"test_id:2642"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+						{
+							Name: "tablet0",
+							Type: "keyboard",
+							Bus:  "virtio",
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(HaveOccurred(), "should not start vmi")
+				})
+
+				It("[test_id:3074]should failed to start the VMI with wrong bus of input device", Labels{"test_id:3074"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+						{
+							Name: "tablet0",
+							Type: "tablet",
+							Bus:  "ps2",
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(HaveOccurred(), "should not start vmi")
+				})
+
+				It("[test_id:3072]should start the VMI with tablet input device with virtio bus", Labels{"test_id:3072"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+						{
+							Name: "tablet0",
+							Type: "tablet",
+							Bus:  "virtio",
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+					By("Checking the tablet input under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -rs '^QEMU Virtio Tablet' /sys/devices | wc -l\n"},
+						&expect.BExp{R: console.RetValue("1")},
+					}, 60)).To(Succeed(), "should report input device")
+				})
+
+				It("[test_id:3073]should start the VMI with tablet input device with usb bus", Labels{"test_id:3073"}, func() {
+					vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+						{
+							Name: "tablet0",
+							Type: "tablet",
+							Bus:  "usb",
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred(), "should start vmi")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+					By("Checking the tablet input under guest OS")
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -rs '^QEMU USB Tablet' /sys/devices | wc -l\n"},
+						&expect.BExp{R: console.RetValue("1")},
+					}, 60)).To(Succeed(), "should report input device")
+				})
 			})
 
-			It("[test_id:3072]should start the VMI with tablet input device with virtio bus", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
-					{
-						Name: "tablet0",
-						Type: "tablet",
-						Bus:  "virtio",
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace memory limits lower than VMI required memory",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var vmi *v1.VirtualMachineInstance
+				It("[test_id:1670]should failed to start the VMI", Labels{"test_id:1670"}, func() {
+					// create a namespace default limit
+					limitRangeObj := kubev1.LimitRange{
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-				By("Checking the tablet input under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -rs '^QEMU Virtio Tablet' /sys/devices | wc -l\n"},
-					&expect.BExp{R: console.RetValue("1")},
-				}, 60)).To(Succeed(), "should report input device")
-			})
-
-			It("[test_id:3073]should start the VMI with tablet input device with usb bus", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
-					{
-						Name: "tablet0",
-						Type: "tablet",
-						Bus:  "usb",
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start vmi")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
-
-				By("Checking the tablet input under guest OS")
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -rs '^QEMU USB Tablet' /sys/devices | wc -l\n"},
-					&expect.BExp{R: console.RetValue("1")},
-				}, 60)).To(Succeed(), "should report input device")
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace memory limits lower than VMI required memory", func() {
-			var vmi *v1.VirtualMachineInstance
-			It("[test_id:1670]should failed to start the VMI", func() {
-				// create a namespace default limit
-				limitRangeObj := kubev1.LimitRange{
-
-					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
-					Spec: kubev1.LimitRangeSpec{
-						Limits: []kubev1.LimitRangeItem{
-							{
-								Type: kubev1.LimitTypeContainer,
-								Default: kubev1.ResourceList{
-									kubev1.ResourceMemory: resource.MustParse("32Mi"),
+						ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
+						Spec: kubev1.LimitRangeSpec{
+							Limits: []kubev1.LimitRangeItem{
+								{
+									Type: kubev1.LimitTypeContainer,
+									Default: kubev1.ResourceList{
+										kubev1.ResourceMemory: resource.MustParse("32Mi"),
+									},
 								},
 							},
 						},
-					},
-				}
-				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+					}
+					_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
-				By("Starting a VirtualMachineInstance")
-				// Retrying up to 5 sec, then if you still succeeds in VMI creation, things must be going wrong.
-				Eventually(func() error {
+					By("Starting a VirtualMachineInstance")
+					// Retrying up to 5 sec, then if you still succeeds in VMI creation, things must be going wrong.
+					Eventually(func() error {
+						vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+						vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+							Requests: kubev1.ResourceList{
+								kubev1.ResourceMemory: resource.MustParse("64M"),
+							},
+						}
+						vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+						return err
+					}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.memory '64M' is greater than spec.domain.resources.limits.memory '32Mi'"))
+				})
+			})
+
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace cpu limits lower than VMI required cpu",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var vmi *v1.VirtualMachineInstance
+				It("[test_id:3119]should fail to start the VMI", Labels{"test_id:3119"}, func() {
+					// create a namespace default limit
+					limitRangeObj := kubev1.LimitRange{
+
+						ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
+						Spec: kubev1.LimitRangeSpec{
+							Limits: []kubev1.LimitRangeItem{
+								{
+									Type: kubev1.LimitTypeContainer,
+									Default: kubev1.ResourceList{
+										kubev1.ResourceCPU: resource.MustParse("500m"),
+									},
+								},
+							},
+						},
+					}
+					_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Starting a VirtualMachineInstance")
+					// Retrying up to 5 sec, then if you still succeeds in VMI creation, things must be going wrong.
+					Eventually(func() error {
+						vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+						vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+							Requests: kubev1.ResourceList{
+								kubev1.ResourceCPU:    resource.MustParse("800m"),
+								kubev1.ResourceMemory: resource.MustParse("512M"),
+							},
+						}
+						vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+						return err
+					}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.cpu '800m' is greater than spec.domain.resources.limits.cpu '500m'"))
+				})
+			})
+
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace limits higher than VMI requests",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var vmi *v1.VirtualMachineInstance
+				It("[test_id:3120]should start the VMI with the right default settings from namespace limits", Labels{"test_id:3120"}, func() {
+					// create a namespace default limit
+					limitRangeObj := kubev1.LimitRange{
+
+						ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
+						Spec: kubev1.LimitRangeSpec{
+							Limits: []kubev1.LimitRangeItem{
+								{
+									Type: kubev1.LimitTypeContainer,
+									Default: kubev1.ResourceList{
+										kubev1.ResourceCPU:    resource.MustParse("2000m"),
+										kubev1.ResourceMemory: resource.MustParse("512M"),
+									},
+									DefaultRequest: kubev1.ResourceList{
+										kubev1.ResourceCPU: resource.MustParse("500m"),
+									},
+								},
+							},
+						},
+					}
+					_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
 					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
 							kubev1.ResourceMemory: resource.MustParse("64M"),
 						},
-					}
-					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-					virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
-					return err
-				}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.memory '64M' is greater than spec.domain.resources.limits.memory '32Mi'"))
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace cpu limits lower than VMI required cpu", func() {
-			var vmi *v1.VirtualMachineInstance
-			It("[test_id:3119]should fail to start the VMI", func() {
-				// create a namespace default limit
-				limitRangeObj := kubev1.LimitRange{
-
-					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
-					Spec: kubev1.LimitRangeSpec{
-						Limits: []kubev1.LimitRangeItem{
-							{
-								Type: kubev1.LimitTypeContainer,
-								Default: kubev1.ResourceList{
-									kubev1.ResourceCPU: resource.MustParse("500m"),
-								},
-							},
-						},
-					},
-				}
-				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Starting a VirtualMachineInstance")
-				// Retrying up to 5 sec, then if you still succeeds in VMI creation, things must be going wrong.
-				Eventually(func() error {
-					vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-						Requests: kubev1.ResourceList{
-							kubev1.ResourceCPU:    resource.MustParse("800m"),
-							kubev1.ResourceMemory: resource.MustParse("512M"),
+						Limits: kubev1.ResourceList{
+							kubev1.ResourceCPU: resource.MustParse("1000m"),
 						},
 					}
-					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-					virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
-					return err
-				}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.cpu '800m' is greater than spec.domain.resources.limits.cpu '500m'"))
-			})
-		})
 
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace limits higher than VMI requests", func() {
-			var vmi *v1.VirtualMachineInstance
-			It("[test_id:3120]should start the VMI with the right default settings from namespace limits", func() {
-				// create a namespace default limit
-				limitRangeObj := kubev1.LimitRange{
+					By("Creating a VMI")
+					Eventually(func() bool {
+						createdVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "should create vmi")
 
-					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
-					Spec: kubev1.LimitRangeSpec{
-						Limits: []kubev1.LimitRangeItem{
-							{
-								Type: kubev1.LimitTypeContainer,
-								Default: kubev1.ResourceList{
-									kubev1.ResourceCPU:    resource.MustParse("2000m"),
-									kubev1.ResourceMemory: resource.MustParse("512M"),
-								},
-								DefaultRequest: kubev1.ResourceList{
-									kubev1.ResourceCPU: resource.MustParse("500m"),
-								},
-							},
-						},
-					},
-				}
-				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+						err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(createdVMI.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred(), "should delete vmi")
 
-				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-					Limits: kubev1.ResourceList{
-						kubev1.ResourceCPU: resource.MustParse("1000m"),
-					},
-				}
-
-				By("Creating a VMI")
-				Eventually(func() bool {
-					createdVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-					Expect(err).ToNot(HaveOccurred(), "should create vmi")
-
-					err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(createdVMI.Name, &metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred(), "should delete vmi")
-
-					return reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega), int64(64)) &&
-						reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega), int64(512)) &&
-						reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Cpu().MilliValue(), int64(500)) &&
-						reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Limits.Cpu().MilliValue(), int64(1000))
-				}, 30*time.Second, time.Second).Should(BeTrue())
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with hugepages", func() {
-			var hugepagesVmi *v1.VirtualMachineInstance
-
-			verifyHugepagesConsumption := func() bool {
-				// TODO: we need to check hugepages state via node allocated resources, but currently it has the issue
-				// https://github.com/kubernetes/kubernetes/issues/64691
-				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(pods.Items).To(HaveLen(1))
-
-				hugepagesSize := resource.MustParse(hugepagesVmi.Spec.Domain.Memory.Hugepages.PageSize)
-				hugepagesDir := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%dkB", hugepagesSize.Value()/int64(1024))
-
-				// Get a hugepages statistics from virt-launcher pod
-				output, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					&pods.Items[0],
-					pods.Items[0].Spec.Containers[0].Name,
-					[]string{"cat", fmt.Sprintf("%s/nr_hugepages", hugepagesDir)},
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				totalHugepages, err := strconv.Atoi(strings.Trim(output, "\n"))
-				Expect(err).ToNot(HaveOccurred())
-
-				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
-					&pods.Items[0],
-					pods.Items[0].Spec.Containers[0].Name,
-					[]string{"cat", fmt.Sprintf("%s/free_hugepages", hugepagesDir)},
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				freeHugepages, err := strconv.Atoi(strings.Trim(output, "\n"))
-				Expect(err).ToNot(HaveOccurred())
-
-				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
-					&pods.Items[0],
-					pods.Items[0].Spec.Containers[0].Name,
-					[]string{"cat", fmt.Sprintf("%s/resv_hugepages", hugepagesDir)},
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				resvHugepages, err := strconv.Atoi(strings.Trim(output, "\n"))
-				Expect(err).ToNot(HaveOccurred())
-
-				// Verify that the VM memory equals to a number of consumed hugepages
-				vmHugepagesConsumption := int64(totalHugepages-freeHugepages+resvHugepages) * hugepagesSize.Value()
-				vmMemory := hugepagesVmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory]
-				if hugepagesVmi.Spec.Domain.Memory != nil && hugepagesVmi.Spec.Domain.Memory.Guest != nil {
-					vmMemory = *hugepagesVmi.Spec.Domain.Memory.Guest
-				}
-
-				if vmHugepagesConsumption == vmMemory.Value() {
-					return true
-				}
-				return false
-			}
-			BeforeEach(func() {
-				hugepagesVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						return reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega), int64(64)) &&
+							reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega), int64(512)) &&
+							reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Cpu().MilliValue(), int64(500)) &&
+							reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Limits.Cpu().MilliValue(), int64(1000))
+					}, 30*time.Second, time.Second).Should(BeTrue())
+				})
 			})
 
-			DescribeTable("should consume hugepages ", func(hugepageSize string, memory string, guestMemory string) {
-				hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + hugepageSize)
-				v, err := cluster.GetKubernetesVersion()
-				Expect(err).ShouldNot(HaveOccurred())
-				if strings.Contains(v, "1.16") {
-					hugepagesVmi.Annotations = map[string]string{
-						v1.MemfdMemoryBackend: "false",
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with hugepages",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var hugepagesVmi *v1.VirtualMachineInstance
+
+				verifyHugepagesConsumption := func() bool {
+					// TODO: we need to check hugepages state via node allocated resources, but currently it has the issue
+					// https://github.com/kubernetes/kubernetes/issues/64691
+					pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(hugepagesVmi))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pods.Items).To(HaveLen(1))
+
+					hugepagesSize := resource.MustParse(hugepagesVmi.Spec.Domain.Memory.Hugepages.PageSize)
+					hugepagesDir := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%dkB", hugepagesSize.Value()/int64(1024))
+
+					// Get a hugepages statistics from virt-launcher pod
+					output, err := tests.ExecuteCommandOnPod(
+						virtClient,
+						&pods.Items[0],
+						pods.Items[0].Spec.Containers[0].Name,
+						[]string{"cat", fmt.Sprintf("%s/nr_hugepages", hugepagesDir)},
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					totalHugepages, err := strconv.Atoi(strings.Trim(output, "\n"))
+					Expect(err).ToNot(HaveOccurred())
+
+					output, err = tests.ExecuteCommandOnPod(
+						virtClient,
+						&pods.Items[0],
+						pods.Items[0].Spec.Containers[0].Name,
+						[]string{"cat", fmt.Sprintf("%s/free_hugepages", hugepagesDir)},
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					freeHugepages, err := strconv.Atoi(strings.Trim(output, "\n"))
+					Expect(err).ToNot(HaveOccurred())
+
+					output, err = tests.ExecuteCommandOnPod(
+						virtClient,
+						&pods.Items[0],
+						pods.Items[0].Spec.Containers[0].Name,
+						[]string{"cat", fmt.Sprintf("%s/resv_hugepages", hugepagesDir)},
+					)
+					Expect(err).ToNot(HaveOccurred())
+
+					resvHugepages, err := strconv.Atoi(strings.Trim(output, "\n"))
+					Expect(err).ToNot(HaveOccurred())
+
+					// Verify that the VM memory equals to a number of consumed hugepages
+					vmHugepagesConsumption := int64(totalHugepages-freeHugepages+resvHugepages) * hugepagesSize.Value()
+					vmMemory := hugepagesVmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory]
+					if hugepagesVmi.Spec.Domain.Memory != nil && hugepagesVmi.Spec.Domain.Memory.Guest != nil {
+						vmMemory = *hugepagesVmi.Spec.Domain.Memory.Guest
 					}
-					log.DefaultLogger().Object(hugepagesVmi).Infof("Fall back to use hugepages source file. Libvirt in the 1.16 provider version doesn't support memfd as memory backend")
-				}
 
-				nodeWithHugepages := tests.GetNodeWithHugepages(virtClient, hugepageType)
-				if nodeWithHugepages == nil {
-					Skip(fmt.Sprintf("No node with hugepages %s capacity", hugepageType))
+					if vmHugepagesConsumption == vmMemory.Value() {
+						return true
+					}
+					return false
 				}
-				// initialHugepages := nodeWithHugepages.Status.Capacity[resourceName]
-				hugepagesVmi.Spec.Affinity = &kubev1.Affinity{
-					NodeAffinity: &kubev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &kubev1.NodeSelector{
-							NodeSelectorTerms: []kubev1.NodeSelectorTerm{
-								{
-									MatchExpressions: []kubev1.NodeSelectorRequirement{
-										{Key: "kubernetes.io/hostname", Operator: kubev1.NodeSelectorOpIn, Values: []string{nodeWithHugepages.Name}},
+				BeforeEach(func() {
+					hugepagesVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				})
+
+				DescribeTable("should consume hugepages ", func(hugepageSize string, memory string, guestMemory string) {
+					hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + hugepageSize)
+					v, err := cluster.GetKubernetesVersion()
+					Expect(err).ShouldNot(HaveOccurred())
+					if strings.Contains(v, "1.16") {
+						hugepagesVmi.Annotations = map[string]string{
+							v1.MemfdMemoryBackend: "false",
+						}
+						log.DefaultLogger().Object(hugepagesVmi).Infof("Fall back to use hugepages source file. Libvirt in the 1.16 provider version doesn't support memfd as memory backend")
+					}
+
+					nodeWithHugepages := tests.GetNodeWithHugepages(virtClient, hugepageType)
+					if nodeWithHugepages == nil {
+						Skip(fmt.Sprintf("No node with hugepages %s capacity", hugepageType))
+					}
+					// initialHugepages := nodeWithHugepages.Status.Capacity[resourceName]
+					hugepagesVmi.Spec.Affinity = &kubev1.Affinity{
+						NodeAffinity: &kubev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &kubev1.NodeSelector{
+								NodeSelectorTerms: []kubev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []kubev1.NodeSelectorRequirement{
+											{Key: "kubernetes.io/hostname", Operator: kubev1.NodeSelectorOpIn, Values: []string{nodeWithHugepages.Name}},
+										},
 									},
 								},
 							},
 						},
-					},
-				}
-				hugepagesVmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse(memory)
-
-				hugepagesVmi.Spec.Domain.Memory = &v1.Memory{
-					Hugepages: &v1.Hugepages{PageSize: hugepageSize},
-				}
-				if guestMemory != "None" {
-					guestMemReq := resource.MustParse(guestMemory)
-					hugepagesVmi.Spec.Domain.Memory.Guest = &guestMemReq
-				}
-
-				By("Starting a VM")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(hugepagesVmi)
-
-				By("Checking that the VM memory equals to a number of consumed hugepages")
-				Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
-			},
-				Entry("[Serial][test_id:1671]hugepages-2Mi", "2Mi", "64Mi", "None"),
-				Entry("[Serial][test_id:1672]hugepages-1Gi", "1Gi", "1Gi", "None"),
-				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", "2Mi", "70Mi", "64Mi"),
-			)
-
-			Context("with unsupported page size", func() {
-				It("[test_id:1673]should failed to schedule the pod", func() {
-					nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					hugepageType2Mi := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + "2Mi")
-					for _, node := range nodes.Items {
-						if _, ok := node.Status.Capacity[hugepageType2Mi]; !ok {
-							Skip("No nodes with hugepages support")
-						}
 					}
-
-					hugepagesVmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("66Mi")
+					hugepagesVmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse(memory)
 
 					hugepagesVmi.Spec.Domain.Memory = &v1.Memory{
-						Hugepages: &v1.Hugepages{PageSize: "3Mi"},
+						Hugepages: &v1.Hugepages{PageSize: hugepageSize},
+					}
+					if guestMemory != "None" {
+						guestMemReq := resource.MustParse(guestMemory)
+						hugepagesVmi.Spec.Domain.Memory.Guest = &guestMemReq
 					}
 
 					By("Starting a VM")
 					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
 					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(hugepagesVmi)
 
-					var vmiCondition v1.VirtualMachineInstanceCondition
-					Eventually(func() bool {
-						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(hugepagesVmi.Name, &metav1.GetOptions{})
+					By("Checking that the VM memory equals to a number of consumed hugepages")
+					Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
+				},
+					Entry("[Serial][test_id:1671]hugepages-2Mi", Labels{"Serial", "test_id:1671"}, "2Mi", "64Mi", "None"),
+					Entry("[Serial][test_id:1672]hugepages-1Gi", Labels{"Serial", "test_id:1672"}, "1Gi", "1Gi", "None"),
+					Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", Labels{"Serial", "test_id:1672"}, "2Mi", "70Mi", "64Mi"),
+				)
+
+				Context("with unsupported page size", func() {
+					It("[test_id:1673]should failed to schedule the pod", Labels{"test_id:1673"}, func() {
+						nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 						Expect(err).ToNot(HaveOccurred())
+
+						hugepageType2Mi := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + "2Mi")
+						for _, node := range nodes.Items {
+							if _, ok := node.Status.Capacity[hugepageType2Mi]; !ok {
+								Skip("No nodes with hugepages support")
+							}
+						}
+
+						hugepagesVmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("66Mi")
+
+						hugepagesVmi.Spec.Domain.Memory = &v1.Memory{
+							Hugepages: &v1.Hugepages{PageSize: "3Mi"},
+						}
+
+						By("Starting a VM")
+						_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(hugepagesVmi)
+						Expect(err).ToNot(HaveOccurred())
+
+						var vmiCondition v1.VirtualMachineInstanceCondition
+						Eventually(func() bool {
+							vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(hugepagesVmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred())
 
 						for _, cond := range vmi.Status.Conditions {
 							if cond.Type == v1.VirtualMachineInstanceConditionType(kubev1.PodScheduled) && cond.Status == kubev1.ConditionFalse {
@@ -1156,189 +1184,71 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		Context("[rfe_id:893][crit:medium][vendor:cnv-qe@redhat.com][level:component]with rng", func() {
-			var rngVmi *v1.VirtualMachineInstance
+		Context("[rfe_id:893][crit:medium][vendor:cnv-qe@redhat.com][level:component]with rng",
+			Labels{"rfe_id:893", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var rngVmi *v1.VirtualMachineInstance
 
-			BeforeEach(func() {
-				rngVmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			})
-
-			It("[test_id:1674]should have the virtio rng device present when present", func() {
-				rngVmi.Spec.Domain.Devices.Rng = &v1.Rng{}
-
-				By("Starting a VirtualMachineInstance")
-				rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(rngVmi)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(rngVmi)).To(Succeed())
-
-				By("Checking the virtio rng presence")
-				Expect(console.SafeExpectBatch(rngVmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -c ^virtio /sys/devices/virtual/misc/hw_random/rng_available\n"},
-					&expect.BExp{R: console.RetValue("1")},
-				}, 400)).To(Succeed())
-			})
-
-			It("[test_id:1675]should not have the virtio rng device when not present", func() {
-				By("Starting a VirtualMachineInstance")
-				rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(rngVmi)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToAlpine(rngVmi)).To(Succeed())
-
-				By("Checking the virtio rng presence")
-				Expect(console.SafeExpectBatch(rngVmi, []expect.Batcher{
-					&expect.BSnd{S: "[[ ! -e /sys/devices/virtual/misc/hw_random/rng_available ]] && echo non\n"},
-					&expect.BExp{R: console.RetValue("non")},
-				}, 400)).To(Succeed())
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent", func() {
-			var agentVMI *v1.VirtualMachineInstance
-
-			prepareAgentVM := func() *v1.VirtualMachineInstance {
-				// TODO: actually review this once the VM image is present
-				agentVMI := tests.NewRandomFedoraVMIWithGuestAgent()
-
-				By("Starting a VirtualMachineInstance")
-				agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-				tests.WaitForSuccessfulVMIStart(agentVMI)
-
-				getOptions := metav1.GetOptions{}
-				var freshVMI *v1.VirtualMachineInstance
-
-				By("VMI has the guest agent connected condition")
-				Eventually(func() []v1.VirtualMachineInstanceCondition {
-					freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-					return freshVMI.Status.Conditions
-				}, 240*time.Second, 2).Should(
-					ContainElement(
-						MatchFields(
-							IgnoreExtras,
-							Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
-					"Should have agent connected condition")
-
-				return agentVMI
-			}
-
-			It("[test_id:1676]should have attached a guest agent channel by default", func() {
-
-				agentVMI = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				By("Starting a VirtualMachineInstance")
-				agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-				tests.WaitForSuccessfulVMIStart(agentVMI)
-
-				getOptions := metav1.GetOptions{}
-				var freshVMI *v1.VirtualMachineInstance
-
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
-
-				Expect(domXML).To(ContainSubstring("<channel type='unix'>"), "Should contain at least one channel")
-				Expect(domXML).To(ContainSubstring("<target type='virtio' name='org.qemu.guest_agent.0' state='disconnected'/>"), "Should have guest agent channel present")
-				Expect(domXML).To(ContainSubstring("<alias name='channel0'/>"), "Should have guest channel present")
-			})
-
-			It("[test_id:1677]VMI condition should signal agent presence", func() {
-				agentVMI := prepareAgentVM()
-				getOptions := metav1.GetOptions{}
-
-				freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-				Expect(freshVMI.Status.Conditions).To(
-					ContainElement(
-						MatchFields(
-							IgnoreExtras,
-							Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
-					"agent should already be connected")
-
-			})
-
-			It("[test_id:4625]should remove condition when agent is off", func() {
-				agentVMI := prepareAgentVM()
-				getOptions := metav1.GetOptions{}
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(agentVMI)).To(Succeed())
-
-				By("Terminating guest agent and waiting for it to disappear.")
-				Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-					&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
-					&expect.BExp{R: console.PromptExpression},
-				}, 400)).To(Succeed())
-
-				By("VMI has the guest agent connected condition")
-				Eventually(func() []v1.VirtualMachineInstanceCondition {
-					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-					return freshVMI.Status.Conditions
-				}, 240*time.Second, 2).ShouldNot(
-					ContainElement(
-						MatchFields(
-							IgnoreExtras,
-							Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
-					"Agent condition should be gone")
-			})
-
-			Context("[Serial]with cluster config changes", func() {
 				BeforeEach(func() {
-					kv := util.GetCurrentKv(virtClient)
-
-					config := kv.Spec.Configuration
-					config.SupportedGuestAgentVersions = []string{"X.*"}
-					tests.UpdateKubeVirtConfigValueAndWait(config)
+					rngVmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				})
 
-				It("[test_id:5267]VMI condition should signal unsupported agent presence", func() {
-					agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-shutdown")
+				It("[test_id:1674]should have the virtio rng device present when present", Labels{"test_id:1674"}, func() {
+					rngVmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+
+					By("Starting a VirtualMachineInstance")
+					rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(rngVmi)
+
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(rngVmi)).To(Succeed())
+
+					By("Checking the virtio rng presence")
+					Expect(console.SafeExpectBatch(rngVmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -c ^virtio /sys/devices/virtual/misc/hw_random/rng_available\n"},
+						&expect.BExp{R: console.RetValue("1")},
+					}, 400)).To(Succeed())
+				})
+
+				It("[test_id:1675]should not have the virtio rng device when not present", Labels{"test_id:1675"}, func() {
+					By("Starting a VirtualMachineInstance")
+					rngVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(rngVmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(rngVmi)
+
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToAlpine(rngVmi)).To(Succeed())
+
+					By("Checking the virtio rng presence")
+					Expect(console.SafeExpectBatch(rngVmi, []expect.Batcher{
+						&expect.BSnd{S: "[[ ! -e /sys/devices/virtual/misc/hw_random/rng_available ]] && echo non\n"},
+						&expect.BExp{R: console.RetValue("non")},
+					}, 400)).To(Succeed())
+				})
+			})
+
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with guestAgent",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var agentVMI *v1.VirtualMachineInstance
+
+				prepareAgentVM := func() *v1.VirtualMachineInstance {
+					// TODO: actually review this once the VM image is present
+					agentVMI := tests.NewRandomFedoraVMIWithGuestAgent()
+
 					By("Starting a VirtualMachineInstance")
 					agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
 					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 					tests.WaitForSuccessfulVMIStart(agentVMI)
 
 					getOptions := metav1.GetOptions{}
-					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-
-					Eventually(func() []v1.VirtualMachineInstanceCondition {
-						freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-						return freshVMI.Status.Conditions
-					}, 240*time.Second, 2).Should(
-						ContainElement(
-							MatchFields(
-								IgnoreExtras,
-								Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
-						"Should have unsupported agent connected condition")
-
-				})
-
-				It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", func() {
-					agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-exec,guest-set-password")
-					By("Starting a VirtualMachineInstance")
-					agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
-					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
-					tests.WaitForSuccessfulVMIStart(agentVMI)
-
-					getOptions := metav1.GetOptions{}
-					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+					var freshVMI *v1.VirtualMachineInstance
 
 					By("VMI has the guest agent connected condition")
 					Eventually(func() []v1.VirtualMachineInstanceCondition {
 						freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 						return freshVMI.Status.Conditions
 					}, 240*time.Second, 2).Should(
 						ContainElement(
@@ -1347,40 +1257,162 @@ var _ = Describe("[sig-compute]Configurations", func() {
 								Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
 						"Should have agent connected condition")
 
-					By("fetching the VMI after agent has connected")
+					return agentVMI
+				}
+
+				It("[test_id:1676]should have attached a guest agent channel by default", Labels{"test_id:1676"}, func() {
+
+					agentVMI = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+					By("Starting a VirtualMachineInstance")
+					agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+					Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(agentVMI)
+
+					getOptions := metav1.GetOptions{}
+					var freshVMI *v1.VirtualMachineInstance
+
 					freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					Expect(freshVMI.Status.Conditions).ToNot(
+					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+
+					domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
+					Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
+
+					Expect(domXML).To(ContainSubstring("<channel type='unix'>"), "Should contain at least one channel")
+					Expect(domXML).To(ContainSubstring("<target type='virtio' name='org.qemu.guest_agent.0' state='disconnected'/>"), "Should have guest agent channel present")
+					Expect(domXML).To(ContainSubstring("<alias name='channel0'/>"), "Should have guest channel present")
+				})
+
+				It("[test_id:1677]VMI condition should signal agent presence", Labels{"test_id:1677"}, func() {
+					agentVMI := prepareAgentVM()
+					getOptions := metav1.GetOptions{}
+
+					freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+					Expect(freshVMI.Status.Conditions).To(
 						ContainElement(
 							MatchFields(
 								IgnoreExtras,
-								Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
-						"Should have unsupported agent connected condition")
+								Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
+						"agent should already be connected")
 
 				})
-			})
 
-			It("[test_id:4626]should have guestosinfo in status when agent is present", func() {
-				agentVMI := prepareAgentVM()
-				getOptions := metav1.GetOptions{}
-				var updatedVmi *v1.VirtualMachineInstance
-				var err error
+				It("[test_id:4625]should remove condition when agent is off", Labels{"test_id:4625"}, func() {
+					agentVMI := prepareAgentVM()
+					getOptions := metav1.GetOptions{}
 
-				By("Expecting the Guest VM information")
-				Eventually(func() bool {
-					updatedVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
-					if err != nil {
-						return false
-					}
-					return updatedVmi.Status.GuestOSInfo.Name != ""
-				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in vmi status")
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 
-				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
-			})
+					By("Terminating guest agent and waiting for it to disappear.")
+					Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
+						&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
+						&expect.BExp{R: console.PromptExpression},
+					}, 400)).To(Succeed())
 
-			It("[test_id:4627]should return the whole data when agent is present", func() {
-				agentVMI := prepareAgentVM()
+					By("VMI has the guest agent connected condition")
+					Eventually(func() []v1.VirtualMachineInstanceCondition {
+						freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+						return freshVMI.Status.Conditions
+					}, 240*time.Second, 2).ShouldNot(
+						ContainElement(
+							MatchFields(
+								IgnoreExtras,
+								Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
+						"Agent condition should be gone")
+				})
+
+				Context("[Serial]with cluster config changes", Labels{"Serial"}, func() {
+					BeforeEach(func() {
+						kv := util.GetCurrentKv(virtClient)
+
+						config := kv.Spec.Configuration
+						config.SupportedGuestAgentVersions = []string{"X.*"}
+						tests.UpdateKubeVirtConfigValueAndWait(config)
+					})
+
+					It("[test_id:5267]VMI condition should signal unsupported agent presence", Labels{"test_id:5267"}, func() {
+						agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-shutdown")
+						By("Starting a VirtualMachineInstance")
+						agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+						tests.WaitForSuccessfulVMIStart(agentVMI)
+
+						getOptions := metav1.GetOptions{}
+						freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+
+						Eventually(func() []v1.VirtualMachineInstanceCondition {
+							freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+							return freshVMI.Status.Conditions
+						}, 240*time.Second, 2).Should(
+							ContainElement(
+								MatchFields(
+									IgnoreExtras,
+									Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
+							"Should have unsupported agent connected condition")
+
+					})
+
+					It("[test_id:6958]VMI condition should not signal unsupported agent presence for optional commands", Labels{"test_id:6958"}, func() {
+						agentVMI := tests.NewRandomFedoraVMIWithBlacklistGuestAgent("guest-exec,guest-set-password")
+						By("Starting a VirtualMachineInstance")
+						agentVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(agentVMI)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+						tests.WaitForSuccessfulVMIStart(agentVMI)
+
+						getOptions := metav1.GetOptions{}
+						freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+
+						By("VMI has the guest agent connected condition")
+						Eventually(func() []v1.VirtualMachineInstanceCondition {
+							freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+							return freshVMI.Status.Conditions
+						}, 240*time.Second, 2).Should(
+							ContainElement(
+								MatchFields(
+									IgnoreExtras,
+									Fields{"Type": Equal(v1.VirtualMachineInstanceAgentConnected)})),
+							"Should have agent connected condition")
+
+						By("fetching the VMI after agent has connected")
+						freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(freshVMI.Status.Conditions).ToNot(
+							ContainElement(
+								MatchFields(
+									IgnoreExtras,
+									Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
+							"Should have unsupported agent connected condition")
+
+					})
+				})
+
+				It("[test_id:4626]should have guestosinfo in status when agent is present", Labels{"test_id:4626"}, func() {
+					agentVMI := prepareAgentVM()
+					getOptions := metav1.GetOptions{}
+					var updatedVmi *v1.VirtualMachineInstance
+					var err error
+
+					By("Expecting the Guest VM information")
+					Eventually(func() bool {
+						updatedVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						if err != nil {
+							return false
+						}
+						return updatedVmi.Status.GuestOSInfo.Name != ""
+					}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in vmi status")
+
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
+				})
+
+				It("[test_id:4627]should return the whole data when agent is present", Labels{"test_id:4627"}, func() {
+					agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
@@ -1399,32 +1431,32 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in subresource")
 			})
 
-			It("[test_id:4628]should not return the whole data when agent is not present", func() {
-				agentVMI := prepareAgentVM()
+				It("[test_id:4628]should not return the whole data when agent is not present", Labels{"test_id:4628"}, func() {
+					agentVMI := prepareAgentVM()
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(agentVMI)).To(Succeed())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 
-				By("Terminating guest agent and waiting for it to disappear.")
-				Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-					&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
-					&expect.BExp{R: console.PromptExpression},
-				}, 400)).To(Succeed())
+					By("Terminating guest agent and waiting for it to disappear.")
+					Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
+						&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
+						&expect.BExp{R: console.PromptExpression},
+					}, 400)).To(Succeed())
 
-				By("Expecting the Guest VM information")
-				Eventually(func() string {
-					_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
-					if err != nil {
-						return err.Error()
-					}
-					return ""
-				}, 240*time.Second, 2).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
-			})
+					By("Expecting the Guest VM information")
+					Eventually(func() string {
+						_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).GuestOsInfo(agentVMI.Name)
+						if err != nil {
+							return err.Error()
+						}
+						return ""
+					}, 240*time.Second, 2).Should(ContainSubstring("VMI does not have guest agent connected"), "Should have not have guest info in subresource")
+				})
 
-			It("[test_id:4629]should return user list", func() {
-				agentVMI := prepareAgentVM()
+				It("[test_id:4629]should return user list", Labels{"test_id:4629"}, func() {
+					agentVMI := prepareAgentVM()
 
-				Expect(console.LoginToFedora(agentVMI)).To(Succeed())
+					Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
@@ -1439,8 +1471,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 240*time.Second, 2).Should(BeTrue(), "Should have fedora users")
 			})
 
-			It("[test_id:4630]should return filesystem list", func() {
-				agentVMI := prepareAgentVM()
+				It("[test_id:4630]should return filesystem list", Labels{"test_id:4630"}, func() {
+					agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
 				Eventually(func() bool {
@@ -1455,56 +1487,58 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 240*time.Second, 2).Should(BeTrue(), "Should have some filesystem")
 			})
 
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with serial-number", func() {
-			var snVmi *v1.VirtualMachineInstance
-
-			BeforeEach(func() {
-				snVmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			})
 
-			It("[test_id:3121]should have serial-number set when present", func() {
-				snVmi.Spec.Domain.Firmware = &v1.Firmware{Serial: "4b2f5496-f3a3-460b-a375-168223f68845"}
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with serial-number",
+			Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				var snVmi *v1.VirtualMachineInstance
 
-				By("Starting a VirtualMachineInstance")
-				snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(snVmi)
+				BeforeEach(func() {
+					snVmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				})
 
-				getOptions := metav1.GetOptions{}
-				var freshVMI *v1.VirtualMachineInstance
+				It("[test_id:3121]should have serial-number set when present", Labels{"test_id:3121"}, func() {
+					snVmi.Spec.Domain.Firmware = &v1.Firmware{Serial: "4b2f5496-f3a3-460b-a375-168223f68845"}
 
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+					By("Starting a VirtualMachineInstance")
+					snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(snVmi)
 
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
+					getOptions := metav1.GetOptions{}
+					var freshVMI *v1.VirtualMachineInstance
 
-				Expect(domXML).To(ContainSubstring("<entry name='serial'>4b2f5496-f3a3-460b-a375-168223f68845</entry>"), "Should have serial-number present")
+					freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
+					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+
+					domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
+					Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
+
+					Expect(domXML).To(ContainSubstring("<entry name='serial'>4b2f5496-f3a3-460b-a375-168223f68845</entry>"), "Should have serial-number present")
+				})
+
+				It("[test_id:3122]should not have serial-number set when not present", Labels{"test_id:3122"}, func() {
+					By("Starting a VirtualMachineInstance")
+					snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(snVmi)
+
+					getOptions := metav1.GetOptions{}
+					var freshVMI *v1.VirtualMachineInstance
+
+					freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
+					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+
+					domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
+					Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
+
+					Expect(domXML).ToNot(ContainSubstring("<entry name='serial'>"), "Should have serial-number present")
+				})
 			})
-
-			It("[test_id:3122]should not have serial-number set when not present", func() {
-				By("Starting a VirtualMachineInstance")
-				snVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(snVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(snVmi)
-
-				getOptions := metav1.GetOptions{}
-				var freshVMI *v1.VirtualMachineInstance
-
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(snVmi.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, freshVMI)
-				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
-
-				Expect(domXML).ToNot(ContainSubstring("<entry name='serial'>"), "Should have serial-number present")
-			})
-		})
 
 		Context("with TSC timer", func() {
-			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", func() {
+			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", Labels{"test_id:6843"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{
@@ -1549,7 +1583,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		Context("with Clock and timezone", func() {
 
-			It("[sig-compute][test_id:5268]guest should see timezone", func() {
+			It("[sig-compute][test_id:5268]guest should see timezone", Labels{"sig-compute", "test_id:5268"}, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				timezone := "America/New_York"
 				tz := v1.ClockOffsetTimezone(timezone)
@@ -1593,7 +1627,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				vmi = tests.NewRandomVMI()
 			})
 
-			It("[test_id:6960]should reject disk with missing volume", func() {
+			It("[test_id:6960]should reject disk with missing volume", Labels{"test_id:6960"}, func() {
 				const diskName = "testdisk"
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: diskName,
@@ -1604,7 +1638,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err.Error()).To(ContainSubstring(expectedErrMessage))
 			})
 
-			It("[test_id:6961]should reject volume with missing disk / file system", func() {
+			It("[test_id:6961]should reject volume with missing disk / file system", Labels{"test_id:6961"}, func() {
 				const volumeName = "testvolume"
 				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 					Name: volumeName,
@@ -1620,7 +1654,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		})
 
-		Context("[Serial]using defaultRuntimeClass configuration", func() {
+		Context("[Serial]using defaultRuntimeClass configuration", Labels{"Serial"}, func() {
 			runtimeClassName := "custom-runtime-class"
 
 			BeforeEach(func() {
@@ -1666,128 +1700,136 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU spec", func() {
-		var cpuVmi *v1.VirtualMachineInstance
-		var nodes *k8sv1.NodeList
+	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU spec",
+		Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			var cpuVmi *v1.VirtualMachineInstance
+			var nodes *k8sv1.NodeList
 
-		parseCPUNiceName := func(name string) string {
-			updatedCPUName := strings.Replace(name, "\n", "", -1)
-			if strings.Contains(updatedCPUName, ":") {
-				updatedCPUName = strings.Split(name, ":")[1]
+			parseCPUNiceName := func(name string) string {
+				updatedCPUName := strings.Replace(name, "\n", "", -1)
+				if strings.Contains(updatedCPUName, ":") {
+					updatedCPUName = strings.Split(name, ":")[1]
 
+				}
+				updatedCPUName = strings.Replace(updatedCPUName, " ", "", 1)
+				updatedCPUName = strings.Replace(updatedCPUName, "(", "", -1)
+				updatedCPUName = strings.Replace(updatedCPUName, ")", "", -1)
+
+				updatedCPUName = strings.Split(updatedCPUName, "-")[0]
+				updatedCPUName = strings.Split(updatedCPUName, "_")[0]
+
+				for i, char := range updatedCPUName {
+					if unicode.IsUpper(char) && i != 0 {
+						updatedCPUName = strings.Split(updatedCPUName, string(char))[0]
+					}
+				}
+				return updatedCPUName
 			}
-			updatedCPUName = strings.Replace(updatedCPUName, " ", "", 1)
-			updatedCPUName = strings.Replace(updatedCPUName, "(", "", -1)
-			updatedCPUName = strings.Replace(updatedCPUName, ")", "", -1)
 
-			updatedCPUName = strings.Split(updatedCPUName, "-")[0]
-			updatedCPUName = strings.Split(updatedCPUName, "_")[0]
+			BeforeEach(func() {
+				nodes = util.GetAllSchedulableNodes(virtClient)
+				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
-			for i, char := range updatedCPUName {
-				if unicode.IsUpper(char) && i != 0 {
-					updatedCPUName = strings.Split(updatedCPUName, string(char))[0]
-				}
-			}
-			return updatedCPUName
-		}
+				cpuVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			})
 
-		BeforeEach(func() {
-			nodes = util.GetAllSchedulableNodes(virtClient)
-			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+			Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model defined",
+				Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				func() {
+					It("[test_id:1678]should report defined CPU model", Labels{"test_id:1678"}, func() {
+						supportedCPUs := tests.GetSupportedCPUModels(*nodes)
+						Expect(supportedCPUs).ToNot(BeEmpty())
+						cpuVmi.Spec.Domain.CPU = &v1.CPU{
+							Model: supportedCPUs[0],
+						}
+						niceName := parseCPUNiceName(supportedCPUs[0])
 
-			cpuVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model defined", func() {
-			It("[test_id:1678]should report defined CPU model", func() {
-				supportedCPUs := tests.GetSupportedCPUModels(*nodes)
-				Expect(supportedCPUs).ToNot(BeEmpty())
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Model: supportedCPUs[0],
-				}
-				niceName := parseCPUNiceName(supportedCPUs[0])
-
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(cpuVmi)
+						By("Starting a VirtualMachineInstance")
+						cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+						Expect(err).ToNot(HaveOccurred())
+						tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
-				By("Checking the CPU model under the guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", niceName)},
-					&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
-				}, 10)).To(Succeed())
-			})
-		})
+						By("Checking the CPU model under the guest OS")
+						Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
+							&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", niceName)},
+							&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
+						}, 10)).To(Succeed())
+					})
+				})
 
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model equals to passthrough", func() {
-			It("[test_id:1679]should report exactly the same model as node CPU", func() {
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Model: "host-passthrough",
-				}
+			Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model equals to passthrough",
+				Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				func() {
+					It("[test_id:1679]should report exactly the same model as node CPU", Labels{"test_id:1679"}, func() {
+						cpuVmi.Spec.Domain.CPU = &v1.CPU{
+							Model: "host-passthrough",
+						}
 
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(cpuVmi)
+						By("Starting a VirtualMachineInstance")
+						cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+						Expect(err).ToNot(HaveOccurred())
+						tests.WaitForSuccessfulVMIStart(cpuVmi)
 
-				By("Checking the CPU model under the guest OS")
-				output := tests.RunCommandOnVmiPod(cpuVmi, []string{"grep", "-m1", "model name", "/proc/cpuinfo"})
+						By("Checking the CPU model under the guest OS")
+						output := tests.RunCommandOnVmiPod(cpuVmi, []string{"grep", "-m1", "model name", "/proc/cpuinfo"})
 
-				niceName := parseCPUNiceName(output)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
-
-				By("Checking the CPU model under the guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", niceName)},
-					&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
-				}, 10)).To(Succeed())
-			})
-		})
-
-		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model not defined", func() {
-			It("[test_id:1680]should report CPU model from libvirt capabilities", func() {
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(cpuVmi)
-
-				output := tests.RunCommandOnVmiPod(cpuVmi, []string{"grep", "-m1", "model name", "/proc/cpuinfo"})
-
-				niceName := parseCPUNiceName(output)
+						niceName := parseCPUNiceName(output)
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
-				By("Checking the CPU model under the guest OS")
-				console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", niceName)},
-					&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
-				}, 10)
-			})
-		})
+						By("Checking the CPU model under the guest OS")
+						Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
+							&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", niceName)},
+							&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
+						}, 10)).To(Succeed())
+					})
+				})
 
-		Context("when CPU features defined", func() {
-			It("[test_id:3123]should start a Virtual Machine with matching features", func() {
-				supportedCPUFeatures := tests.GetSupportedCPUFeatures(*nodes)
-				Expect(supportedCPUFeatures).ToNot(BeEmpty())
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Features: []v1.CPUFeature{
-						{
-							Name: supportedCPUFeatures[0],
+			Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model not defined",
+				Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+				func() {
+					It("[test_id:1680]should report CPU model from libvirt capabilities", Labels{"test_id:1680"}, func() {
+						By("Starting a VirtualMachineInstance")
+						cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+						Expect(err).ToNot(HaveOccurred())
+						tests.WaitForSuccessfulVMIStart(cpuVmi)
+
+						output := tests.RunCommandOnVmiPod(cpuVmi, []string{"grep", "-m1", "model name", "/proc/cpuinfo"})
+
+						niceName := parseCPUNiceName(output)
+
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+
+						By("Checking the CPU model under the guest OS")
+						console.SafeExpectBatch(cpuVmi, []expect.Batcher{
+							&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", niceName)},
+							&expect.BExp{R: fmt.Sprintf(".*model name.*%s.*", niceName)},
+						}, 10)
+					})
+				})
+
+			Context("when CPU features defined", func() {
+				It("[test_id:3123]should start a Virtual Machine with matching features", Labels{"test_id:3123"}, func() {
+					supportedCPUFeatures := tests.GetSupportedCPUFeatures(*nodes)
+					Expect(supportedCPUFeatures).ToNot(BeEmpty())
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						Features: []v1.CPUFeature{
+							{
+								Name: supportedCPUFeatures[0],
+							},
 						},
-					},
-				}
+					}
 
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForSuccessfulVMIStart(cpuVmi)
+					By("Starting a VirtualMachineInstance")
+					cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).ToNot(HaveOccurred())
+					tests.WaitForSuccessfulVMIStart(cpuVmi)
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
@@ -1795,65 +1837,67 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", func() {
-		BeforeEach(func() {
-			kv := util.GetCurrentKv(virtClient)
+	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings",
+		Labels{"Serial", "rfe_id:2869", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			BeforeEach(func() {
+				kv := util.GetCurrentKv(virtClient)
 
-			config := kv.Spec.Configuration
-			config.EmulatedMachines = []string{"q35*", "pc-q35*", "pc*"}
-			tests.UpdateKubeVirtConfigValueAndWait(config)
+				config := kv.Spec.Configuration
+				config.EmulatedMachines = []string{"q35*", "pc-q35*", "pc*"}
+				tests.UpdateKubeVirtConfigValueAndWait(config)
+			})
+
+			It("[test_id:3124]should set machine type from VMI spec", Labels{"test_id:3124"}, func() {
+				vmi := tests.NewRandomVMI()
+				vmi.Spec.Domain.Machine = &v1.Machine{Type: "pc"}
+				tests.RunVMIAndExpectLaunch(vmi, 30)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
+			})
+
+			It("[test_id:3125]should allow creating VM without Machine defined", Labels{"test_id:3125"}, func() {
+				vmi := tests.NewRandomVMI()
+				vmi.Spec.Domain.Machine = nil
+				tests.RunVMIAndExpectLaunch(vmi, 30)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
+			})
+
+			It("[test_id:6964]should allow creating VM defined with Machine with an empty Type", Labels{"test_id:6964"}, func() {
+				// This is needed to provide backward compatibility since our example VMIs used to be defined in this way
+				vmi := tests.NewRandomVMI()
+				vmi.Spec.Domain.Machine = &v1.Machine{Type: ""}
+				tests.RunVMIAndExpectLaunch(vmi, 30)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
+			})
+
+			It("[Serial][test_id:3126]should set machine type from kubevirt-config", Labels{"Serial", "test_id:3126"}, func() {
+				kv := util.GetCurrentKv(virtClient)
+
+				config := kv.Spec.Configuration
+				config.MachineType = "pc"
+				tests.UpdateKubeVirtConfigValueAndWait(config)
+
+				vmi := tests.NewRandomVMI()
+				vmi.Spec.Domain.Machine = nil
+				tests.RunVMIAndExpectLaunch(vmi, 30)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
+			})
 		})
-
-		It("[test_id:3124]should set machine type from VMI spec", func() {
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine = &v1.Machine{Type: "pc"}
-			tests.RunVMIAndExpectLaunch(vmi, 30)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
-		})
-
-		It("[test_id:3125]should allow creating VM without Machine defined", func() {
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine = nil
-			tests.RunVMIAndExpectLaunch(vmi, 30)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
-		})
-
-		It("[test_id:6964]should allow creating VM defined with Machine with an empty Type", func() {
-			// This is needed to provide backward compatibility since our example VMIs used to be defined in this way
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine = &v1.Machine{Type: ""}
-			tests.RunVMIAndExpectLaunch(vmi, 30)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
-		})
-
-		It("[Serial][test_id:3126]should set machine type from kubevirt-config", func() {
-			kv := util.GetCurrentKv(virtClient)
-
-			config := kv.Spec.Configuration
-			config.MachineType = "pc"
-			tests.UpdateKubeVirtConfigValueAndWait(config)
-
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine = nil
-			tests.RunVMIAndExpectLaunch(vmi, 30)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
-		})
-	})
 
 	Context("with a custom scheduler", func() {
-		It("[test_id:4631]should set the custom scheduler on the pod", func() {
+		It("[test_id:4631]should set the custom scheduler on the pod", Labels{"test_id:4631"}, func() {
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.SchedulerName = "my-custom-scheduler"
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
@@ -1862,186 +1906,190 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU request settings", func() {
+	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU request settings",
+		Labels{"rfe_id:140", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-		It("[test_id:3127]should set CPU request from VMI spec", func() {
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceCPU] = resource.MustParse("500m")
-			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+			It("[test_id:3127]should set CPU request from VMI spec", Labels{"test_id:3127"}, func() {
+				vmi := tests.NewRandomVMI()
+				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceCPU] = resource.MustParse("500m")
+				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
-			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
-			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
-			Expect(cpuRequest.String()).To(Equal("500m"))
+				readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
+				Expect(cpuRequest.String()).To(Equal("500m"))
+			})
+
+			It("[test_id:3128]should set CPU request when it is not provided", Labels{"test_id:3128"}, func() {
+				vmi := tests.NewRandomVMI()
+				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+
+				readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
+				Expect(cpuRequest.String()).To(Equal("100m"))
+			})
+
+			It("[Serial][test_id:3129]should set CPU request from kubevirt-config", Labels{"Serial", "test_id:3129"}, func() {
+				kv := util.GetCurrentKv(virtClient)
+
+				config := kv.Spec.Configuration
+				configureCPURequest := resource.MustParse("800m")
+				config.CPURequest = &configureCPURequest
+				tests.UpdateKubeVirtConfigValueAndWait(config)
+
+				vmi := tests.NewRandomVMI()
+				runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+
+				readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+				computeContainer := tests.GetComputeContainerOfPod(readyPod)
+				cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
+				Expect(cpuRequest.String()).To(Equal("800m"))
+			})
 		})
 
-		It("[test_id:3128]should set CPU request when it is not provided", func() {
-			vmi := tests.NewRandomVMI()
-			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC",
+		Labels{"Serial", "rfe_id:904", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "storage-req"},
+		func() {
+			var dataVolume *cdiv1.DataVolume
 
-			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
-			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
-			Expect(cpuRequest.String()).To(Equal("100m"))
-		})
-
-		It("[Serial][test_id:3129]should set CPU request from kubevirt-config", func() {
-			kv := util.GetCurrentKv(virtClient)
-
-			config := kv.Spec.Configuration
-			configureCPURequest := resource.MustParse("800m")
-			config.CPURequest = &configureCPURequest
-			tests.UpdateKubeVirtConfigValueAndWait(config)
-
-			vmi := tests.NewRandomVMI()
-			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
-
-			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
-			computeContainer := tests.GetComputeContainerOfPod(readyPod)
-			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
-			Expect(cpuRequest.String()).To(Equal("800m"))
-		})
-	})
-
-	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC", func() {
-		var dataVolume *cdiv1.DataVolume
-
-		BeforeEach(func() {
-			if !checks.HasFeature(virtconfig.HostDiskGate) {
-				Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
-			}
-			// create a new PV and PVC (PVs can't be reused)
+			BeforeEach(func() {
+				if !checks.HasFeature(virtconfig.HostDiskGate) {
+					Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
+				}
+				// create a new PV and PVC (PVs can't be reused)
 			dataVolume = libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			})
+
+			AfterEach(func() {
+				err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("[test_id:1681]should set appropriate cache modes", Labels{"test_id:1681"}, func() {
+				vmi := tests.NewRandomVMI()
+
+				By("adding disks to a VMI")
+				tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
+
+				tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				vmi.Spec.Domain.Devices.Disks[1].Cache = v1.CacheWriteThrough
+
+				tests.AddEphemeralDisk(vmi, "ephemeral-disk5", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				vmi.Spec.Domain.Devices.Disks[2].Cache = v1.CacheWriteBack
+
+				tests.AddEphemeralDisk(vmi, "ephemeral-disk3", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+				tmpHostDiskDir := tests.RandTmpDir()
+				tests.AddHostDisk(vmi, filepath.Join(tmpHostDiskDir, "test-disk.img"), v1.HostDiskExistsOrCreate, "hostdisk")
+				tests.RunVMIAndExpectLaunch(vmi, 60)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				defer tests.RemoveHostDiskImage(tmpHostDiskDir, vmiPod.Spec.NodeName)
+
+				disks := runningVMISpec.Devices.Disks
+				By("checking if number of attached disks is equal to real disks number")
+				Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
+
+				cacheNone := string(v1.CacheNone)
+				cacheWritethrough := string(v1.CacheWriteThrough)
+				cacheWriteback := string(v1.CacheWriteBack)
+
+				By("checking if requested cache 'none' has been set")
+				Expect(disks[0].Alias.GetName()).To(Equal("ephemeral-disk1"))
+				Expect(disks[0].Driver.Cache).To(Equal(cacheNone))
+
+				By("checking if requested cache 'writethrough' has been set")
+				Expect(disks[1].Alias.GetName()).To(Equal("ephemeral-disk2"))
+				Expect(disks[1].Driver.Cache).To(Equal(cacheWritethrough))
+
+				By("checking if requested cache 'writeback' has been set")
+				Expect(disks[2].Alias.GetName()).To(Equal("ephemeral-disk5"))
+				Expect(disks[2].Driver.Cache).To(Equal(cacheWriteback))
+
+				By("checking if default cache 'none' has been set to ephemeral disk")
+				Expect(disks[3].Alias.GetName()).To(Equal("ephemeral-disk3"))
+				Expect(disks[3].Driver.Cache).To(Equal(cacheNone))
+
+				By("checking if default cache 'none' has been set to cloud-init disk")
+				Expect(disks[4].Alias.GetName()).To(Equal("cloud-init"))
+				Expect(disks[4].Driver.Cache).To(Equal(cacheNone))
+
+				By("checking if default cache 'writethrough' has been set to fs which does not support direct I/O")
+				Expect(disks[5].Alias.GetName()).To(Equal("hostdisk"))
+				Expect(disks[5].Driver.Cache).To(Equal(cacheWritethrough))
+
+			})
+
+			It("[test_id:5360]should set appropriate IO modes", Labels{"test_id:5360"}, func() {
+				vmi := tests.NewRandomVMI()
+
+				By("adding disks to a VMI")
+				// disk[0]:  File, sparsed, no user-input, cache=none
+				tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
+
+				// disk[1]:  Block, no user-input, cache=none
+				tests.AddPVCDisk(vmi, "block-pvc", "virtio", dataVolume.Name)
+
+				// disk[2]: File, not-sparsed, no user-input, cache=none
+				tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
+
+				// disk[3]:  File, sparsed, user-input=threads, cache=none
+				tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				vmi.Spec.Domain.Devices.Disks[3].Cache = v1.CacheNone
+				vmi.Spec.Domain.Devices.Disks[3].IO = v1.IOThreads
+
+				tests.RunVMIAndExpectLaunch(vmi, 60)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				disks := runningVMISpec.Devices.Disks
+				By("checking if number of attached disks is equal to real disks number")
+				Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
+
+				ioNative := v1.IONative
+				ioThreads := v1.IOThreads
+				ioNone := ""
+
+				By("checking if default io has not been set for sparsed file")
+				Expect(disks[0].Alias.GetName()).To(Equal("ephemeral-disk1"))
+				Expect(string(disks[0].Driver.IO)).To(Equal(ioNone))
+
+				By("checking if default io mode has been set to 'native' for block device")
+				Expect(disks[1].Alias.GetName()).To(Equal("block-pvc"))
+				Expect(disks[1].Driver.IO).To(Equal(ioNative))
+
+				By("checking if default cache 'none' has been set to pvc disk")
+				Expect(disks[2].Alias.GetName()).To(Equal("hostpath-pvc"))
+				// PVC is mounted as tmpfs on kind, which does not support direct I/O.
+				// As such, it behaves as plugging in a hostDisk - check disks[6].
+				if tests.IsRunningOnKindInfra() {
+					// The cache mode is set to cacheWritethrough
+					Expect(string(disks[2].Driver.IO)).To(Equal(ioNone))
+				} else {
+					// The cache mode is set to cacheNone
+					Expect(disks[2].Driver.IO).To(Equal(ioNative))
+				}
+
+				By("checking if requested io mode 'threads' has been set")
+				Expect(disks[3].Alias.GetName()).To(Equal("ephemeral-disk2"))
+				Expect(disks[3].Driver.IO).To(Equal(ioThreads))
+
+			})
 		})
-
-		AfterEach(func() {
-			err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("[test_id:1681]should set appropriate cache modes", func() {
-			vmi := tests.NewRandomVMI()
-
-			By("adding disks to a VMI")
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
-
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi.Spec.Domain.Devices.Disks[1].Cache = v1.CacheWriteThrough
-
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk5", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi.Spec.Domain.Devices.Disks[2].Cache = v1.CacheWriteBack
-
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk3", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
-			tmpHostDiskDir := tests.RandTmpDir()
-			tests.AddHostDisk(vmi, filepath.Join(tmpHostDiskDir, "test-disk.img"), v1.HostDiskExistsOrCreate, "hostdisk")
-			tests.RunVMIAndExpectLaunch(vmi, 60)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-			defer tests.RemoveHostDiskImage(tmpHostDiskDir, vmiPod.Spec.NodeName)
-
-			disks := runningVMISpec.Devices.Disks
-			By("checking if number of attached disks is equal to real disks number")
-			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
-
-			cacheNone := string(v1.CacheNone)
-			cacheWritethrough := string(v1.CacheWriteThrough)
-			cacheWriteback := string(v1.CacheWriteBack)
-
-			By("checking if requested cache 'none' has been set")
-			Expect(disks[0].Alias.GetName()).To(Equal("ephemeral-disk1"))
-			Expect(disks[0].Driver.Cache).To(Equal(cacheNone))
-
-			By("checking if requested cache 'writethrough' has been set")
-			Expect(disks[1].Alias.GetName()).To(Equal("ephemeral-disk2"))
-			Expect(disks[1].Driver.Cache).To(Equal(cacheWritethrough))
-
-			By("checking if requested cache 'writeback' has been set")
-			Expect(disks[2].Alias.GetName()).To(Equal("ephemeral-disk5"))
-			Expect(disks[2].Driver.Cache).To(Equal(cacheWriteback))
-
-			By("checking if default cache 'none' has been set to ephemeral disk")
-			Expect(disks[3].Alias.GetName()).To(Equal("ephemeral-disk3"))
-			Expect(disks[3].Driver.Cache).To(Equal(cacheNone))
-
-			By("checking if default cache 'none' has been set to cloud-init disk")
-			Expect(disks[4].Alias.GetName()).To(Equal("cloud-init"))
-			Expect(disks[4].Driver.Cache).To(Equal(cacheNone))
-
-			By("checking if default cache 'writethrough' has been set to fs which does not support direct I/O")
-			Expect(disks[5].Alias.GetName()).To(Equal("hostdisk"))
-			Expect(disks[5].Driver.Cache).To(Equal(cacheWritethrough))
-
-		})
-
-		It("[test_id:5360]should set appropriate IO modes", func() {
-			vmi := tests.NewRandomVMI()
-
-			By("adding disks to a VMI")
-			// disk[0]:  File, sparsed, no user-input, cache=none
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
-
-			// disk[1]:  Block, no user-input, cache=none
-			tests.AddPVCDisk(vmi, "block-pvc", "virtio", dataVolume.Name)
-
-			// disk[2]: File, not-sparsed, no user-input, cache=none
-			tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
-
-			// disk[3]:  File, sparsed, user-input=threads, cache=none
-			tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			vmi.Spec.Domain.Devices.Disks[3].Cache = v1.CacheNone
-			vmi.Spec.Domain.Devices.Disks[3].IO = v1.IOThreads
-
-			tests.RunVMIAndExpectLaunch(vmi, 60)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			disks := runningVMISpec.Devices.Disks
-			By("checking if number of attached disks is equal to real disks number")
-			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
-
-			ioNative := v1.IONative
-			ioThreads := v1.IOThreads
-			ioNone := ""
-
-			By("checking if default io has not been set for sparsed file")
-			Expect(disks[0].Alias.GetName()).To(Equal("ephemeral-disk1"))
-			Expect(string(disks[0].Driver.IO)).To(Equal(ioNone))
-
-			By("checking if default io mode has been set to 'native' for block device")
-			Expect(disks[1].Alias.GetName()).To(Equal("block-pvc"))
-			Expect(disks[1].Driver.IO).To(Equal(ioNative))
-
-			By("checking if default cache 'none' has been set to pvc disk")
-			Expect(disks[2].Alias.GetName()).To(Equal("hostpath-pvc"))
-			// PVC is mounted as tmpfs on kind, which does not support direct I/O.
-			// As such, it behaves as plugging in a hostDisk - check disks[6].
-			if tests.IsRunningOnKindInfra() {
-				// The cache mode is set to cacheWritethrough
-				Expect(string(disks[2].Driver.IO)).To(Equal(ioNone))
-			} else {
-				// The cache mode is set to cacheNone
-				Expect(disks[2].Driver.IO).To(Equal(ioNative))
-			}
-
-			By("checking if requested io mode 'threads' has been set")
-			Expect(disks[3].Alias.GetName()).To(Equal("ephemeral-disk2"))
-			Expect(disks[3].Driver.IO).To(Equal(ioThreads))
-
-		})
-	})
 
 	Context("Block size configuration set", func() {
 
-		It("[test_id:6965][storage-req]Should set BlockIO when using custom block sizes", func() {
+		It("[test_id:6965][storage-req]Should set BlockIO when using custom block sizes", Labels{"test_id:6965", "storage-req"}, func() {
 			By("creating a block volume")
 			dataVolume := libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
@@ -2078,41 +2126,43 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(disks[0].BlockIO.PhysicalBlockSize).To(Equal(physicalSize))
 		})
 
-		It("[test_id:6966][storage-req]Should set BlockIO when set to match volume block sizes on block devices", func() {
-			By("creating a block volume")
+		It("[test_id:6966][storage-req]Should set BlockIO when set to match volume block sizes on block devices",
+			Labels{"test_id:6966", "storage-req"},
+			func() {
+				By("creating a block volume")
 			dataVolume := libstorage.NewRandomBlockDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 
-			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 
-			vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
+				vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 
-			By("setting the disk to match the volume block sizes")
-			vmi.Spec.Domain.Devices.Disks[0].BlockSize = &v1.BlockSize{
-				MatchVolume: &v1.FeatureState{},
-			}
+				By("setting the disk to match the volume block sizes")
+				vmi.Spec.Domain.Devices.Disks[0].BlockSize = &v1.BlockSize{
+					MatchVolume: &v1.FeatureState{},
+				}
 
-			By("initializing the VM")
-			tests.RunVMIAndExpectLaunch(vmi, 60)
-			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
+				By("initializing the VM")
+				tests.RunVMIAndExpectLaunch(vmi, 60)
+				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+				Expect(err).ToNot(HaveOccurred())
 
-			By("checking if number of attached disks is equal to real disks number")
-			disks := runningVMISpec.Devices.Disks
-			Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
+				By("checking if number of attached disks is equal to real disks number")
+				disks := runningVMISpec.Devices.Disks
+				Expect(vmi.Spec.Domain.Devices.Disks).To(HaveLen(len(disks)))
 
-			By("checking if BlockIO is set for the disk")
-			Expect(disks[0].Alias.GetName()).To(Equal("disk0"))
-			Expect(disks[0].BlockIO).ToNot(BeNil())
-			// Block devices should be one of 512n, 512e or 4096n so accept 512 and 4096 values.
-			expectedDiskSizes := SatisfyAny(Equal(uint(512)), Equal(uint(4096)))
-			Expect(disks[0].BlockIO.LogicalBlockSize).To(expectedDiskSizes)
-			Expect(disks[0].BlockIO.PhysicalBlockSize).To(expectedDiskSizes)
-		})
+				By("checking if BlockIO is set for the disk")
+				Expect(disks[0].Alias.GetName()).To(Equal("disk0"))
+				Expect(disks[0].BlockIO).ToNot(BeNil())
+				// Block devices should be one of 512n, 512e or 4096n so accept 512 and 4096 values.
+				expectedDiskSizes := SatisfyAny(Equal(uint(512)), Equal(uint(4096)))
+				Expect(disks[0].BlockIO.LogicalBlockSize).To(expectedDiskSizes)
+				Expect(disks[0].BlockIO.PhysicalBlockSize).To(expectedDiskSizes)
+			})
 
-		It("[test_id:6967]Should set BlockIO when set to match volume block sizes on files", func() {
+		It("[test_id:6967]Should set BlockIO when set to match volume block sizes on files", Labels{"test_id:6967"}, func() {
 			if !checks.HasFeature(virtconfig.HostDiskGate) {
 				Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
 			}
@@ -2163,612 +2213,620 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[rfe_id:898][crit:medium][vendor:cnv-qe@redhat.com][level:component]New VirtualMachineInstance with all supported drives", func() {
+	Context("[rfe_id:898][crit:medium][vendor:cnv-qe@redhat.com][level:component]New VirtualMachineInstance with all supported drives",
+		Labels{"rfe_id:898", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-		var vmi *v1.VirtualMachineInstance
+			var vmi *v1.VirtualMachineInstance
 
-		BeforeEach(func() {
-			// ordering:
-			// use a small disk for the other ones
-			containerImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			// virtio - added by NewRandomVMIWithEphemeralDisk
-			vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, "echo hi!\n")
-			// sata
-			tests.AddEphemeralDisk(vmi, "disk2", "sata", containerImage)
-			// NOTE: we have one disk per bus, so we expect vda, sda
-		})
-		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
-			err := console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "grep DEVNAME /sys/bus/pci/devices/" + expectedPciAddress + "/*/block/vda/uevent|awk -F= '{ print $2 }'\n"},
-				&expect.BExp{R: "vda"},
-			}, 15)
-			Expect(err).ToNot(HaveOccurred())
-		}
+			BeforeEach(func() {
+				// ordering:
+				// use a small disk for the other ones
+				containerImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
+				// virtio - added by NewRandomVMIWithEphemeralDisk
+				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, "echo hi!\n")
+				// sata
+				tests.AddEphemeralDisk(vmi, "disk2", "sata", containerImage)
+				// NOTE: we have one disk per bus, so we expect vda, sda
+			})
+			checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
+				err := console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "grep DEVNAME /sys/bus/pci/devices/" + expectedPciAddress + "/*/block/vda/uevent|awk -F= '{ print $2 }'\n"},
+					&expect.BExp{R: "vda"},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
+			}
 
-		It("[test_id:1682]should have all the device nodes", func() {
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
+			It("[test_id:1682]should have all the device nodes", Labels{"test_id:1682"}, func() {
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
 
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				// keep the ordering!
-				&expect.BSnd{S: "ls /dev/vda  /dev/vdb\n"},
-				&expect.BExp{R: console.PromptExpression},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: console.RetValue("0")},
-			}, 10)).To(Succeed())
-		})
-
-		It("[test_id:3906]should configure custom Pci address", func() {
-			By("checking disk1 Pci address")
-			vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = "0000:00:10.0"
-			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-
-			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
-		})
-
-		It("[test_id:1020]should not create the VM with wrong PCI address", func() {
-			By("setting disk1 Pci address")
-
-			wrongPciAddress := "0000:04:10.0"
-
-			vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = wrongPciAddress
-			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			var vmiCondition v1.VirtualMachineInstanceCondition
-			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				for _, cond := range vmi.Status.Conditions {
-					if cond.Type == v1.VirtualMachineInstanceConditionType(v1.VirtualMachineInstanceSynchronized) && cond.Status == kubev1.ConditionFalse {
-						vmiCondition = cond
-						return true
-					}
-				}
-				return false
-			}, 120*time.Second, time.Second).Should(BeTrue())
-			Expect(vmiCondition.Message).To(ContainSubstring("Invalid PCI address " + wrongPciAddress))
-			Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
-		})
-	})
-	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", func() {
-		var nodes *kubev1.NodeList
-
-		isNodeHasCPUManagerLabel := func(nodeName string) bool {
-			Expect(nodeName).ToNot(BeEmpty())
-
-			nodeObject, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			nodeHaveCpuManagerLabel := false
-			nodeLabels := nodeObject.GetLabels()
-
-			for label, val := range nodeLabels {
-				if label == v1.CPUManager && val == "true" {
-					nodeHaveCpuManagerLabel = true
-					break
-				}
-			}
-			return nodeHaveCpuManagerLabel
-		}
-
-		BeforeEach(func() {
-			checks.SkipTestIfNoCPUManager()
-			nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if len(nodes.Items) == 1 {
-				Skip("Skip cpu pinning test that requires multiple nodes when only one node is present.")
-			}
-		})
-
-		Context("[Serial]with cpu pinning enabled", func() {
-
-			It("[test_id:1684]should set the cpumanager label to false when it's not running", func() {
-
-				By("adding a cpumanger=true label to a node")
-				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
-				Expect(err).ToNot(HaveOccurred())
-				if len(nodes.Items) == 0 {
-					Skip("Skip CPU manager test on clusters where CPU manager is running on all worker/compute nodes")
-				}
-
-				node := &nodes.Items[0]
-				node, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, v1.CPUManager)), metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				By("setting the cpumanager label back to false")
-				Eventually(func() string {
-					n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return n.Labels[v1.CPUManager]
-				}, 3*time.Minute, 2*time.Second).Should(Equal("false"))
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					// keep the ordering!
+					&expect.BSnd{S: "ls /dev/vda  /dev/vdb\n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: console.RetValue("0")},
+				}, 10)).To(Succeed())
 			})
-			It("[test_id:1685]non master node should have a cpumanager label", func() {
-				cpuManagerEnabled := false
-				for idx := 1; idx < len(nodes.Items); idx++ {
-					labels := nodes.Items[idx].GetLabels()
-					for label, val := range labels {
-						if label == "cpumanager" && val == "true" {
-							cpuManagerEnabled = true
+
+			It("[test_id:3906]should configure custom Pci address", Labels{"test_id:3906"}, func() {
+				By("checking disk1 Pci address")
+				vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = "0000:00:10.0"
+				vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+				checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
+			})
+
+			It("[test_id:1020]should not create the VM with wrong PCI address", Labels{"test_id:1020"}, func() {
+				By("setting disk1 Pci address")
+
+				wrongPciAddress := "0000:04:10.0"
+
+				vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = wrongPciAddress
+				vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				var vmiCondition v1.VirtualMachineInstanceCondition
+				Eventually(func() bool {
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					for _, cond := range vmi.Status.Conditions {
+						if cond.Type == v1.VirtualMachineInstanceConditionType(v1.VirtualMachineInstanceSynchronized) && cond.Status == kubev1.ConditionFalse {
+							vmiCondition = cond
+							return true
 						}
 					}
-				}
-				Expect(cpuManagerEnabled).To(BeTrue())
+					return false
+				}, 120*time.Second, time.Second).Should(BeTrue())
+				Expect(vmiCondition.Message).To(ContainSubstring("Invalid PCI address " + wrongPciAddress))
+				Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
 			})
-			It("[test_id:991]should be scheduled on a node with running cpu manager", func() {
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Cores:                 2,
-					DedicatedCPUPlacement: true,
-				}
+		})
+	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning",
+		Labels{"rfe_id:897", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+			var nodes *kubev1.NodeList
 
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+			isNodeHasCPUManagerLabel := func(nodeName string) bool {
+				Expect(nodeName).ToNot(BeEmpty())
+
+				nodeObject, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
+				nodeHaveCpuManagerLabel := false
+				nodeLabels := nodeObject.GetLabels()
 
-				By("Checking that the VMI QOS is guaranteed")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Status.QOSClass).ToNot(BeNil())
-				Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
-
-				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
-
-				By("Checking that the pod QOS is guaranteed")
-				readyPod := tests.GetRunningPodByVirtualMachineInstance(cpuVmi, util.NamespaceTestDefault)
-				podQos := readyPod.Status.QOSClass
-				Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
-
-				var computeContainer *kubev1.Container
-				for _, container := range readyPod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainer = &container
+				for label, val := range nodeLabels {
+					if label == v1.CPUManager && val == "true" {
+						nodeHaveCpuManagerLabel = true
+						break
 					}
 				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
+				return nodeHaveCpuManagerLabel
+			}
+
+			BeforeEach(func() {
+				checks.SkipTestIfNoCPUManager()
+				nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if len(nodes.Items) == 1 {
+					Skip("Skip cpu pinning test that requires multiple nodes when only one node is present.")
 				}
+			})
 
-				output, err := tests.GetPodCPUSet(readyPod)
-				log.Log.Infof("%v", output)
-				Expect(err).ToNot(HaveOccurred())
-				output = strings.TrimSuffix(output, "\n")
-				pinnedCPUsList, err := hw_utils.ParseCPUSetLine(output, 100)
-				Expect(err).ToNot(HaveOccurred())
+			Context("[Serial]with cpu pinning enabled", Labels{"Serial"}, func() {
 
-				Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores)))
+				It("[test_id:1684]should set the cpumanager label to false when it's not running", Labels{"test_id:1684"}, func() {
+
+					By("adding a cpumanger=true label to a node")
+					nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
+					Expect(err).ToNot(HaveOccurred())
+					if len(nodes.Items) == 0 {
+						Skip("Skip CPU manager test on clusters where CPU manager is running on all worker/compute nodes")
+					}
+
+					node := &nodes.Items[0]
+					node, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, v1.CPUManager)), metav1.PatchOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					By("setting the cpumanager label back to false")
+					Eventually(func() string {
+						n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return n.Labels[v1.CPUManager]
+					}, 3*time.Minute, 2*time.Second).Should(Equal("false"))
+				})
+				It("[test_id:1685]non master node should have a cpumanager label", Labels{"test_id:1685"}, func() {
+					cpuManagerEnabled := false
+					for idx := 1; idx < len(nodes.Items); idx++ {
+						labels := nodes.Items[idx].GetLabels()
+						for label, val := range labels {
+							if label == "cpumanager" && val == "true" {
+								cpuManagerEnabled = true
+							}
+						}
+					}
+					Expect(cpuManagerEnabled).To(BeTrue())
+				})
+				It("[test_id:991]should be scheduled on a node with running cpu manager", Labels{"test_id:991"}, func() {
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						Cores:                 2,
+						DedicatedCPUPlacement: true,
+					}
+
+					By("Starting a VirtualMachineInstance")
+					cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).ToNot(HaveOccurred())
+					node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
+
+					By("Checking that the VMI QOS is guaranteed")
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Status.QOSClass).ToNot(BeNil())
+					Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
+
+					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+
+					By("Checking that the pod QOS is guaranteed")
+					readyPod := tests.GetRunningPodByVirtualMachineInstance(cpuVmi, util.NamespaceTestDefault)
+					podQos := readyPod.Status.QOSClass
+					Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
+
+					var computeContainer *kubev1.Container
+					for _, container := range readyPod.Spec.Containers {
+						if container.Name == "compute" {
+							computeContainer = &container
+						}
+					}
+					if computeContainer == nil {
+						util.PanicOnError(fmt.Errorf("could not find the compute container"))
+					}
+
+					output, err := tests.GetPodCPUSet(readyPod)
+					log.Log.Infof("%v", output)
+					Expect(err).ToNot(HaveOccurred())
+					output = strings.TrimSuffix(output, "\n")
+					pinnedCPUsList, err := hw_utils.ParseCPUSetLine(output, 100)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores)))
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
-				By("Checking the number of CPU cores under guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: "2"},
-				}, 15)).To(Succeed())
+					By("Checking the number of CPU cores under guest OS")
+					Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
+						&expect.BExp{R: "2"},
+					}, 15)).To(Succeed())
 
-				By("Check values in domain XML")
-				domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, cpuVmi)
-				Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
-				Expect(domXML).To(ContainSubstring("<hint-dedicated state='on'/>"), "should container the hint-dedicated feature")
-			})
-			It("[test_id:4632]should be able to start a vm with guest memory different from requested and keep guaranteed qos", func() {
-				Skip("Skip test till issue https://github.com/kubevirt/kubevirt/issues/3910 is fixed")
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Sockets:               2,
-					Cores:                 1,
-					DedicatedCPUPlacement: true,
-				}
-				guestMemory := resource.MustParse("64M")
-				cpuVmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("80M"),
-					},
-				}
+					By("Check values in domain XML")
+					domXML, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, cpuVmi)
+					Expect(err).ToNot(HaveOccurred(), "Should return XML from VMI")
+					Expect(domXML).To(ContainSubstring("<hint-dedicated state='on'/>"), "should container the hint-dedicated feature")
+				})
+				It("[test_id:4632]should be able to start a vm with guest memory different from requested and keep guaranteed qos", Labels{"test_id:4632"}, func() {
+					Skip("Skip test till issue https://github.com/kubevirt/kubevirt/issues/3910 is fixed")
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						Sockets:               2,
+						Cores:                 1,
+						DedicatedCPUPlacement: true,
+					}
+					guestMemory := resource.MustParse("64M")
+					cpuVmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+					cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("80M"),
+						},
+					}
 
-				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
+					By("Starting a VirtualMachineInstance")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).ToNot(HaveOccurred())
+					node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
 
-				By("Checking that the VMI QOS is guaranteed")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Status.QOSClass).ToNot(BeNil())
-				Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
+					By("Checking that the VMI QOS is guaranteed")
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Status.QOSClass).ToNot(BeNil())
+					Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
 
-				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
 
-				By("Checking that the pod QOS is guaranteed")
-				readyPod := tests.GetRunningPodByVirtualMachineInstance(cpuVmi, util.NamespaceTestDefault)
-				podQos := readyPod.Status.QOSClass
-				Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
+					By("Checking that the pod QOS is guaranteed")
+					readyPod := tests.GetRunningPodByVirtualMachineInstance(cpuVmi, util.NamespaceTestDefault)
+					podQos := readyPod.Status.QOSClass
+					Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
 
 				//-------------------------------------------------------------------
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
 
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
-					&expect.BExp{R: console.RetValue("pass")},
-					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
-					&expect.BExp{R: console.PromptExpression},
-					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: console.RetValue("0")},
-				}, 15)).To(Succeed())
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
+						&expect.BExp{R: console.RetValue("pass")},
+						&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+					}, 15)).To(Succeed())
 
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				podMemoryUsage, err := getPodMemoryUsage(pod)
-				Expect(err).ToNot(HaveOccurred())
-				By("Converting pod memory usage")
-				m, err := strconv.Atoi(strings.Trim(podMemoryUsage, "\n"))
-				Expect(err).ToNot(HaveOccurred())
-				By("Checking if pod memory usage is > 80Mi")
-				Expect(m > 83886080).To(BeTrue(), "83886080 B = 80 Mi")
-			})
-			It("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", func() {
+					pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+					podMemoryUsage, err := getPodMemoryUsage(pod)
+					Expect(err).ToNot(HaveOccurred())
+					By("Converting pod memory usage")
+					m, err := strconv.Atoi(strings.Trim(podMemoryUsage, "\n"))
+					Expect(err).ToNot(HaveOccurred())
+					By("Checking if pod memory usage is > 80Mi")
+					Expect(m > 83886080).To(BeTrue(), "83886080 B = 80 Mi")
+				})
+				It("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", Labels{"test_id:4023"}, func() {
 
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Cores:                 2,
-					DedicatedCPUPlacement: true,
-					IsolateEmulatorThread: true,
-				}
-
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
-
-				By("Checking that the VMI QOS is guaranteed")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Status.QOSClass).ToNot(BeNil())
-				Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
-
-				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
-
-				By("Checking that the pod QOS is guaranteed")
-				readyPod := tests.GetRunningPodByVirtualMachineInstance(cpuVmi, util.NamespaceTestDefault)
-				podQos := readyPod.Status.QOSClass
-				Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
-
-				var computeContainer *kubev1.Container
-				for _, container := range readyPod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainer = &container
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						Cores:                 2,
+						DedicatedCPUPlacement: true,
+						IsolateEmulatorThread: true,
 					}
-				}
-				if computeContainer == nil {
-					util.PanicOnError(fmt.Errorf("could not find the compute container"))
-				}
 
-				output, err := tests.GetPodCPUSet(readyPod)
-				log.Log.Infof("%v", output)
-				Expect(err).ToNot(HaveOccurred())
-				output = strings.TrimSuffix(output, "\n")
-				pinnedCPUsList, err := hw_utils.ParseCPUSetLine(output, 100)
-				Expect(err).ToNot(HaveOccurred())
+					By("Starting a VirtualMachineInstance")
+					cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).ToNot(HaveOccurred())
+					node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
 
-				// 1 additioan pcpus should be allocated on the pod for the emulation threads
-				Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores) + 1))
+					By("Checking that the VMI QOS is guaranteed")
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(cpuVmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(vmi.Status.QOSClass).ToNot(BeNil())
+					Expect(*vmi.Status.QOSClass).To(Equal(kubev1.PodQOSGuaranteed))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
 
-				By("Checking the number of CPU cores under guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: "2"},
-				}, 15)).To(Succeed())
-			})
+					By("Checking that the pod QOS is guaranteed")
+					readyPod := tests.GetRunningPodByVirtualMachineInstance(cpuVmi, util.NamespaceTestDefault)
+					podQos := readyPod.Status.QOSClass
+					Expect(podQos).To(Equal(kubev1.PodQOSGuaranteed))
 
-			It("[test_id:4024]should fail the vmi creation if IsolateEmulatorThread requested without dedicated cpus", func() {
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Cores:                 2,
-					IsolateEmulatorThread: true,
-				}
+					var computeContainer *kubev1.Container
+					for _, container := range readyPod.Spec.Containers {
+						if container.Name == "compute" {
+							computeContainer = &container
+						}
+					}
+					if computeContainer == nil {
+						util.PanicOnError(fmt.Errorf("could not find the compute container"))
+					}
 
-				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).To(HaveOccurred())
-			})
+					output, err := tests.GetPodCPUSet(readyPod)
+					log.Log.Infof("%v", output)
+					Expect(err).ToNot(HaveOccurred())
+					output = strings.TrimSuffix(output, "\n")
+					pinnedCPUsList, err := hw_utils.ParseCPUSetLine(output, 100)
+					Expect(err).ToNot(HaveOccurred())
 
-			It("[test_id:802]should configure correct number of vcpus with requests.cpus", func() {
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					DedicatedCPUPlacement: true,
-				}
-				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
-
-				By("Starting a VirtualMachineInstance")
-				cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).ToNot(HaveOccurred())
-				node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+					// 1 additioan pcpus should be allocated on the pod for the emulation threads
+					Expect(pinnedCPUsList).To(HaveLen(int(cpuVmi.Spec.Domain.CPU.Cores) + 1))
 
 				By("Expecting the VirtualMachineInstance console")
 				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
 
-				By("Checking the number of CPU cores under guest OS")
-				Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
-					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: "2"},
-				}, 15)).To(Succeed())
+					By("Checking the number of CPU cores under guest OS")
+					Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
+						&expect.BExp{R: "2"},
+					}, 15)).To(Succeed())
+				})
+
+				It("[test_id:4024]should fail the vmi creation if IsolateEmulatorThread requested without dedicated cpus", Labels{"test_id:4024"}, func() {
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						Cores:                 2,
+						IsolateEmulatorThread: true,
+					}
+
+					By("Starting a VirtualMachineInstance")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("[test_id:802]should configure correct number of vcpus with requests.cpus", Labels{"test_id:802"}, func() {
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						DedicatedCPUPlacement: true,
+					}
+					cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
+
+					By("Starting a VirtualMachineInstance")
+					cpuVmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).ToNot(HaveOccurred())
+					node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToCirros(cpuVmi)).To(Succeed())
+
+					By("Checking the number of CPU cores under guest OS")
+					Expect(console.SafeExpectBatch(cpuVmi, []expect.Batcher{
+						&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
+						&expect.BExp{R: "2"},
+					}, 15)).To(Succeed())
+				})
+
+				It("[test_id:1688]should fail the vmi creation if the requested resources are inconsistent", Labels{"test_id:1688"}, func() {
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						Cores:                 2,
+						DedicatedCPUPlacement: true,
+					}
+
+					cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("3")
+
+					By("Starting a VirtualMachineInstance")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).To(HaveOccurred())
+				})
+				It("[test_id:1689]should fail the vmi creation if cpu is not an integer", Labels{"test_id:1689"}, func() {
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						DedicatedCPUPlacement: true,
+					}
+
+					cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("300m")
+
+					By("Starting a VirtualMachineInstance")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).To(HaveOccurred())
+				})
+				It("[test_id:1690]should fail the vmi creation if Guaranteed QOS cannot be set", Labels{"test_id:1690"}, func() {
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						DedicatedCPUPlacement: true,
+					}
+					cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
+					cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Limits: kubev1.ResourceList{
+							kubev1.ResourceCPU: resource.MustParse("4"),
+						},
+					}
+					By("Starting a VirtualMachineInstance")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).To(HaveOccurred())
+				})
+				It("[test_id:830]should start a vm with no cpu pinning after a vm with cpu pinning on same node", Labels{"test_id:830"}, func() {
+					Vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+					cpuVmi.Spec.Domain.CPU = &v1.CPU{
+						DedicatedCPUPlacement: true,
+					}
+
+					cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
+					Vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("1")
+					Vmi.Spec.NodeSelector = map[string]string{v1.CPUManager: "true"}
+
+					By("Starting a VirtualMachineInstance with dedicated cpus")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+					Expect(err).ToNot(HaveOccurred())
+					node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+
+					By("Starting a VirtualMachineInstance without dedicated cpus")
+					_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(Vmi)
+					Expect(err).ToNot(HaveOccurred())
+				node = tests.WaitForSuccessfulVMIStart(Vmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+				})
 			})
 
-			It("[test_id:1688]should fail the vmi creation if the requested resources are inconsistent", func() {
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Cores:                 2,
-					DedicatedCPUPlacement: true,
-				}
+			Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", Labels{"Serial"}, func() {
 
-				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("3")
+				var cpuvmi, vmi *v1.VirtualMachineInstance
+				var node string
 
-				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).To(HaveOccurred())
+				BeforeEach(func() {
+
+					nodes := util.GetAllSchedulableNodes(virtClient)
+					Expect(nodes.Items).ToNot(BeEmpty(), "There should be some nodes")
+					node = nodes.Items[1].Name
+
+					vmi = libvmi.NewFedora()
+
+					cpuvmi = libvmi.NewFedora()
+					cpuvmi.Spec.Domain.CPU = &v1.CPU{
+						Cores:                 2,
+						DedicatedCPUPlacement: true,
+					}
+					cpuvmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("512M"),
+						},
+					}
+					cpuvmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
+
+					vmi.Spec.Domain.CPU = &v1.CPU{
+						Cores: 2,
+					}
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("512M"),
+						},
+					}
+					vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
+				})
+
+				It("[test_id:829]should start a vm with no cpu pinning after a vm with cpu pinning on same node", Labels{"test_id:829"}, func() {
+
+					By("Starting a VirtualMachineInstance with dedicated cpus")
+					cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
+					Expect(err).ToNot(HaveOccurred())
+					node1 := tests.WaitForSuccessfulVMIStart(cpuvmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
+					Expect(node1).To(Equal(node))
+
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
+
+					By("Starting a VirtualMachineInstance without dedicated cpus")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					node2 := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
+					Expect(node2).To(Equal(node))
+
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 			})
-			It("[test_id:1689]should fail the vmi creation if cpu is not an integer", func() {
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					DedicatedCPUPlacement: true,
-				}
 
-				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("300m")
+				It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", Labels{"test_id:832"}, func() {
 
-				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).To(HaveOccurred())
-			})
-			It("[test_id:1690]should fail the vmi creation if Guaranteed QOS cannot be set", func() {
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					DedicatedCPUPlacement: true,
-				}
-				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Limits: kubev1.ResourceList{
-						kubev1.ResourceCPU: resource.MustParse("4"),
-					},
-				}
-				By("Starting a VirtualMachineInstance")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
-				Expect(err).To(HaveOccurred())
-			})
-			It("[test_id:830]should start a vm with no cpu pinning after a vm with cpu pinning on same node", func() {
-				Vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					DedicatedCPUPlacement: true,
-				}
+					By("Starting a VirtualMachineInstance without dedicated cpus")
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					node2 := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
+					Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
+					Expect(node2).To(Equal(node))
 
-				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
-				Vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("1")
-				Vmi.Spec.NodeSelector = map[string]string{v1.CPUManager: "true"}
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuVmi)
+				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
 				Expect(err).ToNot(HaveOccurred())
-				node := tests.WaitForSuccessfulVMIStart(cpuVmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+				node1 := tests.WaitForSuccessfulVMIStart(cpuvmi).Status.NodeName
+				Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
+				Expect(node1).To(Equal(node))
 
-				By("Starting a VirtualMachineInstance without dedicated cpus")
-				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(Vmi)
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
+			})
+		})
+	})
+
+	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check Chassis value",
+		Labels{"rfe_id:2926", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
+
+			It("[Serial][test_id:2927]Test Chassis value in a newly created VM", Labels{"Serial", "test_id:2927"}, func() {
+				vmi := tests.NewRandomFedoraVMIWithDmidecode()
+				vmi.Spec.Domain.Chassis = &v1.Chassis{
+					Asset: "Test-123",
+				}
+
+				By("Starting a VirtualMachineInstance")
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				node = tests.WaitForSuccessfulVMIStart(Vmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node)).To(BeTrue())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				By("Check values on domain XML")
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
+
+			By("Expecting console")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Check value in VM with dmidecode")
+				// Check on the VM, if expected values are there with dmidecode
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') = Test-123 ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+				}, 10)).To(Succeed())
 			})
 		})
 
-		Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", func() {
+	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values",
+		Labels{"Serial", "rfe_id:2926", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		func() {
 
-			var cpuvmi, vmi *v1.VirtualMachineInstance
-			var node string
+			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-
-				nodes := util.GetAllSchedulableNodes(virtClient)
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some nodes")
-				node = nodes.Items[1].Name
-
-				vmi = libvmi.NewFedora()
-
-				cpuvmi = libvmi.NewFedora()
-				cpuvmi.Spec.Domain.CPU = &v1.CPU{
-					Cores:                 2,
-					DedicatedCPUPlacement: true,
-				}
-				cpuvmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("512M"),
-					},
-				}
-				cpuvmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
-
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 2,
-				}
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("512M"),
-					},
-				}
-				vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
+				vmi = tests.NewRandomFedoraVMIWithDmidecode()
 			})
 
-			It("[test_id:829]should start a vm with no cpu pinning after a vm with cpu pinning on same node", func() {
+			It("[test_id:2751]test default SMBios", Labels{"test_id:2751"}, func() {
+				kv := util.GetCurrentKv(virtClient)
 
-				By("Starting a VirtualMachineInstance with dedicated cpus")
-				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
-				Expect(err).ToNot(HaveOccurred())
-				node1 := tests.WaitForSuccessfulVMIStart(cpuvmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
-				Expect(node1).To(Equal(node))
+				config := kv.Spec.Configuration
+				// Clear SMBios values if already set in kubevirt-config, for testing default values.
+				test_smbios := &v1.SMBiosConfiguration{Family: "", Product: "", Manufacturer: ""}
+				config.SMBIOSConfig = test_smbios
+				tests.UpdateKubeVirtConfigValueAndWait(config)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
-
-				By("Starting a VirtualMachineInstance without dedicated cpus")
+				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				node2 := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
-				Expect(node2).To(Equal(node))
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
+				By("Check values in domain XML")
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(domXml).To(ContainSubstring("<entry name='family'>KubeVirt</entry>"))
+				Expect(domXml).To(ContainSubstring("<entry name='product'>None</entry>"))
+				Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
+
+			By("Expecting console")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Check values in dmidecode")
+				// Check on the VM, if expected values are there with dmidecode
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+					&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = None ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+					&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+				}, 1)).To(Succeed())
 			})
 
-			It("[test_id:832]should start a vm with cpu pinning after a vm with no cpu pinning on same node", func() {
+			It("[test_id:2752]test custom SMBios values", Labels{"test_id:2752"}, func() {
+				kv := util.GetCurrentKv(virtClient)
+				config := kv.Spec.Configuration
+				// Set a custom test SMBios
+				test_smbios := &v1.SMBiosConfiguration{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
+				config.SMBIOSConfig = test_smbios
+				tests.UpdateKubeVirtConfigValueAndWait(config)
 
-				By("Starting a VirtualMachineInstance without dedicated cpus")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				By("Starting a VirtualMachineInstance")
+				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				node2 := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node2)).To(BeTrue())
-				Expect(node2).To(Equal(node))
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-				By("Starting a VirtualMachineInstance with dedicated cpus")
-				cpuvmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(cpuvmi)
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
-				node1 := tests.WaitForSuccessfulVMIStart(cpuvmi).Status.NodeName
-				Expect(isNodeHasCPUManagerLabel(node1)).To(BeTrue())
-				Expect(node1).To(Equal(node))
+				Expect(domXml).To(ContainSubstring("<entry name='family'>test</entry>"))
+				Expect(domXml).To(ContainSubstring("<entry name='product'>test</entry>"))
+				Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>None</entry>"))
+				Expect(domXml).To(ContainSubstring("<entry name='sku'>1.0</entry>"))
+				Expect(domXml).To(ContainSubstring("<entry name='version'>1.0</entry>"))
 
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(cpuvmi)).To(Succeed())
+			By("Expecting console")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Check values in dmidecode")
+
+				// Check on the VM, if expected values are there with dmidecode
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = test ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+					&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = test ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+					&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = None ] && echo 'pass'\n"},
+					&expect.BExp{R: console.RetValue("pass")},
+				}, 1)).To(Succeed())
 			})
 		})
-	})
-
-	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check Chassis value", func() {
-
-		It("[Serial][test_id:2927]Test Chassis value in a newly created VM", func() {
-			vmi := tests.NewRandomFedoraVMIWithDmidecode()
-			vmi.Spec.Domain.Chassis = &v1.Chassis{
-				Asset: "Test-123",
-			}
-
-			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("Check values on domain XML")
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
-
-			By("Expecting console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-			By("Check value in VM with dmidecode")
-			// Check on the VM, if expected values are there with dmidecode
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') = Test-123 ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-			}, 10)).To(Succeed())
-		})
-	})
-
-	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", func() {
-
-		var vmi *v1.VirtualMachineInstance
-
-		BeforeEach(func() {
-			vmi = tests.NewRandomFedoraVMIWithDmidecode()
-		})
-
-		It("[test_id:2751]test default SMBios", func() {
-			kv := util.GetCurrentKv(virtClient)
-
-			config := kv.Spec.Configuration
-			// Clear SMBios values if already set in kubevirt-config, for testing default values.
-			test_smbios := &v1.SMBiosConfiguration{Family: "", Product: "", Manufacturer: ""}
-			config.SMBIOSConfig = test_smbios
-			tests.UpdateKubeVirtConfigValueAndWait(config)
-
-			By("Starting a VirtualMachineInstance")
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("Check values in domain XML")
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring("<entry name='family'>KubeVirt</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='product'>None</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
-
-			By("Expecting console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-			By("Check values in dmidecode")
-			// Check on the VM, if expected values are there with dmidecode
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-			}, 1)).To(Succeed())
-		})
-
-		It("[test_id:2752]test custom SMBios values", func() {
-			kv := util.GetCurrentKv(virtClient)
-			config := kv.Spec.Configuration
-			// Set a custom test SMBios
-			test_smbios := &v1.SMBiosConfiguration{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
-			config.SMBIOSConfig = test_smbios
-			tests.UpdateKubeVirtConfigValueAndWait(config)
-
-			By("Starting a VirtualMachineInstance")
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring("<entry name='family'>test</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='product'>test</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>None</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='sku'>1.0</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='version'>1.0</entry>"))
-
-			By("Expecting console")
-			Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-			By("Check values in dmidecode")
-
-			// Check on the VM, if expected values are there with dmidecode
-			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: console.RetValue("pass")},
-			}, 1)).To(Succeed())
-		})
-	})
 
 	Context("With ephemeral CD-ROM", func() {
 		var vmi *v1.VirtualMachineInstance
@@ -2789,10 +2847,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(err.Error()).To(ContainSubstring(errMsg))
 			}
 		},
-			Entry("[test_id:3777] Should be accepted when using sata", "sata", ""),
-			Entry("[test_id:3809] Should be accepted when using scsi", "scsi", ""),
-			Entry("[test_id:3776] Should be rejected when using virtio", "virtio", "Bus type virtio is invalid"),
-			Entry("[test_id:3808] Should be rejected when using ide", "ide", "IDE bus is not supported"),
+			Entry("[test_id:3777] Should be accepted when using sata", Labels{"test_id:3777"}, "sata", ""),
+			Entry("[test_id:3809] Should be accepted when using scsi", Labels{"test_id:3809"}, "scsi", ""),
+			Entry("[test_id:3776] Should be rejected when using virtio", Labels{"test_id:3776"}, "virtio", "Bus type virtio is invalid"),
+			Entry("[test_id:3808] Should be rejected when using ide", Labels{"test_id:3808"}, "ide", "IDE bus is not supported"),
 		)
 	})
 
@@ -2873,8 +2931,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		},
-			Entry("[test_id:5269]across all available PCI root bus slots", 2, numOfSlotsToTest, false),
-			Entry("[test_id:5270]across all available PCI functions of a single slot", 0, numOfFuncsToTest, true),
+			Entry("[test_id:5269]across all available PCI root bus slots", Labels{"test_id:5269"}, 2, numOfSlotsToTest, false),
+			Entry("[test_id:5270]across all available PCI functions of a single slot", Labels{"test_id:5270"}, 0, numOfFuncsToTest, true),
 		)
 	})
 
@@ -2889,7 +2947,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi = tests.NewRandomFedoraVMIWithVirtWhatCpuidHelper()
 		})
 
-		It("[test_id:5271]test cpuid hidden", func() {
+		It("[test_id:5271]test cpuid hidden", Labels{"test_id:5271"}, func() {
 			vmi.Spec.Domain.Features = &v1.Features{
 				KVM: &v1.FeatureKVM{Hidden: true},
 			}
@@ -2916,7 +2974,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			}, 2*time.Second)).To(Succeed())
 		})
 
-		It("[test_id:5272]test cpuid default", func() {
+		It("[test_id:5272]test cpuid default", Labels{"test_id:5272"}, func() {
 			By("Starting a VirtualMachineInstance")
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -15,7 +15,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[sig-compute]Controller devices", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Controller devices", Label("sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -15,7 +15,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[sig-compute]Controller devices", func() {
+var _ = Describe("[sig-compute]Controller devices", Labels{"sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -54,7 +54,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }
 
-var _ = Describe("[Serial][sig-compute]GPU", func() {
+var _ = Describe("[Serial][sig-compute]GPU", Labels{"Serial", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -64,7 +64,7 @@ var _ = Describe("[Serial][sig-compute]GPU", func() {
 	})
 
 	Context("with ephemeral disk", func() {
-		It("[test_id:4607]Should create a valid VMI but pod should not go to running state", func() {
+		It("[test_id:4607]Should create a valid VMI but pod should not go to running state", Labels{"test_id:4607"}, func() {
 			gpuName := "random.com/gpu"
 			randomVMI := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			gpus := []v1.GPU{
@@ -84,7 +84,7 @@ var _ = Describe("[Serial][sig-compute]GPU", func() {
 			Expect(pod.Status.Conditions[0].Reason).To(Equal("Unschedulable"))
 		})
 
-		It("[test_id:4608]Should create a valid VMI and appropriate libvirt domain", func() {
+		It("[test_id:4608]Should create a valid VMI and appropriate libvirt domain", Labels{"test_id:4608"}, func() {
 			nodesList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			var gpuName = ""

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -54,7 +54,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }
 
-var _ = Describe("[Serial][sig-compute]GPU", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]GPU", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -64,7 +64,7 @@ var _ = Describe("[Serial][sig-compute]GPU", Labels{"Serial", "sig-compute"}, fu
 	})
 
 	Context("with ephemeral disk", func() {
-		It("[test_id:4607]Should create a valid VMI but pod should not go to running state", Labels{"test_id:4607"}, func() {
+		It("[test_id:4607]Should create a valid VMI but pod should not go to running state", Label("test_id:4607"), func() {
 			gpuName := "random.com/gpu"
 			randomVMI := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			gpus := []v1.GPU{
@@ -84,7 +84,7 @@ var _ = Describe("[Serial][sig-compute]GPU", Labels{"Serial", "sig-compute"}, fu
 			Expect(pod.Status.Conditions[0].Reason).To(Equal("Unschedulable"))
 		})
 
-		It("[test_id:4608]Should create a valid VMI and appropriate libvirt domain", Labels{"test_id:4608"}, func() {
+		It("[test_id:4608]Should create a valid VMI and appropriate libvirt domain", Label("test_id:4608"), func() {
 			nodesList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			var gpuName = ""

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -38,7 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "sig-compute"}, func() {
+var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Label("rfe_id:609", "sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -52,7 +52,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 	})
 
-	Describe("[rfe_id:609]Creating a VirtualMachineInstance", Labels{"rfe_id:609"}, func() {
+	Describe("[rfe_id:609]Creating a VirtualMachineInstance", Label("rfe_id:609"), func() {
 
 		Context("with headless", func() {
 
@@ -61,11 +61,11 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 				vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &f
 			})
 
-			It("[test_id:707]should create headless vmi without any issue", Labels{"test_id:707"}, func() {
+			It("[test_id:707]should create headless vmi without any issue", Label("test_id:707"), func() {
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 			})
 
-			It("[test_id:714][posneg:positive]should not have vnc graphic device in xml", Labels{"test_id:714", "posneg:positive"}, func() {
+			It("[test_id:714][posneg:positive]should not have vnc graphic device in xml", Label("test_id:714", "posneg:positive"), func() {
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
@@ -74,7 +74,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 				Expect(runningVMISpec.Devices.Graphics).To(BeEmpty(), "should not have any graphics devices present")
 			})
 
-			It("[test_id:737][posneg:positive]should match memory with overcommit enabled", Labels{"test_id:737", "posneg:positive"}, func() {
+			It("[test_id:737][posneg:positive]should match memory with overcommit enabled", Label("test_id:737", "posneg:positive"), func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceMemory: resource.MustParse("100M"),
@@ -89,7 +89,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 				Expect(computeContainer.Resources.Requests.Memory().String()).To(Equal("100M"))
 			})
 
-			It("[test_id:2444][posneg:negative]should not match memory with overcommit disabled", Labels{"test_id:2444", "posneg:negative"}, func() {
+			It("[test_id:2444][posneg:negative]should not match memory with overcommit disabled", Label("test_id:2444", "posneg:negative"), func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceMemory: resource.MustParse("100M"),
@@ -103,7 +103,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 				Expect(computeContainer.Resources.Requests.Memory().String()).ToNot(Equal("100M"))
 			})
 
-			It("[test_id:713]should have more memory on pod when headless", Labels{"test_id:713"}, func() {
+			It("[test_id:713]should have more memory on pod when headless", Label("test_id:713"), func() {
 				normalVmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
@@ -125,7 +125,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 						memDiff.ScaledValue(resource.Mega)))
 			})
 
-			It("[test_id:738][posneg:negative]should not connect to VNC", Labels{"test_id:738", "posneg:negative"}, func() {
+			It("[test_id:738][posneg:negative]should not connect to VNC", Label("test_id:738", "posneg:negative"), func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				_, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
@@ -133,7 +133,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 				Expect(err.Error()).To(Equal("No graphics devices are present."), "vnc should not connect on headless VM")
 			})
 
-			It("[test_id:709][posneg:positive]should connect to console", Labels{"test_id:709", "posneg:positive"}, func() {
+			It("[test_id:709][posneg:positive]should connect to console", Label("test_id:709", "posneg:positive"), func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("checking that console works")
@@ -144,7 +144,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "s
 
 		Context("without headless", func() {
 
-			It("[test_id:714][posneg:negative]should have one vnc graphic device in xml", Labels{"test_id:714", "posneg:negative"}, func() {
+			It("[test_id:714][posneg:negative]should have one vnc graphic device in xml", Label("test_id:714", "posneg:negative"), func() {
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -38,7 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
+var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", Labels{"rfe_id:609", "sig-compute"}, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -52,7 +52,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 	})
 
-	Describe("[rfe_id:609]Creating a VirtualMachineInstance", func() {
+	Describe("[rfe_id:609]Creating a VirtualMachineInstance", Labels{"rfe_id:609"}, func() {
 
 		Context("with headless", func() {
 
@@ -61,11 +61,11 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &f
 			})
 
-			It("[test_id:707]should create headless vmi without any issue", func() {
+			It("[test_id:707]should create headless vmi without any issue", Labels{"test_id:707"}, func() {
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 			})
 
-			It("[test_id:714][posneg:positive]should not have vnc graphic device in xml", func() {
+			It("[test_id:714][posneg:positive]should not have vnc graphic device in xml", Labels{"test_id:714", "posneg:positive"}, func() {
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
@@ -74,7 +74,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				Expect(runningVMISpec.Devices.Graphics).To(BeEmpty(), "should not have any graphics devices present")
 			})
 
-			It("[test_id:737][posneg:positive]should match memory with overcommit enabled", func() {
+			It("[test_id:737][posneg:positive]should match memory with overcommit enabled", Labels{"test_id:737", "posneg:positive"}, func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceMemory: resource.MustParse("100M"),
@@ -89,7 +89,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				Expect(computeContainer.Resources.Requests.Memory().String()).To(Equal("100M"))
 			})
 
-			It("[test_id:2444][posneg:negative]should not match memory with overcommit disabled", func() {
+			It("[test_id:2444][posneg:negative]should not match memory with overcommit disabled", Labels{"test_id:2444", "posneg:negative"}, func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceMemory: resource.MustParse("100M"),
@@ -103,7 +103,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				Expect(computeContainer.Resources.Requests.Memory().String()).ToNot(Equal("100M"))
 			})
 
-			It("[test_id:713]should have more memory on pod when headless", func() {
+			It("[test_id:713]should have more memory on pod when headless", Labels{"test_id:713"}, func() {
 				normalVmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
@@ -125,7 +125,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 						memDiff.ScaledValue(resource.Mega)))
 			})
 
-			It("[test_id:738][posneg:negative]should not connect to VNC", func() {
+			It("[test_id:738][posneg:negative]should not connect to VNC", Labels{"test_id:738", "posneg:negative"}, func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				_, err := virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).VNC(vmi.ObjectMeta.Name)
@@ -133,7 +133,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				Expect(err.Error()).To(Equal("No graphics devices are present."), "vnc should not connect on headless VM")
 			})
 
-			It("[test_id:709][posneg:positive]should connect to console", func() {
+			It("[test_id:709][posneg:positive]should connect to console", Labels{"test_id:709", "posneg:positive"}, func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("checking that console works")
@@ -144,7 +144,7 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 
 		Context("without headless", func() {
 
-			It("[test_id:714][posneg:negative]should have one vnc graphic device in xml", func() {
+			It("[test_id:714][posneg:negative]should have one vnc graphic device in xml", Labels{"test_id:714", "posneg:negative"}, func() {
 				tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -112,7 +112,7 @@ var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
 
 				It("[test_id:3158]should update domain XML with SM BIOS properties", Labels{"test_id:3158"}, func() {
 					By("Reading domain XML using virsh")
-				clientcmd.SkipIfNoCmd("kubectl")
+					clientcmd.SkipIfNoCmd("kubectl")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					tests.WaitForSuccessfulVMIStart(vmi)
 					domainXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -47,7 +47,7 @@ const (
 	sidecarContainerName = "hook-sidecar-0"
 )
 
-var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]HookSidecars", Label("sig-compute"), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -64,7 +64,7 @@ var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
 	})
 
 	Describe("[rfe_id:2667][crit:medium][vendor:cnv-qe@redhat.com][level:component] VMI definition",
-		Labels{"rfe_id:2667", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+		Label("rfe_id:2667", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 		func() {
 			getVMIPod := func(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, bool, error) {
 				podSelector := tests.UnfinishedVMIPodSelector(vmi)
@@ -79,14 +79,14 @@ var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
 			}
 
 			Context("with SM BIOS hook sidecar", func() {
-				It("[test_id:3155]should successfully start with hook sidecar annotation", Labels{"test_id:3155"}, func() {
+				It("[test_id:3155]should successfully start with hook sidecar annotation", Label("test_id:3155"), func() {
 					By("Starting a VMI")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(vmi)
 				})
 
-				It("[test_id:3156]should successfully start with hook sidecar annotation for v1alpha2", Labels{"test_id:3156"}, func() {
+				It("[test_id:3156]should successfully start with hook sidecar annotation for v1alpha2", Label("test_id:3156"), func() {
 					By("Starting a VMI")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					vmi.ObjectMeta.Annotations = RenderSidecar(hooksv1alpha2.Version)
@@ -94,7 +94,7 @@ var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
 					tests.WaitForSuccessfulVMIStart(vmi)
 				})
 
-				It("[test_id:3157]should call Collect and OnDefineDomain on the hook sidecar", Labels{"test_id:3157"}, func() {
+				It("[test_id:3157]should call Collect and OnDefineDomain on the hook sidecar", Label("test_id:3157"), func() {
 					By("Getting hook-sidecar logs")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).ToNot(HaveOccurred())
@@ -110,7 +110,7 @@ var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
 						Should(ContainSubstring("Hook's OnDefineDomain callback method has been called"))
 				})
 
-				It("[test_id:3158]should update domain XML with SM BIOS properties", Labels{"test_id:3158"}, func() {
+				It("[test_id:3158]should update domain XML with SM BIOS properties", Label("test_id:3158"), func() {
 					By("Reading domain XML using virsh")
 					clientcmd.SkipIfNoCmd("kubectl")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -149,12 +149,12 @@ var _ = Describe("[sig-compute]HookSidecars", Labels{"sig-compute"}, func() {
 				})
 			})
 
-			Context("[Serial]with sidecar feature gate disabled", Labels{"Serial"}, func() {
+			Context("[Serial]with sidecar feature gate disabled", Label("Serial"), func() {
 				BeforeEach(func() {
 					tests.DisableFeatureGate(virtconfig.SidecarGate)
 				})
 
-				It("[test_id:2666]should not start with hook sidecar annotation", Labels{"test_id:2666"}, func() {
+				It("[test_id:2666]should not start with hook sidecar annotation", Label("test_id:2666"), func() {
 					By("Starting a VMI")
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).To(HaveOccurred(), "should not create a VMI without sidecar feature gate")

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -25,7 +25,7 @@ const (
 	failedDeleteVMI = "Failed to delete VMI"
 )
 
-var _ = Describe("[Serial][sig-compute]HostDevices", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]HostDevices", Label("Serial", "sig-compute"), func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -25,7 +25,7 @@ const (
 	failedDeleteVMI = "Failed to delete VMI"
 )
 
-var _ = Describe("[Serial][sig-compute]HostDevices", func() {
+var _ = Describe("[Serial][sig-compute]HostDevices", Labels{"Serial", "sig-compute"}, func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]IgnitionData",
-	Labels{"rfe_id:151", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:151", "crit:high", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error
@@ -66,11 +66,11 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		}
 
 		Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance",
-			Labels{"rfe_id:151", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:151", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				Context("with IgnitionData annotation", func() {
 					Context("with injected data", func() {
-						It("[test_id:1616]should have injected data under firmware directory", Labels{"test_id:1616"}, func() {
+						It("[test_id:1616]should have injected data under firmware directory", Label("test_id:1616"), func() {
 							vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
 
 							ignitionData := "ignition injected"

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -41,7 +41,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[sig-compute]IOThreads", func() {
+var _ = Describe("[sig-compute]IOThreads", Labels{"sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -63,7 +63,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
-		It("[test_id:4122]Should honor shared ioThreadsPolicy for single disk", func() {
+		It("[test_id:4122]Should honor shared ioThreadsPolicy for single disk", Labels{"test_id:4122"}, func() {
 			policy := v1.IOThreadsPolicyShared
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
 
@@ -89,7 +89,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(1))
 		})
 
-		It("[test_id:864][ref_id:2065] Should honor a mix of shared and dedicated ioThreadsPolicy", func() {
+		It("[test_id:864][ref_id:2065] Should honor a mix of shared and dedicated ioThreadsPolicy", Labels{"test_id:864", "ref_id:2065"}, func() {
 			policy := v1.IOThreadsPolicyShared
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
 
@@ -139,7 +139,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			Expect(*disk0.Driver.IOThread).ToNot(Equal(*disk1.Driver.IOThread))
 		})
 
-		DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", func(numCpus int, expectedIOThreads int) {
+		DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", Labels{"ref_id:2065"}, func(numCpus int, expectedIOThreads int) {
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
 			)
@@ -218,17 +218,17 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 		},
 			// special case: there's always at least one thread for the shared pool:
 			// two dedicated and one shared thread is 3 threads.
-			Entry("[test_id:3097]for one CPU", 1, 3),
-			Entry("[test_id:856] for two CPUs", 2, 4),
-			Entry("[test_id:3095] for three CPUs", 3, 6),
+			Entry("[test_id:3097]for one CPU", Labels{"test_id:3097"}, 1, 3),
+			Entry("[test_id:856] for two CPUs", Labels{"test_id:856"}, 2, 4),
+			Entry("[test_id:3095] for three CPUs", Labels{"test_id:3095"}, 3, 6),
 			// there's only 6 threads expected because there's 6 total disks, even
 			// though the limit would have supported 8.
-			Entry("[test_id:3096]for four CPUs", 4, 6),
+			Entry("[test_id:3096]for four CPUs", Labels{"test_id:3096"}, 4, 6),
 		)
 
 		// IOThread with Emulator Thread
 
-		It("[test_id:4025]Should place io and emulator threads on the same pcpu with auto ioThreadsPolicy", func() {
+		It("[test_id:4025]Should place io and emulator threads on the same pcpu with auto ioThreadsPolicy", Labels{"test_id:4025"}, func() {
 			checks.SkipTestIfNoCPUManager()
 
 			policy := v1.IOThreadsPolicyAuto

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -41,7 +41,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[sig-compute]IOThreads", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]IOThreads", Label("sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -63,7 +63,7 @@ var _ = Describe("[sig-compute]IOThreads", Labels{"sig-compute"}, func() {
 			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
-		It("[test_id:4122]Should honor shared ioThreadsPolicy for single disk", Labels{"test_id:4122"}, func() {
+		It("[test_id:4122]Should honor shared ioThreadsPolicy for single disk", Label("test_id:4122"), func() {
 			policy := v1.IOThreadsPolicyShared
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
 
@@ -89,7 +89,7 @@ var _ = Describe("[sig-compute]IOThreads", Labels{"sig-compute"}, func() {
 			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(1))
 		})
 
-		It("[test_id:864][ref_id:2065] Should honor a mix of shared and dedicated ioThreadsPolicy", Labels{"test_id:864", "ref_id:2065"}, func() {
+		It("[test_id:864][ref_id:2065] Should honor a mix of shared and dedicated ioThreadsPolicy", Label("test_id:864", "ref_id:2065"), func() {
 			policy := v1.IOThreadsPolicyShared
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
 
@@ -139,7 +139,7 @@ var _ = Describe("[sig-compute]IOThreads", Labels{"sig-compute"}, func() {
 			Expect(*disk0.Driver.IOThread).ToNot(Equal(*disk1.Driver.IOThread))
 		})
 
-		DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", Labels{"ref_id:2065"}, func(numCpus int, expectedIOThreads int) {
+		DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", Label("ref_id:2065"), func(numCpus int, expectedIOThreads int) {
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
 			)
@@ -218,17 +218,17 @@ var _ = Describe("[sig-compute]IOThreads", Labels{"sig-compute"}, func() {
 		},
 			// special case: there's always at least one thread for the shared pool:
 			// two dedicated and one shared thread is 3 threads.
-			Entry("[test_id:3097]for one CPU", Labels{"test_id:3097"}, 1, 3),
-			Entry("[test_id:856] for two CPUs", Labels{"test_id:856"}, 2, 4),
-			Entry("[test_id:3095] for three CPUs", Labels{"test_id:3095"}, 3, 6),
+			Entry("[test_id:3097]for one CPU", Label("test_id:3097"), 1, 3),
+			Entry("[test_id:856] for two CPUs", Label("test_id:856"), 2, 4),
+			Entry("[test_id:3095] for three CPUs", Label("test_id:3095"), 3, 6),
 			// there's only 6 threads expected because there's 6 total disks, even
 			// though the limit would have supported 8.
-			Entry("[test_id:3096]for four CPUs", Labels{"test_id:3096"}, 4, 6),
+			Entry("[test_id:3096]for four CPUs", Label("test_id:3096"), 4, 6),
 		)
 
 		// IOThread with Emulator Thread
 
-		It("[test_id:4025]Should place io and emulator threads on the same pcpu with auto ioThreadsPolicy", Labels{"test_id:4025"}, func() {
+		It("[test_id:4025]Should place io and emulator threads on the same pcpu with auto ioThreadsPolicy", Label("test_id:4025"), func() {
 			checks.SkipTestIfNoCPUManager()
 
 			policy := v1.IOThreadsPolicyAuto

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
 
-var _ = Describe("[sig-compute]VMI with external kernel boot", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]VMI with external kernel boot", Label("sig-compute"), func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error
@@ -53,7 +53,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", Labels{"sig-compu
 	})
 
 	Context("with external alpine-based kernel & initrd images", func() {
-		It("[test_id:7748]ensure successful boot", Labels{"test_id:7748"}, func() {
+		It("[test_id:7748]ensure successful boot", Label("test_id:7748"), func() {
 			vmi := utils.GetVMIKernelBoot()
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -103,7 +103,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", Labels{"sig-compu
 
 	Context("with illegal definition ensure rejection of", func() {
 
-		It("[test_id:7750]VMI defined without an image", Labels{"test_id:7750"}, func() {
+		It("[test_id:7750]VMI defined without an image", Label("test_id:7750"), func() {
 			vmi := utils.GetVMIKernelBoot()
 			kernelBoot := vmi.Spec.Domain.Firmware.KernelBoot
 			kernelBoot.Container.Image = ""
@@ -112,7 +112,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", Labels{"sig-compu
 			Expect(err.Error()).To(ContainSubstring("denied the request: spec.domain.firmware.kernelBoot.container must be defined with an image"))
 		})
 
-		It("[test_id:7751]VMI defined with image but without initrd & kernel paths", Labels{"test_id:7751"}, func() {
+		It("[test_id:7751]VMI defined with image but without initrd & kernel paths", Label("test_id:7751"), func() {
 			vmi := utils.GetVMIKernelBoot()
 			kernelBoot := vmi.Spec.Domain.Firmware.KernelBoot
 			kernelBoot.Container.KernelPath = ""

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
 
-var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
+var _ = Describe("[sig-compute]VMI with external kernel boot", Labels{"sig-compute"}, func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error
@@ -53,7 +53,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 	})
 
 	Context("with external alpine-based kernel & initrd images", func() {
-		It("[test_id:7748]ensure successful boot", func() {
+		It("[test_id:7748]ensure successful boot", Labels{"test_id:7748"}, func() {
 			vmi := utils.GetVMIKernelBoot()
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -103,7 +103,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 
 	Context("with illegal definition ensure rejection of", func() {
 
-		It("[test_id:7750]VMI defined without an image", func() {
+		It("[test_id:7750]VMI defined without an image", Labels{"test_id:7750"}, func() {
 			vmi := utils.GetVMIKernelBoot()
 			kernelBoot := vmi.Spec.Domain.Firmware.KernelBoot
 			kernelBoot.Container.Image = ""
@@ -112,7 +112,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 			Expect(err.Error()).To(ContainSubstring("denied the request: spec.domain.firmware.kernelBoot.container must be defined with an image"))
 		})
 
-		It("[test_id:7751]VMI defined with image but without initrd & kernel paths", func() {
+		It("[test_id:7751]VMI defined with image but without initrd & kernel paths", Labels{"test_id:7751"}, func() {
 			vmi := utils.GetVMIKernelBoot()
 			kernelBoot := vmi.Spec.Domain.Firmware.KernelBoot
 			kernelBoot.Container.KernelPath = ""

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -81,1641 +81,1659 @@ func addNodeAffinityToVMI(vmi *v1.VirtualMachineInstance, nodeName string) {
 	}
 }
 
-var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle", func() {
+var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIlifecycle",
+	Label("rfe_id:273", "crit:high", "arm64", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
+	func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
+		var err error
+		var virtClient kubecli.KubevirtClient
 
-	var vmi *v1.VirtualMachineInstance
+		var vmi *v1.VirtualMachineInstance
 
-	var allowEmulation *bool
+		var allowEmulation *bool
 
-	const fakeLibvirtLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
+		const fakeLibvirtLogFilters = "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*"
 
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
-		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-	})
-
-	AfterEach(func() {
-		// Not every test causes virt-handler to restart, but a few different contexts do.
-		// This check is fast and non-intrusive if virt-handler is already running.
-		tests.EnsureKVMPresent()
-	})
-
-	Context("when virt-handler is deleted", func() {
-		It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {
-			pods, err := virtClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
-			})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pods.Items).ToNot(BeEmpty())
-
-			pod := pods.Items[0]
-			handlerNamespace := pod.GetNamespace()
-
-			By("setting up a watch on Nodes")
-			nodeWatch, err := virtClient.CoreV1().Nodes().Watch(context.Background(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = virtClient.CoreV1().Pods(handlerNamespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(nodeWatch.ResultChan(), 120*time.Second).Should(Receive(WithTransform(func(e k8sWatch.Event) metav1.ObjectMeta {
-				node, ok := e.Object.(*k8sv1.Node)
-				Expect(ok).To(BeTrue())
-				return node.ObjectMeta
-			}, MatchFields(IgnoreExtras, Fields{
-				"Name":   Equal(pod.Spec.NodeName),
-				"Labels": HaveKeyWithValue(v1.NodeSchedulable, "false"),
-			}))), "Failed to observe change in schedulable label")
-		})
-	})
-
-	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
-		It("[test_id:1619]should success", func() {
-			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
+			tests.BeforeTestCleanup()
+			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 		})
 
-		It("[test_id:1620]should start it", func() {
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
+		AfterEach(func() {
+			// Not every test causes virt-handler to restart, but a few different contexts do.
+			// This check is fast and non-intrusive if virt-handler is already running.
+			tests.EnsureKVMPresent()
 		})
 
-		It("[test_id:6095]should start in paused state if start strategy set to paused", func() {
-			strategy := v1.StartStrategyPaused
-			vmi.Spec.StartStrategy = &strategy
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+		Context("when virt-handler is deleted", func() {
+			It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", Label("Serial", "test_id:4716"), func() {
+				pods, err := virtClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pods.Items).ToNot(BeEmpty())
 
-			By("Unpausing VMI")
-			command := clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
-			Expect(command()).To(Succeed())
-			tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
-		})
+				pod := pods.Items[0]
+				handlerNamespace := pod.GetNamespace()
 
-		It("[test_id:1621]should attach virt-launcher to it", func() {
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("Getting virt-launcher logs")
-			logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
-			Eventually(logs,
-				11*time.Second,
-				500*time.Millisecond).
-				Should(ContainSubstring("Found PID for"))
-		})
-
-		It("[test_id:3195]should carry annotations to pod", func() {
-			vmi.Annotations = map[string]string{
-				"testannotation": "annotation from vmi",
-			}
-
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(pod).NotTo(BeNil())
-
-			Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "annotation from vmi"), "annotation should be carried to the pod")
-		})
-
-		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
-			vmi.Annotations = map[string]string{
-				"kubevirt.io/test":   "test",
-				"kubernetes.io/test": "test",
-			}
-
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(pod).NotTo(BeNil())
-
-			Expect(pod.Annotations).To(HaveKey("kubevirt.io/test"), "kubevirt annotation should not be carried to the pod")
-			Expect(pod.Annotations).To(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
-		})
-
-		It("Should prevent eviction when EvictionStratgy: External", func() {
-			strategy := v1.EvictionStrategyExternal
-			vmi.Spec.EvictionStrategy = &strategy
-
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(pod).ToNot(BeNil())
-
-			By("calling evict on VMI's pod")
-			err = virtClient.CoreV1().Pods(vmi.Namespace).EvictV1beta1(context.Background(), &policyv1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
-			// The "too many requests" err is what get's returned when an
-			// eviction would invalidate a pdb. This is what we want to see here.
-			Expect(errors.IsTooManyRequests(err)).To(BeTrue())
-
-			By("should have evacuation node name set on vmi status")
-			Consistently(func() error {
-
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(pod).ToNot(BeNil())
-				Expect(pod.DeletionTimestamp).To(BeNil())
-
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				By("setting up a watch on Nodes")
+				nodeWatch, err := virtClient.CoreV1().Nodes().Watch(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(vmi.Status.EvacuationNodeName).ToNot(Equal(""))
-				return nil
-			}, 20*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				err = virtClient.CoreV1().Pods(handlerNamespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-		})
-
-		It("[test_id:1622]should log libvirtd logs", func() {
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("Getting virt-launcher logs")
-			logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
-			Eventually(logs,
-				11*time.Second,
-				500*time.Millisecond).
-				Should(ContainSubstring("libvirt version: "))
-			Eventually(logs,
-				2*time.Second,
-				500*time.Millisecond).
-				Should(ContainSubstring(`"subcomponent":"libvirt"`))
-		})
-
-		DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {
-			var err error
-			vmi := tests.NewRandomVMI()
-			vmi.Labels = vmiLabels
-			vmi.Annotations = vmiAnnotations
-
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Create VMI successfully")
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("Getting virt-launcher logs")
-			logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
-
-			const totalTestTime = 2 * time.Second
-			const checkIntervalTime = 500 * time.Millisecond
-			const logEntryToSearch = "QEMU_MONITOR_SEND_MSG"
-			const subcomponent = `"subcomponent":"libvirt"`
-
-			// There are plenty of strings we can use to identify the debug logs.
-			// Here we use something we deeply care about when in debug mode.
-			if expectDebugLogs {
-				Eventually(logs,
-					totalTestTime,
-					checkIntervalTime).
-					Should(And(ContainSubstring(logEntryToSearch), ContainSubstring(subcomponent)))
-			} else {
-				Consistently(logs,
-					totalTestTime,
-					checkIntervalTime).
-					ShouldNot(And(ContainSubstring(logEntryToSearch), ContainSubstring(subcomponent)))
-			}
-
-		},
-			Entry("[test_id:3197]enabled when debugLogs label defined", map[string]string{"debugLogs": "true"}, nil, true),
-			Entry("[test_id:8530]enabled when customLogFilters defined", nil, map[string]string{v1.CustomLibvirtLogFiltersAnnotation: fakeLibvirtLogFilters}, true),
-			Entry("[test_id:8531]enabled when log verbosity is high", map[string]string{"logVerbosity": "10"}, nil, true),
-			Entry("[test_id:8532]disabled when log verbosity is low", map[string]string{"logVerbosity": "2"}, nil, false),
-			Entry("[test_id:8533]disabled when log verbosity, debug logs and customLogFilters are not defined", nil, nil, false),
-		)
-
-		It("[test_id:1623]should reject POST if validation webhook deems the spec invalid", func() {
-
-			// Add a disk that doesn't map to a volume.
-			// This should get rejected which tells us the webhook validator is working.
-			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name: "testdisk",
-			})
-			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name: "testdisk2",
-			})
-
-			result := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background())
-
-			// Verify validation failed.
-			statusCode := 0
-			result.StatusCode(&statusCode)
-			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity), "VMI should be rejected as unprocessable")
-
-			reviewResponse := &metav1.Status{}
-			body, _ := result.Raw()
-			err = json.Unmarshal(body, reviewResponse)
-			Expect(err).To(BeNil(), "Result should be unmarshallable")
-
-			Expect(reviewResponse.Details.Causes).To(HaveLen(2), "There should be 2 thing wrong in response")
-			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1].name"))
-			Expect(reviewResponse.Details.Causes[1].Field).To(Equal("spec.domain.devices.disks[2].name"))
-		})
-
-		It("[test_id:1624]should reject PATCH if schema is invalid", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()
-			Expect(err).To(BeNil(), "Send POST successfully")
-
-			// Add a disk without a volume reference (this is in valid)
-			patchStr := fmt.Sprintf("{\"apiVersion\":\"kubevirt.io/%s\",\"kind\":\"VirtualMachineInstance\",\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"fakedisk\"}]}}}}", v1.ApiLatestVersion)
-
-			result := virtClient.RestClient().Patch(types.MergePatchType).Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Name(vmi.Name).Body([]byte(patchStr)).Do(context.Background())
-
-			// Verify validation failed.
-			statusCode := 0
-			result.StatusCode(&statusCode)
-			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity), "The entity should be unprocessable")
-		})
-
-		Context("when name is longer than 63 characters", func() {
-			BeforeEach(func() {
-				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Name = "testvmi" + rand.String(63)
-			})
-			It("[test_id:1625]should start it", func() {
-				By("Creating a VirtualMachineInstance with a long name")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "cannot create VirtualMachineInstance %q: %v", vmi.Name, err)
-				Expect(len(vmi.Name)).To(BeNumerically(">", 63), "VirtualMachineInstance %q name is not longer than 63 characters", vmi.Name)
-
-				By("Waiting until it starts")
-				tests.WaitForSuccessfulVMIStart(vmi)
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
-
-				By("Obtaining serial console")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed(), "VirtualMachineInstance %q console is not accessible: %v", vmi.Name, err)
+				Eventually(nodeWatch.ResultChan(), 120*time.Second).Should(Receive(WithTransform(func(e k8sWatch.Event) metav1.ObjectMeta {
+					node, ok := e.Object.(*k8sv1.Node)
+					Expect(ok).To(BeTrue())
+					return node.ObjectMeta
+				}, MatchFields(IgnoreExtras, Fields{
+					"Name":   Equal(pod.Spec.NodeName),
+					"Labels": HaveKeyWithValue(v1.NodeSchedulable, "false"),
+				}))), "Failed to observe change in schedulable label")
 			})
 		})
 
-		Context("when it already exist", func() {
-			It("[test_id:1626]should be rejected", func() {
-				By("Creating a VirtualMachineInstance")
-				err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()
-				Expect(err).To(BeNil(), "Should create VMI successfully")
-				By("Creating the same VirtualMachineInstance second time")
-				b, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).DoRaw(context.Background())
-				Expect(err).ToNot(BeNil(), "Second VMI should be rejected")
-				By("Checking that POST return status equals to 409")
-				status := metav1.Status{}
-				err = json.Unmarshal(b, &status)
-				Expect(err).To(BeNil(), "Response should be decoded successfully from json")
-				Expect(status.Code).To(Equal(int32(http.StatusConflict)), "There should be conflict with existing VMI")
-			})
-		})
-
-		Context("with boot order", func() {
-			DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should be able to boot from selected disk", func(alpineBootOrder uint, cirrosBootOrder uint, consoleText string, wait int) {
-				By("defining a VirtualMachineInstance with an Alpine disk")
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskAlpine), "#!/bin/sh\n\necho 'hi'\n")
-				By("adding a Cirros Disk")
-				tests.AddEphemeralDisk(vmi, "disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-
-				By("setting boot order")
-				vmi = tests.AddBootOrderToDisk(vmi, "disk0", &alpineBootOrder)
-				vmi = tests.AddBootOrderToDisk(vmi, "disk2", &cirrosBootOrder)
-
-				By("starting VirtualMachineInstance")
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(BeNil(), "VMI should be created successfully")
-
-				By("Waiting the VirtualMachineInstance start")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				By("Checking console text")
-				err = console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: consoleText},
-				}, wait)
-				Expect(err).ToNot(HaveOccurred(), "Should match the console in VMI")
-			},
-				Entry("[test_id:1627]Alpine as first boot", uint(1), uint(2), "Welcome to Alpine", 90),
-				Entry("[test_id:1628]Cirros as first boot", uint(2), uint(1), "cirros", 90),
-			)
-		})
-
-		Context("with user-data", func() {
-
-			Context("without k8s secret", func() {
-				It("[test_id:1629][posneg:negative]should not be able to start virt-launcher pod", func() {
-					userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
-					vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-
-					for _, volume := range vmi.Spec.Volumes {
-						if volume.CloudInitNoCloud != nil {
-							spec := volume.CloudInitNoCloud
-							spec.UserDataBase64 = ""
-							spec.UserDataSecretRef = &k8sv1.LocalObjectReference{Name: "nonexistent"}
-							break
-						}
-					}
-					By("Starting a VirtualMachineInstance")
-					vmi = tests.RunVMIAndExpectScheduling(vmi, 30)
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-					launcher := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-					tests.NewObjectEventWatcher(launcher).
-						SinceWatchedObjectResourceVersion().
-						Timeout(60*time.Second).
-						Watch(ctx, func(event *k8sv1.Event) bool {
-							if event.Type == "Warning" && event.Reason == "FailedMount" {
-								return true
-							}
-							return false
-						},
-							"event of type Warning, reason = FailedMount")
+		Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance",
+			Label("rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+			func() {
+				It("[test_id:1619]should success", Label("test_id:1619"), func() {
+					_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
 				})
 
-				It("[test_id:1630]should log warning and proceed once the secret is there", func() {
-					userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
-					userData64 := ""
-					vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-
-					for _, volume := range vmi.Spec.Volumes {
-						if volume.CloudInitNoCloud != nil {
-							spec := volume.CloudInitNoCloud
-							userData64 = spec.UserDataBase64
-							spec.UserDataBase64 = ""
-							spec.UserDataSecretRef = &k8sv1.LocalObjectReference{Name: "nonexistent"}
-							break
-						}
-					}
-					By("Starting a VirtualMachineInstance")
-					createdVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
-					launcher := libvmi.GetPodByVirtualMachineInstance(createdVMI, createdVMI.Namespace)
-					// Wait until we see that starting the VirtualMachineInstance is failing
-					By(fmt.Sprintf("Checking that VirtualMachineInstance start failed: starting at %v", time.Now()))
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-					event := tests.NewObjectEventWatcher(launcher).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, "FailedMount")
-					Expect(event.Message).To(SatisfyAny(
-						ContainSubstring(`secret "nonexistent" not found`),
-						ContainSubstring(`secrets "nonexistent" not found`), // for k8s 1.11.x
-					), "VMI should not be started")
-
-					// Creat nonexistent secret, so that the VirtualMachineInstance can recover
-					By("Creating a user-data secret")
-					secret := k8sv1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "nonexistent",
-							Namespace: vmi.Namespace,
-							Labels: map[string]string{
-								tests.SecretLabel: "nonexistent",
-							},
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							"userdata": []byte(userData64),
-						},
-					}
-					_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should create secret successfully")
-
-					// Wait for the VirtualMachineInstance to be started, allow warning events to occur
-					By("Checking that VirtualMachineInstance start succeeded")
-					tests.NewObjectEventWatcher(createdVMI).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(ctx, tests.NormalEvent, v1.Started)
+				It("[test_id:1620]should start it", Label("test_id:1620"), func() {
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
 				})
-			})
-		})
 
-		Context("with nodeselector", func() {
-			It("[test_id:5760]should check if vm's with non existing nodeselector is not running and node selector is not updated", func() {
-				vmi := libvmi.NewCirros()
-				By("setting nodeselector with non-existing-os label")
-				vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelOSStable: "not-existing-os"}
-				vmi = tests.RunVMIAndExpectScheduling(vmi, 30)
+				It("[test_id:6095]should start in paused state if start strategy set to paused", Label("test_id:6095"), func() {
+					strategy := v1.StartStrategyPaused
+					vmi.Spec.StartStrategy = &strategy
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
+					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
+					By("Unpausing VMI")
+					command := clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
+					Expect(command()).To(Succeed())
+					tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				})
 
-				for _, pod := range pods.Items {
-					for _, owner := range pod.GetOwnerReferences() {
-						if owner.Name == vmi.Name {
-							break
-						}
+				It("[test_id:1621]should attach virt-launcher to it", Label("test_id:1621"), func() {
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					By("Getting virt-launcher logs")
+					logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
+					Eventually(logs,
+						11*time.Second,
+						500*time.Millisecond).
+						Should(ContainSubstring("Found PID for"))
+				})
+
+				It("[test_id:3195]should carry annotations to pod", Label("test_id:3195"), func() {
+					vmi.Annotations = map[string]string{
+						"testannotation": "annotation from vmi",
 					}
-					Expect(pod.Spec.NodeSelector[k8sv1.LabelOSStable]).To(Equal("not-existing-os"), "pod should have node selector")
-					Expect(pod.Status.Phase).To(Equal(k8sv1.PodPending), "pod has to be in pending state")
-					for _, condition := range pod.Status.Conditions {
-						if condition.Type == k8sv1.PodScheduled {
-							Expect(condition.Reason).To(Equal(k8sv1.PodReasonUnschedulable), "condition reason has to be unschedulable")
-						}
+
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+					Expect(pod).NotTo(BeNil())
+
+					Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "annotation from vmi"), "annotation should be carried to the pod")
+				})
+
+				It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", Label("test_id:3196"), func() {
+					vmi.Annotations = map[string]string{
+						"kubevirt.io/test":   "test",
+						"kubernetes.io/test": "test",
 					}
-				}
-			})
 
-			It("[test_id:5761]should check if vm with valid node selector is scheduled and running and node selector is not updated", func() {
-				vmi := libvmi.NewCirros()
-				vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelOSStable: "linux"}
-				tests.RunVMIAndExpectLaunch(vmi, 60)
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
 
-				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
+					pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+					Expect(pod).NotTo(BeNil())
 
-				for _, pod := range pods.Items {
-					for _, owner := range pod.GetOwnerReferences() {
-						if owner.Name == vmi.Name {
-							break
-						}
+					Expect(pod.Annotations).To(HaveKey("kubevirt.io/test"), "kubevirt annotation should not be carried to the pod")
+					Expect(pod.Annotations).To(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
+				})
+
+				It("Should prevent eviction when EvictionStratgy: External", func() {
+					strategy := v1.EvictionStrategyExternal
+					vmi.Spec.EvictionStrategy = &strategy
+
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+					Expect(pod).ToNot(BeNil())
+
+					By("calling evict on VMI's pod")
+					err = virtClient.CoreV1().Pods(vmi.Namespace).EvictV1beta1(context.Background(), &policyv1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
+					// The "too many requests" err is what get's returned when an
+					// eviction would invalidate a pdb. This is what we want to see here.
+					Expect(errors.IsTooManyRequests(err)).To(BeTrue())
+
+					By("should have evacuation node name set on vmi status")
+					Consistently(func() error {
+
+						pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						Expect(pod).ToNot(BeNil())
+						Expect(pod.DeletionTimestamp).To(BeNil())
+
+						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(vmi.Status.EvacuationNodeName).ToNot(Equal(""))
+						return nil
+					}, 20*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+				})
+
+				It("[test_id:1622]should log libvirtd logs", Label("test_id:1622"), func() {
+					vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					By("Getting virt-launcher logs")
+					logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
+					Eventually(logs,
+						11*time.Second,
+						500*time.Millisecond).
+						Should(ContainSubstring("libvirt version: "))
+					Eventually(logs,
+						2*time.Second,
+						500*time.Millisecond).
+						Should(ContainSubstring(`"subcomponent":"libvirt"`))
+				})
+
+				DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {
+					var err error
+					vmi := tests.NewRandomVMI()
+					vmi.Labels = vmiLabels
+					vmi.Annotations = vmiAnnotations
+
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Create VMI successfully")
+					tests.WaitForSuccessfulVMIStart(vmi)
+
+					By("Getting virt-launcher logs")
+					logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
+
+					const totalTestTime = 2 * time.Second
+					const checkIntervalTime = 500 * time.Millisecond
+					const logEntryToSearch = "QEMU_MONITOR_SEND_MSG"
+					const subcomponent = `"subcomponent":"libvirt"`
+
+					// There are plenty of strings we can use to identify the debug logs.
+					// Here we use something we deeply care about when in debug mode.
+					if expectDebugLogs {
+						Eventually(logs,
+							totalTestTime,
+							checkIntervalTime).
+							Should(And(ContainSubstring(logEntryToSearch), ContainSubstring(subcomponent)))
+					} else {
+						Consistently(logs,
+							totalTestTime,
+							checkIntervalTime).
+							ShouldNot(And(ContainSubstring(logEntryToSearch), ContainSubstring(subcomponent)))
 					}
-					Expect(pod.Spec.NodeSelector[k8sv1.LabelOSStable]).To(Equal("linux"), "pod should have node selector")
-					Expect(pod.Status.Phase).To(Equal(k8sv1.PodRunning), "pod has to be in running state")
-					for _, condition := range pod.Status.Conditions {
-						if condition.Type == k8sv1.ContainersReady {
-							Expect(condition.Reason).To(Equal(""), "condition reason has to be empty")
-						}
-					}
-				}
-			})
-		})
 
-		Context("when virt-launcher crashes", func() {
-			It("[Serial][test_id:1631]should be stopped and have Failed phase", func() {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(BeNil(), "Should create VMI successfully")
+				},
+					Entry("[test_id:3197]enabled when debugLogs label defined", Label("test_id:3197"), map[string]string{"debugLogs": "true"}, nil, true),
+					Entry("[test_id:8530]enabled when customLogFilters defined", Label("test_id:8530"), nil, map[string]string{v1.CustomLibvirtLogFiltersAnnotation: fakeLibvirtLogFilters}, true),
+					Entry("[test_id:8531]enabled when log verbosity is high", Label("test_id:8531"), map[string]string{"logVerbosity": "10"}, nil, true),
+					Entry("[test_id:8532]disabled when log verbosity is low", Label("test_id:8532"), map[string]string{"logVerbosity": "2"}, nil, false),
+					Entry("[test_id:8533]disabled when log verbosity, debug logs and customLogFilters are not defined", Label("test_id:8533"), nil, nil, false),
+				)
 
-				nodeName := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
+				It("[test_id:1623]should reject POST if validation webhook deems the spec invalid", Label("test_id:1623"), func() {
 
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				By("Crashing the virt-launcher")
-				vmiKiller, err := pkillAllLaunchers(virtClient, nodeName)
-				Expect(err).To(BeNil(), "Should create vmi-killer pod to kill virt-launcher successfully")
-				tests.NewObjectEventWatcher(vmiKiller).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(ctx, tests.NormalEvent, v1.Started)
-
-				By("Waiting for the vm to be stopped")
-				tests.NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(ctx, tests.WarningEvent, v1.Stopped)
-
-				By("Checking that VirtualMachineInstance has 'Failed' phase")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI successfully")
-					return vmi.Status.Phase
-				}, 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
-			})
-		})
-
-		Context("[Serial]when virt-handler crashes", func() {
-			// FIXME: This test has the issues that it tests a lot of different timing scenarios in an intransparent way:
-			// e.g. virt-handler can die before or after virt-launcher. If we wait until virt-handler is dead before we
-			// kill virt-launcher then we don't know if virt-handler already restarted.
-			// Also the virt-handler crash-loop plays a role here. We could also change the daemon-set but then we would not check the crash behaviour.
-			It("[test_id:1632]should recover and continue management", func() {
-
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(BeNil(), "Should submit VMI successfully")
-
-				// Start a VirtualMachineInstance
-				nodeName := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
-
-				// Kill virt-handler on the node the VirtualMachineInstance is active on.
-				By("Crashing the virt-handler")
-				err = pkillHandler(virtClient, nodeName)
-				Expect(err).To(BeNil(), "Should kill virt-handler successfully")
-
-				// Crash the VirtualMachineInstance and verify a recovered version of virt-handler processes the crash
-				By("Killing the VirtualMachineInstance")
-				err = pkillAllVMIs(virtClient, nodeName)
-				Expect(err).To(BeNil(), "Should kill VMI successfully")
-
-				// Give virt-handler some time. It can greatly vary when virt-handler will be ready again
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				By("Checking that VirtualMachineInstance has 'Failed' phase")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI successfully")
-					return vmi.Status.Phase
-				}, 240*time.Second, 1*time.Second).Should(Equal(v1.Failed), "VMI should be failed")
-
-				By(fmt.Sprintf("Waiting for %q %q event after the resource version %q", tests.WarningEvent, v1.Stopped, vmi.ResourceVersion))
-				tests.NewObjectEventWatcher(vmi).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, v1.Stopped)
-
-				By("checking that it can still start VMIs")
-				newVMI := newCirrosVMI()
-				newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
-				newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(newVMI)
-				Expect(err).To(BeNil())
-
-				tests.WaitForSuccessfulVMIStart(newVMI)
-			})
-		})
-
-		Context("[Serial]when virt-handler is responsive", func() {
-			It("[test_id:1633]should indicate that a node is ready for vmis", func() {
-
-				By("adding a heartbeat annotation and a schedulable label to the node")
-				nodes := util.GetAllSchedulableNodes(virtClient)
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				for _, node := range nodes.Items {
-					Expect(node.Annotations[v1.VirtHandlerHeartbeat]).ToNot(BeEmpty(), "Nodes should have be ready for VMI")
-				}
-
-				node := &nodes.Items[0]
-				node, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "false"}}}`, v1.NodeSchedulable)), metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should patch node successfully")
-				timestamp := node.Annotations[v1.VirtHandlerHeartbeat]
-
-				By("setting the schedulable label back to true")
-				Eventually(func() string {
-					n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get nodes successfully")
-					return n.Labels[v1.NodeSchedulable]
-				}, 5*time.Minute, 2*time.Second).Should(Equal("true"), "Nodes should be schedulable")
-				By("updating the heartbeat roughly every minute")
-				Expect(func() string {
-					n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get nodes successfully")
-					return n.Labels[v1.VirtHandlerHeartbeat]
-				}()).ShouldNot(Equal(timestamp), "Should not have old vmi heartbeat")
-			})
-
-			It("[test_id:3198]device plugins should re-register if the kubelet restarts", func() {
-
-				By("starting a VMI on a node")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(BeNil(), "Should submit VMI successfully")
-
-				// Start a VirtualMachineInstance
-				nodeName := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
-
-				By("triggering a device plugin re-registration on that node")
-				pod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
-				Expect(err).ToNot(HaveOccurred())
-
-				_, _, err = tests.ExecuteCommandOnPodV2(virtClient, pod,
-					"virt-handler",
-					[]string{
-						"rm",
-						// We want to fail if the file does not exist, but don't want to be asked
-						// if we really want to remove write-protected files
-						"--interactive=never",
-						device_manager.SocketPath("kvm"),
+					// Add a disk that doesn't map to a volume.
+					// This should get rejected which tells us the webhook validator is working.
+					vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+						Name: "testdisk",
 					})
-				Expect(err).ToNot(HaveOccurred())
+					vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+						Name: "testdisk2",
+					})
 
-				By("checking if we see the device plugin restart in the logs")
-				virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
-				Expect(err).ToNot(HaveOccurred(), "Should get virthandler client for node")
+					result := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background())
 
-				handlerName := virtHandlerPod.GetObjectMeta().GetName()
-				handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
-				seconds := int64(10)
-				logsQuery := virtClient.CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
-				Eventually(func() string {
-					data, err := logsQuery.DoRaw(context.Background())
-					Expect(err).ToNot(HaveOccurred(), "Should get logs")
-					return string(data)
-				}, 60, 1).Should(
-					ContainSubstring(
-						fmt.Sprintf("device socket file for device %s was removed, kubelet probably restarted.", "kvm"),
-					), "Should log device plugin restart")
+					// Verify validation failed.
+					statusCode := 0
+					result.StatusCode(&statusCode)
+					Expect(statusCode).To(Equal(http.StatusUnprocessableEntity), "VMI should be rejected as unprocessable")
 
-				// This is a little bit arbitrar
-				// Background is that new pods go into a crash loop if the devices are still report but virt-handler
-				// re-registers exactly during that moment. This is not too bad, since normally kubelet itself deletes
-				// the socket and knows that the devices are not there. However we have to wait in this test a little bit.
-				time.Sleep(10 * time.Second)
+					reviewResponse := &metav1.Status{}
+					body, _ := result.Raw()
+					err = json.Unmarshal(body, reviewResponse)
+					Expect(err).To(BeNil(), "Result should be unmarshallable")
 
-				By("starting another VMI on the same node, to verify devices still work")
-				newVMI := newCirrosVMI()
-				newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
-				newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(newVMI)
-				Expect(err).To(BeNil())
+					Expect(reviewResponse.Details.Causes).To(HaveLen(2), "There should be 2 thing wrong in response")
+					Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1].name"))
+					Expect(reviewResponse.Details.Causes[1].Field).To(Equal("spec.domain.devices.disks[2].name"))
+				})
 
-				tests.WaitForSuccessfulVMIStart(newVMI)
-			})
-		})
+				It("[test_id:1624]should reject PATCH if schema is invalid", Label("test_id:1624"), func() {
+					err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()
+					Expect(err).To(BeNil(), "Send POST successfully")
 
-		Context("[Serial]when virt-handler is not responsive", func() {
+					// Add a disk without a volume reference (this is in valid)
+					patchStr := fmt.Sprintf("{\"apiVersion\":\"kubevirt.io/%s\",\"kind\":\"VirtualMachineInstance\",\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"fakedisk\"}]}}}}", v1.ApiLatestVersion)
 
-			var vmi *v1.VirtualMachineInstance
-			var nodeName string
-			var virtHandler *k8sv1.Pod
-			var virtHandlerAvailablePods int32
+					result := virtClient.RestClient().Patch(types.MergePatchType).Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Name(vmi.Name).Body([]byte(patchStr)).Do(context.Background())
 
-			BeforeEach(func() {
+					// Verify validation failed.
+					statusCode := 0
+					result.StatusCode(&statusCode)
+					Expect(statusCode).To(Equal(http.StatusUnprocessableEntity), "The entity should be unprocessable")
+				})
 
-				// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+				Context("when name is longer than 63 characters", func() {
+					BeforeEach(func() {
+						vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+						vmi.Name = "testvmi" + rand.String(63)
+					})
+					It("[test_id:1625]should start it", Label("test_id:1625"), func() {
+						By("Creating a VirtualMachineInstance with a long name")
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "cannot create VirtualMachineInstance %q: %v", vmi.Name, err)
+						Expect(len(vmi.Name)).To(BeNumerically(">", 63), "VirtualMachineInstance %q name is not longer than 63 characters", vmi.Name)
 
-				// Ensure that the VMI is running. This is necessary to ensure that virt-handler is fully responsible for
-				// the VMI. Otherwise virt-controller may move the VMI to failed instead of the node controller.
-				nodeName = tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi).Status.NodeName
+						By("Waiting until it starts")
+						tests.WaitForSuccessfulVMIStart(vmi)
+						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
 
-				virtHandler, err = kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
-				Expect(err).ToNot(HaveOccurred(), "Should get virthandler client")
+						By("Obtaining serial console")
+						Expect(console.LoginToAlpine(vmi)).To(Succeed(), "VirtualMachineInstance %q console is not accessible: %v", vmi.Name, err)
+					})
+				})
 
-				ds, err := virtClient.AppsV1().DaemonSets(virtHandler.Namespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get virthandler daemonset")
-				// Save virt-handler number of desired pods
-				virtHandlerAvailablePods = ds.Status.DesiredNumberScheduled
+				Context("when it already exist", func() {
+					It("[test_id:1626]should be rejected", Label("test_id:1626"), func() {
+						By("Creating a VirtualMachineInstance")
+						err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()
+						Expect(err).To(BeNil(), "Should create VMI successfully")
+						By("Creating the same VirtualMachineInstance second time")
+						b, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).DoRaw(context.Background())
+						Expect(err).ToNot(BeNil(), "Second VMI should be rejected")
+						By("Checking that POST return status equals to 409")
+						status := metav1.Status{}
+						err = json.Unmarshal(b, &status)
+						Expect(err).To(BeNil(), "Response should be decoded successfully from json")
+						Expect(status.Code).To(Equal(int32(http.StatusConflict)), "There should be conflict with existing VMI")
+					})
+				})
 
-				kv := util.GetCurrentKv(virtClient)
-				kv.Spec.Workloads = &v1.ComponentConfig{
-					NodePlacement: &v1.NodePlacement{
-						Affinity: &k8sv1.Affinity{
-							NodeAffinity: &k8sv1.NodeAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
-									NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
-										{MatchExpressions: []k8sv1.NodeSelectorRequirement{
-											{Key: "kubernetes.io/hostname", Operator: "NotIn", Values: []string{nodeName}},
-										}},
+				Context("with boot order", func() {
+					DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should be able to boot from selected disk",
+						Label("rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+						func(alpineBootOrder uint, cirrosBootOrder uint, consoleText string, wait int) {
+							By("defining a VirtualMachineInstance with an Alpine disk")
+							vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskAlpine), "#!/bin/sh\n\necho 'hi'\n")
+							By("adding a Cirros Disk")
+							tests.AddEphemeralDisk(vmi, "disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+
+							By("setting boot order")
+							vmi = tests.AddBootOrderToDisk(vmi, "disk0", &alpineBootOrder)
+							vmi = tests.AddBootOrderToDisk(vmi, "disk2", &cirrosBootOrder)
+
+							By("starting VirtualMachineInstance")
+							vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+							Expect(err).To(BeNil(), "VMI should be created successfully")
+
+							By("Waiting the VirtualMachineInstance start")
+							tests.WaitForSuccessfulVMIStart(vmi)
+
+							By("Checking console text")
+							err = console.SafeExpectBatch(vmi, []expect.Batcher{
+								&expect.BSnd{S: "\n"},
+								&expect.BExp{R: consoleText},
+							}, wait)
+							Expect(err).ToNot(HaveOccurred(), "Should match the console in VMI")
+						},
+						Entry("[test_id:1627]Alpine as first boot", Label("test_id:1627"), uint(1), uint(2), "Welcome to Alpine", 90),
+						Entry("[test_id:1628]Cirros as first boot", Label("test_id:1628"), uint(2), uint(1), "cirros", 90),
+					)
+				})
+
+				Context("with user-data", func() {
+
+					Context("without k8s secret", func() {
+						It("[test_id:1629][posneg:negative]should not be able to start virt-launcher pod", Label("test_id:1629", "posneg:negative"), func() {
+							userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
+							vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+
+							for _, volume := range vmi.Spec.Volumes {
+								if volume.CloudInitNoCloud != nil {
+									spec := volume.CloudInitNoCloud
+									spec.UserDataBase64 = ""
+									spec.UserDataSecretRef = &k8sv1.LocalObjectReference{Name: "nonexistent"}
+									break
+								}
+							}
+							By("Starting a VirtualMachineInstance")
+							vmi = tests.RunVMIAndExpectScheduling(vmi, 30)
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							launcher := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+							tests.NewObjectEventWatcher(launcher).
+								SinceWatchedObjectResourceVersion().
+								Timeout(60*time.Second).
+								Watch(ctx, func(event *k8sv1.Event) bool {
+									if event.Type == "Warning" && event.Reason == "FailedMount" {
+										return true
+									}
+									return false
+								},
+									"event of type Warning, reason = FailedMount")
+						})
+
+						It("[test_id:1630]should log warning and proceed once the secret is there", Label("test_id:1630"), func() {
+							userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
+							userData64 := ""
+							vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+
+							for _, volume := range vmi.Spec.Volumes {
+								if volume.CloudInitNoCloud != nil {
+									spec := volume.CloudInitNoCloud
+									userData64 = spec.UserDataBase64
+									spec.UserDataBase64 = ""
+									spec.UserDataSecretRef = &k8sv1.LocalObjectReference{Name: "nonexistent"}
+									break
+								}
+							}
+							By("Starting a VirtualMachineInstance")
+							createdVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+							launcher := libvmi.GetPodByVirtualMachineInstance(createdVMI, createdVMI.Namespace)
+							// Wait until we see that starting the VirtualMachineInstance is failing
+							By(fmt.Sprintf("Checking that VirtualMachineInstance start failed: starting at %v", time.Now()))
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							event := tests.NewObjectEventWatcher(launcher).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, "FailedMount")
+							Expect(event.Message).To(SatisfyAny(
+								ContainSubstring(`secret "nonexistent" not found`),
+								ContainSubstring(`secrets "nonexistent" not found`), // for k8s 1.11.x
+							), "VMI should not be started")
+
+							// Creat nonexistent secret, so that the VirtualMachineInstance can recover
+							By("Creating a user-data secret")
+							secret := k8sv1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "nonexistent",
+									Namespace: vmi.Namespace,
+									Labels: map[string]string{
+										tests.SecretLabel: "nonexistent",
+									},
+								},
+								Type: "Opaque",
+								Data: map[string][]byte{
+									"userdata": []byte(userData64),
+								},
+							}
+							_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should create secret successfully")
+
+							// Wait for the VirtualMachineInstance to be started, allow warning events to occur
+							By("Checking that VirtualMachineInstance start succeeded")
+							tests.NewObjectEventWatcher(createdVMI).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(ctx, tests.NormalEvent, v1.Started)
+						})
+					})
+				})
+
+				Context("with nodeselector", func() {
+					It("[test_id:5760]should check if vm's with non existing nodeselector is not running and node selector is not updated", Label("test_id:5760"), func() {
+						vmi := libvmi.NewCirros()
+						By("setting nodeselector with non-existing-os label")
+						vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelOSStable: "not-existing-os"}
+						vmi = tests.RunVMIAndExpectScheduling(vmi, 30)
+
+						pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						for _, pod := range pods.Items {
+							for _, owner := range pod.GetOwnerReferences() {
+								if owner.Name == vmi.Name {
+									break
+								}
+							}
+							Expect(pod.Spec.NodeSelector[k8sv1.LabelOSStable]).To(Equal("not-existing-os"), "pod should have node selector")
+							Expect(pod.Status.Phase).To(Equal(k8sv1.PodPending), "pod has to be in pending state")
+							for _, condition := range pod.Status.Conditions {
+								if condition.Type == k8sv1.PodScheduled {
+									Expect(condition.Reason).To(Equal(k8sv1.PodReasonUnschedulable), "condition reason has to be unschedulable")
+								}
+							}
+						}
+					})
+
+					It("[test_id:5761]should check if vm with valid node selector is scheduled and running and node selector is not updated", Label("test_id:5761"), func() {
+						vmi := libvmi.NewCirros()
+						vmi.Spec.NodeSelector = map[string]string{k8sv1.LabelOSStable: "linux"}
+						tests.RunVMIAndExpectLaunch(vmi, 60)
+
+						pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{})
+						Expect(err).ToNot(HaveOccurred())
+
+						for _, pod := range pods.Items {
+							for _, owner := range pod.GetOwnerReferences() {
+								if owner.Name == vmi.Name {
+									break
+								}
+							}
+							Expect(pod.Spec.NodeSelector[k8sv1.LabelOSStable]).To(Equal("linux"), "pod should have node selector")
+							Expect(pod.Status.Phase).To(Equal(k8sv1.PodRunning), "pod has to be in running state")
+							for _, condition := range pod.Status.Conditions {
+								if condition.Type == k8sv1.ContainersReady {
+									Expect(condition.Reason).To(Equal(""), "condition reason has to be empty")
+								}
+							}
+						}
+					})
+				})
+
+				Context("when virt-launcher crashes", func() {
+					It("[Serial][test_id:1631]should be stopped and have Failed phase", Label("Serial", "test_id:1631"), func() {
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).To(BeNil(), "Should create VMI successfully")
+
+						nodeName := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
+
+						ctx, cancel := context.WithCancel(context.Background())
+						defer cancel()
+
+						By("Crashing the virt-launcher")
+						vmiKiller, err := pkillAllLaunchers(virtClient, nodeName)
+						Expect(err).To(BeNil(), "Should create vmi-killer pod to kill virt-launcher successfully")
+						tests.NewObjectEventWatcher(vmiKiller).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(ctx, tests.NormalEvent, v1.Started)
+
+						By("Waiting for the vm to be stopped")
+						tests.NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(ctx, tests.WarningEvent, v1.Stopped)
+
+						By("Checking that VirtualMachineInstance has 'Failed' phase")
+						Eventually(func() v1.VirtualMachineInstancePhase {
+							vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI successfully")
+							return vmi.Status.Phase
+						}, 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
+					})
+				})
+
+				Context("[Serial]when virt-handler crashes", Label("Serial"), func() {
+					// FIXME: This test has the issues that it tests a lot of different timing scenarios in an intransparent way:
+					// e.g. virt-handler can die before or after virt-launcher. If we wait until virt-handler is dead before we
+					// kill virt-launcher then we don't know if virt-handler already restarted.
+					// Also the virt-handler crash-loop plays a role here. We could also change the daemon-set but then we would not check the crash behaviour.
+					It("[test_id:1632]should recover and continue management", Label("test_id:1632"), func() {
+
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).To(BeNil(), "Should submit VMI successfully")
+
+						// Start a VirtualMachineInstance
+						nodeName := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
+
+						// Kill virt-handler on the node the VirtualMachineInstance is active on.
+						By("Crashing the virt-handler")
+						err = pkillHandler(virtClient, nodeName)
+						Expect(err).To(BeNil(), "Should kill virt-handler successfully")
+
+						// Crash the VirtualMachineInstance and verify a recovered version of virt-handler processes the crash
+						By("Killing the VirtualMachineInstance")
+						err = pkillAllVMIs(virtClient, nodeName)
+						Expect(err).To(BeNil(), "Should kill VMI successfully")
+
+						// Give virt-handler some time. It can greatly vary when virt-handler will be ready again
+						ctx, cancel := context.WithCancel(context.Background())
+						defer cancel()
+
+						By("Checking that VirtualMachineInstance has 'Failed' phase")
+						Eventually(func() v1.VirtualMachineInstancePhase {
+							vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI successfully")
+							return vmi.Status.Phase
+						}, 240*time.Second, 1*time.Second).Should(Equal(v1.Failed), "VMI should be failed")
+
+						By(fmt.Sprintf("Waiting for %q %q event after the resource version %q", tests.WarningEvent, v1.Stopped, vmi.ResourceVersion))
+						tests.NewObjectEventWatcher(vmi).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, v1.Stopped)
+
+						By("checking that it can still start VMIs")
+						newVMI := newCirrosVMI()
+						newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+						newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(newVMI)
+						Expect(err).To(BeNil())
+
+						tests.WaitForSuccessfulVMIStart(newVMI)
+					})
+				})
+
+				Context("[Serial]when virt-handler is responsive", Label("Serial"), func() {
+					It("[test_id:1633]should indicate that a node is ready for vmis", Label("test_id:1633"), func() {
+
+						By("adding a heartbeat annotation and a schedulable label to the node")
+						nodes := util.GetAllSchedulableNodes(virtClient)
+						Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+						for _, node := range nodes.Items {
+							Expect(node.Annotations[v1.VirtHandlerHeartbeat]).ToNot(BeEmpty(), "Nodes should have be ready for VMI")
+						}
+
+						node := &nodes.Items[0]
+						node, err = virtClient.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "false"}}}`, v1.NodeSchedulable)), metav1.PatchOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should patch node successfully")
+						timestamp := node.Annotations[v1.VirtHandlerHeartbeat]
+
+						By("setting the schedulable label back to true")
+						Eventually(func() string {
+							n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get nodes successfully")
+							return n.Labels[v1.NodeSchedulable]
+						}, 5*time.Minute, 2*time.Second).Should(Equal("true"), "Nodes should be schedulable")
+						By("updating the heartbeat roughly every minute")
+						Expect(func() string {
+							n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get nodes successfully")
+							return n.Labels[v1.VirtHandlerHeartbeat]
+						}()).ShouldNot(Equal(timestamp), "Should not have old vmi heartbeat")
+					})
+
+					It("[test_id:3198]device plugins should re-register if the kubelet restarts", Label("test_id:3198"), func() {
+
+						By("starting a VMI on a node")
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).To(BeNil(), "Should submit VMI successfully")
+
+						// Start a VirtualMachineInstance
+						nodeName := tests.WaitForSuccessfulVMIStart(vmi).Status.NodeName
+
+						By("triggering a device plugin re-registration on that node")
+						pod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
+						Expect(err).ToNot(HaveOccurred())
+
+						_, _, err = tests.ExecuteCommandOnPodV2(virtClient, pod,
+							"virt-handler",
+							[]string{
+								"rm",
+								// We want to fail if the file does not exist, but don't want to be asked
+								// if we really want to remove write-protected files
+								"--interactive=never",
+								device_manager.SocketPath("kvm"),
+							})
+						Expect(err).ToNot(HaveOccurred())
+
+						By("checking if we see the device plugin restart in the logs")
+						virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
+						Expect(err).ToNot(HaveOccurred(), "Should get virthandler client for node")
+
+						handlerName := virtHandlerPod.GetObjectMeta().GetName()
+						handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
+						seconds := int64(10)
+						logsQuery := virtClient.CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
+						Eventually(func() string {
+							data, err := logsQuery.DoRaw(context.Background())
+							Expect(err).ToNot(HaveOccurred(), "Should get logs")
+							return string(data)
+						}, 60, 1).Should(
+							ContainSubstring(
+								fmt.Sprintf("device socket file for device %s was removed, kubelet probably restarted.", "kvm"),
+							), "Should log device plugin restart")
+
+						// This is a little bit arbitrar
+						// Background is that new pods go into a crash loop if the devices are still report but virt-handler
+						// re-registers exactly during that moment. This is not too bad, since normally kubelet itself deletes
+						// the socket and knows that the devices are not there. However we have to wait in this test a little bit.
+						time.Sleep(10 * time.Second)
+
+						By("starting another VMI on the same node, to verify devices still work")
+						newVMI := newCirrosVMI()
+						newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+						newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(newVMI)
+						Expect(err).To(BeNil())
+
+						tests.WaitForSuccessfulVMIStart(newVMI)
+					})
+				})
+
+				Context("[Serial]when virt-handler is not responsive", Label("Serial"), func() {
+
+					var vmi *v1.VirtualMachineInstance
+					var nodeName string
+					var virtHandler *k8sv1.Pod
+					var virtHandlerAvailablePods int32
+
+					BeforeEach(func() {
+
+						// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
+						vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
+						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
+
+						// Ensure that the VMI is running. This is necessary to ensure that virt-handler is fully responsible for
+						// the VMI. Otherwise virt-controller may move the VMI to failed instead of the node controller.
+						nodeName = tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi).Status.NodeName
+
+						virtHandler, err = kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
+						Expect(err).ToNot(HaveOccurred(), "Should get virthandler client")
+
+						ds, err := virtClient.AppsV1().DaemonSets(virtHandler.Namespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get virthandler daemonset")
+						// Save virt-handler number of desired pods
+						virtHandlerAvailablePods = ds.Status.DesiredNumberScheduled
+
+						kv := util.GetCurrentKv(virtClient)
+						kv.Spec.Workloads = &v1.ComponentConfig{
+							NodePlacement: &v1.NodePlacement{
+								Affinity: &k8sv1.Affinity{
+									NodeAffinity: &k8sv1.NodeAffinity{
+										RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+											NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+												{MatchExpressions: []k8sv1.NodeSelectorRequirement{
+													{Key: "kubernetes.io/hostname", Operator: "NotIn", Values: []string{nodeName}},
+												}},
+											},
+										},
 									},
 								},
 							},
-						},
-					},
-				}
-				_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
-				Expect(err).ToNot(HaveOccurred(), "Should update kubevirt infra placement")
+						}
+						_, err = virtClient.KubeVirt(kv.Namespace).Update(kv)
+						Expect(err).ToNot(HaveOccurred(), "Should update kubevirt infra placement")
 
-				Eventually(func() bool {
-					_, err := virtClient.CoreV1().Pods(virtHandler.Namespace).Get(context.Background(), virtHandler.Name, metav1.GetOptions{})
-					return errors.IsNotFound(err)
-				}, 120*time.Second, 1*time.Second).Should(BeTrue(), "The virthandler pod should be gone")
-			})
+						Eventually(func() bool {
+							_, err := virtClient.CoreV1().Pods(virtHandler.Namespace).Get(context.Background(), virtHandler.Name, metav1.GetOptions{})
+							return errors.IsNotFound(err)
+						}, 120*time.Second, 1*time.Second).Should(BeTrue(), "The virthandler pod should be gone")
+					})
 
-			It("[test_id:1634]the node controller should mark the node as unschedulable when the virt-handler heartbeat has timedout", func() {
-				// Update virt-handler heartbeat, to trigger a timeout
-				data := []byte(fmt.Sprintf(`{"metadata": { "labels": { "%s": "true" }, "annotations": {"%s": "%s"}}}`, v1.NodeSchedulable, v1.VirtHandlerHeartbeat, nowAsJSONWithOffset(-10*time.Minute)))
-				_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should patch node successfully")
+					It("[test_id:1634]the node controller should mark the node as unschedulable when the virt-handler heartbeat has timedout", Label("test_id:1634"), func() {
+						// Update virt-handler heartbeat, to trigger a timeout
+						data := []byte(fmt.Sprintf(`{"metadata": { "labels": { "%s": "true" }, "annotations": {"%s": "%s"}}}`, v1.NodeSchedulable, v1.VirtHandlerHeartbeat, nowAsJSONWithOffset(-10*time.Minute)))
+						_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should patch node successfully")
 
-				// Delete vmi pod
-				pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{
-					LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
+						// Delete vmi pod
+						pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{
+							LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
+						})
+						Expect(err).ToNot(HaveOccurred(), "Should list pods successfully")
+						Expect(pods.Items).To(HaveLen(1), "There should be only one VMI pod")
+						var gracePeriod int64 = 0
+						Expect(virtClient.CoreV1().Pods(vmi.Namespace).Delete(context.Background(), pods.Items[0].Name, metav1.DeleteOptions{
+							GracePeriodSeconds: &gracePeriod,
+						})).To(Succeed(), "The vmi pod should be deleted successfully")
+
+						// it will take at least 45 seconds until the vmi is gone, check the schedulable state in the meantime
+						By("marking the node as not schedulable")
+						Eventually(func() string {
+							node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get node successfully")
+							return node.Labels[v1.NodeSchedulable]
+						}, 20*time.Second, 1*time.Second).Should(Equal("false"), "The node should not be schedulable")
+
+						By("moving stuck vmis to failed state")
+						Eventually(func() v1.VirtualMachineInstancePhase {
+							failedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get vmi successfully")
+							return failedVMI.Status.Phase
+						}, 180*time.Second, 1*time.Second).Should(Equal(v1.Failed))
+
+						Eventually(func() string {
+							failedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get vmi successfully")
+							return failedVMI.Status.Reason
+						}, 180*time.Second, 1*time.Second).Should(Equal(watch.NodeUnresponsiveReason))
+
+						err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					AfterEach(func() {
+						tests.RestoreKubeVirtResource()
+
+						// Wait until virt-handler ds will have expected number of pods
+						Eventually(func() bool {
+							ds, err := virtClient.AppsV1().DaemonSets(virtHandler.Namespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get virthandler successfully")
+
+							return ds.Status.NumberAvailable == virtHandlerAvailablePods &&
+								ds.Status.CurrentNumberScheduled == virtHandlerAvailablePods &&
+								ds.Status.DesiredNumberScheduled == virtHandlerAvailablePods &&
+								ds.Status.NumberReady == virtHandlerAvailablePods &&
+								ds.Status.UpdatedNumberScheduled == virtHandlerAvailablePods
+						}, 180*time.Second, 1*time.Second).Should(BeTrue(), "Virthandler should be ready to work")
+					})
 				})
-				Expect(err).ToNot(HaveOccurred(), "Should list pods successfully")
-				Expect(pods.Items).To(HaveLen(1), "There should be only one VMI pod")
-				var gracePeriod int64 = 0
-				Expect(virtClient.CoreV1().Pods(vmi.Namespace).Delete(context.Background(), pods.Items[0].Name, metav1.DeleteOptions{
-					GracePeriodSeconds: &gracePeriod,
-				})).To(Succeed(), "The vmi pod should be deleted successfully")
 
-				// it will take at least 45 seconds until the vmi is gone, check the schedulable state in the meantime
-				By("marking the node as not schedulable")
-				Eventually(func() string {
-					node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get node successfully")
-					return node.Labels[v1.NodeSchedulable]
-				}, 20*time.Second, 1*time.Second).Should(Equal("false"), "The node should not be schedulable")
+				Context("[Serial]with node tainted", Label("Serial"), func() {
+					var nodes *k8sv1.NodeList
+					var err error
+					BeforeEach(func() {
+						Eventually(func() []k8sv1.Node {
+							nodes = util.GetAllSchedulableNodes(virtClient)
+							return nodes.Items
+						}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be some compute node")
 
-				By("moving stuck vmis to failed state")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					failedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get vmi successfully")
-					return failedVMI.Status.Phase
-				}, 180*time.Second, 1*time.Second).Should(Equal(v1.Failed))
+						// Taint first node with "NoSchedule"
+						data := []byte(`{"spec":{"taints":[{"effect":"NoSchedule","key":"test","timeAdded":null,"value":"123"}]}}`)
+						_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodes.Items[0].Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should patch node")
 
-				Eventually(func() string {
-					failedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get vmi successfully")
-					return failedVMI.Status.Reason
-				}, 180*time.Second, 1*time.Second).Should(Equal(watch.NodeUnresponsiveReason))
+					})
 
-				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-			})
+					AfterEach(func() {
+						// Untaint first node
+						data := []byte(`{"spec":{"taints":[]}}`)
+						_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodes.Items[0].Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should patch node")
+					})
 
-			AfterEach(func() {
-				tests.RestoreKubeVirtResource()
+					It("[test_id:1635]the vmi with tolerations should be scheduled", Label("test_id:1635"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Tolerations = []k8sv1.Toleration{{Key: "test", Value: "123"}}
+						addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+					})
 
-				// Wait until virt-handler ds will have expected number of pods
-				Eventually(func() bool {
-					ds, err := virtClient.AppsV1().DaemonSets(virtHandler.Namespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get virthandler successfully")
+					It("[test_id:1636]the vmi without tolerations should not be scheduled", Label("test_id:1636"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						By("Waiting for the VirtualMachineInstance to be unschedulable")
+						Eventually(func() string {
+							curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+							scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+								GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+							if scheduledCond != nil {
+								return scheduledCond.Reason
+							}
+							return ""
+						}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
+					})
+				})
 
-					return ds.Status.NumberAvailable == virtHandlerAvailablePods &&
-						ds.Status.CurrentNumberScheduled == virtHandlerAvailablePods &&
-						ds.Status.DesiredNumberScheduled == virtHandlerAvailablePods &&
-						ds.Status.NumberReady == virtHandlerAvailablePods &&
-						ds.Status.UpdatedNumberScheduled == virtHandlerAvailablePods
-				}, 180*time.Second, 1*time.Second).Should(BeTrue(), "Virthandler should be ready to work")
-			})
-		})
+				Context("with affinity", func() {
+					var nodes *k8sv1.NodeList
+					var err error
 
-		Context("[Serial]with node tainted", func() {
-			var nodes *k8sv1.NodeList
-			var err error
-			BeforeEach(func() {
-				Eventually(func() []k8sv1.Node {
-					nodes = util.GetAllSchedulableNodes(virtClient)
-					return nodes.Items
-				}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be some compute node")
+					BeforeEach(func() {
+						nodes = util.GetAllSchedulableNodes(virtClient)
+						Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+					})
 
-				// Taint first node with "NoSchedule"
-				data := []byte(`{"spec":{"taints":[{"effect":"NoSchedule","key":"test","timeAdded":null,"value":"123"}]}}`)
-				_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodes.Items[0].Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should patch node")
+					It("[test_id:1637]the vmi with node affinity and no conflicts should be scheduled", Label("test_id:1637"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+						curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "Updated VMI name run on the same node")
 
-			})
+					})
 
-			AfterEach(func() {
-				// Untaint first node
-				data := []byte(`{"spec":{"taints":[]}}`)
-				_, err = virtClient.CoreV1().Nodes().Patch(context.Background(), nodes.Items[0].Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should patch node")
-			})
+					It("[test_id:1638]the vmi with node affinity and anti-pod affinity should not be scheduled", Label("test_id:1638"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+						curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "VMI should run on the same node")
 
-			It("[test_id:1635]the vmi with tolerations should be scheduled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Tolerations = []k8sv1.Toleration{{Key: "test", Value: "123"}}
-				addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-			})
+						vmiB := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						addNodeAffinityToVMI(vmiB, nodes.Items[0].Name)
 
-			It("[test_id:1636]the vmi without tolerations should not be scheduled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
-			})
-		})
-
-		Context("with affinity", func() {
-			var nodes *k8sv1.NodeList
-			var err error
-
-			BeforeEach(func() {
-				nodes = util.GetAllSchedulableNodes(virtClient)
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-			})
-
-			It("[test_id:1637]the vmi with node affinity and no conflicts should be scheduled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "Updated VMI name run on the same node")
-
-			})
-
-			It("[test_id:1638]the vmi with node affinity and anti-pod affinity should not be scheduled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				addNodeAffinityToVMI(vmi, nodes.Items[0].Name)
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Status.NodeName).To(Equal(nodes.Items[0].Name), "VMI should run on the same node")
-
-				vmiB := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				addNodeAffinityToVMI(vmiB, nodes.Items[0].Name)
-
-				vmiB.Spec.Affinity.PodAntiAffinity = &k8sv1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
-						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{Key: v1.CreatedByLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{string(curVMI.GetUID())}},
+						vmiB.Spec.Affinity.PodAntiAffinity = &k8sv1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{Key: v1.CreatedByLabel, Operator: metav1.LabelSelectorOpIn, Values: []string{string(curVMI.GetUID())}},
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
 								},
 							},
-							TopologyKey: "kubernetes.io/hostname",
+						}
+
+						_, err = virtClient.VirtualMachineInstance(vmiB.Namespace).Create(vmiB)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMIB")
+
+						By("Waiting for the VirtualMachineInstance to be unschedulable")
+						Eventually(func() string {
+							curVmiB, err := virtClient.VirtualMachineInstance(vmiB.Namespace).Get(vmiB.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMIB")
+							scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+								GetCondition(curVmiB, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+							if scheduledCond != nil {
+								return scheduledCond.Reason
+							}
+							return ""
+						}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
+
+					})
+
+				})
+
+				Context("[Serial]with default cpu model", Label("Serial"), func() {
+					var originalConfig v1.KubeVirtConfiguration
+					var defaultCPUModel = "Nehalem"
+					var vmiCPUModel = "SandyBridge"
+
+					//store old kubevirt-config
+					BeforeEach(func() {
+						// arm64 does not support cpu model
+						checks.SkipIfARM64(tests.Arch, "arm64 does not support cpu model")
+						kv := util.GetCurrentKv(virtClient)
+						originalConfig = kv.Spec.Configuration
+					})
+
+					//replace new kubevirt-config with old config
+					AfterEach(func() {
+						tests.UpdateKubeVirtConfigValueAndWait(originalConfig)
+					})
+
+					It("[test_id:3199]should set default cpu model when vmi doesn't have it set", Label("test_id:3199"), func() {
+						config := originalConfig.DeepCopy()
+						config.CPUModel = defaultCPUModel
+						tests.UpdateKubeVirtConfigValueAndWait(*config)
+
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+						curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(curVMI.Spec.Domain.CPU.Model).To(Equal("Nehalem"), "Expected default CPU model")
+
+					})
+
+					It("[test_id:3200]should not set default cpu model when vmi has it set", Label("test_id:3200"), func() {
+						config := originalConfig.DeepCopy()
+						config.CPUModel = defaultCPUModel
+						tests.UpdateKubeVirtConfigValueAndWait(*config)
+
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.CPU = &v1.CPU{
+							Model: vmiCPUModel,
+						}
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(vmiCPUModel), "Expected vmi CPU model")
+
+					})
+
+					It("[sig-compute][test_id:3201]should set cpu model to default when vmi does not have it set and default cpu model is not set", Label("sig-compute", "test_id:3201"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel),
+							fmt.Sprintf("Expected CPU model to equal to the default (%v)", v1.DefaultCPUModel),
+						)
+					})
+				})
+
+				Context("[Serial]with node feature discovery", Label("Serial"), func() {
+					var node *k8sv1.Node
+					var supportedCPU string
+					var supportedCPUs []string
+					var supportedFeatures []string
+
+					var supportedKVMInfoFeature []string
+
+					enableHyperVInVMI := func(label string) v1.FeatureHyperv {
+						features := v1.FeatureHyperv{}
+						trueV := true
+						switch label {
+						case "vpindex":
+							features.VPIndex = &v1.FeatureState{
+								Enabled: &trueV,
+							}
+						case "runtime":
+							features.Runtime = &v1.FeatureState{
+								Enabled: &trueV,
+							}
+						case "reset":
+							features.Reset = &v1.FeatureState{
+								Enabled: &trueV,
+							}
+						case "synic":
+							features.SyNIC = &v1.FeatureState{
+								Enabled: &trueV,
+							}
+						case "frequencies":
+							features.Frequencies = &v1.FeatureState{
+								Enabled: &trueV,
+							}
+						case "reenlightenment":
+							features.Reenlightenment = &v1.FeatureState{
+								Enabled: &trueV,
+							}
+						}
+
+						return features
+					}
+
+					BeforeEach(func() {
+						// arm64 does not support cpu model
+						checks.SkipIfARM64(tests.Arch, "arm64 does not support cpu model")
+						nodes := util.GetAllSchedulableNodes(virtClient)
+						Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+
+						node = &nodes.Items[0]
+						supportedCPUs = tests.GetSupportedCPUModels(*nodes)
+						Expect(supportedCPUs).ToNot(BeEmpty(), "There should be some supported cpu models")
+
+						supportedCPU = supportedCPUs[0]
+
+						supportedFeatures = tests.GetSupportedCPUFeatures(*nodes)
+						Expect(supportedFeatures).ToNot(BeEmpty(), "There should be some supported cpu features")
+
+						for key := range node.Labels {
+							if strings.Contains(key, services.NFD_KVM_INFO_PREFIX) &&
+								!strings.Contains(key, "tlbflush") &&
+								!strings.Contains(key, "ipi") &&
+								!strings.Contains(key, "synictimer") {
+								supportedKVMInfoFeature = append(supportedKVMInfoFeature, strings.TrimPrefix(key, services.NFD_KVM_INFO_PREFIX))
+							}
+
+						}
+
+						tests.EnableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
+						tests.EnableFeatureGate(virtconfig.HypervStrictCheckGate)
+					})
+
+					It("[test_id:1639]the vmi with cpu.model matching a nfd label on a node should be scheduled", Label("test_id:1639"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.CPU = &v1.CPU{
+							Cores: 1,
+							Model: supportedCPU,
+						}
+
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						By("Verifying VirtualMachineInstance's status is Succeeded")
+						Eventually(func() v1.VirtualMachineInstancePhase {
+							currVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+							return currVMI.Status.Phase
+						}, 120, 0.5).Should(Equal(v1.Running), "VMI should be succeeded")
+					})
+
+					It("the vmi with HyperV feature matching a nfd label on a node should be scheduled", func() {
+
+						for _, label := range supportedKVMInfoFeature {
+							fmt.Println("Using " + label)
+							vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+							features := enableHyperVInVMI(label)
+							vmi.Spec.Domain.Features = &v1.Features{
+								Hyperv: &features,
+							}
+
+							_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+							Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+							tests.WaitForSuccessfulVMIStart(vmi)
+
+							_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						}
+
+					})
+
+					It("the vmi with EVMCS HyperV feature should have correct hyperv and cpu features auto filled", func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.Features = &v1.Features{
+							Hyperv: &v1.FeatureHyperv{
+								EVMCS: &v1.FeatureState{},
+							},
+						}
+
+						_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+
+						vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+
+						Expect(vmi.Spec.Domain.Features.Hyperv.EVMCS).ToNot(BeNil(), "evmcs should not be nil")
+						Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).ToNot(BeNil(), "vapic should not be nil")
+						Expect(vmi.Spec.Domain.CPU).ToNot(BeNil(), "cpu topology can't be nil")
+						Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(1), "cpu topology has to contain 1 feature")
+						Expect(vmi.Spec.Domain.CPU.Features[0].Name).To(Equal(nodelabellerutil.VmxFeature), "vmx cpu feature should be requested")
+
+					})
+
+					It("[test_id:1640]the vmi with cpu.model that cannot match an nfd label on node should not be scheduled", Label("test_id:1640"), func() {
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.CPU = &v1.CPU{
+							Cores: 1,
+							Model: "486",
+						}
+
+						//Make sure the vmi should try to be scheduled only on master node
+						vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node.Name}
+
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+
+						By("Waiting for the VirtualMachineInstance to be unschedulable")
+						Eventually(func() string {
+							curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get vmi")
+							scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+								GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+							if scheduledCond != nil {
+								return scheduledCond.Reason
+							}
+							return ""
+						}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
+					})
+
+					It("[test_id:3202]the vmi with cpu.features matching nfd labels on a node should be scheduled", Label("test_id:3202"), func() {
+
+						By("adding a node-feature-discovery CPU model label to a node")
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.CPU = &v1.CPU{
+							Cores: 1,
+							Features: []v1.CPUFeature{
+								{
+									Name:   supportedFeatures[0],
+									Policy: "require",
+								},
+								{
+									Name:   "fpu",
+									Policy: "disable",
+								},
+							},
+						}
+
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						By("Verifying VirtualMachineInstance's status is Succeeded")
+						Eventually(func() v1.VirtualMachineInstancePhase {
+							currVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+							return currVMI.Status.Phase
+						}, 120, 0.5).Should(Equal(v1.Running), "VMI should be succeeded")
+					})
+
+					It("[test_id:3203]the vmi with cpu.features that cannot match nfd labels on a node should not be scheduled", Label("test_id:3203"), func() {
+
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.CPU = &v1.CPU{
+							Cores: 1,
+							Features: []v1.CPUFeature{
+								{
+									Name:   supportedFeatures[0],
+									Policy: "require",
+								},
+								{
+									Name:   supportedFeatures[1],
+									Policy: "forbid",
+								},
+							},
+						}
+
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+
+						By("Waiting for the VirtualMachineInstance to be unschedulable")
+						Eventually(func() string {
+							curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get vmi")
+							scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+								GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+							if scheduledCond != nil {
+								return scheduledCond.Reason
+							}
+							return ""
+						}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
+					})
+
+					It("[test_id:3204]the vmi with cpu.feature policy 'forbid' should not be scheduled on a node with that cpu feature label", Label("test_id:3204"), func() {
+
+						vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+						vmi.Spec.Domain.CPU = &v1.CPU{
+							Cores: 1,
+							Features: []v1.CPUFeature{
+								{
+									Name:   supportedFeatures[0],
+									Policy: "forbid",
+								},
+							},
+						}
+
+						// Add node affinity first to test later on that although there is node affinity to
+						// the specific node - the feature policy 'forbid' will deny shceduling on that node.
+						addNodeAffinityToVMI(vmi, node.Name)
+
+						_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+
+						By("Waiting for the VirtualMachineInstance to be unschedulable")
+						Eventually(func() string {
+							curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+							Expect(err).ToNot(HaveOccurred(), "Should get vmi")
+							scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+								GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+							if scheduledCond != nil {
+								return scheduledCond.Reason
+							}
+							return ""
+						}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
+					})
+
+				})
+
+				Context("with non default namespace", func() {
+					DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should log libvirt start and stop lifecycle events of the domain",
+						Label("rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+						func(namespace *string) {
+
+							nodes := util.GetAllSchedulableNodes(virtClient)
+							Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+							node := nodes.Items[0].Name
+
+							By("Creating a VirtualMachineInstance with different namespace")
+							vmi = tests.NewRandomVMIWithNS(*namespace)
+							virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
+							Expect(err).ToNot(HaveOccurred(), "Should get virthandler client for node")
+
+							handlerName := virtHandlerPod.GetObjectMeta().GetName()
+							handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
+							seconds := int64(120)
+							logsQuery := virtClient.CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
+
+							// Make sure we schedule the VirtualMachineInstance to master
+							vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
+
+							// Start the VirtualMachineInstance and wait for the confirmation of the start
+							vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+							Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+							tests.WaitForSuccessfulVMIStart(vmi)
+
+							// Check if the start event was logged
+							By("Checking that virt-handler logs VirtualMachineInstance creation")
+							Eventually(func() string {
+								data, err := logsQuery.DoRaw(context.Background())
+								Expect(err).ToNot(HaveOccurred(), "Should get logs from virthandler")
+								return string(data)
+							}, 30, 0.5).Should(MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Running reason Unknown","name":"%s"`, vmi.GetObjectMeta().GetName()), "Should verify from logs that domain is running")
+							// Check the VirtualMachineInstance Namespace
+							Expect(vmi.GetObjectMeta().GetNamespace()).To(Equal(*namespace), "VMI should run in the right namespace")
+
+							// Delete the VirtualMachineInstance and wait for the confirmation of the delete
+							By("Deleting the VirtualMachineInstance")
+							_, err = virtClient.RestClient().Delete().Resource("virtualmachineinstances").Namespace(vmi.GetObjectMeta().GetNamespace()).Name(vmi.GetObjectMeta().GetName()).Do(context.Background()).Get()
+							Expect(err).To(BeNil())
+							ctx, cancel := context.WithCancel(context.Background())
+							defer cancel()
+							tests.NewObjectEventWatcher(vmi).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.NormalEvent, v1.Deleted)
+							tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+
+							// Check if the stop event was logged
+							By("Checking that virt-handler logs VirtualMachineInstance deletion")
+							/*
+									Since we deleted the VMI object, there are two possible outcomes and both are expected:
+									1. virt-controller kicks in, registers a deletion request on the launcher pod and K8s deletes the pod
+								       before virt-handler had a chance to set or check the deletion timestamp on the domain.
+									2. virt-handler detects the deletion timestamp on the domain and removes it.
+
+									TODO: https://github.com/kubevirt/kubevirt/issues/3764
+							*/
+							Eventually(func() string {
+								data, err := logsQuery.DoRaw(context.Background())
+								Expect(err).ToNot(HaveOccurred(), "Should get the virthandler logs")
+								return string(data)
+							}, 30, 0.5).Should(SatisfyAny(
+								MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is marked for deletion","name":"%s"`, vmi.GetObjectMeta().GetName()),               // Domain was deleted by virt-handler
+								MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Shutoff reason Destroyed","name":"%s"`, vmi.GetObjectMeta().GetName()), // Domain was destroyed because the launcher pod is gone
+							), "Logs should confirm pod deletion")
 						},
-					},
-				}
+						Entry("[test_id:1641]"+util.NamespaceTestDefault, Label("test_id:1641"), &util.NamespaceTestDefault),
+						Entry("[test_id:1642]"+tests.NamespaceTestAlternative, Label("test_id:1642"), &tests.NamespaceTestAlternative),
+					)
+				})
 
-				_, err = virtClient.VirtualMachineInstance(vmiB.Namespace).Create(vmiB)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMIB")
+				Context("VirtualMachineInstance Emulation Mode", func() {
+					BeforeEach(func() {
+						// allowEmulation won't change in a test suite run, so cache it
+						if allowEmulation == nil {
+							emulation := tests.ShouldAllowEmulation(virtClient)
+							allowEmulation = &emulation
+						}
+						if !(*allowEmulation) {
+							Skip("Software emulation is not enabled on this cluster")
+						}
+					})
 
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVmiB, err := virtClient.VirtualMachineInstance(vmiB.Namespace).Get(vmiB.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMIB")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVmiB, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
+					It("[test_id:1643]should enable emulation in virt-launcher", Label("test_id:1643"), func() {
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred())
 
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						Expect(pod).NotTo(BeNil())
+
+						emulationFlagFound := false
+						computeContainerFound := false
+						for _, container := range pod.Spec.Containers {
+							if container.Name == "compute" {
+								computeContainerFound = true
+								for _, cmd := range container.Command {
+									By(cmd)
+									if cmd == "--allow-emulation" {
+										emulationFlagFound = true
+									}
+								}
+							}
+						}
+
+						Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
+						Expect(emulationFlagFound).To(BeTrue(), "Expected VirtualMachineInstance pod to have '--allow-emulation' flag")
+					})
+
+					It("[test_id:1644]should be reflected in domain XML", Label("test_id:1644"), func() {
+						err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()
+						Expect(err).To(BeNil(), "Should post the VMI")
+
+						listOptions := metav1.ListOptions{}
+
+						Eventually(func() int {
+							podList, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), listOptions)
+							Expect(err).ToNot(HaveOccurred(), "Should list the pods")
+							return len(podList.Items)
+						}, 75, 0.5).Should(Equal(1), "There should be only one pod")
+
+						Eventually(func() error {
+							podList, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), listOptions)
+							Expect(err).ToNot(HaveOccurred(), "Should list the pods")
+							for _, item := range podList.Items {
+								if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
+									return nil
+								}
+							}
+							return fmt.Errorf("Associated pod for VirtualMachineInstance '%s' not found", vmi.Name)
+						}, 75, 0.5).Should(Succeed(), "Should find the VMI pod")
+
+						getOptions := metav1.GetOptions{}
+						var newVMI *v1.VirtualMachineInstance
+
+						newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &getOptions)
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+
+						domain := &api.Domain{}
+						context := &converter.ConverterContext{
+							VirtualMachine: newVMI,
+							AllowEmulation: true,
+						}
+						converter.Convert_v1_VirtualMachineInstance_To_api_Domain(newVMI, domain, context)
+
+						expectedType := ""
+						if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
+							expectedType = "qemu"
+						}
+
+						Expect(domain.Spec.Type).To(Equal(expectedType), "VMI domain type should be of expectedType")
+					})
+
+					It("[test_id:1645]should request a TUN device but not KVM", Label("test_id:1645"), func() {
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred())
+
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						Expect(pod).NotTo(BeNil())
+
+						computeContainerFound := false
+						for _, container := range pod.Spec.Containers {
+							if container.Name == "compute" {
+								computeContainerFound = true
+
+								_, ok := container.Resources.Limits[services.KvmDevice]
+								Expect(ok).To(BeFalse(), "Container should not have requested KVM device")
+
+								_, ok = container.Resources.Limits[services.TunDevice]
+								Expect(ok).To(BeTrue(), "Container should have requested TUN device")
+							}
+						}
+
+						Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
+					})
+				})
+
+				Context("VM Accelerated Mode", func() {
+					BeforeEach(func() {
+						// allowEmulation won't change in a test suite run, so cache it
+						if allowEmulation == nil {
+							emulation := tests.ShouldAllowEmulation(virtClient)
+							allowEmulation = &emulation
+						}
+						if *allowEmulation {
+							Skip("Software emulation is enabled on this cluster")
+						}
+					})
+
+					It("[test_id:1646]should request a KVM and TUN device", Label("test_id:1646"), func() {
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred())
+
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						Expect(pod).NotTo(BeNil())
+
+						computeContainerFound := false
+						for _, container := range pod.Spec.Containers {
+							if container.Name == "compute" {
+								computeContainerFound = true
+
+								_, ok := container.Resources.Limits[services.KvmDevice]
+								Expect(ok).To(BeTrue(), "Container should have requested KVM device")
+
+								_, ok = container.Resources.Limits[services.TunDevice]
+								Expect(ok).To(BeTrue(), "Container should have requested TUN device")
+							}
+						}
+
+						Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
+					})
+
+					It("[test_id:1647]should not enable emulation in virt-launcher", Label("test_id:1647"), func() {
+						vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred())
+
+						tests.WaitForSuccessfulVMIStart(vmi)
+
+						pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+						Expect(pod).NotTo(BeNil())
+
+						emulationFlagFound := false
+						computeContainerFound := false
+						for _, container := range pod.Spec.Containers {
+							if container.Name == "compute" {
+								computeContainerFound = true
+								for _, cmd := range container.Command {
+									By(cmd)
+									if cmd == "--allow-emulation" {
+										emulationFlagFound = true
+									}
+								}
+							}
+						}
+
+						Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
+						Expect(emulationFlagFound).To(BeFalse(), "Expected VM pod not to have '--allow-emulation' flag")
+					})
+
+					It("[test_id:1648]Should provide KVM via plugin framework", Label("test_id:1648"), func() {
+						nodeList := util.GetAllSchedulableNodes(virtClient)
+
+						if len(nodeList.Items) == 0 {
+							Skip("There are no compute nodes in cluster")
+						}
+						node := nodeList.Items[0]
+
+						_, ok := node.Status.Allocatable[services.KvmDevice]
+						Expect(ok).To(BeTrue(), "KVM devices not allocatable on node: %s", node.Name)
+
+						_, ok = node.Status.Capacity[services.KvmDevice]
+						Expect(ok).To(BeTrue(), "No Capacity for KVM devices on node: %s", node.Name)
+					})
+				})
 			})
 
-		})
-
-		Context("[Serial]with default cpu model", func() {
-			var originalConfig v1.KubeVirtConfiguration
-			var defaultCPUModel = "Nehalem"
-			var vmiCPUModel = "SandyBridge"
-
-			//store old kubevirt-config
-			BeforeEach(func() {
-				// arm64 does not support cpu model
-				checks.SkipIfARM64(tests.Arch, "arm64 does not support cpu model")
-				kv := util.GetCurrentKv(virtClient)
-				originalConfig = kv.Spec.Configuration
+		Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Get a VirtualMachineInstance",
+			Label("rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+			func() {
+				Context("when that not exist", func() {
+					It("[test_id:1649]should return 404", Label("test_id:1649"), func() {
+						b, err := virtClient.RestClient().Get().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Name("nonexistnt").DoRaw(context.Background())
+						Expect(err).ToNot(BeNil(), "Should get VMIs")
+						status := metav1.Status{}
+						err = json.Unmarshal(b, &status)
+						Expect(err).To(BeNil(), "Unmarshal without error")
+						Expect(status.Code).To(Equal(int32(http.StatusNotFound)), "There should not be and VMI")
+					})
+				})
 			})
 
-			//replace new kubevirt-config with old config
-			AfterEach(func() {
-				tests.UpdateKubeVirtConfigValueAndWait(originalConfig)
-			})
-
-			It("[test_id:3199]should set default cpu model when vmi doesn't have it set", func() {
-				config := originalConfig.DeepCopy()
-				config.CPUModel = defaultCPUModel
-				tests.UpdateKubeVirtConfigValueAndWait(*config)
-
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal("Nehalem"), "Expected default CPU model")
-
-			})
-
-			It("[test_id:3200]should not set default cpu model when vmi has it set", func() {
-				config := originalConfig.DeepCopy()
-				config.CPUModel = defaultCPUModel
-				tests.UpdateKubeVirtConfigValueAndWait(*config)
-
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Model: vmiCPUModel,
-				}
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(vmiCPUModel), "Expected vmi CPU model")
-
-			})
-
-			It("[sig-compute][test_id:3201]should set cpu model to default when vmi does not have it set and default cpu model is not set", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(v1.DefaultCPUModel),
-					fmt.Sprintf("Expected CPU model to equal to the default (%v)", v1.DefaultCPUModel),
-				)
-			})
-		})
-
-		Context("[Serial]with node feature discovery", func() {
-			var node *k8sv1.Node
-			var supportedCPU string
-			var supportedCPUs []string
-			var supportedFeatures []string
-
-			var supportedKVMInfoFeature []string
-
-			enableHyperVInVMI := func(label string) v1.FeatureHyperv {
-				features := v1.FeatureHyperv{}
-				trueV := true
-				switch label {
-				case "vpindex":
-					features.VPIndex = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "runtime":
-					features.Runtime = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "reset":
-					features.Reset = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "synic":
-					features.SyNIC = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "frequencies":
-					features.Frequencies = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "reenlightenment":
-					features.Reenlightenment = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				}
-
-				return features
-			}
-
-			BeforeEach(func() {
-				// arm64 does not support cpu model
-				checks.SkipIfARM64(tests.Arch, "arm64 does not support cpu model")
-				nodes := util.GetAllSchedulableNodes(virtClient)
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-
-				node = &nodes.Items[0]
-				supportedCPUs = tests.GetSupportedCPUModels(*nodes)
-				Expect(supportedCPUs).ToNot(BeEmpty(), "There should be some supported cpu models")
-
-				supportedCPU = supportedCPUs[0]
-
-				supportedFeatures = tests.GetSupportedCPUFeatures(*nodes)
-				Expect(supportedFeatures).ToNot(BeEmpty(), "There should be some supported cpu features")
-
-				for key := range node.Labels {
-					if strings.Contains(key, services.NFD_KVM_INFO_PREFIX) &&
-						!strings.Contains(key, "tlbflush") &&
-						!strings.Contains(key, "ipi") &&
-						!strings.Contains(key, "synictimer") {
-						supportedKVMInfoFeature = append(supportedKVMInfoFeature, strings.TrimPrefix(key, services.NFD_KVM_INFO_PREFIX))
-					}
-
-				}
-
-				tests.EnableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
-				tests.EnableFeatureGate(virtconfig.HypervStrictCheckGate)
-			})
-
-			It("[test_id:1639]the vmi with cpu.model matching a nfd label on a node should be scheduled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Model: supportedCPU,
-				}
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				By("Verifying VirtualMachineInstance's status is Succeeded")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					currVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					return currVMI.Status.Phase
-				}, 120, 0.5).Should(Equal(v1.Running), "VMI should be succeeded")
-			})
-
-			It("the vmi with HyperV feature matching a nfd label on a node should be scheduled", func() {
-
-				for _, label := range supportedKVMInfoFeature {
-					fmt.Println("Using " + label)
-					vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-					features := enableHyperVInVMI(label)
-					vmi.Spec.Domain.Features = &v1.Features{
-						Hyperv: &features,
-					}
-
-					_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+		Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod",
+			Label("rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+			func() {
+				It("[test_id:1650]should result in the VirtualMachineInstance moving to a finalized state", Label("test_id:1650"), func() {
+					By("Creating the VirtualMachineInstance")
+					obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-					tests.WaitForSuccessfulVMIStart(vmi)
+					tests.WaitForSuccessfulVMIStart(obj)
 
-					_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				}
-
-			})
-
-			It("the vmi with EVMCS HyperV feature should have correct hyperv and cpu features auto filled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.Features = &v1.Features{
-					Hyperv: &v1.FeatureHyperv{
-						EVMCS: &v1.FeatureState{},
-					},
-				}
-
-				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-
-				Expect(vmi.Spec.Domain.Features.Hyperv.EVMCS).ToNot(BeNil(), "evmcs should not be nil")
-				Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).ToNot(BeNil(), "vapic should not be nil")
-				Expect(vmi.Spec.Domain.CPU).ToNot(BeNil(), "cpu topology can't be nil")
-				Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(1), "cpu topology has to contain 1 feature")
-				Expect(vmi.Spec.Domain.CPU.Features[0].Name).To(Equal(nodelabellerutil.VmxFeature), "vmx cpu feature should be requested")
-
-			})
-
-			It("[test_id:1640]the vmi with cpu.model that cannot match an nfd label on node should not be scheduled", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Model: "486",
-				}
-
-				//Make sure the vmi should try to be scheduled only on master node
-				vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node.Name}
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get vmi")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
-			})
-
-			It("[test_id:3202]the vmi with cpu.features matching nfd labels on a node should be scheduled", func() {
-
-				By("adding a node-feature-discovery CPU model label to a node")
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Features: []v1.CPUFeature{
-						{
-							Name:   supportedFeatures[0],
-							Policy: "require",
-						},
-						{
-							Name:   "fpu",
-							Policy: "disable",
-						},
-					},
-				}
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				By("Verifying VirtualMachineInstance's status is Succeeded")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					currVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					return currVMI.Status.Phase
-				}, 120, 0.5).Should(Equal(v1.Running), "VMI should be succeeded")
-			})
-
-			It("[test_id:3203]the vmi with cpu.features that cannot match nfd labels on a node should not be scheduled", func() {
-
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Features: []v1.CPUFeature{
-						{
-							Name:   supportedFeatures[0],
-							Policy: "require",
-						},
-						{
-							Name:   supportedFeatures[1],
-							Policy: "forbid",
-						},
-					},
-				}
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get vmi")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
-			})
-
-			It("[test_id:3204]the vmi with cpu.feature policy 'forbid' should not be scheduled on a node with that cpu feature label", func() {
-
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Features: []v1.CPUFeature{
-						{
-							Name:   supportedFeatures[0],
-							Policy: "forbid",
-						},
-					},
-				}
-
-				// Add node affinity first to test later on that although there is node affinity to
-				// the specific node - the feature policy 'forbid' will deny shceduling on that node.
-				addNodeAffinityToVMI(vmi, node.Name)
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-
-				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() string {
-					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get vmi")
-					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
-						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
-					if scheduledCond != nil {
-						return scheduledCond.Reason
-					}
-					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
-			})
-
-		})
-
-		Context("with non default namespace", func() {
-			DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should log libvirt start and stop lifecycle events of the domain", func(namespace *string) {
-
-				nodes := util.GetAllSchedulableNodes(virtClient)
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				node := nodes.Items[0].Name
-
-				By("Creating a VirtualMachineInstance with different namespace")
-				vmi = tests.NewRandomVMIWithNS(*namespace)
-				virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
-				Expect(err).ToNot(HaveOccurred(), "Should get virthandler client for node")
-
-				handlerName := virtHandlerPod.GetObjectMeta().GetName()
-				handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
-				seconds := int64(120)
-				logsQuery := virtClient.CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
-
-				// Make sure we schedule the VirtualMachineInstance to master
-				vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
-
-				// Start the VirtualMachineInstance and wait for the confirmation of the start
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				// Check if the start event was logged
-				By("Checking that virt-handler logs VirtualMachineInstance creation")
-				Eventually(func() string {
-					data, err := logsQuery.DoRaw(context.Background())
-					Expect(err).ToNot(HaveOccurred(), "Should get logs from virthandler")
-					return string(data)
-				}, 30, 0.5).Should(MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Running reason Unknown","name":"%s"`, vmi.GetObjectMeta().GetName()), "Should verify from logs that domain is running")
-				// Check the VirtualMachineInstance Namespace
-				Expect(vmi.GetObjectMeta().GetNamespace()).To(Equal(*namespace), "VMI should run in the right namespace")
-
-				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
-				By("Deleting the VirtualMachineInstance")
-				_, err = virtClient.RestClient().Delete().Resource("virtualmachineinstances").Namespace(vmi.GetObjectMeta().GetNamespace()).Name(vmi.GetObjectMeta().GetName()).Do(context.Background()).Get()
-				Expect(err).To(BeNil())
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				tests.NewObjectEventWatcher(vmi).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.NormalEvent, v1.Deleted)
-				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-
-				// Check if the stop event was logged
-				By("Checking that virt-handler logs VirtualMachineInstance deletion")
-				/*
-						Since we deleted the VMI object, there are two possible outcomes and both are expected:
-						1. virt-controller kicks in, registers a deletion request on the launcher pod and K8s deletes the pod
-					       before virt-handler had a chance to set or check the deletion timestamp on the domain.
-						2. virt-handler detects the deletion timestamp on the domain and removes it.
-
-						TODO: https://github.com/kubevirt/kubevirt/issues/3764
-				*/
-				Eventually(func() string {
-					data, err := logsQuery.DoRaw(context.Background())
-					Expect(err).ToNot(HaveOccurred(), "Should get the virthandler logs")
-					return string(data)
-				}, 30, 0.5).Should(SatisfyAny(
-					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is marked for deletion","name":"%s"`, vmi.GetObjectMeta().GetName()),               // Domain was deleted by virt-handler
-					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Shutoff reason Destroyed","name":"%s"`, vmi.GetObjectMeta().GetName()), // Domain was destroyed because the launcher pod is gone
-				), "Logs should confirm pod deletion")
-			},
-				Entry("[test_id:1641]"+util.NamespaceTestDefault, &util.NamespaceTestDefault),
-				Entry("[test_id:1642]"+tests.NamespaceTestAlternative, &tests.NamespaceTestAlternative),
-			)
-		})
-
-		Context("VirtualMachineInstance Emulation Mode", func() {
-			BeforeEach(func() {
-				// allowEmulation won't change in a test suite run, so cache it
-				if allowEmulation == nil {
-					emulation := tests.ShouldAllowEmulation(virtClient)
-					allowEmulation = &emulation
-				}
-				if !(*allowEmulation) {
-					Skip("Software emulation is not enabled on this cluster")
-				}
-			})
-
-			It("[test_id:1643]should enable emulation in virt-launcher", func() {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(pod).NotTo(BeNil())
-
-				emulationFlagFound := false
-				computeContainerFound := false
-				for _, container := range pod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainerFound = true
-						for _, cmd := range container.Command {
-							By(cmd)
-							if cmd == "--allow-emulation" {
-								emulationFlagFound = true
-							}
-						}
-					}
-				}
-
-				Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
-				Expect(emulationFlagFound).To(BeTrue(), "Expected VirtualMachineInstance pod to have '--allow-emulation' flag")
-			})
-
-			It("[test_id:1644]should be reflected in domain XML", func() {
-				err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()
-				Expect(err).To(BeNil(), "Should post the VMI")
-
-				listOptions := metav1.ListOptions{}
-
-				Eventually(func() int {
-					podList, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), listOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should list the pods")
-					return len(podList.Items)
-				}, 75, 0.5).Should(Equal(1), "There should be only one pod")
-
-				Eventually(func() error {
-					podList, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), listOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should list the pods")
-					for _, item := range podList.Items {
-						if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
-							return nil
-						}
-					}
-					return fmt.Errorf("Associated pod for VirtualMachineInstance '%s' not found", vmi.Name)
-				}, 75, 0.5).Should(Succeed(), "Should find the VMI pod")
-
-				getOptions := metav1.GetOptions{}
-				var newVMI *v1.VirtualMachineInstance
-
-				newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-
-				domain := &api.Domain{}
-				context := &converter.ConverterContext{
-					VirtualMachine: newVMI,
-					AllowEmulation: true,
-				}
-				converter.Convert_v1_VirtualMachineInstance_To_api_Domain(newVMI, domain, context)
-
-				expectedType := ""
-				if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
-					expectedType = "qemu"
-				}
-
-				Expect(domain.Spec.Type).To(Equal(expectedType), "VMI domain type should be of expectedType")
-			})
-
-			It("[test_id:1645]should request a TUN device but not KVM", func() {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(pod).NotTo(BeNil())
-
-				computeContainerFound := false
-				for _, container := range pod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainerFound = true
-
-						_, ok := container.Resources.Limits[services.KvmDevice]
-						Expect(ok).To(BeFalse(), "Container should not have requested KVM device")
-
-						_, ok = container.Resources.Limits[services.TunDevice]
-						Expect(ok).To(BeTrue(), "Container should have requested TUN device")
-					}
-				}
-
-				Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
-			})
-		})
-
-		Context("VM Accelerated Mode", func() {
-			BeforeEach(func() {
-				// allowEmulation won't change in a test suite run, so cache it
-				if allowEmulation == nil {
-					emulation := tests.ShouldAllowEmulation(virtClient)
-					allowEmulation = &emulation
-				}
-				if *allowEmulation {
-					Skip("Software emulation is enabled on this cluster")
-				}
-			})
-
-			It("[test_id:1646]should request a KVM and TUN device", func() {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(pod).NotTo(BeNil())
-
-				computeContainerFound := false
-				for _, container := range pod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainerFound = true
-
-						_, ok := container.Resources.Limits[services.KvmDevice]
-						Expect(ok).To(BeTrue(), "Container should have requested KVM device")
-
-						_, ok = container.Resources.Limits[services.TunDevice]
-						Expect(ok).To(BeTrue(), "Container should have requested TUN device")
-					}
-				}
-
-				Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
-			})
-
-			It("[test_id:1647]should not enable emulation in virt-launcher", func() {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(pod).NotTo(BeNil())
-
-				emulationFlagFound := false
-				computeContainerFound := false
-				for _, container := range pod.Spec.Containers {
-					if container.Name == "compute" {
-						computeContainerFound = true
-						for _, cmd := range container.Command {
-							By(cmd)
-							if cmd == "--allow-emulation" {
-								emulationFlagFound = true
-							}
-						}
-					}
-				}
-
-				Expect(computeContainerFound).To(BeTrue(), "Compute container was not found in pod")
-				Expect(emulationFlagFound).To(BeFalse(), "Expected VM pod not to have '--allow-emulation' flag")
-			})
-
-			It("[test_id:1648]Should provide KVM via plugin framework", func() {
-				nodeList := util.GetAllSchedulableNodes(virtClient)
-
-				if len(nodeList.Items) == 0 {
-					Skip("There are no compute nodes in cluster")
-				}
-				node := nodeList.Items[0]
-
-				_, ok := node.Status.Allocatable[services.KvmDevice]
-				Expect(ok).To(BeTrue(), "KVM devices not allocatable on node: %s", node.Name)
-
-				_, ok = node.Status.Capacity[services.KvmDevice]
-				Expect(ok).To(BeTrue(), "No Capacity for KVM devices on node: %s", node.Name)
-			})
-		})
-	})
-
-	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Get a VirtualMachineInstance", func() {
-		Context("when that not exist", func() {
-			It("[test_id:1649]should return 404", func() {
-				b, err := virtClient.RestClient().Get().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Name("nonexistnt").DoRaw(context.Background())
-				Expect(err).ToNot(BeNil(), "Should get VMIs")
-				status := metav1.Status{}
-				err = json.Unmarshal(b, &status)
-				Expect(err).To(BeNil(), "Unmarshal without error")
-				Expect(status.Code).To(Equal(int32(http.StatusNotFound)), "There should not be and VMI")
-			})
-		})
-	})
-
-	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance's Pod", func() {
-		It("[test_id:1650]should result in the VirtualMachineInstance moving to a finalized state", func() {
-			By("Creating the VirtualMachineInstance")
-			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-			tests.WaitForSuccessfulVMIStart(obj)
-
-			By("Verifying VirtualMachineInstance's pod is active")
-			pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
-			Expect(err).ToNot(HaveOccurred(), "Should list pods")
-			Expect(pods.Items).To(HaveLen(1), "There should be only one pod")
-			pod := pods.Items[0]
-
-			// Delete the Pod
-			By("Deleting the VirtualMachineInstance's pod")
-			Eventually(func() error {
-				return virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
-			}, 10*time.Second, 1*time.Second).Should(Succeed(), "Should delete VMI pod")
-
-			// Wait for VirtualMachineInstance to finalize
-			By("Waiting for the VirtualMachineInstance to move to a finalized state")
-			Eventually(func() error {
-				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-				if err != nil {
-					return err
-				} else if !curVMI.IsFinal() {
-					return fmt.Errorf("VirtualMachineInstance has not reached a finalized state yet")
-				}
-				return nil
-			}, 60*time.Second, 1*time.Second).Should(Succeed(), "VMI reached finalized state")
-		})
-	})
-	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance", func() {
-		Context("with an active pod.", func() {
-			It("[test_id:1651]should result in pod being terminated", func() {
-
-				By("Creating the VirtualMachineInstance")
-				obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(obj)
-
-				podSelector := tests.UnfinishedVMIPodSelector(vmi)
-				By("Verifying VirtualMachineInstance's pod is active")
-				pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), podSelector)
-				Expect(err).ToNot(HaveOccurred(), "Should list pods")
-				Expect(pods.Items).To(HaveLen(1), "There should be only one pod")
-
-				By("Deleting the VirtualMachineInstance")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")
-
-				By("Verifying VirtualMachineInstance's pod terminates")
-				Eventually(func() int {
-					pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), podSelector)
+					By("Verifying VirtualMachineInstance's pod is active")
+					pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), tests.UnfinishedVMIPodSelector(vmi))
 					Expect(err).ToNot(HaveOccurred(), "Should list pods")
-					return len(pods.Items)
-				}, 75, 0.5).Should(Equal(0), "There should be no pods")
+					Expect(pods.Items).To(HaveLen(1), "There should be only one pod")
+					pod := pods.Items[0]
 
+					// Delete the Pod
+					By("Deleting the VirtualMachineInstance's pod")
+					Eventually(func() error {
+						return virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+					}, 10*time.Second, 1*time.Second).Should(Succeed(), "Should delete VMI pod")
+
+					// Wait for VirtualMachineInstance to finalize
+					By("Waiting for the VirtualMachineInstance to move to a finalized state")
+					Eventually(func() error {
+						curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+						if err != nil {
+							return err
+						} else if !curVMI.IsFinal() {
+							return fmt.Errorf("VirtualMachineInstance has not reached a finalized state yet")
+						}
+						return nil
+					}, 60*time.Second, 1*time.Second).Should(Succeed(), "VMI reached finalized state")
+				})
 			})
-		})
-		Context("with ACPI and some grace period seconds", func() {
-			DescribeTable("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]should result in vmi status succeeded", func(gracePeriod int64) {
-				vmi = newCirrosVMI()
+		Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance",
+			Label("rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+			func() {
+				Context("with an active pod.", func() {
+					It("[test_id:1651]should result in pod being terminated", Label("test_id:1651"), func() {
 
-				if gracePeriod >= 0 {
-					vmi.Spec.TerminationGracePeriodSeconds = &gracePeriod
-				} else {
-					gracePeriod = v1.DefaultGracePeriodSeconds
-					vmi.Spec.TerminationGracePeriodSeconds = nil
-				}
+						By("Creating the VirtualMachineInstance")
+						obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(obj)
 
-				By("Creating the VirtualMachineInstance")
-				obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						podSelector := tests.UnfinishedVMIPodSelector(vmi)
+						By("Verifying VirtualMachineInstance's pod is active")
+						pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), podSelector)
+						Expect(err).ToNot(HaveOccurred(), "Should list pods")
+						Expect(pods.Items).To(HaveLen(1), "There should be only one pod")
 
-				// wait until booted
-				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+						By("Deleting the VirtualMachineInstance")
+						Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")
 
-				By("Deleting the VirtualMachineInstance")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")
+						By("Verifying VirtualMachineInstance's pod terminates")
+						Eventually(func() int {
+							pods, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).List(context.Background(), podSelector)
+							Expect(err).ToNot(HaveOccurred(), "Should list pods")
+							return len(pods.Items)
+						}, 75, 0.5).Should(Equal(0), "There should be no pods")
 
-				By("Verifying VirtualMachineInstance's status is Succeeded")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					currVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					return currVMI.Status.Phase
-				}, gracePeriod+5, 0.5).Should(Equal(v1.Succeeded), "VMI should be succeeded")
-			},
-				Entry("[test_id:1653]with set grace period seconds", int64(10)),
-				Entry("[test_id:1654]with default grace period seconds", int64(-1)),
-			)
-		})
-		Context("with grace period greater than 0", func() {
-			It("[test_id:1655]should run graceful shutdown", func() {
-				nodes := util.GetAllSchedulableNodes(virtClient)
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				node := nodes.Items[0].Name
+					})
+				})
+				Context("with ACPI and some grace period seconds", func() {
+					DescribeTable("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]should result in vmi status succeeded",
+						Label("rfe_id:273", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
+						func(gracePeriod int64) {
+							vmi = newCirrosVMI()
 
-				virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
-				Expect(err).ToNot(HaveOccurred(), "Should get virthandler for node")
+							if gracePeriod >= 0 {
+								vmi.Spec.TerminationGracePeriodSeconds = &gracePeriod
+							} else {
+								gracePeriod = v1.DefaultGracePeriodSeconds
+								vmi.Spec.TerminationGracePeriodSeconds = nil
+							}
 
-				handlerName := virtHandlerPod.GetObjectMeta().GetName()
-				handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
-				seconds := int64(120)
-				logsQuery := virtClient.CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
+							By("Creating the VirtualMachineInstance")
+							obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+							Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
-				By("Setting a VirtualMachineInstance termination grace period to 5")
-				var gracePeriod int64
-				gracePeriod = int64(5)
-				// Give the VirtualMachineInstance a custom grace period
-				vmi.Spec.TerminationGracePeriodSeconds = &gracePeriod
-				// Make sure we schedule the VirtualMachineInstance to master
-				vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
+							// wait until booted
+							vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
-				By("Creating the VirtualMachineInstance")
-				obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-				tests.WaitForSuccessfulVMIStart(obj)
+							By("Deleting the VirtualMachineInstance")
+							Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")
 
-				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
-				By("Deleting the VirtualMachineInstance")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				event := tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().Timeout(75*time.Second).WaitFor(ctx, tests.NormalEvent, v1.Deleted)
-				Expect(event).ToNot(BeNil(), "There should be a delete event")
+							By("Verifying VirtualMachineInstance's status is Succeeded")
+							Eventually(func() v1.VirtualMachineInstancePhase {
+								currVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+								Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+								return currVMI.Status.Phase
+							}, gracePeriod+5, 0.5).Should(Equal(v1.Succeeded), "VMI should be succeeded")
+						},
+						Entry("[test_id:1653]with set grace period seconds", Label("test_id:1653"), int64(10)),
+						Entry("[test_id:1654]with default grace period seconds", Label("test_id:1654"), int64(-1)),
+					)
+				})
+				Context("with grace period greater than 0", func() {
+					It("[test_id:1655]should run graceful shutdown", Label("test_id:1655"), func() {
+						nodes := util.GetAllSchedulableNodes(virtClient)
+						Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+						node := nodes.Items[0].Name
 
-				// Check if the graceful shutdown was logged
-				By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")
-				Eventually(func() string {
-					data, err := logsQuery.DoRaw(context.Background())
-					Expect(err).ToNot(HaveOccurred(), "Should get the logs")
-					return string(data)
-				}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("Signaled graceful shutdown for %s", vmi.GetObjectMeta().GetName())), "Should log graceful shutdown")
+						virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
+						Expect(err).ToNot(HaveOccurred(), "Should get virthandler for node")
 
-				// Verify VirtualMachineInstance is killed after grace period expires
-				By("Checking that the VirtualMachineInstance does not exist after grace period")
-				Eventually(func() string {
-					data, err := logsQuery.DoRaw(context.Background())
-					Expect(err).ToNot(HaveOccurred(), "Should get logs")
-					return string(data)
-				}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())), "Should log graceful kill")
+						handlerName := virtHandlerPod.GetObjectMeta().GetName()
+						handlerNamespace := virtHandlerPod.GetObjectMeta().GetNamespace()
+						seconds := int64(120)
+						logsQuery := virtClient.CoreV1().Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds, Container: "virt-handler"})
+
+						By("Setting a VirtualMachineInstance termination grace period to 5")
+						var gracePeriod int64
+						gracePeriod = int64(5)
+						// Give the VirtualMachineInstance a custom grace period
+						vmi.Spec.TerminationGracePeriodSeconds = &gracePeriod
+						// Make sure we schedule the VirtualMachineInstance to master
+						vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
+
+						By("Creating the VirtualMachineInstance")
+						obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+						Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+						tests.WaitForSuccessfulVMIStart(obj)
+
+						// Delete the VirtualMachineInstance and wait for the confirmation of the delete
+						By("Deleting the VirtualMachineInstance")
+						Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
+						ctx, cancel := context.WithCancel(context.Background())
+						defer cancel()
+						event := tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().Timeout(75*time.Second).WaitFor(ctx, tests.NormalEvent, v1.Deleted)
+						Expect(event).ToNot(BeNil(), "There should be a delete event")
+
+						// Check if the graceful shutdown was logged
+						By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")
+						Eventually(func() string {
+							data, err := logsQuery.DoRaw(context.Background())
+							Expect(err).ToNot(HaveOccurred(), "Should get the logs")
+							return string(data)
+						}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("Signaled graceful shutdown for %s", vmi.GetObjectMeta().GetName())), "Should log graceful shutdown")
+
+						// Verify VirtualMachineInstance is killed after grace period expires
+						By("Checking that the VirtualMachineInstance does not exist after grace period")
+						Eventually(func() string {
+							data, err := logsQuery.DoRaw(context.Background())
+							Expect(err).ToNot(HaveOccurred(), "Should get logs")
+							return string(data)
+						}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("Grace period expired, killing deleted VirtualMachineInstance %s", vmi.GetObjectMeta().GetName())), "Should log graceful kill")
+					})
+				})
 			})
-		})
+
+		Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance",
+			Label("Serial", "rfe_id:273", "crit:high", "vendor:cnv-qe@redhat.com", "level:component"),
+			func() {
+				It("[test_id:1656]should be in Failed phase", Label("test_id:1656"), func() {
+					By("Starting a VirtualMachineInstance")
+					obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Should create VMI")
+
+					nodeName := tests.WaitForSuccessfulVMIStart(obj).Status.NodeName
+
+					By("Killing the VirtualMachineInstance")
+					time.Sleep(10 * time.Second)
+					err = pkillAllVMIs(virtClient, nodeName)
+					Expect(err).To(BeNil(), "Should deploy helper pod to kill VMI")
+
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					tests.NewObjectEventWatcher(obj).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, v1.Stopped)
+
+					By("Checking that the VirtualMachineInstance has 'Failed' phase")
+					Eventually(func() v1.VirtualMachineInstancePhase {
+						failedVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+						return failedVMI.Status.Phase
+					}, 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
+
+				})
+
+				It("[test_id:1657]should be left alone by virt-handler", Label("test_id:1657"), func() {
+					By("Starting a VirtualMachineInstance")
+					obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+					Expect(err).To(BeNil(), "Should create VMI")
+
+					nodeName := tests.WaitForSuccessfulVMIStart(obj).Status.NodeName
+
+					By("Killing the VirtualMachineInstance")
+					err = pkillAllVMIs(virtClient, nodeName)
+					Expect(err).To(BeNil(), "Should create kill pod to kill all VMs")
+
+					// Wait for stop event of the VirtualMachineInstance
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					tests.NewObjectEventWatcher(obj).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, v1.Stopped)
+
+					// Wait for some time and see if a sync event happens on the stopped VirtualMachineInstance
+					By("Checking that virt-handler does not try to sync stopped VirtualMachineInstance")
+					event := tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().Timeout(10*time.Second).WaitNotFor(ctx, tests.WarningEvent, v1.SyncFailed)
+					Expect(event).To(BeNil(), "virt-handler tried to sync on a VirtualMachineInstance in final state")
+				})
+			})
 	})
-
-	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", func() {
-		It("[test_id:1656]should be in Failed phase", func() {
-			By("Starting a VirtualMachineInstance")
-			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Should create VMI")
-
-			nodeName := tests.WaitForSuccessfulVMIStart(obj).Status.NodeName
-
-			By("Killing the VirtualMachineInstance")
-			time.Sleep(10 * time.Second)
-			err = pkillAllVMIs(virtClient, nodeName)
-			Expect(err).To(BeNil(), "Should deploy helper pod to kill VMI")
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			tests.NewObjectEventWatcher(obj).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, v1.Stopped)
-
-			By("Checking that the VirtualMachineInstance has 'Failed' phase")
-			Eventually(func() v1.VirtualMachineInstancePhase {
-				failedVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				return failedVMI.Status.Phase
-			}, 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
-
-		})
-
-		It("[test_id:1657]should be left alone by virt-handler", func() {
-			By("Starting a VirtualMachineInstance")
-			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil(), "Should create VMI")
-
-			nodeName := tests.WaitForSuccessfulVMIStart(obj).Status.NodeName
-
-			By("Killing the VirtualMachineInstance")
-			err = pkillAllVMIs(virtClient, nodeName)
-			Expect(err).To(BeNil(), "Should create kill pod to kill all VMs")
-
-			// Wait for stop event of the VirtualMachineInstance
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			tests.NewObjectEventWatcher(obj).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, tests.WarningEvent, v1.Stopped)
-
-			// Wait for some time and see if a sync event happens on the stopped VirtualMachineInstance
-			By("Checking that virt-handler does not try to sync stopped VirtualMachineInstance")
-			event := tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().Timeout(10*time.Second).WaitNotFor(ctx, tests.WarningEvent, v1.SyncFailed)
-			Expect(event).To(BeNil(), "virt-handler tried to sync on a VirtualMachineInstance in final state")
-		})
-	})
-})
 
 func renderPkillAllPod(processName string) *k8sv1.Pod {
 	return tests.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", processName})

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[sig-compute]Health Monitoring", func() {
+var _ = Describe("[sig-compute]Health Monitoring", Labels{"sig-compute"}, func() {
 
 	var virtClient kubecli.KubevirtClient
 
@@ -47,7 +47,7 @@ var _ = Describe("[sig-compute]Health Monitoring", func() {
 	})
 
 	Describe("A VirtualMachineInstance with a watchdog device", func() {
-		It("[test_id:4641]should be shut down when the watchdog expires", func() {
+		It("[test_id:4641]should be shut down when the watchdog expires", Labels{"test_id:4641"}, func() {
 			vmi := tests.NewRandomVMIWithWatchdog()
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil())

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[sig-compute]Health Monitoring", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]Health Monitoring", Label("sig-compute"), func() {
 
 	var virtClient kubecli.KubevirtClient
 
@@ -47,7 +47,7 @@ var _ = Describe("[sig-compute]Health Monitoring", Labels{"sig-compute"}, func()
 	})
 
 	Describe("A VirtualMachineInstance with a watchdog device", func() {
-		It("[test_id:4641]should be shut down when the watchdog expires", Labels{"test_id:4641"}, func() {
+		It("[test_id:4641]should be shut down when the watchdog expires", Label("test_id:4641"), func() {
 			vmi := tests.NewRandomVMIWithWatchdog()
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil())

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[sig-compute]MultiQueue", Labels{"sig-compute"}, func() {
+var _ = Describe("[sig-compute]MultiQueue", Label("sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -59,7 +59,7 @@ var _ = Describe("[sig-compute]MultiQueue", Labels{"sig-compute"}, func() {
 			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
-		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", Labels{"test_id:4599"}, func() {
+		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", Label("test_id:4599"), func() {
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			numCpus := 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
@@ -80,7 +80,7 @@ var _ = Describe("[sig-compute]MultiQueue", Labels{"sig-compute"}, func() {
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 		})
 
-		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", Labels{"test_id:959", "rfe_id:2065"}, func() {
+		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", Label("test_id:959", "rfe_id:2065"), func() {
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			numCpus := 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[sig-compute]MultiQueue", func() {
+var _ = Describe("[sig-compute]MultiQueue", Labels{"sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -59,7 +59,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
-		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", func() {
+		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", Labels{"test_id:4599"}, func() {
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			numCpus := 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
@@ -80,7 +80,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 		})
 
-		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {
+		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", Labels{"test_id:959", "rfe_id:2065"}, func() {
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			numCpus := 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Sound",
-	Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error
@@ -52,7 +52,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with default sound support",
-			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					vmi, err = createSoundVMI(virtClient, "test-model-empty")
@@ -66,7 +66,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			})
 
 		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ich9 sound support",
-			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					vmi, err = createSoundVMI(virtClient, "ich9")
@@ -81,7 +81,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			})
 
 		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ac97 sound support",
-			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					vmi, err = createSoundVMI(virtClient, "ac97")
@@ -96,7 +96,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			})
 
 		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with unsupported sound support",
-			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				It("should fail to create VMI with unsupported sound device", func() {
 					vmi, err = createSoundVMI(virtClient, "ich7")

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -36,64 +36,74 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Sound", func() {
+var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Sound",
+	Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
-	var vmi *v1.VirtualMachineInstance
+		var err error
+		var virtClient kubecli.KubevirtClient
+		var vmi *v1.VirtualMachineInstance
 
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-	})
-
-	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with default sound support", func() {
 		BeforeEach(func() {
-			vmi, err = createSoundVMI(virtClient, "test-model-empty")
-			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
+
+			tests.BeforeTestCleanup()
 		})
 
-		It("should create an ich9 sound device on empty model", func() {
-			checkAudioDevice(vmi, "ich9")
-		})
+		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with default sound support",
+			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				BeforeEach(func() {
+					vmi, err = createSoundVMI(virtClient, "test-model-empty")
+					Expect(err).To(BeNil())
+					vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				})
+
+				It("should create an ich9 sound device on empty model", func() {
+					checkAudioDevice(vmi, "ich9")
+				})
+			})
+
+		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ich9 sound support",
+			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				BeforeEach(func() {
+					vmi, err = createSoundVMI(virtClient, "ich9")
+					Expect(err).To(BeNil())
+					vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				})
+
+				It("should create ich9 sound device on ich9 model ", func() {
+					checkXMLSoundCard(virtClient, vmi, "ich9")
+					checkAudioDevice(vmi, "ich9")
+				})
+			})
+
+		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ac97 sound support",
+			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				BeforeEach(func() {
+					vmi, err = createSoundVMI(virtClient, "ac97")
+					Expect(err).To(BeNil())
+					vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				})
+
+				It("should create ac97 sound device on ac97 model", func() {
+					checkXMLSoundCard(virtClient, vmi, "ac97")
+					checkAudioDevice(vmi, "ac97")
+				})
+			})
+
+		Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with unsupported sound support",
+			Labels{"crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			func() {
+				It("should fail to create VMI with unsupported sound device", func() {
+					vmi, err = createSoundVMI(virtClient, "ich7")
+					Expect(err).To(HaveOccurred())
+				})
+			})
 	})
-
-	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ich9 sound support", func() {
-		BeforeEach(func() {
-			vmi, err = createSoundVMI(virtClient, "ich9")
-			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-		})
-
-		It("should create ich9 sound device on ich9 model ", func() {
-			checkXMLSoundCard(virtClient, vmi, "ich9")
-			checkAudioDevice(vmi, "ich9")
-		})
-	})
-
-	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with ac97 sound support", func() {
-		BeforeEach(func() {
-			vmi, err = createSoundVMI(virtClient, "ac97")
-			Expect(err).To(BeNil())
-			vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
-		})
-
-		It("should create ac97 sound device on ac97 model", func() {
-			checkXMLSoundCard(virtClient, vmi, "ac97")
-			checkAudioDevice(vmi, "ac97")
-		})
-	})
-
-	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with unsupported sound support", func() {
-		It("should fail to create VMI with unsupported sound device", func() {
-			vmi, err = createSoundVMI(virtClient, "ich7")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-})
 
 func createSoundVMI(virtClient kubecli.KubevirtClient, soundDevice string) (*v1.VirtualMachineInstance, error) {
 	randomVmi := libvmi.NewCirros()

--- a/tests/vmi_tpm_test.go
+++ b/tests/vmi_tpm_test.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[sig-compute]vTPM", func() {
+var _ = Describe("[sig-compute]vTPM", Label("sig-compute"), func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]VMIDefaults", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -76,7 +76,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compu
 			}
 		})
 
-		It("[test_id:4115]Should be applied to VMIs", Labels{"test_id:4115"}, func() {
+		It("[test_id:4115]Should be applied to VMIs", Label("test_id:4115"), func() {
 			// create the VMI first
 			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -108,7 +108,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compu
 			tests.UpdateKubeVirtConfigValueAndWait(kvConfiguration)
 		})
 
-		It("[test_id:4556]Should be present in domain", Labels{"test_id:4556"}, func() {
+		It("[test_id:4556]Should be present in domain", Label("test_id:4556"), func() {
 			By("Creating a virtual machine")
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -157,7 +157,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compu
 			Expect(domain.Devices.Ballooning).ToNot(BeNil(), "There should be memballoon device")
 			Expect(*domain.Devices.Ballooning).To(Equal(expected))
 		},
-			Entry("[test_id:4557]with period 12", Labels{"test_id:4557"}, uint32(12), api.MemBalloon{
+			Entry("[test_id:4557]with period 12", Label("test_id:4557"), uint32(12), api.MemBalloon{
 				Model: "virtio-non-transitional",
 				Stats: &api.Stats{
 					Period: 12,
@@ -170,7 +170,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compu
 					Function: "0x0",
 				},
 			}),
-			Entry("[test_id:4558]with period 0", Labels{"test_id:4558"}, uint32(0), api.MemBalloon{
+			Entry("[test_id:4558]with period 0", Label("test_id:4558"), uint32(0), api.MemBalloon{
 				Model: "virtio-non-transitional",
 				Address: &api.Address{
 					Type:     "pci",
@@ -182,7 +182,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compu
 			}),
 		)
 
-		It("[test_id:4559]Should not be present in domain ", Labels{"test_id:4559"}, func() {
+		It("[test_id:4559]Should not be present in domain ", Label("test_id:4559"), func() {
 			By("Creating a virtual machine with autoAttachmemballoon set to false")
 			f := false
 			vmi.Spec.Domain.Devices.AutoattachMemBalloon = &f

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
+var _ = Describe("[Serial][sig-compute]VMIDefaults", Labels{"Serial", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -76,7 +76,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 			}
 		})
 
-		It("[test_id:4115]Should be applied to VMIs", func() {
+		It("[test_id:4115]Should be applied to VMIs", Labels{"test_id:4115"}, func() {
 			// create the VMI first
 			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -108,7 +108,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(kvConfiguration)
 		})
 
-		It("[test_id:4556]Should be present in domain", func() {
+		It("[test_id:4556]Should be present in domain", Labels{"test_id:4556"}, func() {
 			By("Creating a virtual machine")
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -157,7 +157,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 			Expect(domain.Devices.Ballooning).ToNot(BeNil(), "There should be memballoon device")
 			Expect(*domain.Devices.Ballooning).To(Equal(expected))
 		},
-			Entry("[test_id:4557]with period 12", uint32(12), api.MemBalloon{
+			Entry("[test_id:4557]with period 12", Labels{"test_id:4557"}, uint32(12), api.MemBalloon{
 				Model: "virtio-non-transitional",
 				Stats: &api.Stats{
 					Period: 12,
@@ -170,7 +170,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 					Function: "0x0",
 				},
 			}),
-			Entry("[test_id:4558]with period 0", uint32(0), api.MemBalloon{
+			Entry("[test_id:4558]with period 0", Labels{"test_id:4558"}, uint32(0), api.MemBalloon{
 				Model: "virtio-non-transitional",
 				Address: &api.Address{
 					Type:     "pci",
@@ -182,7 +182,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 			}),
 		)
 
-		It("[test_id:4559]Should not be present in domain ", func() {
+		It("[test_id:4559]Should not be present in domain ", Labels{"test_id:4559"}, func() {
 			By("Creating a virtual machine with autoAttachmemballoon set to false")
 			f := false
 			vmi.Spec.Domain.Devices.AutoattachMemBalloon = &f

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIPreset",
-	Labels{"rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 		var err error
 		var virtClient kubecli.KubevirtClient
@@ -96,7 +96,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		Context("CRD Validation", func() {
-			It("[test_id:1595]Should reject POST if schema is invalid", Labels{"test_id:1595"}, func() {
+			It("[test_id:1595]Should reject POST if schema is invalid", Label("test_id:1595"), func() {
 				// Preset with missing selector should fail CRD validation
 				jsonString := fmt.Sprintf("{\"kind\":\"VirtualMachineInstancePreset\",\"apiVersion\":\"%s\",\"metadata\":{\"generateName\":\"test-memory-\",\"creationTimestamp\":null},\"spec\":{}}", v1.StorageGroupVersion.String())
 
@@ -108,7 +108,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 			})
 
-			It("[test_id:1596]should reject POST if validation webhoook deems the spec is invalid", Labels{"test_id:1596"}, func() {
+			It("[test_id:1596]should reject POST if validation webhoook deems the spec is invalid", Label("test_id:1596"), func() {
 				preset := &v1.VirtualMachineInstancePreset{
 					ObjectMeta: k8smetav1.ObjectMeta{GenerateName: "fake"},
 					Spec: v1.VirtualMachineInstancePresetSpec{
@@ -141,12 +141,12 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		Context("Preset Matching", func() {
-			It("[test_id:1597]Should be accepted on POST", Labels{"test_id:1597"}, func() {
+			It("[test_id:1597]Should be accepted on POST", Label("test_id:1597"), func() {
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 				Expect(err).To(BeNil())
 			})
 
-			It("[test_id:1598]Should reject a second submission of a VMIPreset", Labels{"test_id:1598"}, func() {
+			It("[test_id:1598]Should reject a second submission of a VMIPreset", Label("test_id:1598"), func() {
 				// This test requires an explicit name or the resources won't conflict
 				presetName := "test-preset"
 				memoryPreset.Name = presetName
@@ -160,7 +160,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:1599]Should return 404 if VMIPreset does not exist", Labels{"test_id:1599"}, func() {
+			It("[test_id:1599]Should return 404 if VMIPreset does not exist", Label("test_id:1599"), func() {
 				b, err := virtClient.RestClient().Get().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name("wrong").DoRaw(context.Background())
 				Expect(err).To(HaveOccurred())
 				status := k8smetav1.Status{}
@@ -169,7 +169,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(status.Code).To(Equal(int32(http.StatusNotFound)))
 			})
 
-			It("[test_id:1600]Should reject presets that conflict with VirtualMachineInstance settings", Labels{"test_id:1600"}, func() {
+			It("[test_id:1600]Should reject presets that conflict with VirtualMachineInstance settings", Label("test_id:1600"), func() {
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -192,7 +192,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(found).To(BeFalse())
 			})
 
-			It("[test_id:1601]Should accept presets that don't conflict with VirtualMachineInstance settings", Labels{"test_id:1601"}, func() {
+			It("[test_id:1601]Should accept presets that don't conflict with VirtualMachineInstance settings", Label("test_id:1601"), func() {
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -220,7 +220,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(int(newVMI.Spec.Domain.CPU.Cores)).To(Equal(cores))
 			})
 
-			It("[test_id:1602]Should ignore VMIs that don't match", Labels{"test_id:1602"}, func() {
+			It("[test_id:1602]Should ignore VMIs that don't match", Label("test_id:1602"), func() {
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -245,7 +245,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(newVMI.Status.Phase).ToNot(Equal(v1.Failed))
 			})
 
-			It("[test_id:1603]Should not be applied to existing VMIs", Labels{"test_id:1603"}, func() {
+			It("[test_id:1603]Should not be applied to existing VMIs", Label("test_id:1603"), func() {
 				// create the VirtualMachineInstance first
 				newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -269,7 +269,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		Context("Exclusions", func() {
-			It("[test_id:1604]Should not apply presets to VirtualMachineInstance's with the exclusion marking", Labels{"test_id:1604"}, func() {
+			It("[test_id:1604]Should not apply presets to VirtualMachineInstance's with the exclusion marking", Label("test_id:1604"), func() {
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -321,7 +321,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				}
 			})
 
-			It("[test_id:1605]should denied to start the VMI", Labels{"test_id:1605"}, func() {
+			It("[test_id:1605]should denied to start the VMI", Label("test_id:1605"), func() {
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(conflictPreset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -362,7 +362,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				}
 			})
 
-			It("[test_id:644][rfe_id:609] should override presets", Labels{"test_id:644", "rfe_id:609"}, func() {
+			It("[test_id:644][rfe_id:609] should override presets", Label("test_id:644", "rfe_id:609"), func() {
 				By("Creating preset with 64M")
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(overridePreset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
@@ -419,7 +419,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				}
 			})
 
-			It("[test_id:617][rfe_id:609] should create and delete preset", Labels{"test_id:617", "rfe_id:609"}, func() {
+			It("[test_id:617][rfe_id:609] should create and delete preset", Label("test_id:617", "rfe_id:609"), func() {
 				By("Creating preset")
 				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background()).Error()
 				Expect(err).ToNot(HaveOccurred())
@@ -478,7 +478,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				vmiWin10.Labels = map[string]string{labelKey: win10Label}
 			})
 
-			It("[test_id:726] Should match multiple VMs via MatchExpression", Labels{"test_id:726"}, func() {
+			It("[test_id:726] Should match multiple VMs via MatchExpression", Label("test_id:726"), func() {
 				By("Creating preset with MatchExpression")
 				_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
 				Expect(err).ToNot(HaveOccurred())
@@ -500,7 +500,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 		})
 
-		Context("[rfe_id:613]MatchLabels", Labels{"rfe_id:613"}, func() {
+		Context("[rfe_id:613]MatchLabels", Label("rfe_id:613"), func() {
 			var preset *v1.VirtualMachineInstancePreset
 			labelKey := "kubevirt.io/cpu"
 			labelValue := "dodecacore"
@@ -540,7 +540,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				annotationVal = v1.GroupVersion.String()
 			})
 
-			It("[test_id:672] Should match multiple VMs via MatchLabel", Labels{"test_id:672"}, func() {
+			It("[test_id:672] Should match multiple VMs via MatchLabel", Label("test_id:672"), func() {
 				By("Creating preset with MatchExpression")
 				_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -44,418 +44,35 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIPreset", func() {
-	var err error
-	var virtClient kubecli.KubevirtClient
+var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VMIPreset",
+	Labels{"rfe_id:609", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	func() {
+		var err error
+		var virtClient kubecli.KubevirtClient
 
-	var vmi *v1.VirtualMachineInstance
-	var memoryPreset *v1.VirtualMachineInstancePreset
-	var cpuPreset *v1.VirtualMachineInstancePreset
+		var vmi *v1.VirtualMachineInstance
+		var memoryPreset *v1.VirtualMachineInstancePreset
+		var cpuPreset *v1.VirtualMachineInstancePreset
 
-	flavorKey := fmt.Sprintf("%s/flavor", core.GroupName)
-	memoryFlavor := "memory-test"
-	memoryPrefix := "test-memory-"
-	memory, _ := resource.ParseQuantity("128M")
+		flavorKey := fmt.Sprintf("%s/flavor", core.GroupName)
+		memoryFlavor := "memory-test"
+		memoryPrefix := "test-memory-"
+		memory, _ := resource.ParseQuantity("128M")
 
-	cpuPrefix := "test-cpu"
-	cpuFlavor := "cpu-test"
-	cores := 7
-
-	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
-		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-		vmi.Labels = map[string]string{flavorKey: memoryFlavor}
-
-		selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{flavorKey: memoryFlavor}}
-		memoryPreset = &v1.VirtualMachineInstancePreset{
-			ObjectMeta: k8smetav1.ObjectMeta{GenerateName: memoryPrefix},
-			Spec: v1.VirtualMachineInstancePresetSpec{
-				Selector: selector,
-				Domain: &v1.DomainSpec{
-					Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
-						"memory": memory}},
-				},
-			},
-		}
-
-		selector = k8smetav1.LabelSelector{MatchLabels: map[string]string{flavorKey: cpuFlavor}}
-		cpuPreset = &v1.VirtualMachineInstancePreset{
-			ObjectMeta: k8smetav1.ObjectMeta{GenerateName: cpuPrefix},
-			Spec: v1.VirtualMachineInstancePresetSpec{
-				Selector: selector,
-				Domain: &v1.DomainSpec{
-					CPU: &v1.CPU{Cores: uint32(cores)},
-				},
-			},
-		}
-	})
-
-	Context("CRD Validation", func() {
-		It("[test_id:1595]Should reject POST if schema is invalid", func() {
-			// Preset with missing selector should fail CRD validation
-			jsonString := fmt.Sprintf("{\"kind\":\"VirtualMachineInstancePreset\",\"apiVersion\":\"%s\",\"metadata\":{\"generateName\":\"test-memory-\",\"creationTimestamp\":null},\"spec\":{}}", v1.StorageGroupVersion.String())
-
-			result := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body([]byte(jsonString)).SetHeader("Content-Type", "application/json").Do(context.Background())
-
-			// Verify validation failed.
-			statusCode := 0
-			result.StatusCode(&statusCode)
-			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
-		})
-
-		It("[test_id:1596]should reject POST if validation webhoook deems the spec is invalid", func() {
-			preset := &v1.VirtualMachineInstancePreset{
-				ObjectMeta: k8smetav1.ObjectMeta{GenerateName: "fake"},
-				Spec: v1.VirtualMachineInstancePresetSpec{
-					Selector: k8smetav1.LabelSelector{MatchLabels: map[string]string{"fake": "fake"}},
-					Domain:   &v1.DomainSpec{},
-				},
-			}
-			// disk with two targets is invalid
-			preset.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name: "testdisk",
-				DiskDevice: v1.DiskDevice{
-					Disk:  &v1.DiskTarget{},
-					CDRom: &v1.CDRomTarget{},
-				},
-			})
-			result := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background())
-			// Verify validation failed.
-			statusCode := 0
-			result.StatusCode(&statusCode)
-			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
-
-			reviewResponse := &k8smetav1.Status{}
-			body, _ := result.Raw()
-			err = json.Unmarshal(body, reviewResponse)
-			Expect(err).To(BeNil())
-
-			Expect(reviewResponse.Details.Causes).To(HaveLen(1))
-			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1]"))
-		})
-	})
-
-	Context("Preset Matching", func() {
-		It("[test_id:1597]Should be accepted on POST", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
-			Expect(err).To(BeNil())
-		})
-
-		It("[test_id:1598]Should reject a second submission of a VMIPreset", func() {
-			// This test requires an explicit name or the resources won't conflict
-			presetName := "test-preset"
-			memoryPreset.Name = presetName
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			b, err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).DoRaw(context.Background())
-			Expect(err).To(HaveOccurred())
-			status := k8smetav1.Status{}
-			err = json.Unmarshal(b, &status)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("[test_id:1599]Should return 404 if VMIPreset does not exist", func() {
-			b, err := virtClient.RestClient().Get().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name("wrong").DoRaw(context.Background())
-			Expect(err).To(HaveOccurred())
-			status := k8smetav1.Status{}
-			err = json.Unmarshal(b, &status)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(status.Code).To(Equal(int32(http.StatusNotFound)))
-		})
-
-		It("[test_id:1600]Should reject presets that conflict with VirtualMachineInstance settings", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			newPreset, err := getPreset(virtClient, memoryPrefix)
-			Expect(err).ToNot(HaveOccurred())
-
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			Expect(newVMI.Labels[flavorKey]).To(Equal(memoryFlavor))
-			Expect(newPreset.Spec.Selector.MatchLabels[flavorKey]).To(Equal(memoryFlavor))
-
-			// check the annotations
-			annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
-			_, found := newVMI.Annotations[annotationKey]
-			Expect(found).To(BeFalse())
-		})
-
-		It("[test_id:1601]Should accept presets that don't conflict with VirtualMachineInstance settings", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			newPreset, err := getPreset(virtClient, cpuPrefix)
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi.Labels = map[string]string{flavorKey: cpuFlavor}
-
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			Expect(newVMI.Labels[flavorKey]).To(Equal(cpuFlavor))
-			Expect(newPreset.Spec.Selector.MatchLabels[flavorKey]).To(Equal(cpuFlavor))
-
-			// check the annotations
-			annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
-			Expect(newVMI.Annotations[annotationKey]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
-
-			// check a setting from the preset itself to show it was applied
-			Expect(int(newVMI.Spec.Domain.CPU.Cores)).To(Equal(cores))
-		})
-
-		It("[test_id:1602]Should ignore VMIs that don't match", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			newPreset, err := getPreset(virtClient, memoryPrefix)
-			Expect(err).ToNot(HaveOccurred())
-
-			// reset the label so it will not match
-			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			// check the annotations
-			annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
-			_, found := newVMI.Annotations[annotationKey]
-			Expect(found).To(BeFalse())
-
-			Expect(newVMI.Status.Phase).ToNot(Equal(v1.Failed))
-		})
-
-		It("[test_id:1603]Should not be applied to existing VMIs", func() {
-			// create the VirtualMachineInstance first
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			err = virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			newPreset, err := getPreset(virtClient, memoryPrefix)
-			Expect(err).ToNot(HaveOccurred())
-
-			// check the annotations
-			annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
-			_, found := newVMI.Annotations[annotationKey]
-			Expect(found).To(BeFalse())
-			Expect(newVMI.Status.Phase).ToNot(Equal(v1.Failed))
-		})
-	})
-
-	Context("Exclusions", func() {
-		It("[test_id:1604]Should not apply presets to VirtualMachineInstance's with the exclusion marking", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			newPreset, err := getPreset(virtClient, cpuPrefix)
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi.Labels = map[string]string{flavorKey: cpuFlavor}
-			exclusionMarking := "virtualmachineinstancepresets.admission.kubevirt.io/exclude"
-			vmi.Annotations = map[string]string{exclusionMarking: "true"}
-
-			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			// check the annotations
-			annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
-			_, ok := newVMI.Annotations[annotationKey]
-			Expect(ok).To(BeFalse(), "Preset should not have been applied due to exclusion")
-
-			// check a setting from the preset itself to show it was applied
-			Expect(newVMI.Spec.Domain.CPU.Cores).NotTo(Equal(newPreset.Spec.Domain.CPU.Cores),
-				"CPU should still have been the default value (not defined in spec)")
-		})
-	})
-
-	Context("Conflict", func() {
-		var conflictPreset *v1.VirtualMachineInstancePreset
-
-		conflictKey := fmt.Sprintf("%s/conflict", core.GroupName)
-		conflictFlavor := "conflict-test"
-		conflictMemory, _ := resource.ParseQuantity("256M")
-		conflictPrefix := "test-conflict-"
+		cpuPrefix := "test-cpu"
+		cpuFlavor := "cpu-test"
+		cores := 7
 
 		BeforeEach(func() {
-			selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{conflictKey: conflictFlavor}}
-			conflictPreset = &v1.VirtualMachineInstancePreset{
-				ObjectMeta: k8smetav1.ObjectMeta{GenerateName: conflictPrefix},
-				Spec: v1.VirtualMachineInstancePresetSpec{
-					Selector: selector,
-					Domain: &v1.DomainSpec{
-						Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
-							"memory": conflictMemory}},
-					},
-				},
-			}
-		})
+			virtClient, err = kubecli.GetKubevirtClient()
+			util.PanicOnError(err)
 
-		It("[test_id:1605]should denied to start the VMI", func() {
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(conflictPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			err = virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			vmi.Labels = map[string]string{flavorKey: memoryFlavor, conflictKey: conflictFlavor}
-			By("creating the VirtualMachineInstance")
-			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("Override", func() {
-		var overridePreset *v1.VirtualMachineInstancePreset
-
-		overrideKey := fmt.Sprintf("kubevirt.io/vmPreset")
-		overrideFlavor := "vmi-preset-small"
-		overrideMemory, _ := resource.ParseQuantity("64M")
-		overridePrefix := "test-override-"
-
-		vmiMemory, _ := resource.ParseQuantity("128M")
-
-		BeforeEach(func() {
-			selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{overrideKey: overrideFlavor}}
-			overridePreset = &v1.VirtualMachineInstancePreset{
-				ObjectMeta: k8smetav1.ObjectMeta{GenerateName: overridePrefix},
-				Spec: v1.VirtualMachineInstancePresetSpec{
-					Selector: selector,
-					Domain: &v1.DomainSpec{
-						Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
-							"memory": overrideMemory}},
-					},
-				},
-			}
-		})
-
-		It("[test_id:644][rfe_id:609] should override presets", func() {
-			By("Creating preset with 64M")
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(overridePreset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			By("Creating VMI with 128M")
+			tests.BeforeTestCleanup()
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmi.Labels = map[string]string{overrideKey: overrideFlavor}
-			vmi.Spec.Domain.Resources.Requests["memory"] = vmiMemory
+			vmi.Labels = map[string]string{flavorKey: memoryFlavor}
 
-			newVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Verifying VMI")
-			Expect(newVmi.Annotations).To(BeNil())
-
-			label, ok := vmi.Labels[overrideKey]
-			Expect(ok).To(BeTrue())
-			Expect(label).To(Equal(overrideFlavor))
-			Expect(newVmi.Spec.Domain.Resources.Requests["memory"]).To(Equal(vmiMemory))
-
-			By("Checking event list")
-			evList, err := virtClient.CoreV1().Events(util.NamespaceTestDefault).List(context.Background(), k8smetav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			for _, event := range evList.Items {
-				if event.InvolvedObject.GetObjectKind() == newVmi.GetObjectKind() &&
-					event.InvolvedObject.Name == newVmi.GetName() {
-					Expect(event.Message).ToNot(ContainSubstring("Unable to apply VirtualMachineInstancePreset"))
-				}
-			}
-		})
-	})
-
-	Context("Preset Lifecycle", func() {
-		var preset *v1.VirtualMachineInstancePreset
-		presetNamePrefix := "vmi-preset-small-"
-		selectorKey := "kubevirt.io/vmPreset"
-		selectorLabel := "vmi-preset-small"
-
-		BeforeEach(func() {
-			selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{selectorKey: selectorLabel}}
-			memory, _ := resource.ParseQuantity("64M")
-			preset = &v1.VirtualMachineInstancePreset{
-				ObjectMeta: k8smetav1.ObjectMeta{GenerateName: presetNamePrefix},
-				Spec: v1.VirtualMachineInstancePresetSpec{
-					Selector: selector,
-					Domain: &v1.DomainSpec{
-						Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
-							"memory": memory}},
-					},
-				},
-			}
-		})
-
-		It("[test_id:617][rfe_id:609] should create and delete preset", func() {
-			By("Creating preset")
-			err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Checking that preset was created")
-			newPreset, err := getPreset(virtClient, presetNamePrefix)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Deleting preset")
-			err = virtClient.RestClient().Delete().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name(newPreset.GetName()).Do(context.Background()).Error()
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Checking preset was deleted")
-			waitForPresetDeletion(virtClient, newPreset.GetName())
-		})
-	})
-
-	Context("Match Expressions", func() {
-		var preset *v1.VirtualMachineInstancePreset
-		labelKey := "kubevirt.io/os"
-
-		var vmiWin7 *v1.VirtualMachineInstance
-		var vmiWin10 *v1.VirtualMachineInstance
-		win7Label := "win7"
-		win10Label := "win10"
-
-		BeforeEach(func() {
-			selector := k8smetav1.LabelSelector{
-				MatchExpressions: []k8smetav1.LabelSelectorRequirement{
-					{
-						Key:      labelKey,
-						Operator: k8smetav1.LabelSelectorOpIn,
-						Values:   []string{win10Label, win7Label},
-					},
-				},
-			}
-
-			preset = &v1.VirtualMachineInstancePreset{
+			selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{flavorKey: memoryFlavor}}
+			memoryPreset = &v1.VirtualMachineInstancePreset{
 				ObjectMeta: k8smetav1.ObjectMeta{GenerateName: memoryPrefix},
 				Spec: v1.VirtualMachineInstancePresetSpec{
 					Selector: selector,
@@ -466,110 +83,495 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				},
 			}
 
-			// The actual type of machine is unimportant here. This test is about the label
-			vmiWin7 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			// this helper function explicitly sets a memory req, but we don't want one for this test
-			vmiWin7.Spec.Domain.Resources = v1.ResourceRequirements{}
-			vmiWin7.Labels = map[string]string{labelKey: win7Label}
-			vmiWin10 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmiWin10.Spec.Domain.Resources = v1.ResourceRequirements{}
-			vmiWin10.Labels = map[string]string{labelKey: win10Label}
-		})
-
-		It("[test_id:726] Should match multiple VMs via MatchExpression", func() {
-			By("Creating preset with MatchExpression")
-			_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
-
-			By("Creating first VirtualMachineInstance")
-			newVmi7, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Creating second VirtualMachineInstance")
-			newVmi10, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Checking that preset matched bot VMs")
-			Expect(newVmi7.Spec.Domain.Resources.Requests["memory"]).To(Equal(memory))
-			Expect(newVmi10.Spec.Domain.Resources.Requests["memory"]).To(Equal(memory))
-		})
-	})
-
-	Context("[rfe_id:613]MatchLabels", func() {
-		var preset *v1.VirtualMachineInstancePreset
-		labelKey := "kubevirt.io/cpu"
-		labelValue := "dodecacore"
-		numCores := uint32(12)
-		presetName := "twelve-cores"
-
-		var annotationLabel string
-		var annotationVal string
-
-		var vmiWin7 *v1.VirtualMachineInstance
-		var vmiWin10 *v1.VirtualMachineInstance
-
-		BeforeEach(func() {
-			selector := k8smetav1.LabelSelector{
-				MatchLabels: map[string]string{
-					labelKey: labelValue,
-				},
-			}
-
-			preset = &v1.VirtualMachineInstancePreset{
-				ObjectMeta: k8smetav1.ObjectMeta{Name: presetName},
+			selector = k8smetav1.LabelSelector{MatchLabels: map[string]string{flavorKey: cpuFlavor}}
+			cpuPreset = &v1.VirtualMachineInstancePreset{
+				ObjectMeta: k8smetav1.ObjectMeta{GenerateName: cpuPrefix},
 				Spec: v1.VirtualMachineInstancePresetSpec{
 					Selector: selector,
 					Domain: &v1.DomainSpec{
-						CPU: &v1.CPU{Cores: numCores},
+						CPU: &v1.CPU{Cores: uint32(cores)},
 					},
 				},
 			}
-
-			// The actual type of machine is unimportant here. This test is about the label
-			vmiWin7 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmiWin7.Labels = map[string]string{labelKey: labelValue}
-			vmiWin10 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			vmiWin10.Labels = map[string]string{labelKey: labelValue}
-
-			annotationLabel = fmt.Sprintf("virtualmachinepreset.kubevirt.io/%s", presetName)
-			annotationVal = v1.GroupVersion.String()
 		})
 
-		It("[test_id:672] Should match multiple VMs via MatchLabel", func() {
-			By("Creating preset with MatchExpression")
-			_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
-			Expect(err).ToNot(HaveOccurred())
+		Context("CRD Validation", func() {
+			It("[test_id:1595]Should reject POST if schema is invalid", Labels{"test_id:1595"}, func() {
+				// Preset with missing selector should fail CRD validation
+				jsonString := fmt.Sprintf("{\"kind\":\"VirtualMachineInstancePreset\",\"apiVersion\":\"%s\",\"metadata\":{\"generateName\":\"test-memory-\",\"creationTimestamp\":null},\"spec\":{}}", v1.StorageGroupVersion.String())
 
-			// Give virt-api's cache time to sync before proceeding
-			time.Sleep(3 * time.Second)
+				result := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body([]byte(jsonString)).SetHeader("Content-Type", "application/json").Do(context.Background())
 
-			By("Creating first VirtualMachineInstance")
-			newVmi7, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
-			Expect(err).ToNot(HaveOccurred())
+				// Verify validation failed.
+				statusCode := 0
+				result.StatusCode(&statusCode)
+				Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+			})
 
-			By("Creating second VirtualMachineInstance")
-			newVmi10, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
-			Expect(err).ToNot(HaveOccurred())
+			It("[test_id:1596]should reject POST if validation webhoook deems the spec is invalid", Labels{"test_id:1596"}, func() {
+				preset := &v1.VirtualMachineInstancePreset{
+					ObjectMeta: k8smetav1.ObjectMeta{GenerateName: "fake"},
+					Spec: v1.VirtualMachineInstancePresetSpec{
+						Selector: k8smetav1.LabelSelector{MatchLabels: map[string]string{"fake": "fake"}},
+						Domain:   &v1.DomainSpec{},
+					},
+				}
+				// disk with two targets is invalid
+				preset.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+					Name: "testdisk",
+					DiskDevice: v1.DiskDevice{
+						Disk:  &v1.DiskTarget{},
+						CDRom: &v1.CDRomTarget{},
+					},
+				})
+				result := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background())
+				// Verify validation failed.
+				statusCode := 0
+				result.StatusCode(&statusCode)
+				Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
-			By("Checking that preset matched the first VMI")
-			thisAnnotation, ok := newVmi7.Annotations[annotationLabel]
-			Expect(ok).To(BeTrue(), fmt.Sprintf("VMI is missing expected annotation: %s", annotationLabel))
-			Expect(thisAnnotation).To(Equal(annotationVal))
+				reviewResponse := &k8smetav1.Status{}
+				body, _ := result.Raw()
+				err = json.Unmarshal(body, reviewResponse)
+				Expect(err).To(BeNil())
 
-			By("Checking that preset matched the second VMI")
-			thisAnnotation, ok = newVmi10.Annotations[annotationLabel]
-			Expect(ok).To(BeTrue(), fmt.Sprintf("VMI is missing expected annotation: %s", annotationLabel))
-			Expect(thisAnnotation).To(Equal(annotationVal))
+				Expect(reviewResponse.Details.Causes).To(HaveLen(1))
+				Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1]"))
+			})
+		})
 
-			By("Checking that both VMs have 12 cores")
-			Expect(newVmi7.Spec.Domain.CPU.Cores).To(Equal(numCores))
-			Expect(newVmi10.Spec.Domain.CPU.Cores).To(Equal(numCores))
+		Context("Preset Matching", func() {
+			It("[test_id:1597]Should be accepted on POST", Labels{"test_id:1597"}, func() {
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+				Expect(err).To(BeNil())
+			})
+
+			It("[test_id:1598]Should reject a second submission of a VMIPreset", Labels{"test_id:1598"}, func() {
+				// This test requires an explicit name or the resources won't conflict
+				presetName := "test-preset"
+				memoryPreset.Name = presetName
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				b, err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).DoRaw(context.Background())
+				Expect(err).To(HaveOccurred())
+				status := k8smetav1.Status{}
+				err = json.Unmarshal(b, &status)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("[test_id:1599]Should return 404 if VMIPreset does not exist", Labels{"test_id:1599"}, func() {
+				b, err := virtClient.RestClient().Get().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name("wrong").DoRaw(context.Background())
+				Expect(err).To(HaveOccurred())
+				status := k8smetav1.Status{}
+				err = json.Unmarshal(b, &status)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(status.Code).To(Equal(int32(http.StatusNotFound)))
+			})
+
+			It("[test_id:1600]Should reject presets that conflict with VirtualMachineInstance settings", Labels{"test_id:1600"}, func() {
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				newPreset, err := getPreset(virtClient, memoryPrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				Expect(newVMI.Labels[flavorKey]).To(Equal(memoryFlavor))
+				Expect(newPreset.Spec.Selector.MatchLabels[flavorKey]).To(Equal(memoryFlavor))
+
+				// check the annotations
+				annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
+				_, found := newVMI.Annotations[annotationKey]
+				Expect(found).To(BeFalse())
+			})
+
+			It("[test_id:1601]Should accept presets that don't conflict with VirtualMachineInstance settings", Labels{"test_id:1601"}, func() {
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				newPreset, err := getPreset(virtClient, cpuPrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi.Labels = map[string]string{flavorKey: cpuFlavor}
+
+				newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				Expect(newVMI.Labels[flavorKey]).To(Equal(cpuFlavor))
+				Expect(newPreset.Spec.Selector.MatchLabels[flavorKey]).To(Equal(cpuFlavor))
+
+				// check the annotations
+				annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
+				Expect(newVMI.Annotations[annotationKey]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
+
+				// check a setting from the preset itself to show it was applied
+				Expect(int(newVMI.Spec.Domain.CPU.Cores)).To(Equal(cores))
+			})
+
+			It("[test_id:1602]Should ignore VMIs that don't match", Labels{"test_id:1602"}, func() {
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				newPreset, err := getPreset(virtClient, memoryPrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				// reset the label so it will not match
+				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				// check the annotations
+				annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
+				_, found := newVMI.Annotations[annotationKey]
+				Expect(found).To(BeFalse())
+
+				Expect(newVMI.Status.Phase).ToNot(Equal(v1.Failed))
+			})
+
+			It("[test_id:1603]Should not be applied to existing VMIs", Labels{"test_id:1603"}, func() {
+				// create the VirtualMachineInstance first
+				newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				err = virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				newPreset, err := getPreset(virtClient, memoryPrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				// check the annotations
+				annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
+				_, found := newVMI.Annotations[annotationKey]
+				Expect(found).To(BeFalse())
+				Expect(newVMI.Status.Phase).ToNot(Equal(v1.Failed))
+			})
+		})
+
+		Context("Exclusions", func() {
+			It("[test_id:1604]Should not apply presets to VirtualMachineInstance's with the exclusion marking", Labels{"test_id:1604"}, func() {
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(cpuPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				newPreset, err := getPreset(virtClient, cpuPrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi.Labels = map[string]string{flavorKey: cpuFlavor}
+				exclusionMarking := "virtualmachineinstancepresets.admission.kubevirt.io/exclude"
+				vmi.Annotations = map[string]string{exclusionMarking: "true"}
+
+				newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				// check the annotations
+				annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", core.GroupName, newPreset.Name)
+				_, ok := newVMI.Annotations[annotationKey]
+				Expect(ok).To(BeFalse(), "Preset should not have been applied due to exclusion")
+
+				// check a setting from the preset itself to show it was applied
+				Expect(newVMI.Spec.Domain.CPU.Cores).NotTo(Equal(newPreset.Spec.Domain.CPU.Cores),
+					"CPU should still have been the default value (not defined in spec)")
+			})
+		})
+
+		Context("Conflict", func() {
+			var conflictPreset *v1.VirtualMachineInstancePreset
+
+			conflictKey := fmt.Sprintf("%s/conflict", core.GroupName)
+			conflictFlavor := "conflict-test"
+			conflictMemory, _ := resource.ParseQuantity("256M")
+			conflictPrefix := "test-conflict-"
+
+			BeforeEach(func() {
+				selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{conflictKey: conflictFlavor}}
+				conflictPreset = &v1.VirtualMachineInstancePreset{
+					ObjectMeta: k8smetav1.ObjectMeta{GenerateName: conflictPrefix},
+					Spec: v1.VirtualMachineInstancePresetSpec{
+						Selector: selector,
+						Domain: &v1.DomainSpec{
+							Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
+								"memory": conflictMemory}},
+						},
+					},
+				}
+			})
+
+			It("[test_id:1605]should denied to start the VMI", Labels{"test_id:1605"}, func() {
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(conflictPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(memoryPreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				vmi.Labels = map[string]string{flavorKey: memoryFlavor, conflictKey: conflictFlavor}
+				By("creating the VirtualMachineInstance")
+				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("Override", func() {
+			var overridePreset *v1.VirtualMachineInstancePreset
+
+			overrideKey := fmt.Sprintf("kubevirt.io/vmPreset")
+			overrideFlavor := "vmi-preset-small"
+			overrideMemory, _ := resource.ParseQuantity("64M")
+			overridePrefix := "test-override-"
+
+			vmiMemory, _ := resource.ParseQuantity("128M")
+
+			BeforeEach(func() {
+				selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{overrideKey: overrideFlavor}}
+				overridePreset = &v1.VirtualMachineInstancePreset{
+					ObjectMeta: k8smetav1.ObjectMeta{GenerateName: overridePrefix},
+					Spec: v1.VirtualMachineInstancePresetSpec{
+						Selector: selector,
+						Domain: &v1.DomainSpec{
+							Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
+								"memory": overrideMemory}},
+						},
+					},
+				}
+			})
+
+			It("[test_id:644][rfe_id:609] should override presets", Labels{"test_id:644", "rfe_id:609"}, func() {
+				By("Creating preset with 64M")
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(overridePreset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				By("Creating VMI with 128M")
+				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi.Labels = map[string]string{overrideKey: overrideFlavor}
+				vmi.Spec.Domain.Resources.Requests["memory"] = vmiMemory
+
+				newVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying VMI")
+				Expect(newVmi.Annotations).To(BeNil())
+
+				label, ok := vmi.Labels[overrideKey]
+				Expect(ok).To(BeTrue())
+				Expect(label).To(Equal(overrideFlavor))
+				Expect(newVmi.Spec.Domain.Resources.Requests["memory"]).To(Equal(vmiMemory))
+
+				By("Checking event list")
+				evList, err := virtClient.CoreV1().Events(util.NamespaceTestDefault).List(context.Background(), k8smetav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, event := range evList.Items {
+					if event.InvolvedObject.GetObjectKind() == newVmi.GetObjectKind() &&
+						event.InvolvedObject.Name == newVmi.GetName() {
+						Expect(event.Message).ToNot(ContainSubstring("Unable to apply VirtualMachineInstancePreset"))
+					}
+				}
+			})
+		})
+
+		Context("Preset Lifecycle", func() {
+			var preset *v1.VirtualMachineInstancePreset
+			presetNamePrefix := "vmi-preset-small-"
+			selectorKey := "kubevirt.io/vmPreset"
+			selectorLabel := "vmi-preset-small"
+
+			BeforeEach(func() {
+				selector := k8smetav1.LabelSelector{MatchLabels: map[string]string{selectorKey: selectorLabel}}
+				memory, _ := resource.ParseQuantity("64M")
+				preset = &v1.VirtualMachineInstancePreset{
+					ObjectMeta: k8smetav1.ObjectMeta{GenerateName: presetNamePrefix},
+					Spec: v1.VirtualMachineInstancePresetSpec{
+						Selector: selector,
+						Domain: &v1.DomainSpec{
+							Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
+								"memory": memory}},
+						},
+					},
+				}
+			})
+
+			It("[test_id:617][rfe_id:609] should create and delete preset", Labels{"test_id:617", "rfe_id:609"}, func() {
+				By("Creating preset")
+				err := virtClient.RestClient().Post().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Body(preset).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that preset was created")
+				newPreset, err := getPreset(virtClient, presetNamePrefix)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Deleting preset")
+				err = virtClient.RestClient().Delete().Resource("virtualmachineinstancepresets").Namespace(util.NamespaceTestDefault).Name(newPreset.GetName()).Do(context.Background()).Error()
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking preset was deleted")
+				waitForPresetDeletion(virtClient, newPreset.GetName())
+			})
+		})
+
+		Context("Match Expressions", func() {
+			var preset *v1.VirtualMachineInstancePreset
+			labelKey := "kubevirt.io/os"
+
+			var vmiWin7 *v1.VirtualMachineInstance
+			var vmiWin10 *v1.VirtualMachineInstance
+			win7Label := "win7"
+			win10Label := "win10"
+
+			BeforeEach(func() {
+				selector := k8smetav1.LabelSelector{
+					MatchExpressions: []k8smetav1.LabelSelectorRequirement{
+						{
+							Key:      labelKey,
+							Operator: k8smetav1.LabelSelectorOpIn,
+							Values:   []string{win10Label, win7Label},
+						},
+					},
+				}
+
+				preset = &v1.VirtualMachineInstancePreset{
+					ObjectMeta: k8smetav1.ObjectMeta{GenerateName: memoryPrefix},
+					Spec: v1.VirtualMachineInstancePresetSpec{
+						Selector: selector,
+						Domain: &v1.DomainSpec{
+							Resources: v1.ResourceRequirements{Requests: k8sv1.ResourceList{
+								"memory": memory}},
+						},
+					},
+				}
+
+				// The actual type of machine is unimportant here. This test is about the label
+				vmiWin7 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				// this helper function explicitly sets a memory req, but we don't want one for this test
+				vmiWin7.Spec.Domain.Resources = v1.ResourceRequirements{}
+				vmiWin7.Labels = map[string]string{labelKey: win7Label}
+				vmiWin10 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmiWin10.Spec.Domain.Resources = v1.ResourceRequirements{}
+				vmiWin10.Labels = map[string]string{labelKey: win10Label}
+			})
+
+			It("[test_id:726] Should match multiple VMs via MatchExpression", Labels{"test_id:726"}, func() {
+				By("Creating preset with MatchExpression")
+				_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				By("Creating first VirtualMachineInstance")
+				newVmi7, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating second VirtualMachineInstance")
+				newVmi10, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that preset matched bot VMs")
+				Expect(newVmi7.Spec.Domain.Resources.Requests["memory"]).To(Equal(memory))
+				Expect(newVmi10.Spec.Domain.Resources.Requests["memory"]).To(Equal(memory))
+			})
+		})
+
+		Context("[rfe_id:613]MatchLabels", Labels{"rfe_id:613"}, func() {
+			var preset *v1.VirtualMachineInstancePreset
+			labelKey := "kubevirt.io/cpu"
+			labelValue := "dodecacore"
+			numCores := uint32(12)
+			presetName := "twelve-cores"
+
+			var annotationLabel string
+			var annotationVal string
+
+			var vmiWin7 *v1.VirtualMachineInstance
+			var vmiWin10 *v1.VirtualMachineInstance
+
+			BeforeEach(func() {
+				selector := k8smetav1.LabelSelector{
+					MatchLabels: map[string]string{
+						labelKey: labelValue,
+					},
+				}
+
+				preset = &v1.VirtualMachineInstancePreset{
+					ObjectMeta: k8smetav1.ObjectMeta{Name: presetName},
+					Spec: v1.VirtualMachineInstancePresetSpec{
+						Selector: selector,
+						Domain: &v1.DomainSpec{
+							CPU: &v1.CPU{Cores: numCores},
+						},
+					},
+				}
+
+				// The actual type of machine is unimportant here. This test is about the label
+				vmiWin7 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmiWin7.Labels = map[string]string{labelKey: labelValue}
+				vmiWin10 = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmiWin10.Labels = map[string]string{labelKey: labelValue}
+
+				annotationLabel = fmt.Sprintf("virtualmachinepreset.kubevirt.io/%s", presetName)
+				annotationVal = v1.GroupVersion.String()
+			})
+
+			It("[test_id:672] Should match multiple VMs via MatchLabel", Labels{"test_id:672"}, func() {
+				By("Creating preset with MatchExpression")
+				_, err := virtClient.VirtualMachineInstancePreset(util.NamespaceTestDefault).Create(preset)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Give virt-api's cache time to sync before proceeding
+				time.Sleep(3 * time.Second)
+
+				By("Creating first VirtualMachineInstance")
+				newVmi7, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin7)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating second VirtualMachineInstance")
+				newVmi10, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiWin10)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that preset matched the first VMI")
+				thisAnnotation, ok := newVmi7.Annotations[annotationLabel]
+				Expect(ok).To(BeTrue(), fmt.Sprintf("VMI is missing expected annotation: %s", annotationLabel))
+				Expect(thisAnnotation).To(Equal(annotationVal))
+
+				By("Checking that preset matched the second VMI")
+				thisAnnotation, ok = newVmi10.Annotations[annotationLabel]
+				Expect(ok).To(BeTrue(), fmt.Sprintf("VMI is missing expected annotation: %s", annotationLabel))
+				Expect(thisAnnotation).To(Equal(annotationVal))
+
+				By("Checking that both VMs have 12 cores")
+				Expect(newVmi7.Spec.Domain.CPU.Cores).To(Equal(numCores))
+				Expect(newVmi10.Spec.Domain.CPU.Cores).To(Equal(numCores))
+			})
 		})
 	})
-})
 
 func getPreset(virtClient kubecli.KubevirtClient, prefix string) (*v1.VirtualMachineInstancePreset, error) {
 	presetList := v1.VirtualMachineInstancePresetList{}

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -175,7 +175,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 				It("[test_id:4272]should connect to vnc with --proxy-only flag", Labels{"test_id:4272"}, func() {
 
 					By("Invoking virtctl vnc with --proxy-only")
-			proxyOnlyCommand := clientcmd.NewVirtctlCommand("vnc", "--proxy-only", "--namespace", vmi.Namespace, vmi.Name)
+					proxyOnlyCommand := clientcmd.NewVirtctlCommand("vnc", "--proxy-only", "--namespace", vmi.Namespace, vmi.Name)
 
 					r, w, _ := os.Pipe()
 					proxyOnlyCommand.SetOut(w)
@@ -214,7 +214,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 					testPort := "33333"
 
 					By("Invoking virtctl vnc with --proxy-only")
-			proxyOnlyCommand := clientcmd.NewVirtctlCommand("vnc", "--proxy-only", "--port", testPort, "--namespace", vmi.Namespace, vmi.Name)
+					proxyOnlyCommand := clientcmd.NewVirtctlCommand("vnc", "--proxy-only", "--port", testPort, "--namespace", vmi.Namespace, vmi.Name)
 
 					// Run this as go routine to keep proxy open in the background
 					go func() {

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -47,7 +47,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][level:component][sig-compute]VNC",
-	Labels{"rfe_id:127", "crit:medium", "arm64", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"},
+	Label("rfe_id:127", "crit:medium", "arm64", "vendor:cnv-qe@redhat.com", "level:component", "sig-compute"),
 	func() {
 
 		var err error
@@ -55,7 +55,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 		var vmi *v1.VirtualMachineInstance
 
 		Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance",
-			Labels{"rfe_id:127", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+			Label("rfe_id:127", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 			func() {
 				BeforeEach(func() {
 					virtClient, err = kubecli.GetKubevirtClient()
@@ -123,7 +123,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 						}
 					}
 
-					It("[test_id:1611]should allow accessing the VNC device multiple times", Labels{"test_id:1611"}, func() {
+					It("[test_id:1611]should allow accessing the VNC device multiple times", Label("test_id:1611"), func() {
 
 						for i := 0; i < 10; i++ {
 							vncConnect()
@@ -132,7 +132,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 				})
 
 				DescribeTable("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]should upgrade websocket connection which look like coming from a browser",
-					Labels{"rfe_id:127", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"},
+					Label("rfe_id:127", "crit:medium", "vendor:cnv-qe@redhat.com", "level:component"),
 					func(subresource string) {
 						config, err := kubecli.GetKubevirtClientConfig()
 						Expect(err).ToNot(HaveOccurred())
@@ -154,11 +154,11 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 						Expect(err).ToNot(HaveOccurred())
 						Expect(rt.Response.Header.Get("Sec-Websocket-Protocol")).To(Equal(subresources.PlainStreamProtocolName))
 					},
-					Entry("[test_id:1612]for vnc", Labels{"test_id:1612"}, "vnc"),
-					Entry("[test_id:1613]for serial console", Labels{"test_id:1613"}, "console"),
+					Entry("[test_id:1612]for vnc", Label("test_id:1612"), "vnc"),
+					Entry("[test_id:1613]for serial console", Label("test_id:1613"), "console"),
 				)
 
-				It("[test_id:1614]should upgrade websocket connections without a subprotocol given", Labels{"test_id:1614"}, func() {
+				It("[test_id:1614]should upgrade websocket connections without a subprotocol given", Label("test_id:1614"), func() {
 					config, err := kubecli.GetKubevirtClientConfig()
 					Expect(err).ToNot(HaveOccurred())
 					// If no subprotocol is given, we still want to upgrade to be backward compatible
@@ -172,7 +172,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("[test_id:4272]should connect to vnc with --proxy-only flag", Labels{"test_id:4272"}, func() {
+				It("[test_id:4272]should connect to vnc with --proxy-only flag", Label("test_id:4272"), func() {
 
 					By("Invoking virtctl vnc with --proxy-only")
 					proxyOnlyCommand := clientcmd.NewVirtctlCommand("vnc", "--proxy-only", "--namespace", vmi.Namespace, vmi.Name)
@@ -210,7 +210,7 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 					Expect(c.DesktopName).To(ContainSubstring(vmi.Name))
 				})
 
-				It("[test_id:5274]should connect to vnc with --proxy-only flag to the specified port", Labels{"test_id:5274"}, func() {
+				It("[test_id:5274]should connect to vnc with --proxy-only flag to the specified port", Label("test_id:5274"), func() {
 					testPort := "33333"
 
 					By("Invoking virtctl vnc with --proxy-only")

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -119,7 +119,7 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 
 }
 
-var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"Serial", "sig-compute"}, func() {
+var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Label("Serial", "sig-compute"), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -137,13 +137,13 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
-	It("[test_id:487]should succeed to start a vmi", Labels{"test_id:487"}, func() {
+	It("[test_id:487]should succeed to start a vmi", Label("test_id:487"), func() {
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 		Expect(err).To(BeNil())
 		tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 	})
 
-	It("[test_id:488]should succeed to stop a running vmi", Labels{"test_id:488"}, func() {
+	It("[test_id:488]should succeed to stop a running vmi", Label("test_id:488"), func() {
 		By("Starting the vmi")
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 		Expect(err).To(BeNil())
@@ -178,7 +178,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Context("[ref_id:139]VMI is created", Labels{"ref_id:139"}, func() {
+		Context("[ref_id:139]VMI is created", Label("ref_id:139"), func() {
 
 			BeforeEach(func() {
 				By("Starting the windows VirtualMachineInstance")
@@ -189,7 +189,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 				cli = winrnLoginCommand(virtClient, windowsVMI)
 			})
 
-			It("[test_id:240]should have correct UUID", Labels{"test_id:240"}, func() {
+			It("[test_id:240]should have correct UUID", Label("test_id:240"), func() {
 				command := append(cli, "wmic csproduct get \"UUID\"")
 				By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
 				Eventually(func() error {
@@ -205,7 +205,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 				Expect(output).Should(ContainSubstring(strings.ToUpper(windowsFirmware)))
 			})
 
-			It("[test_id:3159]should have default masquerade IP", Labels{"test_id:3159"}, func() {
+			It("[test_id:3159]should have default masquerade IP", Label("test_id:3159"), func() {
 				command := append(cli, "ipconfig /all")
 				By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
 				Eventually(func() error {
@@ -222,7 +222,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 				Expect(output).Should(ContainSubstring("10.0.2.2"))
 			})
 
-			It("[test_id:3160]should have the domain set properly", Labels{"test_id:3160"}, func() {
+			It("[test_id:3160]should have the domain set properly", Label("test_id:3160"), func() {
 				searchDomain := getPodSearchDomain(windowsVMI)
 				Expect(searchDomain).To(HavePrefix(windowsVMI.Namespace), "should contain a searchdomain with the namespace of the VMI")
 
@@ -309,7 +309,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 		})
 	})
 
-	Context("[ref_id:142]with kubectl command", Labels{"ref_id:142"}, func() {
+	Context("[ref_id:142]with kubectl command", Label("ref_id:142"), func() {
 		var yamlFile string
 		BeforeEach(func() {
 			clientcmd.SkipIfNoCmd("kubectl")
@@ -317,7 +317,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:223]should succeed to start a vmi", Labels{"test_id:223"}, func() {
+		It("[test_id:223]should succeed to start a vmi", Label("test_id:223"), func() {
 			By("Starting the vmi via kubectl command")
 			_, _, err = clientcmd.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
@@ -325,7 +325,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"
 			tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
 		})
 
-		It("[test_id:239]should succeed to stop a vmi", Labels{"test_id:239"}, func() {
+		It("[test_id:239]should succeed to stop a vmi", Label("test_id:239"), func() {
 			By("Starting the vmi via kubectl command")
 			_, _, err = clientcmd.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -119,7 +119,7 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 
 }
 
-var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
+var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Labels{"Serial", "sig-compute"}, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -137,13 +137,13 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
-	It("[test_id:487]should succeed to start a vmi", func() {
+	It("[test_id:487]should succeed to start a vmi", Labels{"test_id:487"}, func() {
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 		Expect(err).To(BeNil())
 		tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 	})
 
-	It("[test_id:488]should succeed to stop a running vmi", func() {
+	It("[test_id:488]should succeed to stop a running vmi", Labels{"test_id:488"}, func() {
 		By("Starting the vmi")
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 		Expect(err).To(BeNil())
@@ -178,7 +178,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Context("[ref_id:139]VMI is created", func() {
+		Context("[ref_id:139]VMI is created", Labels{"ref_id:139"}, func() {
 
 			BeforeEach(func() {
 				By("Starting the windows VirtualMachineInstance")
@@ -189,7 +189,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 				cli = winrnLoginCommand(virtClient, windowsVMI)
 			})
 
-			It("[test_id:240]should have correct UUID", func() {
+			It("[test_id:240]should have correct UUID", Labels{"test_id:240"}, func() {
 				command := append(cli, "wmic csproduct get \"UUID\"")
 				By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
 				Eventually(func() error {
@@ -205,7 +205,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 				Expect(output).Should(ContainSubstring(strings.ToUpper(windowsFirmware)))
 			})
 
-			It("[test_id:3159]should have default masquerade IP", func() {
+			It("[test_id:3159]should have default masquerade IP", Labels{"test_id:3159"}, func() {
 				command := append(cli, "ipconfig /all")
 				By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
 				Eventually(func() error {
@@ -222,7 +222,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 				Expect(output).Should(ContainSubstring("10.0.2.2"))
 			})
 
-			It("[test_id:3160]should have the domain set properly", func() {
+			It("[test_id:3160]should have the domain set properly", Labels{"test_id:3160"}, func() {
 				searchDomain := getPodSearchDomain(windowsVMI)
 				Expect(searchDomain).To(HavePrefix(windowsVMI.Namespace), "should contain a searchdomain with the namespace of the VMI")
 
@@ -309,7 +309,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		})
 	})
 
-	Context("[ref_id:142]with kubectl command", func() {
+	Context("[ref_id:142]with kubectl command", Labels{"ref_id:142"}, func() {
 		var yamlFile string
 		BeforeEach(func() {
 			clientcmd.SkipIfNoCmd("kubectl")
@@ -317,7 +317,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("[test_id:223]should succeed to start a vmi", func() {
+		It("[test_id:223]should succeed to start a vmi", Labels{"test_id:223"}, func() {
 			By("Starting the vmi via kubectl command")
 			_, _, err = clientcmd.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
@@ -325,7 +325,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
 		})
 
-		It("[test_id:239]should succeed to stop a vmi", func() {
+		It("[test_id:239]should succeed to stop a vmi", Labels{"test_id:239"}, func() {
 			By("Starting the vmi via kubectl command")
 			_, _, err = clientcmd.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
In KubeVirt CI, we're filtering tests based on the spec's (`Describe`, `Context`, `When`, `It`, `DescribeTable`) description strings. This creates a link between the test description and the filtering mechanism. It also make the test description less readable, because it should be read as a sentence, but instead, the result is a mix of text and labels; e.g. `Tests Suite: [sig-compute]Subresource Api [rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization with correct permissions [test_id:3170]should be allowed to access subresource endpoint`

ginkgo v2 added the option to add labels. Using the ginkgo v2 new labels, will allow us to split the test description from the filtering mechanism, making the test description more human readable.

ginkgo v2 cli also introduces an advanced filtering, using the labels. It will ease the test script to select the required tests to run in each scenario and lane.

See more details here: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#spec-labels

This PR adds labels to tests, but does not remove the existing labels from the test descriptions. Only after merging this PR, we could use the new filtering in the CI, and only then we can remove the old labels.

The discussion is here: https://groups.google.com/g/kubevirt-dev/c/9b1SZAFPyO8

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```
