### PR TITLE
VM with RunStrategyHalted now accepts manual stop request...

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -257,6 +257,17 @@ func getUpdateTerminatingSecondsGracePeriod(gracePeriod int64) string {
 	return fmt.Sprintf("{\"spec\":{\"terminationGracePeriodSeconds\": %d }}", gracePeriod)
 }
 
+func (app *SubresourceAPIApp) patchVMStatusStopped(vmi *v1.VirtualMachineInstance, vm *v1.VirtualMachine, response *restful.Response, bodyStruct *v1.StopOptions) (error, error) {
+	bodyString, err := getChangeRequestJson(vm,
+		v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
+	if err != nil {
+		writeError(errors.NewInternalError(err), response)
+		return nil, err
+	}
+	log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, bodyString)
+	return app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun}), nil
+}
+
 func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, response *restful.Response) {
 	name := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
@@ -570,7 +581,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 }
 
 func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, response *restful.Response) {
-	// RunStrategyHalted         -> force stop if graceperiod=0, otherwise doesn't make sense
+	// RunStrategyHalted         -> force stop if graceperiod in request is shorter than before, otherwise doesn't make sense
 	// RunStrategyManual         -> send stop request
 	// RunStrategyAlways         -> spec.running = false
 	// RunStrategyRerunOnFailure -> spec.running = false
@@ -612,9 +623,14 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		return
 	}
 
+	var oldGracePeriodSeconds int64
 	patchType := types.MergePatchType
 	var patchErr error
 	if hasVMI && !vmi.IsFinal() && bodyStruct.GracePeriod != nil {
+		// used for stopping a VM with RunStrategyHalted
+		if vmi.Spec.TerminationGracePeriodSeconds != nil {
+			oldGracePeriodSeconds = *vmi.Spec.TerminationGracePeriodSeconds
+		}
 
 		bodyString := getUpdateTerminatingSecondsGracePeriod(*bodyStruct.GracePeriod)
 		log.Log.Object(vmi).V(2).Infof("Patching VMI: %s", bodyString)
@@ -631,24 +647,15 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmNotRunning)), response)
 			return
 		}
-		if bodyStruct.GracePeriod == nil {
-			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v only supports manual stop requests with graceperiod=0", v1.RunStrategyHalted)), response)
-			return
-		}
-		if *bodyStruct.GracePeriod >= *vmi.Spec.TerminationGracePeriodSeconds {
-			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v only supports manual stop requests with graceperiod=0", v1.RunStrategyHalted)), response)
+		if bodyStruct.GracePeriod == nil || (vmi.Spec.TerminationGracePeriodSeconds != nil && *bodyStruct.GracePeriod >= oldGracePeriodSeconds) {
+			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v only supports manual stop requests with a shorter graceperiod", v1.RunStrategyHalted)), response)
 			return
 		}
 		// same behavior as RunStrategyManual
-		patchType = types.JSONPatchType
-		bodyString, err := getChangeRequestJson(vm,
-			v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
+		patchErr, err = app.patchVMStatusStopped(vmi, vm, response, bodyStruct)
 		if err != nil {
-			writeError(errors.NewInternalError(err), response)
 			return
 		}
-		log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, bodyString)
-		patchErr = app.statusUpdater.PatchStatus(vm, patchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	case v1.RunStrategyManual:
 		if !hasVMI || vmi.IsFinal() {
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmNotRunning)), response)
@@ -656,15 +663,10 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		}
 		// pass the buck and ask virt-controller to stop the VM. this way the
 		// VM will retain RunStrategy = manual
-		patchType = types.JSONPatchType
-		bodyString, err := getChangeRequestJson(vm,
-			v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
+		patchErr, err = app.patchVMStatusStopped(vmi, vm, response, bodyStruct)
 		if err != nil {
-			writeError(errors.NewInternalError(err), response)
 			return
 		}
-		log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, bodyString)
-		patchErr = app.statusUpdater.PatchStatus(vm, patchType, []byte(bodyString), &k8smetav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	case v1.RunStrategyRerunOnFailure, v1.RunStrategyAlways, v1.RunStrategyOnce:
 		bodyString := getRunningJson(vm, false)
 		log.Log.Object(vm).V(4).Infof(patchingVMFmt, bodyString)

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -631,11 +631,11 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmNotRunning)), response)
 			return
 		}
-		if vmi.Spec.TerminationGracePeriodSeconds == nil {
+		if bodyStruct.GracePeriod == nil {
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v only supports manual stop requests with graceperiod=0", v1.RunStrategyHalted)), response)
 			return
 		}
-		if *vmi.Spec.TerminationGracePeriodSeconds != 0 {
+		if *bodyStruct.GracePeriod >= *vmi.Spec.TerminationGracePeriodSeconds {
 			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v only supports manual stop requests with graceperiod=0", v1.RunStrategyHalted)), response)
 			return
 		}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1431,7 +1431,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusConflict)
 			// check the msg string that would be presented to virtctl output
-			Expect(statusErr.Error()).To(ContainSubstring("Halted does not support manual stop requests"))
+			Expect(statusErr.Error()).To(ContainSubstring("Halted only supports manual stop requests with graceperiod=0"))
 		})
 
 		It("should fail on VM with RunStrategyHalted", func() {
@@ -1445,9 +1445,24 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusConflict)
 			// check the msg string that would be presented to virtctl output
-			Expect(statusErr.Error()).To(ContainSubstring("Halted does not support manual stop requests"))
+			Expect(statusErr.Error()).To(ContainSubstring("Halted only supports manual stop requests with graceperiod=0"))
 		})
 
+		It("should not fail on VM with RunStrategyHalted and graceperiod=0", func() {
+			vm := newVirtualMachineWithRunStrategy(v1.RunStrategyHalted)
+			vmi := newVirtualMachineInstanceInPhase(v1.Running)
+			vmi.Spec.TerminationGracePeriodSeconds = &gracePeriodZero
+
+			vmClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
+			vmiClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vmi, nil)
+
+			vmClient.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, gomock.Any(), &k8smetav1.PatchOptions{}).Return(vm, nil)
+
+			app.StopVMRequestHandler(request, response)
+
+			//Expect(response.Error()).ToNot(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusAccepted))
+		})
 		DescribeTable("should not fail on VM with RunStrategy", func(runStrategy v1.VirtualMachineRunStrategy) {
 			vm := newVirtualMachineWithRunStrategy(runStrategy)
 			vmi := newVirtualMachineInstanceInPhase(v1.Running)

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -32,13 +32,12 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/golang/mock/gomock"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
 
 	"github.com/emicklei/go-restful"
 	. "github.com/onsi/ginkgo/v2"
@@ -1431,52 +1430,53 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusConflict)
 			// check the msg string that would be presented to virtctl output
-			Expect(statusErr.Error()).To(ContainSubstring("Halted only supports manual stop requests with graceperiod=0"))
+			Expect(statusErr.Error()).To(ContainSubstring("Halted only supports manual stop requests with a shorter graceperiod"))
 		})
 
-		It("should fail on VM with RunStrategyHalted", func() {
+		DescribeTable("for VM with RunStrategyHalted, should", func(terminationGracePeriod *int64, graceperiod *int64, shouldFail bool) {
 			vm := newVirtualMachineWithRunStrategy(v1.RunStrategyHalted)
 			vmi := newVirtualMachineInstanceInPhase(v1.Running)
 
-			vmClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
-			vmiClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vmi, nil)
+			vmi.Spec.TerminationGracePeriodSeconds = terminationGracePeriod
 
-			app.StopVMRequestHandler(request, response)
+			stopOptions := &v1.StopOptions{GracePeriod: graceperiod}
 
-			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusConflict)
-			// check the msg string that would be presented to virtctl output
-			Expect(statusErr.Error()).To(ContainSubstring("Halted only supports manual stop requests with graceperiod=0"))
-		})
-
-		It("should not fail on VM with RunStrategyHalted and a shorter grace period", func() {
-			vm := newVirtualMachineWithRunStrategy(v1.RunStrategyHalted)
-			vmi := newVirtualMachineInstanceInPhase(v1.Running)
-
-			var terminationGracePeriodSeconds int64 = 1800
-			vmi.Spec.TerminationGracePeriodSeconds = &terminationGracePeriodSeconds
-
-			gracePeriodShorter := int64(600)
-			stopOptions := &v1.StopOptions{GracePeriod: &gracePeriodShorter}
-
-			bytesRepresentation, _ := json.Marshal(stopOptions)
+			bytesRepresentation, err := json.Marshal(stopOptions)
+			Expect(err).ToNot(HaveOccurred())
 			request.Request.Body = io.NopCloser(bytes.NewReader(bytesRepresentation))
 
 			vmClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil)
 			vmiClient.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vmi, nil)
 
-			vmiClient.EXPECT().Patch(vmi.Name, types.MergePatchType, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(name string, patchType types.PatchType, body interface{}, opts *k8smetav1.PatchOptions) (interface{}, interface{}) {
-					//check that dryRun option has been propagated to patch request
-					Expect(opts.DryRun).To(BeEquivalentTo(stopOptions.DryRun))
-					return vm, nil
-				})
-			vmClient.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, gomock.Any(), &k8smetav1.PatchOptions{}).Return(vm, nil)
-
+			if graceperiod != nil {
+				vmiClient.EXPECT().Patch(vmi.Name, types.MergePatchType, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(name string, patchType types.PatchType, body interface{}, opts *k8smetav1.PatchOptions) (interface{}, interface{}) {
+						//check that dryRun option has been propagated to patch request
+						Expect(opts.DryRun).To(BeEquivalentTo(stopOptions.DryRun))
+						return vm, nil
+					})
+			}
+			if !shouldFail {
+				vmClient.EXPECT().PatchStatus(vm.Name, types.JSONPatchType, gomock.Any(), &k8smetav1.PatchOptions{}).Return(vm, nil)
+			}
 			app.StopVMRequestHandler(request, response)
 
-			//Expect(response.Error()).ToNot(HaveOccurred())
-			Expect(response.StatusCode()).To(Equal(http.StatusAccepted))
-		})
+			if shouldFail {
+				statusErr := ExpectStatusErrorWithCode(recorder, http.StatusConflict)
+				// check the msg string that would be presented to virtctl output
+				Expect(statusErr.Error()).To(ContainSubstring("Halted only supports manual stop requests with a shorter graceperiod"))
+			} else {
+				Expect(response.Error()).ToNot(HaveOccurred())
+				Expect(response.StatusCode()).To(Equal(http.StatusAccepted))
+			}
+		},
+			Entry("fail with nil graceperiod", pointer.Int64(int64(1800)), nil, true),
+			Entry("fail with equal graceperiod", pointer.Int64(int64(1800)), pointer.Int64(int64(1800)), true),
+			Entry("fail with greater graceperiod", pointer.Int64(int64(1800)), pointer.Int64(int64(2400)), true),
+			Entry("not fail with non-nil graceperiod and nil termination graceperiod", nil, pointer.Int64(int64(1800)), false),
+			Entry("not fail with shorter graceperiod and non-nil termination graceperiod", pointer.Int64(int64(1800)), pointer.Int64(int64(800)), false),
+		)
+
 		DescribeTable("should not fail on VM with RunStrategy", func(runStrategy v1.VirtualMachineRunStrategy) {
 			vm := newVirtualMachineWithRunStrategy(runStrategy)
 			vmi := newVirtualMachineInstanceInPhase(v1.Running)

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -464,7 +464,7 @@ func (o *Command) Run(args []string) error {
 			if gracePeriodIsSet(gracePeriod) {
 				err = virtClient.VirtualMachine(namespace).ForceStop(vmiName, &v1.StopOptions{GracePeriod: &gracePeriod, DryRun: dryRunOption})
 				if err != nil {
-					return fmt.Errorf("Error force stoping VirtualMachine, %v", err)
+					return fmt.Errorf("Error force stopping VirtualMachine, %v", err)
 				}
 			} else if !gracePeriodIsSet(gracePeriod) {
 				return fmt.Errorf("Can not force stop without gracePeriod")

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -709,7 +709,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(vmi.Status.VirtualMachineRevisionName).To(Equal(expectedVMRevisionName))
 			oldVMRevisionName := expectedVMRevisionName
 
-			By("Stoping the VM")
+			By("Stopping the VM")
 			newVM = stopVM(newVM)
 
 			By("Updating the VM template spec")


### PR DESCRIPTION
...when graceperiod is less than the VMI's current termination graceperiod.

Signed-off-by: prnaraya <prnaraya@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Originally, RunStrategyHalted blocked all stop requests. Now, if a user needs to
force stop a VM that has stalled/crashed during shutdown, they can issue a
subsequent force stop command with a grace period less than the VMI's current termination
grace period, which will be honored and send a new stop request.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Any tips for how to better implement this (especially with Stu's suggestion of accepting any shorter grace period request) would be much appreciated, I found myself getting a bit stuck trying to figure this out and I'm not sure if I'm on the right track.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
