### PR TITLE
Better matcher usage have len be empty

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -685,13 +685,13 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				tests.WaitAgentConnected(virtClient, agentVMI)
 
 				getOptions := &metav1.GetOptions{}
-				Eventually(func() bool {
+				Eventually(func() []v1.VirtualMachineInstanceNetworkInterface {
 					updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
 					if err != nil {
-						return false
+						return nil
 					}
-					return len(updatedVmi.Status.Interfaces) == 4
-				}, 420*time.Second, 4).Should(BeTrue(), "Should have interfaces in vmi status")
+					return updatedVmi.Status.Interfaces
+				}, 420*time.Second, 4).Should(HaveLen(4), "Should have interfaces in vmi status")
 
 				updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -186,13 +186,13 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 		Expect(createPtpNetworkAttachmentDefinition(tests.NamespaceTestAlternative, ptpConf2, ptpSubnet)).To(Succeed())
 
 		// Multus tests need to ensure that old VMIs are gone
-		Eventually(func() int {
+		Eventually(func() []v1.VirtualMachineInstance {
 			list1, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&v13.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			list2, err := virtClient.VirtualMachineInstance(tests.NamespaceTestAlternative).List(&v13.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			return len(list1.Items) + len(list2.Items)
-		}, 6*time.Minute, 1*time.Second).Should(BeZero())
+			return append(list1.Items, list2.Items...)
+		}, 6*time.Minute, 1*time.Second).Should(BeEmpty())
 	})
 
 	createVMIOnNode := func(interfaces []v1.Interface, networks []v1.Network) *v1.VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR improves the multus e2e test readability by:
  - assert the list of VMs as empty rather than the sum of the lengths of both lists should be zero
  - using the `HaveLen` matcher rather than checking if the length of an array is equal to the expected number

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
