### PR TITLE
Istio e2e, Use BeforeAll and AfterAll for VMI used as a HTTP Server

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -261,22 +261,22 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 				BeforeEach(func() {
 					vmiPorts = explicitPorts
 				})
-				DescribeTable("request to VMI should reach HTTP server", func(targetPort int) {
+				DescribeTable("request to Istio enabled VMI should reach HTTP server", func(targetPort int) {
 					Expect(checkVMIReachability(vmi, targetPort)).To(Succeed())
 				},
-					Entry("on service declared port on VMI with explicit ports", svcDeclaredTestPort),
-					Entry("on service undeclared port on VMI with explicit ports", svcUndeclaredTestPort),
+					Entry("on service declared port on Istio enabled VMI with explicit ports", svcDeclaredTestPort),
+					Entry("on service undeclared port on Istio enabled VMI with explicit ports", svcUndeclaredTestPort),
 				)
 			})
 			Context("With VMI having no explicit ports specified", func() {
 				BeforeEach(func() {
 					vmiPorts = []v1.Port{}
 				})
-				DescribeTable("request to VMI should reach HTTP server", func(targetPort int) {
+				DescribeTable("request to Istio enabled VMI should reach HTTP server", func(targetPort int) {
 					Expect(checkVMIReachability(vmi, targetPort)).To(Succeed())
 				},
-					Entry("on service declared port on VMI with no explicit ports", svcDeclaredTestPort),
-					Entry("on service undeclared port on VMI with no explicit ports", svcUndeclaredTestPort),
+					Entry("on service declared port on Istio enabled VMI with no explicit ports", svcDeclaredTestPort),
+					Entry("on service undeclared port on Istio enabled VMI with no explicit ports", svcUndeclaredTestPort),
 				)
 				It("Should not be able to reach service running on Istio restricted port", func() {
 					Expect(checkVMIReachability(vmi, istioRestrictedPort)).NotTo(Succeed())

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -94,6 +94,11 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 		if !istioServiceMeshDeployed() {
 			Skip("Istio service mesh is required for service-mesh tests to run")
 		}
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+
+		libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 	})
 
 	Context("Virtual Machine with masquerade interface", func() {
@@ -115,11 +120,6 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 		}
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
-
-			virtClient, err = kubecli.GetKubevirtClient()
-			util.PanicOnError(err)
-
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 
 			By("Create NetworkAttachmentDefinition")
 			nad := generateIstioCNINetworkAttachmentDefinition()


### PR DESCRIPTION
**What this PR does / why we need it**:

    Ginkgo v2 allows using BeforeAll and AfterAll to safe time
    of setup stage by creating VMs once for multiple specs.

    In this commit, Server VMI used in Outbound traffic tests
    is created only once for all specs.
    All the specs use the same Server VMI, so it's a perfect candidate
    to create it only once.

    BeforeAll can only be used in Ordered containers, which is why the
    Outbount Traffic container (describe block) is decorated with Ordered
    decorator.

    BeforeEach is decorated with OncePerOrdered decorator, so that
    in Ordered containers, it's executed only once before the first spec.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE 
```
