### PR TITLE
Set RBAC for VM/addvolume and VM/removevolume

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -756,6 +756,8 @@ spec:
           - virtualmachines/start
           - virtualmachines/stop
           - virtualmachines/restart
+          - virtualmachine/addvolume
+          - virtualmachine/removevolume
           verbs:
           - update
         - apiGroups:
@@ -853,6 +855,8 @@ spec:
           - virtualmachines/start
           - virtualmachines/stop
           - virtualmachines/restart
+          - virtualmachine/addvolume
+          - virtualmachine/removevolume
           verbs:
           - update
         - apiGroups:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -658,6 +658,8 @@ rules:
   - virtualmachines/start
   - virtualmachines/stop
   - virtualmachines/restart
+  - virtualmachine/addvolume
+  - virtualmachine/removevolume
   verbs:
   - update
 - apiGroups:
@@ -755,6 +757,8 @@ rules:
   - virtualmachines/start
   - virtualmachines/stop
   - virtualmachines/restart
+  - virtualmachine/addvolume
+  - virtualmachine/removevolume
   verbs:
   - update
 - apiGroups:

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -172,6 +172,8 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					"virtualmachines/start",
 					"virtualmachines/stop",
 					"virtualmachines/restart",
+					"virtualmachine/addvolume",
+					"virtualmachine/removevolume",
 				},
 				Verbs: []string{
 					"update",
@@ -297,6 +299,8 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"virtualmachines/start",
 					"virtualmachines/stop",
 					"virtualmachines/restart",
+					"virtualmachine/addvolume",
+					"virtualmachine/removevolume",
 				},
 				Verbs: []string{
 					"update",


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The admin/edit user had vmi/addvolume and vmi/removevolume but for the 'persistent' version vm/addvolume and vm/removevolume the permissions were missing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed RBAC for admin/edit user to allow virtualmachine/addvolume and removevolume. This allows for persistent disks
```
