### PR TITLE
virtctl/ssh: Fix missing check when parsing a private key

### DIFF
--- a/pkg/virtctl/ssh/native.go
+++ b/pkg/virtctl/ssh/native.go
@@ -97,10 +97,11 @@ func (o *SSH) tryPrivateKey(methods []ssh.AuthMethod) []ssh.AuthMethod {
 		signer, err := ssh.ParsePrivateKey(key)
 		if _, isPassErr := err.(*ssh.PassphraseMissingError); isPassErr {
 			signer, err = o.parsePrivateKeyWithPassphrase(key)
-			if err != nil {
-				return nil, err
-			}
 		}
+		if err != nil {
+			return nil, err
+		}
+
 		return []ssh.Signer{signer}, nil
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If a private key is parsed and the returned err is not nil and not
ssh.PassphraseMissingError, a nil Signer would have been returned
erroneously without this change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
