### PR TITLE
Simplify e2e probes tests remove boolean input parameters

### DIFF
--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -112,7 +112,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				}, 120)).ToNot(HaveOccurred())
 
 				// Marking the status to not ready can take a little more time
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 300)
+				tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstanceReady, 300)
 
 				By("Enabling the guest-agent again")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR cleans up the e2e probes test by:
  - removing boolean arguments from its table
  - adding some when clauses that make the tests more readable - for instance, one of the booleans was used to run more code *after* the test was executed. This literally means the "old" test is the test setup of this new, unrelated test.
  - add a couple of local (un-exported) `libvmi.Option` for setting probes

It furthermore fixes a bug on the guest agent probes, since the readiness of the VMI **depends** on the availability of the guest agent. It previously was making sure the VMI status is `Ready` after the guest agent is disabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
