### PR TITLE
Removing myself from automated review assignment

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,7 +23,6 @@ aliases:
       - ashleyschuett
       - zcahana
   code-reviewers:
-      - davidvossel
       - rmohr
       - stu-gott
       - vladikr


### PR DESCRIPTION
My focus at the moment has shifted to cluster-api-provider-kubevirt and I'm not able to reliably keep up with the auto-assigned review requests in kubevirt/kubevirt right now.

If you need a review, ping me directly on kubernetes slack (username: vossel).

I'll request to add myself back if my focus becomes freed up again for kubevirt/kubevirt. 


```release-note
NONE
```
