### PR TITLE
Remove redundant parameter from pod template capabilities

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1096,8 +1096,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	// Add ports from interfaces to the pod manifest
 	ports := getPortsFromVMI(vmi)
 
-	capabilities := getRequiredCapabilities(vmi, t.clusterConfig)
-
 	networkToResourceMap, err := getNetworkToResourceMap(t.virtClient, vmi)
 	if err != nil {
 		return nil, err
@@ -1140,7 +1138,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			RunAsUser:  &userId,
 			Privileged: &privileged,
 			Capabilities: &k8sv1.Capabilities{
-				Add:  capabilities,
+				Add:  getRequiredCapabilities(vmi),
 				Drop: []k8sv1.Capability{CAP_NET_RAW},
 			},
 		},
@@ -1806,7 +1804,7 @@ func haveSlirp(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-func getRequiredCapabilities(vmi *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig) []k8sv1.Capability {
+func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
 	if util.IsNonRootVMI(vmi) {
 		return []k8sv1.Capability{CAP_NET_BIND_SERVICE}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The cluster configuration parameter is not in use in the
`getRequiredCapabilities` function.
    
Furthermore, inline the usage of the aforementioned function - there is
no reason to use a variable.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
