### PR TITLE
Fix a wrong unit test

### DIFF
--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Apply", func() {
 
 	Context("Services", func() {
 
-		It("should patch if ClusterIp == \"\" during update", func() {
+		It("should not patch if ClusterIp is empty during update", func() {
 			cachedService := &corev1.Service{}
 			cachedService.Spec.Type = corev1.ServiceTypeClusterIP
 			cachedService.Spec.ClusterIP = "10.10.10.10"
@@ -62,13 +62,10 @@ var _ = Describe("Apply", func() {
 			service.Spec.Type = corev1.ServiceTypeClusterIP
 			service.Spec.ClusterIP = ""
 
-			ops, err := generateServicePatch(cachedService, service)
-			Expect(err).To(BeNil())
-			Expect(ops).ToNot(Equal(""))
+			Expect(generateServicePatch(cachedService, service)).To(BeEmpty())
 		})
 
-		It("should replace if ClusterIp != \"\" during update and ip changes", func() {
-
+		It("should replace if ClusterIp is not empty during update and ip changes", func() {
 			cachedService := &corev1.Service{}
 			cachedService.Spec.Type = corev1.ServiceTypeClusterIP
 			cachedService.Spec.ClusterIP = "10.10.10.10"


### PR DESCRIPTION
fix the 'should patch if ClusterIp == \"\" during update' unit test in
/pkg/virt-operator/resource/apply/core_test.go

The test compared a slice to an empty string (""), expecting them to be
not equal. This condition will always be true and so the test allways
passed, regardless the content of the slice.

This PR fixes the test by expecting the slice to be empty.
The PR also fixes the style of the test description and the also test
description of the following test, to remove the `\"\"`, replace them by
more readable version.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
