### PR TITLE
Configure Kind clusters to use CI's proxy

### DIFF
--- a/cluster-up/cluster/kind-1.22-sriov/provider.sh
+++ b/cluster-up/cluster/kind-1.22-sriov/provider.sh
@@ -36,6 +36,18 @@ function print_sriov_data() {
     done
 }
 
+function configure_registry_proxy() {
+    [ "$CI" != "true" ] && return
+
+    echo "Configuring cluster nodes to work with CI mirror-proxy..."
+
+    local -r ci_proxy_hostname="docker-mirror-proxy.kubevirt-prow.svc"
+    local -r kind_binary_path="${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kind"
+    local -r configure_registry_proxy_script="${KUBEVIRTCI_PATH}/cluster/kind/configure-registry-proxy.sh"
+
+    KIND_BIN="$kind_binary_path" PROXY_HOSTNAME="$ci_proxy_hostname" $configure_registry_proxy_script
+}
+
 function up() {
     # print hardware info for easier debugging based on logs
     echo 'Available NICs'
@@ -44,6 +56,8 @@ function up() {
 
     cp $KIND_MANIFESTS_DIR/kind.yaml ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/kind.yaml
     kind_up
+
+    configure_registry_proxy
 
     # remove the rancher.io kind default storageClass
     _kubectl delete sc standard

--- a/cluster-up/cluster/kind/configure-registry-proxy.sh
+++ b/cluster-up/cluster/kind/configure-registry-proxy.sh
@@ -1,0 +1,40 @@
+# source: https://github.com/rpardini/docker-registry-proxy#kind-cluster
+#
+# This script execute docker-registry-proxy cluster nodes
+# setup script on each cluster node.
+# Basically what the setup script does is loading the proxy certificate
+# and set HTTP_PROXY and NO_PROXY env vars to enable direct communication
+# between cluster components (e.g: pods, nodes and services).
+#
+# Args:
+# KIND_BIN - KinD binary path.
+# PROXY_HOSTNAME - docker-registry-proxy endpoint hostname.
+# CLUSTER_NAME - KinD cluster name.
+#
+# Usage example:
+# KIND_BIN="./kind" CLUSTER_NAME="test" PROXY_HOSTNAME="proxy.ci.com" \
+#   ./configure-registry-proxy.sh
+#
+
+#! /bin/bash
+
+set -ex
+
+CRI=${CRI:-docker}
+
+KIND_BIN="${KIND_BIN:-./kind}"
+PROXY_HOSTNAME="${PROXY_HOSTNAME:-docker-registry-proxy}"
+CLUSTER_NAME="${CLUSTER_NAME:-sriov}"
+
+SETUP_URL="http://${PROXY_HOSTNAME}:3128/setup/systemd"
+pids=""
+for node in $($KIND_BIN get nodes --name "$CLUSTER_NAME"); do
+   $CRI exec "$node" sh -c "\
+      curl $SETUP_URL | \
+      sed s/docker\.service/containerd\.service/g | \
+      sed '/Environment/ s/$/ \"NO_PROXY=127.0.0.0\/8,10.0.0.0\/8,172.16.0.0\/12,192.168.0.0\/16\"/' | \
+      bash" &
+   pids="$pids $!"
+done
+wait $pids
+


### PR DESCRIPTION
This PR tests kubevirt/kubevirtci#772 changes

Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
