### PR TITLE
Shorter tests/utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3404,18 +3404,6 @@ func RenderHostPathPod(podName string, dir string, hostPathType k8sv1.HostPathTy
 	return pod
 }
 
-func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.ResourceName) *k8sv1.Node {
-	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-	for _, node := range nodes.Items {
-		if v, ok := node.Status.Capacity[hugepages]; ok && !v.IsZero() {
-			return &node
-		}
-	}
-	return nil
-}
-
 // CreateVmiOnNodeLabeled creates a VMI a node that has a give label set to a given value
 func CreateVmiOnNodeLabeled(vmi *v1.VirtualMachineInstance, nodeLabel, labelValue string) *v1.VirtualMachineInstance {
 	virtClient, err := kubecli.GetKubevirtClient()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3946,7 +3946,7 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 				continue
 			}
 
-			body, err := CallUrlOnPod(&pod, "8443", "/healthz")
+			body, err := callUrlOnPod(&pod, "8443", "/healthz")
 			if err != nil {
 				return fmt.Errorf("failed to call healthz endpoint. %s", errAdditionalInfo)
 			}
@@ -4145,7 +4145,7 @@ func getCert(pod *k8sv1.Pod, port string) []byte {
 	return cert
 }
 
-func CallUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
+func callUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
 	randPort := strconv.Itoa(int(4321 + rand.Intn(6000)))
 	stopChan := make(chan struct{})
 	defer close(stopChan)


### PR DESCRIPTION
With its 4700 lines, tests/utils.go is too long for me to read and understand. This PR makes it ever so slightly simpler by make two of its functions private.

```release-note
NONE
```
