### PR TITLE
Remove assumption that infra replicas default to 2

### DIFF
--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -16,7 +16,7 @@ conn_check_ipv4_address=${CONN_CHECK_IPV4_ADDRESS:-""}
 conn_check_ipv6_address=${CONN_CHECK_IPV6_ADDRESS:-""}
 conn_check_dns=${CONN_CHECK_DNS:-""}
 migration_network_nic=${MIGRATION_NETWORK_NIC:-"eth1"}
-infra_replicas=${KUBEVIRT_INFRA_REPLICAS:-2}
+infra_replicas=${KUBEVIRT_INFRA_REPLICAS:-0}
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/manifests/generated/kubevirt-cr.yaml.in
+++ b/manifests/generated/kubevirt-cr.yaml.in
@@ -14,6 +14,6 @@ spec:
       {{- end}}{{else}} []{{end}}
   customizeComponents: {}
   imagePullPolicy: {{.ImagePullPolicy}}
-  infra:
-    replicas: {{.InfraReplicas}}
+  infra:{{if .InfraReplicas}}
+    replicas: {{.InfraReplicas}}{{end}}
   workloadUpdateStrategy: {}

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	"kubevirt.io/kubevirt/pkg/virt-operator/util"
-
 	"kubevirt.io/api/flavor"
 
 	"kubevirt.io/api/migrations"
@@ -691,10 +689,8 @@ func NewKubeVirtCR(namespace string, pullPolicy corev1.PullPolicy, featureGates 
 		}
 	}
 
-	if infraReplicas != util.DefaultInfraReplicas {
-		cr.Spec.Infra = &virtv1.ComponentConfig{
-			Replicas: &infraReplicas,
-		}
+	cr.Spec.Infra = &virtv1.ComponentConfig{
+		Replicas: &infraReplicas,
 	}
 
 	return cr

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -28,7 +28,6 @@ import (
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 
-	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -663,37 +662,6 @@ func NewMigrationPolicyCrd() (*extv1.CustomResourceDefinition, error) {
 		return nil, err
 	}
 	return crd, nil
-}
-
-// Used by manifest generation
-func NewKubeVirtCR(namespace string, pullPolicy corev1.PullPolicy, featureGates string, infraReplicas uint8) *virtv1.KubeVirt {
-	cr := &virtv1.KubeVirt{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: virtv1.GroupVersion.String(),
-			Kind:       "KubeVirt",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "kubevirt",
-		},
-		Spec: virtv1.KubeVirtSpec{
-			ImagePullPolicy: pullPolicy,
-		},
-	}
-
-	if featureGates != "" {
-		cr.Spec.Configuration = virtv1.KubeVirtConfiguration{
-			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-				FeatureGates: strings.Split(featureGates, ","),
-			},
-		}
-	}
-
-	cr.Spec.Infra = &virtv1.ComponentConfig{
-		Replicas: &infraReplicas,
-	}
-
-	return cr
 }
 
 // NewKubeVirtPriorityClassCR is used for manifest generation

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -86,9 +86,6 @@ const (
 	// #nosec 101, the variable is not holding any credential
 	// Prefix for env vars that will be passed along
 	PassthroughEnvPrefix = "KV_IO_EXTRA_ENV_"
-
-	// DefaultInfraReplicas is the default number of replicas for virt-api and virt-controller
-	DefaultInfraReplicas = 2
 )
 
 // DefaultMonitorNamespaces holds a set of well known prometheus-operator namespaces.

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -96,7 +96,7 @@ func main() {
 	virtLauncherSha := flag.String("virt-launcher-sha", "", "")
 	gsSha := flag.String("gs-sha", "", "")
 	featureGates := flag.String("feature-gates", "", "")
-	infraReplicas := flag.Uint("infra-replicas", 2, "")
+	infraReplicas := flag.Uint("infra-replicas", 0, "")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
@@ -148,7 +148,9 @@ func main() {
 		if *featureGates != "" {
 			data.FeatureGates = strings.Split(*featureGates, ",")
 		}
-		data.InfraReplicas = uint8(*infraReplicas)
+		if *infraReplicas != 0 {
+			data.InfraReplicas = uint8(*infraReplicas)
+		}
 
 		// operator deployment differs a bit in normal manifest and CSV
 		if strings.Contains(*inputFile, ".clusterserviceversion.yaml") {

--- a/tools/resource-generator/BUILD.bazel
+++ b/tools/resource-generator/BUILD.bazel
@@ -8,8 +8,10 @@ go_library(
     deps = [
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//tools/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -86,7 +86,11 @@ $1{{- end}}{{else}} []{{end}}`)
 	// However, when creating a template, we want its value to be something like "{{.InfraReplicas}}", which is not a uint8.
 	// Therefore, the value was substituted for a placeholder above (255). Replacing with the templated value now.
 	if strings.HasPrefix(*infraReplicasFlag, "{{") {
-		cr = strings.Replace(cr, fmt.Sprintf("replicas: %d", infraReplicasPlaceholder), "replicas: "+*infraReplicasFlag, 1)
+		infraReplicasVar := strings.TrimPrefix(*infraReplicasFlag, "{{")
+		infraReplicasVar = strings.TrimSuffix(infraReplicasVar, "}}")
+		re := regexp.MustCompile(`(?m)\n([ \t]+)replicas: ` + fmt.Sprintf("%d", infraReplicasPlaceholder))
+		cr = re.ReplaceAllString(cr, `{{if `+infraReplicasVar+`}}
+${1}replicas: {{`+infraReplicasVar+`}}{{end}}`)
 	}
 
 	fmt.Print(cr)

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -28,6 +28,10 @@ import (
 	"strconv"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	virtv1 "kubevirt.io/api/core/v1"
+
 	v1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -39,6 +43,36 @@ const (
 	featureGatesPlaceholder  = "FeatureGatesPlaceholder"
 	infraReplicasPlaceholder = 255
 )
+
+func newKubeVirtCR(namespace string, pullPolicy v1.PullPolicy, featureGates string, infraReplicas uint8) *virtv1.KubeVirt {
+	cr := &virtv1.KubeVirt{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: virtv1.GroupVersion.String(),
+			Kind:       "KubeVirt",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "kubevirt",
+		},
+		Spec: virtv1.KubeVirtSpec{
+			ImagePullPolicy: pullPolicy,
+		},
+	}
+
+	if featureGates != "" {
+		cr.Spec.Configuration = virtv1.KubeVirtConfiguration{
+			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
+				FeatureGates: strings.Split(featureGates, ","),
+			},
+		}
+	}
+
+	cr.Spec.Infra = &virtv1.ComponentConfig{
+		Replicas: &infraReplicas,
+	}
+
+	return cr
+}
 
 func generateKubeVirtCR(namespace *string, imagePullPolicy v1.PullPolicy, featureGatesFlag *string, infraReplicasFlag *string) {
 	var featureGates string
@@ -58,7 +92,10 @@ func generateKubeVirtCR(namespace *string, imagePullPolicy v1.PullPolicy, featur
 		infraReplicas = uint8(val)
 	}
 	var buf bytes.Buffer
-	util.MarshallObject(components.NewKubeVirtCR(*namespace, imagePullPolicy, featureGates, infraReplicas), &buf)
+	err := util.MarshallObject(newKubeVirtCR(*namespace, imagePullPolicy, featureGates, infraReplicas), &buf)
+	if err != nil {
+		panic(err)
+	}
 	cr := buf.String()
 	// When creating a template, we need to add code to iterate over the feature-gates slice variable.
 	// util.MarshallObject(), called above, uses yaml.Marshall(), which can only generate valid yaml.
@@ -111,19 +148,28 @@ func main() {
 	case "kv":
 		kv, err := components.NewKubeVirtCrd()
 		if err != nil {
-			panic(fmt.Errorf("This should not happen, %v", err))
+			panic(fmt.Errorf("this should not happen, %v", err))
 		}
-		util.MarshallObject(kv, os.Stdout)
+		err = util.MarshallObject(kv, os.Stdout)
+		if err != nil {
+			panic(err)
+		}
 	case "kv-cr":
 		generateKubeVirtCR(namespace, imagePullPolicy, featureGates, infraReplicas)
 	case "operator-rbac":
 		all := rbac.GetAllOperator(*namespace)
 		for _, r := range all {
-			util.MarshallObject(r, os.Stdout)
+			err := util.MarshallObject(r, os.Stdout)
+			if err != nil {
+				panic(err)
+			}
 		}
 	case "priorityclass":
 		priorityClass := components.NewKubeVirtPriorityClassCR()
-		util.MarshallObject(priorityClass, os.Stdout)
+		err := util.MarshallObject(priorityClass, os.Stdout)
+		if err != nil {
+			panic(err)
+		}
 	default:
 		panic(fmt.Errorf("unknown resource type %s", *resourceType))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When KUBEVIRT_INFRA_REPLICAS is not set, we still add `replicas: 2` in the CR, since it was the default until recently, and made the code simpler.
However, replicas are now dynamic, and we don't want to force a specific value when none is set.
This PR adds an `if` block to the CR template to address that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
