### PR TITLE
NoReadyVirtController and NoReadyVirtOperator are never triggered 

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -226,6 +226,49 @@ tests:
               severity: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+   # All virt controllers are not ready (ImagePullBackOff)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
+        values: "stale stale stale stale stale stale stale stale stale stale"
+
+    alert_rule_test:
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: NoReadyVirtController
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoReadyVirtController
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-controller was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
+            exp_labels:
+              severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # All virt operators are not ready (ImagePullBackOff)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_operator_ready{namespace="ci", pod="virt-operator-1"}'
+        values: "stale stale stale stale stale stale stale stale stale stale"
+
+    alert_rule_test:
+      # no alert before 10 minutes
+      - eval_time: 9m
+        alertname: NoReadyVirtOperator
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoReadyVirtOperator
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-operator was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
+            exp_labels:
+              severity: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
 
   # All virt operators are not ready
   - interval: 1m

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -19,7 +19,7 @@
 source $(dirname "$0")/../common.sh
 
 fail_if_cri_bin_missing
-readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
+readonly PROM_IMAGE="quay.io/prometheus/prometheus:v2.15.2"
 
 function cleanup() {
     local cleanup_files=("${@:?}")

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -42,7 +42,7 @@ function unit_test() {
     local tests_file="${2:?}"
 
     ${KUBEVIRT_CRI} run --rm --entrypoint=/bin/promtool \
-        -v "$tests_file":/tmp/rules.test:ro \
+        -v "$tests_file":/tmp/rules.test:Z \
         -v "$target_file":/tmp/rules.verify:ro \
         "$PROM_IMAGE" \
         test rules /tmp/rules.test

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -154,7 +154,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Record: "kubevirt_virt_controller_ready_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(kubevirt_virt_controller_ready{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_virt_controller_ready{namespace='%s'}) or vector(0)", ns),
 						),
 					},
 					{
@@ -284,7 +284,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Record: "kubevirt_virt_operator_ready_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(kubevirt_virt_operator_ready{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_virt_operator_ready{namespace='%s'}) or vector(0)", ns),
 						),
 					},
 					{


### PR DESCRIPTION
**What this PR does / why we need it**:
The admin can edit deployment and cause the virt-controller/operator to not be ready.
As a consequence, NoReady* alerts would not fire. This PR fixes this case.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://bugzilla.redhat.com/show_bug.cgi?id=2036676

**Special notes for your reviewer**:
I have packaged multiple fixes into this PR. I will try to ping relevant people for reviews.

**Release note**:
```release-note
NoReadyVirtController and NoReadyVirtOperator should be properly fired.
```
