### PR TITLE
[External Kernel Boot]: Disallow kernel args without providing custom kernel

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -97,7 +97,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-        "//tools/vms-generator/utils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2389,7 +2389,19 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 
 // Rejects kernel boot defined with initrd/kernel path but without an image
 func validateKernelBoot(field *k8sfield.Path, kernelBoot *v1.KernelBoot) (causes []metav1.StatusCause) {
-	if kernelBoot == nil || kernelBoot.Container == nil {
+	if kernelBoot == nil {
+		return
+	}
+
+	if kernelBoot.Container == nil {
+		if kernelBoot.KernelArgs != "" {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "kernel arguments cannot be provided without an external kernel",
+				Field:   field.Child("kernelArgs").String(),
+			})
+		}
+
 		return
 	}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2401,7 +2401,6 @@ func validateKernelBoot(field *k8sfield.Path, kernelBoot *v1.KernelBoot) (causes
 				Field:   field.Child("kernelArgs").String(),
 			})
 		}
-
 		return
 	}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 
 	"kubevirt.io/client-go/api"
-	"kubevirt.io/kubevirt/tools/vms-generator/utils"
-
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -2212,29 +2210,39 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 		Context("with kernel boot defined", func() {
 
-			const (
-				fakeKernelArgs = "args"
-				fakeImage      = "image"
-				fakeInitrd     = "initrd"
-				fakeKernel     = "kernel"
-			)
-
-			DescribeTable("", func(kernelArgs, initrdPath, kernelPath, image string, defineContainerNil bool, shouldBeValid bool) {
-				vmi := utils.GetVMIKernelBoot()
-
-				kb := vmi.Spec.Domain.Firmware.KernelBoot
-
-				if defineContainerNil {
-					kb.Container = nil
-				} else {
-					kb.KernelArgs = kernelArgs
-					kb.Container.KernelPath = kernelPath
-					kb.Container.InitrdPath = initrdPath
-					kb.Container.Image = image
+			createKernelBoot := func(kernelArgs, initrdPath, kernelPath, image string) *v1.KernelBoot {
+				var kbContainer *v1.KernelBootContainer
+				if image != "" || kernelPath != "" || initrdPath != "" {
+					kbContainer = &v1.KernelBootContainer{
+						Image:      image,
+						KernelPath: kernelPath,
+						InitrdPath: initrdPath,
+					}
 				}
 
+				return &v1.KernelBoot{
+					KernelArgs: kernelArgs,
+					Container:  kbContainer,
+				}
+			}
+
+			const (
+				validKernelArgs   = "args"
+				withoutKernelArgs = ""
+
+				validImage   = "image"
+				withoutImage = ""
+
+				validInitrd   = "initrd"
+				withoutInitrd = ""
+
+				validKernel   = "kernel"
+				withoutKernel = ""
+			)
+
+			DescribeTable("", func(kernelBoot *v1.KernelBoot, shouldBeValid bool) {
 				kernelBootField := k8sfield.NewPath("spec").Child("domain").Child("firmware").Child("kernelBoot")
-				causes := validateKernelBoot(kernelBootField, kb)
+				causes := validateKernelBoot(kernelBootField, kernelBoot)
 
 				if shouldBeValid {
 					Expect(causes).To(BeEmpty())
@@ -2243,22 +2251,21 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				}
 			},
 				Entry("without kernel args and null container - should approve",
-					"", "", "", "", true, true),
-				Entry("with kernel args and null container - should approve",
-					fakeKernelArgs, "", "", "", true, true),
+					createKernelBoot(withoutKernelArgs, withoutInitrd, withoutKernel, withoutImage), true),
+				Entry("with kernel args and null container - should reject",
+					createKernelBoot(validKernelArgs, withoutInitrd, withoutKernel, withoutImage), false),
 				Entry("without kernel args, with container that has image & kernel & initrd defined - should approve",
-					"", fakeInitrd, fakeKernel, fakeImage, false, true),
+					createKernelBoot(withoutKernelArgs, validInitrd, validKernel, validImage), true),
 				Entry("with kernel args, with container that has image & kernel & initrd defined - should approve",
-					fakeKernelArgs, fakeInitrd, fakeKernel, fakeImage, false, true),
+					createKernelBoot(validKernelArgs, validInitrd, validKernel, validImage), true),
 				Entry("with kernel args, with container that has image & kernel defined - should approve",
-					fakeKernelArgs, "", fakeKernel, fakeImage, false, true),
+					createKernelBoot(validKernelArgs, withoutInitrd, validKernel, validImage), true),
 				Entry("with kernel args, with container that has image & initrd defined - should approve",
-					fakeKernelArgs, fakeInitrd, "", fakeImage, false, true),
+					createKernelBoot(validKernelArgs, validInitrd, withoutKernel, validImage), true),
 				Entry("with kernel args, with container that has only image defined - should reject",
-					fakeKernelArgs, "", "", fakeImage, false, false),
+					createKernelBoot(validKernelArgs, withoutInitrd, withoutKernel, validImage), false),
 				Entry("with kernel args, with container that has initrd and kernel defined but without image - should reject",
-					fakeKernelArgs, fakeInitrd, fakeKernel, "", false, false),
-				Entry("with kernel args, with container that has nothing defined", "", "", "", "", false, false),
+					createKernelBoot(validKernelArgs, validInitrd, validKernel, withoutImage), false),
 			)
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Kernel args are not supported when a custom kernel image is not provided (a QEMU limitation [1]).
Therefore, allowing it is a bug. This PR fixes this by rejecting such VMI definition.

[1] - https://qemu-project.gitlab.io/qemu/system/linuxboot.html

Also made this PR for fixing the upstream documentation: https://github.com/kubevirt/user-guide/pull/529

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2070897

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[External Kernel Boot]: Disallow kernel args without providing custom kernel
```
