### PR TITLE
Refactor virt controller template machine container spec

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "multus_annotations.go",
+        "rendercontainer.go",
         "template.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/services",
@@ -40,6 +41,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "multus_annotations_test.go",
+        "rendercontainer_test.go",
         "services_suite_test.go",
         "template_test.go",
     ],

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -1,0 +1,147 @@
+package services
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/util"
+)
+
+type ContainerSpecRenderer struct {
+	imgPullPolicy   k8sv1.PullPolicy
+	isPrivileged    bool
+	launcherImg     string
+	name            string
+	userID          int64
+	volumeDevices   []k8sv1.VolumeDevice
+	volumeMounts    []k8sv1.VolumeMount
+	resources       k8sv1.ResourceRequirements
+	liveninessProbe *k8sv1.Probe
+	readinessProbe  *k8sv1.Probe
+	ports           []k8sv1.ContainerPort
+	capabilities    *k8sv1.Capabilities
+	args            []string
+}
+
+type Option func(*ContainerSpecRenderer)
+
+func NewContainerSpecRenderer(containerName string, launcherImg string, imgPullPolicy k8sv1.PullPolicy, opts ...Option) *ContainerSpecRenderer {
+	computeContainerSpec := &ContainerSpecRenderer{
+		imgPullPolicy: imgPullPolicy,
+		launcherImg:   launcherImg,
+		name:          containerName,
+	}
+	for _, opt := range opts {
+		opt(computeContainerSpec)
+	}
+	return computeContainerSpec
+}
+
+func (csr *ContainerSpecRenderer) Render(cmd []string) k8sv1.Container {
+	return k8sv1.Container{
+		Name:            csr.name,
+		Image:           csr.launcherImg,
+		ImagePullPolicy: csr.imgPullPolicy,
+		SecurityContext: securityContext(csr.userID, csr.isPrivileged, csr.capabilities),
+		Command:         cmd,
+		VolumeDevices:   csr.volumeDevices,
+		VolumeMounts:    csr.volumeMounts,
+		Resources:       csr.resources,
+		Ports:           csr.ports,
+		Env:             csr.envVars(),
+		LivenessProbe:   csr.liveninessProbe,
+		ReadinessProbe:  csr.readinessProbe,
+		Args:            csr.args,
+	}
+}
+
+func (csr *ContainerSpecRenderer) envVars() []k8sv1.EnvVar {
+	if csr.userID == 0 {
+		return nil
+	}
+	return xdgEnvironmentVariables()
+}
+
+func WithNonRoot(userID int64) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.userID = userID
+	}
+}
+
+func WithPrivileged() Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.isPrivileged = true
+	}
+}
+
+func WithCapabilities(vmi *v1.VirtualMachineInstance) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.capabilities = &k8sv1.Capabilities{
+			Add:  getRequiredCapabilities(vmi),
+			Drop: []k8sv1.Capability{CAP_NET_RAW},
+		}
+	}
+}
+
+func WithVolumeDevices(devices []k8sv1.VolumeDevice) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.volumeDevices = devices
+	}
+}
+
+func WithVolumeMounts(mounts []k8sv1.VolumeMount) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.volumeMounts = mounts
+	}
+}
+
+func WithResourceRequirements(resources k8sv1.ResourceRequirements) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.resources = resources
+	}
+}
+
+func WithPorts(vmi *v1.VirtualMachineInstance) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.ports = getPortsFromVMI(vmi)
+	}
+}
+
+func WithArgs(args []string) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.args = args
+	}
+}
+
+func xdgEnvironmentVariables() []k8sv1.EnvVar {
+	const varRun = "/var/run"
+	return []k8sv1.EnvVar{
+		{
+			Name:  "XDG_CACHE_HOME",
+			Value: util.VirtPrivateDir,
+		},
+		{
+			Name:  "XDG_CONFIG_HOME",
+			Value: util.VirtPrivateDir,
+		},
+		{
+			Name:  "XDG_RUNTIME_DIR",
+			Value: varRun,
+		},
+	}
+}
+
+func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.Capabilities) *k8sv1.SecurityContext {
+	isNonRoot := userId != 0
+	context := &k8sv1.SecurityContext{
+		RunAsUser:    &userId,
+		RunAsNonRoot: &isNonRoot,
+		Privileged:   &privileged,
+		Capabilities: requiredCapabilities,
+	}
+
+	if isNonRoot {
+		context.RunAsGroup = &userId
+	}
+	return context
+}

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -83,13 +83,13 @@ func WithCapabilities(vmi *v1.VirtualMachineInstance) Option {
 	}
 }
 
-func WithVolumeDevices(devices []k8sv1.VolumeDevice) Option {
+func WithVolumeDevices(devices ...k8sv1.VolumeDevice) Option {
 	return func(renderer *ContainerSpecRenderer) {
 		renderer.volumeDevices = devices
 	}
 }
 
-func WithVolumeMounts(mounts []k8sv1.VolumeMount) Option {
+func WithVolumeMounts(mounts ...k8sv1.VolumeMount) Option {
 	return func(renderer *ContainerSpecRenderer) {
 		renderer.volumeMounts = mounts
 	}

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -113,6 +113,22 @@ func WithArgs(args []string) Option {
 	}
 }
 
+func WithLivelinessProbe(vmi *v1.VirtualMachineInstance) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		v1.SetDefaults_Probe(vmi.Spec.LivenessProbe)
+		renderer.liveninessProbe = copyProbe(vmi.Spec.LivenessProbe)
+		updateLivenessProbe(vmi, renderer.liveninessProbe)
+	}
+}
+
+func WithReadinessProbe(vmi *v1.VirtualMachineInstance) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		v1.SetDefaults_Probe(vmi.Spec.ReadinessProbe)
+		renderer.readinessProbe = copyProbe(vmi.Spec.ReadinessProbe)
+		updateReadinessProbe(vmi, renderer.readinessProbe)
+	}
+}
+
 func xdgEnvironmentVariables() []k8sv1.EnvVar {
 	const varRun = "/var/run"
 	return []k8sv1.EnvVar{

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -7,6 +7,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 )
 
+const (
+	cacheHomeEnvVarName  = "XDG_CACHE_HOME"
+	configHomeEnvVarName = "XDG_CONFIG_HOME"
+	runtimeDirEnvVarName = "XDG_RUNTIME_DIR"
+)
+
 type ContainerSpecRenderer struct {
 	imgPullPolicy   k8sv1.PullPolicy
 	isPrivileged    bool
@@ -133,15 +139,15 @@ func xdgEnvironmentVariables() []k8sv1.EnvVar {
 	const varRun = "/var/run"
 	return []k8sv1.EnvVar{
 		{
-			Name:  "XDG_CACHE_HOME",
+			Name:  cacheHomeEnvVarName,
 			Value: util.VirtPrivateDir,
 		},
 		{
-			Name:  "XDG_CONFIG_HOME",
+			Name:  configHomeEnvVarName,
 			Value: util.VirtPrivateDir,
 		},
 		{
-			Name:  "XDG_RUNTIME_DIR",
+			Name:  runtimeDirEnvVarName,
 			Value: varRun,
 		},
 	}

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Container spec renderer", func() {
 		)
 
 		DescribeTable("the expected `VolumeDevice`s are rendered into the container", func(devices ...k8sv1.VolumeDevice) {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeDevices(devices))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeDevices(devices...))
 			Expect(specRenderer.Render(exampleCommand).VolumeDevices).To(ConsistOf(devices))
 		},
 			Entry("no volume devices are passed as options"),
@@ -160,7 +160,7 @@ var _ = Describe("Container spec renderer", func() {
 		)
 
 		DescribeTable("the expected `VolumeMount`s are rendered into the container", func(mounts ...k8sv1.VolumeMount) {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeMounts(mounts))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeMounts(mounts...))
 			Expect(specRenderer.Render(exampleCommand).VolumeMounts).To(ConsistOf(mounts))
 		},
 			Entry("no volume devices are passed as options"),

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -1,0 +1,300 @@
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/util"
+)
+
+var _ = Describe("Container spec renderer", func() {
+	exampleCommand := []string{"/bin/bash"}
+
+	var specRenderer *ContainerSpecRenderer
+
+	const (
+		containerName = "exampleContainer"
+		img           = "megaimage2000"
+		pullPolicy    = k8sv1.PullAlways
+	)
+
+	Context("without any options", func() {
+		BeforeEach(func() {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy)
+		})
+
+		It("should have the unprivileged root user security context", func() {
+			Expect(specRenderer.Render(exampleCommand)).Should(
+				Equal(
+					k8sv1.Container{
+						Name:            containerName,
+						Image:           img,
+						Command:         exampleCommand,
+						ImagePullPolicy: pullPolicy,
+						SecurityContext: unprivilegedRootUserSecurityContext(),
+					}))
+		})
+	})
+
+	Context("with non root user option", func() {
+		const nonRootUser = 207
+
+		BeforeEach(func() {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithNonRoot(nonRootUser))
+		})
+
+		It("should feature the XDG environment variables", func() {
+			Expect(specRenderer.Render(exampleCommand).Env).Should(
+				ConsistOf(
+					k8sv1.EnvVar{
+						Name:  "XDG_CACHE_HOME",
+						Value: util.VirtPrivateDir,
+					}, k8sv1.EnvVar{
+						Name:  "XDG_CONFIG_HOME",
+						Value: util.VirtPrivateDir,
+					}, k8sv1.EnvVar{
+						Name:  "XDG_RUNTIME_DIR",
+						Value: varRun,
+					},
+				))
+		})
+	})
+
+	Context("with privileged option", func() {
+		BeforeEach(func() {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithPrivileged())
+		})
+
+		It("should feature a privileged security context", func() {
+			Expect(specRenderer.Render(exampleCommand).SecurityContext).Should(
+				Equal(privilegedRootUserSecurityContext()),
+			)
+		})
+	})
+
+	Context("vmi capabilities", func() {
+		Context("a VMI running as root", func() {
+			BeforeEach(func() {
+				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCapabilities(simplestVMI()))
+			})
+
+			It("must request to drop the NET_RAW capability", func() {
+				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Drop).Should(
+					Equal([]k8sv1.Capability{CAP_NET_RAW}))
+			})
+
+			It("must request to add the NET_BIND_SERVICE, SYS_NICE and SYS_PTRACE capabilities", func() {
+				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).To(
+					ConsistOf(
+						k8sv1.Capability(CAP_NET_BIND_SERVICE),
+						k8sv1.Capability(CAP_SYS_NICE),
+						k8sv1.Capability(CAP_SYS_PTRACE)))
+			})
+
+			Context("with a virtioFS filesystem", func() {
+				BeforeEach(func() {
+					const rootUser = 0
+					specRenderer = NewContainerSpecRenderer(
+						containerName,
+						img,
+						pullPolicy,
+						WithCapabilities(vmiWithVirtioFS(rootUser)))
+				})
+
+				It("must request the virtio related capabilities", func() {
+					Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).Should(
+						ConsistOf(
+							append(
+								[]k8sv1.Capability{
+									CAP_NET_BIND_SERVICE,
+									CAP_SYS_NICE,
+									CAP_SYS_ADMIN,
+									CAP_SYS_PTRACE},
+								getVirtiofsCapabilities()...),
+						))
+				})
+			})
+		})
+
+		Context("a VMI belonging to a non root user", func() {
+			BeforeEach(func() {
+				const nonRootUser = 207
+				specRenderer = NewContainerSpecRenderer(
+					containerName,
+					img,
+					pullPolicy,
+					WithCapabilities(nonRootVMI(nonRootUser)))
+			})
+
+			It("must request the NET_BIND_SERVICE and SYS_PTRACE capabilities", func() {
+				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).Should(
+					ConsistOf(k8sv1.Capability(CAP_NET_BIND_SERVICE), k8sv1.Capability(CAP_SYS_PTRACE)))
+			})
+		})
+	})
+
+	Context("with volume devices option", func() {
+		const (
+			volumeName = "asd"
+			volumePath = "/tmp/mega-path"
+		)
+
+		DescribeTable("the expected `VolumeDevice`s are rendered into the container", func(devices ...k8sv1.VolumeDevice) {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeDevices(devices))
+			Expect(specRenderer.Render(exampleCommand).VolumeDevices).To(ConsistOf(devices))
+		},
+			Entry("no volume devices are passed as options"),
+			Entry("one optional volume device is added to the renderer", volumeDevice(volumeName, volumePath)),
+		)
+	})
+
+	Context("with volume mounts option", func() {
+		const (
+			mountName = "asd"
+			mountPath = "/tmp/mega-path"
+		)
+
+		DescribeTable("the expected `VolumeMount`s are rendered into the container", func(mounts ...k8sv1.VolumeMount) {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeMounts(mounts))
+			Expect(specRenderer.Render(exampleCommand).VolumeMounts).To(ConsistOf(mounts))
+		},
+			Entry("no volume devices are passed as options"),
+			Entry("one optional volume device is added to the renderer", volumeMount(mountName, mountPath)),
+		)
+	})
+
+	Context("with resources option", func() {
+		var expectedResource k8sv1.ResourceRequirements
+
+		BeforeEach(func() {
+			expectedResource = resources("10", "100")
+			specRenderer = NewContainerSpecRenderer(
+				containerName, img, pullPolicy, WithResourceRequirements(expectedResource))
+		})
+
+		It("the resource requirements are rendered into the container", func() {
+			Expect(specRenderer.Render(exampleCommand).Resources).To(Equal(expectedResource))
+		})
+	})
+
+	Context("vmi with ports allowed in its spec", func() {
+		var ports []v1.Port
+
+		BeforeEach(func() {
+			const ifaceName = "not-relevant"
+			ports = []v1.Port{{
+				Name: "http", Port: 80},
+				{Protocol: "UDP", Port: 80},
+				{Port: 90},
+				{Name: "other-http", Port: 80}}
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithPorts(
+				vmiWithInterfaceWithPortAllowList(ifaceName, ports...)))
+		})
+
+		It("the container should feature the same port list", func() {
+			Expect(specRenderer.Render(exampleCommand).Ports).To(HaveLen(len(ports)))
+			for i := range ports {
+				Expect(specRenderer.Render(exampleCommand).Ports[i]).To(
+					Equal(vmPortToContainerPort(ports[i])))
+			}
+		})
+	})
+
+	Context("container command and arguments", func() {
+		DescribeTable("", func(args ...string) {
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithArgs(args))
+			Expect(specRenderer.Render(exampleCommand).Command).To(Equal(exampleCommand))
+			Expect(specRenderer.Render(exampleCommand).Args).To(Equal(args))
+		},
+			Entry("without input args"),
+			Entry("with an input argument", "do-stuff"),
+		)
+	})
+})
+
+func vmiWithInterfaceWithPortAllowList(ifaceName string, ports ...v1.Port) *v1.VirtualMachineInstance {
+	vmi := simplestVMI()
+	vmi.Spec.Domain = v1.DomainSpec{
+		Devices: v1.Devices{
+			Interfaces: []v1.Interface{
+				{Name: ifaceName, Ports: ports},
+			}},
+	}
+	return vmi
+}
+
+func vmiWithVirtioFS(user uint64) *v1.VirtualMachineInstance {
+	const fsName = "0_o"
+	vmi := nonRootVMI(user)
+	vmi.Spec.Domain = v1.DomainSpec{
+		Devices: v1.Devices{
+			Filesystems: []v1.Filesystem{{
+				Name:     fsName,
+				Virtiofs: &v1.FilesystemVirtiofs{},
+			}},
+		},
+	}
+	return vmi
+}
+
+func nonRootVMI(user uint64) *v1.VirtualMachineInstance {
+	vmi := simplestVMI()
+	vmi.Status = v1.VirtualMachineInstanceStatus{
+		RuntimeUser: user,
+	}
+	return vmi
+}
+
+func simplestVMI() *v1.VirtualMachineInstance {
+	return &v1.VirtualMachineInstance{
+		Spec: v1.VirtualMachineInstanceSpec{},
+	}
+}
+
+func unprivilegedRootUserSecurityContext() *k8sv1.SecurityContext {
+	return securityContext(util.RootUser, false, nil)
+}
+
+func privilegedRootUserSecurityContext() *k8sv1.SecurityContext {
+	return securityContext(util.RootUser, true, nil)
+}
+
+func volumeDevice(name string, path string) k8sv1.VolumeDevice {
+	return k8sv1.VolumeDevice{
+		Name:       name,
+		DevicePath: path,
+	}
+}
+
+func volumeMount(name string, path string) k8sv1.VolumeMount {
+	return k8sv1.VolumeMount{
+		Name:      name,
+		ReadOnly:  false,
+		MountPath: path,
+	}
+}
+
+func resources(cpu string, memory string) k8sv1.ResourceRequirements {
+	return k8sv1.ResourceRequirements{
+		Limits: map[k8sv1.ResourceName]resource.Quantity{
+			k8sv1.ResourceCPU:    resource.MustParse(cpu),
+			k8sv1.ResourceMemory: resource.MustParse(memory),
+		},
+	}
+}
+
+func vmPortToContainerPort(vmiPort v1.Port) k8sv1.ContainerPort {
+	protocol := "TCP"
+	if vmiPort.Protocol != "" {
+		protocol = vmiPort.Protocol
+	}
+	return k8sv1.ContainerPort{
+		Name:          vmiPort.Name,
+		ContainerPort: vmiPort.Port,
+		Protocol:      k8sv1.Protocol(protocol),
+	}
+}

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -52,13 +52,13 @@ var _ = Describe("Container spec renderer", func() {
 			Expect(specRenderer.Render(exampleCommand).Env).Should(
 				ConsistOf(
 					k8sv1.EnvVar{
-						Name:  "XDG_CACHE_HOME",
+						Name:  cacheHomeEnvVarName,
 						Value: util.VirtPrivateDir,
 					}, k8sv1.EnvVar{
-						Name:  "XDG_CONFIG_HOME",
+						Name:  configHomeEnvVarName,
 						Value: util.VirtPrivateDir,
 					}, k8sv1.EnvVar{
-						Name:  "XDG_RUNTIME_DIR",
+						Name:  runtimeDirEnvVarName,
 						Value: varRun,
 					},
 				))

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1136,8 +1136,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	computeContainerOpts := []Option{
-		WithVolumeDevices(volumeDevices),
-		WithVolumeMounts(volumeMounts),
+		WithVolumeDevices(volumeDevices...),
+		WithVolumeMounts(volumeMounts...),
 		WithResourceRequirements(resources),
 		WithPorts(vmi),
 		WithCapabilities(vmi),
@@ -1330,11 +1330,9 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 
 	if HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi) {
 
-		initContainerVolumeMounts := []k8sv1.VolumeMount{
-			{
-				Name:      virtBinDir,
-				MountPath: "/init/usr/bin",
-			},
+		initContainerVolumeMount := k8sv1.VolumeMount{
+			Name:      virtBinDir,
+			MountPath: "/init/usr/bin",
 		}
 
 		initContainerResources := k8sv1.ResourceRequirements{}
@@ -1360,7 +1358,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 
 		const containerDisk = "container-disk-binary"
 		cpInitContainerOpts := []Option{
-			WithVolumeMounts(initContainerVolumeMounts),
+			WithVolumeMounts(initContainerVolumeMount),
 			WithResourceRequirements(initContainerResources),
 		}
 
@@ -1472,12 +1470,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	return &pod, nil
 }
 
-func sidecarVolumeMount() []k8sv1.VolumeMount {
-	return []k8sv1.VolumeMount{
-		{
-			Name:      hookSidecarSocks,
-			MountPath: hooks.HookSocketsSharedDirectory,
-		},
+func sidecarVolumeMount() k8sv1.VolumeMount {
+	return k8sv1.VolumeMount{
+		Name:      hookSidecarSocks,
+		MountPath: hooks.HookSocketsSharedDirectory,
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1102,9 +1102,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		command = append(command, "--simulate-crash")
 	}
 
-	// Add ports from interfaces to the pod manifest
-	ports := getPortsFromVMI(vmi)
-
 	networkToResourceMap, err := getNetworkToResourceMap(t.virtClient, vmi)
 	if err != nil {
 		return nil, err
@@ -1138,43 +1135,23 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		requestResource(&resources, SevDevice)
 	}
 
-	// VirtualMachineInstance target container
-	compute := k8sv1.Container{
-		Name:            "compute",
-		Image:           t.launcherImage,
-		ImagePullPolicy: imagePullPolicy,
-		SecurityContext: &k8sv1.SecurityContext{
-			RunAsUser:  &userId,
-			Privileged: &privileged,
-			Capabilities: &k8sv1.Capabilities{
-				Add:  getRequiredCapabilities(vmi),
-				Drop: []k8sv1.Capability{CAP_NET_RAW},
-			},
-		},
-		Command:       command,
-		VolumeDevices: volumeDevices,
-		VolumeMounts:  volumeMounts,
-		Resources:     resources,
-		Ports:         ports,
+	computeContainerOpts := []Option{
+		WithVolumeDevices(volumeDevices),
+		WithVolumeMounts(volumeMounts),
+		WithResourceRequirements(resources),
+		WithPorts(vmi),
+		WithCapabilities(vmi),
 	}
 	if nonRoot {
-		compute.SecurityContext.RunAsGroup = &userId
-		compute.SecurityContext.RunAsNonRoot = &nonRoot
-		compute.Env = append(compute.Env,
-			k8sv1.EnvVar{
-				Name:  "XDG_CACHE_HOME",
-				Value: util.VirtPrivateDir,
-			},
-			k8sv1.EnvVar{
-				Name:  "XDG_CONFIG_HOME",
-				Value: util.VirtPrivateDir,
-			},
-			k8sv1.EnvVar{
-				Name:  "XDG_RUNTIME_DIR",
-				Value: varRun,
-			},
-		)
+		computeContainerOpts = append(computeContainerOpts, WithNonRoot(userId))
 	}
+	if t.IsPPC64() {
+		computeContainerOpts = append(computeContainerOpts, WithPrivileged())
+	}
+
+	const computeContainerName = "compute"
+	compute := NewContainerSpecRenderer(
+		computeContainerName, t.launcherImage, imagePullPolicy, computeContainerOpts...).Render(command)
 
 	if vmi.Spec.ReadinessProbe != nil {
 		v1.SetDefaults_Probe(vmi.Spec.ReadinessProbe)
@@ -1327,29 +1304,22 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("200m")
 			resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("64M")
 		}
-		sidecar := k8sv1.Container{
-			Name:            fmt.Sprintf("hook-sidecar-%d", i),
-			Image:           requestedHookSidecar.Image,
-			ImagePullPolicy: requestedHookSidecar.ImagePullPolicy,
-			Command:         requestedHookSidecar.Command,
-			Args:            requestedHookSidecar.Args,
-			Resources:       resources,
-			SecurityContext: &k8sv1.SecurityContext{
-				RunAsUser:  &userId,
-				Privileged: &privileged,
-			},
-			VolumeMounts: []k8sv1.VolumeMount{
-				{
-					Name:      hookSidecarSocks,
-					MountPath: hooks.HookSocketsSharedDirectory,
-				},
-			},
+
+		sidecarOpts := []Option{
+			WithResourceRequirements(resources),
+			WithVolumeMounts(sidecarVolumeMount()),
+			WithArgs(requestedHookSidecar.Args),
 		}
+
 		if nonRoot {
-			sidecar.SecurityContext.RunAsGroup = &userId
-			sidecar.SecurityContext.RunAsNonRoot = &nonRoot
+			sidecarOpts = append(sidecarOpts, WithNonRoot(userId))
 		}
-		containers = append(containers, sidecar)
+
+		containers = append(containers, NewContainerSpecRenderer(
+			sidecarContainerName(i),
+			requestedHookSidecar.Image,
+			requestedHookSidecar.ImagePullPolicy,
+			sidecarOpts...).Render(requestedHookSidecar.Command))
 	}
 
 	podAnnotations, err := generatePodAnnotations(vmi)
@@ -1392,24 +1362,22 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			"/usr/bin/container-disk",
 			"/init/usr/bin/container-disk",
 		}
-		cpInitContainer := k8sv1.Container{
-			Name:            "container-disk-binary",
-			Image:           t.launcherImage,
-			ImagePullPolicy: imagePullPolicy,
-			SecurityContext: &k8sv1.SecurityContext{
-				RunAsUser:  &userId,
-				Privileged: &privileged,
-			},
-			Command:      initContainerCommand,
-			VolumeMounts: initContainerVolumeMounts,
-			Resources:    initContainerResources,
-		}
-		if nonRoot {
-			cpInitContainer.SecurityContext.RunAsGroup = &userId
-			cpInitContainer.SecurityContext.RunAsNonRoot = &nonRoot
+
+		const containerDisk = "container-disk-binary"
+		cpInitContainerOpts := []Option{
+			WithVolumeMounts(initContainerVolumeMounts),
+			WithResourceRequirements(initContainerResources),
 		}
 
-		initContainers = append(initContainers, cpInitContainer)
+		if nonRoot {
+			cpInitContainerOpts = append(cpInitContainerOpts, WithNonRoot(userId))
+		}
+		if privileged {
+			cpInitContainerOpts = append(cpInitContainerOpts, WithPrivileged())
+		}
+
+		initContainers = append(initContainers, NewContainerSpecRenderer(
+			containerDisk, t.launcherImage, imagePullPolicy, cpInitContainerOpts...).Render(initContainerCommand))
 
 		// this causes containerDisks to be pre-pulled before virt-launcher starts.
 		initContainers = append(initContainers, containerdisk.GenerateInitContainers(vmi, imageIDs, containerDisks, virtBinDir)...)
@@ -1507,6 +1475,19 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	return &pod, nil
+}
+
+func sidecarVolumeMount() []k8sv1.VolumeMount {
+	return []k8sv1.VolumeMount{
+		{
+			Name:      hookSidecarSocks,
+			MountPath: hooks.HookSocketsSharedDirectory,
+		},
+	}
+}
+
+func sidecarContainerName(i int) string {
+	return fmt.Sprintf("hook-sidecar-%d", i)
 }
 
 func validatePermittedHostDevices(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) error {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1148,22 +1148,17 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	if t.IsPPC64() {
 		computeContainerOpts = append(computeContainerOpts, WithPrivileged())
 	}
+	if vmi.Spec.ReadinessProbe != nil {
+		computeContainerOpts = append(computeContainerOpts, WithReadinessProbe(vmi))
+	}
+
+	if vmi.Spec.LivenessProbe != nil {
+		computeContainerOpts = append(computeContainerOpts, WithLivelinessProbe(vmi))
+	}
 
 	const computeContainerName = "compute"
 	compute := NewContainerSpecRenderer(
 		computeContainerName, t.launcherImage, imagePullPolicy, computeContainerOpts...).Render(command)
-
-	if vmi.Spec.ReadinessProbe != nil {
-		v1.SetDefaults_Probe(vmi.Spec.ReadinessProbe)
-		compute.ReadinessProbe = copyProbe(vmi.Spec.ReadinessProbe)
-		updateReadinessProbe(vmi, compute.ReadinessProbe)
-	}
-
-	if vmi.Spec.LivenessProbe != nil {
-		v1.SetDefaults_Probe(vmi.Spec.LivenessProbe)
-		compute.LivenessProbe = copyProbe(vmi.Spec.LivenessProbe)
-		updateLivenessProbe(vmi, compute.LivenessProbe)
-	}
 
 	for networkName, resourceName := range networkToResourceMap {
 		varName := fmt.Sprintf("KUBEVIRT_RESOURCE_NAME_%s", networkName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR refactors the virt-controller templating service. It is barely understandable. 

It focuses explicitly in generating the specification of containers. It replaces the ad-hoc generation of containers in the `virt-launcher` pod by using a builder pattern, allowing the customization of the spec via options. It is working for the following containers:
  - compute
  - sidecars
  - init container

Follow up PRs will re-use this approach for the following resources:
  - env vars
  - volumes
  - resources (this one will be tricky ... that code is all over the place)
  - compute container command
  - ...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
