### PR TITLE
Nominate xpivarc as an approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,7 @@ aliases:
       - jean-edouard
       - mhenriks
       - enp0s3
+      - xpivarc
   emeritus_approvers:
       - cynepco3hahue
       - slintes
@@ -51,6 +52,7 @@ aliases:
       - kbidarkar
       - phoracek
       - enp0s3
+      - xpivarc
   network-reviewers:
       - AlonaKaplan
       - EdDev


### PR DESCRIPTION
Signed-off-by: Stu Gott <sgott@redhat.com>

**What this PR does / why we need it**:

Nominating @xpivarc as an approver. 

**Special notes for your reviewer**:

Community guidelines on eligibility:

https://github.com/kubevirt/community/blob/main/membership_policy.md#approver

**Release note**:
```release-note
NONE
```
