### PR TITLE
Nominate iholder-redhat as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,6 +41,7 @@ aliases:
       - xpivarc
       - marceloamaral
       - vasiliy-ul
+      - iholder-redhat
   ux-reviewers:
       - matthewcarleton
   test-reviewers:


### PR DESCRIPTION
**What this PR does / why we need it**:

Nominate iholder-redhat as a reviewer

**Special notes for your reviewer**:

Community Guidelines for eligibility:

https://github.com/kubevirt/community/blob/main/membership_policy.md#reviewer

**Release note**:
```release-note
NONE
```
