### PR TITLE
tests reporter: log KubeVirt daemonsets

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -154,6 +154,7 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logVMs(virtCli)
 	r.logDVs(virtCli)
 	r.logDeployments(virtCli)
+	r.logDaemonsets(virtCli)
 
 	r.logAuditLogs(virtCli, nodesDir, nodesWithVirtLauncher, since)
 	r.logDMESG(virtCli, nodesDir, nodesWithVirtLauncher, since)
@@ -683,6 +684,16 @@ func (r *KubernetesReporter) logDeployments(virtCli kubecli.KubevirtClient) {
 	}
 
 	r.logObjects(virtCli, deployments, "deployments")
+}
+
+func (r *KubernetesReporter) logDaemonsets(virtCli kubecli.KubevirtClient) {
+	daemonsets, err := virtCli.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch daemonsets: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, daemonsets, "daemonsets")
 }
 
 func (r *KubernetesReporter) logDVs(virtCli kubecli.KubevirtClient) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Daemonsets can be useful for debugging functional tests, and are crucially absent from the artifacts. Adding them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
