### PR TITLE
tests: Don't try to log a paused VMI

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -363,39 +363,26 @@ func (r *KubernetesReporter) logAuditLogs(virtCli kubecli.KubevirtClient, logsdi
 }
 
 func (r *KubernetesReporter) logVMICommands(virtCli kubecli.KubevirtClient, vmiNamespaces []string) {
+	runningVMIs := getRunningVMIs(virtCli, vmiNamespaces)
 
-	logsdir := filepath.Join(r.artifactsDir, "network", "vmis")
-	if err := os.MkdirAll(logsdir, 0777); err != nil {
+	if len(runningVMIs) < 1 {
+		return
+	}
+
+	logsDir := filepath.Join(r.artifactsDir, "network", "vmis")
+	if err := os.MkdirAll(logsDir, 0777); err != nil {
 		fmt.Fprintf(os.Stderr, failedCreateDirectoryFmt, err)
 		return
 	}
 
-	for _, ns := range vmiNamespaces {
-		vmis, err := virtCli.VirtualMachineInstance(ns).List(&metav1.ListOptions{})
+	for _, vmi := range runningVMIs {
+		vmiType, err := getVmiType(vmi)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to get vmis: %v\n", err)
+			fmt.Fprintf(os.Stderr, "skipping vmi %s/%s: failed to get vmi type: %v\n", vmi.Namespace, vmi.Name, err)
 			continue
 		}
 
-		for _, vmi := range vmis.Items {
-			if vmi.Status.Phase != "Running" {
-				fmt.Fprintf(os.Stderr, "skipping vmi %s, phase is not Running\n", vmi.ObjectMeta.Name)
-				continue
-			}
-
-			vmiType, err := getVmiType(vmi)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to get vmi type: %v\n", err)
-				continue
-			}
-
-			if err := prepareVmiConsole(vmi, vmiType); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to login to vmi: %v\n", err)
-				continue
-			}
-
-			r.executeVMICommands(vmi, logsdir, vmiType)
-		}
+		r.executeVMICommands(vmi, logsDir, vmiType)
 	}
 }
 
@@ -809,6 +796,18 @@ func getRunningVMIs(virtCli kubecli.KubevirtClient, namespace []string) []v12.Vi
 		for _, vmi := range nsVMIs.Items {
 			if vmi.Status.Phase != v12.Running {
 				fmt.Fprintf(os.Stderr, "skipping vmi %s/%s: phase is not Running\n", vmi.Namespace, vmi.Name)
+				continue
+			}
+
+			isPaused := false
+			for _, cond := range vmi.Status.Conditions {
+				if cond.Type == v12.VirtualMachineInstancePaused && cond.Status == v1.ConditionTrue {
+					isPaused = true
+					break
+				}
+			}
+			if isPaused {
+				fmt.Fprintf(os.Stderr, "skipping paused vmi %s\n", vmi.ObjectMeta.Name)
 				continue
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The console is not available when a VMI is in paused state and any attempt to connect blocks the exection for a ~2min timeout. Instead of waiting just skip paused VMIs when dumping the logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Not sure if it makes sense to unpause and then log it instead. Anyway currently no logs are dumped for a paused VMI so this PR does not change the behaviour.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
