### PR TITLE
[e2e]: quarantine a few flaky mdev tests

### DIFF
--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -134,7 +134,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			cleanupConfiguredMdevs()
 		})
 
-		It("Should successfully passthrough a mediated device", func() {
+		It("[QUARANTINE]Should successfully passthrough a mediated device", func() {
 
 			By("Creating a Fedora VMI")
 			vmi = tests.NewRandomFedoraVMIWithGuestAgent()
@@ -194,7 +194,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*display=.?on.?`), "Display should not be enabled")
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should not be enabled")
 		})
-		It("Should override default mdev configuration on a specific node", func() {
+		It("[QUARANTINE]Should override default mdev configuration on a specific node", func() {
 			newDesiredMdevTypeName := "nvidia-223"
 			newExpectedInstancesNum := 8
 			By("Creating a configuration for mediated devices")


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>


**What this PR does / why we need it**:
Some mdev-related tests are being flaky on the vGPU lanes.

**Special notes for your reviewer**:
Flakefinder reports
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-04-11-168h.html#row43
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-04-11-168h.html#row42

**Release note**:
```release-note
NONE
```
