### PR TITLE
Pre-create directories for non-root TPM state

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -158,6 +158,7 @@ pkg_tar(
     name = "swtpm-localca-tar",
     empty_dirs = [
         "var/lib/swtpm-localca",
+        "run/var/lib/swtpm-localca",
     ],
     mode = "0750",
     owner = "107.107",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When run as non-root user swtpm_setup will try to write the state under
${XDG_CONFIG_HOME} which is currently set to /var/run. The default
permissions allow only the root user to write to that directory. Create
the required layout and setup access bits during the image build.

Note: creating the empty_dirs like bellow will set the mode and owner
also for each component in the path (i.e. for /var, /var/lib, /run,
etc.):

    pkg_tar(
        name = "swtpm-localca-tar",
        empty_dirs = [
            "var/lib/swtpm-localca",
            "run/var/lib/swtpm-localca",
        ],
        mode = "0750",
        owner = "107.107",
    )


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The issue fixed by this PR is not reproducable in CI at the moment because of misconfiguration of non-root lanes. Refer to [this thread](https://kubernetes.slack.com/archives/C0163DT0R8X/p1649862361658779)  in kubevirt-dev slack channel for details.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
