### PR TITLE
virt-controller: fix false failed migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -485,7 +485,9 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 				}
 			}
 		case virtv1.MigrationScheduled:
-			if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetNode != "" {
+			if vmi.Status.MigrationState != nil &&
+				vmi.Status.MigrationState.MigrationUID == migration.UID &&
+				vmi.Status.MigrationState.TargetNode != "" {
 				migrationCopy.Status.Phase = virtv1.MigrationPreparingTarget
 			}
 		case virtv1.MigrationPreparingTarget:

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1039,6 +1039,28 @@ var _ = Describe("Migration watcher", func() {
 			// expect nothing to occur
 		})
 
+		It("should not transition to PreparingTarget if VMI MigrationState is outdated", func() {
+			vmi := newVirtualMachine("testvmi", virtv1.Running)
+			vmi.Status.NodeName = "node02"
+			migration := newMigration("testmigration", vmi.Name, virtv1.MigrationScheduled)
+			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
+			pod.Spec.NodeName = "node01"
+
+			const oldMigrationUID = "oldmigrationuid"
+			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID: types.UID(oldMigrationUID),
+			}
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(pod)
+
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/status/migrationState", "value": {"migrationUid":"%s"} }, { "op": "replace", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","sourceNode":"node02","migrationUid":"testmigration",%s} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, oldMigrationUID, pod.Name, getMigrationConfigPatch())
+
+			shouldExpectVirtualMachineInstancePatch(vmi, patch)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulHandOverPodReason)
+		})
 		It("should transition to preparing target phase", func() {
 			vmi := newVirtualMachine("testvmi", virtv1.Running)
 			vmi.Status.NodeName = "node02"

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -3797,6 +3798,43 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		By("Waiting for VMI to disappear")
 		tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+	})
+
+	Context("with a live-migration in flight", func() {
+		It("there should always be a single active migration per VMI", func() {
+			By("Starting a VMI")
+			vmi := libvmi.NewCirros(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			vmi = runVMIAndExpectLaunch(vmi, 240)
+
+			By("Checking that there always is at most one migration running")
+			Consistently(func() int {
+				vmim := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				// not checking err as the migration creation will be blocked immediately by virt-api's validating webhook
+				// if another one is currently running
+				vmim, err = virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(vmim, &metav1.CreateOptions{})
+
+				labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", v1.MigrationSelectorLabel, vmi.Name))
+				Expect(err).ToNot(HaveOccurred())
+				listOptions := &metav1.ListOptions{
+					LabelSelector: labelSelector.String(),
+				}
+				migrations, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).List(listOptions)
+				Expect(err).ToNot(HaveOccurred())
+
+				activeMigrations := 0
+				for _, migration := range migrations.Items {
+					switch migration.Status.Phase {
+					case v1.MigrationScheduled, v1.MigrationPreparingTarget, v1.MigrationTargetReady, v1.MigrationRunning:
+						activeMigrations += 1
+					}
+				}
+				return activeMigrations
+
+			}, time.Second*30, time.Second*1).Should(BeNumerically("<=", 1))
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This patch checks that the vmi.Status.MigrationState.MigrationUID
matches the migration being processed before proceeding in moving
the state of the migration from `MigrationScheduled` to
`MigrationPreparingTarget`.

The fix is needed because the `vmi.Status.MigrationState.MigrationUID`
field is updated during the target handoff (which happens in the
`MigrationScheduled` phase) and it might happen that if the migration
is re-processed immediately (because its key has been re-added in the workqueue)
after updating its `Phase` and the cluster is under moderate load, the
vmi Informer might have not caught up resulting in virt-controller
marking the migration as `Failed` because of a take-over by another
migration object even if it actually was successful and the VMI is still
running fine on the target node.

The false take-over error happens when the VMI has already been
previously migrated and as such the `vmi.Status.MigrationState.MigrationUID`
is already populated with some info about an old migration, specifically
the following check inside `updateStatus`:

```
if migration.TargetIsHandedOff() &&
		vmi.Status.MigrationState != nil &&
		vmi.Status.MigrationState.MigrationUID != migration.UID
```
will evaluate to true incorrectly marking the migration as failed.

This bug is easy to reproduce on kubevirtci by continously migrating
a number of VMs (in my test setup they were 3), on my setup this would
get triggered after ~300 migrations.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix failed reported migrations when actually they were successful.
```
