### PR TITLE
tests: Continue moving helpers that are node related to libnode.

### DIFF
--- a/tests/framework/checks/BUILD.bazel
+++ b/tests/framework/checks/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/libnode:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -16,6 +16,8 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -28,7 +30,7 @@ func SkipTestIfNoCPUManager() {
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 
 	for _, node := range nodes.Items {
 		if IsCPUManagerPresent(&node) {
@@ -51,7 +53,7 @@ func SkipTestIfNotEnoughNodesWithCPUManager(nodeCount int) {
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 
 	found := 0
 	for _, node := range nodes.Items {
@@ -73,7 +75,7 @@ func SkipTestIfNotEnoughNodesWithCPUManager(nodeCount int) {
 func SkipTestIfNotEnoughNodesWith2MiHugepages(nodeCount int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 
 	found := 0
 	for _, node := range nodes.Items {
@@ -101,7 +103,7 @@ func SkipTestIfNotRealtimeCapable() {
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 
 	for _, node := range nodes.Items {
 		if IsRealtimeCapable(&node) && IsCPUManagerPresent(&node) && Has2MiHugepages(&node) {
@@ -115,7 +117,7 @@ func SkipTestIfNotRealtimeCapable() {
 func SkipTestIfNotSEVCapable() {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 
 	for _, node := range nodes.Items {
 		if IsSEVCapable(&node) {
@@ -223,7 +225,7 @@ func SkipIfMigrationIsNotPossible() {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
 
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 	gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty(), "There should be some compute node")
 
 	if len(nodes.Items) < 2 {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -153,7 +153,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", func() {
 			By("first getting the basetime for a replicaset")
-			targetNode := util.GetAllSchedulableNodes(virtClient).Items[0]
+			targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 			vmi := libvmi.NewCirros(
 				libvmi.WithResourceMemory("1Mi"),
 				libvmi.WithNodeSelectorFor(&targetNode),
@@ -427,7 +427,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
 
 				By("finding all schedulable nodes")
-				schedulableNodesList := util.GetAllSchedulableNodes(virtClient)
+				schedulableNodesList := libnode.GetAllSchedulableNodes(virtClient)
 				schedulableNodes := map[string]*k8sv1.Node{}
 				for _, node := range schedulableNodesList.Items {
 					schedulableNodes[node.Name] = node.DeepCopy()

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -47,7 +47,7 @@ var SchedulableNode = ""
 func CleanNodes() {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := util.GetAllSchedulableNodes(virtCli).Items
+	nodes := GetAllSchedulableNodes(virtCli).Items
 
 	clusterDrainKey := GetNodeDrainKey()
 
@@ -208,5 +208,11 @@ func GetNodesWithKVM() []*k8sv1.Node {
 			nodes = append(nodes, virtHandlerNode)
 		}
 	}
+	return nodes
+}
+
+func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
+	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true"})
+	Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
 	return nodes
 }

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -216,3 +216,18 @@ func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
 	Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
 	return nodes
 }
+
+func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
+	var cpus int64
+
+	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	for _, node := range nodes.Items {
+		if v, ok := node.Status.Capacity[k8sv1.ResourceCPU]; ok && v.Value() > cpus {
+			cpus = v.Value()
+		}
+	}
+
+	return int(cpus)
+}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -24,14 +24,14 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
-	v13 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
@@ -54,7 +54,7 @@ func CleanNodes() {
 	for _, node := range nodes {
 
 		old, err := json.Marshal(node)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 		new := node.DeepCopy()
 
 		k8sClient := clientcmd.GetK8sCmdClient()
@@ -65,15 +65,15 @@ func CleanNodes() {
 		}
 
 		found := false
-		taints := []v1.Taint{}
+		taints := []k8sv1.Taint{}
 		for _, taint := range node.Spec.Taints {
 
-			if taint.Key == clusterDrainKey && taint.Effect == v1.TaintEffectNoSchedule {
+			if taint.Key == clusterDrainKey && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				found = true
-			} else if taint.Key == "kubevirt.io/drain" && taint.Effect == v1.TaintEffectNoSchedule {
+			} else if taint.Key == "kubevirt.io/drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				// this key is used as a fallback if the original drain key is built-in
 				found = true
-			} else if taint.Key == "kubevirt.io/alt-drain" && taint.Effect == v1.TaintEffectNoSchedule {
+			} else if taint.Key == "kubevirt.io/alt-drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				// this key is used in testing as a custom alternate drain key
 				found = true
 			} else {
@@ -98,13 +98,13 @@ func CleanNodes() {
 			continue
 		}
 		newJson, err := json.Marshal(new)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, node)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
-		_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, v12.PatchOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, k8smetav1.PatchOptions{})
+		Expect(err).ToNot(HaveOccurred())
 	}
 }
 
@@ -123,85 +123,85 @@ func GetNodeDrainKey() string {
 func AddLabelToNode(nodeName string, key string, value string) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, v12.GetOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
 
 	old, err := json.Marshal(node)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	new := node.DeepCopy()
 	new.Labels[key] = value
 
 	newJson, err := json.Marshal(new)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, node)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
-	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, v12.PatchOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, k8smetav1.PatchOptions{})
+	Expect(err).ToNot(HaveOccurred())
 }
 
 func RemoveLabelFromNode(nodeName string, key string) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, v12.GetOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
 
 	if _, exists := node.Labels[key]; !exists {
 		return
 	}
 
 	old, err := json.Marshal(node)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	new := node.DeepCopy()
 	delete(new.Labels, key)
 
 	newJson, err := json.Marshal(new)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, node)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
-	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, v12.PatchOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, k8smetav1.PatchOptions{})
+	Expect(err).ToNot(HaveOccurred())
 }
 
-func Taint(nodeName string, key string, effect v1.TaintEffect) {
+func Taint(nodeName string, key string, effect k8sv1.TaintEffect) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, v12.GetOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
 
 	old, err := json.Marshal(node)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 	new := node.DeepCopy()
-	new.Spec.Taints = append(new.Spec.Taints, v1.Taint{
+	new.Spec.Taints = append(new.Spec.Taints, k8sv1.Taint{
 		Key:    key,
 		Effect: effect,
 	})
 
 	newJson, err := json.Marshal(new)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
 	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, node)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
-	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, v12.PatchOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, k8smetav1.PatchOptions{})
+	Expect(err).ToNot(HaveOccurred())
 }
 
-func GetNodesWithKVM() []*v1.Node {
+func GetNodesWithKVM() []*k8sv1.Node {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	listOptions := v12.ListOptions{LabelSelector: v13.AppLabel + "=virt-handler"}
+	listOptions := k8smetav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
 	virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 
-	nodes := make([]*v1.Node, 0)
+	nodes := make([]*k8sv1.Node, 0)
 	// cluster is not ready until all nodes are ready.
 	for _, pod := range virtHandlerPods.Items {
-		virtHandlerNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), pod.Spec.NodeName, v12.GetOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		virtHandlerNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), pod.Spec.NodeName, k8smetav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
 		_, ok := virtHandlerNode.Status.Allocatable[services.KvmDevice]
 		if ok {

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -231,3 +231,15 @@ func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
 
 	return int(cpus)
 }
+
+func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.ResourceName) *k8sv1.Node {
+	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	for _, node := range nodes.Items {
+		if v, ok := node.Status.Capacity[hugepages]; ok && !v.IsZero() {
+			return &node
+		}
+	}
+	return nil
+}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -243,3 +243,11 @@ func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.Res
 	}
 	return nil
 }
+
+func GetArch() string {
+	virtCli, err := kubecli.GetKubevirtClient()
+	util.PanicOnError(err)
+	nodes := GetAllSchedulableNodes(virtCli).Items
+	Expect(nodes).ToNot(BeEmpty(), "There should be some node")
+	return nodes[0].Status.NodeInfo.Architecture
+}

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -214,7 +214,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 
 			By("Adding a mdevTestLabel1 that should trigger mdev config change")
 			// There should be only one node in this lane
-			singleNode := util.GetAllSchedulableNodes(virtClient).Items[0]
+			singleNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 			libnode.AddLabelToNode(singleNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), mdevTestLabel)
 
 			By("Creating a Fedora VMI")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1089,7 +1089,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 				Eventually(func() []k8sv1.Node {
-					nodes = util.GetAllSchedulableNodes(virtClient)
+					nodes = libnode.GetAllSchedulableNodes(virtClient)
 					return nodes.Items
 				}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be some compute node")
 			})
@@ -2014,7 +2014,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				// launch killer pod on every node that isn't the vmi's node
 				By("Starting our migration killer pods")
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				for idx, entry := range nodes.Items {
 					if entry.Name == vmi.Status.NodeName {
@@ -2534,7 +2534,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				return others
 			}
 			isHeterogeneousCluster := func() bool {
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				for _, node := range nodes.Items {
 					hostModel := getNodeHostModel(&node)
 					otherNodes := getOtherNodes(nodes, &node)
@@ -3221,7 +3221,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 
 				By("selecting a node as the source")
-				sourceNode := util.GetAllSchedulableNodes(virtClient).Items[0]
+				sourceNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 				libnode.AddLabelToNode(sourceNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), "target")
 
 				By("starting four VMIs on that node")
@@ -3236,7 +3236,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 
 				By("selecting a node as the target")
-				targetNode := util.GetAllSchedulableNodes(virtClient).Items[1]
+				targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[1]
 				libnode.AddLabelToNode(targetNode.Name, cleanup.TestLabelForNamespace(util.NamespaceTestDefault), "target")
 
 				By("tainting the source node as non-schedulabele")

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//tests/libnet:go_default_library",
         "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/service:go_default_library",
+        "//tests/libnode:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -139,7 +140,7 @@ var _ = SIGDescribe("Macvtap", func() {
 		var serverIP string
 
 		BeforeEach(func() {
-			nodeList = util.GetAllSchedulableNodes(virtClient)
+			nodeList = libnode.GetAllSchedulableNodes(virtClient)
 			Expect(nodeList.Items).NotTo(BeEmpty(), "schedulable kubernetes nodes must be present")
 			nodeName = nodeList.Items[0].Name
 			chosenMACHW, err := tests.GenerateRandomMac()

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -651,7 +652,7 @@ func validateSRIOVSetup(virtClient kubecli.KubevirtClient, sriovResourceName str
 }
 
 func getNodesWithAllocatedResource(virtClient kubecli.KubevirtClient, resourceName string) []k8sv1.Node {
-	nodes := util.GetAllSchedulableNodes(virtClient)
+	nodes := libnode.GetAllSchedulableNodes(virtClient)
 	filteredNodes := []k8sv1.Node{}
 	for _, node := range nodes.Items {
 		resourceList := node.Status.Allocatable

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -44,6 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -153,7 +154,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 
 		tests.BeforeTestCleanup()
 
-		nodes = util.GetAllSchedulableNodes(virtClient)
+		nodes = libnode.GetAllSchedulableNodes(virtClient)
 		Expect(nodes.Items).NotTo(BeEmpty())
 
 		const vlanID100 = 100

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -931,7 +931,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				// a node without CPU manager.
 				sourceNode = ""
 				targetNode = ""
-				for _, node := range util.GetAllSchedulableNodes(virtClient).Items {
+				for _, node := range libnode.GetAllSchedulableNodes(virtClient).Items {
 					labels := node.GetLabels()
 					if val, ok := labels[v1.CPUManager]; ok && val == "true" {
 						// Use a node with CPU manager as migration source

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -116,7 +116,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 	}
 
 	skipIfSwapOff := func(message string) {
-		nodes := util.GetAllSchedulableNodes(virtClient)
+		nodes := libnode.GetAllSchedulableNodes(virtClient)
 		for _, node := range nodes.Items {
 			swapSizeKib := getSwapSizeInKib(node)
 			if swapSizeKib < maxSwapSizeToUseKib {
@@ -129,7 +129,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		nodes := util.GetAllSchedulableNodes(virtClient)
+		nodes := libnode.GetAllSchedulableNodes(virtClient)
 		Expect(len(nodes.Items)).To(BeNumerically(">", 1),
 			"should have at least two shcedulable nodes in the cluster")
 
@@ -142,7 +142,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 	Context("Migration to/from memory overcommitted nodes", func() {
 
 		It("Postcopy Migration of vmi that is dirtying(stress-ng) more memory than the source node's memory", func() {
-			nodes := util.GetAllSchedulableNodes(virtClient).Items
+			nodes := libnode.GetAllSchedulableNodes(virtClient).Items
 			sourceNode := nodes[0]
 			targetNode := nodes[1]
 			totalMemKib := getTotalMemSizeInKib(sourceNode)
@@ -218,7 +218,7 @@ var _ = Describe("[Serial][sig-compute]SwapTest", func() {
 		})
 
 		It("Migration of vmi to memory overcommited node", func() {
-			nodes := util.GetAllSchedulableNodes(virtClient).Items
+			nodes := libnode.GetAllSchedulableNodes(virtClient).Items
 			targetNode := nodes[0]
 			sourceNode := nodes[1]
 

--- a/tests/util/BUILD.bazel
+++ b/tests/util/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/flags:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/util/util.go
+++ b/tests/util/util.go
@@ -1,11 +1,9 @@
 package util
 
 import (
-	"context"
 	"time"
 
 	"github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	k6sv1 "kubevirt.io/api/core/v1"
@@ -20,12 +18,6 @@ func PanicOnError(err error) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *v1.NodeList {
-	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{LabelSelector: k6sv1.NodeSchedulable + "=" + "true"})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Should list compute nodes")
-	return nodes
 }
 
 func GetCurrentKv(virtClient kubecli.KubevirtClient) *k6sv1.KubeVirt {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2911,21 +2911,6 @@ func DeprecatedBeforeAll(fn func()) {
 	})
 }
 
-func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
-	var cpus int64
-
-	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-	for _, node := range nodes.Items {
-		if v, ok := node.Status.Capacity[k8sv1.ResourceCPU]; ok && v.Value() > cpus {
-			cpus = v.Value()
-		}
-	}
-
-	return int(cpus)
-}
-
 func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, error) {
 	data, err := json.Marshal(vm)
 	if err != nil {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3131,18 +3131,6 @@ func RenderHostPathPod(podName string, dir string, hostPathType k8sv1.HostPathTy
 	return pod
 }
 
-func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.ResourceName) *k8sv1.Node {
-	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-	for _, node := range nodes.Items {
-		if v, ok := node.Status.Capacity[hugepages]; ok && !v.IsZero() {
-			return &node
-		}
-	}
-	return nil
-}
-
 // CreateVmiOnNodeLabeled creates a VMI a node that has a give label set to a given value
 func CreateVmiOnNodeLabeled(vmi *v1.VirtualMachineInstance, nodeLabel, labelValue string) *v1.VirtualMachineInstance {
 	virtClient, err := kubecli.GetKubevirtClient()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -587,7 +587,7 @@ func BeforeTestSuitSetup(_ []byte) {
 	var err error
 	libstorage.Config, err = libstorage.LoadConfig()
 	Expect(err).ToNot(HaveOccurred())
-	Arch = getArch()
+	Arch = libnode.GetArch()
 
 	// Customize host disk paths
 	// Right now we support three nodes. More image copying needs to happen
@@ -3353,14 +3353,6 @@ func EnableFeatureGate(feature string) *v1.KubeVirt {
 
 func HasCDI() bool {
 	return libstorage.HasDataVolumeCRD()
-}
-
-func getArch() string {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util2.PanicOnError(err)
-	nodes := libnode.GetAllSchedulableNodes(virtCli).Items
-	Expect(nodes).ToNot(BeEmpty(), "There should be some node")
-	return nodes[0].Status.NodeInfo.Architecture
 }
 
 func VolumeExpansionAllowed(sc string) bool {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -600,7 +600,7 @@ func BeforeTestSuitSetup(_ []byte) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 	Eventually(func() int {
-		nodes := util2.GetAllSchedulableNodes(virtClient)
+		nodes := libnode.GetAllSchedulableNodes(virtClient)
 		if len(nodes.Items) > 0 {
 			idx := rand.Intn(len(nodes.Items))
 			schedulableNode = nodes.Items[idx].Name
@@ -919,7 +919,7 @@ func CreateAllSeparateDeviceHostPathPvs(osName string) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 	Eventually(func() int {
-		nodes := util2.GetAllSchedulableNodes(virtClient)
+		nodes := libnode.GetAllSchedulableNodes(virtClient)
 		if len(nodes.Items) > 0 {
 			for _, node := range nodes.Items {
 				createSeparateDeviceHostPathPv(osName, node.Name)
@@ -3385,7 +3385,7 @@ func HasCDI() bool {
 func getArch() string {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
-	nodes := util2.GetAllSchedulableNodes(virtCli).Items
+	nodes := libnode.GetAllSchedulableNodes(virtCli).Items
 	Expect(nodes).ToNot(BeEmpty(), "There should be some node")
 	return nodes[0].Status.NodeInfo.Architecture
 }

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -157,7 +158,7 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
 
-			nodeList = util.GetAllSchedulableNodes(virtCli).Items
+			nodeList = libnode.GetAllSchedulableNodes(virtCli).Items
 			for _, node := range nodeList {
 				setNodeUnschedulable(node.Name)
 			}

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -54,6 +54,7 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
@@ -1195,7 +1196,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				It("[test_id:4119]should migrate a running VM", func() {
-					nodes := util.GetAllSchedulableNodes(virtClient)
+					nodes := libnode.GetAllSchedulableNodes(virtClient)
 					if len(nodes.Items) < 2 {
 						Skip("Migration tests require at least 2 nodes")
 					}
@@ -1222,7 +1223,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				It("[test_id:7743]should not migrate a running vm if dry-run option is passed", func() {
-					nodes := util.GetAllSchedulableNodes(virtClient)
+					nodes := libnode.GetAllSchedulableNodes(virtClient)
 					if len(nodes.Items) < 2 {
 						Skip("Migration tests require at least 2 nodes")
 					}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -59,6 +59,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
@@ -1692,7 +1693,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		}
 
 		BeforeEach(func() {
-			nodes = util.GetAllSchedulableNodes(virtClient)
+			nodes = libnode.GetAllSchedulableNodes(virtClient)
 			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 			cpuVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
@@ -2581,7 +2582,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			BeforeEach(func() {
 
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some nodes")
 				node = nodes.Items[1].Name
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -228,7 +228,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-				availableNumberOfCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+				availableNumberOfCPUs = libnode.GetHighestCPUNumberAmongNodes(virtClient)
 
 				requiredNumberOfCpus := 3
 				Expect(availableNumberOfCPUs).ToNot(BeNumerically("<", requiredNumberOfCpus),

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1075,7 +1075,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					log.DefaultLogger().Object(hugepagesVmi).Infof("Fall back to use hugepages source file. Libvirt in the 1.16 provider version doesn't support memfd as memory backend")
 				}
 
-				nodeWithHugepages := tests.GetNodeWithHugepages(virtClient, hugepageType)
+				nodeWithHugepages := libnode.GetNodeWithHugepages(virtClient, hugepageType)
 				if nodeWithHugepages == nil {
 					Skip(fmt.Sprintf("No node with hugepages %s capacity", hugepageType))
 				}

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libnode"
 )
 
 var _ = Describe("[sig-compute]IOThreads", func() {
@@ -60,7 +61,7 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 		var availableCPUs int
 
 		BeforeEach(func() {
-			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+			availableCPUs = libnode.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
 		It("[test_id:4122]Should honor shared ioThreadsPolicy for single disk", func() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -57,6 +57,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -619,7 +620,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			It("[test_id:1633]should indicate that a node is ready for vmis", func() {
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				for _, node := range nodes.Items {
 					Expect(node.Annotations[v1.VirtHandlerHeartbeat]).ToNot(BeEmpty(), "Nodes should have be ready for VMI")
@@ -816,7 +817,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			var err error
 			BeforeEach(func() {
 				Eventually(func() []k8sv1.Node {
-					nodes = util.GetAllSchedulableNodes(virtClient)
+					nodes = libnode.GetAllSchedulableNodes(virtClient)
 					return nodes.Items
 				}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be some compute node")
 
@@ -867,7 +868,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			var err error
 
 			BeforeEach(func() {
-				nodes = util.GetAllSchedulableNodes(virtClient)
+				nodes = libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 			})
 
@@ -1040,7 +1041,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			BeforeEach(func() {
 				// arm64 does not support cpu model
 				checks.SkipIfARM64(tests.Arch, "arm64 does not support cpu model")
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 				node = &nodes.Items[0]
@@ -1254,7 +1255,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		Context("with non default namespace", func() {
 			DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should log libvirt start and stop lifecycle events of the domain", func(namespace *string) {
 
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
 
@@ -1493,7 +1494,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:1648]Should provide KVM via plugin framework", func() {
-				nodeList := util.GetAllSchedulableNodes(virtClient)
+				nodeList := libnode.GetAllSchedulableNodes(virtClient)
 
 				if len(nodeList.Items) == 0 {
 					Skip("There are no compute nodes in cluster")
@@ -1615,7 +1616,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", func() {
-				nodes := util.GetAllSchedulableNodes(virtClient)
+				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
 

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -56,7 +57,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 		var availableCPUs int
 
 		BeforeEach(func() {
-			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+			availableCPUs = libnode.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
 		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of the effort to cleanup `tests/utils.go` and better structure the e2e tests, move more helpers to `libnode`.
The first commit also includes some import aliases fixes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
