### PR TITLE
Handle virtctl guestfs incorrectly assuming image name, grant access to /guestfs endpoint

### DIFF
--- a/cmd/subresource-access-test/subresource-access-test.go
+++ b/cmd/subresource-access-test/subresource-access-test.go
@@ -39,7 +39,7 @@ func main() {
 
 	resource = flag.Arg(0)
 
-	if resource == "version" {
+	if resource == "version" || resource == "guestfs" {
 		client, err := kubecli.GetKubevirtSubresourceClient()
 		if err != nil {
 			panic(err)

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -725,6 +725,7 @@ spec:
           - subresources.kubevirt.io
           resources:
           - version
+          - guestfs
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -627,6 +627,7 @@ rules:
   - subresources.kubevirt.io
   resources:
   - version
+  - guestfs
   verbs:
   - get
   - list

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1045,9 +1045,10 @@ func (app *virtAPIApp) GetGsInfo() func(_ *restful.Request, response *restful.Re
 			return
 		}
 		response.WriteAsJson(kubecli.GuestfsInfo{
-			Registry: kv.Status.ObservedKubeVirtRegistry,
-			Tag:      kv.Status.ObservedKubeVirtVersion,
-			Digest:   kvConfig.GsSha,
+			Registry:    kv.Status.ObservedKubeVirtRegistry,
+			Tag:         kv.Status.ObservedKubeVirtVersion,
+			Digest:      kvConfig.GsSha,
+			ImagePrefix: kvConfig.GetImagePrefix(),
 		})
 		return
 	}

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -74,6 +74,7 @@ func newDefaultClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					"version",
+					"guestfs",
 				},
 				Verbs: []string{
 					"get", "list",

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -35,6 +35,17 @@ func fakeSetImage(virtClient kubecli.KubevirtClient) error {
 	return nil
 }
 
+func fakeGetImageInfo(virtClient kubecli.KubevirtClient) (*kubecli.GuestfsInfo, error) {
+	info := &kubecli.GuestfsInfo{
+		Registry:    "someregistry.io/kubevirt",
+		Tag:         "sha256:07c601d33793ee987g5417d755665572dc9a9680cea01dfb9bdbcc3ecf866720",
+		Digest:      "89af657d3c226ac3083a0986e19efe70c9ccd7e7278137e9df24b9b430182aa7",
+		ImagePrefix: "some-prefix-",
+	}
+
+	return info, nil
+}
+
 var _ = Describe("Guestfs shell", func() {
 	var (
 		kubeClient     *fake.Clientset
@@ -103,17 +114,24 @@ var _ = Describe("Guestfs shell", func() {
 		kubeClient = fake.NewSimpleClientset()
 		return &guestfs.K8sClient{Client: kubeClient, VirtClient: kubevirtClient}, nil
 	}
-	BeforeEach(func() {
-		guestfs.SetImageSetFunc(fakeSetImage)
-		guestfs.SetAttacher(fakeAttacherCreator)
-	})
+
 	Context("attach to PVC", func() {
+		BeforeEach(func() {
+			guestfs.SetImageSetFunc(fakeSetImage)
+			guestfs.SetAttacher(fakeAttacherCreator)
+		})
+
+		AfterEach(func() {
+			guestfs.SetDefaultImageSet()
+			guestfs.SetDefaulAttacher()
+		})
 
 		It("Succesfully attach to PVC", func() {
 			guestfs.SetClient(fakeCreateClientPVC)
 			cmd := virtctlcmd.NewRepeatableVirtctlCommand(commandName, pvcName)
 			Expect(cmd()).To(BeNil())
 		})
+
 		It("PVC in use", func() {
 			guestfs.SetClient(fakeCreateClientPVCinUse)
 			cmd := virtctlcmd.NewRepeatableVirtctlCommand(commandName, pvcName)
@@ -121,6 +139,7 @@ var _ = Describe("Guestfs shell", func() {
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).Should(Equal(fmt.Sprintf("PVC %s is used by another pod", pvcName)))
 		})
+
 		It("PVC doesn't exist", func() {
 			guestfs.SetClient(fakeCreateClient)
 			cmd := virtctlcmd.NewRepeatableVirtctlCommand(commandName, pvcName)
@@ -130,4 +149,18 @@ var _ = Describe("Guestfs shell", func() {
 		})
 	})
 
+	Context("URL authenticity", func() {
+		BeforeEach(func() {
+			guestfs.SetImageInfoGetFunc(fakeGetImageInfo)
+		})
+
+		AfterEach(func() {
+			guestfs.SetDefaultImageInfoGetFunc()
+		})
+
+		It("Image prefix from kubevirt config not discarded", func() {
+			guestfs.ImageSetFunc(kubevirtClient)
+			Expect(guestfs.ExportedImage).To(Equal("someregistry.io/kubevirt/some-prefix-libguestfs-tools@89af657d3c226ac3083a0986e19efe70c9ccd7e7278137e9df24b9b430182aa7"))
+		})
+	})
 })

--- a/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
@@ -31,9 +31,10 @@ import (
 )
 
 type GuestfsInfo struct {
-	Registry string `json:"registry"`
-	Tag      string `json:"tag"`
-	Digest   string `json:"digest"`
+	Registry    string `json:"registry"`
+	Tag         string `json:"tag"`
+	Digest      string `json:"digest"`
+	ImagePrefix string `json:"imagePrefix"`
 }
 
 func (k *kubevirt) GuestfsVersion() *GuestfsVersion {

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -91,6 +91,21 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 		})
 	})
 
+	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization For Guestfs Command", func() {
+		resource := "guestfs"
+
+		Context("with authenticated user", func() {
+			It("should be allowed to access subresource guestfs endpoint", func() {
+				testClientJob(virtCli, true, resource)
+			})
+		})
+		Context("Without permissions", func() {
+			It("should be able to access subresource guestfs endpoint", func() {
+				testClientJob(virtCli, false, resource)
+			})
+		})
+	})
+
 	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource", func() {
 		Context("with a restart endpoint", func() {
 			It("[test_id:1304] should restart a VM", func() {
@@ -375,7 +390,7 @@ func testClientJob(virtCli kubecli.KubevirtClient, withServiceAccount bool, reso
 	if withServiceAccount {
 		job.Spec.ServiceAccountName = tests.SubresourceServiceAccountName
 		expectedPhase = k8sv1.PodSucceeded
-	} else if resource == "version" {
+	} else if resource == "version" || resource == "guestfs" {
 		expectedPhase = k8sv1.PodSucceeded
 	}
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Handle a case where we were discarding a possible image name prefix in virtctl guestfs
- Grant unprivileged user access to the /guestfs endpoint (otherwise virtctl can't infer image url)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2068905

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: virtctl guestfs incorrectly assumes image name
```
