### PR TITLE
Extend virtctl to Support Interactive SEV Attestation

### DIFF
--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/virtctl/pause:go_default_library",
         "//pkg/virtctl/portforward:go_default_library",
         "//pkg/virtctl/scp:go_default_library",
+        "//pkg/virtctl/sev:go_default_library",
         "//pkg/virtctl/softreboot:go_default_library",
         "//pkg/virtctl/ssh:go_default_library",
         "//pkg/virtctl/templates:go_default_library",

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/pause"
 	"kubevirt.io/kubevirt/pkg/virtctl/portforward"
 	"kubevirt.io/kubevirt/pkg/virtctl/scp"
+	"kubevirt.io/kubevirt/pkg/virtctl/sev"
 	"kubevirt.io/kubevirt/pkg/virtctl/softreboot"
 	"kubevirt.io/kubevirt/pkg/virtctl/ssh"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
@@ -109,6 +110,7 @@ func NewVirtctlCommand() (*cobra.Command, clientcmd.ClientConfig) {
 		vmexport.NewVirtualMachineExportCommand(clientConfig),
 		create.NewCommand(),
 		optionsCmd,
+		sev.NewSEVCommand(clientConfig),
 	)
 	return rootCmd, clientConfig
 }

--- a/pkg/virtctl/sev/BUILD.bazel
+++ b/pkg/virtctl/sev/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["attestation.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/sev",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)

--- a/pkg/virtctl/sev/BUILD.bazel
+++ b/pkg/virtctl/sev/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,5 +12,25 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "attestation_suite_test.go",
+        "attestation_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/clientcmd:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/virtctl/sev/attestation.go
+++ b/pkg/virtctl/sev/attestation.go
@@ -1,0 +1,295 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022
+ *
+ */
+
+package sev
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const (
+	COMMAND_SEV               = "sev"
+	COMMAND_FETCH_CERT_CHAIN  = "fetch-cert-chain"
+	COMMAND_SETUP_SESSION     = "setup-session"
+	COMMAND_QUERY_MEASUREMENT = "query-measurement"
+	COMMAND_INJECT_SECRET     = "inject-secret"
+	output_perm               = 0750
+
+	sessionFlag = "session"
+	dhcertFlag  = "dhcert"
+	secretFlag  = "secret"
+	headerFlag  = "header"
+	outputFlag  = "output"
+)
+
+var (
+	session   string
+	godh      string
+	secret    string
+	header    string
+	outpath   string
+	vmiName   string
+	namespace string
+)
+
+type SEVCommand struct {
+	clientConfig clientcmd.ClientConfig
+	command      string
+}
+
+func NewSEVCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	sevCmd := &cobra.Command{
+		Use:     "sev (VMI)",
+		Short:   "Interact with the SEV platform",
+		Example: usage(COMMAND_SEV),
+		Args:    templates.ExactArgs(COMMAND_SEV, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := SEVCommand{command: COMMAND_SEV, clientConfig: clientConfig}
+			return c.Run(args)
+		},
+	}
+	sevCmd.SetUsageTemplate(templates.MainUsageTemplate())
+	sevCmd.AddCommand(
+		NewFetchCertChainCommand(clientConfig),
+		NewSetupSessionCommand(clientConfig),
+		NewQueryMeasurementCommand(clientConfig),
+		NewInjectSecretCommand(clientConfig),
+	)
+
+	return sevCmd
+}
+
+func NewFetchCertChainCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "fetch-cert-chain (VMI)",
+		Short:   "Fetch Certificate Chain",
+		Long:    `Fetch the platform Diffie-Hellman (PDH) and the complete certificate chain from the SEV platform`,
+		Args:    templates.ExactArgs(COMMAND_FETCH_CERT_CHAIN, 1),
+		Example: usage(COMMAND_FETCH_CERT_CHAIN),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := SEVCommand{
+				command:      COMMAND_FETCH_CERT_CHAIN,
+				clientConfig: clientConfig,
+			}
+			return c.Run(args)
+		},
+	}
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	cmd.Flags().StringVar(&outpath, outputFlag, "",
+		"Filepath where the certificate chain is to be written")
+
+	return cmd
+}
+
+func NewSetupSessionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "setup-session (VMI)",
+		Short:   "Pass session launch parameters into the VM",
+		Long:    `Set up a secure communication channel between the guest and the SEV platform.`,
+		Args:    templates.ExactArgs(COMMAND_SETUP_SESSION, 1),
+		Example: usage(COMMAND_SETUP_SESSION),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := SEVCommand{
+				command:      COMMAND_SETUP_SESSION,
+				clientConfig: clientConfig,
+			}
+			return c.Run(args)
+		},
+	}
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	cmd.Flags().StringVar(&session, sessionFlag, "",
+		"(Required) Base64 encoded session launch blob")
+	cmd.MarkFlagRequired(sessionFlag)
+	cmd.Flags().StringVar(&godh, dhcertFlag, "",
+		"(Required) Base64 encoded guest owner certicate")
+	cmd.MarkFlagRequired(dhcertFlag)
+
+	return cmd
+}
+
+func NewQueryMeasurementCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "query-measurement (VMI)",
+		Short: "Query the launch measurement from the SEV platform",
+		Long: `Query the launch measurement from the SEV platform
+The guest owner can verify the measurement against the measurement provided by the platform owner`,
+		Args:    templates.ExactArgs(COMMAND_QUERY_MEASUREMENT, 1),
+		Example: usage(COMMAND_QUERY_MEASUREMENT),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := SEVCommand{
+				command:      COMMAND_QUERY_MEASUREMENT,
+				clientConfig: clientConfig,
+			}
+			return c.Run(args)
+		},
+	}
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	cmd.Flags().StringVar(&outpath, outputFlag, "",
+		"Filepath where platform measurement info is to be written")
+	return cmd
+}
+
+func NewInjectSecretCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "inject-secret (VMI)",
+		Short:   "Inject the guest owner's secret into the running VM",
+		Long:    `Inject the guest owner's secret into the running VM`,
+		Args:    templates.ExactArgs(COMMAND_INJECT_SECRET, 1),
+		Example: usage(COMMAND_INJECT_SECRET),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := SEVCommand{
+				command:      COMMAND_INJECT_SECRET,
+				clientConfig: clientConfig,
+			}
+			return c.Run(args)
+		},
+	}
+
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	cmd.Flags().StringVar(&secret, secretFlag, "", "(Required) Guest owner secret key")
+	cmd.MarkFlagRequired(secretFlag)
+	cmd.Flags().StringVar(&header, headerFlag, "", "(Required) Guest owner secret key header")
+	cmd.MarkFlagRequired(headerFlag)
+
+	return cmd
+}
+
+func usage(cmd string) string {
+	if cmd == COMMAND_SEV {
+		return fmt.Sprintf(" {{ProgramName}} sev <subcommand> myvmi")
+	}
+	return fmt.Sprintf(" {{ProgramName}} sev %s myvmi", cmd)
+}
+
+func writeOutput(cmd string, data []byte) error {
+	var logFmt, errFmt string
+	switch cmd {
+	case COMMAND_FETCH_CERT_CHAIN:
+		logFmt = "[SEV]Writing platform certificate chain to %s"
+		errFmt = "Error %s/%s: Failed to write certificate chain to %s: %v"
+	case COMMAND_QUERY_MEASUREMENT:
+		logFmt = "[SEV]Writing platform measurement info to %s"
+		errFmt = "Error %s/%s: Failed to write platform measurement info to %s: %v"
+	// Only FETCH_CERT_CHAIN and QUERY_MEASUREMENT support writing to a file
+	default:
+		return nil
+	}
+
+	if outpath != "" {
+		file, err := os.OpenFile(outpath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, output_perm)
+		if err != nil {
+			return fmt.Errorf(errFmt, namespace, vmiName, outpath, err)
+		}
+		defer file.Close()
+
+		_, err = file.Write(data)
+		if err != nil {
+			return fmt.Errorf(errFmt, namespace, vmiName, outpath, err)
+		}
+		log.Log.Infof(logFmt, outpath)
+	} else {
+		fmt.Printf("%s\n", string(data))
+	}
+
+	return nil
+}
+
+func (sc *SEVCommand) Run(args []string) error {
+	var err error
+	vmiName = args[0]
+	namespace, _, err = sc.clientConfig.Namespace()
+	if err != nil {
+		return err
+	}
+
+	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(sc.clientConfig)
+	if err != nil {
+		return fmt.Errorf("Cannot obtain KubeVirt client: %v", err)
+	}
+
+	switch sc.command {
+	case COMMAND_SEV:
+		return fmt.Errorf("Error %s/%s: A subcommand is needed to execute the sev command.\nRun 'virtctl sev --help' for more info", namespace, vmiName)
+
+	case COMMAND_FETCH_CERT_CHAIN:
+		sevPlatformInfo, err := virtClient.VirtualMachineInstance(namespace).SEVFetchCertChain(vmiName)
+		if err != nil {
+			return fmt.Errorf("Error %s/%s: %v", namespace, vmiName, err)
+		}
+		data, err := json.MarshalIndent(sevPlatformInfo, "", "  ")
+		if err != nil {
+			return fmt.Errorf("Error %s/%s: Cannot marshal SEV platform info: %v", namespace, vmiName, err)
+		}
+		err = writeOutput(COMMAND_FETCH_CERT_CHAIN, data)
+		if err != nil {
+			return err
+		}
+
+	case COMMAND_SETUP_SESSION:
+		sevSessionOptions := &v1.SEVSessionOptions{
+			Session: session,
+			DHCert:  godh,
+		}
+		err := virtClient.VirtualMachineInstance(namespace).SEVSetupSession(vmiName, sevSessionOptions)
+		if err != nil {
+			return fmt.Errorf("Error %s/%s: %v", namespace, vmiName, err)
+		}
+
+	case COMMAND_QUERY_MEASUREMENT:
+		sevMeasurementInfo, err := virtClient.VirtualMachineInstance(namespace).SEVQueryLaunchMeasurement(vmiName)
+		if err != nil {
+			return fmt.Errorf("Error %s/%s: %v", namespace, vmiName, err)
+		}
+		data, err := json.MarshalIndent(sevMeasurementInfo, "", "  ")
+		if err != nil {
+			return fmt.Errorf("Error %s/%s: Cannot marshal SEV platform measurement: %v", namespace, vmiName, err)
+		}
+		err = writeOutput(COMMAND_QUERY_MEASUREMENT, data)
+		if err != nil {
+			return err
+		}
+
+	case COMMAND_INJECT_SECRET:
+		sevSecretOptions := &v1.SEVSecretOptions{
+			Header: header,
+			Secret: secret,
+		}
+		err := virtClient.VirtualMachineInstance(namespace).SEVInjectLaunchSecret(vmiName, sevSecretOptions)
+		if err != nil {
+			return fmt.Errorf("Error %s/%s: %v", namespace, vmiName, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/virtctl/sev/attestation_suite_test.go
+++ b/pkg/virtctl/sev/attestation_suite_test.go
@@ -1,0 +1,11 @@
+package sev_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestSEVAttestation(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/sev/attestation_test.go
+++ b/pkg/virtctl/sev/attestation_test.go
@@ -1,0 +1,318 @@
+package sev_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/api"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl/sev"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+)
+
+var _ = Describe("SEV Attestation", func() {
+	const vmiName = "testvm"
+	var vmi *v1.VirtualMachineInstance
+	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
+	var ctrl *gomock.Controller
+	var workDir string
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
+		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		vmi = api.NewMinimalVMI(vmiName)
+		workDir = GinkgoT().TempDir()
+	})
+
+	Describe("The base 'sev' command", func() {
+		Context("Creation", func() {
+			It("should succeed", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV)
+				Expect(cmd).ToNot(BeNil())
+			})
+		})
+		Context("Running with no subcommand", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+	})
+
+	Describe("The 'fetch-cert-chain' command", func() {
+		Context("Creation", func() {
+			It("should succeed", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_FETCH_CERT_CHAIN)
+				Expect(cmd).ToNot(BeNil())
+			})
+		})
+		Context("With no argument", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_FETCH_CERT_CHAIN)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With VMI name", func() {
+			It("should succeed", func() {
+				sevPlatformInfo := v1.SEVPlatformInfo{
+					PDH:       "somelongpdh",
+					CertChain: "somelongcertchain",
+				}
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVFetchCertChain(vmi.Name).Return(sevPlatformInfo, nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_FETCH_CERT_CHAIN, vmiName)
+				Expect(cmd.Execute()).To(BeNil())
+			})
+			It("should print cert chain to file", func() {
+				sevPlatformInfo := v1.SEVPlatformInfo{
+					PDH:       "somelongpdh",
+					CertChain: "somelongcertchain",
+				}
+				var resp v1.SEVPlatformInfo
+				fpath := filepath.Join(workDir, "cert_chain.json")
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVFetchCertChain(vmi.Name).Return(sevPlatformInfo, nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_FETCH_CERT_CHAIN, vmiName, "--output", fpath)
+				Expect(cmd.Execute()).To(BeNil())
+
+				_, err := os.Stat(fpath)
+				Expect(err).ToNot(HaveOccurred(), "File is not created")
+
+				data, err := os.ReadFile(fpath)
+				Expect(err).ToNot(HaveOccurred())
+				err = json.Unmarshal(data, &resp)
+				Expect(err).To(BeNil())
+				Expect(resp).To(Equal(sevPlatformInfo), "Expected JSON is returned")
+			})
+			It("should fail if output filepath already exists", func() {
+				sevPlatformInfo := v1.SEVPlatformInfo{
+					PDH:       "somelongpdh",
+					CertChain: "somelongcertchain",
+				}
+				existingFile := filepath.Join(workDir, "exisiting-file")
+				Expect(ioutil.WriteFile(existingFile, []byte("Exists"), 0750)).To(Succeed())
+
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVFetchCertChain(vmi.Name).Return(sevPlatformInfo, nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_FETCH_CERT_CHAIN, vmiName,
+					"--output", existingFile)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+			It("should not create output file on API failure", func() {
+				fpath := filepath.Join(workDir, "cert_chain.json")
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVFetchCertChain(vmi.Name).Return(v1.SEVPlatformInfo{}, errors.New("API Error")).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_FETCH_CERT_CHAIN, vmiName, "--output", fpath)
+				Expect(cmd.Execute()).ToNot(BeNil())
+
+				_, err := os.Stat(fpath)
+				Expect(err).To(HaveOccurred(), "File is created")
+			})
+		})
+	})
+
+	Describe("The 'setup-session' command", func() {
+		Context("Creation", func() {
+			It("should succeed", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_SETUP_SESSION)
+				Expect(cmd).ToNot(BeNil())
+			})
+		})
+		Context("With no argument", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_SETUP_SESSION)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With VMI name and no flags", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_SETUP_SESSION, vmiName)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With only session flag", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_SETUP_SESSION, vmiName,
+					"--session", "somelongsessionblob")
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With only guest owner certificate flag", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_SETUP_SESSION, vmiName,
+					"--dhcert", "somelongcertificate")
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With session and godh flags", func() {
+			It("should succeed", func() {
+				sevSessionOptions := &v1.SEVSessionOptions{
+					Session: "somelongsessionblob",
+					DHCert:  "somelongcertificate",
+				}
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVSetupSession(vmi.Name, sevSessionOptions).Return(nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_SETUP_SESSION, vmiName,
+					"--session", "somelongsessionblob",
+					"--dhcert", "somelongcertificate")
+				Expect(cmd.Execute()).To(BeNil())
+			})
+		})
+	})
+
+	Describe("The 'query-measurement' command", func() {
+		Context("Creation", func() {
+			It("should succeed", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_QUERY_MEASUREMENT)
+				Expect(cmd).ToNot(BeNil())
+			})
+		})
+		Context("With no argument", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_QUERY_MEASUREMENT)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With VMI name", func() {
+			It("should succeed", func() {
+				sevMeasurementInfo := v1.SEVMeasurementInfo{
+					Measurement: "Somebase64LaunchMeasurement",
+					APIMajor:    1,
+					APIMinor:    1,
+					BuildID:     12345,
+					Policy:      12345,
+					LoaderSHA:   "loaderbinhash",
+				}
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVQueryLaunchMeasurement(vmi.Name).Return(sevMeasurementInfo, nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_QUERY_MEASUREMENT, vmiName)
+				Expect(cmd.Execute()).To(BeNil())
+			})
+			It("should print measurement to file", func() {
+				sevMeasurementInfo := v1.SEVMeasurementInfo{
+					Measurement: "Somebase64LaunchMeasurement",
+					APIMajor:    1,
+					APIMinor:    1,
+					BuildID:     12345,
+					Policy:      12345,
+					LoaderSHA:   "loaderbinhash",
+				}
+				var resp v1.SEVMeasurementInfo
+				fpath := filepath.Join(workDir, "measurement.json")
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVQueryLaunchMeasurement(vmi.Name).Return(sevMeasurementInfo, nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_QUERY_MEASUREMENT, vmiName,
+					"--output", fpath)
+				Expect(cmd.Execute()).To(BeNil())
+
+				_, err := os.Stat(fpath)
+				Expect(err).ToNot(HaveOccurred(), "File is not created")
+
+				data, err := os.ReadFile(fpath)
+				Expect(err).ToNot(HaveOccurred())
+				err = json.Unmarshal(data, &resp)
+				Expect(err).To(BeNil())
+				Expect(resp).To(Equal(sevMeasurementInfo), "Expected JSON is returned")
+			})
+			It("should fail if output filepath already exists", func() {
+				sevMeasurementInfo := v1.SEVMeasurementInfo{
+					Measurement: "Somebase64LaunchMeasurement",
+					APIMajor:    1,
+					APIMinor:    1,
+					BuildID:     12345,
+					Policy:      12345,
+					LoaderSHA:   "loaderbinhash",
+				}
+				existingFile := filepath.Join(workDir, "exisiting-file")
+				Expect(ioutil.WriteFile(existingFile, []byte("Exists"), 0750)).To(Succeed())
+
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVQueryLaunchMeasurement(vmi.Name).Return(sevMeasurementInfo, nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_QUERY_MEASUREMENT, vmiName,
+					"--output", existingFile)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+			It("should not create output file on API failure", func() {
+				fpath := filepath.Join(workDir, "measurement.json")
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVQueryLaunchMeasurement(vmi.Name).Return(v1.SEVMeasurementInfo{}, errors.New("API Error")).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_QUERY_MEASUREMENT, vmiName, "--output", fpath)
+				Expect(cmd.Execute()).ToNot(BeNil())
+
+				_, err := os.Stat(fpath)
+				Expect(err).To(HaveOccurred(), "File is created")
+			})
+		})
+	})
+
+	Describe("The 'inject-secret' command", func() {
+		Context("Creation", func() {
+			It("should succeed", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_INJECT_SECRET)
+				Expect(cmd).ToNot(BeNil())
+			})
+		})
+		Context("With no argument", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_INJECT_SECRET)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With VMI name and no flags", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_INJECT_SECRET, vmiName)
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With only header flag", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_INJECT_SECRET, vmiName,
+					"--header", "somelongheaderblob")
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With only secret flag", func() {
+			It("should fail", func() {
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_INJECT_SECRET, vmiName,
+					"--secret", "somelongsecretblob")
+				Expect(cmd.Execute()).ToNot(BeNil())
+			})
+		})
+		Context("With header and secret flags", func() {
+			It("should succeed", func() {
+				sevSecretOptions := &v1.SEVSecretOptions{
+					Header: "somelongheaderblob",
+					Secret: "somelongsecretblob",
+				}
+				kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
+				vmiInterface.EXPECT().SEVInjectLaunchSecret(vmi.Name, sevSecretOptions).Return(nil).Times(1)
+
+				cmd := clientcmd.NewVirtctlCommand(sev.COMMAND_SEV, sev.COMMAND_INJECT_SECRET, vmiName,
+					"--header", "somelongheaderblob",
+					"--secret", "somelongsecretblob")
+				Expect(cmd.Execute()).To(BeNil())
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: 

This PR extends `virtctl` to support interactive attestation of SEV enabled workloads.

The following subcommands have been added:
- `virtctl sev fetch-cert-chain`
- `virtctl sev setup-session`
- `virtctl sev query-measurement`
- `virtctl sev inject-secret`

**Special notes for your reviewer**:
- This PR relies on #7197 for intial SEV enablement
- Implementation based off initial [design proposal](https://github.com/kubevirt/community/blob/main/design-proposals/amd-sev.md)
- Until #7197 is merged, another [branch](https://github.com/Fuzzy-Math/kubevirt/tree/sev-base) is being maintained to allow building and testing of these changes

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Extending virtctl to support interactive attestation of AMD SEV enabled workloads
```
