### PR TITLE
Introduce a DiskBus type and associated constants

### DIFF
--- a/pkg/testutils/domain.go
+++ b/pkg/testutils/domain.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -13,7 +14,7 @@ const virtioTrans = "virtio-transitional"
 func ExpectVirtioTransitionalOnly(dom *api.DomainSpec) {
 	hit := false
 	for _, disk := range dom.Devices.Disks {
-		if disk.Target.Bus == "virtio" {
+		if disk.Target.Bus == v1.DiskBusVirtio {
 			ExpectWithOffset(1, disk.Model).To(Equal(virtioTrans))
 			hit = true
 		}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
@@ -96,7 +96,8 @@ var _ = Describe("Mutating Webhook Presets", func() {
 							Watchdog: &v1.Watchdog{Name: "testcase",
 								WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionReset}}},
 							Disks: []v1.Disk{{Name: "testdisk",
-								DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{Bus: "virtio", ReadOnly: true}}}}},
+								DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
+									Bus: v1.DiskBusVirtio, ReadOnly: true}}}}},
 					},
 				},
 			}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -655,8 +655,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk",
 				DiskDevice: v1.DiskDevice{
-					Disk:  &v1.DiskTarget{},
-					CDRom: &v1.CDRomTarget{Bus: "sata"},
+					Disk: &v1.DiskTarget{},
+					CDRom: &v1.CDRomTarget{
+						Bus: v1.DiskBusSATA,
+					},
 				},
 			})
 
@@ -2729,7 +2731,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
 						PciAddress: "0000:04:10.0",
-						Bus:        "scsi"},
+						Bus:        v1.DiskBusSCSI},
 				},
 			})
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
@@ -2745,7 +2747,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
 						PciAddress: "0000:81:100.a",
-						Bus:        "virtio"},
+						Bus:        v1.DiskBusVirtio,
+					},
 				},
 			})
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
@@ -2781,7 +2784,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testcdrom",
 				DiskDevice: v1.DiskDevice{
 					CDRom: &v1.CDRomTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 			})
@@ -2838,7 +2841,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk1",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 			})
@@ -2846,7 +2849,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk2",
 				DiskDevice: v1.DiskDevice{
 					LUN: &v1.LunTarget{
-						Bus: "sata",
+						Bus: v1.DiskBusSATA,
 					},
 				},
 			})
@@ -2854,7 +2857,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk3",
 				DiskDevice: v1.DiskDevice{
 					CDRom: &v1.CDRomTarget{
-						Bus: "scsi",
+						Bus: v1.DiskBusSCSI,
 					},
 				},
 			})
@@ -3019,21 +3022,21 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Name:              "disk-with-dedicated-io-thread-and-sata",
 					DedicatedIOThread: &_true,
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
-						Bus: "sata",
+						Bus: v1.DiskBusSATA,
 					}},
 				},
 				v1.Disk{
 					Name:              "disk-with-dedicated-io-thread-and-virtio",
 					DedicatedIOThread: &_true,
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					}},
 				},
 				v1.Disk{
 					Name:              "disk-without-dedicated-io-thread-and-with-sata",
 					DedicatedIOThread: &_false,
 					DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{
-						Bus: "sata",
+						Bus: v1.DiskBusSATA,
 					}},
 				},
 			)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Template", func() {
 				{
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					Name: "containerdisk",

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -1996,7 +1996,7 @@ func createVirtualMachine(namespace, name string) *v1.VirtualMachine {
 									Name: "disk1",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 								},

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -44,6 +44,7 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
+	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
@@ -2472,7 +2473,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "existing",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 			})
@@ -2480,7 +2481,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "hotplug",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: "scsi",
+						Bus: v1.DiskBusSATA,
 					},
 				},
 			})
@@ -2554,7 +2555,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name: "existing",
 				DiskDevice: virtv1.DiskDevice{
 					Disk: &virtv1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 			})

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1862,7 +1862,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -1892,7 +1892,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -1929,7 +1929,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -1968,7 +1968,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2007,7 +2007,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2015,7 +2015,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2062,7 +2062,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2070,7 +2070,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2117,7 +2117,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2149,7 +2149,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2157,7 +2157,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Name: "mydisk1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2621,7 +2621,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 						File: "/var/run/kubevirt-private/vmi-disks/permvolume1/disk.img",
 					},
 					Target: api.DiskTarget{
-						Bus:    "virtio",
+						Bus:    v1.DiskBusVirtio,
 						Device: "vda",
 					},
 					Driver: &api.DiskDriver{
@@ -2638,7 +2638,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 						File: "/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img",
 					},
 					Target: api.DiskTarget{
-						Bus:    "scsi",
+						Bus:    v1.DiskBusSCSI,
 						Device: "sda",
 					},
 					Driver: &api.DiskDriver{

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -623,9 +623,9 @@ type DiskSource struct {
 }
 
 type DiskTarget struct {
-	Bus    string `xml:"bus,attr,omitempty"`
-	Device string `xml:"dev,attr,omitempty"`
-	Tray   string `xml:"tray,attr,omitempty"`
+	Bus    v1.DiskBus `xml:"bus,attr,omitempty"`
+	Device string     `xml:"dev,attr,omitempty"`
+	Tray   string     `xml:"tray,attr,omitempty"`
 }
 
 type DiskDriver struct {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1918,8 +1918,6 @@ func getPrefixFromBus(bus string) string {
 		return "vd"
 	case "sata", "scsi":
 		return "sd"
-	case "fdc":
-		return "fd"
 	default:
 		log.Log.Errorf("Unrecognized bus '%s'", bus)
 		return ""

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -166,7 +166,7 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 			disk.Address.Unit = strconv.Itoa(unit)
 		}
 		if diskDevice.Disk.PciAddress != "" {
-			if diskDevice.Disk.Bus != "virtio" {
+			if diskDevice.Disk.Bus != v1.DiskBusVirtio {
 				return fmt.Errorf("setting a pci address is not allowed for non-virtio bus types, for disk %s", diskDevice.Name)
 			}
 			addr, err := device.NewPciAddressField(diskDevice.Disk.PciAddress)
@@ -175,7 +175,7 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 			}
 			disk.Address = addr
 		}
-		if diskDevice.Disk.Bus == "virtio" {
+		if diskDevice.Disk.Bus == v1.DiskBusVirtio {
 			disk.Model = translateModel(c, "virtio")
 		}
 		disk.ReadOnly = toApiReadOnly(diskDevice.Disk.ReadOnly)
@@ -224,14 +224,14 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 		}
 		disk.ExpandDisksEnabled = c.ExpandDisksEnabled
 	}
-	if numQueues != nil && disk.Target.Bus == "virtio" {
+	if numQueues != nil && disk.Target.Bus == v1.DiskBusVirtio {
 		disk.Driver.Queues = numQueues
 	}
 	disk.Alias = api.NewUserDefinedAlias(diskDevice.Name)
 	if diskDevice.BootOrder != nil {
 		disk.BootOrder = &api.BootOrder{Order: *diskDevice.BootOrder}
 	}
-	if c.UseLaunchSecurity && disk.Target.Bus == "virtio" {
+	if c.UseLaunchSecurity && disk.Target.Bus == v1.DiskBusVirtio {
 		disk.Driver.IOMMU = "on"
 	}
 
@@ -513,7 +513,7 @@ func (n *deviceNamer) getExistingTargetValue(key string) (string, bool) {
 	return "", false
 }
 
-func makeDeviceName(diskName, bus string, prefixMap map[string]deviceNamer) (string, int) {
+func makeDeviceName(diskName string, bus v1.DiskBus, prefixMap map[string]deviceNamer) (string, int) {
 	prefix := getPrefixFromBus(bus)
 	if _, ok := prefixMap[prefix]; !ok {
 		// This should never happen since the prefix map is populated from all disks.
@@ -1912,11 +1912,11 @@ func needsSCSIControler(vmi *v1.VirtualMachineInstance) bool {
 	return !vmi.Spec.Domain.Devices.DisableHotplug
 }
 
-func getPrefixFromBus(bus string) string {
+func getPrefixFromBus(bus v1.DiskBus) string {
 	switch bus {
-	case "virtio":
+	case v1.DiskBusVirtio:
 		return "vd"
-	case "sata", "scsi":
+	case v1.DiskBusSATA, v1.DiskBusSCSI:
 		return "sd"
 	default:
 		log.Log.Errorf("Unrecognized bus '%s'", bus)

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"fmt"
 
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -34,7 +35,7 @@ func PlacePCIDevicesOnRootComplex(spec *api.DomainSpec) (err error) {
 		}
 	}
 	for i, disk := range spec.Devices.Disks {
-		if disk.Target.Bus != "virtio" {
+		if disk.Target.Bus != v1.DiskBusVirtio {
 			continue
 		}
 		spec.Devices.Disks[i].Address, err = assigner.PlacePCIDeviceAtNextSlot(disk.Address)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -432,7 +432,7 @@ var _ = Describe("Manager", func() {
 					Name: "permvolume1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					Cache: "none",
@@ -464,7 +464,7 @@ var _ = Describe("Manager", func() {
 						File: "/var/run/kubevirt-private/vmi-disks/permvolume1/disk.img",
 					},
 					Target: api.DiskTarget{
-						Bus:    "virtio",
+						Bus:    v1.DiskBusVirtio,
 						Device: "vda",
 					},
 					Driver: &api.DiskDriver{
@@ -503,7 +503,7 @@ var _ = Describe("Manager", func() {
 					Name: "permvolume1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					Cache: "none",
@@ -572,7 +572,7 @@ var _ = Describe("Manager", func() {
 						File: "/var/run/kubevirt-private/vmi-disks/permvolume1/disk.img",
 					},
 					Target: api.DiskTarget{
-						Bus:    "virtio",
+						Bus:    v1.DiskBusVirtio,
 						Device: "vda",
 					},
 					Driver: &api.DiskDriver{
@@ -632,7 +632,7 @@ var _ = Describe("Manager", func() {
 					Name: "permvolume1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					Cache: "none",
@@ -742,7 +742,7 @@ var _ = Describe("Manager", func() {
 					Name: "permvolume1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					Cache: "none",
@@ -821,7 +821,7 @@ var _ = Describe("Manager", func() {
 					Name: "permvolume1",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					Cache: "none",
@@ -890,7 +890,7 @@ var _ = Describe("Manager", func() {
 						File: "/var/run/kubevirt-private/vmi-disks/permvolume1/disk.img",
 					},
 					Target: api.DiskTarget{
-						Bus:    "virtio",
+						Bus:    v1.DiskBusVirtio,
 						Device: "vda",
 					},
 					Driver: &api.DiskDriver{
@@ -2478,7 +2478,7 @@ func addCloudInitDisk(vmi *v1.VirtualMachineInstance, userData string, networkDa
 		IO:    v1.IONative,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: "virtio",
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})

--- a/staging/src/kubevirt.io/api/core/v1/defaults.go
+++ b/staging/src/kubevirt.io/api/core/v1/defaults.go
@@ -128,7 +128,7 @@ func setDefaults_Disk(obj *VirtualMachineInstance) {
 	// Setting SATA as the default bus since it is typically supported out of the box by
 	// guest operating systems (we support only q35 and therefore IDE is not supported)
 	// TODO: consider making this OS-specific (VIRTIO for linux, SATA for others)
-	bus := "sata"
+	bus := DiskBusSATA
 
 	for i := range obj.Spec.Domain.Devices.Disks {
 		disk := &obj.Spec.Domain.Devices.Disks[i].DiskDevice

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -603,10 +603,18 @@ type DiskDevice struct {
 	CDRom *CDRomTarget `json:"cdrom,omitempty"`
 }
 
+type DiskBus string
+
+const (
+	DiskBusSCSI   DiskBus = "scsi"
+	DiskBusSATA   DiskBus = "sata"
+	DiskBusVirtio DiskBus = "virtio"
+)
+
 type DiskTarget struct {
 	// Bus indicates the type of disk device to emulate.
 	// supported values: virtio, sata, scsi.
-	Bus string `json:"bus,omitempty"`
+	Bus DiskBus `json:"bus,omitempty"`
 	// ReadOnly.
 	// Defaults to false.
 	ReadOnly bool `json:"readonly,omitempty"`
@@ -626,7 +634,7 @@ type SEV struct {
 type LunTarget struct {
 	// Bus indicates the type of disk device to emulate.
 	// supported values: virtio, sata, scsi.
-	Bus string `json:"bus,omitempty"`
+	Bus DiskBus `json:"bus,omitempty"`
 	// ReadOnly.
 	// Defaults to false.
 	ReadOnly bool `json:"readonly,omitempty"`
@@ -645,7 +653,7 @@ const (
 type CDRomTarget struct {
 	// Bus indicates the type of disk device to emulate.
 	// supported values: virtio, sata, scsi.
-	Bus string `json:"bus,omitempty"`
+	Bus DiskBus `json:"bus,omitempty"`
 	// ReadOnly.
 	// Defaults to true.
 	ReadOnly *bool `json:"readonly,omitempty"`

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -210,7 +210,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		Context("with virtio-win as secondary disk", func() {
 			It("[test_id:1467]should boot and have the virtio as sata CDROM", func() {
 				vmi := libvmi.NewAlpine()
-				tests.AddEphemeralCdrom(vmi, "disk4", "sata", cd.ContainerDiskFor(cd.ContainerDiskVirtio))
+				tests.AddEphemeralCdrom(vmi, "disk4", v1.DiskBusSATA, cd.ContainerDiskFor(cd.ContainerDiskVirtio))
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 
 				By("Checking whether the second disk really contains virtio drivers")

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -131,12 +131,11 @@ func newRandomDataVolumeWithPVCSourceWithStorageClass(sourceNamespace, sourceNam
 }
 
 func AddDataVolumeDisk(vmi *v13.VirtualMachineInstance, diskName, dataVolumeName string) *v13.VirtualMachineInstance {
-	bus := "virtio"
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v13.Disk{
 		Name: diskName,
 		DiskDevice: v13.DiskDevice{
 			Disk: &v13.DiskTarget{
-				Bus: bus,
+				Bus: v13.DiskBusVirtio,
 			},
 		},
 	})

--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -23,13 +23,14 @@ import (
 	"encoding/base64"
 
 	kvirtv1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 )
 
 // WithCloudInitNoCloudUserData adds cloud-init no-cloud user data.
 func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
 	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		diskName, bus := "disk1", "virtio"
-		addDiskVolumeWithCloudInitNoCloud(vmi, diskName, bus)
+		diskName := "disk1"
+		addDiskVolumeWithCloudInitNoCloud(vmi, diskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, diskName)
 		if b64Encoding {
@@ -46,8 +47,8 @@ func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
 // WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
 func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
 	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		diskName, bus := "disk1", "virtio"
-		addDiskVolumeWithCloudInitNoCloud(vmi, diskName, bus)
+		diskName := "disk1"
+		addDiskVolumeWithCloudInitNoCloud(vmi, diskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, diskName)
 		if b64Encoding {
@@ -59,7 +60,7 @@ func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
 	}
 }
 
-func addDiskVolumeWithCloudInitNoCloud(vmi *kvirtv1.VirtualMachineInstance, diskName, bus string) {
+func addDiskVolumeWithCloudInitNoCloud(vmi *kvirtv1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
 	addDisk(vmi, newDisk(diskName, bus))
 	v := newVolume(diskName)
 	setCloudInitNoCloud(&v, &kvirtv1.CloudInitNoCloudSource{})

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -21,13 +21,14 @@ package libvmi
 
 import (
 	kvirtv1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 )
 
 // WithContainerImage specifies the name of the container image to be used.
 func WithContainerImage(name string) Option {
 	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		diskName, bus := "disk0", "virtio"
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, newDisk(diskName, bus))
+		diskName := "disk0"
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, newDisk(diskName, v1.DiskBusVirtio))
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newContainerVolume(diskName, name))
 	}
 }
@@ -71,7 +72,7 @@ func volumeExists(vmi *kvirtv1.VirtualMachineInstance, volume kvirtv1.Volume) bo
 	return false
 }
 
-func newDisk(name, bus string) kvirtv1.Disk {
+func newDisk(name string, bus v1.DiskBus) kvirtv1.Disk {
 	return kvirtv1.Disk{
 		Name: name,
 		DiskDevice: kvirtv1.DiskDevice{

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -735,8 +735,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
-				tests.AddEphemeralCdrom(vmi, "cdrom-0", "sata", cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				tests.AddEphemeralCdrom(vmi, "cdrom-1", "scsi", cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				tests.AddEphemeralCdrom(vmi, "cdrom-0", v1.DiskBusSATA, cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				tests.AddEphemeralCdrom(vmi, "cdrom-1", v1.DiskBusSCSI, cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)
@@ -758,8 +758,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				vmi.Spec.Hostname = string(cd.ContainerDiskAlpine)
 
-				tests.AddEphemeralCdrom(vmi, "cdrom-0", "sata", cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				tests.AddEphemeralCdrom(vmi, "cdrom-1", "scsi", cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				tests.AddEphemeralCdrom(vmi, "cdrom-0", v1.DiskBusSATA, cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				tests.AddEphemeralCdrom(vmi, "cdrom-1", v1.DiskBusSCSI, cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -200,7 +200,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
 			vmi.Spec.Domain.Devices = v1.Devices{}
 			vmi.Spec.Networks = nil
-			tests.AddEphemeralDisk(vmi, "disk0", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(HaveOccurred())

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -380,12 +380,11 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				vmi := tests.NewRandomVMI()
 
 				diskName := "disk0"
-				bus := "virtio"
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: diskName,
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: bus,
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				})
@@ -426,12 +425,11 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				vmi := tests.NewRandomVMI()
 
 				diskName := "disk0"
-				bus := "virtio"
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: diskName,
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: bus,
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				})

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -764,7 +764,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					Name: "blank",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				})
@@ -926,7 +926,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					Name: "blank",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				})

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -395,7 +395,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					Name: "blank",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				})
@@ -474,7 +474,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 					Name: "blank",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				})

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -246,11 +246,11 @@ var getWindowsSysprepVMISpec = func() v1.VirtualMachineInstanceSpec {
 				Disks: []v1.Disk{
 					{
 						Name:       windowsSealedDisk,
-						DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{Bus: "sata"}},
+						DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{Bus: v1.DiskBusSATA}},
 					},
 					{
 						Name:       "sysprep",
-						DiskDevice: v1.DiskDevice{CDRom: &v1.CDRomTarget{Bus: "sata"}},
+						DiskDevice: v1.DiskDevice{CDRom: &v1.CDRomTarget{Bus: v1.DiskBusSATA}},
 					},
 				},
 			},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1854,14 +1854,14 @@ func NewRandomMigration(vmiName string, namespace string) *v1.VirtualMachineInst
 func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
-	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
+	AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, containerImage)
 	if containerImage == cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling) {
 		vmi.Spec.Domain.Devices.Rng = &v1.Rng{} // newer fedora kernels may require hardware RNG to boot
 	}
 	return vmi
 }
 
-func AddEphemeralDisk(vmi *v1.VirtualMachineInstance, name string, bus string, image string) *v1.VirtualMachineInstance {
+func AddEphemeralDisk(vmi *v1.VirtualMachineInstance, name string, bus v1.DiskBus, image string) *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: name,
 		DiskDevice: v1.DiskDevice{
@@ -1892,7 +1892,7 @@ func AddBootOrderToDisk(vmi *v1.VirtualMachineInstance, diskName string, bootord
 	return vmi
 }
 
-func AddPVCDisk(vmi *v1.VirtualMachineInstance, name string, bus string, claimName string) *v1.VirtualMachineInstance {
+func AddPVCDisk(vmi *v1.VirtualMachineInstance, name string, bus v1.DiskBus, claimName string) *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: name,
 		DiskDevice: v1.DiskDevice{
@@ -1913,7 +1913,7 @@ func AddPVCDisk(vmi *v1.VirtualMachineInstance, name string, bus string, claimNa
 	return vmi
 }
 
-func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus string, image string) *v1.VirtualMachineInstance {
+func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus v1.DiskBus, image string) *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: name,
 		DiskDevice: v1.DiskDevice{
@@ -1988,7 +1988,7 @@ func AddPVCFS(vmi *v1.VirtualMachineInstance, name string, claimName string) *v1
 func NewRandomVMIWithFSFromDataVolume(dataVolumeName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 	containerImage := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
+	AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, containerImage)
 	vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
 		Name:     "disk1",
 		Virtiofs: &v1.FilesystemVirtiofs{},
@@ -2008,7 +2008,7 @@ func NewRandomVMIWithPVCFS(claimName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
 	containerImage := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
+	AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, containerImage)
 	vmi = AddPVCFS(vmi, "disk1", claimName)
 	return vmi
 }
@@ -2094,7 +2094,7 @@ func addCloudInitDiskAndVolume(vmi *v1.VirtualMachineInstance, name string, volu
 		Name: name,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: "virtio",
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -2107,14 +2107,14 @@ func addCloudInitDiskAndVolume(vmi *v1.VirtualMachineInstance, name string, volu
 func NewRandomVMIWithPVC(claimName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
-	vmi = AddPVCDisk(vmi, "disk0", "virtio", claimName)
+	vmi = AddPVCDisk(vmi, "disk0", v1.DiskBusVirtio, claimName)
 	return vmi
 }
 
 func NewRandomVMIWithPVCAndUserData(claimName, userData string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
-	vmi = AddPVCDisk(vmi, "disk0", "virtio", claimName)
+	vmi = AddPVCDisk(vmi, "disk0", v1.DiskBusVirtio, claimName)
 	AddUserData(vmi, "disk1", userData)
 	return vmi
 }
@@ -2143,7 +2143,7 @@ func NewRandomVMIWithCDRom(claimName string) *v1.VirtualMachineInstance {
 			CDRom: &v1.CDRomTarget{
 				// Do not specify ReadOnly flag so that
 				// default behavior can be tested
-				Bus: "sata",
+				Bus: v1.DiskBusSATA,
 			},
 		},
 	})
@@ -2165,7 +2165,7 @@ func NewRandomVMIWithEphemeralPVC(claimName string) *v1.VirtualMachineInstance {
 		Name: "disk0",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: "sata",
+				Bus: v1.DiskBusSATA,
 			},
 		},
 	})
@@ -2196,7 +2196,7 @@ func AddHostDisk(vmi *v1.VirtualMachineInstance, path string, diskType v1.HostDi
 		Name: name,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: "virtio",
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -2333,7 +2333,7 @@ func AddDownwardMetricsVolume(vmi *v1.VirtualMachineInstance, volumeName string)
 		Name: volumeName,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: "virtio",
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -3443,7 +3443,7 @@ func GetVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance
 	return podName
 }
 
-func AppendEmptyDisk(vmi *v1.VirtualMachineInstance, diskName, busName, diskSize string) {
+func AppendEmptyDisk(vmi *v1.VirtualMachineInstance, diskName string, busName v1.DiskBus, diskSize string) {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: diskName,
 		DiskDevice: v1.DiskDevice{
@@ -4298,7 +4298,7 @@ func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, 
 		Disk: &v1.Disk{
 			DiskDevice: v1.DiskDevice{
 				Disk: &v1.DiskTarget{
-					Bus: "scsi",
+					Bus: v1.DiskBusSCSI,
 				},
 			},
 			Serial: addVolumeName,

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -96,8 +96,8 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 			// The disk that came with the VMI
 			vmi.Spec.Domain.Devices.Disks[0].DedicatedIOThread = &dedicated
 
-			tests.AddEphemeralDisk(vmi, "shr1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			tests.AddEphemeralDisk(vmi, "shr2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "shr1", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "shr2", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			By("Creating VMI with 1 dedicated and 2 shared ioThreadPolicies")
 			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -149,13 +149,13 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 
 			vmi.Spec.Domain.Devices.Disks[0].DedicatedIOThread = &dedicated
 
-			tests.AddEphemeralDisk(vmi, "ded2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "ded2", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			vmi.Spec.Domain.Devices.Disks[1].DedicatedIOThread = &dedicated
 
-			tests.AddEphemeralDisk(vmi, "shr1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			tests.AddEphemeralDisk(vmi, "shr2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			tests.AddEphemeralDisk(vmi, "shr3", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			tests.AddEphemeralDisk(vmi, "shr4", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "shr1", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "shr2", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "shr3", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "shr4", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			cpuReq := resource.MustParse(fmt.Sprintf("%d", numCpus))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = cpuReq
@@ -239,8 +239,8 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 				IsolateEmulatorThread: true,
 			}
 
-			tests.AddEphemeralDisk(vmi, "disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
-			tests.AddEphemeralDisk(vmi, "ded2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "disk1", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "ded2", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			vmi.Spec.Domain.Devices.Disks[2].DedicatedIOThread = &dedicated
 
 			By("Starting a VirtualMachineInstance")

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -381,7 +381,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				By("defining a VirtualMachineInstance with an Alpine disk")
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskAlpine), "#!/bin/sh\n\necho 'hi'\n")
 				By("adding a Cirros Disk")
-				tests.AddEphemeralDisk(vmi, "disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				tests.AddEphemeralDisk(vmi, "disk2", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 				By("setting boot order")
 				vmi = tests.AddBootOrderToDisk(vmi, "disk0", &alpineBootOrder)

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -92,7 +92,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			cpuReq := resource.MustParse(fmt.Sprintf("%d", numCpus))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = cpuReq
 
-			tests.AddEphemeralDisk(vmi, "disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			tests.AddEphemeralDisk(vmi, "disk1", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			By("Creating VMI with 2 disks, 3 CPUs and multi-queue enabled")
 			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -97,8 +97,12 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 			Devices: v1.Devices{
 				Disks: []v1.Disk{
 					{
-						Name:       windowsDisk,
-						DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{Bus: "sata"}},
+						Name: windowsDisk,
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{
+								Bus: v1.DiskBusSATA,
+							},
+						},
 					},
 				},
 			},

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -96,11 +96,6 @@ const VmiPresetSmall = "vmi-preset-small"
 const VmiMigration = "migration-job"
 
 const (
-	busVirtio = "virtio"
-	busSata   = "sata"
-)
-
-const (
 	imageAlpine     = "alpine-container-disk-demo"
 	imageCirros     = "cirros-container-disk-demo"
 	imageFedora     = "fedora-with-test-tooling-container-disk"
@@ -164,13 +159,13 @@ func getBaseVMI(name string) *v1.VirtualMachineInstance {
 }
 
 func initFedoraWithDisk(spec *v1.VirtualMachineInstanceSpec, containerDisk string) *v1.VirtualMachineInstanceSpec {
-	addContainerDisk(spec, containerDisk, busVirtio)
+	addContainerDisk(spec, containerDisk, v1.DiskBusVirtio)
 	addRNG(spec)
 	return spec
 }
 
 func initFedora(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec {
-	addContainerDisk(spec, fmt.Sprintf(strFmt, DockerPrefix, imageFedora, DockerTag), busVirtio)
+	addContainerDisk(spec, fmt.Sprintf(strFmt, DockerPrefix, imageFedora, DockerTag), v1.DiskBusVirtio)
 	addRNG(spec) // without RNG, newer fedora images may hang waiting for entropy sources
 	return spec
 }
@@ -199,7 +194,7 @@ func addRNG(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec 
 	return spec
 }
 
-func addContainerDisk(spec *v1.VirtualMachineInstanceSpec, image string, bus string) *v1.VirtualMachineInstanceSpec {
+func addContainerDisk(spec *v1.VirtualMachineInstanceSpec, image string, bus v1.DiskBus) *v1.VirtualMachineInstanceSpec {
 	disk := &v1.Disk{
 		Name: "containerdisk",
 		DiskDevice: v1.DiskDevice{
@@ -247,7 +242,7 @@ func addNoCloudDiskWitUserData(spec *v1.VirtualMachineInstanceSpec, data string)
 		Name: "cloudinitdisk",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: busVirtio,
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -268,7 +263,7 @@ func addNoCloudDiskWitUserDataNetworkData(spec *v1.VirtualMachineInstanceSpec, u
 		Name: "cloudinitdisk",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: busVirtio,
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -290,7 +285,7 @@ func addEmptyDisk(spec *v1.VirtualMachineInstanceSpec, size string) *v1.VirtualM
 		Name: "emptydisk",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: busVirtio,
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -306,7 +301,7 @@ func addEmptyDisk(spec *v1.VirtualMachineInstanceSpec, size string) *v1.VirtualM
 	return spec
 }
 
-func addDataVolumeDisk(spec *v1.VirtualMachineInstanceSpec, dataVolumeName string, bus string, diskName string) *v1.VirtualMachineInstanceSpec {
+func addDataVolumeDisk(spec *v1.VirtualMachineInstanceSpec, dataVolumeName string, bus v1.DiskBus, diskName string) *v1.VirtualMachineInstanceSpec {
 	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
 		Name: diskName,
 		DiskDevice: v1.DiskDevice{
@@ -327,7 +322,7 @@ func addDataVolumeDisk(spec *v1.VirtualMachineInstanceSpec, dataVolumeName strin
 	return spec
 }
 
-func addPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus string, diskName string) *v1.VirtualMachineInstanceSpec {
+func addPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus v1.DiskBus, diskName string) *v1.VirtualMachineInstanceSpec {
 	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
 		Name: diskName,
 		DiskDevice: v1.DiskDevice{
@@ -348,7 +343,7 @@ func addPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus strin
 	return spec
 }
 
-func addEphemeralPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus string, diskName string) *v1.VirtualMachineInstanceSpec {
+func addEphemeralPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus v1.DiskBus, diskName string) *v1.VirtualMachineInstanceSpec {
 	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
 		Name: diskName,
 		DiskDevice: v1.DiskDevice{
@@ -376,7 +371,7 @@ func addHostDisk(spec *v1.VirtualMachineInstanceSpec, path string, hostDiskType 
 		Name: "host-disk",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: busVirtio,
+				Bus: v1.DiskBusVirtio,
 			},
 		},
 	})
@@ -400,21 +395,21 @@ func GetVMIMigratable() *v1.VirtualMachineInstance {
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageAlpine, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageAlpine, DockerTag), v1.DiskBusVirtio)
 	return vmi
 }
 
 func GetVMIEphemeral() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiEphemeral)
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	return vmi
 }
 
 func GetVMISata() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiSata)
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busSata)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusSATA)
 	return vmi
 }
 
@@ -429,7 +424,7 @@ func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 func GetVMISecureBoot() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiSecureBoot)
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageFedora, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageFedora, DockerTag), v1.DiskBusVirtio)
 
 	_true := true
 	vmi.Spec.Domain.Features = &v1.Features{
@@ -453,7 +448,7 @@ func GetVMIAlpineEFI() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiAlpineEFI)
 
 	_false := false
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageAlpine, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageAlpine, DockerTag), v1.DiskBusVirtio)
 	vmi.Spec.Domain.Firmware = &v1.Firmware{
 		Bootloader: &v1.Bootloader{
 			EFI: &v1.EFI{
@@ -542,7 +537,7 @@ func GetVMIMultusMultipleNet() *v1.VirtualMachineInstance {
 func GetVMINoCloud() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiNoCloud)
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	addNoCloudDisk(&vmi.Spec)
 	addEmptyDisk(&vmi.Spec, "2Gi")
 	return vmi
@@ -554,14 +549,14 @@ func GetVMIFlavorSmall() *v1.VirtualMachineInstance {
 		"kubevirt.io/flavor": "small",
 	}
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	return vmi
 }
 
 func GetVMIPvc() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiPVC)
 
-	addPVCDisk(&vmi.Spec, "disk-alpine", busVirtio, "pvcdisk")
+	addPVCDisk(&vmi.Spec, "disk-alpine", v1.DiskBusVirtio, "pvcdisk")
 	return vmi
 }
 
@@ -624,7 +619,7 @@ func GetVMIWindows() *v1.VirtualMachineInstance {
 	// pick e1000 network model type for windows machines
 	vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 
-	addPVCDisk(&vmi.Spec, "disk-windows", busSata, "pvcdisk")
+	addPVCDisk(&vmi.Spec, "disk-windows", v1.DiskBusSATA, "pvcdisk")
 	return vmi
 }
 
@@ -714,7 +709,7 @@ func GetVMCirros() *v1.VirtualMachine {
 		kubevirtIoVM: VmCirros,
 	})
 
-	addContainerDisk(&vm.Spec.Template.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vm.Spec.Template.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	addNoCloudDisk(&vm.Spec.Template.Spec)
 	return vm
 }
@@ -777,7 +772,7 @@ func GetTemplateRHEL7() *Template {
 
 	enableNetworkInterfaceMultiqueue(spec, enableNetworkInterfaceMultiqueueForTemplate)
 
-	addPVCDisk(spec, "linux-vm-pvc-${NAME}", busVirtio, "disk0")
+	addPVCDisk(spec, "linux-vm-pvc-${NAME}", v1.DiskBusVirtio, "disk0")
 	pvc := getPVCForTemplate("linux-vm-pvc-${NAME}")
 	template := newTemplateForRHEL7VM(vm)
 	template.Objects = append(template.Objects, pvc)
@@ -787,7 +782,7 @@ func GetTemplateRHEL7() *Template {
 func GetTestTemplateRHEL7() *Template {
 	vm := getBaseVM("", map[string]string{kubevirtVM: vmName, kubevirtIoOS: rhel74})
 	spec := &vm.Spec.Template.Spec
-	addEphemeralPVCDisk(spec, "disk-rhel", busSata, "pvcdisk")
+	addEphemeralPVCDisk(spec, "disk-rhel", v1.DiskBusSATA, "pvcdisk")
 	setDefaultNetworkAndInterface(spec, v1.InterfaceBindingMethod{
 		Masquerade: &v1.InterfaceMasquerade{},
 	},
@@ -822,7 +817,7 @@ func GetTemplateWindows() *Template {
 	windows := GetVMIWindows()
 	vm.Spec.Template.Spec = windows.Spec
 	vm.Spec.Template.ObjectMeta.Annotations = windows.ObjectMeta.Annotations
-	addPVCDisk(&vm.Spec.Template.Spec, "windows-vm-pvc-${NAME}", busVirtio, "disk0")
+	addPVCDisk(&vm.Spec.Template.Spec, "windows-vm-pvc-${NAME}", v1.DiskBusVirtio, "disk0")
 
 	pvc := getPVCForTemplate("windows-vm-pvc-${NAME}")
 
@@ -950,7 +945,7 @@ func GetVMDataVolume() *v1.VirtualMachine {
 	}
 
 	vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, dataVolumeSpec)
-	addDataVolumeDisk(&vm.Spec.Template.Spec, "alpine-dv", busVirtio, "datavolumedisk1")
+	addDataVolumeDisk(&vm.Spec.Template.Spec, "alpine-dv", v1.DiskBusVirtio, "datavolumedisk1")
 
 	return vm
 }
@@ -960,8 +955,8 @@ func GetVMMultiPvc() *v1.VirtualMachine {
 		kubevirtIoVM: VmAlpineMultiPvc,
 	})
 
-	addPVCDisk(&vm.Spec.Template.Spec, "disk-alpine", busVirtio, "pvcdisk1")
-	addPVCDisk(&vm.Spec.Template.Spec, "disk-custom", busVirtio, "pvcdisk2")
+	addPVCDisk(&vm.Spec.Template.Spec, "disk-alpine", v1.DiskBusVirtio, "pvcdisk1")
+	addPVCDisk(&vm.Spec.Template.Spec, "disk-custom", v1.DiskBusVirtio, "pvcdisk2")
 
 	return vm
 }
@@ -1035,7 +1030,7 @@ func GetVMPoolCirros() *poolv1.VirtualMachinePool {
 		"kubevirt.io/vmpool": VmPoolCirros,
 	})
 
-	addContainerDisk(&vmPool.Spec.VirtualMachineTemplate.Spec.Template.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vmPool.Spec.VirtualMachineTemplate.Spec.Template.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	return vmPool
 }
 
@@ -1044,7 +1039,7 @@ func GetVMIReplicaSetCirros() *v1.VirtualMachineInstanceReplicaSet {
 		"kubevirt.io/vmReplicaSet": VmiReplicaSetCirros,
 	})
 
-	addContainerDisk(&vmReplicaSet.Spec.Template.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vmReplicaSet.Spec.Template.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	return vmReplicaSet
 }
 
@@ -1141,7 +1136,7 @@ func GetVMIMacvtap() *v1.VirtualMachineInstance {
 func GetVMIARM() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiARM)
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("256Mi")
-	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), busVirtio)
+	addContainerDisk(&vmi.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	addNoCloudDisk(&vmi.Spec)
 	addEmptyDisk(&vmi.Spec, "2Gi")
 	return vmi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a simpler refactor PR replacing the use of string based disk buses with a specific string based type and associated constants. 

A small amount of leftover floppy disk code was found during this process and is removed in the initial commit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
