### PR TITLE
[Live-Migrations / Bugfix]: Allow aborting non-running migrations

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -9,6 +9,8 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
+const CancelMigrationFailedVmiNotMigratingErr = "failed to cancel migration - vmi is not migrating"
+
 func ListUnfinishedMigrations(informer cache.SharedIndexInformer) []*v1.VirtualMachineInstanceMigration {
 	objs := informer.GetStore().List()
 	migrations := []*v1.VirtualMachineInstanceMigration{}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -103,6 +103,11 @@ type MigrationController struct {
 	clusterConfig           *virtconfig.ClusterConfig
 	statusUpdater           *status.MigrationStatusUpdater
 
+	// the set of cancelled migrations before being handed off to virt-handler.
+	// the map keys are migration keys
+	handOffLock sync.Mutex
+	handOffMap  map[string]struct{}
+
 	unschedulablePendingTimeoutSeconds int64
 	catchAllPendingTimeoutSeconds      int64
 }
@@ -136,6 +141,7 @@ func NewMigrationController(templateService services.TemplateService,
 		migrationStartLock:      &sync.Mutex{},
 		clusterConfig:           clusterConfig,
 		statusUpdater:           status.NewMigrationStatusUpdater(clientset),
+		handOffMap:              make(map[string]struct{}),
 
 		unschedulablePendingTimeoutSeconds: defaultUnschedulablePendingTimeoutSeconds,
 		catchAllPendingTimeoutSeconds:      defaultCatchAllPendingTimeoutSeconds,
@@ -269,6 +275,7 @@ func (c *MigrationController) execute(key string) error {
 
 	if !exists {
 		c.podExpectations.DeleteExpectations(key)
+		c.removeHandOffKey(key)
 		return nil
 	}
 	migration := obj.(*virtv1.VirtualMachineInstanceMigration)
@@ -424,6 +431,17 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "Migration failed vmi shutdown during migration.")
 		handleFailedMigrationMetrics(migration, vmi, pod)
 		log.Log.Object(migration).Error("Unable to migrate vmi because vmi is shutdown.")
+	} else if migration.DeletionTimestamp != nil && !c.isMigrationHandedOff(migration, vmi) {
+		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "Migration failed due to being canceled")
+		if !conditionManager.HasCondition(migration, virtv1.VirtualMachineInstanceMigrationAbortRequested) {
+			condition := virtv1.VirtualMachineInstanceMigrationCondition{
+				Type:          virtv1.VirtualMachineInstanceMigrationAbortRequested,
+				Status:        k8sv1.ConditionTrue,
+				LastProbeTime: v1.Now(),
+			}
+			migrationCopy.Status.Conditions = append(migrationCopy.Status.Conditions, condition)
+		}
+		migrationCopy.Status.Phase = virtv1.MigrationFailed
 	} else if podExists && podIsDown(pod) {
 		migrationCopy.Status.Phase = virtv1.MigrationFailed
 		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "Migration failed because target pod shutdown during migration")
@@ -452,9 +470,10 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 		vmi.Status.MigrationState.Failed {
 
 		migrationCopy.Status.Phase = virtv1.MigrationFailed
-		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "Source node reported migration failed")
+		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedMigrationReason, "source node reported migration failed")
 		handleFailedMigrationMetrics(migration, vmi, pod)
-		log.Log.Object(migration).Errorf("VMI %s/%s reported migration failed.", vmi.Namespace, vmi.Name)
+		log.Log.Object(migration).Errorf("VMI %s/%s reported migration failed", vmi.Namespace, vmi.Name)
+
 	} else if migration.DeletionTimestamp != nil && !migration.IsFinal() &&
 		!conditionManager.HasCondition(migration, virtv1.VirtualMachineInstanceMigrationAbortRequested) {
 		condition := virtv1.VirtualMachineInstanceMigrationCondition{
@@ -677,6 +696,25 @@ func (c *MigrationController) handleMarkMigrationFailedOnVMI(migration *virtv1.V
 	return nil
 }
 
+func (c *MigrationController) handlePreHandoffMigrationCancel(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
+	if pod == nil {
+		return nil
+	}
+
+	c.podExpectations.ExpectDeletions(controller.MigrationKey(migration), []string{controller.PodKey(pod)})
+	err := c.clientset.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, v1.DeleteOptions{})
+	if err != nil {
+		c.podExpectations.DeletionObserved(controller.MigrationKey(migration), controller.PodKey(pod))
+		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedDeletePodReason, "Error deleting canceled migration target pod: %v", err)
+		return fmt.Errorf("cannot delete pending target pod %s/%s for migration although migration is aborted", pod.Name, pod.Namespace)
+	}
+
+	reason := "migration canceled"
+	log.Log.Object(vmi).Infof("Deleted pending migration target pod %s/%s with uuid %s for migration %s with uuid %s with reason [%s]", pod.Namespace, pod.Name, string(pod.UID), migration.Name, string(migration.UID), reason)
+	c.recorder.Eventf(migration, k8sv1.EventTypeNormal, SuccessfulDeletePodReason, reason, pod.Name)
+	return nil
+}
+
 func (c *MigrationController) handleTargetPodHandoff(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
 
 	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.MigrationUID == migration.UID {
@@ -724,29 +762,22 @@ func (c *MigrationController) handleTargetPodHandoff(migration *virtv1.VirtualMa
 		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedHandOverPodReason, fmt.Sprintf("Failed to set MigrationStat in VMI status. :%v", err))
 		return err
 	}
+
+	c.addHandOffKey(controller.MigrationKey(migration))
 	log.Log.Object(vmi).Infof("Handed off migration %s/%s to target virt-handler.", migration.Namespace, migration.Name)
 	c.recorder.Eventf(migration, k8sv1.EventTypeNormal, SuccessfulHandOverPodReason, "Migration target pod is ready for preparation by virt-handler.")
 	return nil
 }
 
-func (c *MigrationController) handleSignalMigrationAbort(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
+func (c *MigrationController) markMigrationAbortInVmiStatus(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
+
+	if vmi.Status.MigrationState == nil {
+		return fmt.Errorf("migration state is nil when trying to mark migratio abortion in vmi status")
+	}
 
 	vmiCopy := vmi.DeepCopy()
-	now := v1.NewTime(time.Now())
 
-	if vmiCopy.Status.MigrationState == nil {
-		vmiCopy.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
-			MigrationUID:   migration.UID,
-			SourceNode:     vmi.Status.NodeName,
-			StartTimestamp: &now,
-		}
-	}
-
-	if vmiCopy.Status.MigrationState.EndTimestamp == nil {
-		vmiCopy.Status.MigrationState.EndTimestamp = &now
-	}
 	vmiCopy.Status.MigrationState.AbortRequested = true
-
 	if !equality.Semantic.DeepEqual(vmi.Status, vmiCopy.Status) {
 
 		newStatus := vmiCopy.Status
@@ -1035,10 +1066,12 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 		pod = pods[0]
 	}
 
-	vmiDeleted := vmi == nil || vmi.DeletionTimestamp != nil
-	migrationFinalizedOnVMI := vmi.Status.MigrationState != nil && vmi.Status.MigrationState.MigrationUID == migration.UID && vmi.Status.MigrationState.EndTimestamp != nil
+	if vmiDeleted := vmi == nil || vmi.DeletionTimestamp != nil; vmiDeleted {
+		return nil
+	}
 
-	if vmiDeleted || migrationFinalizedOnVMI {
+	if migrationFinalizedOnVMI := vmi.Status.MigrationState != nil && vmi.Status.MigrationState.MigrationUID == migration.UID &&
+		vmi.Status.MigrationState.EndTimestamp != nil; migrationFinalizedOnVMI {
 		return nil
 	}
 
@@ -1051,15 +1084,12 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 		return fmt.Errorf("vmi is inelgible for migration because another migration job is running")
 	}
 
-	if migration.DeletionTimestamp != nil {
-		err = c.handleSignalMigrationAbort(migration, vmi)
-		if err != nil {
-			return err
-		}
-	}
-
 	switch migration.Status.Phase {
 	case virtv1.MigrationPending:
+		if migration.DeletionTimestamp != nil {
+			return c.handlePreHandoffMigrationCancel(migration, vmi, pod)
+		}
+
 		if !targetPodExists {
 			sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer)
 			if err != nil {
@@ -1124,11 +1154,19 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			return c.handlePendingPodTimeout(migration, vmi, pod)
 		}
 	case virtv1.MigrationScheduling:
+		if migration.DeletionTimestamp != nil {
+			return c.handlePreHandoffMigrationCancel(migration, vmi, pod)
+		}
+
 		if targetPodExists {
 			return c.handlePendingPodTimeout(migration, vmi, pod)
 		}
 
 	case virtv1.MigrationScheduled:
+		if migration.DeletionTimestamp != nil && !c.isMigrationHandedOff(migration, vmi) {
+			return c.handlePreHandoffMigrationCancel(migration, vmi, pod)
+		}
+
 		// once target pod is running, then alert the VMI of the migration by
 		// setting the target and source nodes. This kicks off the preparation stage.
 		if targetPodExists && isPodReady(pod) {
@@ -1145,6 +1183,12 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			return c.handleMarkMigrationFailedOnVMI(migration, vmi)
 		}
 	case virtv1.MigrationRunning:
+		if migration.DeletionTimestamp != nil && vmi.Status.MigrationState != nil {
+			err = c.markMigrationAbortInVmiStatus(migration, vmi)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -1702,4 +1746,32 @@ func (c *MigrationController) isMigrationPolicyMatched(vmi *virtv1.VirtualMachin
 
 	migrationPolicyName := vmi.Status.MigrationState.MigrationPolicyName
 	return migrationPolicyName != nil && *migrationPolicyName != ""
+}
+
+func (c *MigrationController) isMigrationHandedOff(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) bool {
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.MigrationUID == migration.UID {
+		return true
+	}
+
+	migrationKey := controller.MigrationKey(migration)
+
+	c.handOffLock.Lock()
+	defer c.handOffLock.Unlock()
+
+	_, isHandedOff := c.handOffMap[migrationKey]
+	return isHandedOff
+}
+
+func (c *MigrationController) addHandOffKey(migrationKey string) {
+	c.handOffLock.Lock()
+	defer c.handOffLock.Unlock()
+
+	c.handOffMap[migrationKey] = struct{}{}
+}
+
+func (c *MigrationController) removeHandOffKey(migrationKey string) {
+	c.handOffLock.Lock()
+	defer c.handOffLock.Unlock()
+
+	delete(c.handOffMap, migrationKey)
 }

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -235,6 +235,24 @@ var _ = Describe("Migration watcher", func() {
 		vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
 	}
 
+	shouldExpectMigrationCondition := func(migration *virtv1.VirtualMachineInstanceMigration, conditionType virtv1.VirtualMachineInstanceMigrationConditionType) {
+		migrationInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) (interface{}, interface{}) {
+			vmim := arg.(*virtv1.VirtualMachineInstanceMigration)
+			ExpectWithOffset(1, vmim.Name).To(Equal(migration.Name))
+
+			foundConditionType := false
+			for _, cond := range vmim.Status.Conditions {
+				if cond.Type == conditionType {
+					foundConditionType = true
+					break
+				}
+			}
+			ExpectWithOffset(1, foundConditionType).To(BeTrue(), fmt.Sprintf("condition of type %s is expected but cannot be found in migration %s", string(conditionType), migration.Name))
+
+			return arg, nil
+		})
+	}
+
 	syncCaches := func(stop chan struct{}) {
 		go vmiInformer.Run(stop)
 		go podInformer.Run(stop)
@@ -1754,6 +1772,35 @@ var _ = Describe("Migration watcher", func() {
 
 			expectGaugeValue(migrations.CurrentSchedulingMigrations, labels, scheduling-1)
 			expectCounterValue(migrations.MigrationsFailedTotal, labels, failed+1)
+		})
+	})
+
+	Context("Migration abortion before hand-off to virt-handler", func() {
+
+		var vmi *virtv1.VirtualMachineInstance
+		var migration *virtv1.VirtualMachineInstanceMigration
+
+		BeforeEach(func() {
+			vmi = newVirtualMachine("testvmi", virtv1.Running)
+			migration = newMigration("testmigration", vmi.Name, virtv1.MigrationPending)
+			migration.DeletionTimestamp = now()
+
+			Expect(controller.isMigrationHandedOff(migration, vmi)).To(BeFalse(), "this test assumes migration was not handed off yet")
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+		})
+
+		AfterEach(func() {
+			controller.Execute()
+			testutils.ExpectEvent(recorder, FailedMigrationReason)
+		})
+
+		It("expect abort condition", func() {
+			shouldExpectMigrationCondition(migration, virtv1.VirtualMachineInstanceMigrationAbortRequested)
+		})
+
+		It("expect failure phase", func() {
+			shouldExpectMigrationFailedState(migration)
 		})
 	})
 })

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+
 	"github.com/prometheus/client_golang/prometheus"
 	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 
@@ -1220,6 +1222,7 @@ var _ = Describe("Migration watcher", func() {
 				TargetNodeAddress: "10.10.10.10:1234",
 				StartTimestamp:    now(),
 			}
+			controller.addHandOffKey(virtcontroller.MigrationKey(migration))
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(pod)

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/network/sriov:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
+        "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/util/migrations"
+
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
@@ -482,7 +484,7 @@ func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) e
 	migration := domain.Metadata.KubeVirt.Migration
 	if migration == nil || migration.Completed ||
 		migration.Failed || migration.StartTimestamp == nil {
-		return fmt.Errorf("failed to cancel migration - vmi is not migrating")
+		return fmt.Errorf(migrations.CancelMigrationFailedVmiNotMigratingErr)
 	}
 
 	err = l.setMigrationAbortStatus(vmi, v1.MigrationAbortInProgress)

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnode",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/nodes:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2696,7 +2696,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(limitMigrationBadwidth(resource.MustParse("1Ki"))).To(Succeed())
 
 				By("Starting the VirtualMachineInstance")
-				vmi = runVMIAndExpectLaunch(vmi, 240)
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 				vmiOriginalNode := vmi.Status.NodeName
 
 				// execute a migration, wait for finalized state
@@ -2770,7 +2770,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				It("should be able to properly abort migration", func() {
 					By("Starting a VirtualMachineInstance")
 					vmi := tests.NewRandomVMI()
-					vmi = runVMIAndExpectLaunch(vmi, 240)
+					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 					By("Trying to migrate VM and expect for the migration to get stuck")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1199,7 +1199,7 @@ func WaitForMigrationToDisappearWithTimeout(migration *v1.VirtualMachineInstance
 	EventuallyWithOffset(1, func() bool {
 		_, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
 		return errors.IsNotFound(err)
-	}, seconds, 1*time.Second).Should(BeTrue())
+	}, seconds, 1*time.Second).Should(BeTrue(), fmt.Sprintf("migration %s was expected to dissapear after %d seconds, but it did not", migration.Name, seconds))
 }
 
 func WaitForSuccessfulVMIStart(vmi runtime.Object) *v1.VirtualMachineInstance {

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -129,45 +129,17 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 			).Should(BeTrue())
 		}
 
-		setNodeUnschedulable := func(nodeName string) {
-			Eventually(func() error {
-				selectedNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				selectedNode.Spec.Unschedulable = true
-				if _, err = virtCli.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{}); err != nil {
-					return err
-				}
-				return nil
-			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
-		}
-
-		setNodeSchedulable := func(nodeName string) {
-			Eventually(func() error {
-				selectedNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				selectedNode.Spec.Unschedulable = false
-				if _, err = virtCli.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{}); err != nil {
-					return err
-				}
-				return nil
-			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
-		}
-
 		BeforeEach(func() {
 			nodeList = libnode.GetAllSchedulableNodes(virtCli).Items
 			for _, node := range nodeList {
-				setNodeUnschedulable(node.Name)
+				libnode.SetNodeUnschedulable(node.Name, virtCli)
 			}
 			eventuallyWithTimeout(waitForDeploymentsToStabilize)
 		})
 
 		AfterEach(func() {
 			for _, node := range nodeList {
-				setNodeSchedulable(node.Name)
+				libnode.SetNodeSchedulable(node.Name, virtCli)
 			}
 			eventuallyWithTimeout(waitForDeploymentsToStabilize)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug related to aborting live migrations:
When a migration starts and the target pod cannot be scheduled the migration is stuck. In this situation, if the migration is aborted (which is achieved via deleting the relevant VMIM object), the migration will hang forever and wouldn't be able to be deleted.

The core problem is that we do not have a mechanism to abort a migration before the target pod starts running. Therefore, the current situation is:
* A finalizer is attached to the VMIM, which prevents its deletion. The finalizer is removed only once the the migration is final, which means it's either failed or succeeded.
* virt-contoller's migration controller waits for the target pod to be running before handling abort logic
* virt-handler, at the source, also cannot affect the target pod since it hasn't been scheduled yet.

This PR aims to introduce a race-free, safe solution to aborted non-running migrations. To do so, the following changes are introduced:
* Migration abort is being signaled to the VMI object, even if the migration hadn't started running yet.
* virt-contoller's migration controller will check if migration is aborted and target pod is still pending. If that's the case, the target pod will be deleted.
* virt-contoller's migration controller will remove the VMIM finalizer if the migration had been aborted and does not have any target pods. 

As a side note - this not only fixes the bug, but also lowers performance cost, since even if the target pod can be scheduled eventually, it's better to delete it before it even starts then to wait for migration to begin and only then cancel it out.

**Which issue(s) this PR fixes**:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1719190

In short (taken from Bugzilla page):
```
Steps to Reproduce:
1. oc adm cordon <all-nodes-except-the-vmi-running-node>
2. start a live-migration (oc create -f vmim.yaml...)
3. watch a new pod virt-launcher is created and in 'pending' state
4. try delete the vmim cr (oc delete vmim...)

Actual results:
step 4 above hangs forever

Expected results:
live-migration to be cancelled 
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce a mechanism to abort non-running migrations - fixes "Unable to cancel live-migration if virt-launcher pod in pending state" bug
```
