### PR TITLE
Refactor virt controller template machine volumes

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "multus_annotations.go",
         "rendercontainer.go",
+        "rendervolumes.go",
         "template.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/services",

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     srcs = [
         "multus_annotations_test.go",
         "rendercontainer_test.go",
+        "rendervolumes_test.go",
         "services_suite_test.go",
         "template_test.go",
     ],

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/util"
+	"path/filepath"
+)
+
+type VolumeRendererOption func(renderer *VolumeRenderer)
+
+type VolumeRenderer struct {
+	containerDiskDir string
+	ephemeralDiskDir string
+	virtShareDir     string
+}
+
+func NewVolumeRenderer(ephemeralDisk string, containerDiskDir string, virtShareDir string) *VolumeRenderer {
+	return &VolumeRenderer{
+		containerDiskDir: containerDiskDir,
+		ephemeralDiskDir: ephemeralDisk,
+		virtShareDir:     virtShareDir,
+	}
+}
+
+func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
+	volumeMounts := []k8sv1.VolumeMount{
+		mountPath("private", util.VirtPrivateDir),
+		mountPath("public", util.VirtShareDir),
+		mountPath("ephemeral-disks", vr.ephemeralDiskDir),
+		mountPathWithPropagation(containerDisks, vr.containerDiskDir, k8sv1.MountPropagationHostToContainer),
+		mountPath("libvirt-runtime", "/var/run/libvirt"),
+		mountPath("sockets", filepath.Join(vr.virtShareDir, "sockets")),
+	}
+	return volumeMounts
+}
+
+func (vr *VolumeRenderer) Volumes() []k8sv1.Volume {
+	volumes := []k8sv1.Volume{
+		emptyDirVolume("private"),
+		emptyDirVolume("public"),
+		emptyDirVolume("sockets"),
+	}
+	return volumes
+}
+
+func mountPath(name string, path string) k8sv1.VolumeMount {
+	return k8sv1.VolumeMount{
+		Name:      name,
+		MountPath: path,
+	}
+}
+
+func mountPathWithPropagation(name string, path string, propagation k8sv1.MountPropagationMode) k8sv1.VolumeMount {
+	return k8sv1.VolumeMount{
+		Name:             name,
+		MountPath:        path,
+		MountPropagation: &propagation,
+	}
+}
+
+func emptyDirVolume(name string) k8sv1.Volume {
+	return k8sv1.Volume{
+		Name: name,
+		VolumeSource: k8sv1.VolumeSource{
+			EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+	}
+}

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -1,25 +1,47 @@
 package services
 
 import (
-	k8sv1 "k8s.io/api/core/v1"
-	"kubevirt.io/kubevirt/pkg/util"
+	"fmt"
 	"path/filepath"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/config"
+	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/types"
 )
 
-type VolumeRendererOption func(renderer *VolumeRenderer)
+type VolumeRendererOption func(renderer *VolumeRenderer) error
 
 type VolumeRenderer struct {
 	containerDiskDir string
 	ephemeralDiskDir string
 	virtShareDir     string
+	namespace        string
+	vmiVolumes       []v1.Volume
+	podVolumes       []k8sv1.Volume
+	podVolumeMounts  []k8sv1.VolumeMount
+	volumeDevices    []k8sv1.VolumeDevice
 }
 
-func NewVolumeRenderer(ephemeralDisk string, containerDiskDir string, virtShareDir string) *VolumeRenderer {
-	return &VolumeRenderer{
+func NewVolumeRenderer(namespace string, ephemeralDisk string, containerDiskDir string, virtShareDir string, volumeOptions ...VolumeRendererOption) (*VolumeRenderer, error) {
+	volumeRenderer := &VolumeRenderer{
 		containerDiskDir: containerDiskDir,
 		ephemeralDiskDir: ephemeralDisk,
+		namespace:        namespace,
 		virtShareDir:     virtShareDir,
 	}
+	for _, volumeOption := range volumeOptions {
+		if err := volumeOption(volumeRenderer); err != nil {
+			return nil, err
+		}
+	}
+	return volumeRenderer, nil
 }
 
 func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
@@ -31,7 +53,7 @@ func (vr *VolumeRenderer) Mounts() []k8sv1.VolumeMount {
 		mountPath("libvirt-runtime", "/var/run/libvirt"),
 		mountPath("sockets", filepath.Join(vr.virtShareDir, "sockets")),
 	}
-	return volumeMounts
+	return append(volumeMounts, vr.podVolumeMounts...)
 }
 
 func (vr *VolumeRenderer) Volumes() []k8sv1.Volume {
@@ -40,7 +62,11 @@ func (vr *VolumeRenderer) Volumes() []k8sv1.Volume {
 		emptyDirVolume("public"),
 		emptyDirVolume("sockets"),
 	}
-	return volumes
+	return append(volumes, vr.podVolumes...)
+}
+
+func (vr *VolumeRenderer) VolumeDevices() []k8sv1.VolumeDevice {
+	return vr.volumeDevices
 }
 
 func mountPath(name string, path string) k8sv1.VolumeMount {
@@ -64,4 +90,330 @@ func emptyDirVolume(name string) k8sv1.Volume {
 		VolumeSource: k8sv1.VolumeSource{
 			EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
 	}
+}
+
+func withVMIVolumes(pvcStore cache.Store, vmiSpecVolumes []v1.Volume, vmiVolumeStatus []v1.VolumeStatus) VolumeRendererOption {
+	return func(renderer *VolumeRenderer) error {
+		hotplugVolumes := make(map[string]bool)
+		for _, volumeStatus := range vmiVolumeStatus {
+			if volumeStatus.HotplugVolume != nil {
+				hotplugVolumes[volumeStatus.Name] = true
+			}
+		}
+		// This detects hotplug volumes for a started but not ready VMI
+		for _, volume := range vmiSpecVolumes {
+			if (volume.DataVolume != nil && volume.DataVolume.Hotpluggable) || (volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable) {
+				hotplugVolumes[volume.Name] = true
+			}
+		}
+
+		for _, volume := range vmiSpecVolumes {
+			if hotplugVolumes[volume.Name] {
+				continue
+			}
+			if volume.PersistentVolumeClaim != nil {
+				claimName := volume.PersistentVolumeClaim.ClaimName
+				if err := addPVCToLaunchManifest(pvcStore, volume, claimName, renderer.namespace, &renderer.podVolumeMounts, &renderer.volumeDevices); err != nil {
+					return err
+				}
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: volume.PersistentVolumeClaim.ClaimName,
+							ReadOnly:  volume.PersistentVolumeClaim.ReadOnly,
+						},
+					},
+				})
+			}
+			if volume.Ephemeral != nil {
+				claimName := volume.Ephemeral.PersistentVolumeClaim.ClaimName
+				if err := addPVCToLaunchManifest(pvcStore, volume, claimName, renderer.namespace, &renderer.podVolumeMounts, &renderer.volumeDevices); err != nil {
+					return err
+				}
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						PersistentVolumeClaim: volume.Ephemeral.PersistentVolumeClaim,
+					},
+				})
+			}
+			imgPullSecrets(volume)
+			if volume.HostDisk != nil {
+				var hostPathType k8sv1.HostPathType
+
+				switch hostType := volume.HostDisk.Type; hostType {
+				case v1.HostDiskExists:
+					hostPathType = k8sv1.HostPathDirectory
+				case v1.HostDiskExistsOrCreate:
+					hostPathType = k8sv1.HostPathDirectoryOrCreate
+				}
+
+				renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+					Name:      volume.Name,
+					MountPath: hostdisk.GetMountedHostDiskDir(volume.Name),
+				})
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						HostPath: &k8sv1.HostPathVolumeSource{
+							Path: filepath.Dir(volume.HostDisk.Path),
+							Type: &hostPathType,
+						},
+					},
+				})
+			}
+			if volume.DataVolume != nil {
+				claimName := volume.DataVolume.Name
+				if err := addPVCToLaunchManifest(pvcStore, volume, claimName, renderer.namespace, &renderer.podVolumeMounts, &renderer.volumeDevices); err != nil {
+					return err
+				}
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: claimName,
+						},
+					},
+				})
+			}
+			if volume.ConfigMap != nil {
+				// attach a ConfigMap to the pod
+				renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+					Name:      volume.Name,
+					MountPath: filepath.Join(config.ConfigMapSourceDir, volume.Name),
+					ReadOnly:  true,
+				})
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						ConfigMap: &k8sv1.ConfigMapVolumeSource{
+							LocalObjectReference: volume.ConfigMap.LocalObjectReference,
+							Optional:             volume.ConfigMap.Optional,
+						},
+					},
+				})
+			}
+
+			if volume.Secret != nil {
+				// attach a Secret to the pod
+				renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+					Name:      volume.Name,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
+					ReadOnly:  true,
+				})
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						Secret: &k8sv1.SecretVolumeSource{
+							SecretName: volume.Secret.SecretName,
+							Optional:   volume.Secret.Optional,
+						},
+					},
+				})
+			}
+
+			if volume.DownwardAPI != nil {
+				// attach a Secret to the pod
+				renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+					Name:      volume.Name,
+					MountPath: filepath.Join(config.DownwardAPISourceDir, volume.Name),
+					ReadOnly:  true,
+				})
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						DownwardAPI: &k8sv1.DownwardAPIVolumeSource{
+							Items: volume.DownwardAPI.Fields,
+						},
+					},
+				})
+			}
+
+			if volume.DownwardMetrics != nil {
+				sizeLimit := resource.MustParse("1Mi")
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name: volume.Name,
+					VolumeSource: k8sv1.VolumeSource{
+						EmptyDir: &k8sv1.EmptyDirVolumeSource{
+							Medium:    "Memory",
+							SizeLimit: &sizeLimit,
+						},
+					},
+				})
+				renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+					Name:      volume.Name,
+					MountPath: config.DownwardMetricDisksDir,
+				})
+			}
+
+			if volume.CloudInitNoCloud != nil {
+				if volume.CloudInitNoCloud.UserDataSecretRef != nil {
+					// attach a secret referenced by the user
+					volumeName := volume.Name + "-udata"
+					renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+						Name: volumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							Secret: &k8sv1.SecretVolumeSource{
+								SecretName: volume.CloudInitNoCloud.UserDataSecretRef.Name,
+							},
+						},
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userdata"),
+						SubPath:   "userdata",
+						ReadOnly:  true,
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userData"),
+						SubPath:   "userData",
+						ReadOnly:  true,
+					})
+				}
+				if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
+					// attach a secret referenced by the networkdata
+					volumeName := volume.Name + "-ndata"
+					renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+						Name: volumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							Secret: &k8sv1.SecretVolumeSource{
+								SecretName: volume.CloudInitNoCloud.NetworkDataSecretRef.Name,
+							},
+						},
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkdata"),
+						SubPath:   "networkdata",
+						ReadOnly:  true,
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkData"),
+						SubPath:   "networkData",
+						ReadOnly:  true,
+					})
+				}
+			}
+
+			if volume.Sysprep != nil {
+				var volumeSource k8sv1.VolumeSource
+				// attach a Secret or ConfigMap referenced by the user
+				volumeSource, err := sysprepVolumeSource(*volume.Sysprep)
+				if err != nil {
+					//return nil, err
+				}
+				renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+					Name:         volume.Name,
+					VolumeSource: volumeSource,
+				})
+				renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+					Name:      volume.Name,
+					MountPath: filepath.Join(config.SysprepSourceDir, volume.Name),
+					ReadOnly:  true,
+				})
+			}
+
+			if volume.CloudInitConfigDrive != nil {
+				if volume.CloudInitConfigDrive.UserDataSecretRef != nil {
+					// attach a secret referenced by the user
+					volumeName := volume.Name + "-udata"
+					renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+						Name: volumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							Secret: &k8sv1.SecretVolumeSource{
+								SecretName: volume.CloudInitConfigDrive.UserDataSecretRef.Name,
+							},
+						},
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userdata"),
+						SubPath:   "userdata",
+						ReadOnly:  true,
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userData"),
+						SubPath:   "userData",
+						ReadOnly:  true,
+					})
+				}
+				if volume.CloudInitConfigDrive.NetworkDataSecretRef != nil {
+					// attach a secret referenced by the networkdata
+					volumeName := volume.Name + "-ndata"
+					renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+						Name: volumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							Secret: &k8sv1.SecretVolumeSource{
+								SecretName: volume.CloudInitConfigDrive.NetworkDataSecretRef.Name,
+							},
+						},
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkdata"),
+						SubPath:   "networkdata",
+						ReadOnly:  true,
+					})
+					renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkData"),
+						SubPath:   "networkData",
+						ReadOnly:  true,
+					})
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func imgPullSecrets(volumes ...v1.Volume) []k8sv1.LocalObjectReference {
+	var imagePullSecrets []k8sv1.LocalObjectReference
+	for _, volume := range volumes {
+		if volume.ContainerDisk != nil && volume.ContainerDisk.ImagePullSecret != "" {
+			imagePullSecrets = appendUniqueImagePullSecret(imagePullSecrets, k8sv1.LocalObjectReference{
+				Name: volume.ContainerDisk.ImagePullSecret,
+			})
+		}
+	}
+	return imagePullSecrets
+}
+
+func serviceAccount(volumes ...v1.Volume) string {
+	for _, volume := range volumes {
+		if volume.ServiceAccount != nil {
+			return volume.ServiceAccount.ServiceAccountName
+		}
+	}
+	return ""
+}
+
+func addPVCToLaunchManifest(pvcStore cache.Store, volume v1.Volume, claimName string, namespace string, volumeMounts *[]k8sv1.VolumeMount, volumeDevices *[]k8sv1.VolumeDevice) error {
+	logger := log.DefaultLogger()
+	_, exists, isBlock, err := types.IsPVCBlockFromStore(pvcStore, namespace, claimName)
+	if err != nil {
+		logger.Errorf("error getting PVC: %v", claimName)
+		return err
+	} else if !exists {
+		logger.Errorf("didn't find PVC %v", claimName)
+		return PvcNotFoundError{Reason: fmt.Sprintf("didn't find PVC %v", claimName)}
+	} else if isBlock {
+		devicePath := filepath.Join(string(filepath.Separator), "dev", volume.Name)
+		device := k8sv1.VolumeDevice{
+			Name:       volume.Name,
+			DevicePath: devicePath,
+		}
+		*volumeDevices = append(*volumeDevices, device)
+	} else {
+		volumeMount := k8sv1.VolumeMount{
+			Name:      volume.Name,
+			MountPath: hostdisk.GetMountedHostDiskDir(volume.Name),
+		}
+		*volumeMounts = append(*volumeMounts, volumeMount)
+	}
+	return nil
 }

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -11,6 +11,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/config"
+	"kubevirt.io/kubevirt/pkg/hooks"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/types"
@@ -397,6 +398,24 @@ func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRender
 				Name:      volumeName,
 				MountPath: filepath.Join(config.SecretSourceDir, volumeName),
 				ReadOnly:  true,
+			})
+		}
+		return nil
+	}
+}
+
+func withSidecarVolumes(hookSidecars hooks.HookSidecarList) VolumeRendererOption {
+	return func(renderer *VolumeRenderer) error {
+		if len(hookSidecars) != 0 {
+			renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+				Name: hookSidecarSocks,
+				VolumeSource: k8sv1.VolumeSource{
+					EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+				},
+			})
+			renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+				Name:      hookSidecarSocks,
+				MountPath: hooks.HookSocketsSharedDirectory,
 			})
 		}
 		return nil

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -283,12 +283,7 @@ func withAccessCredentials(accessCredentials []v1.AccessCredential) VolumeRender
 func withSidecarVolumes(hookSidecars hooks.HookSidecarList) VolumeRendererOption {
 	return func(renderer *VolumeRenderer) error {
 		if len(hookSidecars) != 0 {
-			renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
-				Name: hookSidecarSocks,
-				VolumeSource: k8sv1.VolumeSource{
-					EmptyDir: &k8sv1.EmptyDirVolumeSource{},
-				},
-			})
+			renderer.podVolumes = append(renderer.podVolumes, emptyDirVolume(hookSidecarSocks))
 			renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
 				Name:      hookSidecarSocks,
 				MountPath: hooks.HookSocketsSharedDirectory,
@@ -324,12 +319,7 @@ func withHotplugSupport(hotplugDiskDir string) VolumeRendererOption {
 			MountPath:        hotplugDiskDir,
 			MountPropagation: &prop,
 		})
-		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
-			Name: hotplugDisks,
-			VolumeSource: k8sv1.VolumeSource{
-				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
-			},
-		})
+		renderer.podVolumes = append(renderer.podVolumes, emptyDirVolume(hotplugDisks))
 		return nil
 	}
 }

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -440,6 +440,24 @@ func withHugepages() VolumeRendererOption {
 	}
 }
 
+func withHotplugSupport(hotplugDiskDir string) VolumeRendererOption {
+	return func(renderer *VolumeRenderer) error {
+		prop := k8sv1.MountPropagationHostToContainer
+		renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+			Name:             hotplugDisks,
+			MountPath:        hotplugDiskDir,
+			MountPropagation: &prop,
+		})
+		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+			Name: hotplugDisks,
+			VolumeSource: k8sv1.VolumeSource{
+				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+			},
+		})
+		return nil
+	}
+}
+
 func imgPullSecrets(volumes ...v1.Volume) []k8sv1.LocalObjectReference {
 	var imagePullSecrets []k8sv1.LocalObjectReference
 	for _, volume := range volumes {

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -422,6 +422,24 @@ func withSidecarVolumes(hookSidecars hooks.HookSidecarList) VolumeRendererOption
 	}
 }
 
+func withHugepages() VolumeRendererOption {
+	return func(renderer *VolumeRenderer) error {
+		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+			Name: "hugepages",
+			VolumeSource: k8sv1.VolumeSource{
+				EmptyDir: &k8sv1.EmptyDirVolumeSource{
+					Medium: k8sv1.StorageMediumHugePages,
+				},
+			},
+		})
+		renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+			Name:      "hugepages",
+			MountPath: filepath.Join("/dev/hugepages"),
+		})
+		return nil
+	}
+}
+
 func imgPullSecrets(volumes ...v1.Volume) []k8sv1.LocalObjectReference {
 	var imagePullSecrets []k8sv1.LocalObjectReference
 	for _, volume := range volumes {

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -62,6 +62,10 @@ func (vr *VolumeRenderer) Volumes() []k8sv1.Volume {
 		emptyDirVolume("private"),
 		emptyDirVolume("public"),
 		emptyDirVolume("sockets"),
+		emptyDirVolume(virtBinDir),
+		emptyDirVolume("libvirt-runtime"),
+		emptyDirVolume("ephemeral-disks"),
+		emptyDirVolume(containerDisks),
 	}
 	return append(volumes, vr.podVolumes...)
 }

--- a/pkg/virt-controller/services/rendervolumes_test.go
+++ b/pkg/virt-controller/services/rendervolumes_test.go
@@ -1,0 +1,385 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("Container spec renderer", func() {
+	var vsr *VolumeRenderer
+
+	const (
+		containerDisk = "cdisk1"
+		ephemeralDisk = "disk1"
+		namespace     = "ns1"
+		virtShareDir  = "dir1"
+	)
+
+	Context("without any options", func() {
+		BeforeEach(func() {
+			var err error
+			vsr, err = NewVolumeRenderer(namespace, ephemeralDisk, containerDisk, virtShareDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does *not* have any volume devices", func() {
+			Expect(vsr.VolumeDevices()).To(BeEmpty())
+		})
+
+		It("to feature the private, public, ephemeral-disks, libvirt-runtime, and sockets mount points", func() {
+			Expect(vsr.Mounts()).To(ConsistOf(defaultVolumeMounts()))
+		})
+
+		It("to feature the private, public, sockets, virt-bin-share-dir, libvirt-runtime, ephemeral, and container disk volumes", func() {
+			Expect(vsr.Volumes()).To(ConsistOf(defaultVolumes()))
+		})
+	})
+
+	Context("with ephemeral volume option", func() {
+		const ephemeralVolumeName = "evn"
+		BeforeEach(func() {
+			ephemeralVolumeOption := v1.Volume{
+				Name: ephemeralVolumeName,
+				VolumeSource: v1.VolumeSource{
+					Ephemeral: &v1.EphemeralVolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{},
+					},
+				},
+			}
+
+			pvcStore := &cache.FakeCustomStore{
+				GetByKeyFunc: func(key string) (item interface{}, exists bool, err error) {
+					return &k8sv1.PersistentVolumeClaim{
+						Spec: k8sv1.PersistentVolumeClaimSpec{},
+					}, true, nil
+				},
+			}
+
+			var err error
+			vsr, err = NewVolumeRenderer(namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{ephemeralVolumeOption}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should feature the default mount points plus the ephemeral disk volume mount", func() {
+			Expect(vsr.Mounts()).To(ConsistOf(
+				append(
+					defaultVolumeMounts(),
+					k8sv1.VolumeMount{
+						Name:      ephemeralVolumeName,
+						MountPath: vmiDiskPath(ephemeralVolumeName)})))
+		})
+
+		It("should feature the default volumes plus the ephemeral disk volume", func() {
+			Expect(vsr.Volumes()).To(ConsistOf(
+				append(
+					defaultVolumes(),
+					k8sv1.Volume{
+						Name: ephemeralVolumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{},
+						},
+					})))
+		})
+
+		It("does *not* have any volume devices", func() {
+			Expect(vsr.VolumeDevices()).To(BeEmpty())
+		})
+	})
+
+	Context("with host disk volume option", func() {
+		const (
+			hostDiskName = "tiny-winy-disk"
+			hostDiskPath = "/little-bit/to/the/left"
+		)
+
+		var (
+			expectedHostDiskType = v1.HostDiskExistsOrCreate
+			expectedHostPathType = k8sv1.HostPathDirectoryOrCreate
+		)
+
+		BeforeEach(func() {
+			hostDisk := v1.Volume{
+				Name: hostDiskName,
+				VolumeSource: v1.VolumeSource{
+					HostDisk: &v1.HostDisk{
+						Path: hostDiskPath,
+						Type: expectedHostDiskType,
+					},
+				},
+			}
+
+			pvcStore := &cache.FakeCustomStore{
+				GetByKeyFunc: func(key string) (item interface{}, exists bool, err error) {
+					return &hostDisk, true, nil
+				},
+			}
+
+			var err error
+			vsr, err = NewVolumeRenderer(namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{hostDisk}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should feature the default mount points plus the host disk volume mount", func() {
+			Expect(vsr.Mounts()).To(ConsistOf(
+				append(
+					defaultVolumeMounts(),
+					k8sv1.VolumeMount{
+						Name:      hostDiskName,
+						MountPath: vmiDiskPath(hostDiskName)})))
+		})
+
+		It("should feature the default volumes plus the host disk volume", func() {
+			Expect(vsr.Volumes()).To(ConsistOf(
+				append(
+					defaultVolumes(),
+					k8sv1.Volume{
+						Name: hostDiskName,
+						VolumeSource: k8sv1.VolumeSource{
+							HostPath: &k8sv1.HostPathVolumeSource{
+								Type: &expectedHostPathType,
+								Path: hostDiskPath[:strings.LastIndex(hostDiskPath, "/")],
+							}},
+					})))
+		})
+
+		It("does *not* have any volume devices", func() {
+			Expect(vsr.VolumeDevices()).To(BeEmpty())
+		})
+	})
+
+	Context("with CloudInitConfigDrive option", func() {
+		const (
+			cloudInitDriveName = "pepitos-drive"
+			userData           = "break-dancing-flamingo"
+			networkData        = "hoooonk.hooooonk"
+		)
+
+		BeforeEach(func() {
+			cloudInitConfig := v1.Volume{
+				Name: cloudInitDriveName,
+				VolumeSource: v1.VolumeSource{
+					CloudInitConfigDrive: &v1.CloudInitConfigDriveSource{
+						UserDataSecretRef:    &k8sv1.LocalObjectReference{Name: userData},
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: networkData},
+					},
+				},
+			}
+
+			pvcStore := &cache.FakeCustomStore{
+				GetByKeyFunc: func(key string) (item interface{}, exists bool, err error) {
+					return &cloudInitConfig, true, nil
+				},
+			}
+
+			var err error
+			vsr, err = NewVolumeRenderer(namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{cloudInitConfig}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should feature the default mount points plus the cloud init config drive volume mount", func() {
+			Expect(vsr.Mounts()).To(ConsistOf(
+				append(
+					defaultVolumeMounts(),
+					k8sv1.VolumeMount{
+						Name:      "pepitos-drive-udata",
+						ReadOnly:  true,
+						MountPath: "/var/run/kubevirt-private/secret/pepitos-drive/userdata",
+						SubPath:   "userdata",
+					}, k8sv1.VolumeMount{
+						Name:      "pepitos-drive-udata",
+						ReadOnly:  true,
+						MountPath: "/var/run/kubevirt-private/secret/pepitos-drive/userData",
+						SubPath:   "userData",
+					}, k8sv1.VolumeMount{
+						Name:      "pepitos-drive-ndata",
+						ReadOnly:  true,
+						MountPath: "/var/run/kubevirt-private/secret/pepitos-drive/networkdata",
+						SubPath:   "networkdata",
+					}, k8sv1.VolumeMount{
+						Name:      "pepitos-drive-ndata",
+						ReadOnly:  true,
+						MountPath: "/var/run/kubevirt-private/secret/pepitos-drive/networkData",
+						SubPath:   "networkData",
+					})))
+		})
+
+		It("should feature the default volumes plus the  cloud init config drive disk volume", func() {
+			Expect(vsr.Volumes()).To(ConsistOf(
+				append(
+					defaultVolumes(),
+					k8sv1.Volume{
+						Name: "pepitos-drive-udata",
+						VolumeSource: k8sv1.VolumeSource{
+							Secret: &k8sv1.SecretVolumeSource{
+								SecretName: "break-dancing-flamingo",
+							},
+						}}, k8sv1.Volume{
+						Name: "pepitos-drive-ndata",
+						VolumeSource: k8sv1.VolumeSource{
+							Secret: &k8sv1.SecretVolumeSource{
+								SecretName: "hoooonk.hooooonk",
+							},
+						}})))
+		})
+
+		It("does *not* have any volume devices", func() {
+			Expect(vsr.VolumeDevices()).To(BeEmpty())
+		})
+	})
+
+	Context("with DataVolume option", func() {
+		const (
+			dataVolumeName = "dv1"
+		)
+
+		BeforeEach(func() {
+			dataVolume := v1.Volume{
+				Name: dataVolumeName,
+				VolumeSource: v1.VolumeSource{DataVolume: &v1.DataVolumeSource{
+					Name: dataVolumeName,
+				}},
+			}
+
+			pvcStore := &cache.FakeCustomStore{
+				GetByKeyFunc: func(key string) (item interface{}, exists bool, err error) {
+					return &k8sv1.PersistentVolumeClaim{}, true, nil
+				},
+			}
+
+			var err error
+			vsr, err = NewVolumeRenderer(namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{dataVolume}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should feature the default mount points plus the downward API volume mount", func() {
+			Expect(vsr.Mounts()).To(ConsistOf(
+				append(
+					defaultVolumeMounts(),
+					k8sv1.VolumeMount{
+						Name:      "dv1",
+						MountPath: "/var/run/kubevirt-private/vmi-disks/dv1",
+					})))
+		})
+
+		It("should feature the default volumes plus the downward API volume", func() {
+			Expect(vsr.Volumes()).To(ConsistOf(
+				append(
+					defaultVolumes(),
+					k8sv1.Volume{
+						Name: dataVolumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: dataVolumeName,
+							},
+						},
+					})))
+		})
+
+		It("does *not* have any volume devices", func() {
+			Expect(vsr.VolumeDevices()).To(BeEmpty())
+		})
+	})
+
+	Context("with Downward API option", func() {
+		const (
+			downwardAPIVolumeName = "downward-then-upward"
+		)
+
+		BeforeEach(func() {
+			downwardAPIVolume := v1.Volume{
+				Name: downwardAPIVolumeName,
+				VolumeSource: v1.VolumeSource{
+					DownwardAPI: &v1.DownwardAPIVolumeSource{},
+				}}
+
+			pvcStore := &cache.FakeCustomStore{
+				GetByKeyFunc: func(key string) (item interface{}, exists bool, err error) {
+					return &downwardAPIVolume, true, nil
+				},
+			}
+
+			var err error
+			vsr, err = NewVolumeRenderer(namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{downwardAPIVolume}, nil))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should feature the default mount points plus the downward API volume mount", func() {
+			Expect(vsr.Mounts()).To(ConsistOf(
+				append(
+					defaultVolumeMounts(),
+					k8sv1.VolumeMount{
+						Name:      downwardAPIVolumeName,
+						ReadOnly:  true,
+						MountPath: "/var/run/kubevirt-private/downwardapi/downward-then-upward",
+					})))
+		})
+
+		It("should feature the default volumes plus the downward API volume", func() {
+			Expect(vsr.Volumes()).To(ConsistOf(
+				append(
+					defaultVolumes(),
+					k8sv1.Volume{
+						Name: downwardAPIVolumeName,
+						VolumeSource: k8sv1.VolumeSource{
+							DownwardAPI: &k8sv1.DownwardAPIVolumeSource{},
+						},
+					})))
+		})
+
+		It("does *not* have any volume devices", func() {
+			Expect(vsr.VolumeDevices()).To(BeEmpty())
+		})
+	})
+})
+
+func vmiDiskPath(volumeName string) string {
+	return fmt.Sprintf("/var/run/kubevirt-private/vmi-disks/%s", volumeName)
+}
+
+func defaultVolumes() []k8sv1.Volume {
+	return []k8sv1.Volume{
+		{
+			Name:         "private",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		}, {
+			Name:         "public",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		}, {
+			Name:         "sockets",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		}, {
+			Name:         "virt-bin-share-dir",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		}, {
+			Name:         "libvirt-runtime",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		}, {
+			Name:         "ephemeral-disks",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		}, {
+			Name:         "container-disks",
+			VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}},
+		},
+	}
+}
+
+func defaultVolumeMounts() []k8sv1.VolumeMount {
+	hostToContainerPropagation := k8sv1.MountPropagationHostToContainer
+
+	return []k8sv1.VolumeMount{
+		{Name: "private", MountPath: "/var/run/kubevirt-private"},
+		{Name: "public", MountPath: "/var/run/kubevirt"},
+		{Name: "ephemeral-disks", MountPath: "disk1"},
+		{Name: "container-disks", MountPath: "cdisk1", MountPropagation: &hostToContainerPropagation},
+		{Name: "libvirt-runtime", MountPath: "/var/run/libvirt"},
+		{Name: "sockets", MountPath: "dir1/sockets"},
+	}
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -525,10 +525,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		privileged = true
 	}
 
-	gracePeriodSeconds := v1.DefaultGracePeriodSeconds
-	if vmi.Spec.TerminationGracePeriodSeconds != nil {
-		gracePeriodSeconds = *vmi.Spec.TerminationGracePeriodSeconds
-	}
+	gracePeriodSeconds := gracePeriodInSeconds(vmi)
 
 	volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 		Name:      "ephemeral-disks",
@@ -1475,6 +1472,13 @@ func sidecarVolumeMount() k8sv1.VolumeMount {
 		Name:      hookSidecarSocks,
 		MountPath: hooks.HookSocketsSharedDirectory,
 	}
+}
+
+func gracePeriodInSeconds(vmi *v1.VirtualMachineInstance) int64 {
+	if vmi.Spec.TerminationGracePeriodSeconds != nil {
+		return *vmi.Spec.TerminationGracePeriodSeconds
+	}
+	return v1.DefaultGracePeriodSeconds
 }
 
 func sidecarContainerName(i int) string {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1167,14 +1167,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 					},
 				},
 			},
-			Volumes: []k8sv1.Volume{
-				{
-					Name: hotplugDisks,
-					VolumeSource: k8sv1.VolumeSource{
-						EmptyDir: &k8sv1.EmptyDirVolumeSource{},
-					},
-				},
-			},
+			Volumes:                       []k8sv1.Volume{emptyDirVolume(hotplugDisks)},
 			TerminationGracePeriodSeconds: &zero,
 		},
 	}
@@ -1312,12 +1305,7 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 						},
 					},
 				},
-				{
-					Name: hotplugDisks,
-					VolumeSource: k8sv1.VolumeSource{
-						EmptyDir: &k8sv1.EmptyDirVolumeSource{},
-					},
-				},
+				emptyDirVolume(hotplugDisks),
 			},
 			TerminationGracePeriodSeconds: &zero,
 		},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1949,8 +1949,14 @@ var _ = Describe("Template", func() {
 				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
 
 				Expect(pod.Spec.Volumes).To(HaveLen(8))
-				Expect(pod.Spec.Volumes[3].EmptyDir).ToNot(BeNil())
-				Expect(pod.Spec.Volumes[3].EmptyDir.Medium).To(Equal(kubev1.StorageMediumHugePages))
+				Expect(pod.Spec.Volumes).To(
+					ContainElement(
+						kubev1.Volume{
+							Name: "hugepages",
+							VolumeSource: kubev1.VolumeSource{
+								EmptyDir: &kubev1.EmptyDirVolumeSource{Medium: kubev1.StorageMediumHugePages},
+							},
+						}))
 
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(
@@ -2012,11 +2018,22 @@ var _ = Describe("Template", func() {
 				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
 
 				Expect(pod.Spec.Volumes).To(HaveLen(8))
-				Expect(pod.Spec.Volumes[3].EmptyDir).ToNot(BeNil())
-				Expect(pod.Spec.Volumes[3].EmptyDir.Medium).To(Equal(kubev1.StorageMediumHugePages))
+				Expect(pod.Spec.Volumes).To(
+					ContainElement(
+						kubev1.Volume{
+							Name: "hugepages",
+							VolumeSource: kubev1.VolumeSource{
+								EmptyDir: &kubev1.EmptyDirVolumeSource{Medium: kubev1.StorageMediumHugePages},
+							},
+						}))
 
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
-				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(
+					ContainElement(
+						kubev1.VolumeMount{
+							Name:      "hugepages",
+							MountPath: "/dev/hugepages"},
+					))
 			},
 				Entry("on amd64", "amd64", 223),
 				Entry("on arm64", "arm64", 357),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1120,7 +1120,12 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Volumes[0].EmptyDir).ToNot(BeNil())
 
-				Expect(pod.Spec.Containers[0].VolumeMounts[5].MountPath).To(Equal("/var/run/kubevirt/sockets"))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(
+					ContainElement(
+						kubev1.VolumeMount{
+							Name:      "sockets",
+							MountPath: "/var/run/kubevirt/sockets"},
+					))
 
 				Expect(pod.Spec.Volumes[1].EmptyDir.Medium).To(Equal(kubev1.StorageMedium("")))
 
@@ -1948,7 +1953,12 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Volumes[3].EmptyDir.Medium).To(Equal(kubev1.StorageMediumHugePages))
 
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
-				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(
+					ContainElement(
+						kubev1.VolumeMount{
+							Name:      "hugepages",
+							MountPath: "/dev/hugepages"},
+					))
 			},
 				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 223),
 				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 223),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2083,8 +2083,15 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty(), "Found some volumes in manifest")
 				Expect(pod.Spec.Volumes).To(HaveLen(8), "Found 8 volumes in manifest")
-				Expect(pod.Spec.Volumes[3].PersistentVolumeClaim).ToNot(BeNil(), "Found PVC volume")
-				Expect(pod.Spec.Volumes[3].PersistentVolumeClaim.ClaimName).To(Equal(pvcName), "Found PVC volume with correct name")
+				Expect(pod.Spec.Volumes).To(
+					ContainElement(
+						kubev1.Volume{
+							Name: "pvc-volume",
+							VolumeSource: kubev1.VolumeSource{PersistentVolumeClaim: &kubev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							}}},
+					),
+					"Found PVC volume with correct name and source configuration")
 			})
 		})
 
@@ -2147,8 +2154,15 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty(), "Found some volumes in manifest")
 				Expect(pod.Spec.Volumes).To(HaveLen(9), "Found 9 volumes in manifest")
-				Expect(pod.Spec.Volumes[3].PersistentVolumeClaim).ToNot(BeNil(), "Found PVC volume")
-				Expect(pod.Spec.Volumes[3].PersistentVolumeClaim.ClaimName).To(Equal(pvcName), "Found PVC volume with correct name")
+				Expect(pod.Spec.Volumes).To(
+					ContainElement(
+						kubev1.Volume{
+							Name: "pvc-volume",
+							VolumeSource: kubev1.VolumeSource{PersistentVolumeClaim: &kubev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							}}},
+					),
+					"Found PVC volume with correct name and source config")
 			})
 		})
 
@@ -2610,9 +2624,19 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 				Expect(pod.Spec.Volumes).To(HaveLen(8))
-				Expect(pod.Spec.Volumes[3].EmptyDir).ToNot(BeNil())
-				Expect(pod.Spec.Volumes[3].EmptyDir.Medium).To(Equal(kubev1.StorageMediumMemory))
-				Expect(pod.Spec.Volumes[3].EmptyDir.SizeLimit.Equal(resource.MustParse("1Mi"))).To(BeTrue())
+
+				oneMB := resource.MustParse("1Mi")
+				Expect(pod.Spec.Volumes).To(ContainElement(
+					kubev1.Volume{
+						Name: "downardMetrics",
+						VolumeSource: kubev1.VolumeSource{
+							EmptyDir: &kubev1.EmptyDirVolumeSource{
+								Medium:    kubev1.StorageMediumMemory,
+								SizeLimit: &oneMB,
+							},
+						},
+					}))
+
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal(k6tconfig.DownwardMetricDisksDir))
 			})
 
@@ -2668,8 +2692,14 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 				Expect(pod.Spec.Volumes).To(HaveLen(8))
-				Expect(pod.Spec.Volumes[3].ConfigMap).ToNot(BeNil())
-				Expect(pod.Spec.Volumes[3].ConfigMap.LocalObjectReference.Name).To(Equal("test-configmap"))
+				Expect(pod.Spec.Volumes).To(ContainElement(kubev1.Volume{
+					Name: "configmap-volume",
+					VolumeSource: kubev1.VolumeSource{
+						ConfigMap: &kubev1.ConfigMapVolumeSource{
+							LocalObjectReference: kubev1.LocalObjectReference{Name: "test-configmap"},
+						},
+					},
+				}))
 			})
 		})
 
@@ -2701,8 +2731,14 @@ var _ = Describe("Template", func() {
 
 					Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 					Expect(pod.Spec.Volumes).To(HaveLen(9))
-					Expect(pod.Spec.Volumes[3].ConfigMap).ToNot(BeNil())
-					Expect(pod.Spec.Volumes[3].ConfigMap.LocalObjectReference.Name).To(Equal("test-sysprep-configmap"))
+					Expect(pod.Spec.Volumes).To(ContainElement(kubev1.Volume{
+						Name: "sysprep-configmap-volume",
+						VolumeSource: kubev1.VolumeSource{
+							ConfigMap: &kubev1.ConfigMapVolumeSource{
+								LocalObjectReference: kubev1.LocalObjectReference{Name: "test-sysprep-configmap"},
+							},
+						},
+					}))
 				})
 			})
 			Context("with a Secret", func() {
@@ -2732,8 +2768,15 @@ var _ = Describe("Template", func() {
 
 					Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 					Expect(pod.Spec.Volumes).To(HaveLen(9))
-					Expect(pod.Spec.Volumes[3].Secret).ToNot(BeNil())
-					Expect(pod.Spec.Volumes[3].Secret.SecretName).To(Equal("test-sysprep-secret"))
+
+					Expect(pod.Spec.Volumes).To(ContainElement(kubev1.Volume{
+						Name: "sysprep-configmap-volume",
+						VolumeSource: kubev1.VolumeSource{
+							Secret: &kubev1.SecretVolumeSource{
+								SecretName: "test-sysprep-secret",
+							},
+						},
+					}))
 				})
 			})
 		})
@@ -2767,8 +2810,15 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
 				Expect(pod.Spec.Volumes).To(HaveLen(8))
-				Expect(pod.Spec.Volumes[3].Secret).ToNot(BeNil())
-				Expect(pod.Spec.Volumes[3].Secret.SecretName).To(Equal("test-secret"))
+
+				Expect(pod.Spec.Volumes).To(ContainElement(kubev1.Volume{
+					Name: "secret-volume",
+					VolumeSource: kubev1.VolumeSource{
+						Secret: &kubev1.SecretVolumeSource{
+							SecretName: "test-secret",
+						},
+					},
+				}))
 			})
 		})
 		Context("with probes", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR refactors the virt-controller templating service, introducing a builder pattern to generate volume specification.

The ad-hoc generation of volumes for the virt-launcher pod is replaced by a builder pattern, allowing the customization of the launcher spec via options. 

It provides a simpler, more explicit way to achieve the same thing - volume spec generation becomes easier to write, and a lot easier to read / reason about. Going forward, it even defines a solid ground to expand the functionality of volume spec generation, instead of forcing the developer to find the appropriate nested if else and put his adapter copied code there. 

Finally, the added unit tests are a chance to clearly document how to configure each of the relevant options.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Following up on #7534. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
