### PR TITLE
Run chcon on local storage path in disks-images-provider

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -43,12 +43,6 @@ cp -r /hostImages/custom hostImages/custom3
 rm -rf /hostImages/custom
 chmod -R 777 /hostImages
 
-# When the host is ubuntu, by default, selinux is not used, so chcon is not necessary.
-# If selinux tag is set, use chcon to change /hostImages privileges.
-if [ ${SELINUX_TAG:0:1} != "?" ]; then
-    chcon -Rt svirt_sandbox_file_t /hostImages
-fi
-
 # Create a 4Gi blank disk image
 dd if=/dev/zero of=/local-storage/hp_file.img bs=4k count=1024k
 ls -al /local-storage/hp_file.img
@@ -63,7 +57,8 @@ mkdir -p /host/tmp/hostImages/mount_hp/test
 # When the host is ubuntu, by default, selinux is not used, so chcon is not necessary.
 # If selinux tag is set, use chcon to change /hostImages privileges.
 if [ ${SELINUX_TAG:0:1} != "?" ]; then
-    chcon -Rt svirt_sandbox_file_t /host/tmp/hostImages/mount_hp
+    chcon -Rt svirt_sandbox_file_t /host/tmp/hostImages
+    chcon -R unconfined_u:object_r:svirt_sandbox_file_t:s0 /host/mnt/local-storage/
 fi
 chmod 777 /host/tmp/hostImages/mount_hp
 chmod 777 /host/tmp/hostImages/mount_hp/test


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Testing on environments that are not kubevirtci, we won't have https://github.com/kubevirt/kubevirtci/blob/main/cluster-provision/k8s/1.23/k8s_provision.sh#L172-L173
done for us. Let's make sure disks-images-provider does that.
Right now this doesn't happen which results in a broken hotplug test on OpenShift environment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
