### PR TITLE
Code cleanup: avoid Expect(len(X))...

### DIFF
--- a/pkg/host-disk/host-disk_test.go
+++ b/pkg/host-disk/host-disk_test.go
@@ -420,7 +420,7 @@ var _ = Describe("HostDisk", func() {
 			By("Replacing PVCs with hostdisks")
 			ReplacePVCByHostDisk(vmi)
 
-			Expect(len(vmi.Spec.Volumes)).To(Equal(1), "There should still be 1 volume")
+			Expect(vmi.Spec.Volumes).To(HaveLen(1), "There should still be 1 volume")
 
 			if mode == k8sv1.PersistentVolumeFilesystem && pvcReferenceObj == "disk" {
 				Expect(vmi.Spec.Volumes[0].HostDisk).NotTo(BeNil(), "There should be a hostdisk volume")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1547,7 +1547,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
-			Expect(len(causes)).To(Equal(1), "unexpected number of errors")
+			Expect(causes).To(HaveLen(1), "unexpected number of errors")
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0].name"))
 		})
 		It("should reject networks with a pod network source and slirp interface with bad protocol type", func() {
@@ -3878,7 +3878,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(2), "should return error")
+		Expect(causes).To(HaveLen(2), "should return error")
 		Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid), "type should equal")
 		Expect(causes[0].Field).To(Equal("spec.domain.features.hyperv.evmcs"), "field should equal")
 		Expect(causes[1].Type).To(Equal(metav1.CauseTypeFieldValueRequired), "type should equal")
@@ -3904,7 +3904,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(1), "should return error")
+		Expect(causes).To(HaveLen(1), "should return error")
 		Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid), "type should equal")
 		Expect(causes[0].Field).To(Equal("spec.domain.features.hyperv.evmcs"), "field should equal")
 	})
@@ -3924,7 +3924,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(1), "should return error")
+		Expect(causes).To(HaveLen(1), "should return error")
 		Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueRequired), "type should equal")
 		Expect(causes[0].Field).To(Equal("spec.domain.cpu.features"), "field should equal")
 	})
@@ -3952,7 +3952,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(1), "should return error")
+		Expect(causes).To(HaveLen(1), "should return error")
 		Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid), "type should equal")
 		Expect(causes[0].Field).To(Equal("spec.domain.cpu.features[0].policy"), "field should equal")
 	})
@@ -3980,7 +3980,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(Equal(0), "should not return error")
+		Expect(causes).To(BeEmpty(), "should not return error")
 	})
 
 	It("Should not validate VMIs with broken hyperv deps", func() {

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Notify", func() {
 				case event := <-eventChan:
 					newDomain, _ := event.Object.(*api.Domain)
 					newInterfaceStatuses := newDomain.Status.Interfaces
-					Expect(len(newInterfaceStatuses)).To(Equal(1))
+					Expect(newInterfaceStatuses).To(HaveLen(1))
 					Expect(equality.Semantic.DeepEqual(interfaceStatus, newInterfaceStatuses)).To(BeTrue())
 				}
 				Expect(timedOut).To(BeFalse())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The gomega-idiomatic form
Expect(x).To(HaveLen(n))
is better than
Expect(len(x)).To(Equal(n))
because when the expectation fails, the tester sees the value of x, not
just its length, and has more information to debug it.

Similarly,
Expect(x).To(BeEmpty())
fails more clearly than
Expect(len(x)).To(Equal(0)).
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
