### PR TITLE
vmi-create-admitter: Remove duplicate disk and volume length checks 

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1841,16 +1841,6 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 	var causes []metav1.StatusCause
 	nameMap := make(map[string]int)
 
-	if len(volumes) > arrayLenMax {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf(listExceedsLimitMessagePattern, field.String(), arrayLenMax),
-			Field:   field.String(),
-		})
-		// We won't process anything over the limit
-		return causes
-	}
-
 	// check that we have max 1 instance of below disks
 	serviceAccountVolumeCount := 0
 	downwardMetricVolumeCount := 0
@@ -2163,16 +2153,6 @@ func getNumberOfPodInterfaces(spec *v1.VirtualMachineInstanceSpec) int {
 func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	nameMap := make(map[string]int)
-
-	if len(disks) > arrayLenMax {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf(listExceedsLimitMessagePattern, field.String(), arrayLenMax),
-			Field:   field.String(),
-		})
-		// We won't process anything over the limit
-		return causes
-	}
 
 	for idx, disk := range disks {
 		// verify name is unique

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -22,7 +22,6 @@ package admitters
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"kubevirt.io/client-go/api"
@@ -2940,22 +2939,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("writethrough", v1.CacheWriteThrough),
 			Entry("writeback", v1.CacheWriteBack),
 		)
-
-		It("should reject disk count > arrayLenMax", func() {
-			vmi := api.NewMinimalVMI("testvmi")
-			for i := 0; i <= arrayLenMax; i++ {
-				name := strconv.Itoa(i)
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-					Name: "testdisk" + name, DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{}}})
-			}
-
-			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
-			Expect(causes).To(HaveLen(1))
-			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
-			Expect(causes[0].Field).To(Equal("fake"))
-			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake list exceeds the %d "+
-				"element limit in length", arrayLenMax)))
-		})
 
 		It("should reject invalid SN characters", func() {
 			vmi := api.NewMinimalVMI("testvmi")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -829,25 +828,6 @@ var _ = Describe("Validating VM Admitter", func() {
 			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake[1].name"))
-		})
-		It("should reject volume count > arrayLenMax", func() {
-			vmi := api.NewMinimalVMI("testvmi")
-			for i := 0; i <= arrayLenMax; i++ {
-				name := strconv.Itoa(i)
-
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: "testvolume" + name,
-					VolumeSource: v1.VolumeSource{
-						ContainerDisk: testutils.NewFakeContainerDiskSource(),
-					},
-				})
-			}
-
-			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
-			Expect(causes[0].Field).To(Equal("fake"))
-			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake list exceeds the %d element limit in length", arrayLenMax)))
 		})
 
 		DescribeTable("should verify cloud-init userdata length", func(userDataLen int, expectedErrors int, base64Encode bool) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

These checks are not reachable anymore after https://github.com/kubevirt/kubevirt/pull/4935 duplicated them
higher up in ValidateVirtualMachineInstanceSpec [1].

This change removes the checks and associated tests, existing tests
introduced by https://github.com/kubevirt/kubevirt/pull/4935 should continue to provide coverage for the use case
when ValidateVirtualMachineInstanceSpec is called.

[1] https://github.com/kubevirt/kubevirt/blob/52e6e9bdd42c3cd727ba989c3dad0dd169f8259d/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go#L121-L129

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
