### PR TITLE
Remove VirtualMachineInstance volume disk or filesystem requirement

### DIFF
--- a/examples/vm-cirros-sata.yaml
+++ b/examples/vm-cirros-sata.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-cirros-sata
+  name: vm-cirros-sata
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-cirros-sata
+    spec:
+      domain:
+        devices: {}
+        resources:
+          requests:
+            memory: 128Mi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |
+            #!/bin/sh
+
+            echo 'printed from cloud-init userdata'
+        name: cloudinitdisk

--- a/examples/vm-template-windows2012r2.yaml
+++ b/examples/vm-template-windows2012r2.yaml
@@ -44,9 +44,6 @@ objects:
           devices:
             disks:
             - disk:
-                bus: sata
-              name: pvcdisk
-            - disk:
                 bus: virtio
               name: disk0
             interfaces:

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -7,11 +7,7 @@ metadata:
   name: vmi-sata
 spec:
   domain:
-    devices:
-      disks:
-      - disk:
-          bus: sata
-        name: containerdisk
+    devices: {}
     resources:
       requests:
         memory: 128Mi

--- a/examples/vmi-windows.yaml
+++ b/examples/vmi-windows.yaml
@@ -20,10 +20,6 @@ spec:
     cpu:
       cores: 2
     devices:
-      disks:
-      - disk:
-          bus: sata
-        name: pvcdisk
       interfaces:
       - masquerade: {}
         model: e1000

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -465,6 +465,28 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Entry("networks is non-empty", []v1.Interface{}, []v1.Network{{Name: "b"}}),
 	)
 
+	It("should add a missing volume disk", func() {
+		presentVolumeName := "present-vol"
+		missingVolumeName := "missing-vol"
+		vmi.Spec.Domain.Devices.Disks = []v1.Disk{
+			v1.Disk{
+				Name: presentVolumeName,
+			},
+		}
+		vmi.Spec.Volumes = []v1.Volume{
+			v1.Volume{
+				Name: presentVolumeName,
+			},
+			v1.Volume{
+				Name: missingVolumeName,
+			},
+		}
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
+		Expect(vmiSpec.Domain.Devices.Disks).To(HaveLen(2))
+		Expect(vmiSpec.Domain.Devices.Disks[0].Name).To(Equal(presentVolumeName))
+		Expect(vmiSpec.Domain.Devices.Disks[1].Name).To(Equal(missingVolumeName))
+	})
+
 	It("should not override specified properties with defaults on VMI create", func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -615,7 +615,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 		It("should reject volume with missing disk / file system", func() {
 			vmi := api.NewMinimalVMI("testvmi")
-
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
 				Name: "testvolume",
 				VolumeSource: v1.VolumeSource{
@@ -623,10 +622,11 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := validateVirtualMachineInstanceSpecVolumeDisks(k8sfield.NewPath("fake"), &vmi.Spec)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.volumes[0].name"))
 		})
+
 		It("should reject multiple disks referencing same volume", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -124,6 +124,26 @@ var _ = Describe("Validating VM Admitter", func() {
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[0].name"))
 	})
 
+	It("should allow VM with missing volume disk or filesystem", func() {
+		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "testvol",
+			VolumeSource: v1.VolumeSource{
+				ContainerDisk: testutils.NewFakeContainerDiskSource(),
+			},
+		})
+		vm := &v1.VirtualMachine{
+			Spec: v1.VirtualMachineSpec{
+				Running: &notRunning,
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+		}
+		resp := admitVm(vmsAdmitter, vm)
+		Expect(resp.Allowed).To(BeTrue())
+	})
+
 	It("should accept valid vmi spec", func() {
 		vmi := api.NewMinimalVMI("testvmi")
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1608,21 +1608,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				const expectedErrMessage = "denied the request: spec.domain.devices.disks[0].Name '" + diskName + "' not found."
 				Expect(err.Error()).To(ContainSubstring(expectedErrMessage))
 			})
-
-			It("[test_id:6961]should reject volume with missing disk / file system", func() {
-				const volumeName = "testvolume"
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: volumeName,
-					VolumeSource: v1.VolumeSource{
-						CloudInitNoCloud: &v1.CloudInitNoCloudSource{UserData: " "},
-					},
-				})
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(HaveOccurred())
-				const expectedErrMessage = "denied the request: spec.domain.volumes[0].name '" + volumeName + "' not found."
-				Expect(err.Error()).To(ContainSubstring(expectedErrMessage))
-			})
-
 		})
 
 		Context("[Serial]using defaultRuntimeClass configuration", func() {

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -90,6 +90,23 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 			Expect(disk.Disk.Bus).ToNot(BeEmpty(), "DiskTarget's bus should not be empty")
 		})
 
+		It("[test_id:]Should be applied to any auto attached volume disks", func() {
+
+			// Drop the disks to ensure they are added in by setDefaultVolumeDisk
+			vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
+
+			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			newVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(newVMI.Spec.Domain.Devices.Disks).To(HaveLen(1))
+			Expect(newVMI.Spec.Domain.Devices.Disks[0].Name).To(Equal(vmi.Spec.Volumes[0].Name))
+			Expect(newVMI.Spec.Domain.Devices.Disks[0].Disk).ToNot(BeNil(), "DiskTarget should not be nil")
+			Expect(newVMI.Spec.Domain.Devices.Disks[0].Disk.Bus).ToNot(BeEmpty(), "DiskTarget's bus should not be empty")
+		})
+
 	})
 
 	Context("MemBalloon defaults", func() {

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -195,15 +195,18 @@ func addRNG(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec 
 }
 
 func addContainerDisk(spec *v1.VirtualMachineInstanceSpec, image string, bus v1.DiskBus) *v1.VirtualMachineInstanceSpec {
-	disk := &v1.Disk{
-		Name: "containerdisk",
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: bus,
+	// Only add a reference to the disk if it isn't using the default v1.DiskBusSATA bus
+	if bus != v1.DiskBusSATA {
+		disk := &v1.Disk{
+			Name: "containerdisk",
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Bus: bus,
+				},
 			},
-		},
+		}
+		spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, *disk)
 	}
-	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, *disk)
 	volume := &v1.Volume{
 		Name: "containerdisk",
 		VolumeSource: v1.VolumeSource{
@@ -302,14 +305,18 @@ func addEmptyDisk(spec *v1.VirtualMachineInstanceSpec, size string) *v1.VirtualM
 }
 
 func addDataVolumeDisk(spec *v1.VirtualMachineInstanceSpec, dataVolumeName string, bus v1.DiskBus, diskName string) *v1.VirtualMachineInstanceSpec {
-	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
-		Name: diskName,
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: bus,
+
+	// Only add a reference to the disk if it isn't using the default v1.DiskBusSATA bus
+	if bus != v1.DiskBusSATA {
+		spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
+			Name: diskName,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Bus: bus,
+				},
 			},
-		},
-	})
+		})
+	}
 
 	spec.Volumes = append(spec.Volumes, v1.Volume{
 		Name: diskName,
@@ -323,14 +330,18 @@ func addDataVolumeDisk(spec *v1.VirtualMachineInstanceSpec, dataVolumeName strin
 }
 
 func addPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus v1.DiskBus, diskName string) *v1.VirtualMachineInstanceSpec {
-	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
-		Name: diskName,
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: bus,
+
+	// Only add a reference to the disk if it isn't using the default v1.DiskBusSATA bus
+	if bus != v1.DiskBusSATA {
+		spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
+			Name: diskName,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Bus: bus,
+				},
 			},
-		},
-	})
+		})
+	}
 
 	spec.Volumes = append(spec.Volumes, v1.Volume{
 		Name: diskName,
@@ -344,14 +355,18 @@ func addPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus v1.Di
 }
 
 func addEphemeralPVCDisk(spec *v1.VirtualMachineInstanceSpec, claimName string, bus v1.DiskBus, diskName string) *v1.VirtualMachineInstanceSpec {
-	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
-		Name: diskName,
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Bus: bus,
+
+	// Only add a reference to the disk if it isn't using the default v1.DiskBusSATA bus
+	if bus != v1.DiskBusSATA {
+		spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, v1.Disk{
+			Name: diskName,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Bus: bus,
+				},
 			},
-		},
-	})
+		})
+	}
 
 	spec.Volumes = append(spec.Volumes, v1.Volume{
 		Name: diskName,

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -85,6 +85,7 @@ const (
 	VmAlpineMultiPvc   = "vm-alpine-multipvc"
 	VmAlpineDataVolume = "vm-alpine-datavolume"
 	VMPriorityClass    = "vm-priorityclass"
+	VmCirrosSata       = "vm-cirros-sata"
 )
 
 const VmiReplicaSetCirros = "vmi-replicaset-cirros"
@@ -726,6 +727,17 @@ func GetVMCirros() *v1.VirtualMachine {
 
 	addContainerDisk(&vm.Spec.Template.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusVirtio)
 	addNoCloudDisk(&vm.Spec.Template.Spec)
+	return vm
+}
+
+func GetVMCirrosSata() *v1.VirtualMachine {
+	vm := getBaseVM(VmCirrosSata, map[string]string{
+		kubevirtIoVM: VmCirrosSata,
+	})
+
+	addContainerDisk(&vm.Spec.Template.Spec, fmt.Sprintf(strFmt, DockerPrefix, imageCirros, DockerTag), v1.DiskBusSATA)
+	addNoCloudDisk(&vm.Spec.Template.Spec)
+	vm.Spec.Template.Spec.Domain.Devices = v1.Devices{}
 	return vm
 }
 

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -76,6 +76,7 @@ func main() {
 		utils.VmAlpineMultiPvc:   utils.GetVMMultiPvc(),
 		utils.VmAlpineDataVolume: utils.GetVMDataVolume(),
 		utils.VMPriorityClass:    utils.GetVMPriorityClass(),
+		utils.VmCirrosSata:       utils.GetVMCirrosSata(),
 	}
 
 	var vmis = map[string]*v1.VirtualMachineInstance{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

At present users must always define and associate a disk or filesystem with a volume within the VirtualMachineInstanceSpec of a VirtualMachine.  This PR removes this requirement and introduces some basic logic to add a `Disk` for any `Volumes` not associated with a `Disk` or `Filesystem` when generating the `VirtualMachineInstance` at runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The requirement to define a `Disk` or `Filesystem` for each `Volume` associated with a `VirtualMachine` has been removed. Any `Volumes` without a `Disk` or `Filesystem` defined will have a `Disk` defined within the `VirtualMachineInstance` at runtime.
```
