### PR TITLE
Use ginkgo v2 serial decorator

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -17,7 +17,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-set -e
+set -ex
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -63,45 +63,18 @@ function functest() {
     _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
 }
 
+additional_test_args=""
+if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+    additional_test_args="${additional_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
+fi
+
+if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+    additional_test_args="${additional_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
+fi
+
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
     trap "_out/tests/junit-merger -o ${ARTIFACTS}/junit.functest.xml '${ARTIFACTS}/partial.*.xml'" EXIT
-    parallel_test_args=""
-    serial_test_args=""
-
-    if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
-        parallel_test_args="${parallel_test_args} --skip=\\[Serial\\]|${KUBEVIRT_E2E_SKIP}"
-        serial_test_args="${serial_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
-    else
-        parallel_test_args="${parallel_test_args} --skip=\\[Serial\\]"
-    fi
-
-    if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
-        parallel_test_args="${parallel_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
-        serial_test_args="${serial_test_args} --focus=\\[Serial\\].*(${KUBEVIRT_E2E_FOCUS})|(${KUBEVIRT_E2E_FOCUS}).*\\[Serial\\]"
-    else
-        serial_test_args="${serial_test_args} --focus=\\[Serial\\]"
-    fi
-
-    return_value=0
-    set +e
-    functest --nodes=${KUBEVIRT_E2E_PARALLEL_NODES} ${parallel_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
-    return_value="$?"
-    set -e
-    if [ "$return_value" -ne 0 ] && ! [ "$KUBEVIRT_E2E_RUN_ALL_SUITES" == "true" ]; then
-        exit "$return_value"
-    fi
-    KUBEVIRT_FUNC_TEST_SUITE_ARGS="-junit-output ${ARTIFACTS}/partial.junit.functest.xml ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
-    functest ${serial_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
-    exit "$return_value"
+    functest --procs=${KUBEVIRT_E2E_PARALLEL_NODES} ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
 else
-    additional_test_args=""
-    if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
-        additional_test_args="${additional_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
-    fi
-
-    if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
-        additional_test_args="${additional_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
-    fi
-
     functest ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
 fi

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -73,7 +73,7 @@ if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
 fi
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
-    trap "_out/tests/junit-merger -o ${ARTIFACTS}/junit.functest.xml '${ARTIFACTS}/partial.*.xml'" EXIT
+    trap "mv ${ARTIFACTS}/partial.*.xml ${ARTIFACTS}/junit.functest.xml" EXIT
     functest --procs=${KUBEVIRT_E2E_PARALLEL_NODES} ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
 else
     functest ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -60,7 +60,22 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
+    _out/tests/ginkgo -timeout=3h -r --junit-report="${ARTIFACTS}/junit.functest.xml" -slow-spec-threshold=60s $@ _out/tests/tests.test -- \
+        -kubeconfig=${kubeconfig} \
+        -container-tag=${docker_tag} \
+        -container-tag-alt=${docker_tag_alt} \
+        -container-prefix=${functest_docker_prefix} \
+        -image-prefix-alt=${image_prefix_alt} \
+        -oc-path=${oc} -kubectl-path=${kubectl} \
+        -gocli-path=${gocli} \
+        -installed-namespace=${namespace} \
+        -previous-release-tag=${PREVIOUS_RELEASE_TAG} \
+        -previous-release-registry=${previous_release_registry} \
+        -deploy-testing-infra=${deploy_testing_infra} \
+        -config=${kubevirt_test_config} \
+        --artifacts=${ARTIFACTS} \
+        --operator-manifest-path=${OPERATOR_MANIFEST_PATH} \
+        ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
 }
 
 additional_test_args=""
@@ -73,7 +88,6 @@ if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
 fi
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
-    trap "mv ${ARTIFACTS}/partial.*.xml ${ARTIFACTS}/junit.functest.xml" EXIT
     functest --procs=${KUBEVIRT_E2E_PARALLEL_NODES} ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
 else
     functest ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -41,7 +41,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", func() {
+var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, func() {
 
 	var err error
 	var originalKV *v1.KubeVirt

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -40,7 +40,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", func() {
+var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", Serial, func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -137,7 +137,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(startedVMI.Spec).To(Equal(vmi.Spec))
 			})
 		})
-		Context("[Serial]should obey the disk verification limits in the KubeVirt CR", func() {
+		Context("[Serial]should obey the disk verification limits in the KubeVirt CR", Serial, func() {
 			It("[test_id:7182]disk verification should fail when the memory limit is too low", func() {
 				By("Reducing the diskVerificaton memory usage limit")
 				kv := util.GetCurrentKv(virtClient)

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -491,7 +491,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[Serial][test_id:7648]delete a KubeVirt CR", func() {
+		It("[Serial][test_id:7648]delete a KubeVirt CR", Serial, func() {
 			By("Make a Dry-Run request to delete a KubeVirt CR")
 			deletePolicy := metav1.DeletePropagationForeground
 			opts := metav1.DeleteOptions{

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -77,7 +77,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
+var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -26,7 +26,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
+var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -688,7 +688,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[Serial] with bandwidth limitations", func() {
+		Context("[Serial] with bandwidth limitations", Serial, func() {
 
 			var repeatedlyMigrateWithBandwidthLimitation = func(vmi *v1.VirtualMachineInstance, bandwidth string, repeat int) time.Duration {
 				var migrationDurationTotal time.Duration
@@ -1291,7 +1291,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 		})
-		Context("[Serial] with auto converge enabled", func() {
+		Context("[Serial] with auto converge enabled", Serial, func() {
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 
@@ -1645,7 +1645,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration to nonroot", func() {
+		Context("[Serial] migration to nonroot", Serial, func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
 
@@ -1745,7 +1745,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			)
 		})
 		Context("migration security", func() {
-			Context("[Serial] with TLS disabled", func() {
+			Context("[Serial] with TLS disabled", Serial, func() {
 				It("[test_id:6976] should be successfully migrated", func() {
 					cfg := getCurrentKv()
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
@@ -1940,7 +1940,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration postcopy", func() {
+		Context("[Serial] migration postcopy", Serial, func() {
 			var dv *cdiv1.DataVolume
 
 			BeforeEach(func() {
@@ -2010,7 +2010,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration monitor", func() {
+		Context("[Serial] migration monitor", Serial, func() {
 			var createdPods []string
 			AfterEach(func() {
 				for _, podName := range createdPods {
@@ -2697,7 +2697,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectFeatureToBeSupportedOnNode(newNode, requiredFeatures)
 			})
 
-			Context("[Serial]Should trigger event", func() {
+			Context("[Serial]Should trigger event", Serial, func() {
 
 				var originalNodeLabels map[string]string
 				var originalNodeAnnotations map[string]string
@@ -2791,7 +2791,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		})
 
-		Context("[Serial] with migration policies", func() {
+		Context("[Serial] with migration policies", Serial, func() {
 
 			confirmMigrationPolicyName := func(vmi *v1.VirtualMachineInstance, expectedName *string) {
 				By("Verifying the VMI's configuration source")
@@ -3043,7 +3043,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 180*time.Second, 500*time.Millisecond).Should(Equal(v1.MigrationSucceeded))
 			})
 
-			Context("[Serial] with node tainted during node drain", func() {
+			Context("[Serial] with node tainted during node drain", Serial, func() {
 
 				BeforeEach(func() {
 					// Taints defined by k8s are special and can't be applied manually.
@@ -3311,7 +3311,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 			})
 		})
-		Context("[Serial]with multiple VMIs with eviction policies set", func() {
+		Context("[Serial]with multiple VMIs with eviction policies set", Serial, func() {
 
 			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
 				var vmis []*v1.VirtualMachineInstance
@@ -3389,7 +3389,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	})
 
-	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", func() {
+	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", Serial, func() {
 		var originalKV *v1.KubeVirt
 
 		BeforeEach(func() {
@@ -3457,7 +3457,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial] With Huge Pages", func() {
+	Context("[Serial] With Huge Pages", Serial, func() {
 		var hugepagesVmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -3521,7 +3521,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		)
 	})
 
-	Context("[Serial] with CPU pinning and huge pages", func() {
+	Context("[Serial] with CPU pinning and huge pages", Serial, func() {
 		It("should not make migrations fail", func() {
 			checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(2)
 			var err error
@@ -3830,7 +3830,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial]with a dedicated migration network", func() {
+	Context("[Serial]with a dedicated migration network", Serial, func() {
 		BeforeEach(func() {
 			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -44,7 +44,7 @@ const (
 	virtOperatorDeploymentName = "virt-operator"
 )
 
-var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
+var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -23,10 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body ...interface{}) bool {
-	return Describe("[sig-network] "+text, body...)
+func SIGDescribe(text string, args ...interface{}) bool {
+	return Describe("[sig-network] "+text, args...)
 }
 
-func FSIGDescribe(text string, body ...interface{}) bool {
-	return FDescribe("[sig-network] "+text, body...)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	return FDescribe("[sig-network] "+text, args...)
 }

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -23,10 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-network] "+text, body)
+func SIGDescribe(text string, body ...interface{}) bool {
+	return Describe("[sig-network] "+text, body...)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-network] "+text, body)
+func FSIGDescribe(text string, body ...interface{}) bool {
+	return FDescribe("[sig-network] "+text, body...)
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -63,7 +63,7 @@ const (
 	sriovnetLinkEnabled = "sriov-linked"
 )
 
-var _ = Describe("[Serial]SRIOV", func() {
+var _ = Describe("[Serial]SRIOV", Serial, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -76,7 +76,7 @@ const (
 	istioApiVersion   = "v1beta1"
 )
 
-var _ = SIGDescribe("[Serial] Istio", func() {
+var _ = SIGDescribe("[Serial] Istio", Serial, func() {
 	var (
 		err        error
 		vmi        *v1.VirtualMachineInstance

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 
 	Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
 		Context("when virt-handler is responsive", func() {
-			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
+			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", Serial, func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				bridgeVMI := vmi
 				// Remove the masquerade interface to use the default bridge one

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -86,7 +86,7 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
-var _ = SIGDescribe("[Serial]Multus", func() {
+var _ = SIGDescribe("[Serial]Multus", Serial, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -1024,7 +1024,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 
-	Context("[Serial]vmi with default bridge interface on pod network", func() {
+	Context("[Serial]vmi with default bridge interface on pod network", Serial, func() {
 		BeforeEach(func() {
 			setBridgeEnabled(false)
 		})

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -183,7 +183,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 		)
 	})
 
-	Context("[Serial]slirp is the default interface", func() {
+	Context("[Serial]slirp is the default interface", Serial, func() {
 		BeforeEach(func() {
 			setSlirpEnabled(false)
 			setDefaultNetworkInterface("slirp")

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -25,7 +25,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute][Serial]NUMA", func() {
+var _ = Describe("[sig-compute][Serial]NUMA", Serial, func() {
 
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -92,7 +92,7 @@ type vmYamlDefinition struct {
 	vmSnapshots   []vmSnapshotDef
 }
 
-var _ = Describe("[Serial][sig-operator]Operator", func() {
+var _ = Describe("[Serial][sig-operator]Operator", Serial, func() {
 	var originalKv *v1.KubeVirt
 	var originalCDI *cdiv1.CDI
 	var originalOperatorVersion string
@@ -1097,7 +1097,7 @@ spec:
 		waitForKv(kv)
 	})
 
-	Describe("[Serial]should reconcile components", func() {
+	Describe("[Serial]should reconcile components", Serial, func() {
 
 		deploymentName := "virt-controller"
 		daemonSetName := "virt-handler"
@@ -1371,7 +1371,7 @@ spec:
 		})
 	})
 
-	Describe("[test_id:4744][Serial]should apply component customization", func() {
+	Describe("[test_id:4744][Serial]should apply component customization", Serial, func() {
 
 		It("test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -22,6 +22,7 @@ package performance
 import (
 	"flag"
 	"os"
+	"reflect"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,6 +33,8 @@ var (
 	cyclicTestDurationInSeconds uint
 	RunPerfRealtime             bool
 	realtimeThreshold           uint
+
+	serialType = reflect.TypeOf(Serial)
 )
 
 func init() {
@@ -53,12 +56,27 @@ func init() {
 	}
 }
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-performance][Serial] "+text, body)
+func SIGDescribe(text string, body ...interface{}) bool {
+	if !isIncludeSerial(body...) {
+		body = append(body, Serial)
+	}
+	return Describe("[sig-performance][Serial] "+text, body...)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-performance][Serial] "+text, body)
+func FSIGDescribe(text string, body ...interface{}) bool {
+	if !isIncludeSerial(body...) {
+		body = append(body, Serial)
+	}
+	return FDescribe("[sig-performance][Serial] "+text, body...)
+}
+
+func isIncludeSerial(body ...interface{}) bool {
+	for _, item := range body {
+		if reflect.TypeOf(item) == serialType && item == Serial {
+			return true
+		}
+	}
+	return false
 }
 
 func skipIfNoPerformanceTests() {

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -22,7 +22,6 @@ package performance
 import (
 	"flag"
 	"os"
-	"reflect"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,8 +32,6 @@ var (
 	cyclicTestDurationInSeconds uint
 	RunPerfRealtime             bool
 	realtimeThreshold           uint
-
-	serialType = reflect.TypeOf(Serial)
 )
 
 func init() {
@@ -56,27 +53,14 @@ func init() {
 	}
 }
 
-func SIGDescribe(text string, body ...interface{}) bool {
-	if !isIncludeSerial(body...) {
-		body = append(body, Serial)
-	}
-	return Describe("[sig-performance][Serial] "+text, body...)
+func SIGDescribe(text string, args ...interface{}) bool {
+	args = append(args, Serial)
+	return Describe("[sig-performance][Serial] "+text, args...)
 }
 
-func FSIGDescribe(text string, body ...interface{}) bool {
-	if !isIncludeSerial(body...) {
-		body = append(body, Serial)
-	}
-	return FDescribe("[sig-performance][Serial] "+text, body...)
-}
-
-func isIncludeSerial(body ...interface{}) bool {
-	for _, item := range body {
-		if reflect.TypeOf(item) == serialType && item == Serial {
-			return true
-		}
-	}
-	return false
+func FSIGDescribe(text string, args ...interface{}) bool {
+	args = append(args, Serial)
+	return FDescribe("[sig-performance][Serial] "+text, args...)
 }
 
 func skipIfNoPerformanceTests() {

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -127,7 +127,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		return createVirtualMachinePool(newPoolFromVMI(libvmi.NewCirros()))
 	}
 
-	DescribeTable("[Serial]pool should scale", func(startScale int, stopScale int) {
+	DescribeTable("[Serial]pool should scale", Serial, func(startScale int, stopScale int) {
 		newPool := newVirtualMachinePool()
 		doScale(newPool.ObjectMeta.Name, int32(startScale))
 		doScale(newPool.ObjectMeta.Name, int32(stopScale))

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -61,7 +61,7 @@ func byConfiguringTheVMIForRealtime(vmi *v1.VirtualMachineInstance, realtimeMask
 	}
 }
 
-var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
+var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, func() {
 
 	var (
 		vmi        *v1.VirtualMachineInstance

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
+var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -152,7 +152,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source", func() {
 
-		Context("[Serial]without fsgroup support", func() {
+		Context("[Serial]without fsgroup support", Serial, func() {
 			size := "1Gi"
 
 			It("should succesfully start", func() {
@@ -408,7 +408,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				_, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 			})
-			It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself", func() {
+			It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself", Serial, func() {
 				dv := libstorage.NewRandomDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, storageClass.Name, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 				Expect(err).To(BeNil())

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -42,7 +42,7 @@ const (
 	diskName   = "disk0"
 )
 
-var _ = SIGDescribe("[Serial]K8s IO events", func() {
+var _ = SIGDescribe("[Serial]K8s IO events", Serial, func() {
 	var (
 		nodeName   string
 		virtClient kubecli.KubevirtClient

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -23,10 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-storage] "+text, body)
+func SIGDescribe(text string, body ...interface{}) bool {
+	return Describe("[sig-storage] "+text, body...)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-storage] "+text, body)
+func FSIGDescribe(text string, body ...interface{}) bool {
+	return FDescribe("[sig-storage] "+text, body...)
 }

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -23,10 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body ...interface{}) bool {
-	return Describe("[sig-storage] "+text, body...)
+func SIGDescribe(text string, args ...interface{}) bool {
+	return Describe("[sig-storage] "+text, args...)
 }
 
-func FSIGDescribe(text string, body ...interface{}) bool {
-	return FDescribe("[sig-storage] "+text, body...)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	return FDescribe("[sig-storage] "+text, args...)
 }

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -34,7 +34,7 @@ func (f *fakeAttacher) closeChannel() {
 	f.done <- true
 }
 
-var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
+var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		pvcClaim   string

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -791,7 +791,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			},
 				Entry("with VMs", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeFilesystem, false),
 				Entry("with VMIs", addDVVolumeVMI, removeVolumeVMI, corev1.PersistentVolumeFilesystem, true),
-				Entry("[Serial] with VMs and block", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
+				Entry("[Serial] with VMs and block", Serial, addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
 			)
 
 			It("should permanently add hotplug volume when added to VM, but still unpluggable after restart", func() {

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -39,7 +39,7 @@ const (
 	insecure             = "--insecure"
 )
 
-var _ = SIGDescribe("[Serial]ImageUpload", func() {
+var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 	var kubectlCmd *exec.Cmd
 
 	pvcSize := "100Mi"

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -41,7 +41,7 @@ const (
 	creatingSnapshot          = "creating snapshot"
 )
 
-var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
+var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", Serial, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -39,7 +39,7 @@ const (
 	operationComplete        = "Operation complete"
 )
 
-var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
+var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", Serial, func() {
 
 	var (
 		err        error

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -284,8 +284,8 @@ var _ = SIGDescribe("Storage", func() {
 					Entry("[test_id:3130]with Disk PVC", tests.NewRandomVMIWithPVC, "", nil, true),
 					Entry("[test_id:3131]with CDRom PVC", tests.NewRandomVMIWithCDRom, "", nil, true),
 					Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
-					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
-					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
+					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", Serial, k8sv1.IPv6Protocol, true),
+					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", tests.NewRandomVMIWithPVC, "nfs", Serial, k8sv1.IPv4Protocol, false),
 				)
 			})
 
@@ -673,7 +673,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[Serial]With feature gates disabled for", func() {
+		Context("[Serial]With feature gates disabled for", Serial, func() {
 			It("[test_id:4620]HostDisk, it should fail to start a VMI", func() {
 				tests.DisableFeatureGate(virtconfig.HostDiskGate)
 				vmi = tests.NewRandomVMIWithHostDisk("somepath", virtv1.HostDiskExistsOrCreate, "")
@@ -979,7 +979,7 @@ var _ = SIGDescribe("Storage", func() {
 				}
 
 				// Not a candidate for NFS test due to usage of host disk
-				It("[Serial][test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", func() {
+				It("[Serial][test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", Serial, func() {
 
 					configureToleration(10)
 
@@ -997,7 +997,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 
 				// Not a candidate for NFS test due to usage of host disk
-				It("[Serial][test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration", func() {
+				It("[Serial][test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration", Serial, func() {
 
 					configureToleration(30)
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -61,7 +61,7 @@ const (
 	bytesInKib          = 1024
 )
 
-var _ = Describe("[Serial][sig-compute]SwapTest", func() {
+var _ = Describe("[Serial][sig-compute]SwapTest", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -286,7 +286,7 @@ const (
 	windowsSysprepedVMIPassword = "Gauranga"
 )
 
-var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", func() {
+var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -52,7 +52,7 @@ const (
 	defaultMemory     = "2Gi"
 )
 
-var _ = Describe("[Serial][sig-compute]Templates", func() {
+var _ = Describe("[Serial][sig-compute]Templates", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -62,16 +62,19 @@ func TestTests(t *testing.T) {
 		junitOutput = qe_reporters.JunitOutput
 	}
 
-	suiteConfig, _ := GinkgoConfiguration()
-	if suiteConfig.ParallelTotal > 1 {
-		artifactsPath = filepath.Join(artifactsPath, strconv.Itoa(GinkgoParallelProcess()))
-		junitOutput = filepath.Join(flags.ArtifactsDir, fmt.Sprintf("partial.junit.functest.%d.xml", GinkgoParallelProcess()))
-	}
+	suiteConfig, reporterConfig := GinkgoConfiguration()
 
-	outputEnricherReporter := reporter.NewCapturedOutputEnricher(
-		v1reporter.NewV1JUnitReporter(junitOutput),
-	)
-	afterSuiteReporters = append(afterSuiteReporters, outputEnricherReporter)
+	if len(reporterConfig.JUnitReport) == 0 {
+		if suiteConfig.ParallelTotal > 1 {
+			artifactsPath = filepath.Join(artifactsPath, strconv.Itoa(GinkgoParallelProcess()))
+			junitOutput = filepath.Join(flags.ArtifactsDir, fmt.Sprintf("partial.junit.functest.%d.xml", GinkgoParallelProcess()))
+		}
+
+		outputEnricherReporter := reporter.NewCapturedOutputEnricher(
+			v1reporter.NewV1JUnitReporter(junitOutput),
+		)
+		afterSuiteReporters = append(afterSuiteReporters, outputEnricherReporter)
+	}
 
 	if qe_reporters.Polarion.Run {
 		if suiteConfig.ParallelTotal > 1 {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3527,7 +3527,8 @@ func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 	}
 
 	suiteConfig, _ := GinkgoConfiguration()
-	if suiteConfig.ParallelTotal > 1 {
+	// ginkgo runs all the specs with the Serial decorator in process #1.
+	if (suiteConfig.ParallelTotal > 1) && (GinkgoParallelProcess() != 1) {
 		Fail("Tests which alter the global kubevirt configuration must not be executed in parallel")
 	}
 
@@ -3561,7 +3562,7 @@ func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.Kub
 // propagated if the current config in use does not match the original one.
 func resetToDefaultConfig() {
 	suiteConfig, _ := GinkgoConfiguration()
-	if suiteConfig.ParallelTotal > 1 {
+	if (suiteConfig.ParallelTotal > 1) && (GinkgoParallelProcess() != 1) {
 		// Tests which alter the global kubevirt config must be run serial, therefor, if we run in parallel
 		// we can just skip the restore step.
 		return

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -53,7 +53,7 @@ const (
 	singleReplica = false
 )
 
-var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience", func() {
+var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience", Serial, func() {
 
 	var err error
 	var virtCli kubecli.KubevirtClient

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -125,7 +125,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 	})
 
-	Context("[Serial]A mutated VirtualMachine given", func() {
+	Context("[Serial]A mutated VirtualMachine given", Serial, func() {
 
 		var testingMachineType string = "pc-q35-2.7"
 
@@ -421,8 +421,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 		},
 			Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-			Entry("[Serial][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithFileDisk),
-			Entry("[Serial][storage-req]with Block Disk", newVirtualMachineInstanceWithBlockDisk),
+			Entry("[Serial][storage-req]with Filesystem Disk", Serial, newVirtualMachineInstanceWithFileDisk),
+			Entry("[Serial][storage-req]with Block Disk", Serial, newVirtualMachineInstanceWithBlockDisk),
 		)
 
 		DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", func(createTemplate vmiBuilder) {
@@ -439,8 +439,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 300*time.Second, 2*time.Second).Should(BeZero(), "The VirtualMachineInstance did not disappear")
 		},
 			Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-			Entry("[Serial][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithFileDisk),
-			Entry("[Serial][storage-req]with Block Disk", newVirtualMachineInstanceWithBlockDisk),
+			Entry("[Serial][storage-req]with Filesystem Disk", Serial, newVirtualMachineInstanceWithFileDisk),
+			Entry("[Serial][storage-req]with Block Disk", Serial, newVirtualMachineInstanceWithBlockDisk),
 		)
 
 		It("[test_id:1522]should remove owner references on the VirtualMachineInstance if it is orphan deleted", func() {
@@ -563,8 +563,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			stopVM(vm)
 		},
 			Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-			Entry("[Serial][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithFileDisk),
-			Entry("[Serial][storage-req]with Block Disk", newVirtualMachineInstanceWithBlockDisk),
+			Entry("[Serial][storage-req]with Filesystem Disk", Serial, newVirtualMachineInstanceWithFileDisk),
+			Entry("[Serial][storage-req]with Block Disk", Serial, newVirtualMachineInstanceWithBlockDisk),
 		)
 
 		It("[test_id:1526]should start and stop VirtualMachineInstance multiple times", func() {
@@ -1412,7 +1412,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			Context("Using RunStrategyOnce", func() {
-				It("[Serial] Should leave a failed VMI", func() {
+				It("[Serial] Should leave a failed VMI", Serial, func() {
 					By("creating a VM with RunStrategyOnce")
 					virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyOnce)
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -226,7 +226,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	})
 
 	Describe("VirtualMachineInstance definition", func() {
-		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", func() {
+		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", Serial, func() {
 			var availableNumberOfCPUs int
 			var vmi *v1.VirtualMachineInstance
 
@@ -403,7 +403,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 60)).To(Succeed(), "should report number of threads")
 			})
 
-			It("[Serial][test_id:1664]should map cores to virtio block queues", func() {
+			It("[Serial][test_id:1664]should map cores to virtio block queues", Serial, func() {
 				_true := true
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
@@ -482,7 +482,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", func() {
+		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", Serial, func() {
 			BeforeEach(func() {
 				kv := util.GetCurrentKv(virtClient)
 
@@ -583,8 +583,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(domXml).To(MatchRegexp(fileName))
 			}
 		},
-			Entry("[Serial][test_id:1668]should use EFI without secure boot", tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
-			Entry("[Serial][test_id:4437]should enable EFI secure boot", tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
+			Entry("[Serial][test_id:1668]should use EFI without secure boot", tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", Serial, `OVMF_CODE(\.secboot)?\.fd`),
+			Entry("[Serial][test_id:4437]should enable EFI secure boot", tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", Serial, `OVMF_CODE\.secboot\.fd`),
 		)
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {
@@ -1114,9 +1114,9 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				By("Checking that the VM memory equals to a number of consumed hugepages")
 				Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
 			},
-				Entry("[Serial][test_id:1671]hugepages-2Mi", "2Mi", "64Mi", "None"),
-				Entry("[Serial][test_id:1672]hugepages-1Gi", "1Gi", "1Gi", "None"),
-				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", "2Mi", "70Mi", "64Mi"),
+				Entry("[Serial][test_id:1671]hugepages-2Mi", "2Mi", "64Mi", Serial, "None"),
+				Entry("[Serial][test_id:1672]hugepages-1Gi", "1Gi", "1Gi", Serial, "None"),
+				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", "2Mi", "70Mi", Serial, "64Mi"),
 			)
 
 			Context("with unsupported page size", func() {
@@ -1295,7 +1295,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					"Agent condition should be gone")
 			})
 
-			Context("[Serial]with cluster config changes", func() {
+			Context("[Serial]with cluster config changes", Serial, func() {
 				BeforeEach(func() {
 					kv := util.GetCurrentKv(virtClient)
 
@@ -1624,7 +1624,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		})
 
-		Context("[Serial]using defaultRuntimeClass configuration", func() {
+		Context("[Serial]using defaultRuntimeClass configuration", Serial, func() {
 			runtimeClassName := "custom-runtime-class"
 
 			BeforeEach(func() {
@@ -1799,7 +1799,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", func() {
+	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", Serial, func() {
 		BeforeEach(func() {
 			kv := util.GetCurrentKv(virtClient)
 
@@ -1839,7 +1839,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
 		})
 
-		It("[Serial][test_id:3126]should set machine type from kubevirt-config", func() {
+		It("[Serial][test_id:3126]should set machine type from kubevirt-config", Serial, func() {
 			kv := util.GetCurrentKv(virtClient)
 
 			config := kv.Spec.Configuration
@@ -1889,7 +1889,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(cpuRequest.String()).To(Equal("100m"))
 		})
 
-		It("[Serial][test_id:3129]should set CPU request from kubevirt-config", func() {
+		It("[Serial][test_id:3129]should set CPU request from kubevirt-config", Serial, func() {
 			kv := util.GetCurrentKv(virtClient)
 
 			config := kv.Spec.Configuration
@@ -1907,7 +1907,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC", func() {
+	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC", Serial, func() {
 		var dataVolume *cdiv1.DataVolume
 
 		BeforeEach(func() {
@@ -2274,7 +2274,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			}
 		})
 
-		Context("[Serial]with cpu pinning enabled", func() {
+		Context("[Serial]with cpu pinning enabled", Serial, func() {
 
 			It("[test_id:1684]should set the cpumanager label to false when it's not running", func() {
 
@@ -2578,7 +2578,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", func() {
+		Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", Serial, func() {
 
 			var cpuvmi, vmi *v1.VirtualMachineInstance
 			var node string
@@ -2664,7 +2664,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check Chassis value", func() {
 
-		It("[Serial][test_id:2927]Test Chassis value in a newly created VM", func() {
+		It("[Serial][test_id:2927]Test Chassis value in a newly created VM", Serial, func() {
 			vmi := tests.NewRandomFedoraVMIWithDmidecode()
 			vmi.Spec.Domain.Chassis = &v1.Chassis{
 				Asset: "Test-123",
@@ -2692,7 +2692,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", func() {
+	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", Serial, func() {
 
 		var vmi *v1.VirtualMachineInstance
 

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -54,7 +54,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }
 
-var _ = Describe("[Serial][sig-compute]GPU", func() {
+var _ = Describe("[Serial][sig-compute]GPU", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -147,7 +147,7 @@ var _ = Describe("[sig-compute]HookSidecars", func() {
 			})
 		})
 
-		Context("[Serial]with sidecar feature gate disabled", func() {
+		Context("[Serial]with sidecar feature gate disabled", Serial, func() {
 			BeforeEach(func() {
 				tests.DisableFeatureGate(virtconfig.SidecarGate)
 			})

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -25,7 +25,7 @@ const (
 	failedDeleteVMI = "Failed to delete VMI"
 )
 
-var _ = Describe("[Serial][sig-compute]HostDevices", func() {
+var _ = Describe("[Serial][sig-compute]HostDevices", Serial, func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -108,7 +108,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 	})
 
 	Context("when virt-handler is deleted", func() {
-		It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {
+		It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", Serial, func() {
 			pods, err := virtClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
 			})
@@ -543,7 +543,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		Context("when virt-launcher crashes", func() {
-			It("[Serial][test_id:1631]should be stopped and have Failed phase", func() {
+			It("[Serial][test_id:1631]should be stopped and have Failed phase", Serial, func() {
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil(), "Should create VMI successfully")
 
@@ -569,7 +569,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]when virt-handler crashes", func() {
+		Context("[Serial]when virt-handler crashes", Serial, func() {
 			// FIXME: This test has the issues that it tests a lot of different timing scenarios in an intransparent way:
 			// e.g. virt-handler can die before or after virt-launcher. If we wait until virt-handler is dead before we
 			// kill virt-launcher then we don't know if virt-handler already restarted.
@@ -616,7 +616,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]when virt-handler is responsive", func() {
+		Context("[Serial]when virt-handler is responsive", Serial, func() {
 			It("[test_id:1633]should indicate that a node is ready for vmis", func() {
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
@@ -702,7 +702,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]when virt-handler is not responsive", func() {
+		Context("[Serial]when virt-handler is not responsive", Serial, func() {
 
 			var vmi *v1.VirtualMachineInstance
 			var nodeName string
@@ -812,7 +812,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]with node tainted", func() {
+		Context("[Serial]with node tainted", Serial, func() {
 			var nodes *k8sv1.NodeList
 			var err error
 			BeforeEach(func() {
@@ -929,7 +929,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		})
 
-		Context("[Serial]with default cpu model", func() {
+		Context("[Serial]with default cpu model", Serial, func() {
 			var originalConfig v1.KubeVirtConfiguration
 			var defaultCPUModel = "Nehalem"
 			var vmiCPUModel = "SandyBridge"
@@ -997,7 +997,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]with node feature discovery", func() {
+		Context("[Serial]with node feature discovery", Serial, func() {
 			var node *k8sv1.Node
 			var supportedCPU string
 			var supportedCPUs []string
@@ -1668,7 +1668,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 	})
 
-	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", func() {
+	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, func() {
 		It("[test_id:1656]should be in Failed phase", func() {
 			By("Starting a VirtualMachineInstance")
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
+var _ = Describe("[Serial][sig-compute]VMIDefaults", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -123,7 +123,7 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 
 }
 
-var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
+var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
### Add the ginkgo v2 Serial decorator
In functional tests, start replacing the `[Serial]` string within test spec descriptions, with the new ginkgo v2 `Serial`
decorators, by adding these decorators. Later we could remove the `[Serial]` strings from the spec descriptions.

### Use ginkgo v2 Serial decorator in several tests
Change hack/functests.sh to use the new ginkgo v2 Serial decorator:
1. drop the focus/skip for Serial, as ginkgo v2 uses the decorator.
2. Run only once, since ginkgo v2 uses the same algorithm as the old
version of this script: first it runs all the specks w/o the Serial
decorator in parallel, then it runs the tests with the Serial
decorator serialy.
3. rename the `--nodes` parameter with the new ginkgo v2 name `--procs`

Note: Several un-related files were deleted when running `make generate`.

**Special notes for your reviewer**:
For more details: https://github.com/nunnatsa/kubevirt/pull/new/use-ginkgo-v2-serial

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
