### PR TITLE
[Code cleaning]: Delete empty scheduling doc

### DIFF
--- a/docs/devel/scheduling.md
+++ b/docs/devel/scheduling.md
@@ -1,3 +1,0 @@
-# VMI scheduling in KubeVirt
-
-TODO


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes empty `scheduling.md` doc under `docs/devel/`, which only contains a `TODO` text.

The file was introduced in [this commit](https://github.com/kubevirt/kubevirt/commit/0c8f3639b1c2a8f3cc524171997c0d35cc4bb70a) about 5.5 years ago and it is unclear what was the original intent. Some other files (e.g. `storage.md`) were introduced in this commit that were also empty except for the `TODO` text, and they don't exist anymore.

I think that after 5.5 years it's time to remove this empty doc. If this doc is needed, it should be posted by a new PR, and better be added the the [user-guide](https://kubevirt.io/user-guide/) rather then to this repo.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
