### PR TITLE
tests, libstorage: Move `HasCDI` from utils to libstorage

### DIFF
--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -174,3 +174,7 @@ func HasDataVolumeCRD() bool {
 	}
 	return true
 }
+
+func HasCDI() bool {
+	return HasDataVolumeCRD()
+}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1319,7 +1319,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 
-				if !tests.HasCDI() {
+				if !libstorage.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 			})
@@ -2373,7 +2373,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			newVirtualMachineInstanceWithFedoraRWXBlockDisk := func() *v1.VirtualMachineInstance {
-				if !tests.HasCDI() {
+				if !libstorage.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1439,7 +1439,7 @@ spec:
 		// Updating KubeVirt to the target tested code
 		// Ensuring VM/VMI is still operational after the update from previous release.
 		DescribeTable("[release-blocker][test_id:3145]from previous release to target tested release", func(updateOperator bool) {
-			if !tests.HasCDI() {
+			if !libstorage.HasCDI() {
 				Skip("Skip update test when CDI is not present")
 			}
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -76,7 +76,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		util.PanicOnError(err)
 
 		tests.BeforeTestCleanup()
-		if !tests.HasCDI() {
+		if !libstorage.HasCDI() {
 			Skip("Skip DataVolume tests when CDI is not present")
 		}
 	})
@@ -84,7 +84,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 	Context("[storage-req]PVC expansion", func() {
 		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
 			checks.SkipTestIfNoFeatureGate(virtconfig.ExpandDisksGate)
-			if !tests.HasCDI() {
+			if !libstorage.HasCDI() {
 				Skip("Skip DataVolume tests when CDI is not present")
 			}
 			var sc string

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -453,7 +453,7 @@ var _ = SIGDescribe("Storage", func() {
 			BeforeEach(func() {
 				checks.SkipTestIfNoFeatureGate(virtconfig.VirtIOFSGate)
 				checks.SkipIfNonRoot("VirtioFS")
-				if !tests.HasCDI() {
+				if !libstorage.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 				dataVolume = libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1492,7 +1492,7 @@ func cleanNamespaces() {
 
 		// Remove PVCs
 		util2.PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("persistentvolumeclaims").Do(context.Background()).Error())
-		if HasCDI() {
+		if libstorage.HasCDI() {
 			// Remove DataVolumes
 			util2.PanicOnError(virtCli.CdiClient().CdiV1beta1().RESTClient().Delete().Namespace(namespace).Resource("datavolumes").Do(context.Background()).Error())
 		}
@@ -1653,7 +1653,7 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 }
 
 func NewRandomVirtualMachineInstanceWithFileDisk(imageUrl, namespace string, accessMode k8sv1.PersistentVolumeAccessMode) (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-	if !HasCDI() {
+	if !libstorage.HasCDI() {
 		Skip("Skip DataVolume tests when CDI is not present")
 	}
 	sc, exists := libstorage.GetRWOFileSystemStorageClass()
@@ -1668,7 +1668,7 @@ func NewRandomVirtualMachineInstanceWithFileDisk(imageUrl, namespace string, acc
 }
 
 func NewRandomVirtualMachineInstanceWithBlockDisk(imageUrl, namespace string, accessMode k8sv1.PersistentVolumeAccessMode) (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-	if !HasCDI() {
+	if !libstorage.HasCDI() {
 		Skip("Skip DataVolume tests when CDI is not present")
 	}
 	sc, exists := libstorage.GetRWOBlockStorageClass()
@@ -3349,10 +3349,6 @@ func EnableFeatureGate(feature string) *v1.KubeVirt {
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, feature)
 
 	return UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
-}
-
-func HasCDI() bool {
-	return libstorage.HasDataVolumeCRD()
 }
 
 func VolumeExpansionAllowed(sc string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Moving the `HasCDI` function to `libstorage` as part of the effort to cleanup the `utils` file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Several following extractions are dependent of this.

**Release note**:
```release-note
NONE
```
