### PR TITLE
tests, libvmi: Support Cirros VM/s on ARM64

### DIFF
--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -17,6 +17,8 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/containerdisk:go_default_library",
+        "//tests/framework/checks:go_default_library",
+        "//tests/testsuite:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -23,6 +23,8 @@ import (
 	kvirtv1 "kubevirt.io/api/core/v1"
 
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 // Default VMI values
@@ -53,7 +55,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		withNonEmptyUserData,
-		WithResourceMemory("128Mi"),
+		WithResourceMemory(cirrosMemory()),
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
@@ -70,4 +72,11 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	}
 	alpineOpts = append(alpineOpts, opts...)
 	return New(RandName(DefaultVmiName), alpineOpts...)
+}
+
+func cirrosMemory() string {
+	if checks.IsARM64(testsuite.Arch) {
+		return "256Mi"
+	}
+	return "128Mi"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Cirros image needs 256M to boot on ARM64 [1].

[1] https://github.com/kubevirt/kubevirt/issues/6363

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a follow up to #7430 (after resolving the dependency issues caused by `utils`)

This change depends on #7625 (only the last commit is to be examined in this context)

**Release note**:
```release-note
NONE
```