### PR TITLE
Always require capabilites which we set on binary

### DIFF
--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3145,7 +3145,7 @@ var _ = Describe("Template", func() {
 			Entry("when there is slirp interface", "slirp"),
 		)
 
-		It("should not require NET_BIND_SERVICE", func() {
+		It("should require capabilites which we set on virt-launcher binary", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMacvtapNetworkInterface("test")}
 
@@ -3154,7 +3154,8 @@ var _ = Describe("Template", func() {
 
 			for _, container := range pod.Spec.Containers {
 				if container.Name == "compute" {
-					Expect(container.SecurityContext.Capabilities.Add).NotTo(ContainElement(kubev1.Capability("NET_BIND_SERVICE")))
+					Expect(container.SecurityContext.Capabilities.Add).To(
+						ContainElements(kubev1.Capability("NET_BIND_SERVICE"), kubev1.Capability("SYS_PTRACE")))
 					return
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to always require capabilities we set on virt-launcher
binary otherwise we encounter failure. The reason is that
process(virt-launcher) is always trying to acquire these
capabilities to effective set once we set the capabilities on binary.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
