### PR TITLE
NonRoot: move session-mode files to /home/qemu

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -154,13 +154,26 @@ pkg_tar(
     package_dir = "/etc",
 )
 
+# - Ensure /home is created as root (default), in the right mode (0755), before qemu-dirs-tar creates /home/qemu
+# - Ensure /var/lib is created as root (default), in the right mode (0755), before qemu-dirs-tar creates /var/lib/swtpm-localca
 pkg_tar(
-    name = "swtpm-localca-tar",
+    name = "qemu-dirs-prep-tar",
     empty_dirs = [
-        "var/lib/swtpm-localca",
-        "run/var/lib/swtpm-localca",
+        "home",
+        "var/lib",
     ],
-    mode = "0750",
+    mode = "0755",
+)
+
+# - Although we have a passwd entry for the qemu user, its home needs to be created separately
+# - Even in non-root session mode, swtpm needs /var/lib/swtpm-localca to be writable
+pkg_tar(
+    name = "qemu-dirs-tar",
+    empty_dirs = [
+        "home/qemu/libvirt",
+        "var/lib/swtpm-localca",
+    ],
+    mode = "0755",
     owner = "107.107",
 )
 
@@ -173,14 +186,16 @@ container_image(
             ":libvirt-config",
             ":passwd-tar",
             ":nsswitch-tar",
-            ":swtpm-localca-tar",
+            ":qemu-dirs-prep-tar",
+            ":qemu-dirs-tar",
             "//rpm:launcherbase_aarch64",
         ],
         "//conditions:default": [
             ":libvirt-config",
             ":passwd-tar",
             ":nsswitch-tar",
-            "swtpm-localca-tar",
+            ":qemu-dirs-prep-tar",
+            ":qemu-dirs-tar",
             "//rpm:launcherbase_x86_64",
         ],
     }),

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -64,6 +64,7 @@ const (
 	hotplugDisks     = "hotplug-disks"
 	hookSidecarSocks = "hook-sidecar-sockets"
 	varRun           = "/var/run"
+	homeQemu         = "/home/qemu"
 	virtBinDir       = "virt-bin-share-dir"
 	hotplugDisk      = "hotplug-disk"
 )
@@ -551,7 +552,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 
 	volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 		Name:      "libvirt-runtime",
-		MountPath: "/var/run/libvirt",
+		MountPath: filepath.Join(varRun, "libvirt"),
 	})
 
 	// virt-launcher cmd socket dir
@@ -1163,11 +1164,11 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		compute.Env = append(compute.Env,
 			k8sv1.EnvVar{
 				Name:  "XDG_CACHE_HOME",
-				Value: varRun,
+				Value: homeQemu,
 			},
 			k8sv1.EnvVar{
 				Name:  "XDG_CONFIG_HOME",
-				Value: varRun,
+				Value: homeQemu,
 			},
 			k8sv1.EnvVar{
 				Name:  "XDG_RUNTIME_DIR",


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this, the bazel rules chowned /run to qemu:qemu, as a side-effect of chowning /run/var/lib/swtpm-localca.
That makes everything work nicely but it is less than ideal!
Chowning /run back to root and moving XDG_* to /home/qemu seems saner.
The alternative solution would have been to pre-create and chown more /run subdirectories,
but that won't work since swtpm_setup creates files at the root of XDG_RUNTIME_DIR (or another XDG_).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The qemu user no longer owns /run
```
