### PR TITLE
[Flaky] 3188 test - improve reporting to catch a problem

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -304,39 +304,31 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					k8sv1.PersistentVolumeFilesystem,
 				)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
-				vm := tests.NewRandomVirtualMachine(vmi, false)
+				vmSpec := tests.NewRandomVirtualMachine(vmi, false)
 
-				_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+				vm, err := virtClient.VirtualMachine(vmSpec.Namespace).Create(vmSpec)
 				Expect(err).ToNot(HaveOccurred())
-				defer func() {
-					err := virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}()
 
-				Eventually(func() bool {
+				Eventually(func() v1.VirtualMachinePrintableStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-				}, 180*time.Second, 2*time.Second).Should(BeTrue())
+					return vm.Status.PrintableStatus
+				}, 180*time.Second, 2*time.Second).Should(Equal(v1.VirtualMachineStatusStopped))
 
 				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				defer func() {
-					err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				}()
 
-				Eventually(func() bool {
+				Eventually(func() v1.VirtualMachinePrintableStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.PrintableStatus == v1.VirtualMachineStatusProvisioning
-				}, 180*time.Second, 1*time.Second).Should(BeTrue())
+					return vm.Status.PrintableStatus
+				}, 180*time.Second, 1*time.Second).Should(Equal(v1.VirtualMachineStatusProvisioning))
 
-				Eventually(func() bool {
+				Eventually(func() v1.VirtualMachinePrintableStatus {
 					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.PrintableStatus == v1.VirtualMachineStatusStopped
-				}, 180*time.Second, 2*time.Second).Should(BeTrue())
+					return vm.Status.PrintableStatus
+				}, 180*time.Second, 2*time.Second).Should(Equal(v1.VirtualMachineStatusStopped))
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Test: `[sig-storage] DataVolume Integration [rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source Alpine import should accurately report DataVolume provisioning`
fails sometimes, need to investigate if the test is flaky or there is a real issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Improving test reporting - Investigating the issue, trying to run locally and in the CI env. The commit with real fix should follow.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
