### PR TITLE
virt-launcher monitor: read the qemu pid file instead of grepping /proc

### DIFF
--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -30,14 +31,24 @@ import (
 )
 
 func main() {
-	uuid := pflag.String("uuid", "", "some fake arg")
+	uuid := pflag.String("uuid", "", "the UUID of the fake qemu process")
+	pidFile := pflag.String("pidfile", "", "the path of the PID file to create")
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,
 		syscall.SIGTERM,
 	)
 
 	pflag.Parse()
-	fmt.Printf("Started fake qemu process with uuid %s\n", *uuid)
+	fmt.Printf("Started fake qemu process with uuid %s and pidfile %s\n", *uuid, *pidFile)
+
+	if *pidFile != "" {
+		pid := os.Getpid()
+		err := os.WriteFile(*pidFile, []byte(strconv.Itoa(pid)), 0644)
+		if err != nil {
+			fmt.Printf("Could not write to PID file %s: %v\n", *pidFile, err)
+			os.Exit(1)
+		}
+	}
 
 	timeout := time.After(60 * time.Second)
 	select {

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -473,12 +473,14 @@ func main() {
 
 	domain := waitForDomainUUID(*qemuTimeout, events, signalStopChan, domainManager)
 	if domain != nil {
-		// The first argument to NewProcessMonitor will end up being grepped in /proc/*/cmdline
-		// to find what is hopefully the qemu process.
-		// If any other process includes that string, it might wrongly be considered.
-		// FIXME: just read the pidfile libvirt creates for qemu instead of grepping /proc
-		// See: https://github.com/kubevirt/kubevirt/issues/7067
-		mon := virtlauncher.NewProcessMonitor("uuid="+domain.Spec.UUID,
+		var pidDir string
+		if *runWithNonRoot {
+			pidDir = "/run/libvirt/qemu/run"
+		} else {
+			pidDir = "/run/libvirt/qemu"
+		}
+		mon := virtlauncher.NewProcessMonitor(domainName,
+			pidDir,
 			*gracePeriodSeconds,
 			finalShutdownCallback,
 			gracefulShutdownCallback)


### PR DESCRIPTION
**What this PR does / why we need it**:
We used to grep `/proc/*/cmdline` for the domain UUID to find qemu, which created issues when adding TPM, since the swtpm process also include the domain UUID.
So we switched to grepping for "uuid=<uuid>", but that string is found in the smbios option, which is not present on ARM, so ARM testing is currently broken.
This PR tries to end this once and for all by reading the PID file created for qemu under `/run`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7067 
Fixes (hopefully) ARM test suite

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
