### PR TITLE
Reduce nestiness of `OnDefineDomain` method

### DIFF
--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -209,10 +209,6 @@ func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.Vir
 }
 
 func (m *Manager) onDefineDomainCallback(callback *callBackClient, domainSpecXML, vmiJSON []byte) ([]byte, error) {
-	if callback.Version != hooksV1alpha1.Version && callback.Version != hooksV1alpha2.Version {
-		return domainSpecXML, nil
-	}
-
 	conn, err := grpcutil.DialSocketWithTimeout(callback.SocketPath, 1)
 	if err != nil {
 		log.Log.Reason(err).Infof(dialSockErr, callback.SocketPath)
@@ -245,7 +241,7 @@ func (m *Manager) onDefineDomainCallback(callback *callBackClient, domainSpecXML
 		}
 		domainSpecXML = result.GetDomainXML()
 	default:
-		panic("Should never happen, version compatibility check is done during Info call")
+		log.Log.Errorf("Unsupported callback version: %s", callback.Version)
 	}
 
 	return domainSpecXML, nil

--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -187,52 +187,68 @@ func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.Vir
 	if err != nil {
 		return "", fmt.Errorf("Failed to marshal domain spec: %v", domainSpec)
 	}
-	if callbacks, found := m.CallbacksPerHookPoint[hooksInfo.OnDefineDomainHookPointName]; found {
-		for _, callback := range callbacks {
-			if callback.Version == hooksV1alpha1.Version || callback.Version == hooksV1alpha2.Version {
-				vmiJSON, err := json.Marshal(vmi)
-				if err != nil {
-					return "", fmt.Errorf("Failed to marshal VMI spec: %v", vmi)
-				}
 
-				conn, err := grpcutil.DialSocketWithTimeout(callback.SocketPath, 1)
-				if err != nil {
-					log.Log.Reason(err).Infof(dialSockErr, callback.SocketPath)
-					return "", err
-				}
-				defer conn.Close()
+	callbacks, found := m.CallbacksPerHookPoint[hooksInfo.OnDefineDomainHookPointName]
+	if !found {
+		return string(domainSpecXML), nil
+	}
 
-				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-				defer cancel()
+	vmiJSON, err := json.Marshal(vmi)
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal VMI spec: %v", vmi)
+	}
 
-				switch callback.Version {
-				case hooksV1alpha1.Version:
-					client := hooksV1alpha1.NewCallbacksClient(conn)
-					result, err := client.OnDefineDomain(ctx, &hooksV1alpha1.OnDefineDomainParams{
-						DomainXML: domainSpecXML,
-						Vmi:       vmiJSON,
-					})
-					if err != nil {
-						return "", err
-					}
-					domainSpecXML = result.GetDomainXML()
-				case hooksV1alpha2.Version:
-					client := hooksV1alpha2.NewCallbacksClient(conn)
-					result, err := client.OnDefineDomain(ctx, &hooksV1alpha2.OnDefineDomainParams{
-						DomainXML: domainSpecXML,
-						Vmi:       vmiJSON,
-					})
-					if err != nil {
-						return "", err
-					}
-					domainSpecXML = result.GetDomainXML()
-				default:
-					panic("Should never happen, version compatibility check is done during Info call")
-				}
-			}
+	for _, callback := range callbacks {
+		domainSpecXML, err = m.onDefineDomainCallback(callback, domainSpecXML, vmiJSON)
+		if err != nil {
+			return "", err
 		}
 	}
+
 	return string(domainSpecXML), nil
+}
+
+func (m *Manager) onDefineDomainCallback(callback *callBackClient, domainSpecXML, vmiJSON []byte) ([]byte, error) {
+	if callback.Version != hooksV1alpha1.Version && callback.Version != hooksV1alpha2.Version {
+		return domainSpecXML, nil
+	}
+
+	conn, err := grpcutil.DialSocketWithTimeout(callback.SocketPath, 1)
+	if err != nil {
+		log.Log.Reason(err).Infof(dialSockErr, callback.SocketPath)
+		return nil, err
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	switch callback.Version {
+	case hooksV1alpha1.Version:
+		client := hooksV1alpha1.NewCallbacksClient(conn)
+		result, err := client.OnDefineDomain(ctx, &hooksV1alpha1.OnDefineDomainParams{
+			DomainXML: domainSpecXML,
+			Vmi:       vmiJSON,
+		})
+		if err != nil {
+			return nil, err
+		}
+		domainSpecXML = result.GetDomainXML()
+	case hooksV1alpha2.Version:
+		client := hooksV1alpha2.NewCallbacksClient(conn)
+		result, err := client.OnDefineDomain(ctx, &hooksV1alpha2.OnDefineDomainParams{
+			DomainXML: domainSpecXML,
+			Vmi:       vmiJSON,
+		})
+		if err != nil {
+			return nil, err
+		}
+		domainSpecXML = result.GetDomainXML()
+	default:
+		panic("Should never happen, version compatibility check is done during Info call")
+	}
+
+	return domainSpecXML, nil
 }
 
 func (m *Manager) PreCloudInitIso(vmi *v1.VirtualMachineInstance, cloudInitData *cloudinit.CloudInitData) (*cloudinit.CloudInitData, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Reduces complexity/nestiness of `OnDefineDomain` method by reverting if conditions. Also changing the version check so it's easier to catch cases when the hook version is not correctly defined (see https://github.com/kubevirt/kubevirt/pull/7642#discussion_r859648236).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
