### PR TITLE
virt-handler/device-manager tests: use HaveLen and BeEmpty

### DIFF
--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -200,13 +200,13 @@ var _ = Describe("Mediated Device", func() {
 			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
 			permittedDevices := fakeClusterConfig.GetPermittedHostDevices()
 			Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
-			Expect(len(permittedDevices.MediatedDevices)).To(Equal(1), "the fake device was not found")
+			Expect(permittedDevices.MediatedDevices).To(HaveLen(1), "the fake device was not found")
 
 			By("ensuring a device plugin gets created for our fake device")
 			enabledDevicePlugins, disabledDevicePlugins := deviceController.splitPermittedDevices(
 				deviceController.updatePermittedHostDevicePlugins(),
 			)
-			Expect(len(enabledDevicePlugins)).To(Equal(1), "a device plugin wasn't created for the fake device")
+			Expect(enabledDevicePlugins).To(HaveLen(1), "a device plugin wasn't created for the fake device")
 			Expect(disabledDevicePlugins).To(BeEmpty())
 			Ω(enabledDevicePlugins).Should(HaveKey(fakeMdevResourceName))
 			// Manually adding the enabled plugin, since the device controller is not actually running
@@ -219,14 +219,14 @@ var _ = Describe("Mediated Device", func() {
 			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
 			permittedDevices = fakeClusterConfig.GetPermittedHostDevices()
 			Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
-			Expect(len(permittedDevices.MediatedDevices)).To(Equal(0), "the fake device was not deleted")
+			Expect(permittedDevices.MediatedDevices).To(BeEmpty(), "the fake device was not deleted")
 
 			By("ensuring the device plugin gets stopped")
 			enabledDevicePlugins, disabledDevicePlugins = deviceController.splitPermittedDevices(
 				deviceController.updatePermittedHostDevicePlugins(),
 			)
 			Expect(enabledDevicePlugins).To(BeEmpty())
-			Expect(len(disabledDevicePlugins)).To(Equal(1), "the fake device plugin did not get disabled")
+			Expect(disabledDevicePlugins).To(HaveLen(1), "the fake device plugin did not get disabled")
 			Ω(disabledDevicePlugins).Should(HaveKey(fakeMdevResourceName))
 		})
 	})

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -145,13 +145,13 @@ pciHostDevices:
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
 		permittedDevices := fakeClusterConfig.GetPermittedHostDevices()
 		Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
-		Expect(len(permittedDevices.PciHostDevices)).To(Equal(1), "the fake device was not found")
+		Expect(permittedDevices.PciHostDevices).To(HaveLen(1), "the fake device was not found")
 
 		By("ensuring a device plugin gets created for our fake device")
 		enabledDevicePlugins, disabledDevicePlugins := deviceController.splitPermittedDevices(
 			deviceController.updatePermittedHostDevicePlugins(),
 		)
-		Expect(len(enabledDevicePlugins)).To(Equal(1), "a device plugin wasn't created for the fake device")
+		Expect(enabledDevicePlugins).To(HaveLen(1), "a device plugin wasn't created for the fake device")
 		Expect(disabledDevicePlugins).To(BeEmpty(), "no disabled device plugins are expected")
 		Ω(enabledDevicePlugins).Should(HaveKey(fakeName))
 		// Manually adding the enabled plugin, since the device controller is not actually running
@@ -162,14 +162,14 @@ pciHostDevices:
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
 		permittedDevices = fakeClusterConfig.GetPermittedHostDevices()
 		Expect(permittedDevices).ToNot(BeNil(), "something went wrong while parsing the configmap(s)")
-		Expect(len(permittedDevices.PciHostDevices)).To(Equal(0), "the fake device was not deleted")
+		Expect(permittedDevices.PciHostDevices).To(BeEmpty(), "the fake device was not deleted")
 
 		By("ensuring the device plugin gets stopped")
 		enabledDevicePlugins, disabledDevicePlugins = deviceController.splitPermittedDevices(
 			deviceController.updatePermittedHostDevicePlugins(),
 		)
 		Expect(enabledDevicePlugins).To(BeEmpty(), "no enabled device plugins should be found")
-		Expect(len(disabledDevicePlugins)).To(Equal(1), "the fake device plugin did not get disabled")
+		Expect(disabledDevicePlugins).To(HaveLen(1), "the fake device plugin did not get disabled")
 		Ω(disabledDevicePlugins).Should(HaveKey(fakeName))
 	})
 })


### PR DESCRIPTION
HaveLen and BeEmpty expecters make failures more readable.

```release-note
NONE
```
