### PR TITLE
Improve errors in `OnDefineDomain` method

### DIFF
--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -195,7 +195,7 @@ func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.Vir
 
 	vmiJSON, err := json.Marshal(vmi)
 	if err != nil {
-		return "", fmt.Errorf("Failed to marshal VMI spec: %v", vmi)
+		return "", fmt.Errorf("failed to marshal VMI spec: %v, err: %v", vmi, err)
 	}
 
 	for _, callback := range callbacks {
@@ -211,7 +211,7 @@ func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.Vir
 func (m *Manager) onDefineDomainCallback(callback *callBackClient, domainSpecXML, vmiJSON []byte) ([]byte, error) {
 	conn, err := grpcutil.DialSocketWithTimeout(callback.SocketPath, 1)
 	if err != nil {
-		log.Log.Reason(err).Infof(dialSockErr, callback.SocketPath)
+		log.Log.Reason(err).Errorf(dialSockErr, callback.SocketPath)
 		return nil, err
 	}
 	defer conn.Close()
@@ -227,6 +227,7 @@ func (m *Manager) onDefineDomainCallback(callback *callBackClient, domainSpecXML
 			Vmi:       vmiJSON,
 		})
 		if err != nil {
+			log.Log.Reason(err).Error("Failed to call OnDefineDomain")
 			return nil, err
 		}
 		domainSpecXML = result.GetDomainXML()
@@ -237,6 +238,7 @@ func (m *Manager) onDefineDomainCallback(callback *callBackClient, domainSpecXML
 			Vmi:       vmiJSON,
 		})
 		if err != nil {
+			log.Log.Reason(err).Error("Failed to call OnDefineDomain")
 			return nil, err
 		}
 		domainSpecXML = result.GetDomainXML()


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This MR improves the errors in the `OnDefineDomain` method. Now we include errors when we fail on Marshal function. Also changed `Infof` logs to `Error` when error occurs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
