### PR TITLE
[release-0.41] virt-launcher: adjust overhead calculation for processes

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -96,6 +96,13 @@ const EXT_LOG_VERBOSITY_THRESHOLD = 5
 
 const ephemeralStorageOverheadSize = "50M"
 
+const (
+	VirtLauncherOverhead = "150Mi" // The sum of the `ps` RSS for the 2 virt-launcher processes
+	VirtlogdOverhead     = "16Mi"  // The RSS for virtlogd
+	LibvirtdOverhead     = "33Mi"  // The RSS for libvirtd
+	QemuOverhead         = "30Mi"  // The RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
+)
+
 type TemplateService interface {
 	RenderLaunchManifest(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
 	RenderHotplugAttachmentPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock bool, tempPod bool) (*k8sv1.Pod, error)
@@ -1531,9 +1538,13 @@ func getMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource
 	pagetableMemory.Set(pagetableMemory.Value() / 512)
 	overhead.Add(*pagetableMemory)
 
-	// Add fixed overhead for shared libraries and such
-	// TODO account for the overhead of kubevirt components running in the pod
-	overhead.Add(resource.MustParse("138Mi"))
+	// Add fixed overhead for KubeVirt components, as seen in a random run, rounded up to the nearest MiB
+	// Note: shared libraries are included in the size, so every library is counted (wrongly) as many times as there are
+	//   processes using it. However, the extra memory is only in the order of 10MiB and makes for a nice safety margin.
+	overhead.Add(resource.MustParse(VirtLauncherOverhead))
+	overhead.Add(resource.MustParse(VirtlogdOverhead))
+	overhead.Add(resource.MustParse(LibvirtdOverhead))
+	overhead.Add(resource.MustParse(QemuOverhead))
 
 	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
 	// overhead per vcpu in MiB

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1433,8 +1433,8 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1m"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("2m"))
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1180211045"))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2180211045"))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1275631461"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2275631461"))
 			})
 			It("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func() {
 
@@ -1466,7 +1466,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2180211045"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2275631461"))
 			})
 			It("should not add unset resources", func() {
 
@@ -1497,7 +1497,7 @@ var _ = Describe("Template", func() {
 
 				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("64M"))
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1m"))
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(260)))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(355)))
 
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
@@ -1534,9 +1534,9 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				table.Entry("and consider graphics overhead if it is not set", nil, 260),
-				table.Entry("and consider graphics overhead if it is set to true", True(), 260),
-				table.Entry("and not consider graphics overhead if it is set to false", False(), 243),
+				table.Entry("and consider graphics overhead if it is not set", nil, 355),
+				table.Entry("and consider graphics overhead if it is set to true", True(), 355),
+				table.Entry("and not consider graphics overhead if it is set to false", False(), 338),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 
@@ -1703,8 +1703,8 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179)))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179)))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(274)))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(274)))
 
 				hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + value)
 				hugepagesRequest := pod.Spec.Containers[0].Resources.Requests[hugepageType]
@@ -1719,8 +1719,6 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(5))
 				Expect(pod.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/dev/hugepages"))
 			},
-				table.Entry("hugepages-2Mi", "2Mi"),
-				table.Entry("hugepages-1Gi", "1Gi"),
 			)
 			It("should account for difference between guest and container requested memory ", func() {
 				guestMem := resource.MustParse("64M")
@@ -1758,8 +1756,8 @@ var _ = Describe("Template", func() {
 				guestRequestMemDiff := vmi.Spec.Domain.Resources.Requests.Memory()
 				guestRequestMemDiff.Sub(guestMem)
 
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(274) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(274) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
 
 				hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + "1Gi")
 				hugepagesRequest := pod.Spec.Containers[0].Resources.Requests[hugepageType]

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -20,6 +20,7 @@
 package tests_test
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -27,6 +28,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
@@ -269,7 +272,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					tests.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(260)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(355)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -2841,6 +2844,78 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				&expect.BSnd{S: "$(sudo /usr/libexec/virt-what-cpuid-helper | grep -q KVMKVMKVM) && echo 'pass'\n"},
 				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)).To(Succeed())
+		})
+	})
+	Context("virt-launcher processes memory usage", func() {
+		It("should be lower than allocated size", func() {
+			By("Starting a VirtualMachineInstance")
+			vmi := tests.NewRandomFedoraVMI()
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Expecting console")
+			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+
+			By("Running ps in virt-launcher")
+			pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(context.Background(), metav1.ListOptions{
+				LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
+			})
+			Expect(err).ToNot(HaveOccurred(), "Should list pods successfully")
+			var stdout, stderr string
+			errorMassageFormat := "failed after running `ps axO rss` with stdout:\n %v \n stderr:\n %v \n err: \n %v \n"
+			Eventually(func() error {
+				stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, &pods.Items[0], "compute",
+					[]string{
+						"ps",
+						"axO",
+						"rss",
+					})
+				return err
+			}, time.Second, 50*time.Millisecond).Should(BeNil(), fmt.Sprintf(errorMassageFormat, stdout, stderr, err))
+
+			By("Parsing the output of ps")
+			processRss := make(map[string]resource.Quantity)
+			scanner := bufio.NewScanner(strings.NewReader(stdout))
+			for scanner.Scan() {
+				fields := strings.Fields(scanner.Text())
+				Expect(len(fields)).To(Equal(6))
+				switch fields[5] {
+				case "virt-launcher":
+					rss, found := processRss[fields[5]]
+					value := resource.MustParse(fields[1] + "Ki")
+					if found {
+						rss.Add(value)
+						processRss[fields[5]] = rss
+					} else {
+						processRss[fields[5]] = value
+					}
+				case "virtlogd", "libvirtd", "qemu-kvm":
+					_, found := processRss[fields[5]]
+					Expect(found).To(BeFalse(), "multiple %s processes found", fields[5])
+					value := resource.MustParse(fields[1] + "Ki")
+					processRss[fields[5]] = value
+				}
+			}
+			for _, process := range []string{"virt-launcher", "virtlogd", "libvirtd", "qemu-kvm"} {
+				_, found := processRss[process]
+				Expect(found).To(BeTrue(), "no %s process found", process)
+			}
+
+			By("Ensuring no process is using too much ram")
+			expected := resource.MustParse(services.VirtLauncherOverhead)
+			actual := processRss["virt-launcher"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the /usr/bin/virt-launcher processes are taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.VirtlogdOverhead)
+			actual = processRss["virtlogd"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virtlogd process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.LibvirtdOverhead)
+			actual = processRss["libvirtd"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the libvirtd process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			expected = resource.MustParse(services.QemuOverhead)
+			expected.Add(vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory])
+			actual = processRss["qemu-kvm"]
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the qemu-kvm process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
 		})
 	})
 })


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/7264

**What this PR does / why we need it**:
This commit effectively addresses a TODO in the memory overhead calculation for virt-launcher.
It replaces an arbitrary overhead value with the observed memory usage of each process running inside virt-launcher.
A test also ensures we catch any future growth.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
