### PR TITLE
test utils: address various code smells

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -577,7 +577,7 @@ func DeleteAllSeparateDeviceHostPathPvs() {
 	for _, pv := range pvList.Items {
 		if pv.Spec.StorageClassName == StorageClassHostPathSeparateDevice {
 			// ignore error we want to attempt to delete them all.
-			virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
+			_ = virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
 		}
 	}
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -314,7 +314,7 @@ func (w *ObjectEventWatcher) Watch(ctx context.Context, processFunc ProcessFunc,
 	} else {
 		f = func(event *k8sv1.Event) bool {
 			if event.Type == string(WarningEvent) {
-				log.Log.ObjectRef(&event.InvolvedObject).Reason(fmt.Errorf("Warning event received")).Error(event.Message)
+				log.Log.ObjectRef(&event.InvolvedObject).Reason(fmt.Errorf("warning event received")).Error(event.Message)
 			} else {
 				log.Log.ObjectRef(&event.InvolvedObject).Infof(event.Message)
 			}
@@ -504,7 +504,7 @@ func CreatePVC(os, size, storageClass string, recycledPV bool) *k8sv1.Persistent
 	virtCli, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
-	pvc, err := virtCli.CoreV1().PersistentVolumeClaims((util2.NamespaceTestDefault)).Create(context.Background(), newPVC(os, size, storageClass, recycledPV), metav1.CreateOptions{})
+	pvc, err := virtCli.CoreV1().PersistentVolumeClaims(util2.NamespaceTestDefault).Create(context.Background(), newPVC(os, size, storageClass, recycledPV), metav1.CreateOptions{})
 	if !errors.IsAlreadyExists(err) {
 		util2.PanicOnError(err)
 	}
@@ -765,7 +765,7 @@ func DeletePVC(os string) {
 	util2.PanicOnError(err)
 
 	name := fmt.Sprintf("disk-%s", os)
-	err = virtCli.CoreV1().PersistentVolumeClaims((util2.NamespaceTestDefault)).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err = virtCli.CoreV1().PersistentVolumeClaims(util2.NamespaceTestDefault).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if !errors.IsNotFound(err) {
 		util2.PanicOnError(err)
 	}
@@ -1456,7 +1456,7 @@ func DeletePvAndPvc(name string) {
 		util2.PanicOnError(err)
 	}
 
-	err = virtCli.CoreV1().PersistentVolumeClaims((util2.NamespaceTestDefault)).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err = virtCli.CoreV1().PersistentVolumeClaims(util2.NamespaceTestDefault).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if !errors.IsNotFound(err) {
 		util2.PanicOnError(err)
 	}
@@ -1693,7 +1693,7 @@ func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 }
 
-// Block until the specified VirtualMachineInstance reached either Failed or Running states
+// WaitForVMIStartOrFailed blocks until the specified VirtualMachineInstance reached either Failed or Running states
 func WaitForVMIStartOrFailed(obj runtime.Object, seconds int, wp WarningsPolicy) *v1.VirtualMachineInstance {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2145,7 +2145,7 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	// get current vmi
 	freshVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("Failed to get vmi, %s", err)
+		return "", fmt.Errorf("failed to get vmi, %s", err)
 	}
 
 	command := []string{"virsh"}
@@ -2349,7 +2349,7 @@ func CreateNFSPvAndPvc(name string, namespace string, size string, nfsTargetIP s
 		util2.PanicOnError(err)
 	}
 
-	_, err = virtCli.CoreV1().PersistentVolumeClaims((namespace)).Create(context.Background(), newNFSPVC(name, namespace, size, os), metav1.CreateOptions{})
+	_, err = virtCli.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), newNFSPVC(name, namespace, size, os), metav1.CreateOptions{})
 	if !errors.IsAlreadyExists(err) {
 		util2.PanicOnError(err)
 	}
@@ -3064,17 +3064,17 @@ func RetryIfModified(do func() error) (err error) {
 }
 
 func GenerateRandomMac() (net.HardwareAddr, error) {
-	prefix := []byte{0x02, 0x00, 0x00} // local unicast prefix
-	suffix := make([]byte, 3)
+	prefix := net.HardwareAddr{0x02, 0x00, 0x00} // local unicast prefix
+	suffix := make(net.HardwareAddr, 3)
 	_, err := cryptorand.Read(suffix)
 	if err != nil {
 		return nil, err
 	}
-	return net.HardwareAddr(append(prefix, suffix...)), nil
+	return append(prefix, suffix...), nil
 }
 
 func getCert(pod *k8sv1.Pod, port string) []byte {
-	randPort := strconv.Itoa(int(4321 + rand.Intn(6000)))
+	randPort := strconv.Itoa(4321 + rand.Intn(6000))
 	var rawCert []byte
 	mutex := &sync.Mutex{}
 	conf := &tls.Config{
@@ -3109,7 +3109,7 @@ func getCert(pod *k8sv1.Pod, port string) []byte {
 }
 
 func CallUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
-	randPort := strconv.Itoa(int(4321 + rand.Intn(6000)))
+	randPort := strconv.Itoa(4321 + rand.Intn(6000))
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	err := ForwardPorts(pod, []string{fmt.Sprintf("%s:%s", randPort, port)}, stopChan, 10*time.Second)
@@ -3330,7 +3330,7 @@ func DetectLatestUpstreamOfficialTag() (string, error) {
 	}
 
 	if len(vs) == 0 {
-		return "", fmt.Errorf("No kubevirt releases found")
+		return "", fmt.Errorf("no kubevirt releases found")
 	}
 
 	// decending order from most recent.

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2644,7 +2644,7 @@ func DisableFeatureGate(feature string) {
 		}
 	}
 
-	newArray := []string{}
+	var newArray []string
 	featureGates := kv.Spec.Configuration.DeveloperConfiguration.FeatureGates
 	for _, fg := range featureGates {
 		if fg == feature {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a re-open of https://github.com/kubevirt/kubevirt/pull/7222

The PR cleans up a bunch of things in tests/utils.go, like:
- Variables named after imports / builtins
- Unused parameters
- Redundant parentheses / casts
- Capitalized error strings and incomplete function comment
- Empty slice declarations using literals (`x := []Type{}`)
- Non-explicit function return ignoring

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
