### PR TITLE
e2e,libvmi: set cirros memory to 256Mi if on ARM64

### DIFF
--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -17,6 +17,8 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/containerdisk:go_default_library",
+        "//tests/framework/checks:go_default_library",
+        "//tests/testsuite:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -23,6 +23,8 @@ import (
 	kvirtv1 "kubevirt.io/api/core/v1"
 
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 // Default VMI values
@@ -56,7 +58,13 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithResourceMemory("128Mi"),
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
-	cirrosOpts = append(cirrosOpts, opts...)
+
+	if checks.IsARM64(testsuite.Arch) {
+		// Cirros image need 256M to boot on ARM64,
+		// this issue is traced in https://github.com/kubevirt/kubevirt/issues/6363
+		cirrosOpts = append(cirrosOpts, WithResourceMemory("256Mi"))
+	}
+
 	return New(RandName(DefaultVmiName), cirrosOpts...)
 }
 


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
Currently, tests/utils function `NewRandomVMIWithNS` assigns 256Mi when on `Arm64` arch, and 128Mi when on `x86_64`.
This prevents substituting the utils function with libvmi `NewCirros` alternative.

This PR adds the decision logic to `libvmi.NewCirros`, so that the utils function can be substituted, without
changing in behaviour.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
