### PR TITLE
use ProductComponent instead of hardcoded kubevirt value in test_id:8235

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2502,7 +2502,14 @@ spec:
 
 		It("[test_id:8235]should check if kubevirt components have linux node selector", func() {
 			By("Listing only kubevirt components")
-			labelReq, err := labels.NewRequirement("app.kubernetes.io/component", selection.In, []string{"kubevirt"})
+
+			kv := util2.GetCurrentKv(virtClient)
+			productComponent := kv.Spec.ProductComponent
+			if productComponent == "" {
+				productComponent = "kubevirt"
+			}
+
+			labelReq, err := labels.NewRequirement("app.kubernetes.io/component", selection.In, []string{productComponent})
 
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
use ProductComponent instead of hardcoded kubevirt value in test_id:8235
**Which issue(s) this PR fixes**:
Fixes [7663](https://github.com/kubevirt/kubevirt/issues/7663)

**Special notes for your reviewer**:

**Release note**:

```
NONE
```
