### PR TITLE
Quarantine test_id:8482 due to flakiness

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2056,7 +2056,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:8482] Migration Metrics exposed to prometheus during VM migration", func() {
+			It("[QUARANTINE][test_id:8482] Migration Metrics exposed to prometheus during VM migration", func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 


### PR DESCRIPTION
Quarantining due to high flakiness, can be seen here:
https://search.ci.kubevirt.io/?search=tests%2Fmigration_test.go%3A2059&maxAge=336h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-05-02-168h.html

Signed-off-by: borod108 <boris.od@gmail.com>