### PR TITLE
Make names of access tests around test_id:2921 unique

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -407,11 +407,11 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 				testAction(resource, action, "no")
 			},
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/pause", "update"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/unpause", "update"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/softreboot", "update"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/console", "get"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/vnc", "get"),
+				Entry("[test_id:2921]given a vmi (pause)", "virtualmachineinstances/pause", "update"),
+				Entry("[test_id:2921]given a vmi (unpause)", "virtualmachineinstances/unpause", "update"),
+				Entry("[test_id:2921]given a vmi (softreboot)", "virtualmachineinstances/softreboot", "update"),
+				Entry("[test_id:2921]given a vmi (console)", "virtualmachineinstances/console", "get"),
+				Entry("[test_id:2921]given a vmi (vnc)", "virtualmachineinstances/vnc", "get"),
 			)
 		})
 
@@ -448,12 +448,12 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 				testAction(resource, action, "yes")
 			},
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/pause", "update"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/unpause", "update"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/softreboot", "update"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/console", "get"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/vnc", "get"),
-				Entry("[test_id:2921]given a vmi", "virtualmachineinstances/guestosinfo", "get"),
+				Entry("[test_id:2921]given a vmi (pause)", "virtualmachineinstances/pause", "update"),
+				Entry("[test_id:2921]given a vmi (unpause)", "virtualmachineinstances/unpause", "update"),
+				Entry("[test_id:2921]given a vmi (softreboot)", "virtualmachineinstances/softreboot", "update"),
+				Entry("[test_id:2921]given a vmi (console)", "virtualmachineinstances/console", "get"),
+				Entry("[test_id:2921]given a vmi (vnc)", "virtualmachineinstances/vnc", "get"),
+				Entry("[test_id:2921]given a vmi (guestosinfo)", "virtualmachineinstances/guestosinfo", "get"),
 			)
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We need to have the test names unique, otherwise the junit-merger
complains when they are run in parallel (which is always done in CI).

Unfortunately the issue with the touched test names can only be reproduced
with an OKD/OpenShift cluster, as they are specific to these environments.
That is also the reason why these tests never
failed upstream, since they are not run on vanilla k8s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
