### PR TITLE
Add validation for uniqueness of test names

### DIFF
--- a/tools/test-validator/BUILD.bazel
+++ b/tools/test-validator/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,4 +12,14 @@ go_binary(
     name = "test-validator",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["test-validator_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/tools/test-validator/BUILD.bazel
+++ b/tools/test-validator/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["test-validator.go"],
+    importpath = "kubevirt.io/kubevirt/tools/test-validator",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
+)
+
+go_binary(
+    name = "test-validator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/test-validator/test-validator.go
+++ b/tools/test-validator/test-validator.go
@@ -1,0 +1,130 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ginkgoMetadata holds useful bits of information for every entry in the outline
+type ginkgoMetadata struct {
+	// Name is the spec or container function name, e.g. `Describe` or `It`
+	Name string `json:"name"`
+
+	// Text is the `text` argument passed to specs, and some containers
+	Text string `json:"text"`
+
+	// Start is the position of first character of the spec or container block
+	Start int `json:"start"`
+
+	// End is the position of first character immediately after the spec or container block
+	End int `json:"end"`
+
+	Spec    bool `json:"spec"`
+	Focused bool `json:"focused"`
+	Pending bool `json:"pending"`
+}
+
+// ginkgoNode is used to construct the outline as a tree
+type ginkgoNode struct {
+	ginkgoMetadata
+	Nodes []*ginkgoNode `json:"nodes"`
+}
+
+var skipLeaves *regexp.Regexp
+
+func init() {
+	skipLeaves = regexp.MustCompile("By|BeforeEach|AfterEach")
+}
+
+func main() {
+	workDir, err := os.Getwd()
+	fatalIfErr("could not get work dir", err)
+
+	_, err = os.Stat("_out/tests/ginkgo")
+	if err != nil {
+		fatalIfErr("error finding ginkgo binary", err)
+	}
+
+	err = filepath.WalkDir(filepath.Join(workDir, "tests"), func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".go") || strings.HasSuffix(d.Name(), "_suite_test.go") {
+			return nil
+		}
+
+		filename := path
+
+		outlineCmd := exec.Command("_out/tests/ginkgo", "outline", "--format=json", filename)
+		bytes, err := outlineCmd.Output()
+		if err != nil {
+			log.Debugf(fmt.Sprintf("%q: error fetching ginkgo outline output for: %v", filename), err)
+			return nil
+		}
+
+		var nodes []*ginkgoNode
+		json.Unmarshal(bytes, &nodes)
+
+		testNames := expandTestNames("", nodes)
+		testNamesUnique := map[string]struct{}{}
+		for _, testName := range testNames {
+			if _, exists := testNamesUnique[testName]; exists {
+				return fmt.Errorf("%q: test name not unique: %q", filename, testName)
+			}
+			testNamesUnique[testName] = struct{}{}
+		}
+
+		return nil
+	})
+
+	fatalIfErr("failed to validate test files", err)
+}
+
+func expandTestNames(parentText string, nodes []*ginkgoNode) []string {
+	var result []string
+	for _, node := range nodes {
+		if node.Text == "undefined" {
+			continue
+		}
+		trimmedNodeTextWithParent := strings.Trim(fmt.Sprintf("%s %s", parentText, node.Text), " ")
+		if len(node.Nodes) > 0 {
+			result = append(result, expandTestNames(trimmedNodeTextWithParent, node.Nodes)...)
+		} else {
+			if skipLeaves.MatchString(node.Name) {
+				continue
+			}
+			result = append(result, trimmedNodeTextWithParent)
+		}
+	}
+	return result
+}
+
+func fatalIfErr(message string, err error) {
+	if err != nil {
+		log.Fatalf("%s: %v", message, err)
+	}
+}

--- a/tools/test-validator/test-validator_test.go
+++ b/tools/test-validator/test-validator_test.go
@@ -1,0 +1,206 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[tools]test-validator", func() {
+
+	It("should return the same test names on duplicate It with By", func() {
+		Expect(expandTestNames("", []*ginkgoNode{
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "It",
+					Text: "[test_id:4641]should be shut down when the watchdog expires",
+					Spec: true,
+				},
+				Nodes: []*ginkgoNode{
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "By",
+							Text: "Expecting the VirtualMachineInstance console",
+							Spec: false,
+						},
+						Nodes: []*ginkgoNode{},
+					},
+				},
+			},
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "It",
+					Text: "[test_id:4641]should be shut down when the watchdog expires",
+					Spec: true,
+				},
+				Nodes: []*ginkgoNode{
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "By",
+							Text: "Expecting the VirtualMachineInstance console",
+							Spec: false,
+						},
+						Nodes: []*ginkgoNode{},
+					},
+				},
+			},
+		})).To(BeEquivalentTo([]string{
+			"[test_id:4641]should be shut down when the watchdog expires",
+			"[test_id:4641]should be shut down when the watchdog expires",
+		}))
+	})
+
+	It("should return the expanded test description", func() {
+		Expect(expandTestNames("", []*ginkgoNode{
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "Describe",
+					Text: "[sig-compute] parent description",
+				},
+				Nodes: []*ginkgoNode{
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "Context",
+							Text: "[ref_id:4217] the reference context",
+						},
+						Nodes: []*ginkgoNode{
+							{
+								ginkgoMetadata: ginkgoMetadata{
+									Name: "It",
+									Text: "[test_id:1742] what makes this so special?",
+									Spec: true,
+								},
+								Nodes: nil,
+							},
+						},
+					},
+				}}})).To(BeEquivalentTo([]string{
+			"[sig-compute] parent description [ref_id:4217] the reference context [test_id:1742] what makes this so special?",
+		}))
+	})
+
+	It("should not return the expanded test description including the By, but should return something", func() {
+		Expect(expandTestNames("", []*ginkgoNode{
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "Describe",
+					Text: "[sig-compute] parent description",
+				},
+				Nodes: []*ginkgoNode{
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "Context",
+							Text: "[ref_id:4217] the reference context",
+						},
+						Nodes: []*ginkgoNode{
+							{
+								ginkgoMetadata: ginkgoMetadata{
+									Name: "It",
+									Text: "[test_id:1742] what makes this so special?",
+									Spec: true,
+								},
+								Nodes: []*ginkgoNode{
+									{
+										ginkgoMetadata: ginkgoMetadata{
+											Name: "By",
+											Text: "Expecting somthing to happen after this",
+										},
+										Nodes: []*ginkgoNode{},
+									},
+								},
+							},
+						},
+					},
+				}}})).To(BeEquivalentTo([]string{
+			"[sig-compute] parent description [ref_id:4217] the reference context [test_id:1742] what makes this so special?",
+		}))
+	})
+
+	It("should return the same test names on duplicate It with By", func() {
+		Expect(expandTestNames("", []*ginkgoNode{
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "It",
+					Text: "[test_id:1742] what makes this so special?",
+					Spec: true,
+				},
+				Nodes: nil,
+			},
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "It",
+					Text: "[test_id:1742] what makes this so special?",
+					Spec: true,
+				},
+				Nodes: nil,
+			},
+		})).To(BeEquivalentTo([]string{
+			"[test_id:1742] what makes this so special?",
+			"[test_id:1742] what makes this so special?",
+		}))
+	})
+
+	It("don't return entries with description 'undefined' on tables (i.e. where the description is referencing a const)", func() {
+		Expect(expandTestNames("", []*ginkgoNode{
+			{
+				ginkgoMetadata: ginkgoMetadata{
+					Name: "DescribeTable",
+					Text: "[sig-compute] table description",
+				},
+				Nodes: []*ginkgoNode{
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "Entry",
+							Text: "[test_id:1234] first entry",
+							Spec: true,
+						},
+						Nodes: nil,
+					},
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "Entry",
+							Text: "undefined",
+							Spec: true,
+						},
+						Nodes: nil,
+					},
+					{
+						ginkgoMetadata: ginkgoMetadata{
+							Name: "Entry",
+							Text: "[test_id:1234] third entry",
+							Spec: true,
+						},
+						Nodes: nil,
+					},
+				}}})).To(BeEquivalentTo([]string{
+			"[sig-compute] table description [test_id:1234] first entry",
+			"[sig-compute] table description [test_id:1234] third entry",
+		}))
+	})
+
+})
+
+func TestTestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TestTestValidator suite")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds an initial validation of whether test names are unique. Uses ginkgo outline, which parses the source files, but doesn't evaluate symbols, thus, if constants or variables are used, it can't evaluate further ("undefined" case). Should catch the basic cases where we don't run the tests, though.

Caveats:
* only heuristicly validating test names
* no compilation

**Note: dry-run doesn't work**

Checked with
```
mkdir -p _out/artifacts  && _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s _out/tests/tests.test -- -junit-output $(pwd)/artifacts/partial.junit.functest.xml
```

Content of `_out/artifacts/partial.junit.functest.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>                                                                                                    
  <testsuite name="Tests Suite" tests="1111" failures="0" errors="0" time="0">       
      <testcase name="BeforeSuite" classname="Tests Suite" time="0.000159433">       
          <failure type="Failure">tests/tests_suite_test.go:92&#xA;Unexpected error:&#xA;    &lt;*fs.PathError | 0xc00358c750&gt;: {&#xA; 
       Op: &#34;open&#34;,&#xA;        Path: &#34;tests/default-config.json&#34;,&#xA;        Err: &lt;syscall.Errno&gt;0x2,&#xA;    }&#xA;    open tests/default-config.json: no such file or directory&#xA;occurred&#xA;tests/testsuite/fixture.go:83</failure>
      </testcase>                                               
      <testcase name="AfterSuite" classname="Tests Suite" time="0.000230129">
          <failure type="Panic">tests/tests_suite_test.go:94&#xA;Test Panicked&#xA;tests/util/util.go:19</failure>
      </testcase>                                                                                                                         
  </testsuite>                                                  
```

Adding `--dry-run` flag after `_out/test/ginkgo` produces no output into `_out/artifacts/partial.junit.functest.xml`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
