### PR TITLE
Fix and improve implemention of `buildDevicesMetadata` method

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1669,11 +1669,18 @@ func formatPCIAddressStr(address *api.Address) string {
 }
 
 func addToDeviceMetadata(devicesMetadata []cloudinit.DeviceData, metadataType cloudinit.DeviceMetadataType, address *api.Address, mac string, tag string, numa *uint32, numaAlignedCPUs []uint32) []cloudinit.DeviceData {
-	pciAddrStr := formatPCIAddressStr(address)
+	var (
+		addressType string
+		pciAddress  string
+	)
+	if address != nil {
+		addressType = address.Type
+		pciAddress = formatPCIAddressStr(address)
+	}
 	deviceData := cloudinit.DeviceData{
 		Type:    metadataType,
-		Bus:     address.Type,
-		Address: pciAddrStr,
+		Bus:     addressType,
+		Address: pciAddress,
 		MAC:     mac,
 		Tags:    []string{tag},
 	}
@@ -1766,7 +1773,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 			deviceNumaNode, deviceAlignedCPUs := getDeviceNUMACPUAffinity(dev, vmi, domainSpec)
 			devicesMetadata = addToDeviceMetadata(devicesMetadata,
 				cloudinit.NICMetadataType,
-				dev.Source.Address,
+				dev.Address,
 				"",
 				tag,
 				deviceNumaNode,
@@ -1777,7 +1784,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 			deviceNumaNode, deviceAlignedCPUs := getDeviceNUMACPUAffinity(dev, vmi, domainSpec)
 			devicesMetadata = addToDeviceMetadata(devicesMetadata,
 				cloudinit.HostDevMetadataType,
-				dev.Source.Address,
+				dev.Address,
 				"",
 				tag,
 				deviceNumaNode,
@@ -1788,7 +1795,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 			deviceNumaNode, deviceAlignedCPUs := getDeviceNUMACPUAffinity(dev, vmi, domainSpec)
 			devicesMetadata = addToDeviceMetadata(devicesMetadata,
 				cloudinit.HostDevMetadataType,
-				dev.Source.Address,
+				dev.Address,
 				"",
 				tag,
 				deviceNumaNode,

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1766,7 +1766,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 			deviceNumaNode, deviceAlignedCPUs := getDeviceNUMACPUAffinity(dev, vmi, domainSpec)
 			devicesMetadata = addToDeviceMetadata(devicesMetadata,
 				cloudinit.NICMetadataType,
-				dev.Address,
+				dev.Source.Address,
 				"",
 				tag,
 				deviceNumaNode,
@@ -1777,7 +1777,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 			deviceNumaNode, deviceAlignedCPUs := getDeviceNUMACPUAffinity(dev, vmi, domainSpec)
 			devicesMetadata = addToDeviceMetadata(devicesMetadata,
 				cloudinit.HostDevMetadataType,
-				dev.Address,
+				dev.Source.Address,
 				"",
 				tag,
 				deviceNumaNode,
@@ -1788,7 +1788,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 			deviceNumaNode, deviceAlignedCPUs := getDeviceNUMACPUAffinity(dev, vmi, domainSpec)
 			devicesMetadata = addToDeviceMetadata(devicesMetadata,
 				cloudinit.HostDevMetadataType,
-				dev.Address,
+				dev.Source.Address,
 				"",
 				tag,
 				deviceNumaNode,

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2376,9 +2376,11 @@ var _ = Describe("Manager", func() {
 			Expect(devicesData).To(HaveLen(opts.sriovInterfaceCnt + opts.genericInterfaceCnt + opts.hostDeviceCnt + opts.gpuCnt))
 			devicesTypes := make(map[cloudinit.DeviceMetadataType]int)
 			for _, deviceData := range devicesData {
-				Expect(deviceData.Bus).To(Equal("pci"))
+				if deviceData.Type == cloudinit.NICMetadataType {
+					Expect(deviceData.Bus).To(Equal("pci"))
+					Expect(deviceData.Address).NotTo(BeEmpty())
+				}
 				Expect(deviceData.Tags).To(HaveLen(1))
-				Expect(deviceData.Address).NotTo(BeEmpty())
 				devicesTypes[deviceData.Type]++
 			}
 			Expect(devicesTypes[cloudinit.NICMetadataType]).To(Equal(opts.sriovInterfaceCnt + opts.genericInterfaceCnt))


### PR DESCRIPTION
**What this PR does / why we need it**: In old implementation we used `taggedGPUs` map but we never written to it which was basically a bug. Now we use single map `taggedHostDevices` for tagged host devices and gpus. 

**Special notes for your reviewer**: None

**Release note**:
```release-note
GPUs are now correctly returned in `ConfigDriveMetadata.Devices` in cloud-init metadata.
```
