### PR TITLE
Improvement of virtctl ssh command

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -45,6 +45,8 @@ if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* 
     oc=${kubectl}
 fi
 
+virtctl_path=$(pwd)/_out/cmd/virtctl/virtctl
+
 rm -rf $ARTIFACTS
 mkdir -p $ARTIFACTS
 
@@ -61,7 +63,7 @@ function functest() {
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
 
-    _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}
+    _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path}
 }
 
 if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then

--- a/pkg/virtctl/ssh/native.go
+++ b/pkg/virtctl/ssh/native.go
@@ -143,6 +143,13 @@ func (o *NativeSSHConnection) StartSession(client *ssh.Client) error {
 	session.Stderr = os.Stderr
 	session.Stdout = os.Stdout
 
+	if o.Options.Command != "" {
+		if err = session.Run(o.Options.Command); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	restore, err := setupTerminal(int(os.Stdin.Fd()))
 	if err != nil {
 		return err
@@ -152,7 +159,6 @@ func (o *NativeSSHConnection) StartSession(client *ssh.Client) error {
 	if err := requestPty(session); err != nil {
 		return err
 	}
-
 	if err := session.Shell(); err != nil {
 		return err
 	}

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -40,6 +40,7 @@ const (
 	IdentityFilePathFlag, identityFilePathFlagShort = "identity-file", "i"
 	knownHostsFilePathFlag                          = "known-hosts"
 	commandToExecute, commandToExecuteShort         = "command", "c"
+	additionalOpts, additionalOptsShort             = "local-ssh-opts", "t"
 )
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
@@ -78,6 +79,8 @@ func AddCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
 		fmt.Sprintf(`--%s=22: Specify a port on the VM to send SSH traffic to`, portFlag))
 	flagset.StringVarP(&opts.Command, commandToExecute, commandToExecuteShort, opts.Command,
 		fmt.Sprintf(`--%s='ls /': Specify a command to execute the VM`, commandToExecute))
+	flagset.StringArrayVarP(&opts.AdditionalSSHLocalOptions, additionalOpts, additionalOptsShort, opts.AdditionalSSHLocalOptions,
+		fmt.Sprintf(`--%s="-o StrictHostKeyChecking=no" : Additional options to be passed to the local ssh. This is applied only if local-ssh=true `, commandToExecute))
 }
 
 func DefaultSSHOptions() SSHOptions {
@@ -92,6 +95,7 @@ func DefaultSSHOptions() SSHOptions {
 		IdentityFilePathProvided:  false,
 		KnownHostsFilePath:        "",
 		KnownHostsFilePathDefault: "",
+		AdditionalSSHLocalOptions: []string{},
 	}
 
 	if len(homeDir) > 0 {
@@ -114,6 +118,7 @@ type SSHOptions struct {
 	KnownHostsFilePath        string
 	KnownHostsFilePathDefault string
 	Command                   string
+	AdditionalSSHLocalOptions []string
 }
 
 func (o *SSH) Run(cmd *cobra.Command, args []string) error {

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -39,6 +39,7 @@ const (
 	usernameFlag, usernameFlagShort                 = "username", "l"
 	IdentityFilePathFlag, identityFilePathFlagShort = "identity-file", "i"
 	knownHostsFilePathFlag                          = "known-hosts"
+	commandToExecute, commandToExecuteShort         = "command", "c"
 )
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
@@ -75,6 +76,8 @@ func AddCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
 		fmt.Sprintf("--%s=/home/jdoe/.ssh/kubevirt_known_hosts: Set the path to the known_hosts file.", knownHostsFilePathFlag))
 	flagset.IntVarP(&opts.SshPort, portFlag, portFlagShort, opts.SshPort,
 		fmt.Sprintf(`--%s=22: Specify a port on the VM to send SSH traffic to`, portFlag))
+	flagset.StringVarP(&opts.Command, commandToExecute, commandToExecuteShort, opts.Command,
+		fmt.Sprintf(`--%s='ls /': Specify a command to execute the VM`, commandToExecute))
 }
 
 func DefaultSSHOptions() SSHOptions {
@@ -110,6 +113,7 @@ type SSHOptions struct {
 	IdentityFilePathProvided  bool
 	KnownHostsFilePath        string
 	KnownHostsFilePathDefault string
+	Command                   string
 }
 
 func (o *SSH) Run(cmd *cobra.Command, args []string) error {

--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -42,6 +42,9 @@ func (o *SSH) buildProxyCommandOption(kind, namespace, name string) string {
 
 func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
 	target := strings.Builder{}
+	if len(o.options.AdditionalSSHLocalOptions) > 0 {
+		opts = append(opts, o.options.AdditionalSSHLocalOptions...)
+	}
 	if o.options.IdentityFilePathProvided {
 		opts = append(opts, "-i", o.options.IdentityFilePath)
 	}

--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -14,9 +14,9 @@ var runCommand = func(cmd *exec.Cmd) error {
 
 func (o *SSH) runLocalCommandClient(kind, namespace, name string) error {
 
-	args := []string{}
+	args := []string{"-o"}
 	args = append(args, o.buildProxyCommandOption(kind, namespace, name))
-	args = append(args, o.buildSSHTarget(kind, namespace, name))
+	args = append(args, o.buildSSHTarget(kind, namespace, name)...)
 
 	cmd := exec.Command("ssh", args...)
 	fmt.Println("running:", cmd)
@@ -29,7 +29,7 @@ func (o *SSH) runLocalCommandClient(kind, namespace, name string) error {
 
 func (o *SSH) buildProxyCommandOption(kind, namespace, name string) string {
 	proxyCommand := strings.Builder{}
-	proxyCommand.WriteString("-o ProxyCommand=")
+	proxyCommand.WriteString("ProxyCommand=")
 	proxyCommand.WriteString(os.Args[0])
 	proxyCommand.WriteString(" port-forward --stdio=true ")
 	proxyCommand.WriteString(fmt.Sprintf("%s/%s.%s", kind, name, namespace))
@@ -40,10 +40,10 @@ func (o *SSH) buildProxyCommandOption(kind, namespace, name string) string {
 	return proxyCommand.String()
 }
 
-func (o *SSH) buildSSHTarget(kind, namespace, name string) string {
+func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
 	target := strings.Builder{}
 	if o.options.IdentityFilePathProvided {
-		target.WriteString(fmt.Sprintf(" -i %s ", o.options.IdentityFilePath))
+		opts = append(opts, "-i", o.options.IdentityFilePath)
 	}
 	if len(o.options.SshUsername) > 0 {
 		target.WriteString(o.options.SshUsername)
@@ -54,5 +54,6 @@ func (o *SSH) buildSSHTarget(kind, namespace, name string) string {
 	target.WriteString(name)
 	target.WriteRune('.')
 	target.WriteString(namespace)
-	return target.String()
+	opts = append(opts, target.String())
+	return
 }

--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -54,6 +54,10 @@ func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
 	target.WriteString(name)
 	target.WriteRune('.')
 	target.WriteString(namespace)
+
 	opts = append(opts, target.String())
+	if o.options.Command != "" {
+		opts = append(opts, o.options.Command)
+	}
 	return
 }

--- a/pkg/virtctl/ssh/wrapped_test.go
+++ b/pkg/virtctl/ssh/wrapped_test.go
@@ -26,12 +26,12 @@ var _ = Describe("Wrapped SSH", func() {
 		It("with SSH username", func() {
 			ssh.options = SSHOptions{SshUsername: "testuser"}
 			sshTarget := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
-			Expect(sshTarget).To(Equal("testuser@fake-kind/fake-name.fake-ns"))
+			Expect(sshTarget[0]).To(Equal("testuser@fake-kind/fake-name.fake-ns"))
 		})
 
 		It("without SSH username", func() {
 			sshTarget := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
-			Expect(sshTarget).To(Equal("fake-kind/fake-name.fake-ns"))
+			Expect(sshTarget[0]).To(Equal("fake-kind/fake-name.fake-ns"))
 		})
 
 	})
@@ -47,10 +47,10 @@ var _ = Describe("Wrapped SSH", func() {
 	It("runLocalCommandClient", func() {
 		runCommand = func(cmd *exec.Cmd) error {
 			Expect(cmd).ToNot(BeNil())
-			Expect(cmd.Args).To(HaveLen(3))
+			Expect(cmd.Args).To(HaveLen(4))
 			Expect(cmd.Args[0]).To(Equal("ssh"))
-			Expect(cmd.Args[1]).To(Equal(ssh.buildProxyCommandOption(fakeKind, fakeNamespace, fakeName)))
-			Expect(cmd.Args[2]).To(Equal(ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)))
+			Expect(cmd.Args[2]).To(Equal(ssh.buildProxyCommandOption(fakeKind, fakeNamespace, fakeName)))
+			Expect(cmd.Args[3]).To(Equal(ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)[0]))
 
 			return nil
 		}

--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "key.go",
         "scp.go",
+        "ssh.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/virtctl",
     visibility = ["//visibility:public"],

--- a/tests/virtctl/key.go
+++ b/tests/virtctl/key.go
@@ -33,7 +33,7 @@ func DumpPrivateKey(privateKey *ecdsa.PrivateKey, file string) error {
 		Type:  "EC PRIVATE KEY",
 		Bytes: privateKeyBytes,
 	}
-	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY, 0777)
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -1,0 +1,86 @@
+package virtctl
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = Describe("[sig-compute][virtctl]SSH", func() {
+	var pub ssh.PublicKey
+	var keyFile string
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+		// Disable SSH_AGENT to not influence test results
+		Expect(os.Setenv("SSH_AUTH_SOCK", "/dev/null")).To(Succeed())
+		keyFile = filepath.Join(GinkgoT().TempDir(), "id_rsa")
+		tests.BeforeTestCleanup()
+		var priv *ecdsa.PrivateKey
+		priv, pub, err = NewKeyPair()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(DumpPrivateKey(priv, keyFile)).To(Succeed())
+	})
+
+	It("should succeed to execute a command on the VM using the ssh native method", func() {
+		By("injecting a SSH public key into a VMI")
+		vmi := libvmi.NewCirros(
+			libvmi.WithCloudInitNoCloudUserData(renderUserDataWithKey(pub), false))
+		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+		By("ssh into the VM using the native option")
+		Expect(clientcmd.NewRepeatableVirtctlCommand(
+			"ssh",
+			"--local-ssh=false",
+			"--namespace", util.NamespaceTestDefault,
+			"--username", "cirros",
+			"--identity-file", keyFile,
+			"--known-hosts=",
+			`--command='true'`,
+			vmi.Name)()).To(Succeed())
+
+	})
+	It("should succeed execute a command on the VM using local ssh method", func() {
+		By("injecting a SSH public key into a VMI")
+		vmi := libvmi.NewCirros(
+			libvmi.WithCloudInitNoCloudUserData(renderUserDataWithKey(pub), false))
+		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+		By("ssh into the VM using the native option")
+		_, cmd, err := clientcmd.CreateCommandWithNS(util.NamespaceTestDefault, "virtctl",
+			"ssh",
+			"--local-ssh=true",
+			"--namespace", util.NamespaceTestDefault,
+			"--username", "cirros",
+			"--identity-file", keyFile,
+			"-t", "-o StrictHostKeyChecking=no",
+			"-t", "-o UserKnownHostsFile=/dev/null",
+			"--command", "true",
+			vmi.Name)
+		Expect(err).ToNot(HaveOccurred())
+		cmd.Env = append(cmd.Env,
+			"SSH_AUTH_SOCK=/dev/null")
+		out, err := cmd.CombinedOutput()
+		fmt.Println(string(out))
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow to execute arbitrary command on the remote server via SSH. It adds the option to pass additional flag to the local ssh.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubevirt/kubevirt/issues/7680

**Special notes for your reviewer**:
This PR requires and include  the fix https://github.com/kubevirt/kubevirt/pull/7682 . Once merge it needs to be rebased.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add --command and --local-ssh-opts" options to virtctl ssh to execute remote command using local ssh method
```
