### PR TITLE
virt-launcher overhead: bump virtlogd and add logs to functest

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -125,7 +125,7 @@ const ephemeralStorageOverheadSize = "50M"
 const (
 	VirtLauncherMonitorOverhead = "25Mi" // The `ps` RSS for virt-launcher-monitor
 	VirtLauncherOverhead        = "75Mi" // The `ps` RSS for the virt-launcher process
-	VirtlogdOverhead            = "16Mi" // The `ps` RSS for virtlogd
+	VirtlogdOverhead            = "17Mi" // The `ps` RSS for virtlogd
 	LibvirtdOverhead            = "33Mi" // The `ps` RSS for libvirtd
 	QemuOverhead                = "30Mi" // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 )

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1647,8 +1647,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1223202661", "2223202661"),
-				Entry("on arm64", "arm64", "1357420389", "2357420389"),
+				Entry("on amd64", "amd64", "1224251237", "2224251237"),
+				Entry("on arm64", "arm64", "1358468965", "2358468965"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1683,8 +1683,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2223202661"),
-				Entry("on arm64", "arm64", "2357420389"),
+				Entry("on amd64", "amd64", "2224251237"),
+				Entry("on arm64", "arm64", "2358468965"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1721,8 +1721,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 303),
-				Entry("on arm64", "arm64", 437),
+				Entry("on amd64", "amd64", 304),
+				Entry("on arm64", "arm64", 438),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1757,12 +1757,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 303),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 303),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 286),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 437),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 437),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 420),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 304),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 304),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 287),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 438),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 438),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 421),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1950,10 +1950,10 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 222),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 222),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 356),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 356),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 223),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 223),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 357),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 357),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -2008,8 +2008,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
 			},
-				Entry("on amd64", "amd64", 222),
-				Entry("on arm64", "arm64", 356),
+				Entry("on amd64", "amd64", 223),
+				Entry("on arm64", "arm64", 357),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2991,20 +2991,20 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			By("Ensuring no process is using too much ram")
 			expected := resource.MustParse(services.VirtLauncherMonitorOverhead)
 			actual := processRss["virt-launcher-monitor"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virt-launcher-monitor process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virt-launcher-monitor process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
 			expected = resource.MustParse(services.VirtLauncherOverhead)
 			actual = processRss["virt-launcher"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the /usr/bin/virt-launcher process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the /usr/bin/virt-launcher process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
 			expected = resource.MustParse(services.VirtlogdOverhead)
 			actual = processRss["virtlogd"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virtlogd process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virtlogd process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
 			expected = resource.MustParse(services.LibvirtdOverhead)
 			actual = processRss["libvirtd"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the libvirtd process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the libvirtd process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
 			expected = resource.MustParse(services.QemuOverhead)
 			expected.Add(vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory])
 			actual = processRss["qemu-kvm"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the qemu-kvm process is taking too much RAM! (%s > %s)", actual.String(), expected.String())
+			Expect((&actual).Cmp(expected)).To(Equal(-1), "the qemu-kvm process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
 		})
 	})
 })

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -278,7 +278,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(339)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(340)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -2941,6 +2941,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 	Context("virt-launcher processes memory usage", func() {
+		doesntExceedMemoryUsage := func(processRss *map[string]resource.Quantity, process string, memoryLimit resource.Quantity) {
+			actual := (*processRss)[process]
+			ExpectWithOffset(1, (&actual).Cmp(memoryLimit)).To(Equal(-1),
+				"the %s process is taking too much RAM! (%s > %s). All processes: %v",
+				process, actual.String(), memoryLimit.String(), processRss)
+		}
 		It("should be lower than allocated size", func() {
 			By("Starting a VirtualMachineInstance")
 			vmi := tests.NewRandomFedoraVMI()
@@ -2989,22 +2995,13 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			}
 
 			By("Ensuring no process is using too much ram")
-			expected := resource.MustParse(services.VirtLauncherMonitorOverhead)
-			actual := processRss["virt-launcher-monitor"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virt-launcher-monitor process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
-			expected = resource.MustParse(services.VirtLauncherOverhead)
-			actual = processRss["virt-launcher"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the /usr/bin/virt-launcher process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
-			expected = resource.MustParse(services.VirtlogdOverhead)
-			actual = processRss["virtlogd"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the virtlogd process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
-			expected = resource.MustParse(services.LibvirtdOverhead)
-			actual = processRss["libvirtd"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the libvirtd process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
-			expected = resource.MustParse(services.QemuOverhead)
-			expected.Add(vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory])
-			actual = processRss["qemu-kvm"]
-			Expect((&actual).Cmp(expected)).To(Equal(-1), "the qemu-kvm process is taking too much RAM! (%s > %s). All processes: %v", actual.String(), expected.String(), processRss)
+			doesntExceedMemoryUsage(&processRss, "virt-launcher-monitor", resource.MustParse(services.VirtLauncherMonitorOverhead))
+			doesntExceedMemoryUsage(&processRss, "virt-launcher", resource.MustParse(services.VirtLauncherOverhead))
+			doesntExceedMemoryUsage(&processRss, "virtlogd", resource.MustParse(services.VirtlogdOverhead))
+			doesntExceedMemoryUsage(&processRss, "libvirtd", resource.MustParse(services.LibvirtdOverhead))
+			qemuExpected := resource.MustParse(services.QemuOverhead)
+			qemuExpected.Add(vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory])
+			doesntExceedMemoryUsage(&processRss, "qemu-kvm", qemuExpected)
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
On some environments, libvirtd was seen using more than 16Mi of memory, bumping by 1Mi.
Adding the memory usage of every process on functest failure will help updating these values in the future without having to run the test multiple times.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
