### PR TITLE
[release-0.49] Show migration progress timeout in actual seconds

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -67,8 +67,8 @@ type migrationMonitor struct {
 
 	start              int64
 	lastProgressUpdate int64
-	progressWatermark  int64
-	remainingData      int64
+	progressWatermark  uint64
+	remainingData      uint64
 
 	progressTimeout          int64
 	acceptableCompletionTime int64
@@ -586,8 +586,8 @@ func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager
 		vmi:                      vmi,
 		options:                  options,
 		migrationErr:             migrationErr,
-		progressWatermark:        int64(0),
-		remainingData:            int64(0),
+		progressWatermark:        0,
+		remainingData:            0,
 		progressTimeout:          options.ProgressTimeout,
 		acceptableCompletionTime: options.CompletionTimeoutPerGiB * getVMIMigrationDataSize(vmi),
 	}
@@ -630,9 +630,9 @@ func (m *migrationMonitor) isMigrationProgressing(domainSpec *api.DomainSpec) bo
 	now := time.Now().UTC().UnixNano()
 
 	// check if the migration is progressing
-	progressDelay := now - m.lastProgressUpdate
-	if m.progressTimeout != 0 && progressDelay/int64(time.Second) > m.progressTimeout {
-		logger.Warningf("Live migration stuck for %d sec", progressDelay)
+	progressDelay := (now - m.lastProgressUpdate) / int64(time.Second)
+	if m.progressTimeout != 0 && progressDelay > m.progressTimeout {
+		logger.Warningf("Live migration stuck for %d seconds", progressDelay)
 		return false
 	}
 
@@ -694,11 +694,10 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain) *inflight
 	now := time.Now().UTC().UnixNano()
 	elapsed := now - m.start
 
-	if (m.progressWatermark == 0) ||
-		(m.progressWatermark > m.remainingData) {
-		m.progressWatermark = m.remainingData
+	if (m.progressWatermark == 0) || (m.remainingData < m.progressWatermark) {
 		m.lastProgressUpdate = now
 	}
+	m.progressWatermark = m.remainingData
 
 	domainSpec, err := m.l.getDomainSpec(dom)
 	if err != nil {
@@ -743,7 +742,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain) *inflight
 
 		progressDelay := now - m.lastProgressUpdate
 		aborted := &inflightMigrationAborted{}
-		aborted.message = fmt.Sprintf("Live migration stuck for %d sec and has been aborted", progressDelay)
+		aborted.message = fmt.Sprintf("Live migration stuck for %d seconds and has been aborted", progressDelay/int64(time.Second))
 		aborted.abortStatus = v1.MigrationAbortSucceeded
 		return aborted
 	case m.shouldTriggerTimeout(elapsed, domainSpec):
@@ -759,7 +758,7 @@ func (m *migrationMonitor) processInflightMigration(dom cli.VirDomain) *inflight
 		}
 
 		aborted := &inflightMigrationAborted{}
-		aborted.message = fmt.Sprintf("Live migration is not completed after %d sec and has been aborted", m.acceptableCompletionTime)
+		aborted.message = fmt.Sprintf("Live migration is not completed after %d seconds and has been aborted", m.acceptableCompletionTime)
 		aborted.abortStatus = v1.MigrationAbortSucceeded
 		return aborted
 	}
@@ -824,7 +823,11 @@ func (m *migrationMonitor) startMonitor() {
 				continue
 			}
 		}
-		m.remainingData = int64(stats.DataRemaining)
+
+		if stats.DataRemainingSet {
+			m.remainingData = stats.DataRemaining
+		}
+
 		switch stats.Type {
 		case libvirt.DOMAIN_JOB_UNBOUNDED:
 			aborted := m.processInflightMigration(dom)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -975,8 +975,9 @@ var _ = Describe("Manager", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free().AnyTimes()
 			fake_jobinfo := &libvirt.DomainJobInfo{
-				Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-				DataRemaining: 32479827394,
+				Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+				DataRemaining:    32479827394,
+				DataRemainingSet: true,
 			}
 
 			options := &cmdclient.MigrationOptions{


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/7654

```release-note
NONE
```
