### PR TITLE
Fix root to nonroot migration

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1714,6 +1714,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(loginFunc(vmi)).To(Succeed())
 
+				vmi, err := ThisVMI(vmi)()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi.Annotations).To(HaveKey(v1.DeprecatedNonRootVMIAnnotation))
+
 				By("Deleting the VMI")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Launcher in versions v0.43-v0.51 recognizes VMI as nonroot
if kubevirt.io/nonroot annotation is present. Therefore
we need to mark the VMI with this annotation upon migration
to be able to seamlessly update from these versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Updates of the launcher with a version lower than v0.43 are not possible.


**Release note**:
```release-note
NONE
```
