### PR TITLE
kubectl_test: use the more succinct libvmi.NewCirros

### DIFF
--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -8,7 +8,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -156,9 +155,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 
 		Context("'kubectl get vmim'", func() {
 			It("print the expected columns and their corresponding values", func() {
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
-
+				vmi := libvmi.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
 				By("Starting the VirtualMachineInstance")
 				vmi = tests.RunVMIAndExpectLaunch(vmi, tests.MigrationWaitTime)
 


### PR DESCRIPTION
libvmi.NewCirros is preferable over the long tests.NewRandomVMIWithEphemeralDisk().

```release-note
NONE
```
