### PR TITLE
cgroup: Drop unused 'pid' argument

### DIFF
--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -77,7 +77,7 @@ func NewManagerFromPid(pid int) (manager Manager, err error) {
 	if runc_cgroups.IsCgroup2UnifiedMode() {
 		version = V2
 		slicePath := filepath.Join(cgroupBasePath, controllerPaths[""])
-		manager, err = newV2Manager(config, slicePath, isRootless, pid)
+		manager, err = newV2Manager(config, slicePath, isRootless)
 	} else {
 		version = V1
 		for subsystem, path := range controllerPaths {
@@ -87,7 +87,7 @@ func NewManagerFromPid(pid int) (manager Manager, err error) {
 			controllerPaths[subsystem] = filepath.Join("/", subsystem, path)
 		}
 
-		manager, err = newV1Manager(config, controllerPaths, isRootless, pid)
+		manager, err = newV1Manager(config, controllerPaths, isRootless)
 	}
 
 	if err != nil {

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -140,7 +140,7 @@ func newMockManagerFromCtrl(ctrl *gomock.Controller, version CgroupVersion) (*mo
 		nil,
 	}
 
-	execVirtChrootFunc := func(r *runc_configs.Resources, pid int, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error {
+	execVirtChrootFunc := func(r *runc_configs.Resources, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error {
 		mockV1.rulesDefined = r.Devices
 		return nil
 	}
@@ -152,9 +152,9 @@ func newMockManagerFromCtrl(ctrl *gomock.Controller, version CgroupVersion) (*mo
 	var err error
 
 	if version == V1 {
-		realManager, err = newCustomizedV1Manager(&runc_configs.Cgroup{}, nil, false, 123, execVirtChrootFunc, getCurrentlyDefinedRulesFunc)
+		realManager, err = newCustomizedV1Manager(&runc_configs.Cgroup{}, nil, false, execVirtChrootFunc, getCurrentlyDefinedRulesFunc)
 	} else {
-		realManager, err = newCustomizedV2Manager(&runc_configs.Cgroup{}, "fake/dir/path", false, 123, execVirtChrootFunc)
+		realManager, err = newCustomizedV2Manager(&runc_configs.Cgroup{}, "fake/dir/path", false, execVirtChrootFunc)
 	}
 
 	if err != nil {

--- a/pkg/virt-handler/cgroup/cgroup_v1_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v1_manager.go
@@ -17,23 +17,21 @@ import (
 
 type v1Manager struct {
 	runc_cgroups.Manager
-	pid                      int
 	controllerPaths          map[string]string
 	isRootless               bool
 	execVirtChroot           execVirtChrootFunc
 	getCurrentlyDefinedRules getCurrentlyDefinedRulesFunc
 }
 
-func newV1Manager(config *runc_configs.Cgroup, controllerPaths map[string]string, rootless bool, pid int) (Manager, error) {
-	return newCustomizedV1Manager(config, controllerPaths, rootless, pid, execVirtChrootCgroups, getCurrentlyDefinedRules)
+func newV1Manager(config *runc_configs.Cgroup, controllerPaths map[string]string, rootless bool) (Manager, error) {
+	return newCustomizedV1Manager(config, controllerPaths, rootless, execVirtChrootCgroups, getCurrentlyDefinedRules)
 }
 
-func newCustomizedV1Manager(config *runc_configs.Cgroup, controllerPaths map[string]string, rootless bool, pid int,
+func newCustomizedV1Manager(config *runc_configs.Cgroup, controllerPaths map[string]string, rootless bool,
 	execVirtChroot execVirtChrootFunc, getCurrentlyDefinedRules getCurrentlyDefinedRulesFunc) (Manager, error) {
 	runcManager := runc_fs.NewManager(config, controllerPaths, rootless)
 	manager := v1Manager{
 		runcManager,
-		pid,
 		controllerPaths,
 		rootless,
 		execVirtChroot,
@@ -71,7 +69,7 @@ func (v *v1Manager) Set(r *runc_configs.Resources) error {
 	log.Log.V(loggingVerbosity).Infof("Adding current rules to requested for cgroup %s. Rules added: %d", V1, len(requestedAndCurrentRules)-len(r.Devices))
 	resourcesToSet.Devices = requestedAndCurrentRules
 
-	err = v.execVirtChroot(&resourcesToSet, v.pid, v.controllerPaths, v.isRootless, v.GetCgroupVersion())
+	err = v.execVirtChroot(&resourcesToSet, v.controllerPaths, v.isRootless, v.GetCgroupVersion())
 
 	return err
 }

--- a/pkg/virt-handler/cgroup/cgroup_v2_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v2_manager.go
@@ -11,21 +11,19 @@ var rulesPerPid = make(map[string][]*devices.Rule)
 
 type v2Manager struct {
 	runc_cgroups.Manager
-	pid            int
 	dirPath        string
 	isRootless     bool
 	execVirtChroot execVirtChrootFunc
 }
 
-func newV2Manager(config *runc_configs.Cgroup, dirPath string, rootless bool, pid int) (Manager, error) {
-	return newCustomizedV2Manager(config, dirPath, rootless, pid, execVirtChrootCgroups)
+func newV2Manager(config *runc_configs.Cgroup, dirPath string, rootless bool) (Manager, error) {
+	return newCustomizedV2Manager(config, dirPath, rootless, execVirtChrootCgroups)
 }
 
-func newCustomizedV2Manager(config *runc_configs.Cgroup, dirPath string, rootless bool, pid int, execVirtChroot execVirtChrootFunc) (Manager, error) {
+func newCustomizedV2Manager(config *runc_configs.Cgroup, dirPath string, rootless bool, execVirtChroot execVirtChrootFunc) (Manager, error) {
 	runcManager, err := runc_fs.NewManager(config, dirPath, rootless)
 	manager := v2Manager{
 		runcManager,
-		pid,
 		dirPath,
 		rootless,
 		execVirtChroot,
@@ -52,7 +50,7 @@ func (v *v2Manager) Set(r *runc_configs.Resources) error {
 	rulesPerPid[v.dirPath] = rulesToSet
 	resourcesToSet.Devices = rulesToSet
 
-	err = v.execVirtChroot(&resourcesToSet, v.pid, map[string]string{"": v.dirPath}, v.isRootless, v.GetCgroupVersion())
+	err = v.execVirtChroot(&resourcesToSet, map[string]string{"": v.dirPath}, v.isRootless, v.GetCgroupVersion())
 	return err
 }
 

--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -40,7 +40,7 @@ var (
 	defaultDeviceRules []*devices.Rule
 )
 
-type execVirtChrootFunc func(r *runc_configs.Resources, pid int, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error
+type execVirtChrootFunc func(r *runc_configs.Resources, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error
 type getCurrentlyDefinedRulesFunc func(runcManager runc_cgroups.Manager) ([]*devices.Rule, error)
 
 // addCurrentRules gets a slice of rules as a parameter and returns a new slice that contains all given rules
@@ -155,7 +155,7 @@ func GenerateDefaultDeviceRules() []*devices.Rule {
 
 // execVirtChrootCgroups executes virt-chroot cgroups command to apply changes via virt-chroot.
 // This is needed since high privileges are needed and root is needed to change.
-func execVirtChrootCgroups(r *runc_configs.Resources, pid int, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error {
+func execVirtChrootCgroups(r *runc_configs.Resources, subsystemPaths map[string]string, rootless bool, version CgroupVersion) error {
 	marshalledRules, err := json.Marshal(*r)
 	if err != nil {
 		return fmt.Errorf("failed to marshall resources. err: %v resources: %+v", err, *r)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR removes an unused argument and struct field. Neither v1 nor v2 cgroup managers use the process id internally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Just a small cleanup. No functional changes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/cc @iholder-redhat 