### PR TITLE
Initialize properly libvirt.DomainJobInfo struct

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -673,8 +673,9 @@ func (m *migrationMonitor) determineNonRunningMigrationStatus(dom cli.VirDomain)
 		if isMigrationAbortInProgress(domainSpec) {
 			logger.Info("Migration job was canceled")
 			return &libvirt.DomainJobInfo{
-				Type:          libvirt.DOMAIN_JOB_CANCELLED,
-				DataRemaining: uint64(m.remainingData),
+				Type:             libvirt.DOMAIN_JOB_CANCELLED,
+				DataRemaining:    uint64(m.remainingData),
+				DataRemainingSet: true,
 			}
 		}
 
@@ -692,8 +693,9 @@ func (m *migrationMonitor) determineNonRunningMigrationStatus(dom cli.VirDomain)
 		if domainState == libvirt.DOMAIN_RUNNING {
 			logger.Info("Migration job failed")
 			return &libvirt.DomainJobInfo{
-				Type:          libvirt.DOMAIN_JOB_FAILED,
-				DataRemaining: uint64(m.remainingData),
+				Type:             libvirt.DOMAIN_JOB_FAILED,
+				DataRemaining:    uint64(m.remainingData),
+				DataRemainingSet: true,
 			}
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1023,8 +1023,9 @@ var _ = Describe("Manager", func() {
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				migrationData -= 125
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining: uint64(migrationData),
+					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+					DataRemaining:    uint64(migrationData),
+					DataRemainingSet: true,
 				}
 			}()
 
@@ -1076,8 +1077,9 @@ var _ = Describe("Manager", func() {
 
 				migrationData -= 125
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining: uint64(migrationData),
+					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+					DataRemaining:    uint64(migrationData),
+					DataRemainingSet: true,
 				}
 			}
 
@@ -1147,8 +1149,9 @@ var _ = Describe("Manager", func() {
 
 				migrationData -= 125
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining: uint64(migrationData),
+					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+					DataRemaining:    uint64(migrationData),
+					DataRemainingSet: true,
 				}
 			}
 
@@ -1270,8 +1273,9 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().AbortJob().MaxTimes(1)
 			migrationInProgress := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining: uint64(32479827394),
+					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+					DataRemaining:    uint64(32479827394),
+					DataRemainingSet: true,
 				}
 			}()
 			mockDomain.EXPECT().GetJobInfo().MaxTimes(1).Return(migrationInProgress, nil)
@@ -1333,8 +1337,9 @@ var _ = Describe("Manager", func() {
 			}()
 			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining: uint64(32479827777),
+					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+					DataRemaining:    uint64(32479827777),
+					DataRemainingSet: true,
 				}
 			}()
 
@@ -1408,8 +1413,9 @@ var _ = Describe("Manager", func() {
 			}()
 			fake_jobinfo_running := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_UNBOUNDED,
-					DataRemaining: uint64(32479827777),
+					Type:             libvirt.DOMAIN_JOB_UNBOUNDED,
+					DataRemaining:    uint64(32479827777),
+					DataRemainingSet: true,
 				}
 			}()
 
@@ -1497,8 +1503,9 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free().AnyTimes()
 			fake_jobinfo := func() *libvirt.DomainJobInfo {
 				return &libvirt.DomainJobInfo{
-					Type:          libvirt.DOMAIN_JOB_NONE,
-					DataRemaining: uint64(32479827394),
+					Type:             libvirt.DOMAIN_JOB_NONE,
+					DataRemaining:    uint64(32479827394),
+					DataRemainingSet: true,
 				}
 			}()
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

'DataRemainingSet' should be set to 'true' when 'DataRemaining' field
contains some meaningful value. This is checked in the live migration
processing code. The behaviour needs to be replicated in tests as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The checking of `DataRemainingSet` was introduced in https://github.com/kubevirt/kubevirt/pull/7654:

https://github.com/kubevirt/kubevirt/blob/3703b66c94ebac5558a4d22e50c90a0520bdec26/pkg/virt-launcher/virtwrap/live-migration-source.go#L850-L852

Since then I noticed that the unit tests in `pkg/virt-launcher/virtwrap/manager_test.go` were taking much longer to run (~180 secs vs. 30 secs before).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
