### PR TITLE
k8s reporter: Remove deprecated parts

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1068,7 +1068,7 @@ func (r *KubernetesReporter) executeNodeCommands(virtCli kubecli.KubevirtClient,
 		{command: networkPrefix + "nft list ruleset", fileNameSuffix: "nftlist"},
 
 		{command: hostPrefix + "/usr/bin/" + networkPrefix + "/usr/sbin/iptables --list -v", fileNameSuffix: "iptables"},
-		{command: "[ -e /dev/vfio ] && ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
+		{command: "ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}
 
 	r.executeContainerCommands(virtCli, logsdir, pod, virtHandlerName, cmds)
@@ -1083,7 +1083,7 @@ func (r *KubernetesReporter) executeVirtLauncherCommands(virtCli kubecli.Kubevir
 		{command: bridgeJVlanShow, fileNameSuffix: "brvlan"},
 		{command: bridgeFdb, fileNameSuffix: "brfdb"},
 		{command: "env", fileNameSuffix: "env"},
-		{command: "[ -e /dev/vfio ] && ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
+		{command: "ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}
 
 	r.executeContainerCommands(virtCli, logsdir, &pod, "compute", cmds)

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -55,11 +55,6 @@ const (
 )
 
 const (
-	sriovEntityURITemplate            = "/apis/sriovnetwork.openshift.io/v1/namespaces/%s/%s/"
-	sriovNetworksEntity               = "sriovnetworks"
-	sriovNodeNetworkPolicyEntity      = "sriovnetworknodepolicies"
-	sriovNodeStateEntity              = "sriovnetworknodestates"
-	sriovOperatorConfigsEntity        = "sriovoperatorconfigs"
 	k8sCNICNCFEntityURLTemplate       = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/%s/"
 	networkAttachmentDefinitionEntity = "network-attachment-definitions"
 )
@@ -168,8 +163,6 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logDomainXMLs(virtCli, vmis)
 
 	r.logVMIMs(virtCli, vmims)
-
-	r.logSRIOVInfo(virtCli)
 
 	r.logNodeCommands(virtCli, nodesWithVirtLauncher)
 	r.logVirtLauncherCommands(virtCli, networkPodsDir)
@@ -916,39 +909,6 @@ func (r *KubernetesReporter) logEvents(virtCli kubecli.KubevirtClient, since tim
 	}
 
 	r.logObjects(virtCli, eventsToPrint, "events")
-}
-
-func (r *KubernetesReporter) logSRIOVInfo(virtCli kubecli.KubevirtClient) {
-	sriovOutputDir := filepath.Join(r.artifactsDir, "sriov")
-	if err := os.MkdirAll(sriovOutputDir, 0777); err != nil {
-		fmt.Fprintf(os.Stderr, failedCreateDirectoryFmt, err)
-		return
-	}
-
-	r.logSRIOVNodeState(virtCli, sriovOutputDir)
-	r.logSRIOVNodeNetworkPolicies(virtCli, sriovOutputDir)
-	r.logSRIOVNetworks(virtCli, sriovOutputDir)
-	r.logSRIOVOperatorConfigs(virtCli, sriovOutputDir)
-}
-
-func (r *KubernetesReporter) logSRIOVNodeState(virtCli kubecli.KubevirtClient, outputFolder string) {
-	nodeStateLogPath := filepath.Join(outputFolder, fmt.Sprintf("%d_nodestate.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovNodeStateEntity, v1.NamespaceAll, sriovEntityURITemplate, nodeStateLogPath)
-}
-
-func (r *KubernetesReporter) logSRIOVNodeNetworkPolicies(virtCli kubecli.KubevirtClient, outputFolder string) {
-	nodeNetworkPolicyLogPath := filepath.Join(outputFolder, fmt.Sprintf("%d_nodenetworkpolicies.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovNodeNetworkPolicyEntity, v1.NamespaceAll, sriovEntityURITemplate, nodeNetworkPolicyLogPath)
-}
-
-func (r *KubernetesReporter) logSRIOVNetworks(virtCli kubecli.KubevirtClient, outputFolder string) {
-	networksPath := filepath.Join(outputFolder, fmt.Sprintf("%d_networks.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovNetworksEntity, v1.NamespaceAll, sriovEntityURITemplate, networksPath)
-}
-
-func (r *KubernetesReporter) logSRIOVOperatorConfigs(virtCli kubecli.KubevirtClient, outputFolder string) {
-	operatorConfigPath := filepath.Join(outputFolder, fmt.Sprintf("%d_operatorconfigs.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovOperatorConfigsEntity, v1.NamespaceAll, sriovEntityURITemplate, operatorConfigPath)
 }
 
 func (r *KubernetesReporter) logNetworkAttachmentDefinitionInfo(virtCli kubecli.KubevirtClient) {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1082,7 +1082,6 @@ func (r *KubernetesReporter) executeVirtLauncherCommands(virtCli kubecli.Kubevir
 		{command: ipNeighShow, fileNameSuffix: "ipneigh"},
 		{command: bridgeJVlanShow, fileNameSuffix: "brvlan"},
 		{command: bridgeFdb, fileNameSuffix: "brfdb"},
-		{command: "lspci", fileNameSuffix: "lspci"},
 		{command: "env", fileNameSuffix: "env"},
 		{command: "[ -e /dev/vfio ] && ls -lsh -Z -St /dev/vfio", fileNameSuffix: "vfio-devices"},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Maintenance of the k8s reporter:
1. Remove deprecated dumping of sriov operator that we don't use upstream anymore.
2. Remove virt-launcher lspci dumping because we don't have the binary anymore.
3. Update `ls /dev/vfio` commands to not fail due to splitting by spaces.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Fixes the errors written on https://github.com/kubevirt/kubevirt/issues/7170 description

**Release note**:
```release-note
None
```
