### PR TITLE
[CI Stabilization]: disableNodeLabeller() - use patch instead of update

### DIFF
--- a/pkg/util/nodes/BUILD.bazel
+++ b/pkg/util/nodes/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["nodes.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/util/nodes",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+    ],
+)

--- a/pkg/util/nodes/nodes.go
+++ b/pkg/util/nodes/nodes.go
@@ -1,0 +1,33 @@
+package nodes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+func PatchNode(client kubecli.KubevirtClient, original, modified *corev1.Node) error {
+	originalBytes, err := json.Marshal(original)
+	if err != nil {
+		return fmt.Errorf("could not serialize original object: %v", err)
+	}
+	modifiedBytes, err := json.Marshal(modified)
+	if err != nil {
+		return fmt.Errorf("could not serialize modified object: %v", err)
+	}
+	patch, err := strategicpatch.CreateTwoWayMergePatch(originalBytes, modifiedBytes, corev1.Node{})
+	if err != nil {
+		return fmt.Errorf("could not create merge patch: %v", err)
+	}
+	if _, err := client.CoreV1().Nodes().Patch(context.Background(), original.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("could not patch the node: %v", err)
+	}
+	return nil
+}

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/topology",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/nodes:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -20,9 +21,6 @@ go_library(
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnode",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/nodes:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to stabilize CI by making `disableNodeLabeller()` less flaky by using a patch instead of an update.

For more info, please have a look here: https://github.com/kubevirt/kubevirt/issues/7703.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
