### PR TITLE
non-root: use /var/run/kubevirt-private for cache and config files

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -154,16 +154,6 @@ pkg_tar(
     package_dir = "/etc",
 )
 
-pkg_tar(
-    name = "swtpm-localca-tar",
-    empty_dirs = [
-        "var/lib/swtpm-localca",
-        "run/var/lib/swtpm-localca",
-    ],
-    mode = "0750",
-    owner = "107.107",
-)
-
 container_image(
     name = "version-container",
     directory = "/",
@@ -173,14 +163,12 @@ container_image(
             ":libvirt-config",
             ":passwd-tar",
             ":nsswitch-tar",
-            ":swtpm-localca-tar",
             "//rpm:launcherbase_aarch64",
         ],
         "//conditions:default": [
             ":libvirt-config",
             ":passwd-tar",
             ":nsswitch-tar",
-            "swtpm-localca-tar",
             "//rpm:launcherbase_x86_64",
         ],
     }),

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1163,11 +1163,11 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		compute.Env = append(compute.Env,
 			k8sv1.EnvVar{
 				Name:  "XDG_CACHE_HOME",
-				Value: varRun,
+				Value: util.VirtPrivateDir,
 			},
 			k8sv1.EnvVar{
 				Name:  "XDG_CONFIG_HOME",
-				Value: varRun,
+				Value: util.VirtPrivateDir,
 			},
 			k8sv1.EnvVar{
 				Name:  "XDG_RUNTIME_DIR",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -38,7 +38,8 @@ const (
 	qemuConfPath        = "/etc/libvirt/qemu.conf"
 	libvirdConfPath     = "/etc/libvirt/libvirtd.conf"
 	libvirtRuntimePath  = "/var/run/libvirt"
-	qemuNonRootConfPath = libvirtRuntimePath + "/qemu.conf"
+	libvirtHomePath     = "/var/run/kubevirt-private/libvirt"
+	qemuNonRootConfPath = libvirtHomePath + "/qemu.conf"
 )
 
 var LifeCycleTranslationMap = map[libvirt.DomainState]api.LifeCycle{
@@ -493,6 +494,9 @@ func (l LibvirtWrapper) SetupLibvirt(customLogFilters *string) (err error) {
 	if !l.root() {
 		runtimeQemuConfPath = qemuNonRootConfPath
 
+		if err := os.MkdirAll(libvirtHomePath, 0755); err != nil {
+			return err
+		}
 		if err := copyFile(qemuConfPath, runtimeQemuConfPath); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Some processes require adding files to the root of XDG_CACHE_HOME/XDG_CONFIG_HOME.
We currently just use /var/run and assume the container user can write to it.
/var/run/kubevirt-private is a better place for that, since it is managed by k8s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
