### PR TITLE
fix perf test removing a deprecated parameter

### DIFF
--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -25,6 +25,7 @@ _prometheus_port_forward_pid=""
 trap "clean_up" EXIT SIGINT SIGTERM SIGQUIT
 clean_up() {
   kill -9 $_prometheus_port_forward_pid 2> /dev/null | exit 0
+  make cluster-clean
 }
 
 echo "Nodes are ready:"

--- a/hack/perfscale-tests.sh
+++ b/hack/perfscale-tests.sh
@@ -37,8 +37,6 @@ mkdir -p $ARTIFACTS
 
 function perftest() {
     _out/cmd/perfscale-load-generator/perfscale-load-generator \
-        -container-prefix ${DOCKER_PREFIX} \
-        -container-tag ${DOCKER_TAG} \
         -v 6 \
         -workload ${PERFSCALE_WORKLOAD}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The [performance tests](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-performance-cluster-scale-density-test&width=20) are failing after the introduction of the PR #7265.

The PR changed the`perfscale-load-generator` removing docker image parameters, but the `hack/perfscale-tests.sh` was not updated.

This PR is removing the deprecated parameter used in `hack/perfscale-tests.sh`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
