### PR TITLE
[wip] Fix units for the DirtyRate metrics

### DIFF
--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -216,7 +216,7 @@ func Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(info *libvirt.DomainJo
 		DataProcessed:    info.DataProcessed,
 		DataRemainingSet: info.DataRemainingSet,
 		DataRemaining:    info.DataRemaining,
-		MemDirtyRateSet:  info.MemDirtyRateSet,
-		MemDirtyRate:     info.MemDirtyRate,
+		MemDirtyRateSet:  info.MemDirtyRateSet && info.MemPageSizeSet,
+		MemDirtyRate:     info.MemDirtyRate * info.MemPageSize,
 	}
 }


### PR DESCRIPTION
Fix the units of the DirtyRate metrics in live-migration metrics.
Libvirt returns the rate in number of pages, not it bytes.

Signed-off-by: borod108 <boris.od@gmail.com>

```release-note
None
```