### PR TITLE
stop considering cpu node discovery feature gate

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1250,16 +1250,15 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		nodeSelector[k] = v
 
 	}
-	if t.clusterConfig.CPUNodeDiscoveryEnabled() {
-		if cpuModelLabel, err := CPUModelLabelFromCPUModel(vmi); err == nil {
-			if vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
-				nodeSelector[cpuModelLabel] = "true"
-			}
+	if cpuModelLabel, err := CPUModelLabelFromCPUModel(vmi); err == nil {
+		if vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+			nodeSelector[cpuModelLabel] = "true"
 		}
 		for _, cpuFeatureLable := range CPUFeatureLabelsFromCPUFeatures(vmi) {
 			nodeSelector[cpuFeatureLable] = "true"
 		}
 	}
+
 	if t.clusterConfig.HypervStrictCheckEnabled() {
 		hvNodeSelectors := getHypervNodeSelectors(vmi)
 		for k, v := range hvNodeSelectors {
@@ -1444,9 +1443,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		pod.Spec.Affinity = vmi.Spec.Affinity.DeepCopy()
 	}
 
-	if t.clusterConfig.CPUNodeDiscoveryEnabled() {
-		SetNodeAffinityForForbiddenFeaturePolicy(vmi, &pod)
-	}
+	SetNodeAffinityForForbiddenFeaturePolicy(vmi, &pod)
 
 	pod.Spec.Tolerations = vmi.Spec.Tolerations
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1132,8 +1132,7 @@ var _ = Describe("Template", func() {
 
 			It("should add node selector for node discovery feature to template", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
-				enableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
-
+				vmiCpuModel := "Conroe"
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -1146,7 +1145,7 @@ var _ = Describe("Template", func() {
 								DisableHotplug: true,
 							},
 							CPU: &v1.CPU{
-								Model: "Conroe",
+								Model: vmiCpuModel,
 								Features: []v1.CPUFeature{
 									{
 										Name:   "lahf_lm",
@@ -1169,8 +1168,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				cpuModelLabel, err := CPUModelLabelFromCPUModel(&vmi)
-				Expect(err).ToNot(HaveOccurred())
+				cpuModelLabel := NFD_CPU_MODEL_PREFIX + vmiCpuModel
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(cpuModelLabel, "true"))
 
 				cpuFeatureLabels := CPUFeatureLabelsFromCPUFeatures(&vmi)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1110,7 +1110,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				}
 
-				tests.EnableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
 				tests.EnableFeatureGate(virtconfig.HypervStrictCheckGate)
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If vmi starts with some cpuModel that isn't host-model/passthough a node selector must be added to virt-launcher otherwise
this could lead to failure when starting vmi on node that doesn't support the cpuModel in vmi.Spec.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
If CPUNodeDiscovery featureGate is disabled ( which it is by default :\ ) than vmi with some cpuModel might be scheduled to node that doesn't support this cpuModel.
To understand this bug you can create a vmi with Haswell cpuModel in kubevirt-ci, Haswell isn't supported but 
virt-launcher is being scheduled anyway and this is a bug because virt-launcher pod should contain node selector
to make sure that it is being scheduled to a node that support Haswell in that case.
We should not use this feature gate anymore.

**Special notes for your reviewer**:
I don't feel confidence to remove this featureGate from kubevirtCR entirely because of backward compatibility.
If you have an idea on how to to do that please let me know.
We need description policy
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
