### PR TITLE
Increase memory in upgrade test

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -974,7 +974,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 128M
       terminationGracePeriodSeconds: 0
       volumes:
       - dataVolume:


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently we upgraded cirros and alpine images to
new versions. These versions need more memory to
boot. Therefore we are doubling the memory from
64MiB to 128MiB.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
