### PR TITLE
virt-handler: add protection against migration double-starts

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1477,7 +1477,7 @@ func (d *VirtualMachineController) migrationOrphanedSourceNodeExecute(vmi *v1.Vi
 	return nil
 }
 
-func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachineInstance, vmiExists bool, domainExists bool) error {
+func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachineInstance, vmiExists bool, domain *api.Domain) error {
 
 	// set to true when preparation of migration target should be aborted.
 	shouldAbort := false
@@ -1501,6 +1501,7 @@ func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachine
 		shouldCleanUp = true
 	}
 
+	domainExists := domain != nil
 	if shouldAbort {
 		if domainExists {
 			err := d.processVmDelete(vmi)
@@ -1529,7 +1530,7 @@ func (d *VirtualMachineController) migrationTargetExecute(vmi *v1.VirtualMachine
 		log.Log.Object(vmi).Info("Processing vmi migration target update")
 
 		// prepare the POD for the migration
-		err := d.processVmUpdate(vmi, domainExists)
+		err := d.processVmUpdate(vmi, domain)
 		if err != nil {
 			return err
 		}
@@ -1730,7 +1731,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 		syncErr = d.processVmCleanup(vmi)
 	case shouldUpdate:
 		log.Log.Object(vmi).V(3).Info("Processing vmi update")
-		syncErr = d.processVmUpdate(vmi, domainExists)
+		syncErr = d.processVmUpdate(vmi, domain)
 	default:
 		log.Log.Object(vmi).V(3).Info("No update processing required")
 	}
@@ -1837,7 +1838,7 @@ func (d *VirtualMachineController) execute(key string) error {
 		// a different execute path. The target execute path prepares
 		// the local environment for the migration, but does not
 		// start the VMI
-		return d.migrationTargetExecute(vmi, vmiExists, domainExists)
+		return d.migrationTargetExecute(vmi, vmiExists, domain)
 	} else if vmiExists && d.isOrphanedMigrationSource(vmi) {
 		// 3. POST-MIGRATION SOURCE CLEANUP
 		//
@@ -2358,34 +2359,51 @@ func (d *VirtualMachineController) getLauncherClientInfo(vmi *v1.VirtualMachineI
 	return launcherInfo
 }
 
-func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.VirtualMachineInstance) error {
+func isMigrationInProgress(vmi *v1.VirtualMachineInstance, domain *api.Domain) bool {
+	var domainMigrationMetadata *api.MigrationMetadata
+
+	if domain == nil ||
+		vmi.Status.MigrationState == nil ||
+		domain.Spec.Metadata.KubeVirt.Migration == nil {
+		return false
+	}
+	domainMigrationMetadata = domain.Spec.Metadata.KubeVirt.Migration
+
+	if vmi.Status.MigrationState.MigrationUID == domainMigrationMetadata.UID &&
+		domainMigrationMetadata.StartTimestamp != nil {
+		return true
+	}
+	return false
+}
+
+func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.VirtualMachineInstance, domain *api.Domain) error {
+
 	client, err := d.getLauncherClient(origVMI)
 	if err != nil {
 		return fmt.Errorf(unableCreateVirtLauncherConnectionFmt, err)
 	}
 
-	vmi := origVMI.DeepCopy()
-
-	err = hostdisk.ReplacePVCByHostDisk(vmi)
-	if err != nil {
-		return err
-	}
-
-	err = d.handleSourceMigrationProxy(vmi)
-	if err != nil {
-		return fmt.Errorf("failed to handle migration proxy: %v", err)
-	}
-
-	if vmi.Status.MigrationState.AbortRequested {
-		if vmi.Status.MigrationState.AbortStatus != v1.MigrationAbortInProgress {
-			err = client.CancelVirtualMachineMigration(vmi)
+	if origVMI.Status.MigrationState.AbortRequested {
+		if origVMI.Status.MigrationState.AbortStatus != v1.MigrationAbortInProgress {
+			err = client.CancelVirtualMachineMigration(origVMI)
 			if err != nil {
 				return err
 			}
-			d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrating.String(), "VirtualMachineInstance is aborting migration.")
+			d.recorder.Event(origVMI, k8sv1.EventTypeNormal, v1.Migrating.String(), "VirtualMachineInstance is aborting migration.")
 		}
 	} else {
-		migrationConfiguration := vmi.Status.MigrationState.MigrationConfiguration
+		if isMigrationInProgress(origVMI, domain) {
+			// we already started this migration, no need to rerun this
+			log.DefaultLogger().Errorf("migration %s has already been started", origVMI.Status.MigrationState.MigrationUID)
+			return nil
+		}
+
+		err = d.handleSourceMigrationProxy(origVMI)
+		if err != nil {
+			return fmt.Errorf("failed to handle migration proxy: %v", err)
+		}
+
+		migrationConfiguration := origVMI.Status.MigrationState.MigrationConfiguration
 		if migrationConfiguration == nil {
 			migrationConfiguration = d.clusterConfig.GetMigrationConfiguration()
 		}
@@ -2401,9 +2419,15 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.Vir
 
 		marshalledOptions, err := json.Marshal(options)
 		if err != nil {
-			log.Log.Object(vmi).Warning("failed to marshall matched migration options")
+			log.Log.Object(origVMI).Warning("failed to marshall matched migration options")
 		} else {
-			log.Log.Object(vmi).Infof("migration options matched for vmi %s: %s", vmi.Name, string(marshalledOptions))
+			log.Log.Object(origVMI).Infof("migration options matched for vmi %s: %s", origVMI.Name, string(marshalledOptions))
+		}
+
+		vmi := origVMI.DeepCopy()
+		err = hostdisk.ReplacePVCByHostDisk(vmi)
+		if err != nil {
+			return err
 		}
 
 		err = client.MigrateVirtualMachine(vmi, options)
@@ -2699,7 +2723,7 @@ func (d *VirtualMachineController) getMemoryDump(vmi *v1.VirtualMachineInstance)
 	return nil
 }
 
-func (d *VirtualMachineController) processVmUpdate(vmi *v1.VirtualMachineInstance, domainExists bool) error {
+func (d *VirtualMachineController) processVmUpdate(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 
 	isUnresponsive, isInitialized, err := d.isLauncherClientUnresponsive(vmi)
 	if err != nil {
@@ -2717,9 +2741,9 @@ func (d *VirtualMachineController) processVmUpdate(vmi *v1.VirtualMachineInstanc
 	if d.isPreMigrationTarget(vmi) {
 		return d.vmUpdateHelperMigrationTarget(vmi)
 	} else if d.isMigrationSource(vmi) {
-		return d.vmUpdateHelperMigrationSource(vmi)
+		return d.vmUpdateHelperMigrationSource(vmi, domain)
 	} else {
-		return d.vmUpdateHelperDefault(vmi, domainExists)
+		return d.vmUpdateHelperDefault(vmi, domain != nil)
 	}
 }
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1847,6 +1847,44 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIMigrating)
 		})
 
+		It("should not try to migrate a vmi twice", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Running
+			vmi.Labels = make(map[string]string)
+			vmi.Status.NodeName = host
+			vmi.Labels[v1.MigrationTargetNodeNameLabel] = "othernode"
+			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
+			startTimestamp := metav1.Now()
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetNode:                     "othernode",
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     host,
+				MigrationUID:                   "123",
+				TargetDirectMigrationNodePorts: map[string]int{"49152": 12132},
+				StartTimestamp:                 &startTimestamp,
+			}
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+			}
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			mockWatchdog.CreateFile(vmi)
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Running
+			domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
+				StartTimestamp: &startTimestamp,
+				UID:            "123",
+			}
+			domainFeeder.Add(domain)
+			vmiFeeder.Add(vmi)
+			controller.Execute()
+		})
+
 		It("should abort vmi migration vmi when migration object indicates deletion", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID


### PR DESCRIPTION
We currently have no mechanism to protect us from executing
`MigrateVirtualMachine()` (which instructs virt-launcher to start
the migration) twice which has unfortunately happened on some
production clusters.

If this occurs virt-launcher detects the double-start and fails the
migration immediately after tearing down the migration proxies,
unfortunately in the logs this appears as a "network error"
(because the source virt-launcher cannot reach the target node
 anymore) even if it's clearly not a network error but rather
a migration abort.

This patch prevents this and adds a unit test.

Snippet from source virt-launcher:
    ```
    2022-04-26T20:49:10.291497895Z {"component":"virt-launcher","level":"error","msg":"error encountered copying data to outbound connection","outbound":"39d9b031-875d-4dd3-ab06-a61b96652007-49152-source.sock","pos":
    "migration-proxy.go:455","reason":"write unix @-\u003e/proc/275108/root/var/run/kubevirt/migrationproxy/39d9b031-875d-4dd3-ab06-a61b96652007-49152-source.sock: write: broken pipe","timestamp":"2022-04-26T20:49:10
    .291465Z","uid":"39d9b031-875d-4dd3-ab06-a61b96652007"}
    2022-04-26T20:49:10.291505864Z {"component":"virt-launcher","level":"info","msg":"0 bytes copied outbound to inbound","outbound":"39d9b031-875d-4dd3-ab06-a61b96652007-49152-source.sock","pos":"migration-proxy.go:
    442","timestamp":"2022-04-26T20:49:10.291459Z","uid":"39d9b031-875d-4dd3-ab06-a61b96652007"}
    2022-04-26T20:49:10.291576749Z {"component":"virt-launcher","level":"error","msg":"End of file while reading data: Input/output error","pos":"virNetSocketReadWire:1817","subcomponent":"libvirt","thread":"46","tim
    estamp":"2022-04-26T20:49:10.291000Z"}
    2022-04-26T20:49:10.291672988Z {"component":"virt-launcher","level":"error","msg":"operation failed: Lost connection to destination host","pos":"qemuMigrationAnyCompleted:1796","subcomponent":"libvirt","thread":"
    49","timestamp":"2022-04-26T20:49:10.291000Z"}
    ```

    Snippet from source virt-handler
    ```
    2022-04-26T20:49:10.268712108Z {"component":"virt-handler","kind":"","level":"error","msg":"Synchronizing the VirtualMachineInstance failed.","name":"dcnds0305062.dc.gs.com","namespace":"virtualmachines","pos":"v
    m.go:1751","reason":"server error. command Migrate failed: \"migration job already executed\"","timestamp":"2022-04-26T20:49:10.268661Z","uid":"39d9b031-875d-4dd3-ab06-a61b96652007"}
    2022-04-26T20:49:10.290861676Z {"component":"virt-handler","level":"info","msg":"re-enqueuing VirtualMachineInstance virtualmachines/dcnds0305062.dc.gs.com","pos":"vm.go:1408","reason":"server error. command Migr
    ate failed: \"migration job already executed\"","timestamp":"2022-04-26T20:49:10.290816Z"}

    ```

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent virt-handler from starting a migration twice
```
