### PR TITLE
builder: Clean up and reduce in size

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -3,14 +3,14 @@ FROM quay.io/centos/centos:stream8
 ARG SONOBUOY_ARCH
 ARG BAZEL_ARCH
 
-ENV BAZEL_VERSION 4.2.1
+ENV BAZEL_VERSION=4.2.1
 
-ENV KUBEVIRT_CREATE_BAZELRCS false
+ENV KUBEVIRT_CREATE_BAZELRCS=false
 
 # Install packages
 RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --enable powertools && \
-    dnf -y install \
+    dnf install -y \
         java-11-openjdk-devel \
         libvirt-devel \
         cpio \
@@ -37,7 +37,7 @@ RUN dnf install -y dnf-plugins-core && \
         wget \
         rubygems \
         diffutils && \
-    dnf -y clean all
+    dnf clean -y all
 
 # Avoids the need to install sssd-client by disabling lookups
 COPY nsswitch.conf /etc/nsswitch.conf
@@ -121,6 +121,7 @@ COPY entrypoint.sh /entrypoint.sh
 
 COPY create_bazel_cache_rcs.sh /create_bazel_cache_rcs.sh
 
-RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${BAZEL_ARCH} && chmod u+x /usr/bin/bazel
+RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${BAZEL_ARCH} && \
+    chmod u+x /usr/bin/bazel
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -5,6 +5,8 @@ ARG BAZEL_ARCH
 
 ENV BAZEL_VERSION=4.2.1
 ENV GIMME_GO_VERSION=1.17.8
+ENV GRADLE_VERSION=6.6
+ENV OPERATOR_COURIER_VERSION=2.1.11
 ENV SONOBUOY_VERSION=0.19.0
 
 ENV KUBEVIRT_CREATE_BAZELRCS=false
@@ -54,11 +56,11 @@ RUN gem install asciidoctor
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # install gradle (required for swagger)
-RUN wget https://services.gradle.org/distributions/gradle-6.6-bin.zip && \
+RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
     mkdir /opt/gradle && \
-    unzip -d /opt/gradle gradle-6.6-bin.zip
+    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip
 
-ENV PATH=$PATH:/opt/gradle/gradle-6.6/bin \
+ENV PATH=$PATH:/opt/gradle/gradle-${GRADLE_VERSION}/bin \
     JAVA_HOME=/usr/lib/jvm/java-11
 
 # reference to master is for an external repo and can't yet be changed
@@ -106,7 +108,7 @@ RUN set -x && \
     rm -rf /test-infra && \
     rm -rf /go && mkdir /go
 
-RUN pip3 install --upgrade operator-courier==2.1.11
+RUN pip3 install --upgrade operator-courier==${OPERATOR_COURIER_VERSION}
 
 RUN set -x && \
     wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz && \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -21,7 +21,6 @@ RUN dnf install -y dnf-plugins-core && \
         patch \
         make \
         git \
-        mercurial \
         sudo \
         gcc \
         gcc-c++ \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -57,7 +57,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # install gradle (required for swagger)
 RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
     mkdir /opt/gradle && \
-    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip
+    unzip -d /opt/gradle gradle-${GRADLE_VERSION}-bin.zip && \
+    rm gradle-${GRADLE_VERSION}-bin.zip
 
 ENV PATH=$PATH:/opt/gradle/gradle-${GRADLE_VERSION}/bin \
     JAVA_HOME=/usr/lib/jvm/java-11
@@ -113,7 +114,8 @@ RUN set -x && \
     wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz && \
     tar xvf sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz && \
     chmod +x sonobuoy && \
-    mv sonobuoy /usr/bin
+    mv sonobuoy /usr/bin && \
+    rm sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz
 
 COPY rsyncd.conf /etc/rsyncd.conf
 

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -14,7 +14,7 @@ ENV KUBEVIRT_CREATE_BAZELRCS=false
 # Install packages
 RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --enable powertools && \
-    dnf install -y \
+    dnf install -y --setopt=install_weak_deps=False \
         java-11-openjdk-devel \
         libvirt-devel \
         cpio \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -4,6 +4,8 @@ ARG SONOBUOY_ARCH
 ARG BAZEL_ARCH
 
 ENV BAZEL_VERSION=4.2.1
+ENV GIMME_GO_VERSION=1.17.8
+ENV SONOBUOY_VERSION=0.19.0
 
 ENV KUBEVIRT_CREATE_BAZELRCS=false
 
@@ -59,8 +61,6 @@ RUN wget https://services.gradle.org/distributions/gradle-6.6-bin.zip && \
 ENV PATH=$PATH:/opt/gradle/gradle-6.6/bin \
     JAVA_HOME=/usr/lib/jvm/java-11
 
-ENV GIMME_GO_VERSION=1.17.8
-
 # reference to master is for an external repo and can't yet be changed
 RUN mkdir -p /gimme && curl -sL \
     https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | \
@@ -108,7 +108,6 @@ RUN set -x && \
 
 RUN pip3 install --upgrade operator-courier==2.1.11
 
-ENV SONOBUOY_VERSION=0.19.0
 RUN set -x && \
     wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz && \
     tar xvf sonobuoy_${SONOBUOY_VERSION}_linux_${SONOBUOY_ARCH}.tar.gz && \

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -32,5 +32,4 @@ for ARCH in ${ARCHITECTURES}; do
     esac
     ${KUBEVIRT_CRI} pull --platform="linux/${ARCH}" quay.io/centos/centos:stream8
     ${KUBEVIRT_CRI} build --platform="linux/${ARCH}" -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
-    TMP_IMAGES="${TMP_IMAGES} quay.io/kubevirt/builder:${VERSION}-${ARCH}"
 done

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -21,10 +21,6 @@ for ARCH in ${ARCHITECTURES}; do
         sonobuoy_arch="amd64"
         bazel_arch="x86_64"
         ;;
-    arm64)
-        sonobuoy_arch="arm64"
-        bazel_arch="arm64"
-        ;;
     *)
         sonobuoy_arch=${ARCH}
         bazel_arch=${ARCH}


### PR DESCRIPTION
**What this PR does / why we need it**:

This reduces the number of packages included in the builder image and cleans up a few additional bits. The size goes from 2.19GB to 1.96GB, which is a solid 10% reduction. Some tweaks and cleanups not related to image size are also included.

**Special notes for your reviewer**:

I have used the updated builder image to build KubeVirt locally without running into any issues, so I'm fairly confident the packages that are no longer being included in the image were not really needed. It'd be great to have that conclusion double checked though :)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```