### PR TITLE
Fix double free of VirDomain object

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -313,7 +313,6 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 		stat.CPUMapSet = true
 
 		list = append(list, stat)
-		domStat.Domain.Free()
 	}
 
 	return list, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR fixes a double-free error.

Do not call Free() in the main function body. GetDomainStats already registers a defered routine to cleanup the domains.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I already have a PR addressing `Free()` calls in `virtwrap/manager` tests: https://github.com/kubevirt/kubevirt/pull/7700. This definitely needs to be covered by a unit-test so will try to add one there. Meanwhile submitting the fix.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
