### PR TITLE
Flaky test: pause on IO error

### DIFF
--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -78,7 +78,7 @@ func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) (stdout stri
 
 func CreateErrorDisk(nodeName string) (address string, device string) {
 	By("Creating error disk")
-	return CreateSCSIDisk(nodeName, []string{"opts=2", "every_nth=4"})
+	return CreateSCSIDisk(nodeName, []string{"opts=2", "every_nth=4", "dev_size_mb=8"})
 }
 
 // CreateSCSIDisk creates a SCSI disk using the scsi_debug module. This function should be used only to check SCSI disk functionalities and not for creating a filesystem or any data. The disk is stored in ram and it isn't suitable for storing large amount of data.
@@ -196,7 +196,7 @@ func CreatePVandPVCwithSCSIDisk(nodeName, devicePath, namespace, storageClass, p
 		return nil, nil, err
 	}
 
-	size := resource.MustParse("1Gi")
+	size := resource.MustParse("8Mi")
 	volumeMode := corev1.PersistentVolumeBlock
 
 	affinity := corev1.VolumeNodeAffinity{

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -138,17 +138,17 @@ var _ = SIGDescribe("Storage", func() {
 				tests.RemoveSCSIDisk(nodeName, address)
 			})
 
-			It("should pause VMI with error disk on IO error", func() {
+			It("should pause VMI on IO error", func() {
 				By("Creating VMI with faulty disk")
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi = tests.AddPVCDisk(vmi, "pvc-disk", v1.DiskBusVirtio, pvc.Name)
-				_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
 				tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)
 
 				By("Reading from disk")
-				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				Expect(console.LoginToAlpine(vmi)).To(Succeed(), "Should login")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -246,7 +246,7 @@ var _ = SIGDescribe("Storage", func() {
 							}
 						}
 						return false
-					}, 100*time.Second, time.Second).Should(BeTrue())
+					}, 100*time.Second, time.Second).Should(BeTrue(), "Should be paused")
 				err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR tries to find and fix the flakiness in one of the storage tests. 

- first commit - Make sure the actual vmi is used, and improve logging.
- second commit - fix the actual problem. 

The problem is that the test is using a virtual scsi device which randomly returns errors. The device sometimes fails during resize - before actually starting a VM. This is because kubevirt has `ExpandDisks` on, and the pvc has bigger size than the device. The fix creates the device and pvc with the same size so it does not need to be resized. 


```
{"component":"virt-launcher","level":"info","msg":"Domain name event: kubevirt-test-default3_testvmi-f9xqt","pos":"client.go:413","timestamp":"2022-05-19T10:13:31.756618Z"}
{"component":"virt-launcher","level":"error","msg":"internal error: unable to execute QEMU command 'block_resize': Cannot grow device files","pos":"qemuMonitorJSONCheckErrorFull:402","subcomponent":"libvirt","thread":"26","timestamp":"2022-05-19T10:13:31.757000Z"}
{"component":"virt-launcher","kind":"","level":"error","msg":"libvirt failed to expand disk image {disk  block {/dev/pvc-disk    pvc-disk \u003cnil\u003e} {virtio vdb }  0xc0007fa680 \u003cnil\u003e \u003cnil\u003e 0xc00082a5a0 \u003cnil\u003e \u003cnil\u003e \u003cnil\u003e virtio-non-transitional \u003cnil\u003e 0xc000316760 0xc0006ea700 true \u003cnil\u003e}","name":"testvmi-f9xqt","namespace":"kubevirt-test-default3","pos":"manager.go:957","reason":"virError(Code=1, Domain=10, Message='internal error: unable to execute QEMU command 'block_resize': Cannot grow device files')","timestamp":"2022-05-19T10:13:31.757366Z","uid":"063dddee-c169-4bc8-a39e-df9abc52bcc2"}
{"component":"virt-launcher","level":"info","msg":"kubevirt domain status: Paused(3):IOError(5)","pos":"client.go:288","timestamp":"2022-05-19T10:13:31.758798Z"}

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
This fails rarely, and when it fails it is always when trying to login to a VM for one test, and when checking the status for another. Maybe there is some kind of memory pressure or some problem with the parallel run. Below somple runs:

https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7465/pull-kubevirt-e2e-k8s-1.22-sig-storage/1523712386618363904

https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7465/pull-kubevirt-e2e-k8s-1.22-sig-storage/1523663268277653504

https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7699/pull-kubevirt-e2e-k8s-1.22-sig-storage/1522643157060161536

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
