### PR TITLE
Allow edit/admin user to create migration via virtctl

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -761,6 +761,7 @@ spec:
           - virtualmachines/restart
           - virtualmachines/addvolume
           - virtualmachines/removevolume
+          - virtualmachines/migrate
           verbs:
           - update
         - apiGroups:
@@ -861,6 +862,7 @@ spec:
           - virtualmachines/restart
           - virtualmachines/addvolume
           - virtualmachines/removevolume
+          - virtualmachines/migrate
           verbs:
           - update
         - apiGroups:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -663,6 +663,7 @@ rules:
   - virtualmachines/restart
   - virtualmachines/addvolume
   - virtualmachines/removevolume
+  - virtualmachines/migrate
   verbs:
   - update
 - apiGroups:
@@ -763,6 +764,7 @@ rules:
   - virtualmachines/restart
   - virtualmachines/addvolume
   - virtualmachines/removevolume
+  - virtualmachines/migrate
   verbs:
   - update
 - apiGroups:

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -176,6 +176,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					"virtualmachines/restart",
 					"virtualmachines/addvolume",
 					"virtualmachines/removevolume",
+					"virtualmachines/migrate",
 				},
 				Verbs: []string{
 					"update",
@@ -304,6 +305,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"virtualmachines/restart",
 					"virtualmachines/addvolume",
 					"virtualmachines/removevolume",
+					"virtualmachines/migrate",
 				},
 				Verbs: []string{
 					"update",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add `virtualmachines/migrate` resource to edit and admin clusterrole.
Edit and admin users are able to create a virtualmachineinstacemigration
posting a CR, but was not authorized using `virtctl migrate <vm-name>``
returning the error:
```
User <name> cannot update resource "virtualmachines/migrate"
in API group "subresources.kubevirt.io" in the namespace <namespace>
```
This happens because edit and admin user was not granted to make requests
to the subresource "virtualmachines/migrate" of "subresources.kubevirt.io"
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow `virtualmachines/migrate` subresource to admin/edit users
```
/cc @xpivarc @acardace 