### PR TITLE
tests: move GenerateRandomMac into the network package

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "dual_stack_cluster.go",
         "expose.go",
         "framework.go",
+        "mac.go",
         "macvtap.go",
         "networkpolicy.go",
         "port_forward.go",

--- a/tests/network/mac.go
+++ b/tests/network/mac.go
@@ -1,0 +1,16 @@
+package network
+
+import (
+	cryptorand "crypto/rand"
+	"net"
+)
+
+func GenerateRandomMac() (net.HardwareAddr, error) {
+	prefix := net.HardwareAddr{0x02, 0x00, 0x00} // local unicast prefix
+	suffix := make(net.HardwareAddr, 3)
+	_, err := cryptorand.Read(suffix)
+	if err != nil {
+		return nil, err
+	}
+	return append(prefix, suffix...), nil
+}

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -143,7 +143,7 @@ var _ = SIGDescribe("Macvtap", func() {
 			nodeList = libnode.GetAllSchedulableNodes(virtClient)
 			Expect(nodeList.Items).NotTo(BeEmpty(), "schedulable kubernetes nodes must be present")
 			nodeName = nodeList.Items[0].Name
-			chosenMACHW, err := tests.GenerateRandomMac()
+			chosenMACHW, err := GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 			chosenMAC = chosenMACHW.String()
 			serverCIDR := "192.0.2.102/24"
@@ -178,7 +178,7 @@ var _ = SIGDescribe("Macvtap", func() {
 		})
 
 		BeforeEach(func() {
-			macAddressHW, err := tests.GenerateRandomMac()
+			macAddressHW, err := GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 			macAddress := macAddressHW.String()
 			clientVMI, err = createAlpineVMIRandomNode(macvtapNetworkName, macAddress)
@@ -240,7 +240,7 @@ var _ = SIGDescribe("Macvtap", func() {
 			}
 
 			BeforeEach(func() {
-				macAddressHW, err := tests.GenerateRandomMac()
+				macAddressHW, err := GenerateRandomMac()
 				Expect(err).ToNot(HaveOccurred())
 				macAddress := macAddressHW.String()
 

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -171,10 +171,10 @@ var _ = Describe("[Serial]SRIOV", func() {
 			//
 			// This step is needed to guarantee that no VFs on the PF carry a duplicate MAC address that may affect
 			// ability of VMIs to send and receive ICMP packets on their ports.
-			mac1, err := tests.GenerateRandomMac()
+			mac1, err := GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 
-			mac2, err := tests.GenerateRandomMac()
+			mac2, err := GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 
 			// start peer machines with sriov interfaces from the same resource pool

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -602,11 +602,11 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 					bridgeSubnetMask     = "/24"
 				)
 
-				initialMacAddress, err := tests.GenerateRandomMac()
+				initialMacAddress, err := GenerateRandomMac()
 				Expect(err).NotTo(HaveOccurred())
 				initialMacAddressStr := initialMacAddress.String()
 
-				spoofedMacAddress, err := tests.GenerateRandomMac()
+				spoofedMacAddress, err := GenerateRandomMac()
 				Expect(err).NotTo(HaveOccurred())
 				spoofedMacAddressStr := spoofedMacAddress.String()
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3063,16 +3063,6 @@ func RetryIfModified(do func() error) (err error) {
 	return err
 }
 
-func GenerateRandomMac() (net.HardwareAddr, error) {
-	prefix := net.HardwareAddr{0x02, 0x00, 0x00} // local unicast prefix
-	suffix := make(net.HardwareAddr, 3)
-	_, err := cryptorand.Read(suffix)
-	if err != nil {
-		return nil, err
-	}
-	return append(prefix, suffix...), nil
-}
-
 func getCert(pod *k8sv1.Pod, port string) []byte {
 	randPort := strconv.Itoa(4321 + rand.Intn(6000))
 	var rawCert []byte


### PR DESCRIPTION
Let's make tests/utils.go shorter.

```release-note
NONE
```
