### PR TITLE
tests, libnet, cloudinit: Drop redundant slice init

### DIFF
--- a/tests/libnet/cloudinit.go
+++ b/tests/libnet/cloudinit.go
@@ -70,9 +70,6 @@ func WithEthernet(name string, options ...NetworkDataInterfaceOption) NetworkDat
 
 func WithAddresses(addresses ...string) NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		if networkDataInterface.Addresses == nil {
-			networkDataInterface.Addresses = []string{}
-		}
 		networkDataInterface.Addresses = append(networkDataInterface.Addresses, addresses...)
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When using slices, there is no need to initialize it before performing an append operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
