### PR TITLE
Optimize libnode's annotation/label modification functions + stabilize & fix migration functests

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1183,6 +1183,19 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			}
 		})
 
+		expectNodeLabels := func(nodeName string, labelValidation func(map[string]string) (valid bool, errorMsg string)) {
+			var errorMsg string
+
+			EventuallyWithOffset(1, func() (isValid bool) {
+				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				isValid, errorMsg = labelValidation(node.Labels)
+
+				return isValid
+			}, 30*time.Second, 2*time.Second).Should(BeTrue(), errorMsg)
+		}
+
 		Context("basic labelling", func() {
 			It("skip node reconciliation when node has skip annotation", func() {
 
@@ -1328,17 +1341,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				found := false
-				for key := range node.Labels {
-					if key == (v1.CPUModelLabel + obsoleteModel) {
-						found = true
-						break
-					}
-				}
-
-				Expect(found).To(Equal(false), "Node can't contain label "+v1.CPUModelLabel+obsoleteModel)
+				labelKeyExpectedToBeMissing := v1.CPUModelLabel + obsoleteModel
+				expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
+					_, exists := m[labelKeyExpectedToBeMissing]
+					return !exists, fmt.Sprintf("node %s is expected to not have label key %s", node.Name, labelKeyExpectedToBeMissing)
+				})
 			})
 
 			It("[test_id:6250] should update node with new cpu model vendor label", func() {
@@ -1365,10 +1372,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				kvConfig.MinCPUModel = minCPU
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(numberOfLabelsBeforeUpdate).ToNot(Equal(len(node.Labels)), "Node should have different number of labels")
+				expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
+					return len(m) != numberOfLabelsBeforeUpdate, fmt.Sprintf("node %s should have different number of labels", node.Name)
+				})
 			})
 
 			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", func() {
@@ -1389,19 +1395,19 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				kvConfig.ObsoleteCPUModels = obsoleteModels
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				found := false
-				label := ""
-				for key := range node.Labels {
-					if strings.Contains(key, v1.CPUModelLabel) || strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
-						found = true
-						label = key
-						break
+				expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
+					found := false
+					label := ""
+					for key := range m {
+						if strings.Contains(key, v1.CPUModelLabel) || strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
+							found = true
+							label = key
+							break
+						}
 					}
-				}
 
-				Expect(found).To(Equal(false), "Node can't contain any label "+label)
+					return !found, fmt.Sprintf("node %s should not contain any cpu model label, but contains %s", node.Name, label)
+				})
 			})
 		})
 
@@ -1480,26 +1486,41 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				kvConfig.ObsoleteCPUModels = map[string]bool{"486": true}
 				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 
-				time.Sleep(time.Second * 10)
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
+					foundSpecialLabel := false
 
-				foundSpecialLabel := false
-				for key := range node.Labels {
-					Expect(key).ToNot(ContainSubstring(nodelabellerutil.DeprecatedLabelNamespace+nodelabellerutil.DeprecatedcpuModelPrefix), "Node can't contain any label with prefix "+nodelabellerutil.DeprecatedLabelNamespace+nodelabellerutil.DeprecatedcpuModelPrefix)
-					Expect(key).ToNot(ContainSubstring(nodelabellerutil.DeprecatedLabelNamespace+nodelabellerutil.DeprecatedcpuFeaturePrefix), "Node can't contain any label with prefix "+nodelabellerutil.DeprecatedLabelNamespace+nodelabellerutil.DeprecatedcpuFeaturePrefix)
-					Expect(key).ToNot(ContainSubstring(nodelabellerutil.DeprecatedLabelNamespace+nodelabellerutil.DeprecatedHyperPrefix), "Node can't contain any label with prefix "+nodelabellerutil.DeprecatedLabelNamespace+nodelabellerutil.DeprecatedHyperPrefix)
+					for key := range m {
+						for _, deprecatedPrefix := range []string{nodelabellerutil.DeprecatedcpuModelPrefix, nodelabellerutil.DeprecatedcpuFeaturePrefix, nodelabellerutil.DeprecatedHyperPrefix} {
+							fullDeprecationLabel := nodelabellerutil.DeprecatedLabelNamespace + deprecatedPrefix
+							if strings.Contains(key, fullDeprecationLabel) {
+								return false, fmt.Sprintf("node %s should not contain any label with prefix %s", node.Name, fullDeprecationLabel)
+							}
+						}
 
-					if key == nfdLabel {
-						foundSpecialLabel = true
+						if key == nfdLabel {
+							foundSpecialLabel = true
+						}
 					}
-				}
-				Expect(foundSpecialLabel).To(Equal(true), "Labeller should not delete NFD labels")
 
-				for key := range node.Annotations {
-					Expect(key).ToNot(ContainSubstring(nodelabellerutil.DeprecatedLabellerNamespaceAnnotation), "Node can't contain any annotations with prefix "+nodelabellerutil.DeprecatedLabellerNamespaceAnnotation)
+					if !foundSpecialLabel {
+						return false, "labeller should not delete NFD labels"
+					}
 
-				}
+					return true, ""
+				})
+
+				Eventually(func() error {
+					node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					for key := range node.Annotations {
+						if strings.Contains(key, nodelabellerutil.DeprecatedLabellerNamespaceAnnotation) {
+							return fmt.Errorf("node %s shouldn't contain any annotations with prefix %s, but found annotation key %s", node.Name, nodelabellerutil.DeprecatedLabellerNamespaceAnnotation, key)
+						}
+					}
+
+					return nil
+				}, 30*time.Second, 2*time.Second).ShouldNot(HaveOccurred())
 			})
 
 		})

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnode",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/nodes:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -17,6 +17,7 @@ go_library(
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -22,9 +22,13 @@ package libnode
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"time"
 
-	"kubevirt.io/kubevirt/pkg/util/nodes"
+	utiltype "kubevirt.io/kubevirt/pkg/util/types"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	. "github.com/onsi/gomega"
 
@@ -122,56 +126,125 @@ func GetNodeDrainKey() string {
 	return virtconfig.NodeDrainTaintDefaultKey
 }
 
-func addLabelAnnotationHelper(nodeName, key, value string, isLabel bool) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
+type mapType string
 
-	origNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
+const (
+	label      mapType = "label"
+	annotation mapType = "annotation"
+)
 
-	newNode := origNode.DeepCopy()
-	if isLabel {
-		newNode.Labels[key] = value
-	} else {
-		newNode.Annotations[key] = value
+type mapAction string
+
+const (
+	add    mapAction = "add"
+	remove mapAction = "remove"
+)
+
+func patchLabelAnnotationHelper(virtCli kubecli.KubevirtClient, nodeName string, newMap, oldMap map[string]string, mapType mapType) (*k8sv1.Node, error) {
+	p := []utiltype.PatchOperation{
+		{
+			Op:    "test",
+			Path:  "/metadata/" + string(mapType) + "s",
+			Value: oldMap,
+		},
+		{
+			Op:    "replace",
+			Path:  "/metadata/" + string(mapType) + "s",
+			Value: newMap,
+		},
 	}
 
-	// This is done in an inefficient way since we can patch only labels/annotations here.
-	err = nodes.PatchNode(virtCli, origNode, newNode)
-	Expect(err).ShouldNot(HaveOccurred())
-}
-
-func AddLabelToNode(nodeName, key, value string) {
-	addLabelAnnotationHelper(nodeName, key, value, true)
-}
-
-func AddAnnotationToNode(nodeName, key, value string) {
-	addLabelAnnotationHelper(nodeName, key, value, false)
-}
-
-func RemoveLabelFromNode(nodeName string, key string) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util.PanicOnError(err)
-	node, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+	patchBytes, err := json.Marshal(p)
 	Expect(err).ToNot(HaveOccurred())
 
-	if _, exists := node.Labels[key]; !exists {
-		return
+	patchedNode, err := virtCli.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, patchBytes, k8smetav1.PatchOptions{})
+	return patchedNode, err
+}
+
+// Adds or removes a label or annotation from a node. When removing a label/annotation, the "value" parameter
+// is ignored.
+func addRemoveLabelAnnotationHelper(nodeName, key, value string, mapType mapType, mapAction mapAction) *k8sv1.Node {
+	var fetchMap func(node *k8sv1.Node) map[string]string
+	var mutateMap func(key, val string, m map[string]string) map[string]string
+
+	switch mapType {
+	case label:
+		fetchMap = func(node *k8sv1.Node) map[string]string { return node.Labels }
+	case annotation:
+		fetchMap = func(node *k8sv1.Node) map[string]string { return node.Annotations }
 	}
 
-	old, err := json.Marshal(node)
-	Expect(err).ToNot(HaveOccurred())
-	new := node.DeepCopy()
-	delete(new.Labels, key)
+	switch mapAction {
+	case add:
+		mutateMap = func(key, val string, m map[string]string) map[string]string {
+			m[key] = val
+			return m
+		}
+	case remove:
+		mutateMap = func(key, val string, m map[string]string) map[string]string {
+			delete(m, key)
+			return m
+		}
+	}
 
-	newJson, err := json.Marshal(new)
+	Expect(fetchMap).ToNot(BeNil())
+	Expect(mutateMap).ToNot(BeNil())
+
+	virtCli, err := kubecli.GetKubevirtClient()
 	Expect(err).ToNot(HaveOccurred())
 
-	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, node)
-	Expect(err).ToNot(HaveOccurred())
+	var nodeToReturn *k8sv1.Node
+	EventuallyWithOffset(2, func() error {
+		origNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
-	_, err = virtCli.CoreV1().Nodes().Patch(context.Background(), node.Name, types.StrategicMergePatchType, patch, k8smetav1.PatchOptions{})
-	Expect(err).ToNot(HaveOccurred())
+		originalMap := fetchMap(origNode)
+		expectedMap := make(map[string]string, len(originalMap))
+		for k, v := range originalMap {
+			expectedMap[k] = v
+		}
+
+		expectedMap = mutateMap(key, value, expectedMap)
+
+		if equality.Semantic.DeepEqual(originalMap, expectedMap) {
+			// key and value already exist in node
+			nodeToReturn = origNode
+			return nil
+		}
+
+		patchedNode, err := patchLabelAnnotationHelper(virtCli, nodeName, expectedMap, originalMap, mapType)
+		if err != nil {
+			return err
+		}
+
+		resultMap := fetchMap(patchedNode)
+
+		const errPattern = "adding %s (key: %s. value: %s) to node %s failed. Expected %ss: %v, actual: %v"
+		if !equality.Semantic.DeepEqual(resultMap, expectedMap) {
+			return fmt.Errorf(errPattern, string(mapType), key, value, nodeName, string(mapType), expectedMap, resultMap)
+		}
+
+		nodeToReturn = patchedNode
+		return nil
+	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+	return nodeToReturn
+}
+
+func AddLabelToNode(nodeName, key, value string) *k8sv1.Node {
+	return addRemoveLabelAnnotationHelper(nodeName, key, value, label, add)
+}
+
+func AddAnnotationToNode(nodeName, key, value string) *k8sv1.Node {
+	return addRemoveLabelAnnotationHelper(nodeName, key, value, annotation, add)
+}
+
+func RemoveLabelFromNode(nodeName string, key string) *k8sv1.Node {
+	return addRemoveLabelAnnotationHelper(nodeName, key, "", label, remove)
+}
+
+func RemoveAnnotationFromNode(nodeName string, key string) *k8sv1.Node {
+	return addRemoveLabelAnnotationHelper(nodeName, key, "", annotation, remove)
 }
 
 func Taint(nodeName string, key string, effect k8sv1.TaintEffect) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, libnode marshalls the whole node just to add a label/annotation. Then, it patches the whole node.
This is clearly wasteful, and with such a basic operation that could slow up our whole testing suite.

This PR avoids marshalling and patches only the labels / annotations in an efficient way. In addition, it adds support for label/annotation removal.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
