### PR TITLE
Add an alert for excessive migrations on a VMI

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -639,3 +639,49 @@ tests:
             value: 103706112
           - labels: 'kubevirt_vmi_memory_used_bytes{container="virt-handler", name="vm-example-2", namespace="default", node="node-1"}'
             value: 234329980
+
+  # Excessive VMI Migrations in a period of time
+  # Simulating metric resets at time slots 5 and 9
+  - interval: 1h
+    input_series:
+      - series: 'kubevirt_migrate_vmi_succeeded_total{vmi="vmi-example-1", source="node-1", target="node-2"}'
+        # time:  0 1 2 3 4 5 6 7 8 9 10 11 12 13
+        values: "_ 1 2 2 3 _ 1 2 2 _ _  1  2  3+0x13"        # 7 increases, in samples: 2,4,6,7,11,12,13
+      - series: 'kubevirt_migrate_vmi_succeeded_total{vmi="vmi-example-1", source="node-2", target="node-1"}'
+        # time:  0 1 2 3 4 5 6 7 8 9 10 11 12 13
+        values: "_ _ 1 2 2 _ _ 1 2 _ 1  2  2  2+0x13"        # 6 increases, in samples: 2,3,7,8,10,11
+
+    alert_rule_test:
+      # at 11h, there are total of 11 migrations made on a single VMI, so the alert should not be fired.
+      - eval_time: 11h
+        alertname: KubeVirtVMIExcessiveMigrations
+        exp_alerts: []
+      # at 16h, there are total of 13 migrations made on a single VMI, thus the alert is expected to be fired.
+      - eval_time: 16h
+        alertname: KubeVirtVMIExcessiveMigrations
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachineInstance vmi-example-1 has been migrated more than 12 times during the last 24 hours"
+              summary: "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              vmi: vmi-example-1
+      - eval_time: 24h
+        alertname: KubeVirtVMIExcessiveMigrations
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachineInstance vmi-example-1 has been migrated more than 12 times during the last 24 hours"
+              summary: "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              vmi: vmi-example-1
+      # since the first increase occurred in 2h, will need to evaluate at 26h to disregard the first increase and clear the alert.
+      - eval_time: 26h
+        alertname: KubeVirtVMIExcessiveMigrations
+        exp_alerts: []

--- a/pkg/monitoring/vmistats/collector.go
+++ b/pkg/monitoring/vmistats/collector.go
@@ -38,7 +38,7 @@ const none = "<none>"
 
 var (
 
-	// Preffixes used when transforming K8s metadata into metric labels
+	// Prefixes used when transforming K8s metadata into metric labels
 	annotationPrefix = "vm.kubevirt.io/"
 
 	// higher-level, telemetry-friendly metrics

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -546,18 +546,18 @@ func (c *VirtLauncherClient) GetDomainStats() (*stats.DomainStats, bool, error) 
 	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 	defer cancel()
 
-	domainStatsRespose, err := c.v1client.GetDomainStats(ctx, request)
+	domainStatsResponse, err := c.v1client.GetDomainStats(ctx, request)
 	var response *cmdv1.Response
-	if domainStatsRespose != nil {
-		response = domainStatsRespose.Response
+	if domainStatsResponse != nil {
+		response = domainStatsResponse.Response
 	}
 
 	if err = handleError(err, "GetDomainStats", response); err != nil {
 		return stats, exists, err
 	}
 
-	if domainStatsRespose.DomainStats != "" {
-		if err := json.Unmarshal([]byte(domainStatsRespose.DomainStats), stats); err != nil {
+	if domainStatsResponse.DomainStats != "" {
+		if err := json.Unmarshal([]byte(domainStatsResponse.DomainStats), stats); err != nil {
 			log.Log.Reason(err).Error("error unmarshalling domain")
 			return stats, exists, err
 		}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -585,15 +585,15 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 	// When a successful migration is detected, we must transfer ownership of the VMI
 	// from the source node (this node) to the target node (node the domain was migrated to).
 	//
-	// Transfer owership by...
-	// 1. Marking vmi.Status.MigationState as completed
+	// Transfer ownership by...
+	// 1. Marking vmi.Status.MigrationState as completed
 	// 2. Update the vmi.Status.NodeName to reflect the target node's name
 	// 3. Update the VMI's NodeNameLabel annotation to reflect the target node's name
 	// 4. Clear the LauncherContainerImageVersion which virt-controller will detect
 	//    and accurately based on the version used on the target pod
 	//
 	// After a migration, the VMI's phase is no longer owned by this node. Only the
-	// MigrationState status field is elgible to be mutated.
+	// MigrationState status field is eligible to be mutated.
 	migrationHost := ""
 	if vmi.Status.MigrationState != nil {
 		migrationHost = vmi.Status.MigrationState.TargetNode

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -486,6 +486,19 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Record: "kubevirt_vmsnapshot_disks_restored_from_source_bytes",
 						Expr:   intstr.FromString("sum by(vm_name, vm_namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes * on(persistentvolumeclaim, namespace) group_left(vm_name, vm_namespace) kubevirt_vmsnapshot_persistentvolumeclaim_labels)"),
 					},
+					{
+						Alert: "KubeVirtVMIExcessiveMigrations",
+						Expr:  intstr.FromString("floor(increase(sum by (vmi) (kubevirt_migrate_vmi_succeeded_total)[1d:1m])) >= 12"),
+						For:   "1m",
+						Annotations: map[string]string{
+							"description": "VirtualMachineInstance {{ $labels.vmi }} has been migrated more than 12 times during the last 24 hours",
+							"summary":     "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours.",
+							"runbook_url": runbookUrlBasePath + "KubeVirtVMIExcessiveMigrations",
+						},
+						Labels: map[string]string{
+							severityAlertLabelKey: "warning",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
If a VMI has been successfully migrated more than 12 times over a period of 24 hours, which is considerably higher than normal operation including an upgrade, an alert with a severity of `warning` is being fired.

Also, fixing some typos.

Signed-off-by: orenc1 <ocohen@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Excessive number of migrations on a single VMI over a period of time can suggest issues related to cluster configuration or available resources. Firing an alert if excessive migrations have been found on a VMI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
new alert for excessive number of VMI migrations in a period of time.
```
