### PR TITLE
test, Fail on namespace creation failure

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -260,7 +260,7 @@ func createNamespaces() {
 			},
 		}
 		_, err = virtCli.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
-		if !errors.IsAlreadyExists(err) {
+		if err != nil {
 			util.PanicOnError(err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if namespace creation returns AlreadyExist error then
test failure is skipped. Since this can cause scenarios where an
existing namespace has leftovers that can affect later tests,
Failing namespace creation on any non-nil error.

**Special notes for your reviewer**:
This issue was observed while examining [test-kubevirt-cnv-4.11-network-ocs](https://main-jenkins-csb-cnvqe.apps.ocp-c1.prod.psi.redhat.com/job/test-kubevirt-cnv-4.11-network-ocs/98/consoleFull) pipeline failing on namespaces still lingering from prior pipelines. As this PR won't solve the issue causing the namespace to delay deletion, we should fail the test in the first place it is observed, hence this PR

**Release note**:

```release-note
NONE
```
