### PR TITLE
Set `clusterIP` field for kubevirt-prometheus-metrics service to `None`

### DIFF
--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "apiservices_test.go",
         "components_suite_test.go",
         "crds_test.go",
+        "deployments_test.go",
         "secrets_test.go",
         "webhooks_test.go",
     ],

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -78,7 +78,8 @@ func NewPrometheusService(namespace string) *corev1.Service {
 					Protocol: corev1.ProtocolTCP,
 				},
 			},
-			Type: corev1.ServiceTypeClusterIP,
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
 		},
 	}
 }

--- a/pkg/virt-operator/resource/generate/components/deployments_test.go
+++ b/pkg/virt-operator/resource/generate/components/deployments_test.go
@@ -1,0 +1,16 @@
+package components
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Deployments", func() {
+	It("should create Prometheus service that is headless", func() {
+		service := NewPrometheusService("mynamespace")
+		Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+		Expect(service.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**: `kubevirt-prometheus-metrics` Service must be created with `ClusterIP` set to `None`. If not, we end up creating a LoadBalancer rule with endpoints equal to number of nodes in the cluster. If we have a 1000-node cluster, then we will have a LB rule with 1000 endpoints. For more info see: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Service `kubevirt-prometheus-metrics` now sets `ClusterIP` to `None` to make it a headless service.
```
