### PR TITLE
fixing MinCPUModel's field logic

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -68,12 +68,9 @@ func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []
 
 func (n *NodeLabeller) getSupportedCpuFeatures() cpuFeatures {
 	supportedCpuFeatures := make(cpuFeatures)
-	minCpuFeatures := n.getMinCpuFeature()
 
 	for _, feature := range n.supportedFeatures {
-		if _, exist := minCpuFeatures[feature]; !exist {
-			supportedCpuFeatures[feature] = true
-		}
+		supportedCpuFeatures[feature] = true
 	}
 
 	return supportedCpuFeatures
@@ -91,8 +88,6 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 	}
 
 	usableModels := make([]string, 0)
-	minCpuFeatures := n.getMinCpuFeature()
-	log.Log.Infof("CPU features of a minimum baseline CPU model: %+v", minCpuFeatures)
 	for _, mode := range hostDomCapabilities.CPU.Mode {
 		if mode.Name == v1.CPUModeHostModel {
 			n.cpuModelVendor = mode.Vendor.Name
@@ -106,7 +101,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 			n.hostCPUModel.fallback = hostCpuModel.Fallback
 
 			for _, feature := range mode.Feature {
-				if _, isMinCpuFeature := minCpuFeatures[feature.Name]; !isMinCpuFeature && feature.Policy == isRequired {
+				if feature.Policy == isRequired {
 					n.hostCPUModel.requiredFeatures[feature.Name] = true
 				}
 			}

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Node-labeller config", func() {
 
 		Expect(cpuModels).To(HaveLen(3), "number of models must match")
 
-		Expect(cpuFeatures).To(HaveLen(2), "number of features must match")
+		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(counter).ToNot(BeNil())
@@ -134,7 +134,7 @@ var _ = Describe("Node-labeller config", func() {
 
 		Expect(cpuModels).To(BeEmpty(), "no CPU models are expected to be supported")
 
-		Expect(cpuFeatures).To(HaveLen(2), "number of features doesn't match")
+		Expect(cpuFeatures).To(HaveLen(4), "number of features doesn't match")
 	})
 
 	Context("should return correct host cpu", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1294,14 +1294,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 			})
 
-			It("[test_id:6248] should set default min cpu model filter when min-cpu is not set in kubevirt config", func() {
-				node := nodesWithKVM[0]
-
-				for key := range node.Labels {
-					Expect(key).ToNot(Equal(v1.CPUFeatureLabel+"apic"), "Node can't contain label with apic feature (it is feature of default min cpu)")
-				}
-			})
-
 			It("[test_id:6995]should expose tsc frequency and tsc scalability", func() {
 				node := nodesWithKVM[0]
 				Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
@@ -1360,21 +1352,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 
 				Fail("No node contains label " + v1.CPUModelVendorLabel)
-			})
-
-			It("[test_id:6251] should update node with new cpu feature label set", func() {
-				node := nodesWithKVM[0]
-
-				numberOfLabelsBeforeUpdate := len(node.Labels)
-				minCPU := "Haswell"
-
-				kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
-				kvConfig.MinCPUModel = minCPU
-				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
-
-				expectNodeLabels(node.Name, func(m map[string]string) (valid bool, errorMsg string) {
-					return len(m) != numberOfLabelsBeforeUpdate, fmt.Sprintf("node %s should have different number of labels", node.Name)
-				})
 			})
 
 			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently if a source node has a Feature that is in MinCpuModel's features and a target node doesn't a migration to this node will fail and it will be very hard to understand why because the features in MinCpuModel don't appear in the node's labels.
There are two options to solve this:
1) stop considering MinCpuModel's field and maybe remove it completely
(might be a problem because of backward compatibility)
2) check if every node contain at least the MinCpuModel's features and mark it as unschedulable node if it doesn't.

In this PR i chose the first choice since the second choice will result unschedulable nodes.


Another problem with that field:
What if someone want to use node Affinity in the vmi for some feature that is one of the features of the MinCpuModel 
it's not possible because there aren't labels in the nodes for these features.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
