### PR TITLE
Create and delete the kubevirt-density namespace

### DIFF
--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -90,8 +90,13 @@ if [[ (${PERFAUDIT} == "true" || ${PERFAUDIT} == "True") && ${KUBEVIRT_PROVIDER}
   _prometheus_port_forward_pid=$1
 fi
 
+# Tests use the kubevirt-density namespace by default
+kubectl create ns kubevirt-density
+
 # Run performance tests
 ./hack/perfscale-tests.sh
 
 # Undeploy kubevirt from the cluster
 make cluster-clean
+
+kubectl delete ns kubevirt-density


### PR DESCRIPTION
**What this PR does / why we need it**:
The Periodic density test expects the user to create the test namespace.

```
{"component":"","level":"info","msg":"Running Load Generator","pos":"load-generator.go:36","timestamp":"2022-05-17T16:19:06.872610Z"}
{"component":"","level":"info","msg":"Burst Load Generator CreateWorkload","pos":"burst.go:71","timestamp":"2022-05-17T16:19:06.880683Z"}
{"component":"","level":"info","msg":"Replica 1 of 400","pos":"burst.go:83","timestamp":"2022-05-17T16:19:06.880727Z"}
{"component":"","level":"error","msg":"error creating obj VirtualMachineInstance: namespaces \"kubevirt-density\" not found","pos":"utils.go:41","timestamp":"2022-05-17T16:19:07.035660Z"}
{"component":"","level":"info","msg":"Replica 2 of 400","pos":"burst.go:83","timestamp":"2022-05-17T16:19:07.035727Z"}
{"component":"","level":"error","msg":"error creating obj VirtualMachineInstance: namespaces \"kubevirt-density\" not found","pos":"utils.go:41","timestamp":"2022-05-17T16:19:07.122152Z"}
{"component":"","level":"info","msg":"Replica 3 of 400","pos":"burst.go:83","timestamp":"2022-05-17T16:19:07.122213Z"} 
```

```release-note
NONE
```