### PR TITLE
The host-model cpuModel isn't usually fully supported in the nodes and we should take it into account

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -1553,7 +1553,7 @@ func (c *MigrationController) alertIfHostModelIsUnschedulable(vmi *virtv1.Virtua
 
 	requiredNodeLabels := map[string]string{}
 	for key, value := range targetPod.Spec.NodeSelector {
-		if strings.HasPrefix(key, virtv1.CPUModelLabel) || strings.HasPrefix(key, virtv1.CPUFeatureLabel) {
+		if strings.HasPrefix(key, virtv1.SupportedHostModelMigrationCPU) || strings.HasPrefix(key, virtv1.CPUFeatureLabel) {
 			requiredNodeLabels[key] = value
 		}
 	}
@@ -1586,7 +1586,7 @@ func prepareNodeSelectorForHostCpuModel(node *k8sv1.Node, pod *k8sv1.Pod, source
 
 	// if the vmi already migrated before it should include node selector that consider CPUModelLabel
 	for key, value := range sourcePod.Spec.NodeSelector {
-		if strings.Contains(key, virtv1.CPUFeatureLabel) || strings.Contains(key, virtv1.CPUModelLabel) {
+		if strings.Contains(key, virtv1.CPUFeatureLabel) || strings.Contains(key, virtv1.SupportedHostModelMigrationCPU) {
 			pod.Spec.NodeSelector[key] = value
 			migratedAtLeastOnce = true
 		}
@@ -1609,7 +1609,7 @@ func prepareNodeSelectorForHostCpuModel(node *k8sv1.Node, pod *k8sv1.Pod, source
 			return fmt.Errorf("node does not contain labal \"%s\" with information about host cpu model", virtv1.HostModelCPULabel)
 		}
 
-		nodeSelectorKeyForHostModel = virtv1.CPUModelLabel + hostCpuModel
+		nodeSelectorKeyForHostModel = virtv1.SupportedHostModelMigrationCPU + hostCpuModel
 		pod.Spec.NodeSelector[nodeSelectorKeyForHostModel] = hostModelLabelValue
 
 		log.Log.Object(pod).Infof("cpu model label selector (\"%s\") defined for migration target pod", nodeSelectorKeyForHostModel)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1312,6 +1312,7 @@ var _ = Describe("Migration watcher", func() {
 			if toDefineHostModelCPU {
 				node.ObjectMeta.Labels = map[string]string{
 					virtv1.HostModelCPULabel + "fake":              "true",
+					virtv1.SupportedHostModelMigrationCPU + "fake": "true",
 					virtv1.HostModelRequiredFeaturesLabel + "fake": "true",
 				}
 			}
@@ -1323,7 +1324,7 @@ var _ = Describe("Migration watcher", func() {
 			expectPodToHaveProperNodeSelector := func(pod *k8sv1.Pod) {
 				podHasCpuModeLabelSelector := false
 				for key, _ := range pod.Spec.NodeSelector {
-					if strings.Contains(key, virtv1.CPUModelLabel) {
+					if strings.Contains(key, virtv1.SupportedHostModelMigrationCPU) {
 						podHasCpuModeLabelSelector = true
 						break
 					}

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -49,10 +49,9 @@ func (n *NodeLabeller) getMinCpuFeature() cpuFeatures {
 	return n.cpuInfo.models[minCPUModel]
 }
 
-func (n *NodeLabeller) getSupportedCpuModels() []string {
+func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []string {
 	supportedCPUModels := make([]string, 0)
 
-	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
 	if obsoleteCPUsx86 == nil {
 		obsoleteCPUsx86 = util.DefaultObsoleteCPUModels
 	}
@@ -111,7 +110,6 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 					n.hostCPUModel.requiredFeatures[feature.Name] = true
 				}
 			}
-			usableModels = append(usableModels, hostCpuModel.Name)
 		}
 
 		for _, model := range mode.Model {

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(cpuModels).To(HaveLen(4), "number of models must match")
+		Expect(cpuModels).To(HaveLen(3), "number of models must match")
 
 		Expect(cpuFeatures).To(HaveLen(2), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()
@@ -131,7 +131,7 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(cpuModels).To(HaveLen(1), "number of models doesn't match")
+		Expect(cpuModels).To(BeEmpty(), "no CPU models are expected to be supported")
 
 		Expect(cpuFeatures).To(HaveLen(2), "number of features doesn't match")
 	})

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Node-labeller config", func() {
 		err = nlController.loadHostCapabilities()
 		Expect(err).ToNot(HaveOccurred())
 
-		cpuModels := nlController.getSupportedCpuModels()
+		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
 		Expect(cpuModels).To(HaveLen(4), "number of models must match")
@@ -128,7 +128,7 @@ var _ = Describe("Node-labeller config", func() {
 		err = nlController.loadCPUInfo()
 		Expect(err).ToNot(HaveOccurred())
 
-		cpuModels := nlController.getSupportedCpuModels()
+		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
 		Expect(cpuModels).To(HaveLen(1), "number of models doesn't match")

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -160,7 +160,8 @@ func (n *NodeLabeller) loadAll() error {
 }
 
 func (n *NodeLabeller) run() error {
-	cpuModels := n.getSupportedCpuModels()
+	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
+	cpuModels := n.getSupportedCpuModels(obsoleteCPUsx86)
 	cpuFeatures := n.getSupportedCpuFeatures()
 	hostCPUModel := n.GetHostCpuModel()
 
@@ -176,7 +177,7 @@ func (n *NodeLabeller) run() error {
 	}
 
 	//prepare new labels
-	newLabels := n.prepareLabels(cpuModels, cpuFeatures, hostCPUModel)
+	newLabels := n.prepareLabels(cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
 	//remove old labeller labels
 	n.removeLabellerLabels(node)
 	//add new labels
@@ -240,7 +241,7 @@ func (n *NodeLabeller) loadHypervFeatures() {
 
 // prepareLabels converts cpu models, features, hyperv features to map[string]string format
 // e.g. "cpu-feature.node.kubevirt.io/Penryn": "true"
-func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures, hostCpuModel hostCPUModel) map[string]string {
+func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures, hostCpuModel hostCPUModel, obsoleteCPUsx86 map[string]bool) map[string]string {
 	newLabels := make(map[string]string)
 	for key := range cpuFeatures {
 		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
@@ -248,6 +249,11 @@ func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures
 
 	for _, value := range cpuModels {
 		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
+		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+	}
+
+	if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
+		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
 	}
 
 	for _, key := range n.hypervFeatures.items {
@@ -303,6 +309,7 @@ func (n *NodeLabeller) removeLabellerLabels(node *v1.Node) {
 			strings.Contains(label, util.DeprecatedLabelNamespace+util.DeprecatedHyperPrefix) ||
 			strings.Contains(label, kubevirtv1.CPUFeatureLabel) ||
 			strings.Contains(label, kubevirtv1.CPUModelLabel) ||
+			strings.Contains(label, kubevirtv1.SupportedHostModelMigrationCPU) ||
 			strings.Contains(label, kubevirtv1.CPUTimerLabel) ||
 			strings.Contains(label, kubevirtv1.HypervLabel) ||
 			strings.Contains(label, kubevirtv1.RealtimeLabel) ||

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -778,8 +778,9 @@ const (
 	// This label represents supported cpu features on the node
 	CPUFeatureLabel = "cpu-feature.node.kubevirt.io/"
 	// This label represents supported cpu models on the node
-	CPUModelLabel = "cpu-model.node.kubevirt.io/"
-	CPUTimerLabel = "cpu-timer.node.kubevirt.io/"
+	CPUModelLabel                  = "cpu-model.node.kubevirt.io/"
+	SupportedHostModelMigrationCPU = "cpu-model-migration.node.kubevirt.io/"
+	CPUTimerLabel                  = "cpu-timer.node.kubevirt.io/"
 	// This label represents supported HyperV features on the node
 	HypervLabel = "hyperv.node.kubevirt.io/"
 	// This label represents vendor of cpu model on the node

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1408,6 +1408,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					if strings.Contains(key, v1.CPUModelLabel) {
 						obsoleteModels[strings.TrimPrefix(key, v1.CPUModelLabel)] = true
 					}
+					if strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
+						obsoleteModels[strings.TrimPrefix(key, v1.SupportedHostModelMigrationCPU)] = true
+					}
 				}
 
 				kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
@@ -1419,7 +1422,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				found := false
 				label := ""
 				for key := range node.Labels {
-					if strings.Contains(key, v1.CPUModelLabel) {
+					if strings.Contains(key, v1.CPUModelLabel) || strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
 						found = true
 						label = key
 						break

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2699,7 +2699,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectFeatureToBeSupportedOnNode(newNode, requiredFeatures)
 			})
 
-			Context("[Serial]Should trigger event", func() {
+			Context("[Serial]Should trigger event if vmi with host-model start on source node with uniq host-model", func() {
 
 				var originalNodeLabels map[string]string
 				var originalNodeAnnotations map[string]string
@@ -2760,6 +2760,89 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						labelValue, ok := node.Labels[v1.HostModelCPULabel+"fake-model"]
 						return ok && labelValue == "true"
 					}, 10*time.Second, 1*time.Second).Should(BeTrue(), "Node should have fake host model")
+
+					By("Starting the migration")
+					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+					_ = tests.RunMigration(virtClient, migration)
+
+					By("Expecting for an alert to be triggered")
+					Eventually(func() []k8sv1.Event {
+						events, err := virtClient.CoreV1().Events(vmi.Namespace).List(
+							context.Background(),
+							metav1.ListOptions{
+								FieldSelector: fmt.Sprintf("type=%s,reason=%s", k8sv1.EventTypeWarning, watch.NoSuitableNodesForHostModelMigration),
+							},
+						)
+						Expect(err).ToNot(HaveOccurred())
+
+						return events.Items
+					}, 30*time.Second, 1*time.Second).Should(HaveLen(1), "Exactly one alert is expected")
+				})
+
+			})
+
+			Context("[Serial]Should trigger event if the nodes doesn't contain MigrationSelectorLabel for the vmi host-model type", func() {
+
+				var originalNodeLabels []map[string]string
+				var originalNodeAnnotations []map[string]string
+				var vmi *v1.VirtualMachineInstance
+				var backupNodes []k8sv1.Node
+
+				BeforeEach(func() {
+					backupNodes = libnode.GetAllSchedulableNodes(virtClient).Items
+					if len(backupNodes) == 1 || len(backupNodes) > 10 {
+						Skip("This test can't run with single node and it's too slow to run with more than 10 nodes")
+					}
+					originalNodeLabels = make([]map[string]string, len(backupNodes))
+					originalNodeAnnotations = make([]map[string]string, len(backupNodes))
+					By("Creating a VMI with default CPU mode")
+					vmi = alpineVMIWithEvictionStrategy()
+					vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+
+					By("Starting the VirtualMachineInstance")
+					vmi = runVMIAndExpectLaunch(vmi, 240)
+
+					for indx, node := range backupNodes {
+						originalNodeLabels[indx] = copyMap(node.Labels)
+						originalNodeAnnotations[indx] = copyMap(node.Annotations)
+						disableNodeLabeller(&node, virtClient)
+					}
+				})
+
+				AfterEach(func() {
+					By("Restore node to its original state")
+					for indx, node := range backupNodes {
+						currNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+						currNode.Labels = originalNodeLabels[indx]
+						currNode.Annotations = originalNodeAnnotations[indx]
+						_, err = virtClient.CoreV1().Nodes().Update(context.Background(), currNode, metav1.UpdateOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+					}
+					for indx, node := range backupNodes {
+						var currNode *k8sv1.Node
+						Eventually(func() map[string]string {
+							currNode, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+							Expect(err).ShouldNot(HaveOccurred())
+							return currNode.Labels
+						}, 10*time.Second, 1*time.Second).Should(Equal(originalNodeLabels[indx]), "Node should have original labels")
+						Expect(currNode.Annotations).To(Equal(originalNodeAnnotations[indx]))
+					}
+
+				})
+
+				It(" no node contain suited SupportedHostModelMigrationCPU label", func() {
+					By("Changing node labels to support fake host model")
+					// Remove all supported host models
+					for _, node := range backupNodes {
+						currNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+						Expect(err).ShouldNot(HaveOccurred())
+						for key, _ := range currNode.Labels {
+							if strings.HasPrefix(key, v1.SupportedHostModelMigrationCPU) {
+								delete(currNode.Labels, key)
+							}
+						}
+					}
 
 					By("Starting the migration")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2689,7 +2689,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Ensuring that target pod has correct nodeSelector label")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(vmiPod.Spec.NodeSelector).To(HaveKey(v1.CPUModelLabel+hostModel),
+				Expect(vmiPod.Spec.NodeSelector).To(HaveKey(v1.SupportedHostModelMigrationCPU+hostModel),
 					"target pod is expected to have correct nodeSelector label defined")
 
 				By("Ensuring that target node has correct CPU mode & features")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3815,7 +3815,7 @@ func GetValidSourceNodeAndTargetNodeForHostModelMigration(virtCli kubecli.Kubevi
 			}
 			supportedInTarget := false
 			for key, _ := range potentialTargetNode.Labels {
-				if (strings.HasPrefix(key, v1.HostModelCPULabel) || strings.HasPrefix(key, v1.CPUModelLabel)) && strings.Contains(key, sourceHostCpuModel) {
+				if strings.HasPrefix(key, v1.SupportedHostModelMigrationCPU) && strings.Contains(key, sourceHostCpuModel) {
 					supportedInTarget = true
 					break
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently we threat host-model of a node as a supported cpuModel
because the node contains: `cpu-model.node.kubevirt.io/<host-model-name>: "true"` label
in order to run host-model libvirt has to disable some features that the node doesn't have
and if we define the cpuModels to be `<host-model-name>` of some node the vmi will fail.
In this case virt-launcher shouldn't had been scheduled at all because the node doesn't support all the 
<host-model-name> features.
    
In order to fix this we can define new set of labels (`migration-cpu-model.node.kubevirt.io/<model-name>`) just for migrations with   host-model because in migration we need selector that will allow us to migrate to one of the following:
- target node with the same host-model and all the required-features
- target node that support the source node's host-model as a supported model that has all the required features
    
these new labels will be used only when migrating a vm with host-model cpuModel.
As for the other cases we will use `cpu-model.node.kubevirt.io/<model-name>` always and in these cases we don't care about
the required features because these models are well defined(if node has this label it support all the model's features).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
how to reproduce :
deploy the following vm in kubevirt-ci cluster (use the host-model of the node as cpuModel):

```

—

apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  labels:
    kubevirt.io/vm: vm-masquerade
  name: vm-masquerade
spec:
  running: false
  template:
    metadata:
      labels:
        special: vmi-masquerade
      name: vmi-masquerade
    spec:
      domain:
        cpu:
          model: Cooperlake
        devices:
          disks:
          - disk:
              bus: virtio
            name: containerdisk
          - disk:
              bus: virtio
            name: cloudinitdisk
          interfaces:
          - masquerade: {}
            name: testmasquerade
            ports:
            - name: http
              port: 80
              protocol: TCP
          rng: {}
        resources:
          overcommitGuestOverhead: true
          requests:
            memory: 1Gi
      networks:
      - name: testmasquerade
        pod: {}
      terminationGracePeriodSeconds: 0
      volumes:
      - containerDisk:
          image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
        name: containerdisk
      - cloudInitNoCloud:
          networkData: |
            version: 2
            ethernets:
              eth0:
                addresses: [ fd10:0:2::2/120 ]
                dhcp4: true
                gateway6: fd10:0:2::1
          userData: |-
            #!/bin/bash
            echo "fedora" |passwd fedora --stdin
            yum install -y nginx
            systemctl enable --now nginx
        name: cloudinitdisk

```
after deploying this vm you will get libvirt's error that some features are missing .
virt-launcher should not be scheduled in that case.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
