### PR TITLE
virt-launcher: SELinux policy: cleanup the rules and add comments

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -26,14 +26,17 @@
     ;
     ;
     ; Allowing virt-launcher to read files under /proc
-    ; libvirtd seems to run fine without it, but it will trigger AVCs without the permission.
-    ; This could potentially be replaced by a dontaudit, here or upstream (better)
-    (allow process proc_type (file (getattr open read)))
+    ; This is needed by libvirt/qemu to read at least /proc/cpuinfo and /proc/uptime
+    ; The permission below already exists on container_t, but not on its parent attribute container_domain
+    ; This is therefore not blocking the switch to container_t
+    (allow process proc_type (file (open read)))
     ;
     ; Allowing libvirtd to relay network-related debug messages
     ; libvirtd seems to run fine without it.
     ; There is already a dontaudit covering it, removing the permission would not trigger AVCs.
     ; However, without this permission, there would be a lot of warnings poluting the logs.
+    ; The permission below already exists on container_t, but not on its parent attribute container_domain
+    ; This is therefore not blocking the switch to container_t
     (allow process self (netlink_audit_socket (nlmsg_relay)))
     ;
     ; Allowing tun sockets to be relabelled from "virt_launcher.process" to itself.
@@ -41,13 +44,14 @@
     ;   that triggers a relabelling, even if the label is already correct.
     ; "relabelfrom" and "relabelto" were added upstream and won't be necessary in the future.
     ; It is unclear if "attach_queue" is actually needed
+    ; The permission below already exists on container_t, but not on its parent attribute container_domain
+    ; This is therefore not blocking the switch to container_t
     (allow process self (tun_socket (relabelfrom relabelto attach_queue)))
     ;
     ; Allowing libvirtd to access the hugetlbfs to setup huge tables.
     ; Huge tables won't work without it, unless the memory backend is memfd.
-    ; The 2 following rules could be removed if memfd was the only supported memoty backend.
-    (allow process hugetlbfs_t (dir (add_name create write remove_name rmdir setattr)))
-    (allow process hugetlbfs_t (file (create unlink)))
+    ; The following rule could be removed if memfd was the only supported memoty backend.
+    (allow process hugetlbfs_t (dir (create rmdir setattr)))
     ;
     ; This is needed to allow virtiofs to mount filesystem and access NFS
     (allow process nfs_t (dir (mounton)))


### PR DESCRIPTION
**What this PR does / why we need it**:
The SELinux policy for virt-launcher extends`container_domain` from [container-selinux](https://github.com/containers/container-selinux).
Some of the custom rules we defined have been added upstream and don't need to be in the custom virt-launcher policy anymore.
This PR removes them.
Many of our custom rules are now also part of `container_t`, adding comments about those not blocking a potential switch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
These are the commands I use to check our rules against `container_domain`:
```
# sesearch -s container_domain -t proc_type -ds -dt -c file -p getattr,open,read --allow
allow container_domain proc_type:file getattr;

# sesearch -s container_domain -t container_domain -ds -dt -c netlink_audit_socket -p nlmsg_relay --allow

# sesearch -s container_domain -t container_domain -ds -dt -c tun_socket -p relabelfrom,relabelto,attach_queue --allow

# sesearch -s container_domain -t hugetlbfs_t -ds -dt -c dir -p add_name,create,write,remove_name,rmdir,setattr --allow
allow container_domain hugetlbfs_t:dir { add_name getattr ioctl lock open read remove_name search write };

# sesearch -s container_domain -t hugetlbfs_t -ds -dt -c file -p create,unlink --allow
allow container_domain hugetlbfs_t:file { append create execute execute_no_trans getattr ioctl link lock map open read rename setattr unlink write };

# sesearch -s container_domain -t nfs_t -ds -dt -c dir -p mounton --allow

# sesearch -s container_domain -t proc_t -ds -dt -c dir -p mounton --allow

# sesearch -s container_domain -t proc_t -ds -dt -c filesystem -p mount,unmount --allow

```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The SELinux policy for virt-launcher is down to 4 rules, 1 for hugepages and 3 for virtiofs.
KubeVirt depends on container-selinux version 2.170.0 or higher
```
