### PR TITLE
Rename `devises` to `devices`

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool.go
@@ -31,19 +31,19 @@ const (
 
 // NewPCIAddressPool creates a PCI address pool based on the provided list of host-devices and
 // the environment variables that describe the resource.
-func NewPCIAddressPool(hostDevises []v1.HostDevice) *hostdevice.AddressPool {
-	return hostdevice.NewAddressPool(pciResourcePrefix, extractResources(hostDevises))
+func NewPCIAddressPool(hostDevices []v1.HostDevice) *hostdevice.AddressPool {
+	return hostdevice.NewAddressPool(pciResourcePrefix, extractResources(hostDevices))
 }
 
 // NewMDEVAddressPool creates a MDEV address pool based on the provided list of host-devices and
 // the environment variables that describe the resource.
-func NewMDEVAddressPool(hostDevises []v1.HostDevice) *hostdevice.AddressPool {
-	return hostdevice.NewAddressPool(mdevResourcePrefix, extractResources(hostDevises))
+func NewMDEVAddressPool(hostDevices []v1.HostDevice) *hostdevice.AddressPool {
+	return hostdevice.NewAddressPool(mdevResourcePrefix, extractResources(hostDevices))
 }
 
-func extractResources(hostDevises []v1.HostDevice) []string {
+func extractResources(hostDevices []v1.HostDevice) []string {
 	var resourceSet = make(map[string]struct{})
-	for _, hostDevice := range hostDevises {
+	for _, hostDevice := range hostDevices {
 		resourceSet[hostDevice.DeviceName] = struct{}{}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: This MR fixes a typo `devises` -> `devices`.

**Special notes for your reviewer**: None

**Release note**:
```release-note
NONE
```
