### PR TITLE
Unify usage of PCI and MDev prefixes

### DIFF
--- a/pkg/virt-handler/device-manager/BUILD.bazel
+++ b/pkg/virt-handler/device-manager/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/device-manager/deviceplugin/v1beta1:go_default_library",
         "//pkg/virt-handler/virt-chroot:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/virt-handler/device-manager/mediated_device.go
+++ b/pkg/virt-handler/device-manager/mediated_device.go
@@ -33,13 +33,10 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/util"
 	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
-)
-
-const (
-	MDEV_RESOURCE_PREFIX = "MDEV_PCI_RESOURCE"
 )
 
 // Not a const for static test purposes
@@ -172,7 +169,7 @@ func (dpi *MediatedDevicePlugin) GetDeviceName() string {
 func (dpi *MediatedDevicePlugin) Allocate(_ context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
 	log.DefaultLogger().Infof("Allocate: resourceName: %s", dpi.resourceName)
 	log.DefaultLogger().Infof("Allocate: iommuMap: %v", dpi.iommuToMDEVMap)
-	resourceNameEnvVar := util.ResourceNameToEnvVar(MDEV_RESOURCE_PREFIX, dpi.resourceName)
+	resourceNameEnvVar := util.ResourceNameToEnvVar(v1.MDevResourcePrefix, dpi.resourceName)
 	log.DefaultLogger().Infof("Allocate: resourceNameEnvVar: %s", resourceNameEnvVar)
 	allocatedDevices := []string{}
 	resp := new(pluginapi.AllocateResponse)

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -33,16 +33,16 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/util"
 	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )
 
 const (
-	vfioDevicePath      = "/dev/vfio/"
-	vfioMount           = "/dev/vfio/vfio"
-	pciBasePath         = "/sys/bus/pci/devices"
-	PCI_RESOURCE_PREFIX = "PCI_RESOURCE"
+	vfioDevicePath = "/dev/vfio/"
+	vfioMount      = "/dev/vfio/vfio"
+	pciBasePath    = "/sys/bus/pci/devices"
 )
 
 type PCIDevice struct {
@@ -196,7 +196,7 @@ func (dpi *PCIDevicePlugin) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DeviceP
 }
 
 func (dpi *PCIDevicePlugin) Allocate(_ context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
-	resourceNameEnvVar := util.ResourceNameToEnvVar(PCI_RESOURCE_PREFIX, dpi.resourceName)
+	resourceNameEnvVar := util.ResourceNameToEnvVar(v1.PCIResourcePrefix, dpi.resourceName)
 	allocatedDevices := []string{}
 	resp := new(pluginapi.AllocateResponse)
 	containerResponse := new(pluginapi.ContainerAllocateResponse)

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2383,7 +2383,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		})
 
 		Context("check that migration is not supported when using Host Devices", func() {
-			envName := util.ResourceNameToEnvVar("PCI_RESOURCE", "dev1")
+			envName := util.ResourceNameToEnvVar(v1.PCIResourcePrefix, "dev1")
 
 			BeforeEach(func() {
 				_ = os.Setenv(envName, "0000:81:01.0")
@@ -2410,7 +2410,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			})
 
 			It("should not be allowed to live-migrate if the VMI uses PCI GPU", func() {
-				envName := util.ResourceNameToEnvVar("PCI_RESOURCE", "dev1")
+				envName := util.ResourceNameToEnvVar(v1.PCIResourcePrefix, "dev1")
 				_ = os.Setenv(envName, "0000:81:01.0")
 				defer func() {
 					_ = os.Unsetenv(envName)

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool.go
@@ -24,21 +24,16 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 
-const (
-	pciResourcePrefix  = "PCI_RESOURCE"
-	mdevResourcePrefix = "MDEV_PCI_RESOURCE"
-)
-
 // NewPCIAddressPool creates a PCI address pool based on the provided list of host-devices and
 // the environment variables that describe the resource.
 func NewPCIAddressPool(hostDevices []v1.HostDevice) *hostdevice.AddressPool {
-	return hostdevice.NewAddressPool(pciResourcePrefix, extractResources(hostDevices))
+	return hostdevice.NewAddressPool(v1.PCIResourcePrefix, extractResources(hostDevices))
 }
 
 // NewMDEVAddressPool creates a MDEV address pool based on the provided list of host-devices and
 // the environment variables that describe the resource.
 func NewMDEVAddressPool(hostDevices []v1.HostDevice) *hostdevice.AddressPool {
-	return hostdevice.NewAddressPool(mdevResourcePrefix, extractResources(hostDevices))
+	return hostdevice.NewAddressPool(v1.MDevResourcePrefix, extractResources(hostDevices))
 }
 
 func extractResources(hostDevices []v1.HostDevice) []string {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool_test.go
@@ -37,9 +37,6 @@ type envData struct {
 }
 
 const (
-	pciResourcePrefix  = "PCI_RESOURCE"
-	mdevResourcePrefix = "MDEV_PCI_RESOURCE"
-
 	hostdevName0 = "hostdev_name0"
 	hostdevName1 = "hostdev_name1"
 
@@ -91,8 +88,8 @@ var _ = Describe("Generic Address Pool", func() {
 				Expect(pool.Pop(hostdevResource0)).To(Equal(address1))
 			})
 		},
-		Entry("PCI", generic.NewPCIAddressPool, pciResourcePrefix, hostdevPCIAddress0, hostdevPCIAddress1),
-		Entry("MDEV", generic.NewMDEVAddressPool, mdevResourcePrefix, hostdevMDEVAddress0, hostdevMDEVAddress1),
+		Entry("PCI", generic.NewPCIAddressPool, v1.PCIResourcePrefix, hostdevPCIAddress0, hostdevPCIAddress1),
+		Entry("MDEV", generic.NewMDEVAddressPool, v1.MDevResourcePrefix, hostdevMDEVAddress0, hostdevMDEVAddress1),
 	)
 
 	DescribeTable("succeeds to pop 2 addresses from two resources",
@@ -111,8 +108,8 @@ var _ = Describe("Generic Address Pool", func() {
 				Expect(pool.Pop(hostdevResource1)).To(Equal(address1))
 			})
 		},
-		Entry("PCI", generic.NewPCIAddressPool, pciResourcePrefix, hostdevPCIAddress0, hostdevPCIAddress1),
-		Entry("MDEV", generic.NewMDEVAddressPool, mdevResourcePrefix, hostdevMDEVAddress0, hostdevMDEVAddress1),
+		Entry("PCI", generic.NewPCIAddressPool, v1.PCIResourcePrefix, hostdevPCIAddress0, hostdevPCIAddress1),
+		Entry("MDEV", generic.NewMDEVAddressPool, v1.MDevResourcePrefix, hostdevMDEVAddress0, hostdevMDEVAddress1),
 	)
 })
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool.go
@@ -24,21 +24,16 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 
-const (
-	pciResourcePrefix  = "PCI_RESOURCE"
-	mdevResourcePrefix = "MDEV_PCI_RESOURCE"
-)
-
 // NewPCIAddressPool creates a PCI address pool based on the provided list of host-devices and
 // the environment variables that describe the resource.
 func NewPCIAddressPool(gpuDevices []v1.GPU) *hostdevice.AddressPool {
-	return hostdevice.NewAddressPool(pciResourcePrefix, extractResources(gpuDevices))
+	return hostdevice.NewAddressPool(v1.PCIResourcePrefix, extractResources(gpuDevices))
 }
 
 // NewMDEVAddressPool creates a MDEV address pool based on the provided list of host-devices and
 // the environment variables that describe the resource.
 func NewMDEVAddressPool(gpuDevices []v1.GPU) *hostdevice.AddressPool {
-	return hostdevice.NewAddressPool(mdevResourcePrefix, extractResources(gpuDevices))
+	return hostdevice.NewAddressPool(v1.MDevResourcePrefix, extractResources(gpuDevices))
 }
 
 func extractResources(gpuDevices []v1.GPU) []string {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool_test.go
@@ -37,9 +37,6 @@ type envData struct {
 }
 
 const (
-	pciResourcePrefix  = "PCI_RESOURCE"
-	mdevResourcePrefix = "MDEV_PCI_RESOURCE"
-
 	gpuName0 = "gpu_name0"
 	gpuName1 = "gpu_name1"
 
@@ -91,8 +88,8 @@ var _ = Describe("GPU Address Pool", func() {
 				Expect(pool.Pop(gpuResource0)).To(Equal(address1))
 			})
 		},
-		Entry("PCI", gpu.NewPCIAddressPool, pciResourcePrefix, gpuPCIAddress0, gpuPCIAddress1),
-		Entry("MDEV", gpu.NewMDEVAddressPool, mdevResourcePrefix, gpuMDEVAddress0, gpuMDEVAddress1),
+		Entry("PCI", gpu.NewPCIAddressPool, v1.PCIResourcePrefix, gpuPCIAddress0, gpuPCIAddress1),
+		Entry("MDEV", gpu.NewMDEVAddressPool, v1.MDevResourcePrefix, gpuMDEVAddress0, gpuMDEVAddress1),
 	)
 
 	DescribeTable("succeeds to pop 2 addresses from two resources",
@@ -111,8 +108,8 @@ var _ = Describe("GPU Address Pool", func() {
 				Expect(pool.Pop(gpuResource1)).To(Equal(address1))
 			})
 		},
-		Entry("PCI", gpu.NewPCIAddressPool, pciResourcePrefix, gpuPCIAddress0, gpuPCIAddress1),
-		Entry("MDEV", gpu.NewMDEVAddressPool, mdevResourcePrefix, gpuMDEVAddress0, gpuMDEVAddress1),
+		Entry("PCI", gpu.NewPCIAddressPool, v1.PCIResourcePrefix, gpuPCIAddress0, gpuPCIAddress1),
+		Entry("MDEV", gpu.NewMDEVAddressPool, v1.MDevResourcePrefix, gpuMDEVAddress0, gpuMDEVAddress1),
 	)
 })
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -89,11 +89,6 @@ const (
 	failedDomainMemoryDump = "Domain memory dump failed"
 )
 
-const (
-	PCI_RESOURCE_PREFIX  = "PCI_RESOURCE"
-	MDEV_RESOURCE_PREFIX = "MDEV_PCI_RESOURCE"
-)
-
 const maxConcurrentHotplugHostDevices = 1
 const maxConcurrentMemoryDumps = 1
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2212,6 +2212,11 @@ type LogVerbosity struct {
 	NodeVerbosity map[string]uint `json:"nodeVerbosity,omitempty"`
 }
 
+const (
+	PCIResourcePrefix  = "PCI_RESOURCE"
+	MDevResourcePrefix = "MDEV_PCI_RESOURCE"
+)
+
 // PermittedHostDevices holds information about devices allowed for passthrough
 type PermittedHostDevices struct {
 	// +listType=atomic


### PR DESCRIPTION
**What this PR does / why we need it**: We have been using `PCI_RESOURCE`  and `MDEV_PCI_RESOURCE` constant in different places. This MR unifies usage.

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
