### PR TITLE
Remove unused `HostDeviceList` struct

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -65,15 +65,11 @@ import (
 
 const deviceTypeNotCompatibleFmt = "device %s is of type lun. Not compatible with a file based disk"
 
-type HostDeviceType string
-
 // The location of uefi boot loader on ARM64 is different from that on x86
 const (
-	defaultIOThread                 = uint(1)
-	HostDevicePCI    HostDeviceType = "pci"
-	HostDeviceMDEV   HostDeviceType = "mdev"
-	resolvConf                      = "/etc/resolv.conf"
-	SEVPolicyNoDebug                = "0x1"
+	defaultIOThread  = uint(1)
+	resolvConf       = "/etc/resolv.conf"
+	SEVPolicyNoDebug = "0x1"
 )
 
 const (
@@ -84,11 +80,6 @@ const (
 type deviceNamer struct {
 	existingNameMap map[string]string
 	usedDeviceMap   map[string]string
-}
-
-type HostDevicesList struct {
-	Type     HostDeviceType
-	AddrList []string
 }
 
 type EFIConfiguration struct {


### PR DESCRIPTION
**What this PR does / why we need it**: `HostDeviceList` is unused anywhere and should be removed. This is something that I've noticed during refactor in https://github.com/kubevirt/kubevirt/pull/7786

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
