### PR TITLE
[release-0.41]Post copy 4747 fix

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1351,6 +1351,9 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				config := defaultKVConfig()
 				config.MigrationConfiguration.AllowPostCopy = pointer.BoolPtr(true)
 				config.MigrationConfiguration.CompletionTimeoutPerGiB = pointer.Int64Ptr(1)
+
+				bwLimit := resource.MustParse("40Mi")
+				config.MigrationConfiguration.BandwidthPerMigration = &bwLimit
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
@@ -1365,7 +1368,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				tests.WaitAgentConnected(virtClient, vmi)
 
-				runStressTest(vmi, "800", stressdefaultTimeout)
+				runStressTest(vmi, "400", stressdefaultTimeout)
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")


### PR DESCRIPTION
**What this PR does / why we need it**:
Using stress to delay migration showed to be not reliable.
We have often seen that stress fails because it doesn't
have enough memory available. Limiting bandwidth seems to
work just fine.

This commit also reduces the memory consumption to 400(from 800)
which showed to be enough.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
NONE
```
