### PR TITLE
Add an infra label to each of kubevirt alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -24,6 +24,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-controller-8546c99968-x9jgg"
@@ -50,6 +51,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedMemory"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: ci
@@ -88,6 +90,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 10m
@@ -98,6 +101,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 10m
@@ -108,6 +112,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       # it must trigger when operators are not healthy
@@ -119,6 +124,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 16m
@@ -129,6 +135,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 16m
@@ -139,6 +146,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       # it must not trigger when operators are healthy
@@ -178,6 +186,7 @@ tests:
               node: "node01"
               pod: "virt-handler-asdf"
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -202,6 +211,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtControllersCount"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -224,6 +234,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
    # All virt controllers are not ready (ImagePullBackOff)
@@ -245,6 +256,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -267,6 +279,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -289,6 +302,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -329,6 +343,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 20m
@@ -339,6 +354,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 20m
@@ -349,6 +365,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 20m
@@ -358,6 +375,7 @@ tests:
               summary: "More than 80% of the rest calls failed in virt-api for the last 5 minutes"
             exp_labels:
               severity: "critical"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -397,6 +415,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 100m
@@ -407,6 +426,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 100m
@@ -417,6 +437,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 100m
@@ -426,6 +447,7 @@ tests:
               summary: "More than 5% of the rest calls failed in virt-api for the last hour"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -447,6 +469,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -468,6 +491,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
+              infra_alert: "true"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -504,6 +528,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              infra_alert: "false"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
@@ -529,6 +554,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              infra_alert: "false"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
@@ -554,6 +580,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              infra_alert: "false"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
@@ -590,6 +617,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMCannotBeEvicted"
             exp_labels:
               severity: "warning"
+              infra_alert: "false"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               name: "vm-evict-nonmigratable"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -19,6 +19,7 @@ const (
 	partOfAlertLabelValue         = "kubevirt"
 	componentAlertLabelKey        = "kubernetes_operator_component"
 	componentAlertLabelValue      = "kubevirt"
+	infraAlertLabelKey            = "infra_alert"
 	durationFiveMinutes           = "5 minutes"
 )
 
@@ -110,6 +111,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -126,6 +128,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -143,6 +146,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -167,6 +171,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -179,6 +184,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -191,6 +197,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -203,6 +210,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -214,6 +222,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -226,6 +235,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -244,6 +254,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -256,6 +267,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -267,6 +279,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -279,6 +292,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -303,6 +317,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -315,6 +330,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -327,6 +343,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -346,6 +363,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -357,6 +375,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -369,6 +388,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -379,6 +399,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -390,6 +411,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "critical",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -415,6 +437,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "false",
 						},
 					},
 					{
@@ -431,6 +454,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -444,6 +468,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "false",
 						},
 					},
 					{
@@ -457,6 +482,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -472,6 +498,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						},
 						Labels: map[string]string{
 							severityAlertLabelKey: "warning",
+							infraAlertLabelKey:    "true",
 						},
 					},
 					{
@@ -503,6 +530,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey: "warning",
+				infraAlertLabelKey:    "true",
 			},
 		})
 	}


### PR DESCRIPTION
This PR adds a boolean label to each of kubevirt alerts, so that we can differentiate between alerts that are related to infrastructure, and alerts that are related to vmi. 

Signed-off-by: assafad <aadmi@redhat.com>

```release-note
None
```
