### PR TITLE
Fixing flacky test_id:3203

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1003,7 +1003,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			var supportedCPU string
 			var supportedCPUs []string
 			var supportedFeatures []string
-
+			var nodes *k8sv1.NodeList
 			var supportedKVMInfoFeature []string
 
 			enableHyperVInVMI := func(label string) v1.FeatureHyperv {
@@ -1042,7 +1042,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			BeforeEach(func() {
 				// arm64 does not support cpu model
 				checks.SkipIfARM64(testsuite.Arch, "arm64 does not support cpu model")
-				nodes := libnode.GetAllSchedulableNodes(virtClient)
+				nodes = libnode.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 				node = &nodes.Items[0]
@@ -1186,17 +1186,74 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 
 			It("[test_id:3203]the vmi with cpu.features that cannot match nfd labels on a node should not be scheduled", func() {
+				var featureDenyList = map[string]struct{}{
+					"svm": {},
+				}
+				appendFeatureFromFeatureLabel := func(supportedFeatures []string, label string) []string {
+					if strings.Contains(label, services.NFD_CPU_FEATURE_PREFIX) {
+						feature := strings.TrimPrefix(label, services.NFD_CPU_FEATURE_PREFIX)
+						if _, exist := featureDenyList[feature]; !exist {
+							return append(supportedFeatures, feature)
+						}
+					}
+					return supportedFeatures
+				}
 
+				removeDups := func(elements []string) (intersection []string) {
+					found := make(map[string]struct{})
+					for _, element := range elements {
+						if _, exist := found[element]; !exist {
+							intersection = append(intersection, element)
+							found[element] = struct{}{}
+						}
+					}
+					return intersection
+				}
+
+				setIntersection := func(firstSet, secondSet []string) []string {
+					firstSetMap := make(map[string]struct{})
+					var setOfFeaturesWithDups []string
+
+					for _, element := range firstSet {
+						firstSetMap[element] = struct{}{}
+					}
+
+					for _, element := range secondSet {
+						if _, exist := firstSetMap[element]; exist {
+							setOfFeaturesWithDups = append(setOfFeaturesWithDups, element)
+						}
+					}
+					return removeDups(setOfFeaturesWithDups)
+				}
+
+				GetSupportedCPUFeaturesFromNodes := func(nodes k8sv1.NodeList) []string {
+					var supportedFeatures []string
+					for label := range nodes.Items[0].Labels {
+						supportedFeatures = appendFeatureFromFeatureLabel(supportedFeatures, label)
+					}
+
+					for _, node := range nodes.Items {
+						var currFeatures []string
+						for label := range node.Labels {
+							currFeatures = appendFeatureFromFeatureLabel(currFeatures, label)
+						}
+						supportedFeatures = setIntersection(supportedFeatures, currFeatures)
+					}
+
+					return supportedFeatures
+				}
+
+				supportedFeaturesAmongAllNodes := GetSupportedCPUFeaturesFromNodes(*nodes)
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Cores: 1,
 					Features: []v1.CPUFeature{
 						{
-							Name:   supportedFeatures[0],
+							Name:   supportedFeaturesAmongAllNodes[0],
 							Policy: "require",
 						},
 						{
-							Name:   supportedFeatures[1],
+							Name:   supportedFeaturesAmongAllNodes[1],
 							Policy: "forbid",
 						},
 					},


### PR DESCRIPTION
Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently the supportedFeatures var is set to be all the Features that are supported
in at least one node in the cluster but in tests we assume that this set of features exist 
in all the nodes of the cluster.
This might cause flakiness if the cluster is heterogeneous and some of the features 
are not supported in all node as this test try to avoid scheduling vm to node with one of
those features and verify that the VMI is unschedulable but it can still schedule the vm to a node
that doesn't support this feature.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
To fix this i modifed the the test to consider only features that are supported in all the nodes.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
