### PR TITLE
Fix incorrect `emitempty` tag with `omitempty`

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -528,7 +528,7 @@ type Input struct {
 	Type    string   `xml:"type,attr"`
 	Bus     string   `xml:"bus,attr"`
 	Alias   *Alias   `xml:"alias,omitempty"`
-	Address *Address `xml:"address,emitempty"`
+	Address *Address `xml:"address,omitempty"`
 	Model   string   `xml:"model,attr,omitempty"`
 }
 
@@ -541,7 +541,7 @@ type HostDevice struct {
 	Managed   string           `xml:"managed,attr"`
 	Mode      string           `xml:"mode,attr,omitempty"`
 	Model     string           `xml:"model,attr,omitempty"`
-	Address   *Address         `xml:"address,emitempty"`
+	Address   *Address         `xml:"address,omitempty"`
 	Alias     *Alias           `xml:"alias,omitempty"`
 	Display   string           `xml:"display,attr,omitempty"`
 	RamFB     string           `xml:"ramfb,attr,omitempty"`
@@ -562,7 +562,7 @@ type Controller struct {
 	Model   string            `xml:"model,attr,omitempty"`
 	Driver  *ControllerDriver `xml:"driver,omitempty"`
 	Alias   *Alias            `xml:"alias,omitempty"`
-	Address *Address          `xml:"address,emitempty"`
+	Address *Address          `xml:"address,omitempty"`
 }
 
 // END Controller -----------------------------
@@ -1011,8 +1011,8 @@ type Stats struct {
 type MemBalloon struct {
 	Model   string            `xml:"model,attr"`
 	Stats   *Stats            `xml:"stats,omitempty"`
-	Address *Address          `xml:"address,emitempty"`
-	Driver  *MemBalloonDriver `xml:"driver,emitempty"`
+	Address *Address          `xml:"address,omitempty"`
+	Driver  *MemBalloonDriver `xml:"driver,omitempty"`
 }
 
 type MemBalloonDriver struct {
@@ -1023,7 +1023,7 @@ type Watchdog struct {
 	Model   string   `xml:"model,attr"`
 	Action  string   `xml:"action,attr"`
 	Alias   *Alias   `xml:"alias,omitempty"`
-	Address *Address `xml:"address,emitempty"`
+	Address *Address `xml:"address,omitempty"`
 }
 
 // Rng represents the source of entropy from host to VM
@@ -1032,8 +1032,8 @@ type Rng struct {
 	Model string `xml:"model,attr"`
 	// Backend specifies the source of entropy to be used
 	Backend *RngBackend `xml:"backend,omitempty"`
-	Address *Address    `xml:"address,emitempty"`
-	Driver  *RngDriver  `xml:"driver,emitempty"`
+	Address *Address    `xml:"address,omitempty"`
+	Driver  *RngDriver  `xml:"driver,omitempty"`
 }
 
 type RngDriver struct {


### PR DESCRIPTION
**What this PR does / why we need it**: This MR fixes incorrect/nonexistent `emitempty` tag with `omitempty`. It looks like a simple typo.

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Empty (`nil` values) of `Address` and `Driver` fields in XML will be omitted.
```
