### PR TITLE
Move pod template func to container renderer

### DIFF
--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -83,7 +83,7 @@ func WithPrivileged() Option {
 func WithCapabilities(vmi *v1.VirtualMachineInstance) Option {
 	return func(renderer *ContainerSpecRenderer) {
 		renderer.capabilities = &k8sv1.Capabilities{
-			Add:  getRequiredCapabilities(vmi),
+			Add:  requiredCapabilities(vmi),
 			Drop: []k8sv1.Capability{CAP_NET_RAW},
 		}
 	}
@@ -206,7 +206,7 @@ func updateLivenessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Pro
 	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
 }
 
-func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
+func requiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
 	// These capabilies are always required because we set them on virt-launcher binary
 	// add CAP_SYS_PTRACE capability needed by libvirt + swtpm
 	// TODO: drop SYS_PTRACE after updating libvirt to a release containing:

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -109,7 +109,7 @@ func WithResourceRequirements(resources k8sv1.ResourceRequirements) Option {
 
 func WithPorts(vmi *v1.VirtualMachineInstance) Option {
 	return func(renderer *ContainerSpecRenderer) {
-		renderer.ports = getPortsFromVMI(vmi)
+		renderer.ports = containerPortsFromVMI(vmi)
 	}
 }
 
@@ -168,7 +168,7 @@ func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.
 	return context
 }
 
-func getPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort {
+func containerPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort {
 	var ports []k8sv1.ContainerPort
 
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -205,3 +205,23 @@ func updateLivenessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Pro
 	wrapExecProbeWithVirtProbe(vmi, computeProbe)
 	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
 }
+
+func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
+	// These capabilies are always required because we set them on virt-launcher binary
+	// add CAP_SYS_PTRACE capability needed by libvirt + swtpm
+	// TODO: drop SYS_PTRACE after updating libvirt to a release containing:
+	// https://github.com/libvirt/libvirt/commit/a9c500d2b50c5c041a1bb6ae9724402cf1cec8fe
+	capabilities := []k8sv1.Capability{CAP_NET_BIND_SERVICE, CAP_SYS_PTRACE}
+
+	if !util.IsNonRootVMI(vmi) {
+		// add a CAP_SYS_NICE capability to allow setting cpu affinity
+		capabilities = append(capabilities, CAP_SYS_NICE)
+		// add CAP_SYS_ADMIN capability to allow virtiofs
+		if util.IsVMIVirtiofsEnabled(vmi) {
+			capabilities = append(capabilities, CAP_SYS_ADMIN)
+			capabilities = append(capabilities, getVirtiofsCapabilities()...)
+		}
+	}
+
+	return capabilities
+}

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -167,3 +167,25 @@ func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.
 	}
 	return context
 }
+
+func getPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort {
+	ports := make([]k8sv1.ContainerPort, 0)
+
+	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if iface.Ports != nil {
+			for _, port := range iface.Ports {
+				if port.Protocol == "" {
+					port.Protocol = "TCP"
+				}
+
+				ports = append(ports, k8sv1.ContainerPort{Protocol: k8sv1.Protocol(port.Protocol), Name: port.Name, ContainerPort: port.Port})
+			}
+		}
+	}
+
+	if len(ports) == 0 {
+		return nil
+	}
+
+	return ports
+}

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -169,7 +169,7 @@ func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.
 }
 
 func getPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort {
-	ports := make([]k8sv1.ContainerPort, 0)
+	var ports []k8sv1.ContainerPort
 
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		if iface.Ports != nil {
@@ -181,10 +181,6 @@ func getPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort {
 				ports = append(ports, k8sv1.ContainerPort{Protocol: k8sv1.Protocol(port.Protocol), Name: port.Name, ContainerPort: port.Port})
 			}
 		}
-	}
-
-	if len(ports) == 0 {
-		return nil
 	}
 
 	return ports

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -185,3 +185,23 @@ func containerPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort
 
 	return ports
 }
+
+func updateReadinessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Probe) {
+	if vmi.Spec.ReadinessProbe.GuestAgentPing != nil {
+		wrapGuestAgentPingWithVirtProbe(vmi, computeProbe)
+		computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
+		return
+	}
+	wrapExecProbeWithVirtProbe(vmi, computeProbe)
+	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
+}
+
+func updateLivenessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Probe) {
+	if vmi.Spec.LivenessProbe.GuestAgentPing != nil {
+		wrapGuestAgentPingWithVirtProbe(vmi, computeProbe)
+		computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
+		return
+	}
+	wrapExecProbeWithVirtProbe(vmi, computeProbe)
+	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1938,26 +1938,6 @@ func addProbeOverhead(probe *v1.Probe, to *resource.Quantity) bool {
 	return false
 }
 
-func updateReadinessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Probe) {
-	if vmi.Spec.ReadinessProbe.GuestAgentPing != nil {
-		wrapGuestAgentPingWithVirtProbe(vmi, computeProbe)
-		computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
-		return
-	}
-	wrapExecProbeWithVirtProbe(vmi, computeProbe)
-	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
-}
-
-func updateLivenessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Probe) {
-	if vmi.Spec.LivenessProbe.GuestAgentPing != nil {
-		wrapGuestAgentPingWithVirtProbe(vmi, computeProbe)
-		computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
-		return
-	}
-	wrapExecProbeWithVirtProbe(vmi, computeProbe)
-	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
-}
-
 func HaveMasqueradeInterface(interfaces []v1.Interface) bool {
 	for _, iface := range interfaces {
 		if iface.Masquerade != nil {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1958,28 +1958,6 @@ func updateLivenessProbe(vmi *v1.VirtualMachineInstance, computeProbe *k8sv1.Pro
 	computeProbe.InitialDelaySeconds = computeProbe.InitialDelaySeconds + LibvirtStartupDelay
 }
 
-func getPortsFromVMI(vmi *v1.VirtualMachineInstance) []k8sv1.ContainerPort {
-	ports := make([]k8sv1.ContainerPort, 0)
-
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Ports != nil {
-			for _, port := range iface.Ports {
-				if port.Protocol == "" {
-					port.Protocol = "TCP"
-				}
-
-				ports = append(ports, k8sv1.ContainerPort{Protocol: k8sv1.Protocol(port.Protocol), Name: port.Name, ContainerPort: port.Port})
-			}
-		}
-	}
-
-	if len(ports) == 0 {
-		return nil
-	}
-
-	return ports
-}
-
 func HaveMasqueradeInterface(interfaces []v1.Interface) bool {
 	for _, iface := range interfaces {
 		if iface.Masquerade != nil {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1767,26 +1767,6 @@ func getVirtiofsCapabilities() []k8sv1.Capability {
 	}
 }
 
-func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
-	// These capabilies are always required because we set them on virt-launcher binary
-	// add CAP_SYS_PTRACE capability needed by libvirt + swtpm
-	// TODO: drop SYS_PTRACE after updating libvirt to a release containing:
-	// https://github.com/libvirt/libvirt/commit/a9c500d2b50c5c041a1bb6ae9724402cf1cec8fe
-	capabilities := []k8sv1.Capability{CAP_NET_BIND_SERVICE, CAP_SYS_PTRACE}
-
-	if !util.IsNonRootVMI(vmi) {
-		// add a CAP_SYS_NICE capability to allow setting cpu affinity
-		capabilities = append(capabilities, CAP_SYS_NICE)
-		// add CAP_SYS_ADMIN capability to allow virtiofs
-		if util.IsVMIVirtiofsEnabled(vmi) {
-			capabilities = append(capabilities, CAP_SYS_ADMIN)
-			capabilities = append(capabilities, getVirtiofsCapabilities()...)
-		}
-	}
-
-	return capabilities
-}
-
 func getRequiredResources(vmi *v1.VirtualMachineInstance, allowEmulation bool) k8sv1.ResourceList {
 	res := k8sv1.ResourceList{}
 	if util.NeedTunDevice(vmi) {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -2033,30 +2033,6 @@ func wrapGuestAgentPingWithVirtProbe(vmi *v1.VirtualMachineInstance, probe *k8sv
 	return
 }
 
-func wrapExecProbeWithVirtProbe(vmi *v1.VirtualMachineInstance, probe *k8sv1.Probe) {
-	if probe == nil || probe.ProbeHandler.Exec == nil {
-		return
-	}
-
-	originalCommand := probe.ProbeHandler.Exec.Command
-	if len(originalCommand) < 1 {
-		return
-	}
-
-	wrappedCommand := []string{
-		"virt-probe",
-		"--domainName", api.VMINamespaceKeyFunc(vmi),
-		"--timeoutSeconds", strconv.FormatInt(int64(probe.TimeoutSeconds), 10),
-		"--command", originalCommand[0],
-		"--",
-	}
-	wrappedCommand = append(wrappedCommand, originalCommand[1:]...)
-
-	probe.ProbeHandler.Exec.Command = wrappedCommand
-	// we add 1s to the pod probe to compensate for the additional steps in probing
-	probe.TimeoutSeconds += 1
-}
-
 func alignPodMultiCategorySecurity(pod *k8sv1.Pod, selinuxType string) {
 	pod.Spec.SecurityContext.SELinuxOptions = &k8sv1.SELinuxOptions{Type: selinuxType}
 	// more info on https://github.com/kubernetes/kubernetes/issues/90759


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR improves the virt-controller pod templating by:
  - moving helper functions to the render container file - when it is their only caller
  - rename function names to something more golang idiomatic, by removing the `get` prefix. That prefix is at best redundant
  - remove a slice initialization when computing the list of container ports from the VMI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
