### PR TITLE
Makefile: add a lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,12 @@ format:
 
 fmt: format
 
+lint:
+	# tests/utils.go is too long already. Don't make it worse.
+	# this is a placeholder for a proper linter.
+	git diff --numstat $$(git merge-base HEAD origin/main) -- tests/utils.go | \
+		awk '{if ($$1-$$2 > 0) {print $$3 " grew longer"; exit 1} }'
+
 .PHONY: \
 	build-verify \
 	conformance \
@@ -222,4 +228,6 @@ fmt: format
 	fossa \
 	realtime-perftest \
 	format \
-	fmt
+	fmt \
+	lint \
+	$(NULL)


### PR DESCRIPTION
It is very tempting to add code to tests/utils.go, even though it is
already too long to read. Let us try to avoid further growth of this
file by adding this lint target.

This simple/stupid validation is intended to start the discussion. It
should probably be replaced by a test of the specific diff from
origin/master. Or even better: be replaced by a proper go linter that
can guide us about the quality of the code we write.

This suggested target should be exercisable locally and via a job such as the one proposed by https://github.com/kubevirt/project-infra/pull/2124 

```release-note
NONE
```
