### PR TITLE
cloud-init: make cloud-init 'instance-id' persistent

### DIFF
--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
+        "//vendor/github.com/pborman/uuid:go_default_library",
     ],
 )
 
@@ -29,5 +30,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -31,6 +31,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pborman/uuid"
+
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
@@ -110,6 +112,13 @@ func IsValidCloudInitData(cloudInitData *CloudInitData) bool {
 	return cloudInitData != nil && cloudInitData.UserData != "" && (cloudInitData.NoCloudMetaData != nil || cloudInitData.ConfigDriveMetaData != nil)
 }
 
+func cloudInitUUIDFromVMI(vmi *v1.VirtualMachineInstance) string {
+	if vmi.Spec.Domain.Firmware == nil {
+		return uuid.NewRandom().String()
+	}
+	return string(vmi.Spec.Domain.Firmware.UUID)
+}
+
 // ReadCloudInitVolumeDataSource scans the given VMI for CloudInit volumes and
 // reads their content into a CloudInitData struct. Does not resolve secret refs.
 func ReadCloudInitVolumeDataSource(vmi *v1.VirtualMachineInstance, secretSourceDir string) (cloudInitData *CloudInitData, err error) {
@@ -131,7 +140,7 @@ func ReadCloudInitVolumeDataSource(vmi *v1.VirtualMachineInstance, secretSourceD
 			}
 
 			cloudInitData, err = readCloudInitNoCloudSource(volume.CloudInitNoCloud)
-			cloudInitData.NoCloudMetaData = readCloudInitNoCloudMetaData(vmi.Name, hostname, vmi.Namespace, flavor)
+			cloudInitData.NoCloudMetaData = readCloudInitNoCloudMetaData(hostname, cloudInitUUIDFromVMI(vmi), flavor)
 			cloudInitData.VolumeName = volume.Name
 			return cloudInitData, err
 		}
@@ -142,8 +151,9 @@ func ReadCloudInitVolumeDataSource(vmi *v1.VirtualMachineInstance, secretSourceD
 				return nil, err
 			}
 
+			uuid := cloudInitUUIDFromVMI(vmi)
 			cloudInitData, err = readCloudInitConfigDriveSource(volume.CloudInitConfigDrive)
-			cloudInitData.ConfigDriveMetaData = readCloudInitConfigDriveMetaData(string(vmi.UID), vmi.Name, hostname, vmi.Namespace, keys, flavor)
+			cloudInitData.ConfigDriveMetaData = readCloudInitConfigDriveMetaData(vmi.Name, uuid, hostname, vmi.Namespace, keys, flavor)
 			cloudInitData.VolumeName = volume.Name
 			return cloudInitData, err
 		}
@@ -366,18 +376,18 @@ func readCloudInitConfigDriveSource(source *v1.CloudInitConfigDriveSource) (*Clo
 	}, nil
 }
 
-func readCloudInitNoCloudMetaData(name, hostname, namespace string, instanceType string) *NoCloudMetadata {
+func readCloudInitNoCloudMetaData(hostname, instanceId string, instanceType string) *NoCloudMetadata {
 	return &NoCloudMetadata{
 		InstanceType:  instanceType,
-		InstanceID:    fmt.Sprintf("%s.%s", name, namespace),
+		InstanceID:    instanceId,
 		LocalHostname: hostname,
 	}
 }
 
-func readCloudInitConfigDriveMetaData(uid, name, hostname, namespace string, keys map[string]string, instanceType string) *ConfigDriveMetadata {
+func readCloudInitConfigDriveMetaData(name, uuid, hostname, namespace string, keys map[string]string, instanceType string) *ConfigDriveMetadata {
 	return &ConfigDriveMetadata{
 		InstanceType:  instanceType,
-		UUID:          uid,
+		UUID:          uuid,
 		InstanceID:    fmt.Sprintf("%s.%s", name, namespace),
 		Hostname:      hostname,
 		PublicSSHKeys: keys,
@@ -537,14 +547,14 @@ func GenerateEmptyIso(vmiName string, namespace string, data *CloudInitData, siz
 	return nil
 }
 
-func GenerateLocalData(vmiName string, namespace string, instanceType string, data *CloudInitData) error {
-	precond.MustNotBeEmpty(vmiName)
+func GenerateLocalData(vmi *v1.VirtualMachineInstance, instanceType string, data *CloudInitData) error {
+	precond.MustNotBeEmpty(vmi.Name)
 	precond.MustNotBeNil(data)
 
 	var metaData []byte
 	var err error
 
-	domainBasePath := getDomainBasePath(vmiName, namespace)
+	domainBasePath := getDomainBasePath(vmi.Name, vmi.Namespace)
 	dataBasePath := fmt.Sprintf("%s/data", domainBasePath)
 
 	var dataPath, metaFile, userFile, networkFile, iso, isoStaging string
@@ -554,12 +564,12 @@ func GenerateLocalData(vmiName string, namespace string, instanceType string, da
 		metaFile = fmt.Sprintf("%s/%s", dataPath, "meta-data")
 		userFile = fmt.Sprintf("%s/%s", dataPath, "user-data")
 		networkFile = fmt.Sprintf("%s/%s", dataPath, "network-config")
-		iso = GetIsoFilePath(DataSourceNoCloud, vmiName, namespace)
+		iso = GetIsoFilePath(DataSourceNoCloud, vmi.Name, vmi.Namespace)
 		isoStaging = fmt.Sprintf(isoStagingFmt, iso)
 		if data.NoCloudMetaData == nil {
 			log.Log.V(2).Infof("No metadata found in cloud-init data. Create minimal metadata with instance-id.")
 			data.NoCloudMetaData = &NoCloudMetadata{
-				InstanceID: fmt.Sprintf("%s.%s", vmiName, namespace),
+				InstanceID: cloudInitUUIDFromVMI(vmi),
 			}
 			data.NoCloudMetaData.InstanceType = instanceType
 		}
@@ -572,12 +582,14 @@ func GenerateLocalData(vmiName string, namespace string, instanceType string, da
 		metaFile = fmt.Sprintf("%s/%s", dataPath, "meta_data.json")
 		userFile = fmt.Sprintf("%s/%s", dataPath, "user_data")
 		networkFile = fmt.Sprintf("%s/%s", dataPath, "network_data.json")
-		iso = GetIsoFilePath(DataSourceConfigDrive, vmiName, namespace)
+		iso = GetIsoFilePath(DataSourceConfigDrive, vmi.Name, vmi.Namespace)
 		isoStaging = fmt.Sprintf(isoStagingFmt, iso)
 		if data.ConfigDriveMetaData == nil {
 			log.Log.V(2).Infof("No metadata found in cloud-init data. Create minimal metadata with instance-id.")
+			instanceId := fmt.Sprintf("%s.%s", vmi.Name, vmi.Namespace)
 			data.ConfigDriveMetaData = &ConfigDriveMetadata{
-				InstanceID: fmt.Sprintf("%s.%s", vmiName, namespace),
+				InstanceID: instanceId,
+				UUID:       cloudInitUUIDFromVMI(vmi),
 			}
 			data.ConfigDriveMetaData.InstanceType = instanceType
 		}

--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -380,6 +380,20 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 	return !exists, nil
 }
 
+func stripIdentityInfo(vm *kubevirtv1.VirtualMachine) {
+	vmTemplate := vm.Spec.Template
+	if vmTemplate == nil {
+		return
+	}
+
+	fw := vmTemplate.Spec.Domain.Firmware
+	if fw == nil {
+		return
+	}
+
+	fw.UUID = ""
+}
+
 func (t *vmRestoreTarget) Reconcile() (bool, error) {
 	log.Log.Object(t.vmRestore).V(3).Info("Reconciling VM")
 
@@ -523,6 +537,8 @@ func (t *vmRestoreTarget) Reconcile() (bool, error) {
 			Spec:   *snapshotVM.Spec.DeepCopy(),
 			Status: kubevirtv1.VirtualMachineStatus{},
 		}
+
+		stripIdentityInfo(newVM)
 	} else {
 		newVM = t.vm.DeepCopy()
 		newVM.Spec = *snapshotVM.Spec.DeepCopy()

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -469,7 +469,7 @@ func (l *LibvirtDomainManager) generateSomeCloudInitISO(vmi *v1.VirtualMachineIn
 				flavor = vmi.Annotations[v1.FlavorAnnotation]
 			}
 
-			err = cloudinit.GenerateLocalData(vmi.Name, vmi.Namespace, flavor, cloudInitDataStore)
+			err = cloudinit.GenerateLocalData(vmi, flavor, cloudInitDataStore)
 		}
 		if err != nil {
 			return fmt.Errorf("generating local cloud-init data failed: %v", err)

--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -60,6 +60,31 @@ func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
 	}
 }
 
+// WithCloudInitConfigDriveData adds cloud-init config-drive user data.
+func WithCloudInitConfigDriveData(data string, b64Encoding bool) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		diskName := "disk1"
+		addDiskVolumeWithCloudInitConfigDrive(vmi, diskName, v1.DiskBusVirtio)
+
+		volume := getVolume(vmi, diskName)
+		if b64Encoding {
+			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
+			volume.CloudInitConfigDrive.UserData = ""
+			volume.CloudInitConfigDrive.UserDataBase64 = encodedData
+		} else {
+			volume.CloudInitConfigDrive.UserData = data
+			volume.CloudInitConfigDrive.UserDataBase64 = ""
+		}
+	}
+}
+
+func addDiskVolumeWithCloudInitConfigDrive(vmi *kvirtv1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
+	addDisk(vmi, newDisk(diskName, bus))
+	v := newVolume(diskName)
+	v.VolumeSource = kvirtv1.VolumeSource{CloudInitConfigDrive: &kvirtv1.CloudInitConfigDriveSource{}}
+	addVolume(vmi, v)
+}
+
 func addDiskVolumeWithCloudInitNoCloud(vmi *kvirtv1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
 	addDisk(vmi, newDisk(diskName, bus))
 	v := newVolume(diskName)

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -277,7 +277,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				metadataStruct := cloudinit.ConfigDriveMetadata{
 					InstanceID: fmt.Sprintf("%s.%s", vmi.Name, vmi.Namespace),
 					Hostname:   dns.SanitizeHostname(vmi),
-					UUID:       string(vmi.UID),
+					UUID:       string(vmi.Spec.Domain.Firmware.UUID),
 					Devices:    &deviceData,
 				}
 
@@ -340,7 +340,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 					InstanceID:   fmt.Sprintf("%s.%s", vmi.Name, vmi.Namespace),
 					InstanceType: testFlavor,
 					Hostname:     dns.SanitizeHostname(vmi),
-					UUID:         string(vmi.UID),
+					UUID:         string(vmi.Spec.Domain.Firmware.UUID),
 					Devices:      &deviceData,
 				}
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -36,6 +36,7 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -198,6 +199,58 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						&expect.BExp{R: "test-ssh-key"},
 					}, time.Second*300)
 				})
+			})
+
+			It("cloud-init instance-id should be stable", func() {
+				getInstanceId := func(vmi *v1.VirtualMachineInstance) (string, error) {
+					cmd := "cat /var/lib/cloud/data/instance-id"
+					instanceId, err := console.RunCommandAndStoreOutput(vmi, cmd, time.Second*30)
+					return instanceId, err
+				}
+
+				userData := fmt.Sprintf(
+					"#cloud-config\npassword: %s\nchpasswd: { expire: False }",
+					fedoraPassword,
+				)
+				vmi := libvmi.NewFedora(libvmi.WithCloudInitConfigDriveData(userData, false))
+				// runStrategy := v1.RunStrategyManual
+				vm := &v1.VirtualMachine{
+					ObjectMeta: vmi.ObjectMeta,
+					Spec: v1.VirtualMachineSpec{
+						Running: tests.NewBool(false),
+						Template: &v1.VirtualMachineInstanceTemplateSpec{
+							Spec: vmi.Spec,
+						},
+					},
+				}
+
+				By("Start VM")
+				vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+				Expect(vm.Namespace).ToNot(BeEmpty())
+				Expect(err).ToNot(HaveOccurred())
+				vm = tests.StartVirtualMachine(vm)
+				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+
+				By("Get VM cloud-init instance-id")
+				instanceId, err := getInstanceId(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(instanceId).ToNot(BeEmpty())
+
+				By("Restart VM")
+				vm = tests.StopVirtualMachine(vm)
+				tests.StartVirtualMachine(vm)
+				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+
+				By("Get VM cloud-init instance-id after restart")
+				newInstanceId, err := getInstanceId(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Make sure the instance-ids match")
+				Expect(instanceId).To(Equal(newInstanceId))
 			})
 		})
 
@@ -411,7 +464,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					vmi.Annotations = make(map[string]string)
 				}
 				vmi.Annotations[v1.FlavorAnnotation] = testFlavor
-				LaunchVMI(vmi)
+				vmi = LaunchVMI(vmi)
 				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
@@ -439,7 +492,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					InstanceID:   fmt.Sprintf("%s.%s", vmi.Name, vmi.Namespace),
 					InstanceType: testFlavor,
 					Hostname:     dns.SanitizeHostname(vmi),
-					UUID:         string(vmi.UID),
+					UUID:         string(vmi.Spec.Domain.Firmware.UUID),
 					Devices:      &deviceData,
 				}
 


### PR DESCRIPTION
Before this patch the VMI uuid was used as the cloud-init `uuid`
(which is then used by cloud-init to build the `instance-id`),
this had the side-effect of letting the cloud-init `instance-id`
change on every VM reboot causing the 'on-first boot' cloud-init
configuration to be executed on every restart and not just once.

This for example would cause the VMI to regenerate SSH keys at
every restart which is not desirable (thus causing a ssh public key
mismatch when connnecting with a client).

This patch fixes this by using the VM UID as uuid which
makes the cloud-init 'instance-id' stable, in case the VMI is not
associated to a VM the VMI's UID will be used instead.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
make cloud-init 'instance-id' persistent across reboots
```
