### PR TITLE
Fix vmsnapshot unittests flakiness

### DIFF
--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -1912,6 +1912,11 @@ func expectVMSnapshotContentCreate(client *kubevirtfake.Clientset, content *snap
 		Expect(ok).To(BeTrue())
 
 		createObj := create.GetObject().(*snapshotv1.VirtualMachineSnapshotContent)
+		Expect(createObj.ObjectMeta).To(Equal(content.ObjectMeta))
+		Expect(createObj.Spec.Source).To(Equal(content.Spec.Source))
+		Expect(*createObj.Spec.VirtualMachineSnapshotName).To(Equal(*content.Spec.VirtualMachineSnapshotName))
+		Expect(createObj.Spec.VolumeBackups).To(Equal(content.Spec.VolumeBackups))
+		Expect(createObj.Status).To(Equal(content.Status))
 		Expect(createObj).To(Equal(content))
 
 		return true, create.GetObject(), nil


### PR DESCRIPTION
There was an issue with the volume snapshot class sometimes taking time to be added.
Fixed by adding in the relevant tests a waiter to check the add had occured.
Ran all the snapshot UT for more then 200 times and no flakiness with this fix.
This solves at lease this 2 issues: 
https://github.com/kubevirt/kubevirt/issues/7776
https://github.com/kubevirt/kubevirt/issues/7647

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
