### PR TITLE
test: move LibvirtDomainIsPersistent from utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2197,36 +2197,6 @@ func LibvirtDomainIsPaused(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMac
 	return strings.Contains(stdout, "paused"), nil
 }
 
-func LibvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
-	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, util2.NamespaceTestDefault)
-	if err != nil {
-		return false, err
-	}
-
-	found := false
-	containerIdx := 0
-	for idx, container := range vmiPod.Spec.Containers {
-		if container.Name == "compute" {
-			containerIdx = idx
-			found = true
-		}
-	}
-	if !found {
-		return false, fmt.Errorf(CouldNotFindComputeContainer)
-	}
-
-	stdout, stderr, err := ExecuteCommandOnPodV2(
-		virtClient,
-		vmiPod,
-		vmiPod.Spec.Containers[containerIdx].Name,
-		[]string{"virsh", "--quiet", "list", "--persistent", "--name"},
-	)
-	if err != nil {
-		return false, fmt.Errorf("could not dump libvirt domxml (remotely on pod): %v: %s", err, stderr)
-	}
-	return strings.Contains(stdout, vmi.Namespace+"_"+vmi.Name), nil
-}
-
 // Deprecated: DeprecatedBeforeAll must not be used. Tests need to be self-contained to allow sane cleanup, accurate reporting and
 // parallel execution.
 func DeprecatedBeforeAll(fn func()) {


### PR DESCRIPTION
Move LibvirtDomainIsPersistent from utils to
migration_test to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Special notes for your reviewer**:

We had [here](https://github.com/kubevirt/kubevirt/pull/7810/files#diff-847cd06c1bf6ef597ea96894f8b32ecb4d074ad1bc785b39871e11fb6ab71b3dL2201):
```
	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, util2.NamespaceTestDefault)
	if err != nil {
		return false, err
	}
```
Now we're using `GetRunningPodByVirtualMachineInstance` and have `util2.PanicOnError(err)` [there](https://github.com/benukhanov/kubevirt/blob/19e78a2ec267db569acf8c1e662a52332df8d6a1/tests/utils.go#L845).

**Release note**:
```release-note
NONE
```