### PR TITLE
Add reason to AgentVersionNotSupported condition

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1535,7 +1535,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			destSrcPorts := controller.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
-			fmt.Println("destSrcPorts: ", destSrcPorts)
 			updatedVmi := vmi.DeepCopy()
 			updatedVmi.Status.MigrationState.TargetNodeAddress = controller.migrationIpAddress
 			updatedVmi.Status.MigrationState.TargetDirectMigrationNodePorts = destSrcPorts
@@ -1609,7 +1608,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			destSrcPorts := controller.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
-			fmt.Println("destSrcPorts: ", destSrcPorts)
 			updatedVmi := vmi.DeepCopy()
 			updatedVmi.Status.MigrationState.TargetNodeAddress = controller.migrationIpAddress
 			updatedVmi.Status.MigrationState.TargetDirectMigrationNodePorts = destSrcPorts
@@ -2687,6 +2685,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		var vmiWithSSH *v1.VirtualMachineInstance
 		var basicCommands []v1.GuestAgentCommandInfo
 		var allCommands []v1.GuestAgentCommandInfo
+		const agentSupported = "This guest agent is supported"
 
 		BeforeEach(func() {
 			vmi = &v1.VirtualMachineInstance{}
@@ -2744,33 +2743,39 @@ var _ = Describe("VirtualMachineInstance", func() {
 		})
 
 		It("should succeed with empty VMI and basic commands", func() {
-			result := isGuestAgentSupported(vmi, basicCommands)
+			result, reason := isGuestAgentSupported(vmi, basicCommands)
 			Expect(result).To(BeTrue())
+			Expect(reason).To(Equal(agentSupported))
 		})
 
 		It("should succeed with empty VMI and all commands", func() {
-			result := isGuestAgentSupported(vmi, allCommands)
+			result, reason := isGuestAgentSupported(vmi, allCommands)
 			Expect(result).To(BeTrue())
+			Expect(reason).To(Equal(agentSupported))
 		})
 
 		It("should fail with password and basic commands", func() {
-			result := isGuestAgentSupported(vmiWithPassword, basicCommands)
+			result, reason := isGuestAgentSupported(vmiWithPassword, basicCommands)
 			Expect(result).To(BeFalse())
+			Expect(reason).To(Equal("This guest agent doesn't support required password commands"))
 		})
 
 		It("should succeed with password and all commands", func() {
-			result := isGuestAgentSupported(vmiWithPassword, allCommands)
+			result, reason := isGuestAgentSupported(vmiWithPassword, allCommands)
 			Expect(result).To(BeTrue())
+			Expect(reason).To(Equal(agentSupported))
 		})
 
 		It("should fail with SSH and basic commands", func() {
-			result := isGuestAgentSupported(vmiWithSSH, basicCommands)
+			result, reason := isGuestAgentSupported(vmiWithSSH, basicCommands)
 			Expect(result).To(BeFalse())
+			Expect(reason).To(Equal("This guest agent doesn't support required public key commands"))
 		})
 
 		It("should succeed with SSH and all commands", func() {
-			result := isGuestAgentSupported(vmiWithSSH, allCommands)
+			result, reason := isGuestAgentSupported(vmiWithSSH, allCommands)
 			Expect(result).To(BeTrue())
+			Expect(reason).To(Equal(agentSupported))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Add reason to AgentVersionNotSupported condition.

**Which issue(s) this PR fixes**:
Fixes #7433

**Release note**:
```release-note
User now gets information about the type of commands which the guest agent does not support.
```