### PR TITLE
Add VMI filesystem usage metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -36,6 +36,12 @@ Indication for a virt-controller that is ready to take the lead. Type: Gauge.
 ### kubevirt_vmi_cpu_affinity
 The vcpu affinity details. Type: Counter.
 
+### kubevirt_vmi_filesystem_total_bytes
+Total VM filesystem capacity in bytes. Type: Gauge.
+
+### kubevirt_vmi_filesystem_used_bytes
+Used VM filesystem capacity in bytes. Type: Gauge.
+
 ### kubevirt_vmi_memory_actual_balloon_bytes
 Current balloon bytes. Type: Gauge.
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -480,6 +480,36 @@ func (metrics *vmiMetrics) updateNetwork(netStats []stats.DomainStatsNet) {
 	}
 }
 
+func (metrics *vmiMetrics) updateFilesystem(vmFSStats k6tv1.VirtualMachineInstanceFileSystemList) {
+	if len(vmFSStats.Items) == 0 {
+		return
+	}
+
+	fsLabels := []string{"disk_name", "mount_point", "file_system_type"}
+
+	for _, fsStat := range vmFSStats.Items {
+		fsLabelValues := []string{fsStat.DiskName, fsStat.MountPoint, fsStat.FileSystemType}
+
+		metrics.pushCustomMetric(
+			"kubevirt_vmi_filesystem_total_bytes",
+			"Total VM filesystem capacity in bytes.",
+			prometheus.GaugeValue,
+			float64(fsStat.TotalBytes),
+			fsLabels,
+			fsLabelValues,
+		)
+
+		metrics.pushCustomMetric(
+			"kubevirt_vmi_filesystem_used_bytes",
+			"Used VM filesystem capacity in bytes.",
+			prometheus.GaugeValue,
+			float64(fsStat.UsedBytes),
+			fsLabels,
+			fsLabelValues,
+		)
+	}
+}
+
 func updateVersion(ch chan<- prometheus.Metric) {
 	verinfo := version.Get()
 	ch <- prometheus.MustNewConstMetric(
@@ -543,6 +573,11 @@ type prometheusScraper struct {
 	ch chan<- prometheus.Metric
 }
 
+type VirtualMachineInstanceStats struct {
+	DomainStats *stats.DomainStats
+	FsStats     k6tv1.VirtualMachineInstanceFileSystemList
+}
+
 func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineInstance) {
 	ts := time.Now()
 	cli, err := cmdclient.NewClient(socketFile)
@@ -556,13 +591,22 @@ func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachine
 	}
 	defer cli.Close()
 
-	vmStats, exists, err := cli.GetDomainStats()
+	vmStats := &VirtualMachineInstanceStats{}
+	var exists bool
+
+	vmStats.DomainStats, exists, err = cli.GetDomainStats()
 	if err != nil {
-		log.Log.Reason(err).Errorf("failed to update stats from socket %s", socketFile)
+		log.Log.Reason(err).Errorf("failed to update domain stats from socket %s", socketFile)
 		return
 	}
-	if !exists || vmStats.Name == "" {
+	if !exists || vmStats.DomainStats.Name == "" {
 		log.Log.V(2).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
+		return
+	}
+
+	vmStats.FsStats, err = cli.GetFilesystems()
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to update filesystem stats from socket %s", socketFile)
 		return
 	}
 
@@ -579,8 +623,8 @@ func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachine
 	ps.Report(socketFile, vmi, vmStats)
 }
 
-func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats) {
-	// statsMaxAge is an estimation - and there is not better way to do that. So it is possible that
+func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachineInstance, vmStats *VirtualMachineInstanceStats) {
+	// statsMaxAge is an estimation - and there is no better way to do that. So it is possible that
 	// GetDomainStats() takes enough time to lag behind, but not enough to trigger the statsMaxAge check.
 	// In this case the next functions will end up writing on a closed channel. This will panic.
 	// It is actually OK in this case to abort the goroutine that panicked -that's what we want anyway,
@@ -614,18 +658,19 @@ type vmiMetrics struct {
 	ch             chan<- prometheus.Metric
 }
 
-func (metrics *vmiMetrics) updateMetrics(vmStats *stats.DomainStats) {
+func (metrics *vmiMetrics) updateMetrics(vmStats *VirtualMachineInstanceStats) {
 	metrics.updateKubernetesLabels()
 
-	metrics.updateMemory(vmStats.Memory)
-	metrics.updateVcpu(vmStats.Vcpu)
-	metrics.updateBlock(vmStats.Block)
-	metrics.updateNetwork(vmStats.Net)
+	metrics.updateMemory(vmStats.DomainStats.Memory)
+	metrics.updateVcpu(vmStats.DomainStats.Vcpu)
+	metrics.updateBlock(vmStats.DomainStats.Block)
+	metrics.updateNetwork(vmStats.DomainStats.Net)
 
-	if vmStats.CPUMapSet {
-		metrics.updateCPUAffinity(vmStats.CPUMap)
+	if vmStats.DomainStats.CPUMapSet {
+		metrics.updateCPUAffinity(vmStats.DomainStats.CPUMap)
 	}
-	metrics.updateMigrateInfo(vmStats.MigrateDomainJobInfo)
+	metrics.updateMigrateInfo(vmStats.DomainStats.MigrateDomainJobInfo)
+	metrics.updateFilesystem(vmStats.FsStats)
 }
 
 func (metrics *vmiMetrics) newPrometheusDesc(name string, help string, customLabels []string) *prometheus.Desc {

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -40,6 +40,19 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = Describe("Prometheus", func() {
+	newVmStats := func(domainStats *stats.DomainStats, fsStats *k6tv1.VirtualMachineInstanceFileSystemList) *VirtualMachineInstanceStats {
+		if fsStats == nil {
+			fsStats = &k6tv1.VirtualMachineInstanceFileSystemList{
+				Items: []k6tv1.VirtualMachineInstanceFileSystem{},
+			}
+		}
+
+		return &VirtualMachineInstanceStats{
+			DomainStats: domainStats,
+			FsStats:     *fsStats,
+		}
+	}
+
 	Context("on blocked source", func() {
 		It("should handle closed reporting socket", func() {
 			ch := make(chan prometheus.Metric)
@@ -48,7 +61,7 @@ var _ = Describe("Prometheus", func() {
 			ps := prometheusScraper{ch: ch}
 
 			testReportPanic := func() {
-				vmStats := &stats.DomainStats{
+				domainStats := &stats.DomainStats{
 					Cpu: &stats.DomainStatsCPU{},
 					Memory: &stats.DomainStatsMemory{
 						// trigger write on a socket. We need a value set - any value
@@ -57,7 +70,7 @@ var _ = Describe("Prometheus", func() {
 					},
 				}
 				vmi := k6tv1.VirtualMachineInstance{}
-				ps.Report("test", &vmi, vmStats)
+				ps.Report("test", &vmi, newVmStats(domainStats, nil))
 			}
 			Expect(testReportPanic).ToNot(Panic())
 		})
@@ -70,7 +83,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					// trigger write on a socket. We need a value set - any value
@@ -79,7 +92,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -92,7 +105,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					AvailableSet: true,
@@ -100,7 +113,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -117,7 +130,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					UnusedSet: true,
@@ -125,7 +138,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -142,7 +155,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					SwapInSet: true,
@@ -150,7 +163,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -167,7 +180,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					SwapOutSet: true,
@@ -175,7 +188,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -192,7 +205,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					MajorFaultSet: true,
@@ -200,7 +213,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -217,7 +230,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					MinorFaultSet: true,
@@ -225,7 +238,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -242,7 +255,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					ActualBalloonSet: true,
@@ -250,7 +263,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -267,7 +280,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					UsableSet: true,
@@ -275,7 +288,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -292,7 +305,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					TotalSet: true,
@@ -300,7 +313,7 @@ var _ = Describe("Prometheus", func() {
 				},
 			}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -318,13 +331,13 @@ var _ = Describe("Prometheus", func() {
 
 				ps := prometheusScraper{ch: ch}
 
-				vmStats := &stats.DomainStats{
+				domainStats := &stats.DomainStats{
 					Cpu:                  &stats.DomainStatsCPU{},
 					Memory:               &stats.DomainStatsMemory{},
 					MigrateDomainJobInfo: migrateDomainJobInfoStats,
 				}
 				vmi := k6tv1.VirtualMachineInstance{}
-				ps.Report("test", &vmi, vmStats)
+				ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 				result := <-ch
 				dto := &io_prometheus_client.Metric{}
@@ -372,7 +385,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Vcpu: []stats.DomainStatsVcpu{
@@ -386,7 +399,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -399,7 +412,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Vcpu: []stats.DomainStatsVcpu{
@@ -412,7 +425,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			// metrics about invalid stats never get pushed into the channel
 			Eventually(ch).Should(BeEmpty())
@@ -424,7 +437,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Vcpu: []stats.DomainStatsVcpu{
@@ -439,7 +452,7 @@ var _ = Describe("Prometheus", func() {
 
 			metric := &io_prometheus_client.Metric{}
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			result.Write(metric)
@@ -451,7 +464,7 @@ var _ = Describe("Prometheus", func() {
 				}
 			}
 
-			vmStats = &stats.DomainStats{
+			domainStats = &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Vcpu: []stats.DomainStatsVcpu{
@@ -465,7 +478,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			metric = &io_prometheus_client.Metric{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result = <-ch
 			result.Write(metric)
@@ -477,7 +490,7 @@ var _ = Describe("Prometheus", func() {
 				}
 			}
 
-			vmStats = &stats.DomainStats{
+			domainStats = &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Vcpu: []stats.DomainStatsVcpu{
@@ -491,7 +504,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			metric = &io_prometheus_client.Metric{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result = <-ch
 			result.Write(metric)
@@ -510,7 +523,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -524,7 +537,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -537,7 +550,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -551,7 +564,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -564,7 +577,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -578,7 +591,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -591,7 +604,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -605,7 +618,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -618,7 +631,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -632,7 +645,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -645,7 +658,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -659,7 +672,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -672,7 +685,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -686,7 +699,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -699,7 +712,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -713,7 +726,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -726,7 +739,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -741,7 +754,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -758,7 +771,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -773,7 +786,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -790,7 +803,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Block: []stats.DomainStatsBlock{
@@ -802,7 +815,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			Eventually(ch).Should(BeEmpty())
 		})
@@ -813,7 +826,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -827,7 +840,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -844,7 +857,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -858,7 +871,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -875,7 +888,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -889,7 +902,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -902,7 +915,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -916,7 +929,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -929,7 +942,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -943,7 +956,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -956,7 +969,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -970,7 +983,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -983,7 +996,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -997,7 +1010,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -1010,7 +1023,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -1024,7 +1037,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -1037,7 +1050,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net: []stats.DomainStatsNet{
@@ -1049,7 +1062,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			Eventually(ch).Should(BeEmpty())
 		})
@@ -1060,7 +1073,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu: &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{
 					RSS:    1024,
@@ -1075,7 +1088,7 @@ var _ = Describe("Prometheus", func() {
 					},
 				},
 			}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -1088,7 +1101,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:    &stats.DomainStatsCPU{},
 				Memory: &stats.DomainStatsMemory{},
 				Net:    []stats.DomainStatsNet{},
@@ -1101,7 +1114,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
@@ -1114,7 +1127,7 @@ var _ = Describe("Prometheus", func() {
 
 			ps := prometheusScraper{ch: ch}
 
-			vmStats := &stats.DomainStats{
+			domainStats := &stats.DomainStats{
 				Cpu:       &stats.DomainStatsCPU{},
 				Memory:    &stats.DomainStatsMemory{},
 				Net:       []stats.DomainStatsNet{},
@@ -1124,7 +1137,7 @@ var _ = Describe("Prometheus", func() {
 			}
 
 			vmi := k6tv1.VirtualMachineInstance{}
-			ps.Report("test", &vmi, vmStats)
+			ps.Report("test", &vmi, newVmStats(domainStats, nil))
 
 			result := <-ch
 			dto := &io_prometheus_client.Metric{}
@@ -1139,6 +1152,40 @@ var _ = Describe("Prometheus", func() {
 			Expect(s).To(ContainSubstring("vcpu_0_cpu_0=true"))
 			Expect(s).To(ContainSubstring("vcpu_0_cpu_1=false"))
 			Expect(s).To(ContainSubstring("vcpu_0_cpu_2=true"))
+		})
+
+		It("should expose filesystem metrics", func() {
+			ch := make(chan prometheus.Metric, 2)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			domainStats := &stats.DomainStats{
+				Cpu:                  &stats.DomainStatsCPU{},
+				Memory:               &stats.DomainStatsMemory{},
+				Net:                  []stats.DomainStatsNet{},
+				MigrateDomainJobInfo: &stats.DomainJobInfo{},
+			}
+
+			fsStats := &k6tv1.VirtualMachineInstanceFileSystemList{
+				Items: []k6tv1.VirtualMachineInstanceFileSystem{
+					{
+						DiskName:   "disk1",
+						TotalBytes: 1000,
+						UsedBytes:  10,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, newVmStats(domainStats, fsStats))
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_total_bytes"))
+			result = <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_used_bytes"))
+			Expect(ch).To(BeEmpty())
 		})
 	})
 

--- a/tools/doc-generator/fakeCollector.go
+++ b/tools/doc-generator/fakeCollector.go
@@ -33,6 +33,7 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 	inDomInfo := &libvirt.DomainInfo{}
 	jobInfo := stats.DomainJobInfo{}
 	out := stats.DomainStats{}
+	fs := k6tv1.VirtualMachineInstanceFileSystemList{}
 	ident := statsconv.DomainIdentifier(&fakeIdentifier{})
 	devAliasMap := make(map[string]string)
 
@@ -51,13 +52,23 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 	out.Memory.MajorFaultSet = true
 	out.CPUMapSet = true
 
+	fs.Items = []k6tv1.VirtualMachineInstanceFileSystem{
+		{
+			DiskName:       "disk1",
+			MountPoint:     "/",
+			FileSystemType: "EXT4",
+			TotalBytes:     1000,
+			UsedBytes:      10,
+		},
+	}
+
 	vmi := k6tv1.VirtualMachineInstance{
 		Status: k6tv1.VirtualMachineInstanceStatus{
 			Phase:    k6tv1.Running,
 			NodeName: "test",
 		},
 	}
-	ps.Report("test", &vmi, &out)
+	ps.Report("test", &vmi, &domainstats.VirtualMachineInstanceStats{DomainStats: &out, FsStats: fs})
 }
 
 type fakeIdentifier struct {


### PR DESCRIPTION
Currently, in the dashboard, under Virtualization -> Overview, the filesystem
report uses a metric about the pod filesystem usage. This PR adds new metrics
with values corresponding to VM filesystem usage so they can be used in the 
dashboard.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VMI filesystem usage metrics
```
