### PR TITLE
k8s-reporter: Stop dumping unreachable container's info

### DIFF
--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2/config:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to keep to logs cleaner and more informative,
refrain from printing the same error again again,
and also save time if the container / pod aren't
reachable (instead of running more commands).

Additionally - Fix logic of checking if the virt-handler's compute container is healthy,
not just exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7799 

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
