### PR TITLE
test: move isLauncher functions from utils

### DIFF
--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -40,6 +40,13 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
+const (
+	capNetRaw         k8sv1.Capability = "NET_RAW"
+	capSysNice        k8sv1.Capability = "SYS_NICE"
+	capSysPTrace      k8sv1.Capability = "SYS_PTRACE"
+	capNetBindService k8sv1.Capability = "NET_BIND_SERVICE"
+)
+
 var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -248,13 +255,33 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 
 			By("Checking virt-launcher Pod's compute container has precisely the documented extra capabilities")
 			for _, capa := range caps.Add {
-				Expect(tests.IsLauncherCapabilityValid(capa)).To(BeTrue(), "Expected compute container of virt_launcher to be granted only specific capabilities")
+				Expect(isLauncherCapabilityValid(capa)).To(BeTrue(), "Expected compute container of virt_launcher to be granted only specific capabilities")
 			}
 			By("Checking virt-launcher Pod's compute container has precisely the documented dropped capabilities")
 			Expect(caps.Drop).To(HaveLen(1))
 			for _, capa := range caps.Drop {
-				Expect(tests.IsLauncherCapabilityDropped(capa)).To(BeTrue(), "Expected compute container of virt_launcher to drop only specific capabilities")
+				Expect(isLauncherCapabilityDropped(capa)).To(BeTrue(), "Expected compute container of virt_launcher to drop only specific capabilities")
 			}
 		})
 	})
 })
+
+func isLauncherCapabilityValid(capability k8sv1.Capability) bool {
+	switch capability {
+	case
+		capNetBindService,
+		capSysNice,
+		capSysPTrace:
+		return true
+	}
+	return false
+}
+
+func isLauncherCapabilityDropped(capability k8sv1.Capability) bool {
+	switch capability {
+	case
+		capNetRaw:
+		return true
+	}
+	return false
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -173,13 +173,6 @@ const (
 	tmpPath = "/var/provision/kubevirt.io/tests"
 )
 
-const (
-	capNetRaw         k8sv1.Capability = "NET_RAW"
-	capSysNice        k8sv1.Capability = "SYS_NICE"
-	capSysPTrace      k8sv1.Capability = "SYS_PTRACE"
-	capNetBindService k8sv1.Capability = "NET_BIND_SERVICE"
-)
-
 const MigrationWaitTime = 240
 const ContainerCompletionWaitTime = 60
 
@@ -3373,26 +3366,6 @@ func DetectLatestUpstreamOfficialTag() (string, error) {
 
 	By(fmt.Sprintf("By detecting latest upstream official tag %s for current branch", tag))
 	return tag, nil
-}
-
-func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
-	switch capability {
-	case
-		capNetBindService,
-		capSysNice,
-		capSysPTrace:
-		return true
-	}
-	return false
-}
-
-func IsLauncherCapabilityDropped(capability k8sv1.Capability) bool {
-	switch capability {
-	case
-		capNetRaw:
-		return true
-	}
-	return false
 }
 
 // VMILauncherIgnoreWarnings waiting for the VMI to be up but ignoring warnings like a disconnected guest-agent


### PR DESCRIPTION
Move isLauncherCapabilityValid and
isLauncherCapabilityDropped from utils
to security_features_test to make utils
shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```