### PR TITLE
test: move WaitForPodToDisappearWithTimeout func

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -968,7 +968,7 @@ var _ = SIGDescribe("Storage", func() {
 						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 					}
 					Expect(virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
-					tests.WaitForPodToDisappearWithTimeout(pod.Name, 120)
+					waitForPodToDisappearWithTimeout(pod.Name, 120)
 				})
 
 				configureToleration := func(toleration int) {
@@ -1393,3 +1393,12 @@ var _ = SIGDescribe("Storage", func() {
 		})
 	})
 })
+
+func waitForPodToDisappearWithTimeout(podName string, seconds int) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	EventuallyWithOffset(1, func() bool {
+		_, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), podName, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, seconds, 1*time.Second).Should(BeTrue())
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1802,15 +1802,6 @@ func WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi runtime.Object, seco
 	return waitForVMIStart(ctx, vmi, seconds, wp)
 }
 
-func WaitForPodToDisappearWithTimeout(podName string, seconds int) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	EventuallyWithOffset(1, func() bool {
-		_, err := virtClient.CoreV1().Pods(util2.NamespaceTestDefault).Get(context.Background(), podName, metav1.GetOptions{})
-		return errors.IsNotFound(err)
-	}, seconds, 1*time.Second).Should(BeTrue())
-}
-
 func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())


### PR DESCRIPTION
Move WaitForPodToDisappearWithTimeout from
utils to storage to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```