### PR TITLE
test: move HasExperimentalIgnitionSupport func

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2746,10 +2746,6 @@ func IsStorageClassBindingModeWaitForFirstConsumer(sc string) bool {
 		*storageClass.VolumeBindingMode == wffc
 }
 
-func HasExperimentalIgnitionSupport() bool {
-	return checks.HasFeature("ExperimentalIgnitionSupport")
-}
-
 func GetVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
 	uid := vmi.GetObjectMeta().GetUID()

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -47,7 +48,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		util.PanicOnError(err)
 		tests.BeforeTestCleanup()
 
-		if !tests.HasExperimentalIgnitionSupport() {
+		if !hasExperimentalIgnitionSupport() {
 			Skip("ExperimentalIgnitionSupport feature gate is not enabled in kubevirt-config")
 		}
 	})
@@ -90,3 +91,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	})
 })
+
+func hasExperimentalIgnitionSupport() bool {
+	return checks.HasFeature("ExperimentalIgnitionSupport")
+}


### PR DESCRIPTION
Move HasExperimentalIgnitionSupport from utils
to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```