### PR TITLE
test: move GetUpstreamReleaseAssetURL from utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3293,28 +3293,6 @@ func getTagHint() string {
 
 }
 
-func GetUpstreamReleaseAssetURL(tag string, assetName string) string {
-	client := github.NewClient(nil)
-
-	var err error
-	var release *github.RepositoryRelease
-
-	Eventually(func() error {
-		release, _, err = client.Repositories.GetReleaseByTag(context.Background(), "kubevirt", "kubevirt", tag)
-
-		return err
-	}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
-	for _, asset := range release.Assets {
-		if asset.GetName() == assetName {
-			return asset.GetBrowserDownloadURL()
-		}
-	}
-
-	Fail(fmt.Sprintf("Asset %s not found in release %s of kubevirt upstream repo", assetName, tag))
-	return ""
-}
-
 func DetectLatestUpstreamOfficialTag() (string, error) {
 	client := github.NewClient(nil)
 


### PR DESCRIPTION
Move GetUpstreamReleaseAssetURL from utils
to operator_test to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```