### PR TITLE
test: move GetContainerDiskContainerOfPod func

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -90,7 +90,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 		Expect(vmi.Spec.Volumes[0].ContainerDisk.ImagePullPolicy).To(Equal(expectedPolicy))
 		pod := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-		container := tests.GetContainerDiskContainerOfPod(pod, vmi.Spec.Volumes[0].Name)
+		container := getContainerDiskContainerOfPod(pod, vmi.Spec.Volumes[0].Name)
 		Expect(container.ImagePullPolicy).To(Equal(expectedPolicy))
 	},
 		Entry("[test_id:3246]generate and set Always pull policy", "test", k8sv1.PullPolicy(""), k8sv1.PullAlways),
@@ -273,3 +273,8 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 })
+
+func getContainerDiskContainerOfPod(pod *k8sv1.Pod, volumeName string) *k8sv1.Container {
+	diskContainerName := fmt.Sprintf("volume%s", volumeName)
+	return tests.GetContainerOfPod(pod, diskContainerName)
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -978,11 +978,6 @@ func GetComputeContainerOfPod(pod *k8sv1.Pod) *k8sv1.Container {
 	return GetContainerOfPod(pod, "compute")
 }
 
-func GetContainerDiskContainerOfPod(pod *k8sv1.Pod, volumeName string) *k8sv1.Container {
-	diskContainerName := fmt.Sprintf("volume%s", volumeName)
-	return GetContainerOfPod(pod, diskContainerName)
-}
-
 func GetContainerOfPod(pod *k8sv1.Pod, containerName string) *k8sv1.Container {
 	var computeContainer *k8sv1.Container
 	for _, container := range pod.Spec.Containers {


### PR DESCRIPTION
Move GetContainerDiskContainerOfPod from utils
to container_disk_test to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```