### PR TITLE
test: move GenerateVMIJson from utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2291,20 +2291,6 @@ func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, er
 	return jsonFile, nil
 }
 
-func GenerateVMIJson(vmi *v1.VirtualMachineInstance, generateDirectory string) (string, error) {
-	data, err := json.Marshal(vmi)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate json for vmi %s", vmi.Name)
-	}
-
-	jsonFile := filepath.Join(generateDirectory, fmt.Sprintf("%s.json", vmi.Name))
-	err = ioutil.WriteFile(jsonFile, data, 0644)
-	if err != nil {
-		return "", fmt.Errorf("failed to write json file %s", jsonFile)
-	}
-	return jsonFile, nil
-}
-
 func GenerateTemplateJson(template *vmsgen.Template, generateDirectory string) (string, error) {
 	data, err := json.Marshal(template)
 	if err != nil {


### PR DESCRIPTION
Move GenerateVMIJson from utils to window_test
to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```