### PR TITLE
test: move GenerateTemplateJson from utils

### DIFF
--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -20,7 +20,9 @@
 package tests_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -99,7 +101,7 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 				ExpectWithOffset(1, template).NotTo(BeNil(), "template object was not provided")
 				By("Creating the Template JSON file")
 				var err error
-				templateFile, err = tests.GenerateTemplateJson(template, workDir)
+				templateFile, err = generateTemplateJson(template, workDir)
 				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to write template JSON file: %v", err)
 				ExpectWithOffset(1, templateFile).To(BeAnExistingFile(), "template JSON file %q was not created", templateFile)
 
@@ -275,3 +277,16 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 		})
 	})
 })
+
+func generateTemplateJson(template *vmsgen.Template, generateDirectory string) (string, error) {
+	data, err := json.Marshal(template)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate json for template %q: %v", template.Name, err)
+	}
+
+	jsonFile := filepath.Join(generateDirectory, template.Name+".json")
+	if err = ioutil.WriteFile(jsonFile, data, 0644); err != nil {
+		return "", fmt.Errorf("failed to write json to file %q: %v", jsonFile, err)
+	}
+	return jsonFile, nil
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -96,7 +96,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	launcherApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
-	vmsgen "kubevirt.io/kubevirt/tools/vms-generator/utils"
 
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -2301,19 +2300,6 @@ func GenerateVMIJson(vmi *v1.VirtualMachineInstance, generateDirectory string) (
 	err = ioutil.WriteFile(jsonFile, data, 0644)
 	if err != nil {
 		return "", fmt.Errorf("failed to write json file %s", jsonFile)
-	}
-	return jsonFile, nil
-}
-
-func GenerateTemplateJson(template *vmsgen.Template, generateDirectory string) (string, error) {
-	data, err := json.Marshal(template)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate json for template %q: %v", template.Name, err)
-	}
-
-	jsonFile := filepath.Join(generateDirectory, template.Name+".json")
-	if err = ioutil.WriteFile(jsonFile, data, 0644); err != nil {
-		return "", fmt.Errorf("failed to write json to file %q: %v", jsonFile, err)
 	}
 	return jsonFile, nil
 }


### PR DESCRIPTION
Move GenerateTemplateJson from utils
to template_test to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```