### PR TITLE
test: move IsUsingBuiltinNodeDrainKey from utils

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3123,7 +3123,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				BeforeEach(func() {
 					// Taints defined by k8s are special and can't be applied manually.
 					// Temporarily configure KubeVirt to use something else for the duration of these tests.
-					if tests.IsUsingBuiltinNodeDrainKey() {
+					if isUsingBuiltinNodeDrainKey() {
 						drain := "kubevirt.io/drain"
 						cfg := getCurrentKv()
 						cfg.MigrationConfiguration.NodeDrainTaintKey = &drain
@@ -4236,4 +4236,8 @@ func libvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.Virtua
 		return false, fmt.Errorf("could not dump libvirt domxml (remotely on pod): %v: %s", err, stderr)
 	}
 	return strings.Contains(stdout, vmi.Namespace+"_"+vmi.Name), nil
+}
+
+func isUsingBuiltinNodeDrainKey() bool {
+	return libnode.GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3237,10 +3237,6 @@ func IsRunningOnKindInfra() bool {
 	return strings.HasPrefix(provider, "kind")
 }
 
-func IsUsingBuiltinNodeDrainKey() bool {
-	return libnode.GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
-}
-
 func RandTmpDir() string {
 	return filepath.Join(tmpPath, rand.String(10))
 }


### PR DESCRIPTION
Move IsUsingBuiltinNodeDrainKey from utils
to migration_test to make utils shorter.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

**Release note**:
```release-note
NONE
```