### PR TITLE
OWNERS, network-reviewers: Remove inactive member

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -52,7 +52,6 @@ aliases:
       - AlonaKaplan
       - EdDev
       - RamLavi
-      - alonSadan
       - maiqueb
       - ormergi
       - oshoval


### PR DESCRIPTION
**What this PR does / why we need it**:

@alonSadan is not longer an active participant in the project for 1.5 years now.
Removing him from the network-reviewers list so he will no longer be
assigned as reviewer by the bot.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```