### PR TITLE
Fix KubevirtVmHighMemoryUsage alert

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -487,11 +487,11 @@ tests:
   # Memory utilization less than 20MB close to requested memory - based on memory working set
   - interval: 1m
     input_series:
-      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
-      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "47185920 48234496 48234496 49283072"
-      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
 
     alert_rule_test:
@@ -499,7 +499,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to requested memory"
+              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 20 MB and it is close to requested memory"
               summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
@@ -508,15 +508,16 @@ tests:
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
               container: "compute"
+              namespace: "ns-test"
 
   # Memory utilization less than 20MB close to requested memory - based on memory RSS
   - interval: 1m
     input_series:
-      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
-      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
-      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "47185920 48234496 48234496 49283072"
 
     alert_rule_test:
@@ -524,7 +525,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to requested memory"
+              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 20 MB and it is close to requested memory"
               summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
@@ -533,15 +534,16 @@ tests:
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
               container: "compute"
+              namespace: "ns-test"
 
   # Memory utilization less than 20MB close to requested memory - based on memory RSS and memory working set
   - interval: 1m
     input_series:
-      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
-      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "47185920 48234496 48234496 49283072"
-      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "47185920 48234496 48234496 49283072"
 
     alert_rule_test:
@@ -549,7 +551,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to requested memory"
+              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 20 MB and it is close to requested memory"
               summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
@@ -558,15 +560,16 @@ tests:
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
               container: "compute"
+              namespace: "ns-test"
 
   # Memory utilization more than 20MB close to requested memory
   - interval: 30s
     input_series:
-      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory"}'
+      - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
-      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
-      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute"}'
+      - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
 
     alert_rule_test:

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -398,18 +398,18 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Record: "kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes",
-						Expr:   intstr.FromString("sum by(pod, container) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
+						Expr:   intstr.FromString("sum by(pod, container, namespace) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container, namespace) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
 					},
 					{
 						Record: "kubevirt_vm_container_free_memory_bytes_based_on_rss",
-						Expr:   intstr.FromString("sum by(pod, container) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container) container_memory_rss{pod=~'virt-launcher-.*', container='compute'})"),
+						Expr:   intstr.FromString("sum by(pod, container, namespace) (kube_pod_container_resource_requests{pod=~'virt-launcher-.*', container='compute', resource='memory'}- on(pod,container, namespace) container_memory_rss{pod=~'virt-launcher-.*', container='compute'})"),
 					},
 					{
 						Alert: "KubevirtVmHighMemoryUsage",
 						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 20971520 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 20971520"),
 						For:   "1m",
 						Annotations: map[string]string{
-							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} free memory is less than 20 MB and it is close to requested memory",
+							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than 20 MB and it is close to requested memory",
 							"summary":     "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime.",
 							"runbook_url": runbookUrlBasePath + "KubevirtVmHighMemoryUsage",
 						},


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added namespace to the KubevirtVmHighMemoryUsage
alert so that the pod will be correctly identified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
