### PR TITLE
tests, libstorage: relocate some recently introduced PVC utils

### DIFF
--- a/tests/libstorage/BUILD.bazel
+++ b/tests/libstorage/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "datavolume.go",
+        "pvc.go",
         "storageclass.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/libstorage",

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package libstorage
+
+import (
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+const (
+	DefaultPvcMountPath = "/pvc"
+)
+
+func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
+	volumeName := "disk0"
+	// Change to 'pod := RenderPod(name, cmd, args)' once we have a libpod package
+	pod := &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: name,
+			Namespace:    util.NamespaceTestDefault,
+			Labels: map[string]string{
+				v1.AppLabel: "test",
+			},
+		},
+		Spec: k8sv1.PodSpec{
+			RestartPolicy: k8sv1.RestartPolicyNever,
+			Containers: []k8sv1.Container{
+				{
+					Name:    name,
+					Image:   fmt.Sprintf("%s/vm-killer:%s", flags.KubeVirtUtilityRepoPrefix, flags.KubeVirtUtilityVersionTag),
+					Command: cmd,
+					Args:    args,
+				},
+			},
+			Volumes: []k8sv1.Volume{
+				{
+					Name: volumeName,
+					VolumeSource: k8sv1.VolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvc.GetName(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	volumeMode := pvc.Spec.VolumeMode
+	if volumeMode != nil && *volumeMode == k8sv1.PersistentVolumeBlock {
+		pod.Spec.Containers[0].VolumeDevices = addVolumeDevices(volumeName)
+	} else {
+		pod.Spec.Containers[0].VolumeMounts = addVolumeMounts(volumeName)
+	}
+
+	return pod
+}
+
+// this is being called for pods using PV with block volume mode
+func addVolumeDevices(volumeName string) []k8sv1.VolumeDevice {
+	volumeDevices := []k8sv1.VolumeDevice{
+		{
+			Name:       volumeName,
+			DevicePath: DefaultPvcMountPath,
+		},
+	}
+	return volumeDevices
+}
+
+// this is being called for pods using PV with filesystem volume mode
+func addVolumeMounts(volumeName string) []k8sv1.VolumeMount {
+	volumeMounts := []k8sv1.VolumeMount{
+		{
+			Name:      volumeName,
+			MountPath: DefaultPvcMountPath,
+		},
+	}
+	return volumeMounts
+}

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -251,7 +251,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			virtClient,
 			executorPod,
 			executorPod.Spec.Containers[0].Name,
-			[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s", tests.DefaultPvcMountPath)},
+			[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s", libstorage.DefaultPvcMountPath)},
 		)
 		lsOutput = strings.TrimSpace(lsOutput)
 		log.Log.Infof("%s", lsOutput)
@@ -260,7 +260,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			virtClient,
 			executorPod,
 			executorPod.Spec.Containers[0].Name,
-			[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s | wc -l", tests.DefaultPvcMountPath)},
+			[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s | wc -l", libstorage.DefaultPvcMountPath)},
 		)
 		wcOutput = strings.TrimSpace(wcOutput)
 		log.Log.Infof("%s", wcOutput)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -115,7 +115,6 @@ import (
 const (
 	KubernetesIoHostName         = "kubernetes.io/hostname"
 	BinBash                      = "/bin/bash"
-	DefaultPvcMountPath          = "/pvc"
 	StartingVMInstance           = "Starting a VirtualMachineInstance"
 	WaitingVMInstanceStart       = "Waiting until the VirtualMachineInstance will start"
 	CouldNotFindComputeContainer = "could not find compute container for pod"
@@ -1953,52 +1952,6 @@ func RenderPod(name string, cmd []string, args []string) *k8sv1.Pod {
 	return &pod
 }
 
-func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
-	pod := RenderPod(name, cmd, args)
-
-	volumeName := "disk0"
-	pod.Spec.Volumes = []k8sv1.Volume{
-		{
-			Name: volumeName,
-			VolumeSource: k8sv1.VolumeSource{
-				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvc.GetName(),
-				},
-			},
-		},
-	}
-	volumeMode := pvc.Spec.VolumeMode
-	if volumeMode != nil && *volumeMode == k8sv1.PersistentVolumeBlock {
-		pod.Spec.Containers[0].VolumeDevices = addVolumeDevices(volumeName)
-	} else {
-		pod.Spec.Containers[0].VolumeMounts = addVolumeMounts(volumeName)
-	}
-
-	return pod
-}
-
-// this is being called for pods using PV with block volume mode
-func addVolumeDevices(volumeName string) []k8sv1.VolumeDevice {
-	volumeDevices := []k8sv1.VolumeDevice{
-		{
-			Name:       volumeName,
-			DevicePath: DefaultPvcMountPath,
-		},
-	}
-	return volumeDevices
-}
-
-// this is being called for pods using PV with filesystem volume mode
-func addVolumeMounts(volumeName string) []k8sv1.VolumeMount {
-	volumeMounts := []k8sv1.VolumeMount{
-		{
-			Name:      volumeName,
-			MountPath: DefaultPvcMountPath,
-		},
-	}
-	return volumeMounts
-}
-
 // CreateExecutorPodWithPVC creates a Pod with the passed in PVC mounted under /pvc. You can then use the executor utilities to
 // run commands against the PVC through this Pod.
 func CreateExecutorPodWithPVC(podName string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
@@ -2006,7 +1959,7 @@ func CreateExecutorPodWithPVC(podName string, pvc *k8sv1.PersistentVolumeClaim) 
 }
 
 func newExecutorPodWithPVC(podName string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
-	return RenderPodWithPVC(podName, []string{"/bin/bash", "-c", "while true; do echo hello; sleep 2;done"}, nil, pvc)
+	return libstorage.RenderPodWithPVC(podName, []string{"/bin/bash", "-c", "while true; do echo hello; sleep 2;done"}, nil, pvc)
 }
 
 func RunPod(pod *k8sv1.Pod) *k8sv1.Pod {
@@ -2036,10 +1989,10 @@ func RunPodAndExpectCompletion(pod *k8sv1.Pod) *k8sv1.Pod {
 }
 
 func ChangeImgFilePermissionsToNonQEMU(pvc *k8sv1.PersistentVolumeClaim) {
-	args := []string{fmt.Sprintf(`chmod 640 %s && chown root:root %s && sync`, filepath.Join(DefaultPvcMountPath, "disk.img"), filepath.Join(DefaultPvcMountPath, "disk.img"))}
+	args := []string{fmt.Sprintf(`chmod 640 %s && chown root:root %s && sync`, filepath.Join(libstorage.DefaultPvcMountPath, "disk.img"), filepath.Join(libstorage.DefaultPvcMountPath, "disk.img"))}
 
 	By("changing disk.img permissions to non qemu")
-	pod := RenderPodWithPVC("change-permissions-disk-img-pod", []string{"/bin/bash", "-c"}, args, pvc)
+	pod := libstorage.RenderPodWithPVC("change-permissions-disk-img-pod", []string{"/bin/bash", "-c"}, args, pvc)
 
 	RunPodAndExpectCompletion(pod)
 }


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
These were introduced in #7324 and would perfectly fit in libstorage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Looking at pod funcs in the big utils.go, I think we have enough justification to create `libpod`.
WDYT?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
