### PR TITLE
k8s reporter: Fix virt-launcher pid find logic

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -437,7 +437,7 @@ func (r *KubernetesReporter) logVirtLauncherPrivilegedCommands(virtCli kubecli.K
 		if virtHandlerPod, ok := nodeMap[virtLauncherPod.Spec.NodeName]; ok {
 			labels := virtLauncherPod.GetLabels()
 			if uid, ok := labels["kubevirt.io/created-by"]; ok {
-				pid, err := getVirtLauncherPID(virtCli, &virtHandlerPod, uid)
+				pid, err := getVirtLauncherMonitorPID(virtCli, &virtHandlerPod, uid)
 				if err != nil {
 					continue
 				}
@@ -1210,11 +1210,11 @@ func (r *KubernetesReporter) executeCloudInitCommands(vmi v12.VirtualMachineInst
 	}
 }
 
-func getVirtLauncherPID(virtCli kubecli.KubevirtClient, virtHandlerPod *v1.Pod, uid string) (string, error) {
+func getVirtLauncherMonitorPID(virtCli kubecli.KubevirtClient, virtHandlerPod *v1.Pod, uid string) (string, error) {
 	command := []string{
 		"/bin/bash",
 		"-c",
-		fmt.Sprintf("pgrep -f \"uid %s.*no-fork\"", uid),
+		fmt.Sprintf("pgrep -f \"monitor.*uid %s\"", uid),
 	}
 
 	stdout, stderr, err := tests.ExecuteCommandOnPodV2(virtCli, virtHandlerPod, virtHandlerName, command)


### PR DESCRIPTION
**What this PR does / why we need it**:
Since virt-launcher core code was changed (https://github.com/kubevirt/kubevirt/pull/7451),
and the processes are not suffixed with no-fork
anymore, fix the pgrep logic that find the pid
according the new naming (`virt-launcher-monitor` and `virt-launcher`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
