### PR TITLE
migration: enable migrating from non-root to root

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -1052,9 +1052,11 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 				// will be marked as failed too.
 				return nil
 			}
-			if c.clusterConfig.NonRootEnabled() && util.CanBeNonRoot(vmi) == nil {
-				patches := []string{}
 
+			var patches []string
+			if c.clusterConfig.NonRootEnabled() && util.CanBeNonRoot(vmi) == nil {
+				// The cluster is configured for non-root VMs, ensure the VMI is non-root.
+				// If the VMI is root, the migration will be a root -> non-root migration.
 				if vmi.Status.RuntimeUser != util.NonRootUID {
 					patches = append(patches, fmt.Sprintf(`{ "op": "replace", "path": "/status/runtimeUser", "value": %d }`, util.NonRootUID))
 				}
@@ -1064,18 +1066,28 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 					patches = append(patches, fmt.Sprintf(`{ "op": "add", "path": "/metadata/annotations", "value":  { "%s": "true"} }`, virtv1.DeprecatedNonRootVMIAnnotation))
 				} else if _, ok := vmi.Annotations[virtv1.DeprecatedNonRootVMIAnnotation]; !ok {
 					patches = append(patches, fmt.Sprintf(`{ "op": "add", "path": "/metadata/annotations/%s", "value": "true"}`, controller.EscapeJSONPointer(virtv1.DeprecatedNonRootVMIAnnotation)))
-
+				}
+			} else {
+				// The cluster is configured for root VMs, ensure the VMI is root.
+				// If the VMI is non-root, the migration will be a non-root -> root migration.
+				if vmi.Status.RuntimeUser != util.RootUser {
+					patches = append(patches, fmt.Sprintf(`{ "op": "replace", "path": "/status/runtimeUser", "value": %d }`, util.RootUser))
 				}
 
-				if len(patches) != 0 {
-					vmi, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(vmi.Name, types.JSONPatchType, controller.GeneratePatchBytes(patches), &v1.PatchOptions{})
-					if err != nil {
-						return fmt.Errorf("failed to mark VMI as nonroot: %v", err)
-
+				if vmi.Annotations != nil {
+					if _, ok := vmi.Annotations[virtv1.DeprecatedNonRootVMIAnnotation]; ok {
+						patches = append(patches, fmt.Sprintf(`{ "op": "remove", "path": "/metadata/annotations/%s"}`, controller.EscapeJSONPointer(virtv1.DeprecatedNonRootVMIAnnotation)))
 					}
 				}
-
 			}
+			if len(patches) != 0 {
+				vmi, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(vmi.Name, types.JSONPatchType, controller.GeneratePatchBytes(patches), &v1.PatchOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to mark VMI as nonroot: %v", err)
+
+				}
+			}
+
 			return c.handleTargetPodCreation(key, migration, vmi, sourcePod)
 		} else if isPodReady(pod) {
 			if controller.VMIHasHotplugVolumes(vmi) {

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -1083,8 +1083,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			if len(patches) != 0 {
 				vmi, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(vmi.Name, types.JSONPatchType, controller.GeneratePatchBytes(patches), &v1.PatchOptions{})
 				if err != nil {
-					return fmt.Errorf("failed to mark VMI as nonroot: %v", err)
-
+					return fmt.Errorf("failed to set VMI RuntimeUser: %v", err)
 				}
 			}
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1644,6 +1644,30 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
+		createDataVolumePVCAndChangeDiskImgPermissions := func(size string) *cdiv1.DataVolume {
+			var dv *cdiv1.DataVolume
+			// Create DV and alter permission of disk.img
+			url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
+			dv = libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
+			tests.SetDataVolumeForceBindAnnotation(dv)
+			dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
+			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+			Expect(err).To(BeNil())
+			var pvc *k8sv1.PersistentVolumeClaim
+			Eventually(func() *k8sv1.PersistentVolumeClaim {
+				pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+				if err != nil {
+					return nil
+				}
+				return pvc
+			}, 30*time.Second).Should(Not(BeNil()))
+			By("waiting for the dv import to pvc to finish")
+			Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
+			tests.ChangeImgFilePermissionsToNonQEMU(pvc)
+			pvName = pvc.Name
+			return dv
+		}
+
 		Context("[Serial] migration to nonroot", func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
@@ -1662,28 +1686,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					dv = nil
 				}
 			})
-
-			createDataVolumePVCAndChangeDiskImgPermissions := func() {
-				// Create DV and alter permission of disk.img
-				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-				dv = libstorage.NewRandomDataVolumeWithRegistryImport(url, util.NamespaceTestDefault, k8sv1.ReadWriteMany)
-				tests.SetDataVolumeForceBindAnnotation(dv)
-				dv.Spec.PVC.Resources.Requests["storage"] = resource.MustParse(size)
-				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-				Expect(err).To(BeNil())
-				var pvc *k8sv1.PersistentVolumeClaim
-				Eventually(func() *k8sv1.PersistentVolumeClaim {
-					pvc, err = virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-					if err != nil {
-						return nil
-					}
-					return pvc
-				}, 30*time.Second).Should(Not(BeNil()))
-				By("waiting for the dv import to pvc to finish")
-				Eventually(ThisDV(dv), 180*time.Second).Should(HaveSucceeded())
-				tests.ChangeImgFilePermissionsToNonQEMU(pvc)
-				pvName = pvc.Name
-			}
 
 			DescribeTable("should migrate root implementation to nonroot", func(createVMI func() *v1.VirtualMachineInstance, loginFunc func(*v1.VirtualMachineInstance) error) {
 				By("Create a VMI that will run root(default)")
@@ -1731,7 +1733,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, console.LoginToAlpine),
 
 				Entry("[test_id:8610] with DataVolume", func() *v1.VirtualMachineInstance {
-					createDataVolumePVCAndChangeDiskImgPermissions()
+					dv = createDataVolumePVCAndChangeDiskImgPermissions(size)
 					// Use the DataVolume
 					return tests.NewRandomVMIWithDataVolume(pvName)
 				}, console.LoginToAlpine),
@@ -1741,8 +1743,94 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, console.LoginToFedora),
 
 				Entry("[test_id:8612] with PVC", func() *v1.VirtualMachineInstance {
-					createDataVolumePVCAndChangeDiskImgPermissions()
+					dv = createDataVolumePVCAndChangeDiskImgPermissions(size)
 					// Use the Underlying PVC
+					return tests.NewRandomVMIWithPVC(pvName)
+				}, console.LoginToAlpine),
+			)
+		})
+		Context("[Serial] migration to root", func() {
+			var dv *cdiv1.DataVolume
+			var clusterIsRoot bool
+			size := "256Mi"
+
+			BeforeEach(func() {
+				clusterIsRoot = !checks.HasFeature(virtconfig.NonRoot)
+				if clusterIsRoot {
+					tests.EnableFeatureGate(virtconfig.NonRoot)
+				}
+			})
+			AfterEach(func() {
+				if clusterIsRoot {
+					tests.DisableFeatureGate(virtconfig.NonRoot)
+				} else {
+					tests.EnableFeatureGate(virtconfig.NonRoot)
+				}
+				if dv != nil {
+					By("Deleting the DataVolume")
+					Expect(virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed())
+					dv = nil
+				}
+			})
+
+			DescribeTable("should migrate nonroot implementation to root", func(createVMI func() *v1.VirtualMachineInstance, loginFunc func(*v1.VirtualMachineInstance) error) {
+				By("Create a VMI that will run root(default)")
+				vmi := createVMI()
+
+				By("Starting the VirtualMachineInstance")
+				// Resizing takes too long and therefor a warning is thrown
+				vmi = runVMIAndExpectLaunchIgnoreWarnings(vmi, 240)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(loginFunc(vmi)).To(Succeed())
+
+				By("Checking that the launcher is running as root")
+				Expect(tests.GetIdOfLauncher(vmi)).To(Equal("107"))
+
+				tests.DisableFeatureGate(virtconfig.NonRoot)
+
+				By("Starting new migration and waiting for it to succeed")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
+
+				By("Verifying Second Migration Succeeeds")
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+
+				By("Checking that the launcher is running as qemu")
+				Expect(tests.GetIdOfLauncher(vmi)).To(Equal("0"))
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(loginFunc(vmi)).To(Succeed())
+
+				vmi, err := ThisVMI(vmi)()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi.Annotations).ToNot(HaveKey(v1.DeprecatedNonRootVMIAnnotation))
+
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+
+			},
+				Entry("with simple VMI", func() *v1.VirtualMachineInstance {
+					return libvmi.NewAlpine(
+						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithNetwork(v1.DefaultPodNetwork()))
+				}, console.LoginToAlpine),
+
+				Entry("with DataVolume", func() *v1.VirtualMachineInstance {
+					dv = createDataVolumePVCAndChangeDiskImgPermissions(size)
+					// Use the DataVolume
+					return tests.NewRandomVMIWithDataVolume(pvName)
+				}, console.LoginToAlpine),
+
+				Entry("with CD + CloudInit + SA + ConfigMap + Secret + DownwardAPI + Kernel Boot", func() *v1.VirtualMachineInstance {
+					return prepareVMIWithAllVolumeSources()
+				}, console.LoginToFedora),
+
+				Entry("with PVC", func() *v1.VirtualMachineInstance {
+					dv = createDataVolumePVCAndChangeDiskImgPermissions(size)
+					// Use the underlying PVC
 					return tests.NewRandomVMIWithPVC(pvName)
 				}, console.LoginToAlpine),
 			)


### PR DESCRIPTION
**What this PR does / why we need it**:
The migration code allows VMIs to migrate from root to non-root, but not the other way around.
Sounds like an oversight to me, this PR addresses that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2091911

**Special notes for your reviewer**:
Will write unit/functional test(s) if preliminary reviews are positive.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Non-root VMs will now migrate to root VMs after a cluster disables non-root.
```
