### PR TITLE
Fix CRD validation code generation

### DIFF
--- a/tools/crd-validation-generator/validation-generator.go
+++ b/tools/crd-validation-generator/validation-generator.go
@@ -68,6 +68,7 @@ func generateGoFile(outputDir string, validations map[string]*extv1.CustomResour
 
 	for _, crdname := range crds {
 		crd := validations[crdname]
+		crd.OpenAPIV3Schema = sanitizeSchema(crd.OpenAPIV3Schema)
 		b, _ := yaml.Marshal(crd)
 		file.WriteString(fmt.Sprintf(variable, crdname, string(b)))
 	}
@@ -88,4 +89,34 @@ func getValidation(filename string) (string, *extv1.CustomResourceValidation) {
 		panic(fmt.Errorf("Failed to parse crd from file %v, %v", filename, err))
 	}
 	return crd.Spec.Names.Singular, crd.Spec.Versions[0].Schema
+}
+
+// sanitizeSchema traverses the given JSON-Schema object and replaces all occurrences of the
+// backtick (`) character in the (sub-)schema Description fields with single quote characters
+func sanitizeSchema(inSchema *extv1.JSONSchemaProps) *extv1.JSONSchemaProps {
+	schema := inSchema.DeepCopy()
+	if schema.Description != "" {
+		schema.Description = strings.ReplaceAll(schema.Description, "`", "'")
+	}
+
+	// Traverse Items
+	if schema.Items != nil {
+		if schema.Items.Schema != nil {
+			schema.Items.Schema = sanitizeSchema(schema.Items.Schema)
+		}
+		if len(schema.Items.JSONSchemas) > 0 {
+			sanitizedProps := make([]extv1.JSONSchemaProps, 0, len(schema.Items.JSONSchemas))
+			for _, schema := range schema.Items.JSONSchemas {
+				sanitizedProps = append(sanitizedProps, *sanitizeSchema(&schema))
+			}
+			schema.Items.JSONSchemas = sanitizedProps
+		}
+	}
+
+	// Traverse Properties
+	for name, prop := range schema.Properties {
+		schema.Properties[name] = *sanitizeSchema(&prop)
+	}
+
+	return schema
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This fixes the issue where generating the CRD validation code fails if code comments for API types contain backticks (`).
Any backticks in the schema description fields are now replaced with single quotes so that they don't break the code syntax when wrapped in string literals / raw strings.

**Which issue(s) this PR fixes**:
See #7844

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that caused `make generate` to fail when API code comments contain backticks. (#7844, @janeczku)
```