### PR TITLE
tests: simplify libvmi and use it to start diskless VM

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -34,8 +34,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"kubevirt.io/kubevirt/tests/framework/checks"
 
 	expect "github.com/google/goexpect"
@@ -162,15 +160,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", func() {
 			By("first getting the basetime for a replicaset")
 			targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-				k8sv1.ResourceMemory: resource.MustParse("1Mi"),
-			}
-
-			if vmi.Spec.NodeSelector == nil {
-				vmi.Spec.NodeSelector = map[string]string{}
-			}
-			vmi.Spec.NodeSelector["kubernetes.io/hostname"] = targetNode.Name
+			vmi := libvmi.New(
+				libvmi.RandName(),
+				libvmi.WithResourceMemory("1Mi"),
+				libvmi.WithNodeSelectorFor(&targetNode),
+			)
 
 			replicaset := tests.NewRandomReplicaSetFromVMI(vmi, 0)
 			replicaset, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -27,17 +27,11 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-// Default VMI values
-const (
-	DefaultTestGracePeriod int64 = 0
-)
-
 // NewFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options.
 // This image has tooling for the guest agent, stress, SR-IOV and more.
 func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	fedoraOptions := []Option{
-		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory("512M"),
 		WithRng(),
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
@@ -55,7 +49,6 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		withNonEmptyUserData,
 		WithResourceMemory(cirrosMemory()),
-		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
 	return New(RandName(), cirrosOpts...)
@@ -68,7 +61,6 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
 		WithResourceMemory(alpineMemory()),
 		WithRng(),
-		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	alpineOpts = append(alpineOpts, opts...)
 	return New(RandName(), alpineOpts...)
@@ -80,7 +72,6 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
 		WithResourceMemory(alpineMemory()),
 		WithRng(),
-		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	alpineOpts = append(alpineOpts, opts...)
 	return New(RandName(), alpineOpts...)

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -30,7 +30,6 @@ import (
 // Default VMI values
 const (
 	DefaultTestGracePeriod int64 = 0
-	DefaultVmiName               = "testvmi"
 )
 
 // NewFedora instantiates a new Fedora based VMI configuration,
@@ -44,7 +43,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
 	}
 	opts = append(fedoraOptions, opts...)
-	return New(RandName(DefaultVmiName), opts...)
+	return New(RandName(), opts...)
 }
 
 // NewCirros instantiates a new CirrOS based VMI configuration
@@ -59,7 +58,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
-	return New(RandName(DefaultVmiName), cirrosOpts...)
+	return New(RandName(), cirrosOpts...)
 }
 
 // NewAlpine instantiates a new Alpine based VMI configuration
@@ -72,7 +71,7 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	alpineOpts = append(alpineOpts, opts...)
-	return New(RandName(DefaultVmiName), alpineOpts...)
+	return New(RandName(), alpineOpts...)
 }
 
 func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
@@ -84,7 +83,7 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	alpineOpts = append(alpineOpts, opts...)
-	return New(RandName(DefaultVmiName), alpineOpts...)
+	return New(RandName(), alpineOpts...)
 }
 
 func cirrosMemory() string {

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -45,9 +45,9 @@ func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return vmi
 }
 
-// RandName returns a random name by concatenating the given name with a hyphen and a random string.
-func RandName(name string) string {
-	return name + "-" + rand.String(5)
+// RandName returns a random name for a virtual machine
+func RandName() string {
+	return "testvmi" + "-" + rand.String(5)
 }
 
 // WithLabel sets a label with specified value

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -38,6 +38,7 @@ type Option func(vmi *kvirtv1.VirtualMachineInstance)
 func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 	vmi := baseVmi(name)
 
+	WithTerminationGracePeriod(0)(vmi)
 	for _, f := range opts {
 		f(vmi)
 	}

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -194,7 +194,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 		})
 		It("should reject VMIs with default interface slirp when it's not permitted", func() {
 			var t int64 = 0
-			vmi := tests.NewRandomVMIWithNS(util.NamespaceTestDefault)
+			vmi := tests.NewRandomVMI()
 			vmi.Spec.TerminationGracePeriodSeconds = &t
 			// Reset memory, devices and networks
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1043,7 +1043,7 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 }
 
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
-	vmi := v1.NewVMIReferenceFromNameWithNS(namespace, libvmi.RandName(libvmi.DefaultVmiName))
+	vmi := v1.NewVMIReferenceFromNameWithNS(namespace, libvmi.RandName())
 	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}
 	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 	vmi.TypeMeta = metav1.TypeMeta{


### PR DESCRIPTION
This PR purges two public constants from `tests.libvmi`, as they are not required and dropping them makes the code simpler. In particular, it makes it simpler to start a diskless VM via `libvmi` and simplifies the code introduced in PR #7649.

/cc @EdDev as this modifies `libvmi` APIs
/cc @enp0s3 as this modifies `infra_test`'s rate limiter test

```release-note
NONE
```
