### PR TITLE
test/utils: static file length limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,7 @@ format:
 fmt: format
 
 lint:
-	# tests/utils.go is too long already. Don't make it worse.
-	# this is a placeholder for a proper linter.
-	git diff --numstat $$(git merge-base HEAD origin/main) -- tests/utils.go | \
-		awk '{if ($$1-$$2 > 0) {print $$3 " grew longer"; exit 1} }'
+	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 .PHONY: \
 	build-verify \


### PR DESCRIPTION
My former attempt at `make lint` used `git-diff` and as such can confuse
Tide. Far worse it simply did not work failing with
     fatal: Not a valid object name origin/main
and should not have been merged.

Let us quickly revert to simple static approach, where someone (e.g. me)
is going to update the threathold once in a while, until tests/utils is
gone.

This version is tested to fail when the file grows above the threshold
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7852/pull-kubevirt-code-lint/1537101643487645696#1:build-log.txt%3A25


```release-note
NONE
```
