### PR TITLE
panic if CDIConfig status FilesystemOverhead is nil

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2139,6 +2139,9 @@ func (c *VMIController) getFilesystemOverhead(pvc *k8sv1.PersistentVolumeClaim) 
 	if !ok {
 		return "0", fmt.Errorf("Failed to convert CDIConfig object %v to type CDIConfig", cdiConfigInterface)
 	}
+	if cdiConfig.Status.FilesystemOverhead == nil {
+		return "0", fmt.Errorf("Failed to get FilesystemOverhead from CDIConfig's status")
+	}
 	if pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == k8sv1.PersistentVolumeBlock {
 		return "0", nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: vm-pvc
spec:
  running: true
  template:
    metadata:
      labels:
        kubevirt.io/size: small
        kubevirt.io/domain: vm-pvc
    spec:
      domain:
        devices:
          disks:
            - name: pvcdisk
              disk:
                bus: virtio
        resources:
          requests:
            memory: 1G
        machine:
          type: ""
      volumes:
        - name: pvcdisk
          persistentVolumeClaim:
            claimName: registry-image-datavolume`

when create vm with CDI pvc, the kubevirt controller manager will panic if cdiConfig status FilesystemOverhead is nil. 

`# kubectl get cdiconfigs.cdi.kubevirt.io config -oyaml
apiVersion: cdi.kubevirt.io/v1beta1
kind: CDIConfig
metadata:
  creationTimestamp: "2022-06-05T13:17:44Z"
  generation: 1
  labels:
    app: containerized-data-importer
    app.kubernetes.io/component: storage
    app.kubernetes.io/managed-by: cdi-controller
    cdi.kubevirt.io: ""
  name: config
  ownerReferences:
  - apiVersion: cdi.kubevirt.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: CDI
    name: cdi
    uid: 9e5cca0e-1cc8-493f-9f25-f1c71b973c64
  resourceVersion: "79068481"
  selfLink: /apis/cdi.kubevirt.io/v1beta1/cdiconfigs/config
  uid: 05441ad0-65cf-4dd8-9fd0-684fcc702aa1
spec: {}
status: {}
`

`E0605 19:28:00.344491       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 934 [running]:
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1d08820, 0x37b15d0})
	vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x7d
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc002f9c1d0})
	vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x1d08820, 0x37b15d0})
	GOROOT/src/runtime/panic.go:1038 +0x215
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).getFilesystemOverhead(0xc000288460, 0xc00566c740)
	pkg/virt-controller/watch/vmi.go:2140 +0x117
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).updateVolumeStatus(0xc000288460, 0xc0040c1400, 0xc006559c00)
	pkg/virt-controller/watch/vmi.go:2081 +0xeef
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).updateStatus(0xc000288460, 0xc003eee500, 0xc006559c00, {0xc000118188, 0x1, 0x1}, {0x0, 0x0})
	pkg/virt-controller/watch/vmi.go:532 +0x7dc
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).execute(0xc000288460, {0xc004c7fa70, 0xe})
	pkg/virt-controller/watch/vmi.go:339 +0x83c
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).Execute(0xc000288460)
	pkg/virt-controller/watch/vmi.go:269 +0x20d
kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).runWorker(...)
	pkg/virt-controller/watch/vmi.go:253
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x7f95404be3a8)
	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x67
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x6669636570732073, {0x2465d20, 0xc000826420}, 0x1, 0xc002f73440)
	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb6
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x696c707061207369, 0x3b9aca00, 0x0, 0x6f, 0x6563617073656d61)
	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x89
kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait.Until(0x6120646c65696620, 0x6f2065687420646e, 0x656c65732073656e)
	vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90 +0x25
created by kubevirt.io/kubevirt/pkg/virt-controller/watch.(*VMIController).Run
	pkg/virt-controller/watch/vmi.go:245 +0x5c8
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1a30497]
`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
