### PR TITLE
tests: libvmi.New: no explicit name

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -161,7 +161,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			By("first getting the basetime for a replicaset")
 			targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 			vmi := libvmi.New(
-				libvmi.RandName(),
 				libvmi.WithResourceMemory("1Mi"),
 				libvmi.WithNodeSelectorFor(&targetNode),
 			)

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -37,7 +37,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)),
 	}
 	opts = append(fedoraOptions, opts...)
-	return New(RandName(), opts...)
+	return New(opts...)
 }
 
 // NewCirros instantiates a new CirrOS based VMI configuration
@@ -51,7 +51,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithResourceMemory(cirrosMemory()),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
-	return New(RandName(), cirrosOpts...)
+	return New(cirrosOpts...)
 }
 
 // NewAlpine instantiates a new Alpine based VMI configuration
@@ -63,7 +63,7 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithRng(),
 	}
 	alpineOpts = append(alpineOpts, opts...)
-	return New(RandName(), alpineOpts...)
+	return New(alpineOpts...)
 }
 
 func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
@@ -74,7 +74,7 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithRng(),
 	}
 	alpineOpts = append(alpineOpts, opts...)
-	return New(RandName(), alpineOpts...)
+	return New(alpineOpts...)
 }
 
 func cirrosMemory() string {

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -35,8 +35,8 @@ type Option func(vmi *kvirtv1.VirtualMachineInstance)
 
 // New instantiates a new VMI configuration,
 // building its properties based on the specified With* options.
-func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
-	vmi := baseVmi(name)
+func New(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	vmi := baseVmi(randName())
 
 	WithTerminationGracePeriod(0)(vmi)
 	for _, f := range opts {
@@ -46,8 +46,8 @@ func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return vmi
 }
 
-// RandName returns a random name for a virtual machine
-func RandName() string {
+// randName returns a random name for a virtual machine
+func randName() string {
 	return "testvmi" + "-" + rand.String(5)
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -999,7 +999,6 @@ func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	// To avoid mac address issue in the tests change the pod interface binding to masquerade
 	// https://github.com/kubevirt/kubevirt/issues/1494
 	vmi := libvmi.New(
-		libvmi.RandName(),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -996,24 +996,16 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 }
 
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
-	vmi := v1.NewVMIReferenceFromNameWithNS(namespace, libvmi.RandName())
-	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}
-	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
-	vmi.TypeMeta = metav1.TypeMeta{
-		APIVersion: v1.GroupVersion.String(),
-		Kind:       "VirtualMachineInstance",
-	}
-
-	t := defaultTestGracePeriod
-	vmi.Spec.TerminationGracePeriodSeconds = &t
-
 	// To avoid mac address issue in the tests change the pod interface binding to masquerade
 	// https://github.com/kubevirt/kubevirt/issues/1494
-	vmi.Spec.Domain.Devices = v1.Devices{Interfaces: []v1.Interface{{Name: "default",
-		InterfaceBindingMethod: v1.InterfaceBindingMethod{
-			Masquerade: &v1.InterfaceMasquerade{}}}}}
+	vmi := libvmi.New(
+		libvmi.RandName(),
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+	)
+	vmi.ObjectMeta.Namespace = namespace
+	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	if checks.IsARM64(testsuite.Arch) {
 		// Cirros image need 256M to boot on ARM64,
 		// this issue is traced in https://github.com/kubevirt/kubevirt/issues/6363

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -992,17 +992,13 @@ func NewRandomVirtualMachineInstanceWithBlockDisk(imageUrl, namespace string, ac
 }
 
 func NewRandomVMI() *v1.VirtualMachineInstance {
-	return NewRandomVMIWithNS(util2.NamespaceTestDefault)
-}
-
-func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	// To avoid mac address issue in the tests change the pod interface binding to masquerade
 	// https://github.com/kubevirt/kubevirt/issues/1494
 	vmi := libvmi.New(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
-	vmi.ObjectMeta.Namespace = namespace
+	vmi.ObjectMeta.Namespace = util2.NamespaceTestDefault
 	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 
 	if checks.IsARM64(testsuite.Arch) {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1306,7 +1306,11 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				node := nodes.Items[0].Name
 
 				By("Creating a VirtualMachineInstance with different namespace")
-				vmi = tests.NewRandomVMIWithNS(*namespace)
+				vmi = libvmi.New(
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				)
 				virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
 				Expect(err).ToNot(HaveOccurred(), "Should get virthandler client for node")
 
@@ -1319,7 +1323,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				vmi.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": node}
 
 				// Start the VirtualMachineInstance and wait for the confirmation of the start
-				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+				vmi, err = virtClient.VirtualMachineInstance(*namespace).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 				tests.WaitForSuccessfulVMIStart(vmi)
 


### PR DESCRIPTION
In continuation to PR #7850, this PR suggests to further simplify the API of `libvmi` by dropping the compulsory `name` argument, which is never used by us. This makes it simpler to reimplemnt `tests.NewRandomVMIWithNS` with `libvmi`. If we ever need to set the VMI name, we can add a WithName() builder option.

```release-note
NONE
```
