### PR TITLE
network: Primary intefrace should be first in Status.Interfaces list

### DIFF
--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -50,12 +50,26 @@ func FilterInterfacesSpec(ifaces []v1.Interface, predicate func(i v1.Interface) 
 }
 
 func IsPodNetworkWithMasqueradeBindingInterface(networks []v1.Network, ifaces []v1.Interface) bool {
-	if podNetwork := lookupPodNetwork(networks); podNetwork != nil {
+	if podNetwork := LookupPodNetwork(networks); podNetwork != nil {
 		if podInterface := LookupInterfaceByNetwork(ifaces, podNetwork); podInterface != nil {
 			return podInterface.Masquerade != nil
 		}
 	}
 	return true
+}
+
+func PopInterfaceByNetwork(statusIfaces []v1.VirtualMachineInstanceNetworkInterface, network *v1.Network) (*v1.VirtualMachineInstanceNetworkInterface, []v1.VirtualMachineInstanceNetworkInterface) {
+	if network == nil {
+		return nil, statusIfaces
+	}
+	for index, currStatusIface := range statusIfaces {
+		if currStatusIface.Name == network.Name {
+			primaryIface := statusIfaces[index]
+			statusIfaces = append(statusIfaces[:index], statusIfaces[index+1:]...)
+			return &primaryIface, statusIfaces
+		}
+	}
+	return nil, statusIfaces
 }
 
 func LookupInterfaceStatusByMac(interfaces []v1.VirtualMachineInstanceNetworkInterface, macAddress string) *v1.VirtualMachineInstanceNetworkInterface {

--- a/pkg/network/vmispec/network.go
+++ b/pkg/network/vmispec/network.go
@@ -21,7 +21,7 @@ package vmispec
 
 import v1 "kubevirt.io/api/core/v1"
 
-func lookupPodNetwork(networks []v1.Network) *v1.Network {
+func LookupPodNetwork(networks []v1.Network) *v1.Network {
 	for _, network := range networks {
 		if network.Pod != nil {
 			net := network

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "dual_stack_cluster.go",
         "expose.go",
         "framework.go",
+        "kubectl.go",
         "mac.go",
         "macvtap.go",
         "networkpolicy.go",

--- a/tests/network/kubectl.go
+++ b/tests/network/kubectl.go
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+const (
+	defaultPodNetworkName  = "default"
+	linuxBridgeIfaceName1  = "nic1"
+	linuxBridgeIfaceName2  = "nic2"
+	linuxBridgeNetworkName = "linux-br"
+	bridgeCNIType          = "bridge"
+	bridgeName             = "br10"
+
+	linuxBridgeNAD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"mynet\", \"plugins\": [{\"type\": \"%s\", \"bridge\": \"%s\"}]}"}}`
+)
+
+var _ = SIGDescribe("kubectl", func() {
+
+	var err error
+	var virtClient kubecli.KubevirtClient
+
+	getVmiHeader := []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY"}
+
+	createBridgeNetworkAttachmentDefinition := func(namespace, networkName string, bridgeCNIType string, bridgeName string) error {
+		bridgeNad := fmt.Sprintf(linuxBridgeNAD, networkName, namespace, bridgeCNIType, bridgeName)
+		return createNetworkAttachmentDefinition(virtClient, networkName, namespace, bridgeNad)
+	}
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+	})
+
+	It("should verify vmi ip value match primary interface ip value", func() {
+		Expect(createBridgeNetworkAttachmentDefinition(util.NamespaceTestDefault, linuxBridgeNetworkName, bridgeCNIType, bridgeName)).
+			To(Succeed())
+
+		vmi := libvmi.New(
+			libvmi.WithResourceMemory("2Mi"),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeIfaceName1, linuxBridgeNetworkName)),
+			libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeIfaceName2, linuxBridgeNetworkName)),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName1)),
+			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName2)),
+		)
+
+		vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+		Expect(err).ToNot(HaveOccurred())
+		vmi = tests.WaitForSuccessfulVMIStart(vmi)
+
+		primaryIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, defaultPodNetworkName)
+		Expect(primaryIfaceStatus).ToNot(BeNil())
+
+		var result, errStr string
+		pollErr := wait.PollImmediate(time.Second*1, time.Second*5, func() (bool, error) {
+			result, errStr, err = clientcmd.RunCommand(clientcmd.GetK8sCmdClient(), "get", "vmi", vmi.Name)
+			return err == nil, nil
+		})
+
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error: %s", errStr))
+		Expect(pollErr).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeEmpty())
+		resultFields := strings.Fields(result)
+
+		Expect(resultFields[getVMIHeaderIPIndex(getVmiHeader)]).To(Equal(primaryIfaceStatus.IP), "should match primary interface ip")
+	})
+})
+
+func getVMIHeaderIPIndex(getVmiHeader []string) int {
+	const ipPosition = 3
+
+	return len(getVmiHeader) + ipPosition
+}


### PR DESCRIPTION
Signed-off-by: Diana Teplits <dteplits@redhat.com>

**What this PR does / why we need it**:
Currently "kubectl get vmis" API return details of the first interface in Status.Interfaces list.
In case primary interface exist but is not the first one in the list, the user will not receive it's details.
This PR adds a change that makes sure that once primary interface exist, it will always be returned as a result of "kubectl get vmis" API call.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2093996

**Special notes for your reviewer**:

**Release note**:

```Having primary interface defined in vm spec, it will always appear first in Status.Interfaces list regardless it's index in Domain.Devices.Interfaces list```