### PR TITLE
Store the finalized VMI migration status in the migration object

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18740,6 +18740,10 @@
        "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationCondition"
       }
      },
+     "migrationState": {
+      "description": "Represents the status of a live migration",
+      "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationState"
+     },
      "phase": {
       "type": "string"
      },

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -414,6 +414,10 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 
 	// Remove the finalizer and conditions if the migration has already completed
 	if migration.IsFinal() {
+		// store the finalized migration state data from the VMI status in the migration object
+		migrationCopy.Status.MigrationState = vmi.Status.MigrationState
+
+		// remove the migration finalizaer
 		controller.RemoveFinalizer(migrationCopy, virtv1.VirtualMachineInstanceMigrationFinalizer)
 
 		// Status checking of active Migration job.
@@ -548,6 +552,7 @@ func (c *MigrationController) updateStatus(migration *virtv1.VirtualMachineInsta
 		if err != nil {
 			return err
 		}
+
 	} else if !equality.Semantic.DeepEqual(migration.Finalizers, migrationCopy.Finalizers) {
 		_, err := c.clientset.VirtualMachineInstanceMigration(migrationCopy.Namespace).Update(migrationCopy)
 		if err != nil {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11317,34 +11317,72 @@ var CRDsValidation map[string]string = map[string]string{
               description: Migration configurations to apply
               properties:
                 allowAutoConverge:
+                  description: AllowAutoConverge allows the platform to compromise
+                    performance/availability of VMIs to guarantee successful VMI live
+                    migrations. Defaults to false
                   type: boolean
                 allowPostCopy:
+                  description: AllowPostCopy enables post-copy live migrations. Such
+                    migrations allow even the busiest VMIs to successfully live-migrate.
+                    However, events like a network failure can cause a VMI crash.
+                    If set to true, migrations will still start in pre-copy, but switch
+                    to post-copy when CompletionTimeoutPerGiB triggers. Defaults to
+                    false
                   type: boolean
                 bandwidthPerMigration:
                   anyOf:
                   - type: integer
                   - type: string
+                  description: BandwidthPerMigration limits the amount of network
+                    bandwith live migrations are allowed to use. The value is in quantity
+                    per second. Defaults to 0 (no limit)
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 completionTimeoutPerGiB:
+                  description: CompletionTimeoutPerGiB is the maximum number of seconds
+                    per GiB a migration is allowed to take. If a live-migration takes
+                    longer to migrate than this value multiplied by the size of the
+                    VMI, the migration will be cancelled, unless AllowPostCopy is
+                    true. Defaults to 800
                   format: int64
                   type: integer
                 disableTLS:
+                  description: When set to true, DisableTLS will disable the additional
+                    layer of live migration encryption provided by KubeVirt. This
+                    is usually a bad idea. Defaults to false
                   type: boolean
                 network:
+                  description: Network is the name of the CNI network to use for live
+                    migrations. By default, migrations go through the pod network.
                   type: string
                 nodeDrainTaintKey:
+                  description: 'NodeDrainTaintKey defines the taint key that indicates
+                    a node should be drained. Note: this option relies on the deprecated
+                    node taint feature. Default: kubevirt.io/drain'
                   type: string
                 parallelMigrationsPerCluster:
+                  description: ParallelMigrationsPerCluster is the total number of
+                    concurrent live migrations allowed cluster-wide. Defaults to 5
                   format: int32
                   type: integer
                 parallelOutboundMigrationsPerNode:
+                  description: ParallelOutboundMigrationsPerNode is the maximum number
+                    of concurrent outgoing live migrations allowed per node. Defaults
+                    to 2
                   format: int32
                   type: integer
                 progressTimeout:
+                  description: ProgressTimeout is the maximum number of seconds a
+                    live migration is allowed to make no progress. Hitting this timeout
+                    means a migration transferred 0 data for that many seconds. The
+                    migration is then considered stuck and therefore cancelled. Defaults
+                    to 150
                   format: int64
                   type: integer
                 unsafeMigrationOverride:
+                  description: UnsafeMigrationOverride allows live migrations to occur
+                    even if the compatibility check indicates the migration will be
+                    unsafe to the guest. Defaults to false
                   type: boolean
               type: object
             migrationPolicyName:

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11293,6 +11293,113 @@ var CRDsValidation map[string]string = map[string]string{
             - type
             type: object
           type: array
+        migrationState:
+          description: Represents the status of a live migration
+          properties:
+            abortRequested:
+              description: Indicates that the migration has been requested to abort
+              type: boolean
+            abortStatus:
+              description: Indicates the final status of the live migration abortion
+              type: string
+            completed:
+              description: Indicates the migration completed
+              type: boolean
+            endTimestamp:
+              description: The time the migration action ended
+              format: date-time
+              nullable: true
+              type: string
+            failed:
+              description: Indicates that the migration failed
+              type: boolean
+            migrationConfiguration:
+              description: Migration configurations to apply
+              properties:
+                allowAutoConverge:
+                  type: boolean
+                allowPostCopy:
+                  type: boolean
+                bandwidthPerMigration:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                completionTimeoutPerGiB:
+                  format: int64
+                  type: integer
+                disableTLS:
+                  type: boolean
+                network:
+                  type: string
+                nodeDrainTaintKey:
+                  type: string
+                parallelMigrationsPerCluster:
+                  format: int32
+                  type: integer
+                parallelOutboundMigrationsPerNode:
+                  format: int32
+                  type: integer
+                progressTimeout:
+                  format: int64
+                  type: integer
+                unsafeMigrationOverride:
+                  type: boolean
+              type: object
+            migrationPolicyName:
+              description: Name of the migration policy. If string is empty, no policy
+                is matched
+              type: string
+            migrationUid:
+              description: The VirtualMachineInstanceMigration object associated with
+                this migration
+              type: string
+            mode:
+              description: Lets us know if the vmi is currently running pre or post
+                copy migration
+              type: string
+            sourceNode:
+              description: The source node that the VMI originated on
+              type: string
+            startTimestamp:
+              description: The time the migration action began
+              format: date-time
+              nullable: true
+              type: string
+            targetAttachmentPodUID:
+              description: The UID of the target attachment pod for hotplug volumes
+              type: string
+            targetCPUSet:
+              description: If the VMI requires dedicated CPUs, this field will hold
+                the dedicated CPU set on the target node
+              items:
+                type: integer
+              type: array
+              x-kubernetes-list-type: atomic
+            targetDirectMigrationNodePorts:
+              additionalProperties:
+                type: integer
+              description: The list of ports opened for live migration on the destination
+                node
+              type: object
+            targetNode:
+              description: The target node that the VMI is moving to
+              type: string
+            targetNodeAddress:
+              description: The address of the target node to use for the migration
+              type: string
+            targetNodeDomainDetected:
+              description: The Target Node has seen the Domain Start Event
+              type: boolean
+            targetNodeTopology:
+              description: If the VMI requires dedicated CPUs, this field will hold
+                the numa topology on the target node
+              type: string
+            targetPod:
+              description: The target pod that the VMI is moving to
+              type: string
+          type: object
         phase:
           description: VirtualMachineInstanceMigrationPhase is a label for the condition
             of a VirtualMachineInstanceMigration at the current time.

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -4341,6 +4341,11 @@ func (in *VirtualMachineInstanceMigrationStatus) DeepCopyInto(out *VirtualMachin
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.MigrationState != nil {
+		in, out := &in.MigrationState, &out.MigrationState
+		*out = new(VirtualMachineInstanceMigrationState)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1178,6 +1178,8 @@ type VirtualMachineInstanceMigrationStatus struct {
 	// +listType=atomic
 	// +optional
 	PhaseTransitionTimestamps []VirtualMachineInstanceMigrationPhaseTransitionTimestamp `json:"phaseTransitionTimestamps,omitempty"`
+	// Represents the status of a live migration
+	MigrationState *VirtualMachineInstanceMigrationState `json:"migrationState,omitempty"`
 }
 
 // VirtualMachineInstanceMigrationPhase is a label for the condition of a VirtualMachineInstanceMigration at the current time.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -281,7 +281,7 @@ func (VirtualMachineInstanceMigrationStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                          "VirtualMachineInstanceMigration reprents information pertaining to a VMI's migration.",
 		"phaseTransitionTimestamps": "PhaseTransitionTimestamp is the timestamp of when the last phase change occurred\n+listType=atomic\n+optional",
-		"migrationState": "Represents the status of a live migration",
+		"migrationState":            "Represents the status of a live migration",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -281,6 +281,7 @@ func (VirtualMachineInstanceMigrationStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                          "VirtualMachineInstanceMigration reprents information pertaining to a VMI's migration.",
 		"phaseTransitionTimestamps": "PhaseTransitionTimestamp is the timestamp of when the last phase change occurred\n+listType=atomic\n+optional",
+		"migrationState": "Represents the status of a live migration",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21335,8 +21335,8 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationStatus(ref com
 									},
 								},
 							},
-                        },
-                    },
+						},
+					},
 					"migrationState": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents the status of a live migration",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21335,13 +21335,19 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationStatus(ref com
 									},
 								},
 							},
+                        },
+                    },
+					"migrationState": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Represents the status of a live migration",
+							Ref:         ref("kubevirt.io/api/core/v1.VirtualMachineInstanceMigrationState"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/api/core/v1.VirtualMachineInstanceMigrationCondition", "kubevirt.io/api/core/v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp"},
+			"kubevirt.io/api/core/v1.VirtualMachineInstanceMigrationCondition", "kubevirt.io/api/core/v1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp", "kubevirt.io/api/core/v1.VirtualMachineInstanceMigrationState"},
 	}
 }
 

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -26,13 +26,12 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-func ExpectMigrationSuccess(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) string {
+func ExpectMigrationSuccess(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) *v1.VirtualMachineInstanceMigration {
 	return expectMigrationSuccessWithOffset(2, virtClient, migration, timeout)
 }
 
-func expectMigrationSuccessWithOffset(offset int, virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) string {
+func expectMigrationSuccessWithOffset(offset int, virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) *v1.VirtualMachineInstanceMigration {
 	By("Waiting until the Migration Completes")
-	uid := ""
 	EventuallyWithOffset(offset, func() error {
 		migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
 		if err != nil {
@@ -41,17 +40,16 @@ func expectMigrationSuccessWithOffset(offset int, virtClient kubecli.KubevirtCli
 
 		ExpectWithOffset(offset+1, migration.Status.Phase).ToNot(Equal(v1.MigrationFailed), "migration should not fail")
 
-		uid = string(migration.UID)
 		if migration.Status.Phase == v1.MigrationSucceeded {
 			return nil
 		}
 		return fmt.Errorf("migration is in the phase: %s", migration.Status.Phase)
 
 	}, timeout, 1*time.Second).ShouldNot(HaveOccurred(), fmt.Sprintf("migration should succeed after %d s", timeout))
-	return uid
+	return migration
 }
 
-func RunMigrationAndExpectCompletion(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) string {
+func RunMigrationAndExpectCompletion(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, timeout int) *v1.VirtualMachineInstanceMigration {
 	migration = RunMigration(virtClient, migration)
 
 	return ExpectMigrationSuccess(virtClient, migration, timeout)
@@ -66,7 +64,24 @@ func RunMigration(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachin
 	return migrationCreated
 }
 
-func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, migrationUID string) *v1.VirtualMachineInstance {
+func ConfirmMigrationDataIsStored(virtClient kubecli.KubevirtClient, migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance) {
+	By("Retrieving the VMI and the migration object")
+	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred(), "should have been able to retrive the VMI instance")
+	migration, migerr := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+	Expect(migerr).ToNot(HaveOccurred(), "should have been able to retrive the migration")
+
+	By("Verifying the stored migration state")
+	Expect(migration.Status.MigrationState).ToNot(BeNil(), "should have been able to retrieve the migration `Status::MigrationState`")
+	Expect(vmi.Status.MigrationState.StartTimestamp).To(Equal(migration.Status.MigrationState.StartTimestamp), "the VMI and the migration `Status::MigrationState::StartTimestamp` should be equal")
+	Expect(vmi.Status.MigrationState.EndTimestamp).To(Equal(migration.Status.MigrationState.EndTimestamp), "the VMI and the migration `Status::MigrationState::EndTimestamp` should be equal")
+	Expect(vmi.Status.MigrationState.Completed).To(Equal(migration.Status.MigrationState.Completed), "the VMI and migration completed state should be equal")
+	Expect(vmi.Status.MigrationState.Failed).To(Equal(migration.Status.MigrationState.Failed), "the VMI nad migration failed status must be equal")
+	Expect(vmi.Status.MigrationState.MigrationUID).To(Equal(migration.Status.MigrationState.MigrationUID), "the VMI migration UID and the migration object UID should match")
+	return
+}
+
+func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, migration *v1.VirtualMachineInstanceMigration) *v1.VirtualMachineInstance {
 	By("Retrieving the VMI post migration")
 	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred(), "should have been able to retrive the VMI instance")
@@ -80,7 +95,7 @@ func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualM
 	Expect(vmi.Status.MigrationState.Completed).To(BeTrue(), "the VMI migration state must have completed")
 	Expect(vmi.Status.MigrationState.Failed).To(BeFalse(), "the VMI migration status must not have failed")
 	Expect(vmi.Status.MigrationState.TargetNodeAddress).NotTo(Equal(""), "the VMI `Status::MigrationState::TargetNodeAddress` must not be empty")
-	Expect(string(vmi.Status.MigrationState.MigrationUID)).To(Equal(migrationUID), "the VMI migration UID must be the expected one")
+	Expect(string(vmi.Status.MigrationState.MigrationUID)).To(Equal(string(migration.UID)), "the VMI migration UID must be the expected one")
 
 	By("Verifying the VMI's is in the running state")
 	Expect(vmi.Status.Phase).To(Equal(v1.Running), "the VMI must be in `Running` state after the migration")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -668,10 +668,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			// execute a migration, wait for finalized state
 			By("Starting the Migration for iteration")
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 			By("Checking VMI, confirm migration state")
-			tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+			tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			confirmMigrationMode(vmi, mode)
 
 			By("Is agent connected after migration")
@@ -744,10 +743,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 					By("starting the migration")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-					migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+					migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 					// check VMI, confirm migration state
-					tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+					tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -791,10 +790,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -817,10 +816,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -854,10 +853,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			})
 
 			It("should migrate vmi and use Live Migration method with read-only disks", func() {
@@ -874,10 +873,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Ensuring migration is using Live Migration method")
 				Eventually(func() v1.VirtualMachineInstanceMigrationMethod {
@@ -898,9 +897,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("checking if the metrics are still updated after the migration")
 				Eventually(func() error {
@@ -952,9 +951,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Checking the TSC frequency on the Domain XML on the new node")
 				domainSpec, err = tests.GetRunningVMIDomainSpec(vmi)
@@ -985,10 +984,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("checking that we really migrated a VMI with only the root bus")
 				domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
@@ -1026,10 +1025,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			})
 
 			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", func() {
@@ -1049,10 +1048,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					// execute a migration, wait for finalized state
 					By(fmt.Sprintf("Starting the Migration for iteration %d", i))
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-					migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+					migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 					// check VMI, confirm migration state
-					tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+					tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
+					tests.ConfirmMigrationDataIsStored(virtClient, migration, vmi)
 
 					By("Check if Migrated VMI has updated IP and IPs fields")
 					Eventually(func() error {
@@ -1118,10 +1118,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By(fmt.Sprintf("Starting the Migration"))
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -1146,10 +1146,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By(fmt.Sprintf("Starting the Migration"))
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// ensure the libvirt domain is persistent
 				persistent, err := libvirtDomainIsPersistent(virtClient, vmi)
@@ -1187,10 +1187,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("verifying that the vmi is still paused after migration")
 				isPaused, err := tests.LibvirtDomainIsPaused(virtClient, vmi)
@@ -1372,10 +1372,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -1409,10 +1409,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Checking that the migrated VirtualMachineInstance has an updated time")
@@ -1497,10 +1497,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting a Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -1573,10 +1573,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting a Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -1595,10 +1595,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				// execute a migration, wait for finalized state
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -1627,10 +1627,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("Starting the Migration for iteration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -1774,10 +1774,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting new migration and waiting for it to succeed")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
 
 				By("Verifying Second Migration Succeeeds")
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Checking that the launcher is running as qemu")
 				Expect(tests.GetIdOfLauncher(vmi)).To(Equal("107"))
@@ -1861,10 +1861,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting new migration and waiting for it to succeed")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
 
 				By("Verifying Second Migration Succeeeds")
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Checking that the launcher is running as qemu")
 				Expect(tests.GetIdOfLauncher(vmi)).To(Equal("0"))
@@ -1924,10 +1924,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 					By("starting the migration")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-					migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+					migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 					// check VMI, confirm migration state
-					tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+					tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 					// delete VMI
 					By("Deleting the VMI")
@@ -2160,10 +2160,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 				confirmMigrationMode(vmi, v1.MigrationPostCopy)
 
 				// delete VMI
@@ -2311,10 +2311,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting new migration and waiting for it to succeed")
 				migration = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID = tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 340)
 
 				By("Verifying Second Migration Succeeeds")
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// delete VMI
 				By("Deleting the VMI")
@@ -2646,10 +2646,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 
 				migration = runAndCancelMigration(migration, vmi, with_virtctl, 180)
-				migrationUID := string(migration.UID)
 
 				// check VMI, confirm migration state
-				confirmVMIPostMigrationAborted(vmi, migrationUID, 180)
+				confirmVMIPostMigrationAborted(vmi, string(migration.UID), 180)
 
 				By("Waiting for the migration object to disappear")
 				libwait.WaitForMigrationToDisappearWithTimeout(migration, 240)
@@ -3103,10 +3102,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Starting the Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				By("Retrieving the VMI post migration")
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -3135,10 +3134,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			// execute a migration, wait for finalized state
 			By("Starting the Migration")
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 			// check VMI, confirm migration state
-			tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+			tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 			// delete VMI
 			By("Deleting the VMI")
@@ -3779,10 +3778,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			By("starting the migration")
 			migration := tests.NewRandomMigration(hugepagesVmi.Name, hugepagesVmi.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 			// check VMI, confirm migration state
-			tests.ConfirmVMIPostMigration(virtClient, hugepagesVmi, migrationUID)
+			tests.ConfirmVMIPostMigration(virtClient, hugepagesVmi, migration)
 
 			// delete VMI
 			By("Deleting the VMI")
@@ -4204,8 +4203,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			libnode.AddLabelToNode(nodes[1].Name, testLabel1, "true")
 			cpuSetSource := getVirtLauncherCPUSet(vmi)
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-			tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 			By("ensuring the target cpuset is different from the source")
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
@@ -4254,10 +4253,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			By("Starting the migration")
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 			By("Checking if the migration happened, and over the right network")
-			vmi = tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+			vmi = tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			Expect(vmi.Status.MigrationState.TargetNodeAddress).To(HavePrefix("172.21.42."), "The migration did not appear to go over the dedicated migration network")
 
 			// delete VMI
@@ -4276,8 +4275,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		By("Starting a Migration")
 		migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-		migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
-		tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+		migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, 180)
+		tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 		By("Ensuring MigrationConfiguration is updated")
 		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -620,10 +620,10 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, decorators
 			By("Migrating the VMI 13 times")
 			for i := 0; i < 13; i++ {
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				// check VMI, confirm migration state
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			}
 
 			By("Verifying KubeVirtVMIExcessiveMigration alert exists")

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -187,10 +187,10 @@ var _ = SIGDescribe("Macvtap", decorators.Macvtap, func() {
 		It("should be successful when the VMI MAC address is defined in its spec", func() {
 			By("starting the migration")
 			migration := tests.NewRandomMigration(clientVMI.Name, clientVMI.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 			// check VMI, confirm migration state
-			tests.ConfirmVMIPostMigration(virtClient, clientVMI, migrationUID)
+			tests.ConfirmVMIPostMigration(virtClient, clientVMI, migration)
 		})
 
 		Context("with live traffic", func() {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -355,8 +355,8 @@ var _ = Describe("[Serial]SRIOV", Serial, decorators.SRIOV, func() {
 			It("should be successful with a running VMI on the target", func() {
 				By("starting the migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+				migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 
 				// It may take some time for the VMI interface status to be updated with the information reported by
 				// the guest-agent.

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1000,8 +1000,8 @@ var _ = SIGDescribe("Hotplug", func() {
 					Expect(sourceAttachmentPods).To(HaveLen(1))
 
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-					migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-					tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+					migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+					tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 					By("Verifying the volume is still accessible and usable")
 					verifyVolumeAccessible(vmi, targets[0])
 					verifyWriteReadData(vmi, targets[0])

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -204,10 +204,10 @@ var _ = Describe("[Serial][sig-compute]SwapTest", Serial, decorators.SigCompute,
 			// execute a migration, wait for finalized state
 			By("Starting the Migration")
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-			migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime*2)
+			migration = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime*2)
 
 			// check VMI, confirm migration state
-			tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+			tests.ConfirmVMIPostMigration(virtClient, vmi, migration)
 			confirmMigrationMode(vmi, virtv1.MigrationPostCopy)
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The VMI status holds the MigrationState data that reflects the most updated status of an ongoing/completed migration.
However, the final state of a given migration does not propagate to the migration object.
The migration object only contains the final status (i.e failed/succeeded) without any additional information about the migration.
Keeping this additional could be very helpful when debugging migration related issues on a long running system. 

**Release note**:
```release-note
Store the finalized VMI migration status in the migration objects.
```
