### PR TITLE
[release-v0.53] fix test id 8235

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2545,11 +2545,20 @@ spec:
 
 		It("[test_id:8235]should check if kubevirt components have linux node selector", func() {
 			By("Listing only kubevirt components")
-			labelReq, err := labels.NewRequirement("app.kubernetes.io/component", selection.In, []string{"kubevirt"})
+
+			kv := util2.GetCurrentKv(virtClient)
+			productComponent := kv.Spec.ProductComponent
+			if productComponent == "" {
+				productComponent = "kubevirt"
+			}
+
+			labelReq, err := labels.NewRequirement("app.kubernetes.io/component", selection.In, []string{productComponent})
 
 			if err != nil {
 				panic(err)
 			}
+
+			By("Looking for pods with " + productComponent + " component")
 
 			pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: labels.NewSelector().Add(


### PR DESCRIPTION
**What this PR does / why we need it**:
fix test id 8235
in release-v0.53 branch product component value was hardcoded to kubevirt in test id 8235. This caused test to fail, when product component was different. Now test uses value from kubevirt config and if empty, it will use kubevirt value.

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
