### PR TITLE
vmi_networking, Move flaky tests to Cirros

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -257,16 +257,17 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 		Context("VirtualMachineInstance with default interface model", func() {
 			BeforeEach(func() {
-				inboundVMI = libvmi.NewAlpine()
-				outboundVMI = libvmi.NewAlpine()
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				inboundVMI = libvmi.NewCirros()
+				outboundVMI = libvmi.NewCirros()
 
 				inboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(inboundVMI)
 				Expect(err).ToNot(HaveOccurred())
 				outboundVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(outboundVMI)
 				Expect(err).ToNot(HaveOccurred())
 
-				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToAlpine)
-				outboundVMI = tests.WaitUntilVMIReady(outboundVMI, console.LoginToAlpine)
+				inboundVMI = tests.WaitUntilVMIReady(inboundVMI, console.LoginToCirros)
+				outboundVMI = tests.WaitUntilVMIReady(outboundVMI, console.LoginToCirros)
 			})
 
 			// Unless an explicit interface model is specified, the default interface model is virtio.
@@ -287,7 +288,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					// Create a virtual machine with an unsupported interface model
 					masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 					masqIface.Model = "gibberish"
-					customIfVMI := libvmi.NewAlpine(
+					customIfVMI := libvmi.NewCirros(
 						libvmi.WithInterface(masqIface),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					)
@@ -361,17 +362,18 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
 		It("[test_id:1772]should configure custom MAC address", func() {
+			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 			By(checkingEth0MACAddr)
 			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 			masqIface.MacAddress = "BE-AF-00-00-DE-AD"
-			beafdeadVMI := libvmi.NewAlpine(
+			beafdeadVMI := libvmi.NewCirros(
 				libvmi.WithInterface(masqIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			beafdeadVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(beafdeadVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(beafdeadVMI, console.LoginToAlpine)
+			tests.WaitUntilVMIReady(beafdeadVMI, console.LoginToCirros)
 			checkMacAddress(beafdeadVMI, "be:af:00:00:de:ad")
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
test_ids: 1550,1551,1772 are experiencing flakiness issues [0,1,2] with Alpine login on
OCP clusters.
Moving to use Cirros image to check if the issues persist.
Also, in order to avoid a known issue in Cirros on ipv6-only clusters, skipping these tests in such case.

[0] https://issues.redhat.com/browse/CNV-18762
[1] https://issues.redhat.com/browse/CNV-18761
[2] https://issues.redhat.com/browse/CNV-18823

Note that this PR is not offering to fix the Alpine issue, but simply check that it is not needed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
