### PR TITLE
vmi_networking, Skip test_ids:1550, 1551 tests on IPv6-only clusters

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -271,6 +271,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 			// Unless an explicit interface model is specified, the default interface model is virtio.
 			It("[test_id:1550]should expose the right device type to the guest", func() {
+				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+
 				By("checking the device vendor in /sys/class")
 
 				// Taken from https://wiki.osdev.org/Virtio#Technical_Details
@@ -284,6 +286,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 			Context("VirtualMachineInstance with unsupported interface model", func() {
 				It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", func() {
+					libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+
 					// Create a virtual machine with an unsupported interface model
 					masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 					masqIface.Model = "gibberish"


### PR DESCRIPTION
**What this PR does / why we need it**:
The following tests should not run on ipv6 only clusters:
* test_id:1550 - runs on bridge binding, so it should not run on ipv6-only cluster
* test_id:1551 - is a negative test, expecting the vmi to fail with error. Ergo, IPv6 has nothing to do with it, and nothing is gained from it running it on the ipv6 lane.

Setting a skip test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
