### PR TITLE
Use `math/rand` instead of `crypto/rand` in tests to speed up execution 

### DIFF
--- a/pkg/virt-operator/resource/generate/components/secrets_test.go
+++ b/pkg/virt-operator/resource/generate/components/secrets_test.go
@@ -1,11 +1,11 @@
 package components
 
 import (
-	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"math/rand"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -325,7 +325,8 @@ func NewSelfSignedCert(notBefore time.Time, notAfter time.Time) *tls.Certificate
 		IsCA:                  true,
 	}
 
-	certDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &tmpl, &tmpl, key.Public(), key)
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	certDERBytes, err := x509.CreateCertificate(r, &tmpl, &tmpl, key.Public(), key)
 	Expect(err).ToNot(HaveOccurred())
 	leaf, err := x509.ParseCertificate(certDERBytes)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-operator/resource/generate/components/secrets_test.go
+++ b/pkg/virt-operator/resource/generate/components/secrets_test.go
@@ -22,12 +22,12 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should drop expired CAs", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			current := newSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{
-				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(-10*time.Minute)),
+				newSelfSignedCert(now.Add(-20*time.Minute), now.Add(-10*time.Minute)),
 			}
-			givenBundle := CACertsToBundle(given)
-			expectBundle := CACertsToBundle([]*tls.Certificate{current})
+			givenBundle := caCertsToBundle(given)
+			expectBundle := caCertsToBundle([]*tls.Certificate{current})
 			bundle, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(1))
@@ -36,12 +36,12 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should be properly appended when within the overlap period", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			current := newSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{
-				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
 			}
-			givenBundle := CACertsToBundle(given)
-			expectBundle := CACertsToBundle([]*tls.Certificate{current, given[0]})
+			givenBundle := caCertsToBundle(given)
+			expectBundle := caCertsToBundle([]*tls.Certificate{current, given[0]})
 			bundle, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(2))
@@ -50,12 +50,12 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should kick out the first CA cert if it is outside of the overlap period", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now.Add(-3*time.Minute), now.Add(1*time.Hour))
+			current := newSelfSignedCert(now.Add(-3*time.Minute), now.Add(1*time.Hour))
 			given := []*tls.Certificate{
-				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
 			}
-			givenBundle := CACertsToBundle(given)
-			expectBundle := CACertsToBundle([]*tls.Certificate{current})
+			givenBundle := caCertsToBundle(given)
+			expectBundle := caCertsToBundle([]*tls.Certificate{current})
 			bundle, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(1))
@@ -64,13 +64,13 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should kick out a CA cert which are outside of the overlap period", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			current := newSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{
-				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
-				NewSelfSignedCert(now.Add(-10*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-10*time.Minute), now.Add(1*time.Hour)),
 			}
-			givenBundle := CACertsToBundle(given)
-			expectBundle := CACertsToBundle([]*tls.Certificate{current, given[1]})
+			givenBundle := caCertsToBundle(given)
+			expectBundle := caCertsToBundle([]*tls.Certificate{current, given[1]})
 			bundle, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(2))
@@ -79,14 +79,14 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should kick out multiple CA certs which are outside of the overlap period", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now.Add(-5*time.Minute), now.Add(-5*time.Minute).Add(1*time.Hour))
+			current := newSelfSignedCert(now.Add(-5*time.Minute), now.Add(-5*time.Minute).Add(1*time.Hour))
 			given := []*tls.Certificate{
-				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
-				NewSelfSignedCert(now.Add(-10*time.Minute), now.Add(1*time.Hour)),
-				NewSelfSignedCert(now.Add(-5*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-10*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-5*time.Minute), now.Add(1*time.Hour)),
 			}
-			givenBundle := CACertsToBundle(given)
-			expectBundle := CACertsToBundle([]*tls.Certificate{current})
+			givenBundle := caCertsToBundle(given)
+			expectBundle := caCertsToBundle([]*tls.Certificate{current})
 			bundle, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(1))
@@ -95,14 +95,14 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should ensure that the current CA is not added over and over again", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			current := newSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{
-				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
+				newSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
 				current,
 				current,
 			}
-			givenBundle := CACertsToBundle(given)
-			expectBundle := CACertsToBundle([]*tls.Certificate{current, given[0]})
+			givenBundle := caCertsToBundle(given)
+			expectBundle := caCertsToBundle([]*tls.Certificate{current, given[0]})
 			bundle, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(2))
@@ -111,12 +111,12 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should be protected against misuse by cropping big arrays", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			current := newSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{}
 			for i := 1; i < 20; i++ {
-				given = append(given, NewSelfSignedCert(now.Add(-1*time.Minute), now.Add(1*time.Hour)))
+				given = append(given, newSelfSignedCert(now.Add(-1*time.Minute), now.Add(1*time.Hour)))
 			}
-			givenBundle := CACertsToBundle(given)
+			givenBundle := caCertsToBundle(given)
 			_, count, err := MergeCABundle(current, givenBundle, 2*time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(11))
@@ -124,8 +124,8 @@ var _ = Describe("Certificate Management", func() {
 
 		It("should immediately suggest a rotation if the cert is not signed by the provided CA", func() {
 			now := time.Now()
-			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
-			ca := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			current := newSelfSignedCert(now, now.Add(1*time.Hour))
+			ca := newSelfSignedCert(now, now.Add(1*time.Hour))
 			renewal := &v1.Duration{Duration: 4 * time.Hour}
 			deadline := NextRotationDeadline(current, ca, renewal, nil)
 			Expect(deadline.Before(time.Now())).To(BeTrue())
@@ -308,8 +308,8 @@ var _ = Describe("Certificate Management", func() {
 	})
 })
 
-// NewSelfSignedCert creates a CA certificate
-func NewSelfSignedCert(notBefore time.Time, notAfter time.Time) *tls.Certificate {
+// newSelfSignedCert creates a CA certificate
+func newSelfSignedCert(notBefore time.Time, notAfter time.Time) *tls.Certificate {
 	key, err := certutil.NewPrivateKey()
 	Expect(err).ToNot(HaveOccurred())
 	tmpl := x509.Certificate{
@@ -340,7 +340,7 @@ func NewSelfSignedCert(notBefore time.Time, notAfter time.Time) *tls.Certificate
 	return &crt
 }
 
-func CACertsToBundle(crts []*tls.Certificate) []byte {
+func caCertsToBundle(crts []*tls.Certificate) []byte {
 	var caBundle []byte
 	for _, crt := range crts {
 		caBundle = append(caBundle, certutil.EncodeCertPEM(crt.Leaf)...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Running secrets tests on machine that doesn't create too much entropy the tests will be slow and even failing. To fix that we can simply use a different `rand` library. The randomness of the bits don't actually matter in tests, so the change itself shouldn't break anything.

<details>
  <summary>Tests on slow machine</summary>

```
��� [SLOW TEST:5.097 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should kick out the first CA cert if it is outside of the overlap period
    pkg/virt-operator/resource/generate/components/secrets_test.go:52
------------------------------
��� [SLOW TEST:16.312 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should kick out a CA cert which are outside of the overlap period
    pkg/virt-operator/resource/generate/components/secrets_test.go:66
------------------------------
��� [SLOW TEST:12.192 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should kick out multiple CA certs which are outside of the overlap period
    pkg/virt-operator/resource/generate/components/secrets_test.go:81
------------------------------
��� [SLOW TEST:8.099 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should ensure that the current CA is not added over and over again
    pkg/virt-operator/resource/generate/components/secrets_test.go:97
------------------------------
��� [SLOW TEST:94.207 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should be protected against misuse by cropping big arrays
    pkg/virt-operator/resource/generate/components/secrets_test.go:113
------------------------------
��� [SLOW TEST:8.803 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should immediately suggest a rotation if the cert is not signed by the provided CA
    pkg/virt-operator/resource/generate/components/secrets_test.go:126
------------------------------
��� [SLOW TEST:9.018 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should set notBefore on the certificate to notBefore value of the CA certificate 
    pkg/virt-operator/resource/generate/components/secrets_test.go:135
------------------------------
��� Failure [24.179 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should set the notAfter on the certificate according to the supplied duration
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      with a long valid CA [It]
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43

      Expected
          <int64>: 1654627875
      to be within 10 of ==
          <int64>: 1654627850

      pkg/virt-operator/resource/generate/components/secrets_test.go:160
------------------------------
��� Failure [13.204 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should set the notAfter on the certificate according to the supplied duration
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      with a CA which expires before the certificate rotation [It]
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43

      Expected
          <int64>: 1654627887
      to be within 10 of ==
          <int64>: 1654627875

      pkg/virt-operator/resource/generate/components/secrets_test.go:160
------------------------------
��� Failure [15.699 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should suggest a rotation on the certificate according to its expiration
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      with a long valid CA [It]
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43

      Expected
          <int64>: 1654624304
      to be within 3 of ==
          <int64>: 1654624297

      pkg/virt-operator/resource/generate/components/secrets_test.go:183
------------------------------
��� [SLOW TEST:13.401 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should suggest a rotation on the certificate according to its expiration
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      with a CA which expires before the certificate rotation
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
------------------------------
��� [SLOW TEST:10.297 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should successfully sign with the current CA the certificate for
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      virt-handler
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
------------------------------
��� [SLOW TEST:6.301 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should successfully sign with the current CA the certificate for
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      virt-controller
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
------------------------------
��� [SLOW TEST:5.302 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should successfully sign with the current CA the certificate for
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      virt-api
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
------------------------------
��� [SLOW TEST:5.200 seconds]
Certificate Management
pkg/virt-operator/resource/generate/components/secrets_test.go:21
  CA certificate bundle
  pkg/virt-operator/resource/generate/components/secrets_test.go:22
    should successfully sign with the current CA the certificate for
    vendor/github.com/onsi/ginkgo/extensions/table/table.go:92
      virt-operator
      vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
```
</details>

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
