### PR TITLE
[Bug] [Node-labeller]: Reconcile on node / Kubevirt CR changes instead of polling every 3 minutes

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -310,7 +310,10 @@ func (app *virtHandlerApp) Run() {
 	var capabilities *api.Capabilities
 	var hostCpuModel string
 	if virtconfig.IsAMD64(runtime.GOARCH) {
-		nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig, app.virtCli, app.HostOverride, app.namespace)
+		nodeInformer := factory.KubeVirtNode(app.HostOverride)
+		kvInformer := factory.KubeVirt()
+
+		nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig, app.virtCli, app.HostOverride, app.namespace, nodeInformer, kvInformer)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -329,7 +329,7 @@ func Execute() {
 
 	app.vmiInformer = app.informerFactory.VMI()
 	app.kvPodInformer = app.informerFactory.KubeVirtPod()
-	app.nodeInformer = app.informerFactory.KubeVirtNode()
+	app.nodeInformer = app.informerFactory.KubeVirtNodes()
 
 	app.vmiCache = app.vmiInformer.GetStore()
 	app.vmiRecorder = app.newRecorder(k8sv1.NamespaceAll, "virtualmachine-controller")

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
     ],
 )

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -57,5 +57,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
     ],
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "io_utils.go",
         "job.go",
         "migration.go",
+        "node_labeller.go",
         "pod_servers.go",
         "utils.go",
         "vmi_servers.go",

--- a/tests/node_labeller.go
+++ b/tests/node_labeller.go
@@ -1,0 +1,126 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"kubevirt.io/kubevirt/tests/util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k6tv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/libnode"
+)
+
+var _ = Describe("[Serial]Node Labeller", func() {
+	var virtClient kubecli.KubevirtClient
+	var err error
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+
+		BeforeTestCleanup()
+	})
+
+	Context("basic node-labeller operations", func() {
+
+		Context("ensure node-labeller wakes up", func() {
+
+			It("When node updates its labels", func() {
+				By("Fetching one of the nodes")
+				nodeList := libnode.GetAllSchedulableNodes(virtClient)
+				Expect(nodeList.Items).ToNot(BeEmpty())
+				node := nodeList.Items[0].DeepCopy()
+
+				By("Finding host model label key")
+				var hostModelLabelKey string
+				for key, _ := range node.Labels {
+					if strings.HasPrefix(key, k6tv1.SupportedHostModelMigrationCPU) {
+						hostModelLabelKey = key
+						break
+					}
+				}
+				Expect(hostModelLabelKey).ToNot(BeEmpty(), "cannot find host model for node %s", node.Name)
+
+				By("Removing host model label key")
+				libnode.RemoveLabelFromNode(node.Name, hostModelLabelKey)
+
+				By("Expecting host model label key to re-appear")
+				Eventually(func() bool {
+					node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					_, exists := node.Labels[hostModelLabelKey]
+					return exists
+				}, 30*time.Second, 3*time.Second).Should(BeTrue(), "host model label is expected to re-appear")
+			})
+
+			It("When Kubevirt CR configurations change", func() {
+				By("Fetching one of the nodes")
+				nodeList := libnode.GetAllSchedulableNodes(virtClient)
+				Expect(nodeList.Items).ToNot(BeEmpty())
+				node := nodeList.Items[0].DeepCopy()
+
+				By("Finding one supported CPU model")
+				var supportedCpuModel string
+				for key, _ := range node.Labels {
+					if strings.HasPrefix(key, k6tv1.CPUModelLabel) {
+						supportedCpuModel = strings.TrimPrefix(key, k6tv1.CPUModelLabel)
+						break
+					}
+				}
+				Expect(supportedCpuModel).ToNot(BeEmpty(), "cannot find a supported CPU model for node %s", node.Name)
+
+				By(fmt.Sprintf("Found supported CPU: %s. Marking it as an obsolete CPU model", supportedCpuModel))
+				kv := util.GetCurrentKv(virtClient)
+				config := kv.Spec.Configuration
+				if config.ObsoleteCPUModels == nil {
+					config.ObsoleteCPUModels = make(map[string]bool)
+				}
+				config.ObsoleteCPUModels[supportedCpuModel] = true
+				UpdateKubeVirtConfigValueAndWait(config)
+
+				By("Expecting CPU model label to disappear from all nodes")
+				Eventually(func() error {
+					nodeList = libnode.GetAllSchedulableNodes(virtClient)
+
+					for _, node := range nodeList.Items {
+						_, exists := node.Labels[k6tv1.CPUModelLabel+supportedCpuModel]
+						if exists {
+							return fmt.Errorf("CPU %s did not dissapear from node %s", supportedCpuModel, node.Name)
+						}
+					}
+
+					return nil
+				}, 30*time.Second, 3*time.Second).ShouldNot(HaveOccurred())
+			})
+
+		})
+
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently node-labeller does not watch any resource via informers. Instead, it wakes up every 3 minutes.

This is a bug. Before listing the main (bad) influences of this behavior, I want to stress that the labels added by node-labeller are **crucial for migrations to work properly**. In other words, migrations can hang or fail because of this - or even worse - migrations can succeed to a non-supported node which will probably lead to the VM crashing right after the migration finishes.

As migrations are one of Kubevirt's core features which are involved in almost every important flow (updates, node drains, and many more) this bug has major affect.

To be more specific, the main influences are:
* If a new node joins the cluster, it won't be updated with migration metadata for up to 3 minutes
* If metadata labels are changed / removed from a node, they won't be reconciled for up to 3 minutes
* Some functional tests (mainly migration tests) would have to wait for 3 minutes in order to pass.
  * If you're wondering, the only reason functional tests pass right now is because of other bugs that were hidden because of many reasons. Some of these are being fixed as part of this PR: https://github.com/kubevirt/kubevirt/pull/7752.
* If Kubevirt CR's configuration updates (For instance, a new obsolete CPU model is added) it would take 3 minutes to be reconciled
* Node labeller wakes up every 3 minutes even if there is absolutely no reason to wake up (i.e. queue is empty and nothing changed).

New unit tests and functional tests are added, and old tests are fixed.

**Which issue(s) this PR fixes**:
Bugzilla page: https://bugzilla.redhat.com/show_bug.cgi?id=2095175

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: node-labeller to reconcile on node / Kubevirt CR changes
```
