### PR TITLE
tests, login: Fix error printing

### DIFF
--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -101,7 +101,7 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 		&expect.BExp{R: PromptExpression}})
 	res, err := expecter.ExpectBatch(b, 180*time.Second)
 	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
+		log.DefaultLogger().Object(vmi).Reason(err).Errorf("Login failed: %+v", res)
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In case LoginToAlpine fails,
it printed Infof instead of Errorf.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
