### PR TITLE
Add apiGroup to Template resource

### DIFF
--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   annotations:

--- a/examples/vm-template-rhel7.yaml
+++ b/examples/vm-template-rhel7.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   annotations:

--- a/examples/vm-template-windows2012r2.yaml
+++ b/examples/vm-template-windows2012r2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   annotations:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -902,7 +902,7 @@ func getBaseTemplate(vm *v1.VirtualMachine, memory string, cores string) *Templa
 	return &Template{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Template",
-			APIVersion: "v1",
+			APIVersion: "template.openshift.io/v1",
 		},
 		Objects: []runtime.Object{
 			obj,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Up to release 4.8 the `oc` command fixes `apiVersion` in YAML or JSON ocp resource files
from v1 to the correct value for the object.
From release 4.9 this is not true anymore, and we have to specify not only the version but also the apiGroup.

ref: https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html - Table 1. Deprecated and removed features tracker
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @dhiller @Barakmor1 