### PR TITLE
tests/utils: a very minor cleanup

### DIFF
--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -238,7 +239,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 		var archivePath string
 
 		BeforeEach(func() {
-			archivePath = tests.CreateArchive("archive", os.TempDir(), imagePath)
+			archivePath = createArchive("archive", os.TempDir(), imagePath)
 		})
 
 		AfterEach(func() {
@@ -297,3 +298,14 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 })
+
+func createArchive(targetFile, tgtDir string, sourceFilesNames ...string) string {
+	tgtPath := filepath.Join(tgtDir, filepath.Base(targetFile)+".tar")
+	tgtFile, err := os.Create(tgtPath)
+	Expect(err).ToNot(HaveOccurred())
+	defer tgtFile.Close()
+
+	tests.ArchiveToFile(tgtFile, sourceFilesNames...)
+
+	return tgtPath
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3358,17 +3358,6 @@ func CreateBlockPVC(virtClient kubecli.KubevirtClient, name string, size resourc
 	return createdPvc
 }
 
-func CreateArchive(targetFile, tgtDir string, sourceFilesNames ...string) string {
-	tgtPath := filepath.Join(tgtDir, filepath.Base(targetFile)+".tar")
-	tgtFile, err := os.Create(tgtPath)
-	Expect(err).ToNot(HaveOccurred())
-	defer tgtFile.Close()
-
-	ArchiveToFile(tgtFile, sourceFilesNames...)
-
-	return tgtPath
-}
-
 func ArchiveToFile(tgtFile *os.File, sourceFilesNames ...string) {
 	w := tar.NewWriter(tgtFile)
 	defer w.Close()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2822,7 +2822,7 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 				continue
 			}
 
-			body, err := CallUrlOnPod(&pod, "8443", "/healthz")
+			body, err := callUrlOnPod(&pod, "8443", "/healthz")
 			if err != nil {
 				return fmt.Errorf("failed to call healthz endpoint. %s", errAdditionalInfo)
 			}
@@ -3011,7 +3011,7 @@ func getCert(pod *k8sv1.Pod, port string) []byte {
 	return certificate
 }
 
-func CallUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
+func callUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
 	randPort := strconv.Itoa(4321 + rand.Intn(6000))
 	stopChan := make(chan struct{})
 	defer close(stopChan)


### PR DESCRIPTION
Make test/utils.go slightly shorter by moving `createArchive` into its only user.

```release-note
NONE
```