### PR TITLE
tests: empty iso: handle potentially paused target

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2405,11 +2405,16 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 										continue
 									}
 									// Wait for the iso to be created
-									Eventually(func() string {
+									Eventually(func() error {
 										output, err := tests.RunCommandOnVmiTargetPod(vmi, []string{"/bin/bash", "-c", "[[ -f " + volPath + " ]] && echo found || true"})
-										Expect(err).ToNot(HaveOccurred())
-										return output
-									}, 30*time.Second, time.Second).Should(ContainSubstring("found"), volPath+" never appeared")
+										if err != nil {
+											return err
+										}
+										if !strings.Contains(output, "found") {
+											return fmt.Errorf("%s never appeared", volPath)
+										}
+										return nil
+									}, 30*time.Second, time.Second).Should(Not(HaveOccurred()))
 									output, err := tests.RunCommandOnVmiTargetPod(vmi, []string{"/bin/bash", "-c", "/usr/bin/stat --printf=%s " + volPath})
 									Expect(err).ToNot(HaveOccurred())
 									Expect(strconv.Atoi(output)).To(Equal(int(volStatus.Size)), "ISO file for volume %s is not the right size", volume.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This test is flaky because the target pod is potentially paused when reaching the exec code, failing the test.
Including the exec error in the Eventually loop instead of failing on it should address the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
