### PR TITLE
tests: fix flaky migration test by patching node instead of updating

### DIFF
--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/nodes:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2724,8 +2724,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					By("Restore node to its original state")
 					node.Labels = originalNodeLabels
 					node.Annotations = originalNodeAnnotations
-					node, err = virtClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
-					Expect(err).ShouldNot(HaveOccurred())
+					err = libnode.PatchNodeLabels(virtClient, node)
+					Expect(err).ToNot(HaveOccurred())
 
 					Eventually(func() map[string]string {
 						node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
@@ -2746,8 +2746,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					}
 					node.Labels[v1.HostModelCPULabel+"fake-model"] = "true"
 
-					node, err = virtClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
-					Expect(err).ShouldNot(HaveOccurred())
+					err = libnode.PatchNodeLabels(virtClient, node)
+					Expect(err).ToNot(HaveOccurred())
 
 					Eventually(func() bool {
 						node, err = virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
Running `Update()` on a global object can fail if the object changed since the last `Get()`.
We can either keep retrying to get + update, or just patch. I picked patch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
