### PR TITLE
tests: console: bootloader expecters: give the VMI enough time to start

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -131,12 +131,13 @@ func RunCommand(vmi *v1.VirtualMachineInstance, command string, timeout time.Dur
 
 // SecureBootExpecter should be called on a VMI that has EFI enabled
 // It will parse the kernel output (dmesg) and succeed if it finds that Secure boot is enabled
+// The VMI was just created and may not be running yet. This is because we want to catch early boot logs.
 func SecureBootExpecter(vmi *v1.VirtualMachineInstance) error {
 	virtClient, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		return err
 	}
-	expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
 	if err != nil {
 		return err
 	}
@@ -156,12 +157,13 @@ func SecureBootExpecter(vmi *v1.VirtualMachineInstance) error {
 
 // NetBootExpecter should be called on a VMI that has BIOS serial logging enabled
 // It will parse the SeaBIOS output and succeed if it finds the string "iPXE"
+// The VMI was just created and may not be running yet. This is because we want to catch early boot logs.
 func NetBootExpecter(vmi *v1.VirtualMachineInstance) error {
 	virtClient, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		return err
 	}
-	expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The expecters working on BIOS/EFI logs are given a freshly created VMI, to maximize their chance of catching those early logs.
Therefore, they need an initial timeout long enough for the VMI to start, 10 seconds is just not enough.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
