### PR TITLE
tests, sriov: Fix finding the iface name by mac

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -681,7 +681,7 @@ func defaultCloudInitNetworkData() string {
 
 func findIfaceByMAC(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, mac string, timeout time.Duration) (string, error) {
 	var ifaceName string
-	err := wait.Poll(timeout, 5*time.Second, func() (done bool, err error) {
+	err := wait.Poll(timeout, 5*time.Second, func() (bool, error) {
 		vmi, err := virtClient.VirtualMachineInstance(vmi.GetNamespace()).Get(vmi.GetName(), &k8smetav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -688,7 +688,7 @@ func findIfaceByMAC(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIns
 		}
 
 		ifaceName, err = getInterfaceNameByMAC(vmi, mac)
-		if err != nil {
+		if err != nil || ifaceName == "" {
 			return false, nil
 		}
 		return true, nil

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -485,7 +485,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 					// It may take some time for the VMI interface status to be updated with the information reported by
 					// the guest-agent.
-					ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 30*time.Second)
+					ifaceName, err := findIfaceByMAC(virtClient, vmi, mac, 140*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 					updatedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &k8smetav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

The existing logic may return an empty iface name, when the mac
appears in the VMI status interface report as sourcing from the
domain.

Here is an example of such a report:
```
{
  "mac": "de:ad:00:00:be:ef",
  "name": "sriov",
  "infoSource": "domain"
}
```
(the `interfaceName` parameter is missing)

In such cases, the poll loop should continue waiting for the data
to be updated by the guest-agent or just fail after the timeout.

---

This change also includes some minor cleanups to the poll function, removing the named parameters and the variable shadowing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
