### PR TITLE
tests, network, primary-pod: Remove VMI deletion on teardown

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -43,6 +43,8 @@ import (
 var _ = SIGDescribe("Primary Pod Network", func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -27,7 +27,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/util"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -66,10 +65,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 				vmi = setupVMI(virtClient, vmiWithDefaultBinding())
 			})
 
-			AfterEach(func() {
-				cleanupVMI(virtClient, vmi)
-			})
-
 			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
 		})
 
@@ -104,10 +99,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					tests.WaitAgentConnected(virtClient, vmi)
 				})
 
-				AfterEach(func() {
-					cleanupVMI(virtClient, vmi)
-				})
-
 				It("should report PodIP/s IPv4 as its own on interface status", func() {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Eventually(vmiIP).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
@@ -123,10 +114,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 
 				BeforeEach(func() {
 					vmi = setupVMI(virtClient, vmiWithBridgeBinding())
-				})
-
-				AfterEach(func() {
-					cleanupVMI(virtClient, vmi)
 				})
 
 				It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
@@ -146,10 +133,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					vmi = tests.WaitUntilVMIReady(tmpVmi, console.LoginToFedora)
 
 					tests.WaitAgentConnected(virtClient, vmi)
-				})
-
-				AfterEach(func() {
-					cleanupVMI(virtClient, vmi)
 				})
 
 				It("[test_id:4153]should report PodIP/s as its own on interface status", func() {
@@ -172,10 +155,6 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					vmi = setupVMI(virtClient, vmiWithMasqueradeBinding())
 				})
 
-				AfterEach(func() {
-					cleanupVMI(virtClient, vmi)
-				})
-
 				It("[Conformance] should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
 			})
 		})
@@ -192,19 +171,6 @@ func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance)
 	vmi = tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 	return vmi
-}
-
-func cleanupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	if vmi != nil {
-		By("Deleting the VMI")
-		Expect(virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(vmi.GetName(), &metav1.DeleteOptions{})).To(Succeed())
-
-		By("Waiting for the VMI to be gone")
-		Eventually(func() error {
-			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.GetName(), &metav1.GetOptions{})
-			return err
-		}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
-	}
 }
 
 func vmiWithDefaultBinding() *v1.VirtualMachineInstance {


### PR DESCRIPTION
**What this PR does / why we need it**:

The existing testing framework flow requires that the cleanup of the
test be executed at the beginning (setup) of the next test [1].

Therefore, remove all VMI cleanups from the teardown fixtures.

[1] Cleaning up at the teardown step will remove objects before they
are collected by the custom reporting (which helps debug).
This reporting is hooked into ginkgo where it is called only after a
test finishes (either with success or failure).

The cleanup is added at the beginning of the tests (setup).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
