### PR TITLE
tests/storage/restore: less `echo hello`

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -41,6 +41,7 @@ const (
 	creatingSnapshot          = "creating snapshot"
 
 	macAddressCloningPatchPattern = `{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "%s"}`
+	bashHelloScript               = "#!/bin/bash\necho 'hello'\n"
 )
 
 var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
@@ -216,7 +217,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 		BeforeEach(func() {
 			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, tests.BashHelloScript)
+			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, bashHelloScript)
 			vm = tests.NewRandomVirtualMachine(vmi, false)
 			vm.Labels = map[string]string{
 				"kubevirt.io/dummy-webhook-identifier": vm.Name,
@@ -419,7 +420,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 			It("should fail restoring to a different VM that already exists", func() {
 				By("Creating a new VM")
-				newVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), tests.BashHelloScript)
+				newVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), bashHelloScript)
 				newVM := tests.NewRandomVirtualMachine(newVMI, false)
 				newVM, err = virtClient.VirtualMachine(newVM.Namespace).Create(newVM)
 				Expect(err).ToNot(HaveOccurred())
@@ -785,7 +786,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
-					tests.BashHelloScript,
+					bashHelloScript,
 					snapshotStorageClass,
 				))
 
@@ -817,7 +818,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm = tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
-					tests.BashHelloScript,
+					bashHelloScript,
 					snapshotStorageClass,
 				)
 				quantity, err := resource.ParseQuantity("1528Mi")
@@ -853,7 +854,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
-					tests.BashHelloScript,
+					bashHelloScript,
 					snapshotStorageClass,
 				))
 
@@ -878,7 +879,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm = tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
-					tests.BashHelloScript,
+					bashHelloScript,
 					snapshotStorageClass,
 				)
 
@@ -950,7 +951,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				originalPVCName := pvc.Name
 
-				vmi = tests.NewRandomVMIWithPVCAndUserData(pvc.Name, tests.BashHelloScript)
+				vmi = tests.NewRandomVMIWithPVCAndUserData(pvc.Name, bashHelloScript)
 				vm = tests.NewRandomVirtualMachine(vmi, false)
 
 				vm, vmi = createAndStartVM(vm)
@@ -989,7 +990,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros),
-					tests.BashHelloScript,
+					bashHelloScript,
 				)
 				vm = tests.NewRandomVirtualMachine(vmi, false)
 
@@ -1053,7 +1054,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
-					tests.BashHelloScript,
+					bashHelloScript,
 					snapshotStorageClass,
 				))
 
@@ -1153,7 +1154,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),
 					util.NamespaceTestDefault,
-					tests.BashHelloScript,
+					bashHelloScript,
 					snapshotStorageClass,
 				))
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -29,6 +29,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 const (
@@ -216,9 +217,11 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 		var vm *v1.VirtualMachine
 
 		BeforeEach(func() {
-			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, bashHelloScript)
-			vm = tests.NewRandomVirtualMachine(vmi, false)
+			vm = tests.NewRandomVirtualMachine(
+				libvmi.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				), false)
 			vm.Labels = map[string]string{
 				"kubevirt.io/dummy-webhook-identifier": vm.Name,
 			}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -109,7 +109,6 @@ const (
 	WaitingVMInstanceStart       = "Waiting until the VirtualMachineInstance will start"
 	CouldNotFindComputeContainer = "could not find compute container for pod"
 	EchoLastReturnValue          = "echo $?\n"
-	BashHelloScript              = "#!/bin/bash\necho 'hello'\n"
 )
 
 const defaultTestGracePeriod int64 = 0


### PR DESCRIPTION
`echo hello` userdata is an implementation detail of Cirros VMs. It should not be mentioned in each test, and it does not deserve its own public constant. This PR makes the constant public and replaces one of its usages by a `libvmi.NewCirros` call.

/sig code-quality

/cc @brybacki as this is storage

```release-note
NONE
```
