### PR TITLE
tests, network, primary pod: use libvmi to create VMI specs

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -62,7 +62,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-				vmi = setupVMI(virtClient, vmiWithDefaultBinding())
+				vmi = setupVMI(virtClient, libvmi.NewAlpine())
 			})
 
 			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
@@ -170,13 +170,6 @@ func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance)
 	By("Waiting until the VMI gets ready")
 	vmi = tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
-	return vmi
-}
-
-func vmiWithDefaultBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-	vmi.Spec.Domain.Devices.Interfaces = nil
-	vmi.Spec.Networks = nil
 	return vmi
 }
 

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -113,7 +113,13 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 				var vmi *v1.VirtualMachineInstance
 
 				BeforeEach(func() {
-					vmi = setupVMI(virtClient, vmiWithBridgeBinding())
+					vmi = setupVMI(
+						virtClient,
+						libvmi.NewAlpine(
+							libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
+							libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						),
+					)
 				})
 
 				It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
@@ -170,13 +176,6 @@ func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance)
 	By("Waiting until the VMI gets ready")
 	vmi = tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
-	return vmi
-}
-
-func vmiWithBridgeBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	return vmi
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `libvmi` to create the VMI spec/s in the network, primary-pod e2e tests.

Prefer explicitly showing in the tests the building blocks of the VMI rather than hide it in helpers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
