### PR TITLE
unit test, isolation: Make test agnostic to virt-launcher process name

### DIFF
--- a/pkg/virt-handler/isolation/detector_test.go
+++ b/pkg/virt-handler/isolation/detector_test.go
@@ -120,16 +120,16 @@ var _ = Describe("Isolation Detector", func() {
 
 var _ = Describe("findIsolatedQemuProcess", func() {
 	const virtLauncherPid = 1
-	virtLauncherProc := ProcessStub{pid: virtLauncherPid, ppid: 0, binary: "virt-launcher"}
-	virtLauncherForkedProc := ProcessStub{pid: 26, ppid: 1, binary: "virt-launcher --no-fork true"}
-	libvirtdProc := ProcessStub{pid: 226, ppid: 26, binary: "libvirtd"}
+	fakeProcess1 := ProcessStub{pid: virtLauncherPid, ppid: 0, binary: "fake-process-1"}
+	fakeProcess2 := ProcessStub{pid: 26, ppid: virtLauncherPid, binary: "fake-process-2"}
+	fakeProcess3 := ProcessStub{pid: 226, ppid: 26, binary: "fake-process-3"}
 	virtLauncherProcesses := []ps.Process{
-		virtLauncherProc,
-		virtLauncherForkedProc,
-		libvirtdProc}
+		fakeProcess1,
+		fakeProcess2,
+		fakeProcess3}
 
-	qemuKvmProc := ProcessStub{pid: 101, ppid: 1, binary: "qemu-kvm"}
-	qemuSystemProc := ProcessStub{pid: 101, ppid: 1, binary: "qemu-system"}
+	qemuKvmProc := ProcessStub{pid: 101, ppid: virtLauncherPid, binary: "qemu-kvm"}
+	qemuSystemProc := ProcessStub{pid: 101, ppid: virtLauncherPid, binary: "qemu-system"}
 
 	DescribeTable("should return QEMU process",
 		func(processes []ps.Process, pid int, expectedProcess ps.Process) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since https://github.com/kubevirt/kubevirt/pull/7451
virt-launcher processes names were changed.
Adapt the unit test accordingly, by being agnostic
to the binary names, as it doesn't affect the test
as long as the stubs don't have the expected qemu
names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7878 

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
