### PR TITLE
builder, makefile, lint: Introduce golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,110 @@
+# golangci configuration
+
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  gci:
+    local-prefixes: github.com/kubevirt/kubevirt
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+    settings:
+      hugeParam:
+        sizeThreshold: 1024
+      rangeValCopy:
+        sizeThreshold: 1024
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/kiagnose/kiagnose
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goheader
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - revive
+  # - wsl

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,8 @@ fmt: format
 lint:
 	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
+	hack/dockerized "golangci-lint run --timeout 3m --verbose tests/libvmi/..."
+
 .PHONY: \
 	build-verify \
 	conformance \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -8,6 +8,7 @@ ENV GIMME_GO_VERSION=1.17.8
 ENV GRADLE_VERSION=6.6
 ENV OPERATOR_COURIER_VERSION=2.1.11
 ENV SONOBUOY_VERSION=0.19.0
+ENV GOLANGCI_LINT_VERSION=v1.46.2
 
 ENV KUBEVIRT_CREATE_BAZELRCS=false
 
@@ -107,6 +108,10 @@ RUN set -x && \
     go clean -cache -modcache -r && \
     rm -rf /test-infra && \
     rm -rf /go && mkdir /go
+
+RUN set -x && \
+    source /etc/profile.d/gimme.sh && \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOROOT)"/bin $GOLANGCI_LINT_VERSION
 
 RUN pip3 install --upgrade operator-courier==${OPERATOR_COURIER_VERSION}
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2205231002-ca5ef667d"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2206141426-2d31aa580"
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce golangci-lint [1] into the builder image in order to start
using a linter to detect common mistakes and attempt to place some
order in the code.

Include golangci-lint in the makefile `lint` target and a basic
configuration file.

At this stage, it processes only `tests/libvmi` folder.

[1] https://github.com/golangci/golangci-lint

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The linter is reporting a few errors which need treatment.
These will be handled in a separate PR.

**Release note**:
```release-note
NONE
```
