### PR TITLE
tests, reporter: Collect data at JustAfterEach

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -118,6 +118,6 @@ var _ = ReportBeforeEach(func(specReport SpecReport) {
 	k8sReporter.JustBeforeEach(CurrentSpecReport())
 })
 
-var _ = ReportAfterEach(func(specReport SpecReport) {
+var _ = JustAfterEach(func() {
 	k8sReporter.JustAfterEach(CurrentSpecReport())
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
In case some tests is cleaning up at proper place AfterEach the current
implementation will miss the data needed by the reporter. This change
move the reporter collect function to JustAfterEach so data is collected
before cleaned up.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
