### PR TITLE
Add alerts for VMs unhealthy states

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -33,6 +33,21 @@ Indication for an operating virt-controller. Type: Gauge.
 ### kubevirt_virt_controller_ready
 Indication for a virt-controller that is ready to take the lead. Type: Gauge.
 
+### kubevirt_vm_error_status_last_transition_timestamp_seconds
+Virtual Machine last transition timestamp to error status. Type: Counter.
+
+### kubevirt_vm_migrating_status_last_transition_timestamp_seconds
+Virtual Machine last transition timestamp to migrating status. Type: Counter.
+
+### kubevirt_vm_non_running_status_last_transition_timestamp_seconds
+Virtual Machine last transition timestamp to paused/stopped status. Type: Counter.
+
+### kubevirt_vm_running_status_last_transition_timestamp_seconds
+Virtual Machine last transition timestamp to running status. Type: Counter.
+
+### kubevirt_vm_starting_status_last_transition_timestamp_seconds
+Virtual Machine last transition timestamp to starting status. Type: Counter.
+
 ### kubevirt_vmi_cpu_affinity
 The vcpu affinity details. Type: Counter.
 

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -742,3 +742,120 @@ tests:
       - eval_time: 26h
         alertname: KubeVirtVMIExcessiveMigrations
         exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # time:  0   1   2   3   4   5   6   7   8   9   10  11
+      - series: 'kubevirt_vm_starting_status_last_transition_timestamp_seconds{name="starting-vm-1", namespace="ns-test"}'
+        values: "_   _   _   _   0   240 240 240 240 240 240 0"
+      - series: 'kubevirt_vm_starting_status_last_transition_timestamp_seconds{name="starting-vm-2", namespace="ns-test"}'
+        values: "_   _   _   0   0   60  60  0   0   0   0   0"
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: KubeVirtVMStuckInStartingState
+        exp_alerts: []
+
+      - eval_time: 4m
+        alertname: KubeVirtVMStuckInStartingState
+        exp_alerts: []
+
+      - eval_time: 8m
+        alertname: KubeVirtVMStuckInStartingState
+        exp_alerts: []
+
+      - eval_time: 10m
+        alertname: KubeVirtVMStuckInStartingState
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachine starting-vm-1 is in starting state for 6m 0s"
+              summary: "A Virtual Machine has been in an unwanted starting state for more than 5 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInStartingState"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "starting-vm-1"
+              namespace: "ns-test"
+
+      - eval_time: 11m
+        alertname: KubeVirtVMStuckInStartingState
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      # time:  0   1   2   3   4   5   6   7   8   9   10  11
+      - series: 'kubevirt_vm_migrating_status_last_transition_timestamp_seconds{name="migrating-vm-1", namespace="ns-test"}'
+        values: "_   _   _   _   0   240 240 240 240 240 240 0"
+      - series: 'kubevirt_vm_migrating_status_last_transition_timestamp_seconds{name="migrating-vm-2", namespace="ns-test"}'
+        values: "_   _   _   0   0   60  60  0   0   0   0   0"
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: KubeVirtVMStuckInMigratingState
+        exp_alerts: []
+
+      - eval_time: 4m
+        alertname: KubeVirtVMStuckInMigratingState
+        exp_alerts: []
+
+      - eval_time: 8m
+        alertname: KubeVirtVMStuckInMigratingState
+        exp_alerts: []
+
+      - eval_time: 10m
+        alertname: KubeVirtVMStuckInMigratingState
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachine migrating-vm-1 is in migrating state for 6m 0s"
+              summary: "A Virtual Machine has been in an unwanted migrating state for more than 5 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInMigratingState"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "migrating-vm-1"
+              namespace: "ns-test"
+
+      - eval_time: 11m
+        alertname: KubeVirtVMStuckInMigratingState
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+        # time:  0   1   2   3   4   5   6   7   8   9   10  11
+      - series: 'kubevirt_vm_error_status_last_transition_timestamp_seconds{name="error-vm-1", namespace="ns-test"}'
+        values: "_   _   _   _   0   240 240 240 240 240 240 0"
+      - series: 'kubevirt_vm_error_status_last_transition_timestamp_seconds{name="error-vm-2", namespace="ns-test"}'
+        values: "_   _   _   0   0   60  60  0   0   0   0   0"
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: KubeVirtVMStuckInErrorState
+        exp_alerts: []
+
+      - eval_time: 4m
+        alertname: KubeVirtVMStuckInErrorState
+        exp_alerts: []
+
+      - eval_time: 8m
+        alertname: KubeVirtVMStuckInErrorState
+        exp_alerts: []
+
+      - eval_time: 10m
+        alertname: KubeVirtVMStuckInErrorState
+        exp_alerts:
+          - exp_annotations:
+              description: "VirtualMachine error-vm-1 is in error state for 6m 0s"
+              summary: "A Virtual Machine has been in an unwanted error state for more than 5 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInErrorState"
+            exp_labels:
+              severity: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "error-vm-1"
+              namespace: "ns-test"
+
+      - eval_time: 11m
+        alertname: KubeVirtVMStuckInErrorState
+        exp_alerts: []

--- a/pkg/monitoring/vmstats/BUILD.bazel
+++ b/pkg/monitoring/vmstats/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["collector.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/monitoring/vmstats",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "collector_test.go",
+        "vmstats_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/monitoring/vmstats/collector.go
+++ b/pkg/monitoring/vmstats/collector.go
@@ -1,0 +1,235 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package vmstats
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	k6tv1 "kubevirt.io/api/core/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"kubevirt.io/client-go/log"
+)
+
+const (
+	startingMetric   = "kubevirt_vm_starting_status_last_transition_timestamp_seconds"
+	runningMetric    = "kubevirt_vm_running_status_last_transition_timestamp_seconds"
+	migratingMetric  = "kubevirt_vm_migrating_status_last_transition_timestamp_seconds"
+	nonRunningMetric = "kubevirt_vm_non_running_status_last_transition_timestamp_seconds"
+	errorMetric      = "kubevirt_vm_error_status_last_transition_timestamp_seconds"
+)
+
+var (
+	startingStatuses = []k6tv1.VirtualMachinePrintableStatus{
+		k6tv1.VirtualMachineStatusProvisioning,
+		k6tv1.VirtualMachineStatusStarting,
+		k6tv1.VirtualMachineStatusWaitingForVolumeBinding,
+	}
+
+	runningStatuses = []k6tv1.VirtualMachinePrintableStatus{
+		k6tv1.VirtualMachineStatusRunning,
+	}
+
+	migratingStatuses = []k6tv1.VirtualMachinePrintableStatus{
+		k6tv1.VirtualMachineStatusMigrating,
+	}
+
+	nonRunningStatuses = []k6tv1.VirtualMachinePrintableStatus{
+		k6tv1.VirtualMachineStatusStopped,
+		k6tv1.VirtualMachineStatusPaused,
+		k6tv1.VirtualMachineStatusStopping,
+		k6tv1.VirtualMachineStatusTerminating,
+	}
+
+	errorStatuses = []k6tv1.VirtualMachinePrintableStatus{
+		k6tv1.VirtualMachineStatusCrashLoopBackOff,
+		k6tv1.VirtualMachineStatusUnknown,
+		k6tv1.VirtualMachineStatusUnschedulable,
+		k6tv1.VirtualMachineStatusErrImagePull,
+		k6tv1.VirtualMachineStatusImagePullBackOff,
+		k6tv1.VirtualMachineStatusPvcNotFound,
+		k6tv1.VirtualMachineStatusDataVolumeError,
+	}
+
+	metrics = map[string]*prometheus.Desc{
+		startingMetric: prometheus.NewDesc(
+			startingMetric,
+			"Virtual Machine last transition timestamp to starting status.",
+			labels,
+			nil,
+		),
+		runningMetric: prometheus.NewDesc(
+			runningMetric,
+			"Virtual Machine last transition timestamp to running status.",
+			labels,
+			nil,
+		),
+		migratingMetric: prometheus.NewDesc(
+			migratingMetric,
+			"Virtual Machine last transition timestamp to migrating status.",
+			labels,
+			nil,
+		),
+		nonRunningMetric: prometheus.NewDesc(
+			nonRunningMetric,
+			"Virtual Machine last transition timestamp to paused/stopped status.",
+			labels,
+			nil,
+		),
+		errorMetric: prometheus.NewDesc(
+			errorMetric,
+			"Virtual Machine last transition timestamp to error status.",
+			labels,
+			nil,
+		),
+	}
+
+	labels = []string{"name", "namespace"}
+)
+
+type VMCollector struct {
+	vmInformer cache.SharedIndexInformer
+}
+
+func (co *VMCollector) Describe(_ chan<- *prometheus.Desc) {
+	// TODO: Use DescribeByCollect?
+}
+
+func SetupVMCollector(vmInformer cache.SharedIndexInformer) *VMCollector {
+	log.Log.Infof("Starting vm collector")
+	co := &VMCollector{
+		vmInformer: vmInformer,
+	}
+
+	prometheus.MustRegister(co)
+	return co
+}
+
+func (co *VMCollector) Collect(ch chan<- prometheus.Metric) {
+	cachedObjs := co.vmInformer.GetIndexer().List()
+	if len(cachedObjs) == 0 {
+		return
+	}
+
+	vms := make([]*k6tv1.VirtualMachine, len(cachedObjs))
+	for i, obj := range cachedObjs {
+		vms[i] = obj.(*k6tv1.VirtualMachine)
+	}
+
+	scraper := NewPrometheusScraper(ch)
+	scraper.Report(vms)
+}
+
+func NewPrometheusScraper(ch chan<- prometheus.Metric) *prometheusScraper {
+	return &prometheusScraper{ch: ch}
+}
+
+type prometheusScraper struct {
+	ch chan<- prometheus.Metric
+}
+
+func (ps *prometheusScraper) Report(vms []*k6tv1.VirtualMachine) {
+	for _, vm := range vms {
+		ps.updateVMMetrics(vm)
+	}
+}
+
+func (ps *prometheusScraper) updateVMMetrics(vm *k6tv1.VirtualMachine) {
+	status := vm.Status.PrintableStatus
+	currentStateMetric := getMetricDesc(status)
+
+	lastTransitionTime := getLastConditionDetails(vm)
+
+	for _, metric := range metrics {
+		if metric == currentStateMetric {
+			ps.pushMetric(currentStateMetric, float64(lastTransitionTime), vm.Name, vm.Namespace)
+		} else {
+			ps.pushMetric(metric, 0, vm.Name, vm.Namespace)
+		}
+	}
+}
+
+func (ps *prometheusScraper) pushMetric(desc *prometheus.Desc, value float64, labelValues ...string) {
+	mv, err := prometheus.NewConstMetric(
+		desc,
+		prometheus.CounterValue,
+		value,
+		labelValues...,
+	)
+	if err != nil {
+		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", desc, err)
+		return
+	}
+	ps.ch <- mv
+}
+
+func getLastConditionDetails(vm *k6tv1.VirtualMachine) int64 {
+	conditions := []k6tv1.VirtualMachineConditionType{
+		k6tv1.VirtualMachineReady,
+		k6tv1.VirtualMachineFailure,
+		k6tv1.VirtualMachinePaused,
+	}
+
+	latestTransitionTime := int64(-1)
+
+	for _, c := range vm.Status.Conditions {
+		if containsCondition(c.Type, conditions) && c.LastTransitionTime.Unix() > latestTransitionTime {
+			latestTransitionTime = c.LastTransitionTime.Unix()
+		}
+	}
+
+	return latestTransitionTime
+}
+
+func containsCondition(target k6tv1.VirtualMachineConditionType, elems []k6tv1.VirtualMachineConditionType) bool {
+	for _, elem := range elems {
+		if elem == target {
+			return true
+		}
+	}
+	return false
+}
+
+func getMetricDesc(status k6tv1.VirtualMachinePrintableStatus) *prometheus.Desc {
+	switch {
+	case containsStatus(status, startingStatuses):
+		return metrics[startingMetric]
+	case containsStatus(status, runningStatuses):
+		return metrics[runningMetric]
+	case containsStatus(status, migratingStatuses):
+		return metrics[migratingMetric]
+	case containsStatus(status, nonRunningStatuses):
+		return metrics[nonRunningMetric]
+	case containsStatus(status, errorStatuses):
+		return metrics[errorMetric]
+	}
+
+	return metrics[errorMetric]
+}
+
+func containsStatus(target k6tv1.VirtualMachinePrintableStatus, elems []k6tv1.VirtualMachinePrintableStatus) bool {
+	for _, elem := range elems {
+		if elem == target {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/monitoring/vmstats/collector_test.go
+++ b/pkg/monitoring/vmstats/collector_test.go
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package vmstats
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k6tv1 "kubevirt.io/api/core/v1"
+)
+
+var _ = BeforeSuite(func() {
+})
+
+var _ = Describe("VM Stats Collector", func() {
+	Context("VM status collector", func() {
+		var ch chan prometheus.Metric
+		var scrapper *prometheusScraper
+
+		createVM := func(status k6tv1.VirtualMachinePrintableStatus, vmLastTransitionsTime time.Time) *k6tv1.VirtualMachine {
+			return &k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-vm"},
+				Status: k6tv1.VirtualMachineStatus{
+					PrintableStatus: status,
+					Conditions: []k6tv1.VirtualMachineCondition{
+						{
+							Type:               k6tv1.VirtualMachineFailure,
+							Status:             "any",
+							Reason:             "any",
+							LastTransitionTime: metav1.NewTime(vmLastTransitionsTime.Add(-20 * time.Second)),
+						},
+						{
+							Type:               k6tv1.VirtualMachineReady,
+							Status:             "any",
+							Reason:             "any",
+							LastTransitionTime: metav1.NewTime(vmLastTransitionsTime),
+						},
+						{
+							Type:               k6tv1.VirtualMachinePaused,
+							Status:             "any",
+							Reason:             "any",
+							LastTransitionTime: metav1.NewTime(vmLastTransitionsTime.Add(-40 * time.Second)),
+						},
+					},
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			ch = make(chan prometheus.Metric, 5)
+			scrapper = &prometheusScraper{ch: ch}
+		})
+
+		DescribeTable("Add VM status metrics", func(status k6tv1.VirtualMachinePrintableStatus, metric string) {
+			t := time.Now()
+			vms := []*k6tv1.VirtualMachine{
+				createVM(status, t),
+			}
+
+			scrapper.Report(vms)
+			close(ch)
+
+			containsStateMetric := false
+
+			for m := range ch {
+				dto := &io_prometheus_client.Metric{}
+				m.Write(dto)
+
+				if strings.Contains(m.Desc().String(), metric) {
+					containsStateMetric = true
+					Expect(*dto.Counter.Value).To(Equal(float64(t.Unix())))
+				} else {
+					Expect(*dto.Counter.Value).To(BeZero())
+				}
+			}
+
+			Expect(containsStateMetric).To(BeTrue())
+		},
+			Entry("Starting VM", k6tv1.VirtualMachineStatusProvisioning, startingMetric),
+			Entry("Running VM", k6tv1.VirtualMachineStatusRunning, runningMetric),
+			Entry("Migrating VM", k6tv1.VirtualMachineStatusMigrating, migratingMetric),
+			Entry("Non running VM", k6tv1.VirtualMachineStatusStopped, nonRunningMetric),
+			Entry("Errored VM", k6tv1.VirtualMachineStatusCrashLoopBackOff, errorMetric),
+		)
+	})
+})

--- a/pkg/monitoring/vmstats/vmstats_suite_test.go
+++ b/pkg/monitoring/vmstats/vmstats_suite_test.go
@@ -1,0 +1,11 @@
+package vmstats_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVMStats(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/monitoring/perfscale:go_default_library",
         "//pkg/monitoring/profiler:go_default_library",
         "//pkg/monitoring/vmistats:go_default_library",
+        "//pkg/monitoring/vmstats:go_default_library",
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/service:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -75,6 +75,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/monitoring/perfscale"
 	vmiprom "kubevirt.io/kubevirt/pkg/monitoring/vmistats" // import for prometheus metrics
+	vmprom "kubevirt.io/kubevirt/pkg/monitoring/vmstats"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/storage/export/export"
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
@@ -503,6 +504,7 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 			vca.disruptionBudgetControllerThreads)
 
 		vmiprom.SetupVMICollector(vca.vmiInformer, vca.clusterConfig)
+		vmprom.SetupVMCollector(vca.vmInformer)
 		perfscale.RegisterPerfScaleMetrics(vca.vmiInformer)
 		if vca.migrationInformer == nil {
 			vca.migrationInformer = vca.informerFactory.VirtualMachineInstanceMigration()

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/coreos/prometheus-operator/pkg/apis/monitoring"
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -89,6 +90,30 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 		errorRatioQuery := "sum ( rate ( rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\",code=~\"%s\"} [%dm] ) )  /  sum ( rate ( rest_client_requests_total{namespace=\"%s\",pod=~\"%s-.*\"} [%dm] ) )"
 		return fmt.Sprintf(errorRatioQuery, ns, podName, errorCodeRegex, durationInMinutes, ns, podName, durationInMinutes)
 	}
+
+	vmStuckInStatusRule := func(status string) v1.Rule {
+		const fiveMinutesInSec = 60 * 5
+
+		alertName := fmt.Sprintf("KubeVirtVMStuckIn%sState", strings.Title(status))
+		metric := fmt.Sprintf("kubevirt_vm_%s_status_last_transition_timestamp_seconds", status)
+		expr := fmt.Sprintf("time() - %s >= %d and %s != 0", metric, fiveMinutesInSec, metric)
+		description := fmt.Sprintf("VirtualMachine {{ $labels.name }} is in %s state for {{ humanizeDuration $value }}", status)
+		summary := fmt.Sprintf("A Virtual Machine has been in an unwanted %s state for more than 5 minutes", status)
+
+		return v1.Rule{
+			Alert: alertName,
+			Expr:  intstr.FromString(expr),
+			Annotations: map[string]string{
+				"description": description,
+				"summary":     summary,
+				"runbook_url": runbookUrlBasePath + alertName,
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey: "warning",
+			},
+		}
+	}
+
 	ruleSpec := &v1.PrometheusRuleSpec{
 		Groups: []v1.RuleGroup{
 			{
@@ -497,6 +522,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							severityAlertLabelKey: "warning",
 						},
 					},
+					vmStuckInStatusRule("starting"),
+					vmStuckInStatusRule("migrating"),
+					vmStuckInStatusRule("error"),
 				},
 			},
 		},

--- a/tools/doc-generator/BUILD.bazel
+++ b/tools/doc-generator/BUILD.bazel
@@ -5,17 +5,20 @@ go_library(
     srcs = [
         "doc-generator.go",
         "fakeCollector.go",
+        "fakeVMCollector.go",
     ],
     importpath = "kubevirt.io/kubevirt/tools/doc-generator",
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/monitoring/domainstats/prometheus:go_default_library",
+        "//pkg/monitoring/vmstats:go_default_library",
         "//pkg/virt-controller/watch:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -61,6 +61,7 @@ const (
 func main() {
 	handler := domainstats.Handler(1)
 	RegisterFakeCollector()
+	RegisterFakeMigrationsCollector()
 
 	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	checkError(err)

--- a/tools/doc-generator/fakeVMCollector.go
+++ b/tools/doc-generator/fakeVMCollector.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k6tv1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/monitoring/vmstats"
+)
+
+type fakeVMCollector struct {
+}
+
+func (fc fakeVMCollector) Describe(_ chan<- *prometheus.Desc) {
+}
+
+//Collect needs to report all metrics to see it in docs
+func (fc fakeVMCollector) Collect(ch chan<- prometheus.Metric) {
+	ps := vmstats.NewPrometheusScraper(ch)
+
+	vms := []*k6tv1.VirtualMachine{
+		createVM(k6tv1.VirtualMachineStatusRunning),
+	}
+
+	ps.Report(vms)
+}
+
+func RegisterFakeMigrationsCollector() {
+	prometheus.MustRegister(fakeVMCollector{})
+}
+
+func createVM(status k6tv1.VirtualMachinePrintableStatus) *k6tv1.VirtualMachine {
+	return &k6tv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-vm"},
+		Status: k6tv1.VirtualMachineStatus{
+			PrintableStatus: status,
+			Conditions: []k6tv1.VirtualMachineCondition{
+				{
+					Type:               k6tv1.VirtualMachineReady,
+					Status:             "any",
+					Reason:             "any",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Sometimes VMs are stuck in unhealthy starting, migrating, or error status. This PR adds new metrics and alerts to provide more visibility over these situations.

For these metrics we considered some options:

1. We discarded using a binary value (0 or 1) to identify if a VM is or is not in a given status because we would lose a considerable amount of information such as for how long the VM has a given status, when did the transitions to those status happened, etc. Having the transition timestamps in the labels was not considered. Each different set of labels represents a new time series. If we had a new time series for each transition timestamp, that would dramatically increase the amount of data stored.

2.  We considered using the number of seconds a VM is in a given status as the value. Despite allowing us to obtain all observability information we want, this approach would have 2 downsides. First, we would need to perform a calculation in the controller every time we push a metric, to know for how long the VM was in the given status (time.Now() - vm.Status.LastTransitionTime) and, secondly, since the value was different every time Prometheus would never be able to optimize the storage and querying.

3. The last option, and approach selected, was to use the VM last transition time as the metric value. This allow the user to have visibility on when the VM transitioned status, it is also possible to calculate how long the VM was in the given state, by subtracting the value from the timestamp of the metric. And since the value only changes when a status transition occurs, the value of the metric would be mostly the same. 


Added metrics:

```
kubevirt_vm_error_status_last_transition_timestamp_seconds
kubevirt_vm_migrating_status_last_transition_timestamp_seconds
kubevirt_vm_non_running_status_last_transition_timestamp_seconds
kubevirt_vm_running_status_last_transition_timestamp_seconds
kubevirt_vm_starting_status_last_transition_timestamp_seconds
```

Example metric for VM in error state for 10 minutes:

```
kubevirt_vm_error_status_last_transition_timestamp_seconds{name='vm-example-1', namespace='ns-example-1'} 1663087616
```

Added alerts:

```
KubeVirtVMStuckInErrorState
KubeVirtVMStuckInMigratingState
KubeVirtVMStuckInStartingState
```

Example alert for VM in error state for 6 minutes and 30 seconds:

```
KubeVirtVMStuckInErrorState:
  annotations:
    description: "VirtualMachine error-vm is in error state for 6m 30s"
    summary: "A Virtual Machine has been in an unwanted error state for more than 5 minutes"
    runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInErrorState"
  labels:
    severity: "warning"
    name: "vm-example-1"
    namespace: "ns-example-1"
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add alerts for VMs unhealthy states
```
