### PR TITLE
flavors: Apply preferences to any added default network interfaces or missing volume disks

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -185,3 +185,27 @@ func CanBeNonRoot(vmi *v1.VirtualMachineInstance) error {
 func MarkAsNonroot(vmi *v1.VirtualMachineInstance) {
 	vmi.Status.RuntimeUser = 107
 }
+
+func SetDefaultVolumeDisk(obj *v1.VirtualMachineInstance) {
+
+	diskAndFilesystemNames := make(map[string]struct{})
+
+	for _, disk := range obj.Spec.Domain.Devices.Disks {
+		diskAndFilesystemNames[disk.Name] = struct{}{}
+	}
+
+	for _, fs := range obj.Spec.Domain.Devices.Filesystems {
+		diskAndFilesystemNames[fs.Name] = struct{}{}
+	}
+
+	for _, volume := range obj.Spec.Volumes {
+		if _, foundDisk := diskAndFilesystemNames[volume.Name]; !foundDisk {
+			obj.Spec.Domain.Devices.Disks = append(
+				obj.Spec.Domain.Devices.Disks,
+				v1.Disk{
+					Name: volume.Name,
+				},
+			)
+		}
+	}
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -91,7 +91,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
 		}
-		mutator.setDefaultVolumeDisk(newVMI)
+		util.SetDefaultVolumeDisk(newVMI)
 		v1.SetObjectDefaults_VirtualMachineInstance(newVMI)
 
 		// In a future, yet undecided, release either libvirt or QEMU are going to check the hyperv dependencies, so we can get rid of this code.
@@ -200,30 +200,6 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 		Allowed:   true,
 		Patch:     patchBytes,
 		PatchType: &jsonPatchType,
-	}
-}
-
-func (mutator *VMIsMutator) setDefaultVolumeDisk(obj *v1.VirtualMachineInstance) {
-
-	diskAndFilesystemNames := make(map[string]struct{})
-
-	for _, disk := range obj.Spec.Domain.Devices.Disks {
-		diskAndFilesystemNames[disk.Name] = struct{}{}
-	}
-
-	for _, fs := range obj.Spec.Domain.Devices.Filesystems {
-		diskAndFilesystemNames[fs.Name] = struct{}{}
-	}
-
-	for _, volume := range obj.Spec.Volumes {
-		if _, foundDisk := diskAndFilesystemNames[volume.Name]; !foundDisk {
-			obj.Spec.Domain.Devices.Disks = append(
-				obj.Spec.Domain.Devices.Disks,
-				v1.Disk{
-					Name: volume.Name,
-				},
-			)
-		}
 	}
 }
 

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -24,6 +24,8 @@ package virtconfig
 */
 
 import (
+	"fmt"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -163,6 +165,36 @@ func (c *ClusterConfig) GetNodeSelectors() map[string]string {
 
 func (c *ClusterConfig) GetDefaultNetworkInterface() string {
 	return c.GetConfig().NetworkConfiguration.NetworkInterface
+}
+
+func (c *ClusterConfig) SetVMIDefaultNetworkInterface(vmi *v1.VirtualMachineInstance) error {
+	autoAttach := vmi.Spec.Domain.Devices.AutoattachPodInterface
+	if autoAttach != nil && *autoAttach == false {
+		return nil
+	}
+
+	// Override only when nothing is specified
+	if len(vmi.Spec.Networks) == 0 && len(vmi.Spec.Domain.Devices.Interfaces) == 0 {
+		iface := v1.NetworkInterfaceType(c.GetDefaultNetworkInterface())
+		switch iface {
+		case v1.BridgeInterface:
+			if !c.IsBridgeInterfaceOnPodNetworkEnabled() {
+				return fmt.Errorf("Bridge interface is not enabled in kubevirt-config")
+			}
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		case v1.MasqueradeInterface:
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		case v1.SlirpInterface:
+			if !c.IsSlirpInterfaceEnabled() {
+				return fmt.Errorf("Slirp interface is not enabled in kubevirt-config")
+			}
+			defaultIface := v1.DefaultSlirpNetworkInterface()
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*defaultIface}
+		}
+
+		vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	}
+	return nil
 }
 
 func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -157,7 +157,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -583,7 +583,8 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.controllerRevisionInformer,
 		flavor.NewMethods(vca.flavorInformer.GetStore(), vca.clusterFlavorInformer.GetStore(), vca.preferenceInformer.GetStore(), vca.clusterPreferenceInformer.GetStore()),
 		recorder,
-		vca.clientSet)
+		vca.clientSet,
+		vca.clusterConfig)
 }
 
 func (vca *VirtControllerApp) initDisruptionBudgetController() {

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -137,7 +137,8 @@ var _ = Describe("Application", func() {
 			crInformer,
 			flavorMethods,
 			recorder,
-			virtClient)
+			virtClient,
+			config)
 		app.migrationController = NewMigrationController(services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
 			vmiInformer,
 			podInformer,

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -51,6 +51,7 @@ import (
 	cdiclone "kubevirt.io/containerized-data-importer/pkg/clone"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/flavor"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/pkg/util/status"
 	traceUtils "kubevirt.io/kubevirt/pkg/util/trace"
@@ -962,6 +963,8 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) error {
 	if err != nil {
 		return err
 	}
+
+	util.SetDefaultVolumeDisk(vmi)
 
 	err = c.applyFlavorToVmi(vm, vmi)
 	if err != nil {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -55,6 +55,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/status"
 	traceUtils "kubevirt.io/kubevirt/pkg/util/trace"
 	typesutil "kubevirt.io/kubevirt/pkg/util/types"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 const (
@@ -92,7 +93,8 @@ func NewVMController(vmiInformer cache.SharedIndexInformer,
 	crInformer cache.SharedIndexInformer,
 	flavorMethods flavor.Methods,
 	recorder record.EventRecorder,
-	clientset kubecli.KubevirtClient) *VMController {
+	clientset kubecli.KubevirtClient,
+	clusterConfig *virtconfig.ClusterConfig) *VMController {
 
 	proxy := &sarProxy{client: clientset}
 
@@ -112,6 +114,7 @@ func NewVMController(vmiInformer cache.SharedIndexInformer,
 			return cdiclone.CanServiceAccountClonePVC(proxy, pvcNamespace, pvcName, saNamespace, saName)
 		},
 		statusUpdater: status.NewVMStatusUpdater(clientset),
+		clusterConfig: clusterConfig,
 	}
 
 	c.vmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -157,6 +160,7 @@ type VMController struct {
 	dataVolumeExpectations *controller.UIDTrackingControllerExpectations
 	cloneAuthFunc          CloneAuthFunc
 	statusUpdater          *status.VMStatusUpdater
+	clusterConfig          *virtconfig.ClusterConfig
 }
 
 func (c *VMController) Run(threadiness int, stopCh <-chan struct{}) {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -958,6 +958,11 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) error {
 	// the VMI before it is deleted
 	vmi.Finalizers = append(vmi.Finalizers, virtv1.VirtualMachineControllerFinalizer)
 
+	err = c.clusterConfig.SetVMIDefaultNetworkInterface(vmi)
+	if err != nil {
+		return err
+	}
+
 	err = c.applyFlavorToVmi(vm, vmi)
 	if err != nil {
 		log.Log.Object(vm).Infof("Failed to apply flavor to VirtualMachineInstance: %s/%s", vmi.Namespace, vmi.Name)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -104,6 +104,8 @@ var _ = Describe("VirtualMachine", func() {
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
 
+			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+
 			controller = NewVMController(vmiInformer,
 				vmInformer,
 				dataVolumeInformer,
@@ -111,7 +113,8 @@ var _ = Describe("VirtualMachine", func() {
 				crInformer,
 				flavorMethods,
 				recorder,
-				virtClient)
+				virtClient,
+				config)
 
 			// Wrap our workqueue to have a way to detect when we are done processing updates
 			mockQueue = testutils.NewMockWorkQueue(controller.Queue)

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -322,6 +322,40 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(vmi.Spec.Domain.Devices.Interfaces[0].Model).To(Equal(preference.Spec.Devices.PreferredInterfaceModel))
 		})
 
+		It("[test_id:TODO] should apply preferences to default volume disks", func() {
+			vmi := tests.NewRandomVMIWithEphemeralDisk(
+				cd.ContainerDiskFor(cd.ContainerDiskCirros),
+			)
+
+			preference := newVirtualMachineClusterPreference()
+			preference.Spec.Devices = &flavorv1alpha1.DevicePreferences{
+				PreferredDiskBus: v1.DiskBusVirtio,
+			}
+
+			preference, err := virtClient.VirtualMachineClusterPreference().
+				Create(context.Background(), preference, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			vm := tests.NewRandomVirtualMachine(vmi, false)
+			vm.Spec.Preference = &v1.PreferenceMatcher{
+				Name: preference.Name,
+			}
+			vm.Spec.Template.Spec.Domain.Devices.Disks = []v1.Disk{}
+
+			vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			vm = tests.StartVMAndExpectRunning(virtClient, vm)
+
+			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, disk := range vmi.Spec.Domain.Devices.Disks {
+				Expect(disk.DiskDevice.Disk.Bus).To(Equal(preference.Spec.Devices.PreferredDiskBus))
+			}
+
+		})
+
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

With the introduction of flavors and preferences we now need to ensure some of the default logic fired by the `VirtualMachineInstance` mutation webhook is called *before* any flavor and/or preference application within the `VirtualMachine` controller. Doing so should ensure that any device preferences (such as preferred disk bus or interface model) are applied to any default network interfaces or missing volume disks that are added to the `VirtualMachineInstance` at runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Device preferences are now applied to any default network interfaces or missing volume disks added to a `VirtualMachineInstance` at runtime.
```
