### PR TITLE
vmi_lifecycle_test: consume less memory

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1365,7 +1365,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				By("Creating a VirtualMachineInstance with different namespace")
 				vmi = libvmi.New(
-					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithResourceMemory("1Mi"),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				)


### PR DESCRIPTION
The rfe_id:273 test starts a VM with no disk and no operating system.
However, it allocates 256Mi for the VM RAM. This memory size was chosen
as it is the minimal memory required for running a Fedora guest on the
ARM architecture. This motivation is irrelevant for this test and
needlessly causes us to waste 255Mi of runtime RAM.

Let us reduce the memory consumed by this test, in order to strain our CI platform a bit less.

This PR was split  from https://github.com/kubevirt/kubevirt/pull/7858 to allow clearer discussion.

/sig code-quality

```release-note
NONE
```
