### PR TITLE
Pause tests

### DIFF
--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -26,8 +26,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
 
 	expect "github.com/google/goexpect"
@@ -117,16 +117,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 
 			By("Waiting on access credentials to sync")
 			// this ensures the keys have propagated before we attempt to read
-			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, cond := range vmi.Status.Conditions {
-					if cond.Type == v1.VirtualMachineInstanceAccessCredentialsSynchronized && cond.Status == kubev1.ConditionTrue {
-						return true
-					}
-				}
-				return false
-			}, 45*time.Second, time.Second).Should(BeTrue())
+			Eventually(matcher.ThisVMI(vmi), 45*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAccessCredentialsSynchronized))
 
 			By("Verifying all three pub ssh keys in secret are in VMI guest")
 			ExecutingBatchCmd(vmi, []expect.Batcher{
@@ -194,17 +185,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 
 			By("Waiting on access credentials to sync")
 			// this ensures the keys have propagated before we attempt to read
-			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				for _, cond := range vmi.Status.Conditions {
-					if cond.Type == v1.VirtualMachineInstanceAccessCredentialsSynchronized && cond.Status == kubev1.ConditionTrue {
-						return true
-					}
-				}
-				return false
-			}, 45*time.Second, time.Second).Should(BeTrue())
-
+			Eventually(matcher.ThisVMI(vmi), 45*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAccessCredentialsSynchronized))
 			ExecutingBatchCmd(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BSnd{S: "\n"},
@@ -262,20 +243,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			tests.WaitAgentConnected(virtClient, vmi)
 
 			By("Checking that denylisted commands triggered unsupported guest agent condition")
-			getOptions := metav1.GetOptions{}
-			freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &getOptions)
-			Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-
-			Eventually(func() []v1.VirtualMachineInstanceCondition {
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-				return freshVMI.Status.Conditions
-			}, 240*time.Second, 2).Should(
-				ContainElement(
-					MatchFields(
-						IgnoreExtras,
-						Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
-				"Should have unsupported agent connected condition")
+			Eventually(matcher.ThisVMI(vmi), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
 		})
 
 		It("[test_id:6223]should update guest agent for user password", func() {
@@ -323,21 +291,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			tests.WaitAgentConnected(virtClient, vmi)
 
 			By("Checking that denylisted commands triggered unsupported guest agent condition")
-			getOptions := metav1.GetOptions{}
-			freshVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &getOptions)
-			Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-
-			Eventually(func() []v1.VirtualMachineInstanceCondition {
-				freshVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &getOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
-				return freshVMI.Status.Conditions
-			}, 240*time.Second, 2).Should(
-				ContainElement(
-					MatchFields(
-						IgnoreExtras,
-						Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
-				"Should have unsupported agent connected condition")
-
+			Eventually(matcher.ThisVMI(vmi), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
 		})
 	})
 	Context("with secret and configDrive propagation", func() {

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -113,7 +113,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			LaunchVMI(vmi)
 
 			By("Waiting for agent to connect")
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Waiting on access credentials to sync")
 			// this ensures the keys have propagated before we attempt to read
@@ -179,7 +179,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			LaunchVMI(vmi)
 
 			By("Waiting for agent to connect")
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Verifying signin with custom password works")
 
@@ -240,7 +240,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			LaunchVMI(vmi)
 
 			By("Waiting for agent to connect")
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Checking that denylisted commands triggered unsupported guest agent condition")
 			Eventually(matcher.ThisVMI(vmi), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))
@@ -288,7 +288,7 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 			LaunchVMI(vmi)
 
 			By("Waiting for agent to connect")
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Checking that denylisted commands triggered unsupported guest agent condition")
 			Eventually(matcher.ThisVMI(vmi), 240*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceUnsupportedAgent))

--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "conditions.go",
         "existence.go",
         "getter.go",
         "owner.go",
@@ -16,6 +17,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/framework/matcher/helper:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/format:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -30,6 +32,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "conditions_test.go",
         "existence_test.go",
         "matcher_suite_test.go",
         "owner_test.go",
@@ -43,6 +46,7 @@ go_test(
         "//tests/framework/matcher/helper:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tests/framework/matcher/conditions.go
+++ b/tests/framework/matcher/conditions.go
@@ -28,6 +28,14 @@ func HaveConditionTrue(conditionType interface{}) types.GomegaMatcher {
 	}
 }
 
+func HaveConditionFalse(conditionType interface{}) types.GomegaMatcher {
+	return conditionMatcher{
+		expectedType:          conditionType,
+		expectedStatus:        k8sv1.ConditionFalse,
+		conditionCanBeMissing: false,
+	}
+}
+
 type conditionMatcher struct {
 	expectedType          interface{}
 	expectedStatus        k8sv1.ConditionStatus

--- a/tests/framework/matcher/conditions.go
+++ b/tests/framework/matcher/conditions.go
@@ -1,0 +1,195 @@
+package matcher
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
+)
+
+func HaveConditionMissingOrFalse(conditionType interface{}) types.GomegaMatcher {
+	return conditionMatcher{
+		expectedType:          conditionType,
+		expectedStatus:        k8sv1.ConditionFalse,
+		conditionCanBeMissing: true,
+	}
+}
+
+func HaveConditionTrue(conditionType interface{}) types.GomegaMatcher {
+	return conditionMatcher{
+		expectedType:          conditionType,
+		expectedStatus:        k8sv1.ConditionTrue,
+		conditionCanBeMissing: false,
+	}
+}
+
+type conditionMatcher struct {
+	expectedType          interface{}
+	expectedStatus        k8sv1.ConditionStatus
+	conditionCanBeMissing bool
+}
+
+func (c conditionMatcher) Match(actual interface{}) (success bool, err error) {
+	if helper.IsNil(actual) {
+		return false, nil
+	}
+
+	if helper.IsSlice(actual) {
+		// Not implemented
+		return false, nil
+	}
+
+	u, err := helper.ToUnstructured(actual)
+	if err != nil {
+		return false, err
+	}
+
+	if _, exist := u.Object["status"]; !exist {
+		return false, fmt.Errorf("object doesn't contain status")
+	}
+
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found {
+		if c.conditionCanBeMissing {
+			return true, nil
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	conditionStatus, err := c.getStatusForExpectedConditionType(conditions)
+	if err != nil {
+		return false, err
+	}
+
+	if conditionStatus == "" {
+		if c.conditionCanBeMissing {
+			return true, nil
+		}
+		return false, nil
+	}
+	return conditionStatus == string(c.expectedStatus), nil
+}
+
+func (c conditionMatcher) FailureMessage(actual interface{}) string {
+	if helper.IsSlice(actual) {
+		// Not implemented
+		return "slices are not implemented"
+	}
+
+	u, err := helper.ToUnstructured(actual)
+	if err != nil {
+		return err.Error()
+	}
+
+	if _, exist := u.Object["status"]; !exist {
+		return "object doesn't contain status"
+	}
+
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found {
+		if c.conditionCanBeMissing {
+			return ""
+		}
+		return format.Message(actual, "to contain conditions")
+
+	}
+	if err != nil {
+		return err.Error()
+	}
+
+	conditionStatus, err := c.getStatusForExpectedConditionType(conditions)
+	if err != nil {
+		return err.Error()
+	}
+
+	if conditionStatus == "" {
+		if c.conditionCanBeMissing {
+			return ""
+		}
+		return format.Message(conditions, fmt.Sprintf("expected condition of type '%s' was not found", c.expectedType))
+	}
+	return format.Message(conditions, fmt.Sprintf("to find condition of type '%v' and status '%s' but got '%s'", c.expectedType, c.expectedStatus, conditionStatus))
+}
+
+func (c conditionMatcher) NegatedFailureMessage(actual interface{}) string {
+	if helper.IsSlice(actual) {
+		// Not implemented
+		return "slices are not implemented"
+	}
+
+	u, err := helper.ToUnstructured(actual)
+	if err != nil {
+		return err.Error()
+	}
+
+	if _, exist := u.Object["status"]; !exist {
+		return "object doesn't contain status"
+	}
+
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found {
+		if c.conditionCanBeMissing {
+			return format.Message(conditions, fmt.Sprintf("to find condition of type '%s'", c.expectedType))
+		}
+		return "object doesn't contain conditions"
+	}
+	if err != nil {
+		return err.Error()
+	}
+
+	conditionStatus, err := c.getStatusForExpectedConditionType(conditions)
+	if err != nil {
+		return err.Error()
+	}
+
+	if conditionStatus == "" {
+		if c.conditionCanBeMissing {
+			return format.Message(conditions, fmt.Sprintf("to find condition of type '%s'", c.expectedType))
+		}
+		return format.Message(conditions, fmt.Sprintf("expected condition of type '%s' was not found", c.expectedType))
+	}
+	return format.Message(conditions, fmt.Sprintf("to not find condition of type '%v' with status '%s'", c.expectedType, c.expectedStatus))
+}
+
+func (c conditionMatcher) getExpectedType() string {
+	return reflect.ValueOf(c.expectedType).String()
+}
+
+func (c conditionMatcher) getStatusForExpectedConditionType(conditions []interface{}) (status string, err error) {
+	for _, condition := range conditions {
+		condition, err := helper.ToUnstructured(condition)
+		if err != nil {
+			return "", err
+		}
+
+		foundType, found, err := unstructured.NestedString(condition.Object, "type")
+		if !found {
+			return "", fmt.Errorf("conditions don't contain type")
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if foundType == c.getExpectedType() {
+			value, found, err := unstructured.NestedString(condition.Object, "status")
+			if !found {
+				return "", fmt.Errorf("conditions don't contain status")
+			}
+			if err != nil {
+				return "", err
+			}
+
+			return value, nil
+		}
+	}
+
+	return "", nil
+}

--- a/tests/framework/matcher/conditions_test.go
+++ b/tests/framework/matcher/conditions_test.go
@@ -97,4 +97,26 @@ var _ = Describe("Condition matcher", func() {
 		)
 	})
 
+	Context("False", func() {
+		DescribeTable("should work with", func(matcher types.GomegaMatcher, obj interface{}, shouldMatch bool) {
+			match, err := matcher.Match(obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(match).To(Equal(shouldMatch))
+		},
+			Entry("pod that has positive condition", HaveConditionFalse(k8sv1.PodReady), readyPod, false),
+			Entry("pod that has negative condition", HaveConditionFalse(k8sv1.PodReady), notReadyPod, true),
+			Entry("pod that is missing condition", HaveConditionFalse(k8sv1.PodReady), missingReadyPod, false),
+
+			Entry("vmi that has positive condition", HaveConditionFalse(v1.VirtualMachineInstancePaused), pausedVMI, false),
+			Entry("vmi that has negative condition", HaveConditionFalse(v1.VirtualMachineInstancePaused), notPausedVMI, true),
+			Entry("vmi that is missing condition", HaveConditionFalse(v1.VirtualMachineInstancePaused), missingPausedVMI, false),
+			Entry("vmi that is missing conditions", HaveConditionFalse(v1.VirtualMachineInstancePaused), missingConditionsVMI, false),
+
+			Entry("condition type as string", HaveConditionFalse("Paused"), notPausedVMI, true),
+			Entry("with nil object", HaveConditionFalse(v1.VirtualMachineInstancePaused), nilVMI, false),
+			Entry("with nil", HaveConditionFalse(v1.VirtualMachineInstancePaused), nil, false),
+			Entry("with nil as condition type", HaveConditionFalse(nil), nil, false),
+		)
+	})
+
 })

--- a/tests/framework/matcher/conditions_test.go
+++ b/tests/framework/matcher/conditions_test.go
@@ -1,0 +1,100 @@
+package matcher
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("Condition matcher", func() {
+	readyPod := &k8sv1.Pod{
+		Status: k8sv1.PodStatus{
+			Conditions: []k8sv1.PodCondition{
+				{
+					Type:   k8sv1.PodReady,
+					Status: k8sv1.ConditionTrue,
+				},
+			},
+		},
+	}
+	notReadyPod := readyPod.DeepCopy()
+	notReadyPod.Status.Conditions[0].Status = k8sv1.ConditionFalse
+
+	missingReadyPod := readyPod.DeepCopy()
+	missingReadyPod.Status.Conditions = []k8sv1.PodCondition{}
+
+	pausedVMI := &v1.VirtualMachineInstance{
+		Status: v1.VirtualMachineInstanceStatus{
+			Conditions: []v1.VirtualMachineInstanceCondition{
+				{
+					Type:   v1.VirtualMachineInstancePaused,
+					Status: k8sv1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	notPausedVMI := pausedVMI.DeepCopy()
+	notPausedVMI.Status.Conditions[0].Status = k8sv1.ConditionFalse
+
+	missingPausedVMI := pausedVMI.DeepCopy()
+	missingPausedVMI.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+		{
+			Type:   v1.VirtualMachineInstanceAgentConnected,
+			Status: k8sv1.ConditionTrue,
+		},
+	}
+
+	missingConditionsVMI := pausedVMI.DeepCopy()
+	missingConditionsVMI.Status.Conditions = []v1.VirtualMachineInstanceCondition{}
+
+	var nilVMI *v1.VirtualMachineInstance = nil
+
+	Context("Missing or false", func() {
+		DescribeTable("should work with", func(matcher types.GomegaMatcher, obj interface{}, shouldMatch bool) {
+			match, err := matcher.Match(obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(match).To(Equal(shouldMatch))
+		},
+			Entry("pod that has positive condition", HaveConditionMissingOrFalse(k8sv1.PodReady), readyPod, false),
+			Entry("pod that has negative condition", HaveConditionMissingOrFalse(k8sv1.PodReady), notReadyPod, true),
+			Entry("pod that is missing condition", HaveConditionMissingOrFalse(k8sv1.PodReady), missingReadyPod, true),
+
+			Entry("vmi that has positive condition", HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused), pausedVMI, false),
+			Entry("vmi that has negative condition", HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused), notPausedVMI, true),
+			Entry("vmi that is missing condition", HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused), missingPausedVMI, true),
+			Entry("vmi that is missing conditions", HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused), missingConditionsVMI, true),
+
+			Entry("condition type as string", HaveConditionMissingOrFalse("Paused"), notPausedVMI, true),
+			Entry("with nil object", HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused), nilVMI, false),
+			Entry("with nil", HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused), nil, false),
+			Entry("with nil as condition type", HaveConditionMissingOrFalse(nil), nil, false),
+		)
+	})
+
+	Context("True", func() {
+		DescribeTable("should work with", func(matcher types.GomegaMatcher, obj interface{}, shouldMatch bool) {
+			match, err := matcher.Match(obj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(match).To(Equal(shouldMatch))
+		},
+			Entry("pod that has positive condition", HaveConditionTrue(k8sv1.PodReady), readyPod, true),
+			Entry("pod that has negative condition", HaveConditionTrue(k8sv1.PodReady), notReadyPod, false),
+			Entry("pod that is missing condition", HaveConditionTrue(k8sv1.PodReady), missingReadyPod, false),
+
+			Entry("vmi that has positive condition", HaveConditionTrue(v1.VirtualMachineInstancePaused), pausedVMI, true),
+			Entry("vmi that has negative condition", HaveConditionTrue(v1.VirtualMachineInstancePaused), notPausedVMI, false),
+			Entry("vmi that is missing condition", HaveConditionTrue(v1.VirtualMachineInstancePaused), missingPausedVMI, false),
+			Entry("vmi that is missing conditions", HaveConditionTrue(v1.VirtualMachineInstancePaused), missingConditionsVMI, false),
+
+			Entry("condition type as string", HaveConditionTrue("Paused"), notPausedVMI, false),
+			Entry("with nil object", HaveConditionTrue(v1.VirtualMachineInstancePaused), nilVMI, false),
+			Entry("with nil", HaveConditionTrue(v1.VirtualMachineInstancePaused), nil, false),
+			Entry("with nil as condition type", HaveConditionTrue(nil), nil, false),
+		)
+	})
+
+})

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -11,6 +11,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -130,8 +131,9 @@ func setOrClearDedicatedMigrationNetwork(nad string, set bool) *v1.KubeVirt {
 		}
 		Expect(err).ToNot(HaveOccurred(), "Failed to list the virt-handler pods")
 		for _, pod := range newVirtHandlerPods.Items {
-			podReady := PodReady(&pod)
-			if podReady != k8sv1.ConditionTrue {
+			// TODO implement list option to condition matcher
+			if success, err := matcher.HaveConditionTrue(k8sv1.PodReady).Match(pod); !success {
+				Expect(err).ToNot(HaveOccurred())
 				return false
 			}
 		}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -727,15 +727,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				gotExpectedCondition := false
-				for _, c := range vmi.Status.Conditions {
-					if c.Type == v1.VirtualMachineInstanceIsMigratable {
-						Expect(c.Status).To(Equal(k8sv1.ConditionFalse))
-						gotExpectedCondition = true
-					}
-				}
-
-				Expect(gotExpectedCondition).Should(BeTrue())
+				Expect(vmi).To(HaveConditionFalse(v1.VirtualMachineInstanceIsMigratable))
 
 				// execute a migration, wait for finalized state
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -1492,15 +1484,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				gotExpectedCondition := false
-				for _, c := range vmi.Status.Conditions {
-					if c.Type == v1.VirtualMachineInstanceIsMigratable {
-						Expect(c.Status).To(Equal(k8sv1.ConditionFalse))
-						gotExpectedCondition = true
-					}
-				}
-
-				Expect(gotExpectedCondition).Should(BeTrue())
+				Expect(vmi).Should(matcher.HaveConditionFalse(v1.VirtualMachineInstanceIsMigratable))
 
 				// execute a migration, wait for finalized state
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -2600,15 +2584,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
-				gotExpectedCondition := false
-				for _, c := range vmi.Status.Conditions {
-					if c.Type == v1.VirtualMachineInstanceIsMigratable {
-						Expect(c.Status).To(Equal(k8sv1.ConditionFalse))
-						gotExpectedCondition = true
-					}
-				}
-
-				Expect(gotExpectedCondition).Should(BeTrue())
+				Expect(vmi).Should(HaveConditionFalse(v1.VirtualMachineInstanceIsMigratable))
 
 				// execute a migration, wait for finalized state
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -671,7 +671,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 			// Wait for cloud init to finish and start the agent inside the vmi.
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
@@ -691,7 +691,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			confirmMigrationMode(vmi, mode)
 
 			By("Is agent connected after migration")
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			By("Checking that the migrated VirtualMachineInstance console has expected output")
 			Expect(console.OnPrivilegedPrompt(vmi, 60)).To(BeTrue(), "Should stay logged in to the migrated VM")
@@ -1378,7 +1378,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 				// Need to wait for cloud init to finnish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -1414,7 +1414,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				// Need to wait for cloud init to finnish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Set wrong time on the guest")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
@@ -1429,7 +1429,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				// check VMI, confirm migration state
 				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Checking that the migrated VirtualMachineInstance has an updated time")
 				if !console.OnPrivilegedPrompt(vmi, 60) {
@@ -1533,7 +1533,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -1699,7 +1699,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 				By("Checking guest agent")
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Starting the Migration for iteration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -1955,7 +1955,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 					// Run
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -2033,7 +2033,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 					// Need to wait for cloud init to finish and start the agent inside the vmi.
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 					// Run
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -2159,7 +2159,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
 
@@ -2217,7 +2217,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
 
@@ -3297,7 +3297,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Checking that the VirtualMachineInstance console has expected output")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
 
@@ -3368,7 +3368,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					By("Starting the VirtualMachineInstance")
 					vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
 
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 					// Mark the masters as schedulable so we can migrate there
 					setControlPlaneUnschedulable(false)
@@ -3420,7 +3420,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					By("Checking that the VirtualMachineInstance console has expected output")
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 					// Put VMI under load
 					runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
@@ -3685,7 +3685,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			// Need to wait for cloud init to finnish and start the agent inside the vmi.
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 			runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -35,6 +35,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 
@@ -1498,6 +1499,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						gotExpectedCondition = true
 					}
 				}
+
 				Expect(gotExpectedCondition).Should(BeTrue())
 
 				// execute a migration, wait for finalized state
@@ -1720,16 +1722,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				_ = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 				By("Agent stays connected")
-				Consistently(func() error {
-					updatedVmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					for _, condition := range updatedVmi.Status.Conditions {
-						if condition.Type == v1.VirtualMachineInstanceAgentConnected && condition.Status == k8sv1.ConditionTrue {
-							return nil
-						}
-					}
-					return fmt.Errorf("Guest Agent Disconnected")
-				}, 5*time.Minute, 10*time.Second).Should(Succeed())
+				Consistently(matcher.ThisVMI(vmi), 5*time.Minute, 10*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			})
 		})
 
@@ -2614,6 +2607,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						gotExpectedCondition = true
 					}
 				}
+
 				Expect(gotExpectedCondition).Should(BeTrue())
 
 				// execute a migration, wait for finalized state

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1194,7 +1194,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Pausing the VirtualMachineInstance")
 				virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				By("verifying that the vmi is still paused before migration")
 				isPausedb, err := tests.LibvirtDomainIsPaused(virtClient, vmi)
@@ -1216,7 +1216,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("verify that VMI can be unpaused after migration")
 				command := clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed(), "should successfully unpause tthe vmi")
-				tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 				By("verifying that the vmi is running")
 				isPaused, err = tests.LibvirtDomainIsPaused(virtClient, vmi)

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,7 +94,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 					Expect(err).NotTo(HaveOccurred())
 					tests.WaitForSuccessfulVMIStart(vmi)
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				})
 
 				It("should report PodIP/s IPv4 as its own on interface status", func() {
@@ -135,7 +136,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					Expect(err).NotTo(HaveOccurred())
 					vmi = tests.WaitUntilVMIReady(tmpVmi, console.LoginToFedora)
 
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				})
 
 				It("[test_id:4153]should report PodIP/s as its own on interface status", func() {

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -108,7 +108,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 
 				By("Waiting for agent to connect")
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			}
 
 			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 120)
@@ -133,7 +133,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 							createGuestAgentPingProbe(period, initialSeconds)))...)
 				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 				By("Waiting for agent to connect")
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, guestAgentConnectTimeout)
 				By("Disabling the guest-agent")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -210,7 +210,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 
 				By("Waiting for agent to connect")
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			}
 
 			By("Checking that the VMI is still running after a while")
@@ -235,7 +235,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 				vmi = tests.VMILauncherIgnoreWarnings(virtClient)(vmi)
 
 				By("Waiting for agent to connect")
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 			})
 

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmi"
@@ -716,7 +717,7 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 		panic(err)
 	}
 
-	tests.WaitAgentConnected(virtClient, vmi)
+	Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 	return virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &k8smetav1.GetOptions{})
 }

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -31,12 +31,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kvirtv1 "kubevirt.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
 
 	network "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -90,7 +92,7 @@ var _ = SIGDescribe("Infosource", func() {
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmiSpec)
 			Expect(err).NotTo(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
-			tests.WaitAgentConnected(virtClient, vmi)
+			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 		})
 
 		It("should have the expected entries in vmi status", func() {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -37,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	"kubevirt.io/kubevirt/tests/util"
 
@@ -455,7 +456,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, func() {
 				vmiOne = tests.CreateVmiOnNode(vmiOne, nodes.Items[0].Name)
 
 				vmiOne = tests.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
-				tests.WaitAgentConnected(virtClient, vmiOne)
+				Eventually(matcher.ThisVMI(vmiOne), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Verifying the desired custom MAC is the one that were actually configured on the interface.")
 				vmiIfaceStatusByName := libvmi.IndexInterfaceStatusByName(vmiOne)
@@ -687,7 +688,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, func() {
 				tests.WaitForSuccessfulVMIStart(agentVMI)
 
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, agentVMI)
+				Eventually(matcher.ThisVMI(agentVMI), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				getOptions := &metav1.GetOptions{}
 				Eventually(func() []v1.VirtualMachineInstanceNetworkInterface {

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -76,7 +76,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(vmi.Name, &v1.UnpauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -90,14 +90,14 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 			})
 
 			It("[test_id:3080]should signal unpaused state with removed condition", func() {
 
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
 				Expect(command()).To(Succeed())
@@ -112,7 +112,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					By("Pausing VMI")
 					command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
 					Expect(command()).To(Succeed())
-					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+					Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 					By("Unpausing VMI")
 					command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
@@ -166,28 +166,18 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--dry-run", "--namespace", vmi.Namespace, vmi.Name)
 				Expect(command()).To(Succeed())
 
 				By("Checking that VMI remains paused")
-				Consistently(func() bool {
-					updatedVmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v12.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					for _, condition := range updatedVmi.Status.Conditions {
-						if condition.Type == v1.VirtualMachineInstancePaused && condition.Status == k8sv1.ConditionTrue {
-							return true
-						}
-					}
-					return false
-				}, time.Duration(5)*time.Second).Should(BeTrue())
+				Consistently(matcher.ThisVMI(vmi), 5*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 			})
 		})
 
 		It("should not appear as ready when paused", func() {
-
-			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 30)
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
 
 			By("Pausing the VMI and expecting to become unready")
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
@@ -197,7 +187,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Unpausing the VMI and expecting to become ready")
 			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(vmi.Name, &v1.UnpauseOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceReady, 30)
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReady))
 		})
 	})
 
@@ -221,7 +211,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:4598]should signal paused state with condition", func() {
 				err = virtClient.VirtualMachineInstance(vm.Namespace).Pause(vm.Name, &v1.PauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				err = virtClient.VirtualMachineInstance(vm.Namespace).Unpause(vm.Name, &v1.UnpauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -235,13 +225,13 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:3059]should signal paused state with condition", func() {
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 			})
 
 			It("[test_id:3081]should gracefully handle pausing the VM again", func() {
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				err := command()
@@ -251,7 +241,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:3088]should gracefully handle pausing the VMI again", func() {
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vm.Namespace, vm.Name)
 				err := command()
@@ -261,7 +251,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:3060]should signal unpaused state with removed condition", func() {
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
@@ -271,7 +261,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:3082]should gracefully handle unpausing again", func() {
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
@@ -286,7 +276,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				By("Stopping the VM")
 				command = clientcmd.NewRepeatableVirtctlCommand("stop", "--namespace", vm.Namespace, vm.Name)
@@ -315,7 +305,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				By("Starting the VM")
 				command = clientcmd.NewRepeatableVirtctlCommand("start", "--namespace", vm.Namespace, vm.Name)
@@ -333,7 +323,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				By("Restarting the VM")
 				command = clientcmd.NewRepeatableVirtctlCommand("restart", "--namespace", vm.Namespace, vm.Name)
@@ -369,7 +359,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				By("Trying to migrate the VM")
 				command = clientcmd.NewRepeatableVirtctlCommand("migrate", "--namespace", vm.Namespace, vm.Name)
@@ -382,7 +372,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				By("Trying to console into the VM")
 				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
@@ -393,7 +383,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				By("Trying to vnc into the VM")
 				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).VNC(vm.ObjectMeta.Name)
@@ -415,22 +405,13 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			It("[test_id:7674]should not unpaused", func() {
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
+				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand("unpause", "vm", "--dry-run", "--namespace", vm.Namespace, vm.Name)
 				Expect(command()).To(Succeed())
 
 				By("Checking that VM remains paused")
-				Consistently(func() bool {
-					updatedVm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					for _, condition := range updatedVm.Status.Conditions {
-						if condition.Type == v1.VirtualMachinePaused && condition.Status == k8sv1.ConditionTrue {
-							return true
-						}
-					}
-					return false
-				}, time.Duration(5)*time.Second).Should(BeTrue())
+				Consistently(matcher.ThisVM(vm), 5*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
 			})
 		})
 	})
@@ -478,7 +459,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Pausing the VMI")
 			command := clientcmd.NewRepeatableVirtctlCommand("pause", "vmi", "--namespace", vmi.Namespace, vmi.Name)
 			Expect(command()).To(Succeed(), "should successfully pause the vmi")
-			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 			time.Sleep(10 * time.Second) // sleep to increase uptime diff
 
 			By("Unpausing the VMI")

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -64,11 +64,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			vmi = libvmi.NewCirros(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), 90)
 		})
 
 		When("paused via API", func() {
@@ -441,12 +437,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			By("Starting a Cirros VMI")
-			vmi = libvmi.NewCirros(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), 240)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToCirros(vmi)).To(Succeed())

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -53,6 +53,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 	var err error
 	var virtClient kubecli.KubevirtClient
+	const cirrosStartupTimeout = 90
 
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
@@ -64,7 +65,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), 90)
+			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), cirrosStartupTimeout)
 		})
 
 		When("paused via API", func() {
@@ -437,7 +438,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			By("Starting a Cirros VMI")
-			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), 240)
+			vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), cirrosStartupTimeout)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(console.LoginToCirros(vmi)).To(Succeed())

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -28,6 +28,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -329,14 +330,11 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		_, err := virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, []byte("[{ \"op\": \"add\", \"path\": \"/spec/paused\", \"value\": true }]"))
 		Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() v1.VirtualMachineInstanceReplicaSetConditionType {
+		Eventually(func() *v1.VirtualMachineInstanceReplicaSet {
 			rs, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			if len(rs.Status.Conditions) > 0 {
-				return rs.Status.Conditions[0].Type
-			}
-			return ""
-		}, 10*time.Second, 1*time.Second).Should(Equal(v1.VirtualMachineInstanceReplicaSetReplicaPaused))
+			return rs
+		}, 10*time.Second, 1*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceReplicaSetReplicaPaused))
 
 		// set new replica count while still being paused
 		By("Updating the number of replicas")

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -97,7 +97,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), vmiLaunchTimeout)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
-				tests.WaitAgentDisconnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 
 				err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).SoftReboot(vmi.Name)
 				Expect(err).ToNot(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(), vmiLaunchTimeout)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
-				tests.WaitAgentDisconnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 
 				command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed())
@@ -138,7 +138,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewCirros(withoutACPI()), vmiLaunchTimeout)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
-				tests.WaitAgentDisconnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 
 				command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 				err := command()

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -36,6 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -82,7 +83,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			It("should succeed", func() {
 				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(withoutACPI()), vmiLaunchTimeout)
 
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).SoftReboot(vmi.Name)
 				Expect(err).ToNot(HaveOccurred())
@@ -109,7 +110,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			It("should succeed", func() {
 				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(withoutACPI()), vmiLaunchTimeout)
 
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				command := clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed())
@@ -149,7 +150,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		When("soft reboot vmi after paused and unpaused via virtctl", func() {
 			It("should failed to soft reboot a paused vmi", func() {
 				vmi = tests.RunVMIAndExpectLaunch(libvmi.NewFedora(), vmiLaunchTimeout)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				command := clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_PAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed())
@@ -164,7 +165,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				Expect(command()).To(Succeed())
 				tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				command = clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed())

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -154,7 +154,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 				command := clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_PAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				command = clientcmd.NewRepeatableVirtctlCommand(virtctlsoftreboot.COMMAND_SOFT_REBOOT, "--namespace", util.NamespaceTestDefault, vmi.Name)
 				err := command()
@@ -163,7 +163,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 				command = clientcmd.NewRepeatableVirtctlCommand(virtctlpause.COMMAND_UNPAUSE, "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 				Expect(command()).To(Succeed())
-				tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 
 				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -169,10 +169,8 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 		}
 		Expect(r.Status.RestoreTime).ToNot(BeNil())
 		Expect(r.Status.Conditions).To(HaveLen(2))
-		Expect(r.Status.Conditions[0].Type).To(Equal(snapshotv1.ConditionProgressing))
-		Expect(r.Status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
-		Expect(r.Status.Conditions[1].Type).To(Equal(snapshotv1.ConditionReady))
-		Expect(r.Status.Conditions[1].Status).To(Equal(corev1.ConditionTrue))
+		Expect(r).To(matcher.HaveConditionMissingOrFalse(snapshotv1.ConditionProgressing))
+		Expect(r).To(matcher.HaveConditionTrue(snapshotv1.ConditionReady))
 		return r
 	}
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1478,7 +1478,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				doRestore("/dev/vdc", console.LoginToFedora, onlineSnapshot, getTargetVMName(restoreToNewVM, newVmName))
 				Expect(restore.Status.Restores).To(HaveLen(1))
@@ -1497,7 +1497,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					util.NamespaceTestDefault,
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				originalDVName := vm.Spec.DataVolumeTemplates[0].Name
@@ -1514,7 +1514,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					util.NamespaceTestDefault,
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Updating the VM template spec")
@@ -1589,7 +1589,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					util.NamespaceTestDefault,
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
@@ -1674,7 +1674,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						util.NamespaceTestDefault,
 						snapshotStorageClass,
 						corev1.ReadWriteOnce))
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 					By("Get VM memory dump")

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -810,7 +810,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				By("Pausing the VirtualMachineInstance")
 				err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 				By("Calling Velero pre-backup hook")
 				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -338,10 +339,8 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				conditionsLength := 2
 				Expect(snapshot.Status.Conditions).To(HaveLen(conditionsLength))
-				Expect(snapshot.Status.Conditions[0].Type).To(Equal(snapshotv1.ConditionProgressing))
-				Expect(snapshot.Status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
-				Expect(snapshot.Status.Conditions[1].Type).To(Equal(snapshotv1.ConditionReady))
-				Expect(snapshot.Status.Conditions[1].Status).To(Equal(corev1.ConditionTrue))
+				Expect(snapshot).To(matcher.HaveConditionMissingOrFalse(snapshotv1.ConditionProgressing))
+				Expect(snapshot).To(matcher.HaveConditionTrue(snapshotv1.ConditionReady))
 
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 				journalctlCheck := "journalctl --file /var/log/journal/*/system.journal"

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -445,7 +445,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				initialMemory := vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]
 				newMemory := resource.MustParse("1Gi")
@@ -546,7 +546,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				snapshot = newSnapshot()
 
@@ -569,7 +569,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					util.NamespaceTestDefault,
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				createDenyVolumeSnapshotCreateWebhook()
@@ -599,7 +599,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					util.NamespaceTestDefault,
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				createDenyVolumeSnapshotCreateWebhook()
@@ -648,7 +648,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					util.NamespaceTestDefault,
 					snapshotStorageClass,
 					corev1.ReadWriteOnce))
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				By("Add persistent hotplug disk")
@@ -724,7 +724,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Logging into Fedora")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -802,7 +802,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				vm, vmi = createAndStartVM(vm)
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By("Logging into Fedora")
 				Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -869,7 +869,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 						util.NamespaceTestDefault,
 						snapshotStorageClass,
 						corev1.ReadWriteOnce))
-					tests.WaitAgentConnected(virtClient, vmi)
+					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 					By("Get VM memory dump")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -435,7 +435,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 
 				// Wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By(checkingVMInstanceConsoleOut)
 				Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
@@ -499,7 +499,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 
 				// Wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By(checkingVMInstanceConsoleOut)
 				Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
@@ -564,7 +564,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
 
 				// Wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 				By(checkingVMInstanceConsoleOut)
 				Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -31,6 +31,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/util"
+
 	v1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
@@ -40,7 +43,6 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/testsuite"
-	"kubevirt.io/kubevirt/tests/util"
 )
 
 var _ = Describe("[sig-compute]Subresource Api", func() {
@@ -317,7 +319,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 					return vmi.Status.Phase == v1.Running
 				}, 180*time.Second, time.Second).Should(BeTrue())
 				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
-				tests.WaitAgentConnected(virtCli, vmi)
+				Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			})
 
 			waitVMIFSFreezeStatus := func(expectedStatus string) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -69,6 +69,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	util2 "kubevirt.io/kubevirt/tests/util"
 
@@ -1329,11 +1330,9 @@ func CreateExecutorPodWithPVC(podName string, pvc *k8sv1.PersistentVolumeClaim) 
 	}
 	pod = RunPod(pod)
 
-	Eventually(func() bool {
-		pod, err = ThisPod(pod)()
-		Expect(err).ToNot(HaveOccurred())
-		return PodReady(pod) == k8sv1.ConditionTrue
-	}, 120).Should(BeTrue())
+	Eventually(ThisPod(pod), 120).Should(matcher.HaveConditionTrue(k8sv1.PodReady))
+	pod, err = ThisPod(pod)()
+	Expect(err).ToNot(HaveOccurred())
 	return pod
 }
 
@@ -2099,15 +2098,6 @@ func EncodePrivateKeyToPEM(privateKey *rsa.PrivateKey) []byte {
 	privatePEM := pem.EncodeToMemory(&privateBlock)
 
 	return privatePEM
-}
-
-func PodReady(pod *k8sv1.Pod) k8sv1.ConditionStatus {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == k8sv1.PodReady {
-			return cond.Status
-		}
-	}
-	return k8sv1.ConditionFalse
 }
 
 func RetryWithMetadataIfModified(objectMeta metav1.ObjectMeta, do func(objectMeta metav1.ObjectMeta) error) (err error) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2057,10 +2057,6 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 	}, duration, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
-func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceAgentConnected, 12*60)
-}
-
 func WaitAgentDisconnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
 	WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstanceAgentConnected, 30)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2057,10 +2057,6 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 	}, duration, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
-func WaitAgentDisconnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstanceAgentConnected, 30)
-}
-
 func WaitForVMICondition(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, conditionType v1.VirtualMachineInstanceConditionType, timeoutSec int) {
 	By(fmt.Sprintf("Waiting for %s condition", conditionType))
 	EventuallyWithOffset(1, func() bool {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2093,34 +2093,6 @@ func WaitForVMIConditionRemovedOrFalse(virtClient kubecli.KubevirtClient, vmi *v
 	}, time.Duration(timeoutSec)*time.Second, 2).Should(BeFalse(), fmt.Sprintf("Should have no or false %s condition", conditionType))
 }
 
-func WaitForVMCondition(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, conditionType v1.VirtualMachineConditionType, timeoutSec int) {
-	By(fmt.Sprintf("Waiting for %s condition", conditionType))
-	EventuallyWithOffset(1, func() bool {
-		updatedVm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		for _, condition := range updatedVm.Status.Conditions {
-			if condition.Type == conditionType && condition.Status == k8sv1.ConditionTrue {
-				return true
-			}
-		}
-		return false
-	}, time.Duration(timeoutSec)*time.Second, 2).Should(BeTrue(), fmt.Sprintf("Should have %s condition", conditionType))
-}
-
-func WaitForVMConditionRemovedOrFalse(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, conditionType v1.VirtualMachineConditionType, timeoutSec int) {
-	By(fmt.Sprintf("Waiting for %s condition removed or false", conditionType))
-	EventuallyWithOffset(1, func() bool {
-		updatedVm, err := virtClient.VirtualMachine(util2.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		for _, condition := range updatedVm.Status.Conditions {
-			if condition.Type == conditionType && condition.Status == k8sv1.ConditionTrue {
-				return true
-			}
-		}
-		return false
-	}, time.Duration(timeoutSec)*time.Second, 2).Should(BeFalse(), fmt.Sprintf("Should have no or false %s condition", conditionType))
-}
-
 // GeneratePrivateKey creates a RSA Private Key of specified byte size
 func GeneratePrivateKey(bitSize int) (*rsa.PrivateKey, error) {
 	privateKey, err := rsa.GenerateKey(cryptorand.Reader, bitSize)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2057,34 +2057,6 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 	}, duration, 1*time.Second).ShouldNot(HaveOccurred())
 }
 
-func WaitForVMICondition(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, conditionType v1.VirtualMachineInstanceConditionType, timeoutSec int) {
-	By(fmt.Sprintf("Waiting for %s condition", conditionType))
-	EventuallyWithOffset(1, func() bool {
-		updatedVmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		for _, condition := range updatedVmi.Status.Conditions {
-			if condition.Type == conditionType && condition.Status == k8sv1.ConditionTrue {
-				return true
-			}
-		}
-		return false
-	}, time.Duration(timeoutSec)*time.Second, 2).Should(BeTrue(), fmt.Sprintf("Should have %s condition", conditionType))
-}
-
-func WaitForVMIConditionRemovedOrFalse(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, conditionType v1.VirtualMachineInstanceConditionType, timeoutSec int) {
-	By(fmt.Sprintf("Waiting for %s condition removed or false", conditionType))
-	EventuallyWithOffset(1, func() bool {
-		updatedVmi, err := virtClient.VirtualMachineInstance(util2.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		for _, condition := range updatedVmi.Status.Conditions {
-			if condition.Type == conditionType && condition.Status == k8sv1.ConditionTrue {
-				return true
-			}
-		}
-		return false
-	}, time.Duration(timeoutSec)*time.Second, 2).Should(BeFalse(), fmt.Sprintf("Should have no or false %s condition", conditionType))
-}
-
 // GeneratePrivateKey creates a RSA Private Key of specified byte size
 func GeneratePrivateKey(bitSize int) (*rsa.PrivateKey, error) {
 	privateKey, err := rsa.GenerateKey(cryptorand.Reader, bitSize)

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
@@ -79,10 +80,12 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 				if pod.Status.Phase != k8sv1.PodRunning {
 					continue
 				}
-				podReady := tests.PodReady(&pod)
-				if podReady != k8sv1.ConditionTrue {
+
+				if success, err := matcher.HaveConditionTrue(k8sv1.PodReady).Match(pod); !success {
+					Expect(err).ToNot(HaveOccurred())
 					continue
 				}
+
 				for _, podName := range podNames {
 					if strings.HasPrefix(pod.Name, podName) {
 						if len(nodeNames) > 0 {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/pointer"
 
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -960,7 +961,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					vmi, err := virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(*vmi.Spec.StartStrategy).To(Equal(v1.StartStrategyPaused))
-					tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+					Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 					return vmi.Status.Phase == v1.Running
 				}, 240*time.Second, 1*time.Second).Should(BeTrue())
 			})
@@ -1569,7 +1570,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 						vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &k8smetav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
 						Expect(*vmi.Spec.StartStrategy).To(Equal(v1.StartStrategyPaused))
-						tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+						Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 						return vmi.Status.Phase == v1.Running
 					}, 240*time.Second, 1*time.Second).Should(BeTrue())
 				})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -30,6 +30,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
@@ -153,12 +154,12 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred(), "Create VMI successfully")
 			tests.WaitForSuccessfulVMIStart(vmi)
-			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused))
 
 			By("Unpausing VMI")
 			command := clientcmd.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", util.NamespaceTestDefault, vmi.Name)
 			Expect(command()).To(Succeed())
-			tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
 		})
 
 		It("[test_id:1621]should attach virt-launcher to it", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does 2 following things:
1. Uses libvmi in pause tests and cleans the tests a little bit
2. Introduce VM/I condition matcher that is showing all conditions and what condition was expected. This is better than seeing false is not true or similar outputs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I recommend reviewing commit by commit.

**Release note**:

```release-note
NONE
```
