### PR TITLE
virt-api: start subresource: clearer error message

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -373,7 +373,7 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 		return
 	}
 	if runStrategy == v1.RunStrategyHalted || runStrategy == v1.RunStrategyOnce {
-		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v does not support manual restart requests", runStrategy)), response)
+		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("RunStategy %v does not support manual restart requests", runStrategy)), response)
 		return
 	}
 


### PR DESCRIPTION
The current error message lacks context about what "Always" is.

```
$ virtctl start xyz
Error starting VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "xyz": Always does not support manual start requests
```

```release-note
NONE
```
