### PR TITLE
[Code Quality]: Improve & ease patch generation

### DIFF
--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -64,3 +64,10 @@ func GenerateTestReplacePatch(path string, oldValue, newValue interface{}) ([]by
 		},
 	)
 }
+
+func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
+	var p []PatchOperation
+	err := json.Unmarshal(patch, &p)
+
+	return p, err
+}

--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -30,6 +30,13 @@ type PatchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
+const (
+	PatchReplaceOp = "replace"
+	PatchTestOp    = "test"
+	PatchAddOp     = "add"
+	PatchRemoveOp  = "remove"
+)
+
 func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
 	if len(patches) == 0 {
 		return nil, fmt.Errorf("list of patches is empty")
@@ -41,4 +48,19 @@ func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
 	}
 
 	return payloadBytes, nil
+}
+
+func GenerateTestReplacePatch(path string, oldValue, newValue interface{}) ([]byte, error) {
+	return GeneratePatchPayload(
+		PatchOperation{
+			Op:    PatchTestOp,
+			Path:  path,
+			Value: oldValue,
+		},
+		PatchOperation{
+			Op:    PatchReplaceOp,
+			Path:  path,
+			Value: newValue,
+		},
+	)
 }

--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -19,8 +19,26 @@
 
 package types
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type PatchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
 	Value interface{} `json:"value,omitempty"`
+}
+
+func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
+	if len(patches) == 0 {
+		return nil, fmt.Errorf("list of patches is empty")
+	}
+
+	payloadBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloadBytes, nil
 }

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/monitoring/api:go_default_library",
         "//pkg/rest:go_default_library",
         "//pkg/util/status:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1alpha1:go_default_library",

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -957,7 +957,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 					},
 				},
 				nil,
-				"[{ \"op\": \"test\", \"path\": \"/status/volumeRequests\", \"value\": null}, { \"op\": \"add\", \"path\": \"/status/volumeRequests\", \"value\": [{\"addVolumeOptions\":{\"name\":\"vol1\",\"disk\":{\"name\":\"\"},\"volumeSource\":{}}}]}]",
+				`[{"op":"test","path":"/status/volumeRequests","value":null},{"op":"add","path":"/status/volumeRequests","value":[{"addVolumeOptions":{"name":"vol1","disk":{"name":""},"volumeSource":{}}}]}]`,
 				false),
 			Entry("add volume request that already exists should fail",
 				&v1.VirtualMachineVolumeRequest{
@@ -995,7 +995,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 						},
 					},
 				},
-				"[{ \"op\": \"test\", \"path\": \"/status/volumeRequests\", \"value\": [{\"addVolumeOptions\":{\"name\":\"vol2\",\"disk\":{\"name\":\"\"},\"volumeSource\":{}}}]}, { \"op\": \"replace\", \"path\": \"/status/volumeRequests\", \"value\": [{\"addVolumeOptions\":{\"name\":\"vol2\",\"disk\":{\"name\":\"\"},\"volumeSource\":{}}},{\"addVolumeOptions\":{\"name\":\"vol1\",\"disk\":{\"name\":\"\"},\"volumeSource\":{}}}]}]",
+				`[{"op":"test","path":"/status/volumeRequests","value":[{"addVolumeOptions":{"name":"vol2","disk":{"name":""},"volumeSource":{}}}]},{"op":"replace","path":"/status/volumeRequests","value":[{"addVolumeOptions":{"name":"vol2","disk":{"name":""},"volumeSource":{}}},{"addVolumeOptions":{"name":"vol1","disk":{"name":""},"volumeSource":{}}}]}]`,
 				false),
 			Entry("remove volume request with no existing volume request", &v1.VirtualMachineVolumeRequest{
 				RemoveVolumeOptions: &v1.RemoveVolumeOptions{
@@ -1003,7 +1003,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				},
 			},
 				nil,
-				"[{ \"op\": \"test\", \"path\": \"/status/volumeRequests\", \"value\": null}, { \"op\": \"add\", \"path\": \"/status/volumeRequests\", \"value\": [{\"removeVolumeOptions\":{\"name\":\"vol1\"}}]}]",
+				`[{"op":"test","path":"/status/volumeRequests","value":null},{"op":"add","path":"/status/volumeRequests","value":[{"removeVolumeOptions":{"name":"vol1"}}]}]`,
 				false),
 			Entry("remove volume request should replace add volume request",
 				&v1.VirtualMachineVolumeRequest{
@@ -1020,7 +1020,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 						},
 					},
 				},
-				"[{ \"op\": \"test\", \"path\": \"/status/volumeRequests\", \"value\": [{\"addVolumeOptions\":{\"name\":\"vol2\",\"disk\":{\"name\":\"\"},\"volumeSource\":{}}}]}, { \"op\": \"replace\", \"path\": \"/status/volumeRequests\", \"value\": [{\"removeVolumeOptions\":{\"name\":\"vol2\"}}]}]",
+				`[{"op":"test","path":"/status/volumeRequests","value":[{"addVolumeOptions":{"name":"vol2","disk":{"name":""},"volumeSource":{}}}]},{"op":"replace","path":"/status/volumeRequests","value":[{"removeVolumeOptions":{"name":"vol2"}}]}]`,
 				false),
 			Entry("remove volume request that already exists should fail",
 				&v1.VirtualMachineVolumeRequest{

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -61,24 +61,20 @@ func (mutator *MigrationCreateMutator) Mutate(ar *admissionv1.AdmissionReview) *
 
 	// Add a finalizer
 	migration.Finalizers = append(migration.Finalizers, v1.VirtualMachineInstanceMigrationFinalizer)
-	var patch []utiltypes.PatchOperation
-	var value interface{}
 
-	value = migration.Spec
-	patch = append(patch, utiltypes.PatchOperation{
-		Op:    "replace",
-		Path:  "/spec",
-		Value: value,
-	})
+	patchBytes, err := utiltypes.GeneratePatchPayload(
+		utiltypes.PatchOperation{
+			Op:    utiltypes.PatchReplaceOp,
+			Path:  "/spec",
+			Value: migration.Spec,
+		},
+		utiltypes.PatchOperation{
+			Op:    utiltypes.PatchReplaceOp,
+			Path:  "/metadata",
+			Value: migration.ObjectMeta,
+		},
+	)
 
-	value = migration.ObjectMeta
-	patch = append(patch, utiltypes.PatchOperation{
-		Op:    "replace",
-		Path:  "/metadata",
-		Value: value,
-	})
-
-	patchBytes, err := json.Marshal(patch)
 	if err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -63,23 +63,19 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	mutator.setDefaultFlavorKind(&vm)
 	mutator.setDefaultPreferenceKind(&vm)
 
-	var patch []utiltypes.PatchOperation
-	var value interface{}
-	value = vm.Spec
-	patch = append(patch, utiltypes.PatchOperation{
-		Op:    "replace",
-		Path:  "/spec",
-		Value: value,
-	})
+	patchBytes, err := utiltypes.GeneratePatchPayload(
+		utiltypes.PatchOperation{
+			Op:    utiltypes.PatchReplaceOp,
+			Path:  "/spec",
+			Value: vm.Spec,
+		},
+		utiltypes.PatchOperation{
+			Op:    utiltypes.PatchReplaceOp,
+			Path:  "/metadata",
+			Value: vm.ObjectMeta,
+		},
+	)
 
-	value = vm.ObjectMeta
-	patch = append(patch, utiltypes.PatchOperation{
-		Op:    "replace",
-		Path:  "/metadata",
-		Value: value,
-	})
-
-	patchBytes, err := json.Marshal(patch)
 	if err != nil {
 		log.Log.Reason(err).Error("admission failed to marshall patch to JSON")
 		return &admissionv1.AdmissionResponse{

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1260,8 +1260,7 @@ var _ = Describe("Migration watcher", func() {
 
 				vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any(), &metav1.PatchOptions{}).DoAndReturn(func(name interface{}, ptype interface{}, vmiStatusPatch []byte, options interface{}) (*virtv1.VirtualMachineInstance, error) {
 
-					vmiSP := []utiltype.PatchOperation{}
-					err := json.Unmarshal(vmiStatusPatch, &vmiSP)
+					vmiSP, err := utiltype.UnmarshalPatch(vmiStatusPatch)
 					Expect(err).To(BeNil())
 					Expect(vmiSP).To(HaveLen(2))
 

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -369,8 +369,8 @@ var _ = Describe("Apply Apps", func() {
 					Expect(ok).To(BeTrue())
 					patched = true
 
-					patches := []utiltypes.PatchOperation{}
-					json.Unmarshal(a.GetPatch(), &patches)
+					patches, err := utiltypes.UnmarshalPatch(a.GetPatch())
+					Expect(err).ToNot(HaveOccurred())
 
 					var dsSpec *appsv1.DaemonSetSpec
 					for _, v := range patches {


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid manually writing strings for patches, which is error prone, delicate and hard to debug, the `PatchOperation` struct was introduced. While being a very good idea that eases the process, it can still be improved. This PR aims to improve the patch generation process in terms of ease of use, readability and code safety.

This PR introduces:
* `GeneratePatchPayload(patches ...PatchOperation)` function. This eliminates the need to manually initialize an array of patch operations + marshalling it.
* `GenerateTestReplacePatch()` function. This aims to ease the process of making a test & replace patches.
* Constant patch operations (add, replace, etc) to reduce probability of errors in patch operations

I believe these changes contribute to the code being shorter, cleaner, clearer and safer.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
