### PR TITLE
tests, sriov: Improve error of finding VMI iface by MAC assert

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -694,7 +694,7 @@ func findIfaceByMAC(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIns
 		return true, nil
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("could not find interface with MAC %q on VMI %q: %v", mac, vmi.Name, err)
 	}
 	return ifaceName, nil
 }


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a test failed due to failure in finding SR-IOV interface by MAC, there is no description why it failed
that could help with realizing when and how many times such test failed (for example, by using SearchCI).

This PR add description to find VMI interface by MAC address assertions.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
