### PR TITLE
tests, cleanup: Move cleanup to global BeforeEach

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -41,7 +41,6 @@ import (
 	pool "kubevirt.io/api/pool"
 	"kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/tests"
 )
 
 type rightsEntry struct {
@@ -205,8 +204,6 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		Expect(err).ToNot(HaveOccurred())
 		authClient, err = authClientV1.NewForConfig(virtClient.Config())
 		Expect(err).ToNot(HaveOccurred())
-
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("With default kubevirt service accounts", func() {

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -35,7 +35,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/util"
 
@@ -58,8 +57,6 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", func() {
 	)
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		if !checks.HasAtLeastTwoNodes() {
 			Skip("this test requires at least 2 nodes")
 		}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -73,8 +73,6 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("With a ConfigMap defined", func() {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -64,8 +64,6 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	expectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -53,10 +53,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		util.PanicOnError(err)
 	})
 
-	AfterEach(func() {
-		tests.BeforeTestCleanup()
-	})
-
 	verifyContainerDiskVMI := func(vmi *v1.VirtualMachineInstance, obj runtime.Object) {
 		_, ok := obj.(*v1.VirtualMachineInstance)
 		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -55,7 +55,6 @@ var _ = Describe("[sig-compute]Guest Access Credentials", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 
 		LaunchVMI = tests.VMILauncherIgnoreWarnings(virtClient)
 	})

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -53,7 +53,6 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 		restClient = virtClient.RestClient()
-		tests.BeforeTestCleanup()
 	})
 
 	Context("VirtualMachineInstances", func() {

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -32,8 +32,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("Flavor validation", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -105,11 +105,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("changes to the kubernetes client", func() {
-
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		scheduledToRunning := func(vmis []v1.VirtualMachineInstance) time.Duration {
 			var duration time.Duration
 			for _, vmi := range vmis {
@@ -247,10 +242,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
-
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
 
 		It("[test_id:4099] should be rotated when a new CA is created", func() {
 			By("checking that the config-map gets the new CA bundle attached")
@@ -699,7 +690,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		}
 
 		tests.DeprecatedBeforeAll(func() {
-			tests.BeforeTestCleanup()
 
 			By("Finding the virt-controller prometheus endpoint")
 			virtControllerLeaderPodName := getLeader()
@@ -1089,10 +1079,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("Start a VirtualMachineInstance", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		Context("when the controller pod is not running and an election happens", func() {
 			It("[test_id:4642]should succeed afterwards", func() {
 				// This test needs at least 2 controller pods. Skip on single-replica.
@@ -1150,7 +1136,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		}
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			nodesWithKVM = libnode.GetNodesWithKVM()
 			if len(nodesWithKVM) == 0 {
 				Skip("Skip testing with node-labeller, because there are no nodes with kvm")
@@ -1393,7 +1378,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			var originalKubeVirt *v1.KubeVirt
 
 			BeforeEach(func() {
-				tests.BeforeTestCleanup()
 				originalKubeVirt = util.GetCurrentKv(virtClient)
 
 			})
@@ -1504,10 +1488,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	})
 
 	Describe("cluster profiler for pprof data aggregation", func() {
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-		})
-
 		Context("when ClusterProfiler feature gate", func() {
 			It("is disabled it should prevent subresource access", func() {
 				tests.DisableFeatureGate("ClusterProfiler")

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -689,7 +689,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			return nodeName
 		}
 
-		tests.DeprecatedBeforeAll(func() {
+		BeforeEach(func() {
+			preparedVMIs = []*v1.VirtualMachineInstance{}
+			pod = nil
+			handlerMetricIPs = []string{}
+			controllerMetricIPs = []string{}
 
 			By("Finding the virt-controller prometheus endpoint")
 			virtControllerLeaderPodName := getLeader()

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -31,7 +31,6 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 
 		k8sClient = clientcmd.GetK8sCmdClient()
 		clientcmd.SkipIfNoCmd(k8sClient)
-		tests.BeforeTestCleanup()
 	})
 
 	DescribeTable("[test_id:3812]explain vm/vmi", func(resource string) {

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -16,7 +16,6 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", func(
 	BeforeEach(func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.WorkloadEncryptionSEV)
 		checks.SkipTestIfNotSEVCapable()
-		tests.BeforeTestCleanup()
 	})
 
 	It("should start a SEV VM", func() {

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -121,7 +121,6 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 		var mdevTestLabel = "mdevTestLabel1"
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			kv := util.GetCurrentKv(virtClient)
 
 			By("Creating a configuration for mediated devices")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -319,10 +319,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	}
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		checks.SkipIfMigrationIsNotPossible()
-
 	})
 
 	runVMIAndExpectLaunch := func(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
@@ -1182,7 +1179,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with an pending target pod", func() {
 			var nodes *k8sv1.NodeList
 			BeforeEach(func() {
-				tests.BeforeTestCleanup()
 				Eventually(func() []k8sv1.Node {
 					nodes = libnode.GetAllSchedulableNodes(virtClient)
 					return nodes.Items
@@ -1317,7 +1313,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 		Context("[Serial] with auto converge enabled", func() {
 			BeforeEach(func() {
-				tests.BeforeTestCleanup()
 
 				// set autoconverge flag
 				config := getCurrentKv()
@@ -1410,8 +1405,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		Context("with an Alpine DataVolume", func() {
 			BeforeEach(func() {
-				tests.BeforeTestCleanup()
-
 				if !libstorage.HasCDI() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
@@ -3986,7 +3979,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			// However, we need to be sig-something or we'll fail the check, even if we don't run on any sig- lane.
 			// So let's be sig-compute and skip ourselves on sig-compute always... (they have only 1 node with CPU manager)
 			checks.SkipTestIfNotEnoughNodesWithCPUManager(2)
-			tests.BeforeTestCleanup()
 			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//tests:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -29,8 +29,6 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/util"
 
-	"kubevirt.io/kubevirt/tests"
-
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -136,7 +134,6 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
 		Expect(virtClient).ToNot(BeNil())
 
 		checks.SkipIfPrometheusRuleIsNotEnabled(virtClient)
-		tests.BeforeTestCleanup()
 	})
 
 	Context("Up metrics", func() {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -86,7 +86,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	const xfailError = "Secondary ip on dual stack service is not working. Tracking issue - https://github.com/kubevirt/kubevirt/issues/5477"
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 	})

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -64,9 +64,6 @@ var _ = SIGDescribe("Macvtap", func() {
 
 		macvtapLowerDevice = "eth0"
 		macvtapNetworkName = "net1"
-
-		// cleanup the environment
-		tests.BeforeTestCleanup()
 	})
 
 	BeforeEach(func() {

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -35,8 +35,6 @@ var _ = SIGDescribe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:com
 		serverVMILabels map[string]string
 	)
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred(), "should succeed retrieving the kubevirt client")

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -52,8 +52,6 @@ var _ = SIGDescribe("Port-forward", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("VMI With masquerade binding", func() {

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -41,8 +41,6 @@ import (
 var _ = SIGDescribe("Primary Pod Network", func() {
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -42,8 +42,6 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	buildProbeBackendPodSpec := func(probe *v1.Probe) (*corev1.Pod, func() error) {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -91,10 +91,6 @@ var _ = Describe("[Serial]SRIOV", func() {
 		}
 	})
 
-	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-	})
-
 	Context("VirtualMachineInstance with sriov plugin interface", func() {
 
 		getSriovVmi := func(networks []string, cloudInitNetworkData string) *v1.VirtualMachineInstance {

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -48,8 +48,6 @@ var _ = SIGDescribe("Infosource", func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("VMI with 3 interfaces", func() {

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -114,8 +114,6 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 			)
 		}
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-
 			virtClient, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
 

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -50,8 +50,6 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 		vmi = libvmi.NewAlpine()
 	})
 

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -153,8 +153,6 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
-
 		nodes = libnode.GetAllSchedulableNodes(virtClient)
 		Expect(nodes.Items).NotTo(BeEmpty())
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -73,8 +73,6 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	)
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -71,8 +71,6 @@ var _ = SIGDescribe("Slirp Networking", func() {
 	}
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -56,8 +56,6 @@ var _ = SIGDescribe("Subdomain", func() {
 
 		// Should be skipped as long as masquerade binding doesn't have dhcpv6 + ra (issue- https://github.com/kubevirt/kubevirt/issues/7184)
 		libnet.SkipWhenClusterNotSupportIpv4(virtClient)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("with a headless service given", func() {

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -21,8 +21,6 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("should cause fail in creating of vmi with", func() {

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -33,7 +33,6 @@ var _ = Describe("[sig-compute][Serial]NUMA", func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
 	})
 
 	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated", func() {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1030,8 +1030,6 @@ spec:
 	})
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		workDir = GinkgoT().TempDir()
 
 		vmYamls = make(map[string]*vmYamlDefinition)

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -55,8 +55,6 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("A valid VMI", func() {

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -78,7 +78,6 @@ var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
 		}
 
 		startTime = time.Now()
-		tests.BeforeTestCleanup()
 	})
 
 	AfterEach(func() {

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -77,7 +77,6 @@ var _ = SIGDescribe("CPU latency tests for measuring realtime VMs performance", 
 		util.PanicOnError(err)
 		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
 		checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(1)
-		tests.BeforeTestCleanup()
 	})
 
 	It("running cyclictest and collecting results directly from VM", func() {

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -50,8 +50,6 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	waitForVMIs := func(namespace string, expectedCount int) {

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -44,8 +44,6 @@ var _ = Describe("[sig-compute]PortForward", func() {
 	)
 
 	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -75,7 +75,6 @@ var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.NUMAFeatureGate)
 		checks.SkipTestIfNoFeatureGate(virtconfig.CPUManager)
 		checks.SkipTestIfNotRealtimeCapable()
-		tests.BeforeTestCleanup()
 
 	})
 

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -57,8 +57,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	doScale := func(name string, scale int32) {

--- a/tests/scale/BUILD.bazel
+++ b/tests/scale/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//tests:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -10,7 +10,6 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
-	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -23,7 +22,6 @@ var _ = Describe("[sig-compute] virt-api scaling", func() {
 
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
 	})
 
 	calcExpectedReplicas := func(nodesCount int) (expectedReplicas int32) {

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -54,7 +54,6 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 	})
 
 	Context("Check virt-launcher securityContext", func() {

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -71,8 +71,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("Soft reboot VMI", func() {

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -13,10 +13,6 @@ import (
 // Replace PDescribe with FDescribe in order to measure if your changes made
 // VMI startup any worse
 var _ = PDescribe("Ensure stable functionality", func() {
-	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-	})
-
 	It("by repeately starting vmis many times without issues", func() {
 		experiment := gmeasure.NewExperiment("VMs creation")
 		AddReportEntry(experiment.Name, experiment)

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -76,7 +76,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		if !libstorage.HasCDI() {
 			Skip("Skip DataVolume tests when CDI is not present")
 		}

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -88,7 +88,6 @@ var _ = SIGDescribe("Export", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		waitExportProxyReady()
 	})
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -83,8 +83,6 @@ var _ = SIGDescribe("Hotplug", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	getDryRunOption := func(dryRun bool) []string {

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -73,8 +73,6 @@ var _ = SIGDescribe("Memory dump", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	createVirtualMachine := func(running bool, template *v1.VirtualMachineInstance) *v1.VirtualMachine {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -53,8 +53,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	createRestoreDef := func(vmName, snapshotName string) *snapshotv1.VirtualMachineRestore {

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -162,8 +162,6 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	AfterEach(func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -85,7 +85,6 @@ var _ = SIGDescribe("Storage", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("Starting a VirtualMachineInstance", func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -85,6 +85,7 @@ var _ = SIGDescribe("Storage", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
+		tests.SetupAlpineHostPath()
 	})
 
 	Describe("Starting a VirtualMachineInstance", func() {

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -52,8 +52,6 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 	BeforeEach(func() {
 		virtCli, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization", func() {

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -295,7 +295,6 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 		checks.SkipIfMissingRequiredImage(virtClient, tests.DiskWindowsSysprep)
 		tests.CreatePVC(tests.OSWindowsSysprep, "35Gi", libstorage.Config.StorageClassWindows, true)
 		answerFileWithKey := insertProductKeyToAnswerFileTemplate(answerFileTemplate)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -70,7 +70,6 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 		util.PanicOnError(err)
 
 		clientcmd.SkipIfNoCmd("oc")
-		tests.BeforeTestCleanup()
 		SetDefaultEventuallyTimeout(120 * time.Second)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -95,7 +95,7 @@ var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite
 var _ = SynchronizedAfterSuite(testsuite.AfterTestSuitCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
 
 var _ = AfterEach(func() {
-	tests.BeforeTestCleanup()
+	tests.TestCleanup()
 })
 
 func getMaxFailsFromEnv() int {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -119,10 +119,10 @@ var _ = ReportAfterSuite("TestTests", func(report Report) {
 	}
 })
 
-var _ = ReportBeforeEach(func(specReport SpecReport) {
+var _ = JustBeforeEach(func() {
 	k8sReporter.JustBeforeEach(CurrentSpecReport())
 })
 
-var _ = ReportAfterEach(func(specReport SpecReport) {
+var _ = JustAfterEach(func() {
 	k8sReporter.JustAfterEach(CurrentSpecReport())
 })

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -94,7 +94,7 @@ var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite
 
 var _ = SynchronizedAfterSuite(testsuite.AfterTestSuitCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
 
-var _ = BeforeEach(func() {
+var _ = AfterEach(func() {
 	tests.BeforeTestCleanup()
 })
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
 
+	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/reporter"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -92,6 +93,10 @@ func TestTests(t *testing.T) {
 var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite.BeforeTestSuitSetup)
 
 var _ = SynchronizedAfterSuite(testsuite.AfterTestSuitCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
+
+var _ = BeforeEach(func() {
+	tests.BeforeTestCleanup()
+})
 
 func getMaxFailsFromEnv() int {
 	maxFailsEnv := os.Getenv("REPORTER_MAX_FAILS")

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -98,6 +98,7 @@ func SynchronizedBeforeTestSetup() []byte {
 }
 
 func BeforeTestSuitSetup(_ []byte) {
+
 	worker := GinkgoParallelProcess()
 	rand.Seed(int64(worker))
 	log.InitializeLogging("tests")

--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -58,8 +58,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance without usbredir support", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -159,7 +159,7 @@ const StorageClassHostPathSeparateDevice = "host-path-sd"
 
 var wffc = storagev1.VolumeBindingWaitForFirstConsumer
 
-func BeforeTestCleanup() {
+func TestCleanup() {
 	testsuite.CleanNamespaces()
 	libnode.CleanNodes()
 	resetToDefaultConfig()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -164,6 +164,10 @@ func BeforeTestCleanup() {
 	libnode.CleanNodes()
 	resetToDefaultConfig()
 	testsuite.EnsureKubevirtInfra()
+	SetupAlpineHostPath()
+}
+
+func SetupAlpineHostPath() {
 	CreateHostPathPv(osAlpineHostPath, testsuite.HostPathAlpine)
 	CreateHostPathPVC(osAlpineHostPath, defaultDiskSize)
 }

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -29,7 +29,6 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/tests"
 )
 
 var _ = Describe("[sig-compute]Version", func() {
@@ -40,8 +39,6 @@ var _ = Describe("[sig-compute]Version", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("Check that version parameters where loaded by ldflags in build time", func() {

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -157,8 +157,6 @@ var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resil
 		}
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-
 			nodeList = libnode.GetAllSchedulableNodes(virtCli).Items
 			for _, node := range nodeList {
 				setNodeUnschedulable(node.Name)

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -30,7 +30,6 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 		// Disable SSH_AGENT to not influence test results
 		Expect(os.Setenv("SSH_AUTH_SOCK", "/dev/null")).To(Succeed())
 		keyFile = filepath.Join(GinkgoT().TempDir(), "id_rsa")
-		tests.BeforeTestCleanup()
 		var priv *ecdsa.PrivateKey
 		priv, pub, err = NewKeyPair()
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -30,7 +30,6 @@ var _ = Describe("[sig-compute][virtctl]SSH", func() {
 		// Disable SSH_AGENT to not influence test results
 		Expect(os.Setenv("SSH_AUTH_SOCK", "/dev/null")).To(Succeed())
 		keyFile = filepath.Join(GinkgoT().TempDir(), "id_rsa")
-		tests.BeforeTestCleanup()
 		var priv *ecdsa.PrivateKey
 		priv, pub, err = NewKeyPair()
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -71,8 +71,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("An invalid VirtualMachine given", func() {

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -92,8 +92,6 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#FAKE")
 		vmi.ObjectMeta.Annotations = map[string]string{
 			"hooks.kubevirt.io/hookSidecars": fmt.Sprintf(`[{"image": "%s/%s:%s", "imagePullPolicy": "IfNotPresent"}]`, flags.KubeVirtUtilityRepoPrefix, cloudinitHookSidecarImage, flags.KubeVirtUtilityVersionTag),

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -75,7 +75,6 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 
 		// from default virt-launcher flag: do we need to make this configurable in some cases?
 		cloudinit.SetLocalDirectoryOnly("/var/run/kubevirt-ephemeral-disks/cloud-init-data")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -107,8 +107,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("with all devices on the root PCI bus", func() {

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -48,7 +48,6 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 	})
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -58,7 +58,6 @@ var _ = Describe("[sig-compute]HookSidecars", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 		vmi.ObjectMeta.Annotations = RenderSidecar(hooksv1alpha1.Version)
 	})

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -46,7 +46,6 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 
 		if !checks.HasFeature("ExperimentalIgnitionSupport") {
 			Skip("ExperimentalIgnitionSupport feature gate is not enabled in kubevirt-config")

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -53,7 +53,6 @@ var _ = Describe("[sig-compute]IOThreads", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 	})
 

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -49,7 +49,6 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
 	})
 
 	Context("with external alpine-based kernel & initrd images", func() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -99,7 +99,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 	})
 

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -43,7 +43,6 @@ var _ = Describe("[sig-compute]Health Monitoring", func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		Expect(err).ToNot(HaveOccurred())
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("A VirtualMachineInstance with a watchdog device", func() {

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -49,8 +49,6 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Context("MultiQueue Behavior", func() {

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -45,8 +45,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-
-		tests.BeforeTestCleanup()
 	})
 
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with default sound support", func() {

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -47,7 +47,6 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 	Context("Disk defaults", func() {
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			// create VMI with missing disk target
 			vmi = tests.NewRandomVMI()
 			vmi.Spec = v1.VirtualMachineInstanceSpec{
@@ -113,7 +112,6 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 		var kvConfiguration v1.KubeVirtConfiguration
 
 		BeforeEach(func() {
-			tests.BeforeTestCleanup()
 			// create VMI with missing disk target
 			vmi = tests.NewRandomVMI()
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -65,7 +65,6 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 		vmi.Labels = map[string]string{flavorKey: memoryFlavor}
 

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -57,7 +57,6 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 			virtClient, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
 
-			tests.BeforeTestCleanup()
 			vmi = tests.NewRandomVMI()
 			Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()).To(Succeed())
 			tests.WaitForSuccessfulVMIStart(vmi)

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -135,7 +135,6 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
-		tests.BeforeTestCleanup()
 		checks.SkipIfMissingRequiredImage(virtClient, tests.DiskWindows)
 		tests.CreatePVC(tests.OSWindows, "30Gi", libstorage.Config.StorageClassWindows, true)
 		windowsVMI = tests.NewRandomVMI()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the e2e tests to use global AfterEach for cleanup and move k8s reporter dump at `JustAfterEach`.
- global `JustBeforeEach` -> `k8sreporter.JustBeforeEach` (it prints the place where the artifacts are dump).
- test run
- globa `JustAfterEach` -> `k8sreporter.JustAfterEach` (dump k8s artifacts to a directory)
- global `AfterEach` -> `tests.TestCleanup()` (remove test namespaces and VMs).

Before this PR the proper call of TestCleanup function depends on test author, whit this PR the call is done at a global place so new test does not need to call cleanup and we can trust that the cleanup is being done propertly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
tests: Move main clean function to global AfterEach and create a VM per each infra_test.go Entry.
```
