### PR TITLE
[Bugfix] [Node-Labeller]: Properly remove all node-labeller labels

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -23,6 +23,7 @@ package nodelabeller
 
 import (
 	"path"
+	"strings"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -183,4 +184,169 @@ var _ = Describe("Node-labeller config", func() {
 			Expect(nlController.SEV.ReducedPhysBits).To(BeEmpty())
 		})
 	})
+
+	It("Make sure proper labels are removed on removeLabellerLabels()", func() {
+		node := &k8sv1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: nodeLabels,
+			},
+		}
+
+		nlController.removeLabellerLabels(node)
+
+		badKey := ""
+		for key, _ := range node.Labels {
+			for _, labellerPrefix := range nodeLabellerLabels {
+				if strings.HasPrefix(key, labellerPrefix) {
+					badKey = key
+					break
+				}
+			}
+		}
+		Expect(badKey).To(BeEmpty())
+	})
 })
+
+var nodeLabels = map[string]string{
+	"beta.kubernetes.io/arch":                                          "amd64",
+	"beta.kubernetes.io/os":                                            "linux",
+	"cpu-feature.node.kubevirt.io/3dnowprefetch":                       "true",
+	"cpu-feature.node.kubevirt.io/abm":                                 "true",
+	"cpu-feature.node.kubevirt.io/adx":                                 "true",
+	"cpu-feature.node.kubevirt.io/aes":                                 "true",
+	"cpu-feature.node.kubevirt.io/amd-ssbd":                            "true",
+	"cpu-feature.node.kubevirt.io/amd-stibp":                           "true",
+	"cpu-feature.node.kubevirt.io/arat":                                "true",
+	"cpu-feature.node.kubevirt.io/arch-capabilities":                   "true",
+	"cpu-feature.node.kubevirt.io/avx":                                 "true",
+	"cpu-feature.node.kubevirt.io/avx2":                                "true",
+	"cpu-feature.node.kubevirt.io/bmi1":                                "true",
+	"cpu-feature.node.kubevirt.io/bmi2":                                "true",
+	"cpu-feature.node.kubevirt.io/clflushopt":                          "true",
+	"cpu-feature.node.kubevirt.io/erms":                                "true",
+	"cpu-feature.node.kubevirt.io/f16c":                                "true",
+	"cpu-feature.node.kubevirt.io/fma":                                 "true",
+	"cpu-feature.node.kubevirt.io/fsgsbase":                            "true",
+	"cpu-feature.node.kubevirt.io/hypervisor":                          "true",
+	"cpu-feature.node.kubevirt.io/ibpb":                                "true",
+	"cpu-feature.node.kubevirt.io/ibrs":                                "true",
+	"cpu-feature.node.kubevirt.io/ibrs-all":                            "true",
+	"cpu-feature.node.kubevirt.io/invpcid":                             "true",
+	"cpu-feature.node.kubevirt.io/invtsc":                              "true",
+	"cpu-feature.node.kubevirt.io/md-clear":                            "true",
+	"cpu-feature.node.kubevirt.io/mds-no":                              "true",
+	"cpu-feature.node.kubevirt.io/movbe":                               "true",
+	"cpu-feature.node.kubevirt.io/mpx":                                 "true",
+	"cpu-feature.node.kubevirt.io/pcid":                                "true",
+	"cpu-feature.node.kubevirt.io/pclmuldq":                            "true",
+	"cpu-feature.node.kubevirt.io/pdcm":                                "true",
+	"cpu-feature.node.kubevirt.io/pdpe1gb":                             "true",
+	"cpu-feature.node.kubevirt.io/popcnt":                              "true",
+	"cpu-feature.node.kubevirt.io/pschange-mc-no":                      "true",
+	"cpu-feature.node.kubevirt.io/rdctl-no":                            "true",
+	"cpu-feature.node.kubevirt.io/rdrand":                              "true",
+	"cpu-feature.node.kubevirt.io/rdseed":                              "true",
+	"cpu-feature.node.kubevirt.io/rdtscp":                              "true",
+	"cpu-feature.node.kubevirt.io/skip-l1dfl-vmentry":                  "true",
+	"cpu-feature.node.kubevirt.io/smap":                                "true",
+	"cpu-feature.node.kubevirt.io/smep":                                "true",
+	"cpu-feature.node.kubevirt.io/spec-ctrl":                           "true",
+	"cpu-feature.node.kubevirt.io/ss":                                  "true",
+	"cpu-feature.node.kubevirt.io/ssbd":                                "true",
+	"cpu-feature.node.kubevirt.io/sse4.2":                              "true",
+	"cpu-feature.node.kubevirt.io/stibp":                               "true",
+	"cpu-feature.node.kubevirt.io/tsc-deadline":                        "true",
+	"cpu-feature.node.kubevirt.io/tsc_adjust":                          "true",
+	"cpu-feature.node.kubevirt.io/tsx-ctrl":                            "true",
+	"cpu-feature.node.kubevirt.io/umip":                                "true",
+	"cpu-feature.node.kubevirt.io/vme":                                 "true",
+	"cpu-feature.node.kubevirt.io/vmx":                                 "true",
+	"cpu-feature.node.kubevirt.io/x2apic":                              "true",
+	"cpu-feature.node.kubevirt.io/xgetbv1":                             "true",
+	"cpu-feature.node.kubevirt.io/xsave":                               "true",
+	"cpu-feature.node.kubevirt.io/xsavec":                              "true",
+	"cpu-feature.node.kubevirt.io/xsaveopt":                            "true",
+	"cpu-feature.node.kubevirt.io/xsaves":                              "true",
+	"cpu-model-migration.node.kubevirt.io/Broadwell-noTSX":             "true",
+	"cpu-model-migration.node.kubevirt.io/Broadwell-noTSX-IBRS":        "true",
+	"cpu-model-migration.node.kubevirt.io/Haswell-noTSX":               "true",
+	"cpu-model-migration.node.kubevirt.io/Haswell-noTSX-IBRS":          "true",
+	"cpu-model-migration.node.kubevirt.io/IvyBridge":                   "true",
+	"cpu-model-migration.node.kubevirt.io/IvyBridge-IBRS":              "true",
+	"cpu-model-migration.node.kubevirt.io/Nehalem":                     "true",
+	"cpu-model-migration.node.kubevirt.io/Nehalem-IBRS":                "true",
+	"cpu-model-migration.node.kubevirt.io/Opteron_G1":                  "true",
+	"cpu-model-migration.node.kubevirt.io/Opteron_G2":                  "true",
+	"cpu-model-migration.node.kubevirt.io/Penryn":                      "true",
+	"cpu-model-migration.node.kubevirt.io/SandyBridge":                 "true",
+	"cpu-model-migration.node.kubevirt.io/SandyBridge-IBRS":            "true",
+	"cpu-model-migration.node.kubevirt.io/Skylake-Client-IBRS":         "true",
+	"cpu-model-migration.node.kubevirt.io/Skylake-Client-noTSX-IBRS":   "true",
+	"cpu-model-migration.node.kubevirt.io/Westmere":                    "true",
+	"cpu-model-migration.node.kubevirt.io/Westmere-IBRS":               "true",
+	"cpu-model.node.kubevirt.io/Broadwell-noTSX":                       "true",
+	"cpu-model.node.kubevirt.io/Broadwell-noTSX-IBRS":                  "true",
+	"cpu-model.node.kubevirt.io/Haswell-noTSX":                         "true",
+	"cpu-model.node.kubevirt.io/Haswell-noTSX-IBRS":                    "true",
+	"cpu-model.node.kubevirt.io/IvyBridge":                             "true",
+	"cpu-model.node.kubevirt.io/IvyBridge-IBRS":                        "true",
+	"cpu-model.node.kubevirt.io/Nehalem":                               "true",
+	"cpu-model.node.kubevirt.io/Nehalem-IBRS":                          "true",
+	"cpu-model.node.kubevirt.io/Opteron_G1":                            "true",
+	"cpu-model.node.kubevirt.io/Opteron_G2":                            "true",
+	"cpu-model.node.kubevirt.io/Penryn":                                "true",
+	"cpu-model.node.kubevirt.io/SandyBridge":                           "true",
+	"cpu-model.node.kubevirt.io/SandyBridge-IBRS":                      "true",
+	"cpu-model.node.kubevirt.io/Skylake-Client-noTSX-IBRS":             "true",
+	"cpu-model.node.kubevirt.io/Westmere":                              "true",
+	"cpu-model.node.kubevirt.io/Westmere-IBRS":                         "true",
+	"cpu-timer.node.kubevirt.io/tsc-frequency":                         "2111998000",
+	"cpu-timer.node.kubevirt.io/tsc-scalable":                          "false",
+	"cpu-vendor.node.kubevirt.io/Intel":                                "true",
+	"cpumanager":                                                       "false",
+	"host-model-cpu.node.kubevirt.io/Skylake-Client-IBRS":              "true",
+	"host-model-required-features.node.kubevirt.io/amd-ssbd":           "true",
+	"host-model-required-features.node.kubevirt.io/amd-stibp":          "true",
+	"host-model-required-features.node.kubevirt.io/arch-capabilities":  "true",
+	"host-model-required-features.node.kubevirt.io/clflushopt":         "true",
+	"host-model-required-features.node.kubevirt.io/hypervisor":         "true",
+	"host-model-required-features.node.kubevirt.io/ibpb":               "true",
+	"host-model-required-features.node.kubevirt.io/ibrs":               "true",
+	"host-model-required-features.node.kubevirt.io/ibrs-all":           "true",
+	"host-model-required-features.node.kubevirt.io/invtsc":             "true",
+	"host-model-required-features.node.kubevirt.io/md-clear":           "true",
+	"host-model-required-features.node.kubevirt.io/mds-no":             "true",
+	"host-model-required-features.node.kubevirt.io/pdcm":               "true",
+	"host-model-required-features.node.kubevirt.io/pdpe1gb":            "true",
+	"host-model-required-features.node.kubevirt.io/pschange-mc-no":     "true",
+	"host-model-required-features.node.kubevirt.io/rdctl-no":           "true",
+	"host-model-required-features.node.kubevirt.io/skip-l1dfl-vmentry": "true",
+	"host-model-required-features.node.kubevirt.io/ss":                 "true",
+	"host-model-required-features.node.kubevirt.io/ssbd":               "true",
+	"host-model-required-features.node.kubevirt.io/stibp":              "true",
+	"host-model-required-features.node.kubevirt.io/tsc_adjust":         "true",
+	"host-model-required-features.node.kubevirt.io/tsx-ctrl":           "true",
+	"host-model-required-features.node.kubevirt.io/umip":               "true",
+	"host-model-required-features.node.kubevirt.io/vmx":                "true",
+	"host-model-required-features.node.kubevirt.io/xsaves":             "true",
+	"hyperv.node.kubevirt.io/base":                                     "true",
+	"hyperv.node.kubevirt.io/frequencies":                              "true",
+	"hyperv.node.kubevirt.io/ipi":                                      "true",
+	"hyperv.node.kubevirt.io/reenlightenment":                          "true",
+	"hyperv.node.kubevirt.io/reset":                                    "true",
+	"hyperv.node.kubevirt.io/runtime":                                  "true",
+	"hyperv.node.kubevirt.io/synic":                                    "true",
+	"hyperv.node.kubevirt.io/synic2":                                   "true",
+	"hyperv.node.kubevirt.io/synictimer":                               "true",
+	"hyperv.node.kubevirt.io/time":                                     "true",
+	"hyperv.node.kubevirt.io/tlbflush":                                 "true",
+	"hyperv.node.kubevirt.io/vpindex":                                  "true",
+	"kubernetes.io/arch":                                               "amd64",
+	"kubernetes.io/hostname":                                           "node01",
+	"kubernetes.io/os":                                                 "linux",
+	"kubevirt.io/schedulable":                                          "true",
+	"node-role.kubernetes.io/control-plane":                            "",
+	"node-role.kubernetes.io/master":                                   "",
+	"node.kubernetes.io/exclude-from-external-load-balancers":          "",
+	"scheduling.node.kubevirt.io/tsc-frequency-2111998000":             "true",
+}

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -43,6 +43,21 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
+var nodeLabellerLabels = []string{
+	util.DeprecatedLabelNamespace + util.DeprecatedcpuModelPrefix,
+	util.DeprecatedLabelNamespace + util.DeprecatedcpuFeaturePrefix,
+	util.DeprecatedLabelNamespace + util.DeprecatedHyperPrefix,
+	kubevirtv1.CPUFeatureLabel,
+	kubevirtv1.CPUModelLabel,
+	kubevirtv1.SupportedHostModelMigrationCPU,
+	kubevirtv1.CPUTimerLabel,
+	kubevirtv1.HypervLabel,
+	kubevirtv1.RealtimeLabel,
+	kubevirtv1.SEVLabel,
+	kubevirtv1.HostModelCPULabel,
+	kubevirtv1.HostModelRequiredFeaturesLabel,
+}
+
 //NodeLabeller struct holds informations needed to run node-labeller
 type NodeLabeller struct {
 	clientset               kubecli.KubevirtClient
@@ -304,18 +319,7 @@ func (n *NodeLabeller) HostCapabilities() *api.Capabilities {
 // removeLabellerLabels removes labels from node
 func (n *NodeLabeller) removeLabellerLabels(node *v1.Node) {
 	for label := range node.Labels {
-		if strings.HasPrefix(label, util.DeprecatedLabelNamespace+util.DeprecatedcpuModelPrefix) ||
-			strings.HasPrefix(label, util.DeprecatedLabelNamespace+util.DeprecatedcpuFeaturePrefix) ||
-			strings.HasPrefix(label, util.DeprecatedLabelNamespace+util.DeprecatedHyperPrefix) ||
-			strings.HasPrefix(label, kubevirtv1.CPUFeatureLabel) ||
-			strings.HasPrefix(label, kubevirtv1.CPUModelLabel) ||
-			strings.HasPrefix(label, kubevirtv1.SupportedHostModelMigrationCPU) ||
-			strings.HasPrefix(label, kubevirtv1.CPUTimerLabel) ||
-			strings.HasPrefix(label, kubevirtv1.HypervLabel) ||
-			strings.HasPrefix(label, kubevirtv1.RealtimeLabel) ||
-			strings.HasPrefix(label, kubevirtv1.SEVLabel) ||
-			strings.HasPrefix(label, kubevirtv1.HostModelCPULabel) ||
-			strings.HasPrefix(label, kubevirtv1.HostModelRequiredFeaturesLabel) {
+		if isNodeLabellerLabel(label) {
 			delete(node.Labels, label)
 		}
 	}
@@ -341,4 +345,14 @@ func isNodeRealtimeCapable() (bool, error) {
 	}
 	st := strings.Trim(string(ret), "\n")
 	return fmt.Sprintf("%s = -1", kernelSchedRealtimeRuntimeInMicrosecods) == st, nil
+}
+
+func isNodeLabellerLabel(label string) bool {
+	for _, prefix := range nodeLabellerLabels {
+		if strings.HasPrefix(label, prefix) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -304,22 +304,24 @@ func (n *NodeLabeller) HostCapabilities() *api.Capabilities {
 // removeLabellerLabels removes labels from node
 func (n *NodeLabeller) removeLabellerLabels(node *v1.Node) {
 	for label := range node.Labels {
-		if strings.Contains(label, util.DeprecatedLabelNamespace+util.DeprecatedcpuModelPrefix) ||
-			strings.Contains(label, util.DeprecatedLabelNamespace+util.DeprecatedcpuFeaturePrefix) ||
-			strings.Contains(label, util.DeprecatedLabelNamespace+util.DeprecatedHyperPrefix) ||
-			strings.Contains(label, kubevirtv1.CPUFeatureLabel) ||
-			strings.Contains(label, kubevirtv1.CPUModelLabel) ||
-			strings.Contains(label, kubevirtv1.SupportedHostModelMigrationCPU) ||
-			strings.Contains(label, kubevirtv1.CPUTimerLabel) ||
-			strings.Contains(label, kubevirtv1.HypervLabel) ||
-			strings.Contains(label, kubevirtv1.RealtimeLabel) ||
-			strings.Contains(label, kubevirtv1.SEVLabel) {
+		if strings.HasPrefix(label, util.DeprecatedLabelNamespace+util.DeprecatedcpuModelPrefix) ||
+			strings.HasPrefix(label, util.DeprecatedLabelNamespace+util.DeprecatedcpuFeaturePrefix) ||
+			strings.HasPrefix(label, util.DeprecatedLabelNamespace+util.DeprecatedHyperPrefix) ||
+			strings.HasPrefix(label, kubevirtv1.CPUFeatureLabel) ||
+			strings.HasPrefix(label, kubevirtv1.CPUModelLabel) ||
+			strings.HasPrefix(label, kubevirtv1.SupportedHostModelMigrationCPU) ||
+			strings.HasPrefix(label, kubevirtv1.CPUTimerLabel) ||
+			strings.HasPrefix(label, kubevirtv1.HypervLabel) ||
+			strings.HasPrefix(label, kubevirtv1.RealtimeLabel) ||
+			strings.HasPrefix(label, kubevirtv1.SEVLabel) ||
+			strings.HasPrefix(label, kubevirtv1.HostModelCPULabel) ||
+			strings.HasPrefix(label, kubevirtv1.HostModelRequiredFeaturesLabel) {
 			delete(node.Labels, label)
 		}
 	}
 
 	for annotation := range node.Annotations {
-		if strings.Contains(annotation, util.DeprecatedLabellerNamespaceAnnotation) {
+		if strings.HasPrefix(annotation, util.DeprecatedLabellerNamespaceAnnotation) {
 			delete(node.Annotations, annotation)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
On each and every node-labeller control loop, it removed its managed labels from the node and assigns them again.
But two labels are not being removed currently. These are:
```go
const HostModelCPULabel              = "host-model-cpu.node.kubevirt.io/"
const HostModelRequiredFeaturesLabel = "host-model-required-features.node.kubevirt.io/"
```

These are now being removed.

In addition, I've added a test and did some minor refactoring to node-labeller.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: node-labeller now removes "host-model-cpu.node.kubevirt.io/" and "host-model-required-features.node.kubevirt.io/" prefixes
```
