### PR TITLE
ci, reporter, Add step before reporter dump starts

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -98,6 +98,7 @@ func (r *KubernetesReporter) JustAfterEach(specReport types.SpecReport) {
 	if r.artifactsDir == "" {
 		return
 	}
+	By("Collecting Logs for failed test")
 	r.DumpTestNamespaces(specReport.RunTime)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when a test fails a dump is collected from the cluster for
later debugging. This dump includes various ssh expecter sessions to the vmi,
which are also printed to the screen. This makes it hard understanding when
the test ended and when the repoting started.
A simple solution is to add a step before the dump is collected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
