### PR TITLE
Fix vm restore in case of restore size bigger then PVC requested size

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -658,6 +658,7 @@ func (vca *VirtControllerApp) initRestoreController() {
 		DataVolumeInformer:        vca.dataVolumeInformer,
 		PVCInformer:               vca.persistentVolumeClaimInformer,
 		StorageClassInformer:      vca.storageClassInformer,
+		VolumeSnapshotProvider:    vca.snapshotController,
 		Recorder:                  recorder,
 	}
 	vca.restoreController.Init()

--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -740,6 +740,24 @@ func (ctrl *VMRestoreController) createRestorePVC(
 		return fmt.Errorf("missing VolumeSnapshot name")
 	}
 
+	volumeSnapshot, err := ctrl.VolumeSnapshotProvider.GetVolumeSnapshot(vmRestore.Namespace, *volumeBackup.VolumeSnapshotName)
+	if err != nil {
+		return err
+	}
+
+	if volumeSnapshot == nil {
+		log.Log.Errorf("VolumeSnapshot %s is missing", *volumeBackup.VolumeSnapshotName)
+		return fmt.Errorf("missing VolumeSnapshot %s", *volumeBackup.VolumeSnapshotName)
+	}
+
+	if volumeSnapshot.Status != nil && volumeSnapshot.Status.RestoreSize != nil {
+		restorePVCSize, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		// Update restore pvc size to be the maximum between the source PVC and the restore size
+		if !ok || restorePVCSize.Cmp(*volumeSnapshot.Status.RestoreSize) < 0 {
+			pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *volumeSnapshot.Status.RestoreSize
+		}
+	}
+
 	if pvc.Labels == nil {
 		pvc.Labels = make(map[string]string)
 	}
@@ -768,7 +786,7 @@ func (ctrl *VMRestoreController) createRestorePVC(
 
 	target.Own(pvc)
 
-	_, err := ctrl.Client.CoreV1().PersistentVolumeClaims(vmRestore.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+	_, err = ctrl.Client.CoreV1().PersistentVolumeClaims(vmRestore.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/snapshot/restore_base.go
+++ b/pkg/virt-controller/watch/snapshot/restore_base.go
@@ -51,6 +51,8 @@ type VMRestoreController struct {
 	PVCInformer               cache.SharedIndexInformer
 	StorageClassInformer      cache.SharedIndexInformer
 
+	VolumeSnapshotProvider VolumeSnapshotProvider
+
 	Recorder record.EventRecorder
 
 	vmRestoreQueue workqueue.RateLimitingInterface

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -227,7 +227,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 
 		vsName := *volumeBackup.VolumeSnapshotName
 
-		volumeSnapshot, err := ctrl.getVolumeSnapshot(content.Namespace, vsName)
+		volumeSnapshot, err := ctrl.GetVolumeSnapshot(content.Namespace, vsName)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/virt-controller/watch/snapshot/snapshot_base.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_base.go
@@ -556,24 +556,6 @@ func (ctrl *VMSnapshotController) handlePVC(obj interface{}) {
 	}
 }
 
-func (ctrl *VMSnapshotController) getVolumeSnapshot(namespace, name string) (*vsv1.VolumeSnapshot, error) {
-	di := ctrl.dynamicInformerMap[volumeSnapshotCRD]
-	di.mutex.Lock()
-	defer di.mutex.Unlock()
-
-	if di.informer == nil {
-		return nil, nil
-	}
-
-	key := fmt.Sprintf("%s/%s", namespace, name)
-	obj, exists, err := di.informer.GetStore().GetByKey(key)
-	if !exists || err != nil {
-		return nil, err
-	}
-
-	return obj.(*vsv1.VolumeSnapshot).DeepCopy(), nil
-}
-
 func (ctrl *VMSnapshotController) getVolumeSnapshotClasses() []vsv1.VolumeSnapshotClass {
 	di := ctrl.dynamicInformerMap[volumeSnapshotClassCRD]
 	di.mutex.Lock()
@@ -639,4 +621,26 @@ func (ctrl *VMSnapshotController) deleteDynamicInformer(name string) (time.Durat
 	log.Log.Infof("Successfully deleted informer for %q", name)
 
 	return 0, nil
+}
+
+type VolumeSnapshotProvider interface {
+	GetVolumeSnapshot(string, string) (*vsv1.VolumeSnapshot, error)
+}
+
+func (ctrl *VMSnapshotController) GetVolumeSnapshot(namespace, name string) (*vsv1.VolumeSnapshot, error) {
+	di := ctrl.dynamicInformerMap[volumeSnapshotCRD]
+	di.mutex.Lock()
+	defer di.mutex.Unlock()
+
+	if di.informer == nil {
+		return nil, nil
+	}
+
+	key := fmt.Sprintf("%s/%s", namespace, name)
+	obj, exists, err := di.informer.GetStore().GetByKey(key)
+	if !exists || err != nil {
+		return nil, err
+	}
+
+	return obj.(*vsv1.VolumeSnapshot).DeepCopy(), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2086825

**Special notes for your reviewer**:
Copy of https://github.com/kubevirt/kubevirt/pull/7920 which needs a rebase

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fix vm restore in case of restore size bigger then PVC requested size
```
