### PR TITLE
tests, libvmi: Adjust code to pass linter

### DIFF
--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -22,17 +22,17 @@ package libvmi
 import (
 	"encoding/base64"
 
-	kvirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 )
 
+const cloudInitDiskName = "disk1"
+
 // WithCloudInitNoCloudUserData adds cloud-init no-cloud user data.
 func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		diskName := "disk1"
-		addDiskVolumeWithCloudInitNoCloud(vmi, diskName, v1.DiskBusVirtio)
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
-		volume := getVolume(vmi, diskName)
+		volume := getVolume(vmi, cloudInitDiskName)
 		if b64Encoding {
 			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
 			volume.CloudInitNoCloud.UserData = ""
@@ -46,11 +46,10 @@ func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
 
 // WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
 func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		diskName := "disk1"
-		addDiskVolumeWithCloudInitNoCloud(vmi, diskName, v1.DiskBusVirtio)
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
-		volume := getVolume(vmi, diskName)
+		volume := getVolume(vmi, cloudInitDiskName)
 		if b64Encoding {
 			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
 			volume.CloudInitNoCloud.NetworkDataBase64 = encodedData
@@ -62,11 +61,10 @@ func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
 
 // WithCloudInitConfigDriveData adds cloud-init config-drive user data.
 func WithCloudInitConfigDriveData(data string, b64Encoding bool) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		diskName := "disk1"
-		addDiskVolumeWithCloudInitConfigDrive(vmi, diskName, v1.DiskBusVirtio)
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDiskVolumeWithCloudInitConfigDrive(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
-		volume := getVolume(vmi, diskName)
+		volume := getVolume(vmi, cloudInitDiskName)
 		if b64Encoding {
 			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
 			volume.CloudInitConfigDrive.UserData = ""
@@ -78,20 +76,20 @@ func WithCloudInitConfigDriveData(data string, b64Encoding bool) Option {
 	}
 }
 
-func addDiskVolumeWithCloudInitConfigDrive(vmi *kvirtv1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
+func addDiskVolumeWithCloudInitConfigDrive(vmi *v1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
 	addDisk(vmi, newDisk(diskName, bus))
 	v := newVolume(diskName)
-	v.VolumeSource = kvirtv1.VolumeSource{CloudInitConfigDrive: &kvirtv1.CloudInitConfigDriveSource{}}
+	v.VolumeSource = v1.VolumeSource{CloudInitConfigDrive: &v1.CloudInitConfigDriveSource{}}
 	addVolume(vmi, v)
 }
 
-func addDiskVolumeWithCloudInitNoCloud(vmi *kvirtv1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
+func addDiskVolumeWithCloudInitNoCloud(vmi *v1.VirtualMachineInstance, diskName string, bus v1.DiskBus) {
 	addDisk(vmi, newDisk(diskName, bus))
 	v := newVolume(diskName)
-	setCloudInitNoCloud(&v, &kvirtv1.CloudInitNoCloudSource{})
+	setCloudInitNoCloud(&v, &v1.CloudInitNoCloudSource{})
 	addVolume(vmi, v)
 }
 
-func setCloudInitNoCloud(volume *kvirtv1.Volume, source *kvirtv1.CloudInitNoCloudSource) {
-	volume.VolumeSource = kvirtv1.VolumeSource{CloudInitNoCloud: source}
+func setCloudInitNoCloud(volume *v1.Volume, source *v1.CloudInitNoCloudSource) {
+	volume.VolumeSource = v1.VolumeSource{CloudInitNoCloud: source}
 }

--- a/tests/libvmi/status.go
+++ b/tests/libvmi/status.go
@@ -24,9 +24,10 @@ func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace st
 	}
 
 	var controlledPod *k8sv1.Pod
-	for _, pod := range pods.Items {
-		if controller.IsControlledBy(&pod, vmi) {
-			controlledPod = &pod
+	for podIndex := range pods.Items {
+		pod := &pods.Items[podIndex]
+		if controller.IsControlledBy(pod, vmi) {
+			controlledPod = pod
 			break
 		}
 	}

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -20,32 +20,31 @@
 package libvmi
 
 import (
-	kvirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 )
 
 // WithContainerImage specifies the name of the container image to be used.
 func WithContainerImage(name string) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		diskName := "disk0"
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, newDisk(diskName, v1.DiskBusVirtio))
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newContainerVolume(diskName, name))
 	}
 }
 
-func addDisk(vmi *kvirtv1.VirtualMachineInstance, disk kvirtv1.Disk) {
+func addDisk(vmi *v1.VirtualMachineInstance, disk v1.Disk) {
 	if !diskExists(vmi, disk) {
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
 	}
 }
 
-func addVolume(vmi *kvirtv1.VirtualMachineInstance, volume kvirtv1.Volume) {
+func addVolume(vmi *v1.VirtualMachineInstance, volume v1.Volume) {
 	if !volumeExists(vmi, volume) {
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
 	}
 }
 
-func getVolume(vmi *kvirtv1.VirtualMachineInstance, name string) *kvirtv1.Volume {
+func getVolume(vmi *v1.VirtualMachineInstance, name string) *v1.Volume {
 	for i := range vmi.Spec.Volumes {
 		if vmi.Spec.Volumes[i].Name == name {
 			return &vmi.Spec.Volumes[i]
@@ -54,7 +53,7 @@ func getVolume(vmi *kvirtv1.VirtualMachineInstance, name string) *kvirtv1.Volume
 	return nil
 }
 
-func diskExists(vmi *kvirtv1.VirtualMachineInstance, disk kvirtv1.Disk) bool {
+func diskExists(vmi *v1.VirtualMachineInstance, disk v1.Disk) bool {
 	for _, d := range vmi.Spec.Domain.Devices.Disks {
 		if d.Name == disk.Name {
 			return true
@@ -63,7 +62,7 @@ func diskExists(vmi *kvirtv1.VirtualMachineInstance, disk kvirtv1.Disk) bool {
 	return false
 }
 
-func volumeExists(vmi *kvirtv1.VirtualMachineInstance, volume kvirtv1.Volume) bool {
+func volumeExists(vmi *v1.VirtualMachineInstance, volume v1.Volume) bool {
 	for _, v := range vmi.Spec.Volumes {
 		if v.Name == volume.Name {
 			return true
@@ -72,26 +71,26 @@ func volumeExists(vmi *kvirtv1.VirtualMachineInstance, volume kvirtv1.Volume) bo
 	return false
 }
 
-func newDisk(name string, bus v1.DiskBus) kvirtv1.Disk {
-	return kvirtv1.Disk{
+func newDisk(name string, bus v1.DiskBus) v1.Disk {
+	return v1.Disk{
 		Name: name,
-		DiskDevice: kvirtv1.DiskDevice{
-			Disk: &kvirtv1.DiskTarget{
+		DiskDevice: v1.DiskDevice{
+			Disk: &v1.DiskTarget{
 				Bus: bus,
 			},
 		},
 	}
 }
 
-func newVolume(name string) kvirtv1.Volume {
-	return kvirtv1.Volume{Name: name}
+func newVolume(name string) v1.Volume {
+	return v1.Volume{Name: name}
 }
 
-func newContainerVolume(name, image string) kvirtv1.Volume {
-	return kvirtv1.Volume{
+func newContainerVolume(name, image string) v1.Volume {
+	return v1.Volume{
 		Name: name,
-		VolumeSource: kvirtv1.VolumeSource{
-			ContainerDisk: &kvirtv1.ContainerDiskSource{
+		VolumeSource: v1.VolumeSource{
+			ContainerDisk: &v1.ContainerDiskSource{
 				Image: image,
 			},
 		},

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -26,16 +26,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 
-	kvirtv1 "kubevirt.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 )
 
 // Option represents an action that enables an option.
-type Option func(vmi *kvirtv1.VirtualMachineInstance)
+type Option func(vmi *v1.VirtualMachineInstance)
 
 // New instantiates a new VMI configuration,
 // building its properties based on the specified With* options.
-func New(opts ...Option) *kvirtv1.VirtualMachineInstance {
+func New(opts ...Option) *v1.VirtualMachineInstance {
 	vmi := baseVmi(randName())
 
 	WithTerminationGracePeriod(0)(vmi)
@@ -48,12 +47,13 @@ func New(opts ...Option) *kvirtv1.VirtualMachineInstance {
 
 // randName returns a random name for a virtual machine
 func randName() string {
-	return "testvmi" + "-" + rand.String(5)
+	const randomPostfixLen = 5
+	return "testvmi" + "-" + rand.String(randomPostfixLen)
 }
 
 // WithLabel sets a label with specified value
 func WithLabel(key, value string) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Labels == nil {
 			vmi.Labels = map[string]string{}
 		}
@@ -63,7 +63,7 @@ func WithLabel(key, value string) Option {
 
 // WithAnnotation adds an annotation with specified value
 func WithAnnotation(key, value string) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Annotations == nil {
 			vmi.Annotations = map[string]string{}
 		}
@@ -73,21 +73,21 @@ func WithAnnotation(key, value string) Option {
 
 // WithTerminationGracePeriod specifies the termination grace period in seconds.
 func WithTerminationGracePeriod(seconds int64) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.TerminationGracePeriodSeconds = &seconds
 	}
 }
 
 // WithRng adds `rng` to the the vmi devices.
 func WithRng() Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Devices.Rng = &kvirtv1.Rng{}
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 	}
 }
 
 // WithResourceMemory specifies the vmi memory resource.
 func WithResourceMemory(value string) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
 			k8sv1.ResourceMemory: resource.MustParse(value),
 		}
@@ -96,7 +96,7 @@ func WithResourceMemory(value string) Option {
 
 // WithNodeSelectorFor ensures that the VMI gets scheduled on the specified node
 func WithNodeSelectorFor(node *k8sv1.Node) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Spec.NodeSelector == nil {
 			vmi.Spec.NodeSelector = map[string]string{}
 		}
@@ -106,7 +106,7 @@ func WithNodeSelectorFor(node *k8sv1.Node) Option {
 
 // WithUefi configures EFI bootloader and SecureBoot.
 func WithUefi(secureBoot bool) Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Firmware = &v1.Firmware{
 			Bootloader: &v1.Bootloader{
 				EFI: &v1.EFI{
@@ -119,18 +119,18 @@ func WithUefi(secureBoot bool) Option {
 
 // WithSEV adds `launchSecurity` with `sev`.
 func WithSEV() Option {
-	return func(vmi *kvirtv1.VirtualMachineInstance) {
+	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
 			SEV: &v1.SEV{},
 		}
 	}
 }
 
-func baseVmi(name string) *kvirtv1.VirtualMachineInstance {
-	vmi := kvirtv1.NewVMIReferenceFromNameWithNS("", name)
-	vmi.Spec = kvirtv1.VirtualMachineInstanceSpec{Domain: kvirtv1.DomainSpec{}}
+func baseVmi(name string) *v1.VirtualMachineInstance {
+	vmi := v1.NewVMIReferenceFromNameWithNS("", name)
+	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}
 	vmi.TypeMeta = k8smetav1.TypeMeta{
-		APIVersion: kvirtv1.GroupVersion.String(),
+		APIVersion: v1.GroupVersion.String(),
 		Kind:       "VirtualMachineInstance",
 	}
 	return vmi


### PR DESCRIPTION
**What this PR does / why we need it**:

The lint target [1] revealed several issues with the covered libvmi
codebase.
The various issues have been fixed by this change.

[1] https://github.com/kubevirt/kubevirt/pull/7908

The original linter report which this change fixed based is:

```
tests/libvmi/cloudinit.go:32:15: string `disk1` has 2 occurrences, make it a constant (goconst)
		diskName := "disk1"
		            ^
tests/libvmi/status.go:28:32: G601: Implicit memory aliasing in for loop. (gosec)
		if controller.IsControlledBy(&pod, vmi) {
		                             ^
tests/libvmi/status.go:29:20: G601: Implicit memory aliasing in for loop. (gosec)
			controlledPod = &pod
			                ^
tests/libvmi/vmi.go:51:39: mnd: Magic number: 5, in <argument> detected (gomnd)
	return "testvmi" + "-" + rand.String(5)
	                                     ^
tests/libvmi/cloudinit.go:25:2: ST1019: package "kubevirt.io/api/core/v1" is being imported more than once (stylecheck)
	kvirtv1 "kubevirt.io/api/core/v1"
	^
tests/libvmi/cloudinit.go:26:2: ST1019(related information): other import of "kubevirt.io/api/core/v1" (stylecheck)
	v1 "kubevirt.io/api/core/v1"
	^
tests/libvmi/storage.go:23:2: ST1019: package "kubevirt.io/api/core/v1" is being imported more than once (stylecheck)
	kvirtv1 "kubevirt.io/api/core/v1"
	^
tests/libvmi/storage.go:24:2: ST1019(related information): other import of "kubevirt.io/api/core/v1" (stylecheck)
	v1 "kubevirt.io/api/core/v1"
	^
tests/libvmi/vmi.go:29:2: ST1019: package "kubevirt.io/api/core/v1" is being imported more than once (stylecheck)
	kvirtv1 "kubevirt.io/api/core/v1"
	^
tests/libvmi/vmi.go:30:2: ST1019(related information): other import of "kubevirt.io/api/core/v1" (stylecheck)
	v1 "kubevirt.io/api/core/v1"
	^
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
