### PR TITLE
[release-0.47] Fixing host model support heterogeneus cluster 

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1005,6 +1005,7 @@ var _ = Describe("Migration watcher", func() {
 			if toDefineHostModelCPU {
 				node.ObjectMeta.Labels = map[string]string{
 					virtv1.HostModelCPULabel + "fake":              "true",
+					virtv1.SupportedHostModelMigrationCPU + "fake": "true",
 					virtv1.HostModelRequiredFeaturesLabel + "fake": "true",
 				}
 			}
@@ -1016,7 +1017,7 @@ var _ = Describe("Migration watcher", func() {
 			expectPodToHaveProperNodeSelector := func(pod *k8sv1.Pod) {
 				podHasCpuModeLabelSelector := false
 				for key, _ := range pod.Spec.NodeSelector {
-					if strings.Contains(key, virtv1.HostModelCPULabel) {
+					if strings.Contains(key, virtv1.SupportedHostModelMigrationCPU) {
 						podHasCpuModeLabelSelector = true
 						break
 					}

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -49,10 +49,9 @@ func (n *NodeLabeller) getMinCpuFeature() cpuFeatures {
 	return n.cpuInfo.models[minCPUModel]
 }
 
-func (n *NodeLabeller) getSupportedCpuModels() []string {
+func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []string {
 	supportedCPUModels := make([]string, 0)
 
-	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
 	if obsoleteCPUsx86 == nil {
 		obsoleteCPUsx86 = util.DefaultObsoleteCPUModels
 	}

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -1,3 +1,4 @@
+//go:build amd64
 // +build amd64
 
 /*
@@ -110,7 +111,7 @@ var _ = Describe("Node-labeller config", func() {
 		err = nlController.loadHostCapabilities()
 		Expect(err).ToNot(HaveOccurred())
 
-		cpuModels := nlController.getSupportedCpuModels()
+		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
 		Expect(len(cpuModels)).To(Equal(3), "number of models must match")
@@ -131,7 +132,7 @@ var _ = Describe("Node-labeller config", func() {
 		err = nlController.loadCPUInfo()
 		Expect(err).ToNot(HaveOccurred())
 
-		cpuModels := nlController.getSupportedCpuModels()
+		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
 		Expect(len(cpuModels)).To(Equal(0), "number of models doesn't match")

--- a/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/core/v1/types.go
@@ -760,8 +760,9 @@ const (
 	// This label represents supported cpu features on the node
 	CPUFeatureLabel = "cpu-feature.node.kubevirt.io/"
 	// This label represents supported cpu models on the node
-	CPUModelLabel = "cpu-model.node.kubevirt.io/"
-	CPUTimerLabel = "cpu-timer.node.kubevirt.io/"
+	CPUModelLabel                  = "cpu-model.node.kubevirt.io/"
+	SupportedHostModelMigrationCPU = "cpu-model-migration.node.kubevirt.io/"
+	CPUTimerLabel                  = "cpu-timer.node.kubevirt.io/"
 	// This label represents supported HyperV features on the node
 	HypervLabel = "hyperv.node.kubevirt.io/"
 	// This label represents vendor of cpu model on the node

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1424,6 +1424,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					if strings.Contains(key, v1.CPUModelLabel) {
 						obsoleteModels[strings.TrimPrefix(key, v1.CPUModelLabel)] = true
 					}
+					if strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
+						obsoleteModels[strings.TrimPrefix(key, v1.SupportedHostModelMigrationCPU)] = true
+					}
 				}
 
 				kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
@@ -1435,7 +1438,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				found := false
 				label := ""
 				for key := range node.Labels {
-					if strings.Contains(key, v1.CPUModelLabel) {
+					if strings.Contains(key, v1.CPUModelLabel) || strings.Contains(key, v1.SupportedHostModelMigrationCPU) {
 						found = true
 						label = key
 						break

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2087,7 +2087,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				By("Ensuring that target pod has correct nodeSelector label")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(vmiPod.Spec.NodeSelector).To(HaveKey(v1.HostModelCPULabel+hostModel),
+				Expect(vmiPod.Spec.NodeSelector).To(HaveKey(v1.SupportedHostModelMigrationCPU+hostModel),
 					"target pod is expected to have correct nodeSelector label defined")
 
 				By("Ensuring that target node has correct CPU mode & features")
@@ -2804,6 +2804,149 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			Expect(imageIDs).To(HaveKeyWithValue(container.Name, digest), "expected image:%s for container %s to be the same like on the source pod but got %s", container.Image, container.Name, imageIDs[container.Name])
 		}
 	})
+	Context("[Serial]Testing host-model cpuModel edge cases in the cluster if the cluster is host-model migratable", func() {
+
+		var backedUpTargetNode *k8sv1.Node
+		var sourceNode *k8sv1.Node
+		var targetNode *k8sv1.Node
+
+		BeforeEach(func() {
+			sourceNode, targetNode, err = tests.GetValidSourceNodeAndTargetNodeForHostModelMigration(virtClient)
+			if err != nil {
+				Skip(err.Error())
+			}
+			disableNodeLabeller(targetNode, virtClient)
+		})
+
+		AfterEach(func() {
+			By("Restore node to its original state")
+			Eventually(func() error {
+				targetNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), targetNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				delete(targetNode.Annotations, v1.LabellerSkipNodeAnnotation)
+				_, err = virtClient.CoreV1().Nodes().Update(context.Background(), targetNode, metav1.UpdateOptions{})
+				return err
+			}, 10*time.Second, 1*time.Second).Should(BeNil())
+			wakeNodeLabellerUp(virtClient)
+			Eventually(func() bool {
+				backedUpTargetNode, err = virtClient.CoreV1().Nodes().Get(context.Background(), targetNode.Name, metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				_, amazingFeatureExist := backedUpTargetNode.Labels[v1.HostModelRequiredFeaturesLabel+"amazingFeature"]
+				_, amazingHostModelExist := backedUpTargetNode.Labels[v1.HostModelCPULabel+"amazingHostModel"]
+				_, skipNodeExist := backedUpTargetNode.Annotations[v1.LabellerSkipNodeAnnotation]
+				return amazingFeatureExist || amazingHostModelExist || skipNodeExist
+			}, 30*time.Second, 1*time.Second).Should(Equal(false), "Node should not have amazingFeature or amazing host-model after the test")
+
+		})
+
+		It("Should be able to migrate back to the initial node from target node with host-model even if target is newer than source", func() {
+			targetNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), targetNode.Name, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			targetNode.Labels[v1.HostModelRequiredFeaturesLabel+"amazingFeature"] = "true"
+			Eventually(func() error {
+				if targetNode, err = virtClient.CoreV1().Nodes().Update(context.Background(), targetNode, metav1.UpdateOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+
+			vmiToMigrate := libvmi.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			By("Creating a VMI with default CPU mode to land in source node")
+			vmiToMigrate.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+			By("Making sure the vmi start running on the source node and will be able to run only in source/target nodes")
+			nodeAffinityRule, err := tests.AffinityToMigrateFromSourceToTargetAndBack(sourceNode, targetNode)
+			Expect(err).ToNot(HaveOccurred())
+			vmiToMigrate.Spec.Affinity = &k8sv1.Affinity{
+				NodeAffinity: nodeAffinityRule,
+			}
+			By("Starting the VirtualMachineInstance")
+			vmiToMigrate = runVMIAndExpectLaunch(vmiToMigrate, 240)
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
+			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
+
+			// execute a migration, wait for finalized state
+			By("Starting the Migration to target node(with the amazing feature")
+			migration := tests.NewRandomMigration(vmiToMigrate.Name, vmiToMigrate.Namespace)
+			tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+
+			vmiToMigrate, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiToMigrate.GetName(), &metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(targetNode.Name))
+
+			labelsBeforeMigration := make(map[string]string)
+			labelsAfterMigration := make(map[string]string)
+			By("Fetching virt-launcher pod")
+			virtLauncherPod := tests.GetRunningPodByVirtualMachineInstance(vmiToMigrate, util.NamespaceTestDefault)
+			for key, value := range virtLauncherPod.Spec.NodeSelector {
+				if strings.HasPrefix(key, v1.CPUFeatureLabel) {
+					labelsBeforeMigration[key] = value
+				}
+			}
+
+			By("Starting the Migration to return to the source node")
+			tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
+
+			vmiToMigrate, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiToMigrate.GetName(), &metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
+			By("Fetching virt-launcher pod")
+			virtLauncherPod = tests.GetRunningPodByVirtualMachineInstance(vmiToMigrate, util.NamespaceTestDefault)
+			for key, value := range virtLauncherPod.Spec.NodeSelector {
+				if strings.HasPrefix(key, v1.CPUFeatureLabel) {
+					labelsAfterMigration[key] = value
+				}
+			}
+			Expect(labelsAfterMigration).To(BeEquivalentTo(labelsBeforeMigration))
+		})
+
+		It("vmi with host-model should be able to migrate to node that support the initial node's host-model even if this model isn't the target's host-model", func() {
+			targetNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), targetNode.Name, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			targetHostModel := tests.GetNodeHostModel(targetNode)
+			delete(targetNode.Labels, v1.HostModelCPULabel+targetHostModel)
+			targetNode.Labels[v1.HostModelCPULabel+"amazingHostModel"] = "true"
+			Eventually(func() error {
+				if targetNode, err = virtClient.CoreV1().Nodes().Update(context.Background(), targetNode, metav1.UpdateOptions{}); err != nil {
+					return err
+				}
+				return nil
+			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+
+			vmiToMigrate := libvmi.NewFedora(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			By("Creating a VMI with default CPU mode to land in source node")
+			vmiToMigrate.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
+			By("Making sure the vmi start running on the source node and will be able to run only in source/target nodes")
+			nodeAffinityRule, err := tests.AffinityToMigrateFromSourceToTargetAndBack(sourceNode, targetNode)
+			Expect(err).ToNot(HaveOccurred())
+			vmiToMigrate.Spec.Affinity = &k8sv1.Affinity{
+				NodeAffinity: nodeAffinityRule,
+			}
+			By("Starting the VirtualMachineInstance")
+			vmiToMigrate = runVMIAndExpectLaunch(vmiToMigrate, 240)
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(sourceNode.Name))
+			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
+
+			// execute a migration, wait for finalized state
+			By("Starting the Migration to target node(with the amazing feature")
+			migration := tests.NewRandomMigration(vmiToMigrate.Name, vmiToMigrate.Namespace)
+			tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+
+			vmiToMigrate, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmiToMigrate.GetName(), &metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(vmiToMigrate.Status.NodeName).To(Equal(targetNode.Name))
+			Expect(console.LoginToFedora(vmiToMigrate)).To(Succeed())
+
+		})
+	})
 })
 
 func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
@@ -2841,4 +2984,37 @@ func temporaryTLSConfig() *tls.Config {
 			return &cert, nil
 		},
 	}
+}
+func disableNodeLabeller(node *k8sv1.Node, virtClient kubecli.KubevirtClient) *k8sv1.Node {
+	Eventually(func() error {
+		node, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		node.Annotations[v1.LabellerSkipNodeAnnotation] = "true"
+
+		node, err = virtClient.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+		return err
+
+	}, 10*time.Second, 1*time.Second).Should(BeNil())
+
+	Eventually(func() bool {
+		node, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		value, ok := node.Annotations[v1.LabellerSkipNodeAnnotation]
+		return ok && value == "true"
+	}, 30*time.Second, time.Second).Should(BeTrue())
+
+	return node
+}
+func wakeNodeLabellerUp(virtClient kubecli.KubevirtClient) {
+	const fakeModel = "fake-model-1423"
+
+	By("Updating Kubevirt CR to wake node-labeller up")
+	kvConfig := util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
+	if kvConfig.ObsoleteCPUModels == nil {
+		kvConfig.ObsoleteCPUModels = make(map[string]bool)
+	}
+	kvConfig.ObsoleteCPUModels[fakeModel] = true
+	tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+	delete(kvConfig.ObsoleteCPUModels, fakeModel)
+	tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5203,3 +5203,115 @@ func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, 
 
 	return addVolumeName
 }
+
+func GetNodeHostModel(node *k8sv1.Node) (hostModel string) {
+	for key, _ := range node.Labels {
+		if strings.HasPrefix(key, v1.HostModelCPULabel) {
+			hostModel = strings.TrimPrefix(key, v1.HostModelCPULabel)
+			break
+		}
+	}
+	return hostModel
+}
+func GetValidSourceNodeAndTargetNodeForHostModelMigration(virtCli kubecli.KubevirtClient) (sourceNode *k8sv1.Node, targetNode *k8sv1.Node, err error) {
+	getNodeHostRequiredFeatures := func(node *k8sv1.Node) (features []string) {
+		for key, _ := range node.Labels {
+			if strings.HasPrefix(key, v1.HostModelRequiredFeaturesLabel) {
+				features = append(features, strings.TrimPrefix(key, v1.HostModelRequiredFeaturesLabel))
+			}
+		}
+		return features
+	}
+	doesFeaturesSupportedOnNode := func(node *k8sv1.Node, features []string) bool {
+		isFeatureSupported := func(feature string) bool {
+			for key, _ := range node.Labels {
+				if strings.HasPrefix(key, v1.CPUFeatureLabel) && strings.Contains(key, feature) {
+					return true
+				}
+			}
+			return false
+		}
+		for _, feature := range features {
+			if !isFeatureSupported(feature) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	var sourceHostCpuModel string
+
+	nodes := GetAllSchedulableNodes(virtCli)
+	Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
+	for _, potentialSourceNode := range nodes.Items {
+		for _, potentialTargetNode := range nodes.Items {
+			if potentialSourceNode.Name == potentialTargetNode.Name {
+				continue
+			}
+
+			sourceHostCpuModel = GetNodeHostModel(&potentialSourceNode)
+			if sourceHostCpuModel == "" {
+				continue
+			}
+			supportedInTarget := false
+			for key, _ := range potentialTargetNode.Labels {
+				if strings.HasPrefix(key, v1.SupportedHostModelMigrationCPU) && strings.Contains(key, sourceHostCpuModel) {
+					supportedInTarget = true
+					break
+				}
+			}
+
+			if supportedInTarget == false {
+				continue
+			}
+			sourceNodeHostModelRequiredFeatures := getNodeHostRequiredFeatures(&potentialSourceNode)
+			if doesFeaturesSupportedOnNode(&potentialTargetNode, sourceNodeHostModelRequiredFeatures) == false {
+				continue
+			}
+			return &potentialSourceNode, &potentialTargetNode, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("couldn't find valid nodes for host-model migration")
+}
+
+func AffinityToMigrateFromSourceToTargetAndBack(sourceNode *k8sv1.Node, targetNode *k8sv1.Node) (nodefiinity *k8sv1.NodeAffinity, err error) {
+	if sourceNode == nil || targetNode == nil {
+		return nil, fmt.Errorf("couldn't find valid nodes for host-model migration")
+	}
+	return &k8sv1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+			NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+				{
+					MatchExpressions: []k8sv1.NodeSelectorRequirement{
+						{
+							Key:      "kubernetes.io/hostname",
+							Operator: k8sv1.NodeSelectorOpIn,
+							Values:   []string{sourceNode.Name, targetNode.Name},
+						},
+					},
+				},
+			},
+		},
+		PreferredDuringSchedulingIgnoredDuringExecution: []k8sv1.PreferredSchedulingTerm{
+			{
+				Preference: k8sv1.NodeSelectorTerm{
+					MatchExpressions: []k8sv1.NodeSelectorRequirement{
+						{
+							Key:      "kubernetes.io/hostname",
+							Operator: k8sv1.NodeSelectorOpIn,
+							Values:   []string{sourceNode.Name},
+						},
+					},
+				},
+				Weight: 1,
+			},
+		},
+	}, nil
+}
+
+func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
+	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true"})
+	Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
+	return nodes
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Calculate selectors only for the initial Node to remeber the required features,
allow vmi with host-model to migrate when target node does't have the same host-model cpuModel.
manual backporting https://github.com/kubevirt/kubevirt/pull/7672 ,https://github.com/kubevirt/kubevirt/pull/7770 from main
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
