### PR TITLE
Remove identity stripping logic leftovers from restore controller

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -393,20 +393,6 @@ func (t *vmRestoreTarget) Ready() (bool, error) {
 	return !exists, nil
 }
 
-func stripIdentityInfo(vm *kubevirtv1.VirtualMachine) {
-	vmTemplate := vm.Spec.Template
-	if vmTemplate == nil {
-		return
-	}
-
-	fw := vmTemplate.Spec.Domain.Firmware
-	if fw == nil {
-		return
-	}
-
-	fw.UUID = ""
-}
-
 func (t *vmRestoreTarget) Reconcile() (bool, error) {
 	log.Log.Object(t.vmRestore).V(3).Info("Reconciling VM")
 
@@ -547,7 +533,6 @@ func (t *vmRestoreTarget) Reconcile() (bool, error) {
 			Status: kubevirtv1.VirtualMachineStatus{},
 		}
 
-		stripIdentityInfo(newVM)
 	} else {
 		newVM = t.vm.DeepCopy()
 		newVM.Spec = *snapshotVM.Spec.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up PR to https://github.com/kubevirt/kubevirt/pull/7807.

As laid out in [this comment](https://github.com/kubevirt/kubevirt/pull/7807#discussion_r901681007), no identity stripping logic should reside within snapshot / restore controllers, but only at the [cloning controller](https://github.com/kubevirt/kubevirt/pull/7336).

This PR removed the identity stripping from snapshot package. Instead, the functional tests now use a custom patch to strip the firmware UUID.

**Special notes for your reviewer**:
Please read this comment for some more context: https://github.com/kubevirt/kubevirt/pull/7807#discussion_r901681007

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
