### PR TITLE
Refactor virt controller template resources

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "multus_annotations.go",
         "rendercontainer.go",
+        "renderresources.go",
         "rendervolumes.go",
         "template.go",
     ],
@@ -44,6 +45,7 @@ go_test(
     srcs = [
         "multus_annotations_test.go",
         "rendercontainer_test.go",
+        "renderresources_test.go",
         "rendervolumes_test.go",
         "services_suite_test.go",
         "template_test.go",

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -3,6 +3,12 @@ package services
 import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/downwardmetrics"
+	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 )
 
 type ResourceRenderer struct {
@@ -43,4 +49,104 @@ func copyResources(srcResources, dstResources k8sv1.ResourceList) {
 	for key, value := range srcResources {
 		dstResources[key] = value
 	}
+}
+
+// GetMemoryOverhead computes the estimation of total
+// memory needed for the domain to operate properly.
+// This includes the memory needed for the guest and memory
+// for Qemu and OS overhead.
+//
+// The return value is overhead memory quantity
+//
+// Note: This is the best estimation we were able to come up with
+//       and is still not 100% accurate
+func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource.Quantity {
+	domain := vmi.Spec.Domain
+	vmiMemoryReq := domain.Resources.Requests.Memory()
+
+	overhead := resource.NewScaledQuantity(0, resource.Kilo)
+
+	// Add the memory needed for pagetables (one bit for every 512b of RAM size)
+	pagetableMemory := resource.NewScaledQuantity(vmiMemoryReq.ScaledValue(resource.Kilo), resource.Kilo)
+	pagetableMemory.Set(pagetableMemory.Value() / 512)
+	overhead.Add(*pagetableMemory)
+
+	// Add fixed overhead for KubeVirt components, as seen in a random run, rounded up to the nearest MiB
+	// Note: shared libraries are included in the size, so every library is counted (wrongly) as many times as there are
+	//   processes using it. However, the extra memory is only in the order of 10MiB and makes for a nice safety margin.
+	overhead.Add(resource.MustParse(VirtLauncherMonitorOverhead))
+	overhead.Add(resource.MustParse(VirtLauncherOverhead))
+	overhead.Add(resource.MustParse(VirtlogdOverhead))
+	overhead.Add(resource.MustParse(LibvirtdOverhead))
+	overhead.Add(resource.MustParse(QemuOverhead))
+
+	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
+	// overhead per vcpu in MiB
+	coresMemory := resource.MustParse("8Mi")
+	var vcpus int64
+	if domain.CPU != nil {
+		vcpus = hardware.GetNumberOfVCPUs(domain.CPU)
+	} else {
+		// Currently, a default guest CPU topology is set by the API webhook mutator, if not set by a user.
+		// However, this wasn't always the case.
+		// In case when the guest topology isn't set, take value from resources request or limits.
+		resources := vmi.Spec.Domain.Resources
+		if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
+			vcpus = cpuLimit.Value()
+		} else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
+			vcpus = cpuRequests.Value()
+		}
+	}
+
+	// if neither CPU topology nor request or limits provided, set vcpus to 1
+	if vcpus < 1 {
+		vcpus = 1
+	}
+	value := coresMemory.Value() * vcpus
+	coresMemory = *resource.NewQuantity(value, coresMemory.Format)
+	overhead.Add(coresMemory)
+
+	// static overhead for IOThread
+	overhead.Add(resource.MustParse("8Mi"))
+
+	// Add video RAM overhead
+	if domain.Devices.AutoattachGraphicsDevice == nil || *domain.Devices.AutoattachGraphicsDevice == true {
+		overhead.Add(resource.MustParse("16Mi"))
+	}
+
+	// When use uefi boot on aarch64 with edk2 package, qemu will create 2 pflash(64Mi each, 128Mi in total)
+	// it should be considered for memory overhead
+	// Additional information can be found here: https://github.com/qemu/qemu/blob/master/hw/arm/virt.c#L120
+	if cpuArch == "arm64" {
+		overhead.Add(resource.MustParse("128Mi"))
+	}
+
+	// Additional overhead of 1G for VFIO devices. VFIO requires all guest RAM to be locked
+	// in addition to MMIO memory space to allow DMA. 1G is often the size of reserved MMIO space on x86 systems.
+	// Additial information can be found here: https://www.redhat.com/archives/libvir-list/2015-November/msg00329.html
+	if util.IsVFIOVMI(vmi) {
+		overhead.Add(resource.MustParse("1Gi"))
+	}
+
+	// DownardMetrics volumes are using emptyDirs backed by memory.
+	// the max. disk size is only 256Ki.
+	if downwardmetrics.HasDownwardMetricDisk(vmi) {
+		overhead.Add(resource.MustParse("1Mi"))
+	}
+
+	addProbeOverheads(vmi, overhead)
+
+	// Consider memory overhead for SEV guests.
+	// Additional information can be found here: https://libvirt.org/kbase/launch_security_sev.html#memory
+	if util.IsSEVVMI(vmi) {
+		overhead.Add(resource.MustParse("256Mi"))
+	}
+
+	// Having a TPM device will spawn a swtpm process
+	// In `ps`, swtpm has VSZ of 53808 and RSS of 3496, so 53Mi should do
+	if vmi.Spec.Domain.Devices.TPM != nil {
+		overhead.Add(resource.MustParse("53Mi"))
+	}
+
+	return overhead
 }

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -360,26 +360,19 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource
 // Hence we don't copy Limits value to Requests if the latter is missing.
 func requestResource(resources *k8sv1.ResourceRequirements, resourceName string) {
 	name := k8sv1.ResourceName(resourceName)
+	bumpResources(resources.Limits, name)
+	bumpResources(resources.Requests, name)
+}
 
-	// assume resources are countable, singular, and cannot be divided
+func bumpResources(resources k8sv1.ResourceList, name k8sv1.ResourceName) {
 	unitQuantity := *resource.NewQuantity(1, resource.DecimalSI)
 
-	// Fill in limits
-	val, ok := resources.Limits[name]
+	val, ok := resources[name]
 	if ok {
 		val.Add(unitQuantity)
-		resources.Limits[name] = val
+		resources[name] = val
 	} else {
-		resources.Limits[name] = unitQuantity
-	}
-
-	// Fill in requests
-	val, ok = resources.Requests[name]
-	if ok {
-		val.Add(unitQuantity)
-		resources.Requests[name] = val
-	} else {
-		resources.Requests[name] = unitQuantity
+		resources[name] = unitQuantity
 	}
 }
 

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -27,6 +27,31 @@ type ResourceRenderer struct {
 	calculatedRequests k8sv1.ResourceList
 }
 
+type resourcePredicate func(*v1.VirtualMachineInstance) bool
+
+type VMIResourcePredicates struct {
+	resourceRules []VMIResourceRule
+	vmi           *v1.VirtualMachineInstance
+}
+
+type VMIResourceRule struct {
+	predicate resourcePredicate
+	option    ResourceRendererOption
+}
+
+func not(p resourcePredicate) resourcePredicate {
+	return func(vmi *v1.VirtualMachineInstance) bool {
+		return !p(vmi)
+	}
+}
+func NewVMIResourceRule(p resourcePredicate, option ResourceRendererOption) VMIResourceRule {
+	return VMIResourceRule{predicate: p, option: option}
+}
+
+func doesVMIRequireDedicatedCPU(vmi *v1.VirtualMachineInstance) bool {
+	return vmi.IsCPUDedicated()
+}
+
 func NewResourceRenderer(vmLimits k8sv1.ResourceList, vmRequests k8sv1.ResourceList, options ...ResourceRendererOption) *ResourceRenderer {
 	limits := map[k8sv1.ResourceName]resource.Quantity{}
 	requests := map[k8sv1.ResourceName]resource.Quantity{}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type ResourceRenderer struct {
+	vmLimits           k8sv1.ResourceList
+	vmRequests         k8sv1.ResourceList
+	calculatedLimits   k8sv1.ResourceList
+	calculatedRequests k8sv1.ResourceList
+}
+
+func NewResourceRenderer(vmLimits k8sv1.ResourceList, vmRequests k8sv1.ResourceList) *ResourceRenderer {
+	limits := map[k8sv1.ResourceName]resource.Quantity{}
+	requests := map[k8sv1.ResourceName]resource.Quantity{}
+	copyResources(vmLimits, limits)
+	copyResources(vmRequests, requests)
+	return &ResourceRenderer{
+		vmLimits:           limits,
+		vmRequests:         requests,
+		calculatedLimits:   map[k8sv1.ResourceName]resource.Quantity{},
+		calculatedRequests: map[k8sv1.ResourceName]resource.Quantity{},
+	}
+}
+
+func (rr *ResourceRenderer) Limits() k8sv1.ResourceList {
+	podLimits := map[k8sv1.ResourceName]resource.Quantity{}
+	copyResources(rr.calculatedLimits, podLimits)
+	copyResources(rr.vmLimits, podLimits)
+	return podLimits
+}
+
+func (rr *ResourceRenderer) Requests() k8sv1.ResourceList {
+	podRequests := map[k8sv1.ResourceName]resource.Quantity{}
+	copyResources(rr.calculatedRequests, podRequests)
+	copyResources(rr.vmRequests, podRequests)
+	return podRequests
+}
+
+func copyResources(srcResources, dstResources k8sv1.ResourceList) {
+	for key, value := range srcResources {
+		dstResources[key] = value
+	}
+}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -452,3 +452,15 @@ func validatePermittedHostDevices(spec *v1.VirtualMachineInstanceSpec, config *v
 
 	return nil
 }
+
+func sidecarResources(vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements {
+	resources := k8sv1.ResourceRequirements{}
+	// add default cpu and memory limits to enable cpu pinning if requested
+	// TODO(vladikr): make the hookSidecar express resources
+	if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
+		resources.Limits = make(k8sv1.ResourceList)
+		resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("200m")
+		resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("64M")
+	}
+	return resources
+}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -464,3 +464,38 @@ func sidecarResources(vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements
 	}
 	return resources
 }
+
+func initContainerResourceRequirementsForVMI(vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements {
+	if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
+		return k8sv1.ResourceRequirements{
+			Limits:   initContainerDedicatedCPURequiredResources(),
+			Requests: initContainerDedicatedCPURequiredResources(),
+		}
+	} else {
+		return k8sv1.ResourceRequirements{
+			Limits:   initContainerMinimalLimits(),
+			Requests: initContainerMinimalRequests(),
+		}
+	}
+}
+
+func initContainerDedicatedCPURequiredResources() k8sv1.ResourceList {
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    resource.MustParse("10m"),
+		k8sv1.ResourceMemory: resource.MustParse("40M"),
+	}
+}
+
+func initContainerMinimalLimits() k8sv1.ResourceList {
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    resource.MustParse("100m"),
+		k8sv1.ResourceMemory: resource.MustParse("40M"),
+	}
+}
+
+func initContainerMinimalRequests() k8sv1.ResourceList {
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    resource.MustParse("10m"),
+		k8sv1.ResourceMemory: resource.MustParse("1M"),
+	}
+}

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -128,6 +128,21 @@ func WithHugePages(vmMemory *v1.Memory, memoryOverhead *resource.Quantity) Resou
 	}
 }
 
+func WithMemoryOverhead(guestResourceSpec v1.ResourceRequirements, memoryOverhead *resource.Quantity) ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		memoryRequest := renderer.vmRequests[k8sv1.ResourceMemory]
+		if !guestResourceSpec.OvercommitGuestOverhead {
+			memoryRequest.Add(*memoryOverhead)
+		}
+		renderer.vmRequests[k8sv1.ResourceMemory] = memoryRequest
+
+		if memoryLimit, ok := renderer.vmLimits[k8sv1.ResourceMemory]; ok {
+			memoryLimit.Add(*memoryOverhead)
+			renderer.vmLimits[k8sv1.ResourceMemory] = memoryLimit
+		}
+	}
+}
+
 func copyResources(srcResources, dstResources k8sv1.ResourceList) {
 	for key, value := range srcResources {
 		dstResources[key] = value

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -220,6 +220,15 @@ func WithHostDevices(hostDevices []v1.HostDevice) ResourceRendererOption {
 	}
 }
 
+func WithSEV() ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		resources := renderer.ResourceRequirements()
+		requestResource(&resources, SevDevice)
+		copyResources(resources.Limits, renderer.calculatedLimits)
+		copyResources(resources.Requests, renderer.calculatedRequests)
+	}
+}
+
 func copyResources(srcResources, dstResources k8sv1.ResourceList) {
 	for key, value := range srcResources {
 		dstResources[key] = value

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -25,4 +26,31 @@ var _ = Describe("Resource pod spec renderer", func() {
 		Expect(rr.Limits()).To(BeEmpty())
 		Expect(rr.Requests()).To(ConsistOf(resource.MustParse("1m"), resource.MustParse("64M")))
 	})
+
+	Context("WithEphemeral option", func() {
+		It("adds an expected 50M memory overhead", func() {
+			thirtyMegabytes := resource.MustParse("30M")
+			seventyMegabytes := resource.MustParse("70M")
+			ephemeralStorageRequests := kubev1.ResourceList{kubev1.ResourceEphemeralStorage: thirtyMegabytes}
+			ephemeralStorageLimit := kubev1.ResourceList{kubev1.ResourceEphemeralStorage: seventyMegabytes}
+			ephemeralStorageAddition := resource.MustParse(ephemeralStorageOverheadSize)
+
+			rr = NewResourceRenderer(ephemeralStorageLimit, ephemeralStorageRequests, WithEphemeralStorageRequest())
+			Expect(rr.Requests()).To(HaveKeyWithValue(
+				kubev1.ResourceEphemeralStorage,
+				addResources(thirtyMegabytes, ephemeralStorageAddition),
+			))
+			Expect(rr.Limits()).To(HaveKeyWithValue(
+				kubev1.ResourceEphemeralStorage,
+				addResources(seventyMegabytes, ephemeralStorageAddition),
+			))
+		})
+	})
 })
+
+func addResources(firstQuantity resource.Quantity, resources ...resource.Quantity) resource.Quantity {
+	for _, resourceQuantity := range resources {
+		firstQuantity.Add(resourceQuantity)
+	}
+	return firstQuantity
+}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -6,6 +6,8 @@ import (
 
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("Resource pod spec renderer", func() {
@@ -45,6 +47,22 @@ var _ = Describe("Resource pod spec renderer", func() {
 				addResources(seventyMegabytes, ephemeralStorageAddition),
 			))
 		})
+	})
+
+	Context("Default CPU configuration", func() {
+		cpu := &v1.CPU{Cores: 5}
+		It("Requests one CPU per core, when CPU allocation ratio is 1", func() {
+			rr = NewResourceRenderer(nil, nil, WithoutDedicatedCPU(cpu, 1))
+			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("5")))
+			Expect(rr.Limits()).To(BeEmpty())
+		})
+
+		It("Requests 100m per core, when CPU allocation ratio is 10", func() {
+			rr = NewResourceRenderer(nil, nil, WithoutDedicatedCPU(cpu, 10))
+			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("500m")))
+			Expect(rr.Limits()).To(BeEmpty())
+		})
+
 	})
 })
 

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -62,7 +62,6 @@ var _ = Describe("Resource pod spec renderer", func() {
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("500m")))
 			Expect(rr.Limits()).To(BeEmpty())
 		})
-
 	})
 
 	Context("WithMemoryOverhead option", func() {
@@ -241,6 +240,17 @@ var _ = Describe("Resource pod spec renderer", func() {
 			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceName("discombobulator2000"), *resource.NewScaledQuantity(1, 0)))
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceName("discombobulator2000"), *resource.NewScaledQuantity(1, 0)))
 		})
+	})
+
+	It("WithSEV option adds ", func() {
+		sevResourceKey := kubev1.ResourceName("devices.kubevirt.io/sev")
+		rr = NewResourceRenderer(nil, nil, WithSEV())
+		Expect(rr.Requests()).To(Equal(kubev1.ResourceList{
+			sevResourceKey: *resource.NewQuantity(1, resource.DecimalSI),
+		}))
+		Expect(rr.Limits()).To(Equal(kubev1.ResourceList{
+			sevResourceKey: *resource.NewQuantity(1, resource.DecimalSI),
+		}))
 	})
 })
 

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -161,6 +161,34 @@ var _ = Describe("Resource pod spec renderer", func() {
 			})
 		})
 	})
+
+	Context("WithNetworkResources option", func() {
+		It("does not request / set any limit when no network resources are required", func() {
+			rr = NewResourceRenderer(
+				nil,
+				nil,
+				WithNetworkResources(map[string]string{}),
+			)
+			Expect(rr.Limits()).To(BeEmpty())
+			Expect(rr.Requests()).To(BeEmpty())
+		})
+
+		It("adds a request and sets limit for each multus network resource", func() {
+			netToResourceMap := map[string]string{
+				"net1": "res1",
+				"net2": "res44",
+			}
+			rr = NewResourceRenderer(
+				nil,
+				nil,
+				WithNetworkResources(netToResourceMap),
+			)
+			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceName("res1"), *resource.NewScaledQuantity(1, 0)))
+			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceName("res44"), *resource.NewScaledQuantity(1, 0)))
+			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceName("res1"), *resource.NewScaledQuantity(1, 0)))
+			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceName("res44"), *resource.NewScaledQuantity(1, 0)))
+		})
+	})
 })
 
 func addResources(firstQuantity resource.Quantity, resources ...resource.Quantity) resource.Quantity {

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -189,6 +189,59 @@ var _ = Describe("Resource pod spec renderer", func() {
 			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceName("res44"), *resource.NewScaledQuantity(1, 0)))
 		})
 	})
+
+	Context("WithHostDevices / WithGPU option", func() {
+		It("host device requests / limits are absent when not requested", func() {
+			rr = NewResourceRenderer(
+				nil,
+				nil,
+				WithHostDevices([]v1.HostDevice{}),
+			)
+			Expect(rr.Limits()).To(BeEmpty())
+			Expect(rr.Requests()).To(BeEmpty())
+		})
+
+		It("host device requests / limits are honored", func() {
+			hostDevice := v1.HostDevice{
+				Name:       "hd1",
+				DeviceName: "discombobulator2000",
+				Tag:        "not-so-megatag",
+			}
+			hostDevices := []v1.HostDevice{hostDevice}
+			rr = NewResourceRenderer(
+				nil,
+				nil,
+				WithHostDevices(hostDevices),
+			)
+			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceName("discombobulator2000"), *resource.NewScaledQuantity(1, 0)))
+			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceName("discombobulator2000"), *resource.NewScaledQuantity(1, 0)))
+		})
+
+		It("GPU requests / limits are absent when not requested", func() {
+			rr = NewResourceRenderer(
+				nil,
+				nil,
+				WithGPUs([]v1.GPU{}),
+			)
+			Expect(rr.Limits()).To(BeEmpty())
+			Expect(rr.Requests()).To(BeEmpty())
+		})
+
+		It("GPU requests / limits are honored", func() {
+			gp1 := v1.GPU{
+				Name:       "gp1",
+				DeviceName: "discombobulator2000",
+				Tag:        "megatag",
+			}
+			requestedGPUs := []v1.GPU{gp1}
+			rr = NewResourceRenderer(
+				nil,
+				nil,
+				WithGPUs(requestedGPUs))
+			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceName("discombobulator2000"), *resource.NewScaledQuantity(1, 0)))
+			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceName("discombobulator2000"), *resource.NewScaledQuantity(1, 0)))
+		})
+	})
 })
 
 func addResources(firstQuantity resource.Quantity, resources ...resource.Quantity) resource.Quantity {

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kubev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var _ = Describe("Resource pod spec renderer", func() {
+	var rr *ResourceRenderer
+
+	It("an empty resource renderer does not feature requests nor limits", func() {
+		rr = NewResourceRenderer(nil, nil)
+		Expect(rr.Requests()).To(BeEmpty())
+		Expect(rr.Limits()).To(BeEmpty())
+	})
+
+	It("user provided CPU and memory requests are honored", func() {
+		requests := kubev1.ResourceList{
+			kubev1.ResourceCPU:    resource.MustParse("1m"),
+			kubev1.ResourceMemory: resource.MustParse("64M"),
+		}
+		rr = NewResourceRenderer(nil, requests)
+		Expect(rr.Limits()).To(BeEmpty())
+		Expect(rr.Requests()).To(ConsistOf(resource.MustParse("1m"), resource.MustParse("64M")))
+	})
+})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -479,10 +479,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		command = append(command, "--simulate-crash")
 	}
 
-	if util.IsSEVVMI(vmi) {
-		requestResource(&resources, SevDevice)
-	}
-
 	volumeRenderer, err := t.newVolumeRenderer(vmi, namespace, requestedHookSidecarList)
 	if err != nil {
 		return nil, err
@@ -884,6 +880,10 @@ func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance) (*
 
 	if util.IsHostDevVMI(vmi) {
 		options = append(options, WithHostDevices(vmi.Spec.Domain.Devices.HostDevices))
+	}
+
+	if util.IsSEVVMI(vmi) {
+		options = append(options, WithSEV())
 	}
 
 	return NewResourceRenderer(

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -357,54 +357,6 @@ func sysprepVolumeSource(sysprepVolume v1.SysprepSource) (k8sv1.VolumeSource, er
 	return k8sv1.VolumeSource{}, fmt.Errorf(errorStr)
 }
 
-// Request a resource by name. This function bumps the number of resources,
-// both its limits and requests attributes.
-//
-// If we were operating with a regular resource (CPU, memory, network
-// bandwidth), we would need to take care of QoS. For example,
-// https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
-// explains that when Limits are set but Requests are not then scheduler
-// assumes that Requests are the same as Limits for a particular resource.
-//
-// But this function is not called for this standard resources but for
-// resources managed by device plugins. The device plugin design document says
-// the following on the matter:
-// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md#end-user-story
-//
-// ```
-// Devices can be selected using the same process as for OIRs in the pod spec.
-// Devices have no impact on QOS. However, for the alpha, we expect the request
-// to have limits == requests.
-// ```
-//
-// Which suggests that, for resources managed by device plugins, 1) limits
-// should be equal to requests; and 2) QoS rules do not apVFIO//
-// Hence we don't copy Limits value to Requests if the latter is missing.
-func requestResource(resources *k8sv1.ResourceRequirements, resourceName string) {
-	name := k8sv1.ResourceName(resourceName)
-
-	// assume resources are countable, singular, and cannot be divided
-	unitQuantity := *resource.NewQuantity(1, resource.DecimalSI)
-
-	// Fill in limits
-	val, ok := resources.Limits[name]
-	if ok {
-		val.Add(unitQuantity)
-		resources.Limits[name] = val
-	} else {
-		resources.Limits[name] = unitQuantity
-	}
-
-	// Fill in requests
-	val, ok = resources.Requests[name]
-	if ok {
-		val.Add(unitQuantity)
-		resources.Requests[name] = val
-	} else {
-		resources.Requests[name] = unitQuantity
-	}
-}
-
 func (t *templateService) GetLauncherImage() string {
 	return t.launcherImage
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -36,8 +36,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
-	"kubevirt.io/kubevirt/pkg/downwardmetrics"
-
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -1401,106 +1399,6 @@ func appendUniqueImagePullSecret(secrets []k8sv1.LocalObjectReference, newsecret
 		}
 	}
 	return append(secrets, newsecret)
-}
-
-// GetMemoryOverhead computes the estimation of total
-// memory needed for the domain to operate properly.
-// This includes the memory needed for the guest and memory
-// for Qemu and OS overhead.
-//
-// The return value is overhead memory quantity
-//
-// Note: This is the best estimation we were able to come up with
-//       and is still not 100% accurate
-func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource.Quantity {
-	domain := vmi.Spec.Domain
-	vmiMemoryReq := domain.Resources.Requests.Memory()
-
-	overhead := resource.NewScaledQuantity(0, resource.Kilo)
-
-	// Add the memory needed for pagetables (one bit for every 512b of RAM size)
-	pagetableMemory := resource.NewScaledQuantity(vmiMemoryReq.ScaledValue(resource.Kilo), resource.Kilo)
-	pagetableMemory.Set(pagetableMemory.Value() / 512)
-	overhead.Add(*pagetableMemory)
-
-	// Add fixed overhead for KubeVirt components, as seen in a random run, rounded up to the nearest MiB
-	// Note: shared libraries are included in the size, so every library is counted (wrongly) as many times as there are
-	//   processes using it. However, the extra memory is only in the order of 10MiB and makes for a nice safety margin.
-	overhead.Add(resource.MustParse(VirtLauncherMonitorOverhead))
-	overhead.Add(resource.MustParse(VirtLauncherOverhead))
-	overhead.Add(resource.MustParse(VirtlogdOverhead))
-	overhead.Add(resource.MustParse(LibvirtdOverhead))
-	overhead.Add(resource.MustParse(QemuOverhead))
-
-	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
-	// overhead per vcpu in MiB
-	coresMemory := resource.MustParse("8Mi")
-	var vcpus int64
-	if domain.CPU != nil {
-		vcpus = hardware.GetNumberOfVCPUs(domain.CPU)
-	} else {
-		// Currently, a default guest CPU topology is set by the API webhook mutator, if not set by a user.
-		// However, this wasn't always the case.
-		// In case when the guest topology isn't set, take value from resources request or limits.
-		resources := vmi.Spec.Domain.Resources
-		if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
-			vcpus = cpuLimit.Value()
-		} else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
-			vcpus = cpuRequests.Value()
-		}
-	}
-
-	// if neither CPU topology nor request or limits provided, set vcpus to 1
-	if vcpus < 1 {
-		vcpus = 1
-	}
-	value := coresMemory.Value() * vcpus
-	coresMemory = *resource.NewQuantity(value, coresMemory.Format)
-	overhead.Add(coresMemory)
-
-	// static overhead for IOThread
-	overhead.Add(resource.MustParse("8Mi"))
-
-	// Add video RAM overhead
-	if domain.Devices.AutoattachGraphicsDevice == nil || *domain.Devices.AutoattachGraphicsDevice == true {
-		overhead.Add(resource.MustParse("16Mi"))
-	}
-
-	// When use uefi boot on aarch64 with edk2 package, qemu will create 2 pflash(64Mi each, 128Mi in total)
-	// it should be considered for memory overhead
-	// Additional information can be found here: https://github.com/qemu/qemu/blob/master/hw/arm/virt.c#L120
-	if cpuArch == "arm64" {
-		overhead.Add(resource.MustParse("128Mi"))
-	}
-
-	// Additional overhead of 1G for VFIO devices. VFIO requires all guest RAM to be locked
-	// in addition to MMIO memory space to allow DMA. 1G is often the size of reserved MMIO space on x86 systems.
-	// Additial information can be found here: https://www.redhat.com/archives/libvir-list/2015-November/msg00329.html
-	if util.IsVFIOVMI(vmi) {
-		overhead.Add(resource.MustParse("1Gi"))
-	}
-
-	// DownardMetrics volumes are using emptyDirs backed by memory.
-	// the max. disk size is only 256Ki.
-	if downwardmetrics.HasDownwardMetricDisk(vmi) {
-		overhead.Add(resource.MustParse("1Mi"))
-	}
-
-	addProbeOverheads(vmi, overhead)
-
-	// Consider memory overhead for SEV guests.
-	// Additional information can be found here: https://libvirt.org/kbase/launch_security_sev.html#memory
-	if util.IsSEVVMI(vmi) {
-		overhead.Add(resource.MustParse("256Mi"))
-	}
-
-	// Having a TPM device will spawn a swtpm process
-	// In `ps`, swtpm has VSZ of 53808 and RSS of 3496, so 53Mi should do
-	if vmi.Spec.Domain.Devices.TPM != nil {
-		overhead.Add(resource.MustParse("53Mi"))
-	}
-
-	return overhead
 }
 
 // We need to add this overhead due to potential issues when using exec probes.

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -585,19 +585,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	podLabels[v1.VirtualMachineNameLabel] = hostName
 
 	for i, requestedHookSidecar := range requestedHookSidecarList {
-		resources := k8sv1.ResourceRequirements{}
-		// add default cpu and memory limits to enable cpu pinning if requested
-		// TODO(vladikr): make the hookSidecar express resources
-		if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
-			resources.Limits = make(k8sv1.ResourceList)
-			resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("200m")
-			resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("64M")
-		}
-
 		containers = append(
 			containers,
 			newSidecarContainerRenderer(
-				sidecarContainerName(i), vmi, resources, requestedHookSidecar, userId).Render(requestedHookSidecar.Command))
+				sidecarContainerName(i), vmi, sidecarResources(vmi), requestedHookSidecar, userId).Render(requestedHookSidecar.Command))
 	}
 
 	podAnnotations, err := generatePodAnnotations(vmi)

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -603,22 +603,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	var initContainers []k8sv1.Container
 
 	if HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi) {
-		initContainerResources := k8sv1.ResourceRequirements{}
-		if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
-			initContainerResources.Limits = make(k8sv1.ResourceList)
-			initContainerResources.Limits[k8sv1.ResourceCPU] = resource.MustParse("10m")
-			initContainerResources.Limits[k8sv1.ResourceMemory] = resource.MustParse("40M")
-			initContainerResources.Requests = make(k8sv1.ResourceList)
-			initContainerResources.Requests[k8sv1.ResourceCPU] = resource.MustParse("10m")
-			initContainerResources.Requests[k8sv1.ResourceMemory] = resource.MustParse("40M")
-		} else {
-			initContainerResources.Limits = make(k8sv1.ResourceList)
-			initContainerResources.Limits[k8sv1.ResourceCPU] = resource.MustParse("100m")
-			initContainerResources.Limits[k8sv1.ResourceMemory] = resource.MustParse("40M")
-			initContainerResources.Requests = make(k8sv1.ResourceList)
-			initContainerResources.Requests[k8sv1.ResourceCPU] = resource.MustParse("10m")
-			initContainerResources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1M")
-		}
 		initContainerCommand := []string{"/usr/bin/cp",
 			"/usr/bin/container-disk",
 			"/init/usr/bin/container-disk",
@@ -628,7 +612,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			initContainers,
 			t.newInitContainerRenderer(vmi,
 				initContainerVolumeMount(),
-				initContainerResources,
+				initContainerResourceRequirementsForVMI(vmi),
 				userId).Render(initContainerCommand))
 
 		// this causes containerDisks to be pre-pulled before virt-launcher starts.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR refactors the virt-controller templating service, introducing a builder pattern to generate resource specification.

The ad-hoc generation of resources for the virt-launcher pod is replaced by a builder pattern, allowing the customization of the launcher spec via options.

It provides a simpler, more explicit way to achieve the same thing - resource spec generation becomes easier to write, and a lot easier to read / reason about. Going forward, it even defines a solid ground to expand the functionality of resource spec generation, instead of forcing the developer to find the appropriate nested if else and put his adapter copied code there.

Finally, the added unit tests are a chance to clearly document how to configure each of the relevant options.

**Special notes for your reviewer**:


Following up on PRs:
- #7534
- #7600 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
