### PR TITLE
tests: shorten tests/utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ format:
 fmt: format
 
 lint:
-	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
+	if [ $$(wc -l < tests/utils.go) -gt 2813 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 	hack/dockerized "golangci-lint run --timeout 10m --verbose \
 	  pkg/network/domainspec/... \

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -365,6 +365,8 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 })
 
 func testClientJob(virtCli kubecli.KubevirtClient, withServiceAccount bool, resource string) {
+	const subresourceTestLabel = "subresource-access-test-pod"
+
 	namespace := util.NamespaceTestDefault
 	expectedPhase := k8sv1.PodFailed
 	name := "subresource-access-tester"
@@ -372,7 +374,7 @@ func testClientJob(virtCli kubecli.KubevirtClient, withServiceAccount bool, reso
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
 			Labels: map[string]string{
-				v1.AppLabel: tests.SubresourceTestLabel,
+				v1.AppLabel: subresourceTestLabel,
 			},
 		},
 		Spec: k8sv1.PodSpec{

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -294,10 +294,11 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 	var windowsVMI *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		const OSWindowsSysprep = "windows-sysprep"
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 		checks.SkipIfMissingRequiredImage(virtClient, tests.DiskWindowsSysprep)
-		libstorage.CreatePVC(tests.OSWindowsSysprep, "35Gi", libstorage.Config.StorageClassWindows, true)
+		libstorage.CreatePVC(OSWindowsSysprep, "35Gi", libstorage.Config.StorageClassWindows, true)
 		answerFileWithKey := insertProductKeyToAnswerFileTemplate(answerFileTemplate)
 		tests.CreateConfigMap("sysprepautounattend", map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey})
 		windowsVMI = tests.NewRandomVMI()

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -43,7 +43,6 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	vmsgen "kubevirt.io/kubevirt/tools/vms-generator/utils"
@@ -268,8 +267,9 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 
 		Context("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]with RHEL Template", func() {
 			BeforeEach(func() {
+				const OSRhel = "rhel"
 				checks.SkipIfNoRhelImage(virtClient)
-				libstorage.CreatePVC(tests.OSRhel, "15Gi", libstorage.Config.StorageClassRhel, true)
+				libstorage.CreatePVC(OSRhel, "15Gi", libstorage.Config.StorageClassRhel, true)
 				AssertTemplateSetupSuccess(vmsgen.GetTestTemplateRHEL7(), nil)()
 			})
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -109,8 +109,6 @@ const (
 	EchoLastReturnValue          = "echo $?\n"
 )
 
-const SubresourceTestLabel = "subresource-access-test-pod"
-
 const (
 	OSWindows        = "windows"
 	OSWindowsSysprep = "windows-sysprep" // This is for sysprep tests, they run on a syspreped image of windows of a different version.

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -132,11 +132,6 @@ const VMIResource = "virtualmachineinstances"
 const MigrationWaitTime = 240
 const ContainerCompletionWaitTime = 60
 
-const (
-	cgroupV1cpusetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
-	cgroupV2cpusetPath = "/sys/fs/cgroup/cpuset.cpus.effective"
-)
-
 func TestCleanup() {
 	testsuite.CleanNamespaces()
 	libnode.CleanNodes()
@@ -365,6 +360,11 @@ func getPodsByLabel(label, labelType, namespace string) (*k8sv1.PodList, error) 
 }
 
 func GetPodCPUSet(pod *k8sv1.Pod) (output string, err error) {
+	const (
+		cgroupV1cpusetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+		cgroupV2cpusetPath = "/sys/fs/cgroup/cpuset.cpus.effective"
+	)
+
 	virtClient, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		return

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -112,7 +112,6 @@ const (
 const SubresourceTestLabel = "subresource-access-test-pod"
 
 const (
-	osAlpineHostPath = "alpine-host-path"
 	OSWindows        = "windows"
 	OSWindowsSysprep = "windows-sysprep" // This is for sysprep tests, they run on a syspreped image of windows of a different version.
 	OSRhel           = "rhel"
@@ -153,6 +152,7 @@ func TestCleanup() {
 }
 
 func SetupAlpineHostPath() {
+	const osAlpineHostPath = "alpine-host-path"
 	libstorage.CreateHostPathPv(osAlpineHostPath, testsuite.HostPathAlpine)
 	libstorage.CreateHostPathPVC(osAlpineHostPath, defaultDiskSize)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -109,8 +109,6 @@ const (
 	EchoLastReturnValue          = "echo $?\n"
 )
 
-const defaultTestGracePeriod int64 = 0
-
 const SubresourceTestLabel = "subresource-access-test-pod"
 
 const (

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -124,8 +124,6 @@ const (
 	defaultDiskSize = "1Gi"
 )
 
-const VMIResource = "virtualmachineinstances"
-
 const MigrationWaitTime = 240
 const ContainerCompletionWaitTime = 60
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -129,10 +129,6 @@ const (
 
 const VMIResource = "virtualmachineinstances"
 
-const (
-	tmpPath = "/var/provision/kubevirt.io/tests"
-)
-
 const MigrationWaitTime = 240
 const ContainerCompletionWaitTime = 60
 
@@ -2484,6 +2480,7 @@ func IsRunningOnKindInfra() bool {
 }
 
 func RandTmpDir() string {
+	const tmpPath = "/var/provision/kubevirt.io/tests"
 	return filepath.Join(tmpPath, rand.String(10))
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -110,10 +110,7 @@ const (
 )
 
 const (
-	OSWindows        = "windows"
-	OSWindowsSysprep = "windows-sysprep" // This is for sysprep tests, they run on a syspreped image of windows of a different version.
-	OSRhel           = "rhel"
-	CustomHostPath   = "custom-host-path"
+	CustomHostPath = "custom-host-path"
 )
 
 const (

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -134,10 +134,11 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	var windowsVMI *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		const OSWindows = "windows"
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 		checks.SkipIfMissingRequiredImage(virtClient, tests.DiskWindows)
-		libstorage.CreatePVC(tests.OSWindows, "30Gi", libstorage.Config.StorageClassWindows, true)
+		libstorage.CreatePVC(OSWindows, "30Gi", libstorage.Config.StorageClassWindows, true)
 		windowsVMI = tests.NewRandomVMI()
 		windowsVMI.Spec = getWindowsVMISpec()
 		tests.AddExplicitPodNetworkInterface(windowsVMI)

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -346,7 +346,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the vmi does not exist anymore")
-			result := virtClient.RestClient().Get().Resource(tests.VMIResource).Namespace(k8sv1.NamespaceDefault).Name(windowsVMI.Name).Do(context.Background())
+			result := virtClient.RestClient().Get().Resource("virtualmachineinstances").Namespace(k8sv1.NamespaceDefault).Name(windowsVMI.Name).Do(context.Background())
 			Expect(result).To(testutils.HaveStatusCode(http.StatusNotFound))
 
 			By("Checking that the vmi pod terminated")


### PR DESCRIPTION
tests/utils.go is still too long to read and understand. This PR moves some of its content to more relevant locations.

```release-note
NONE
```
