### PR TITLE
[release-0.44] Backport 'Fix vm restore in case of restore size bigger then PVC requested size'

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -610,6 +610,7 @@ func (vca *VirtControllerApp) initRestoreController() {
 		DataVolumeInformer:        vca.dataVolumeInformer,
 		PVCInformer:               vca.persistentVolumeClaimInformer,
 		StorageClassInformer:      vca.storageClassInformer,
+		VolumeSnapshotProvider:    vca.snapshotController,
 		Recorder:                  recorder,
 	}
 	vca.restoreController.Init()

--- a/pkg/virt-controller/watch/snapshot/restore_base.go
+++ b/pkg/virt-controller/watch/snapshot/restore_base.go
@@ -50,6 +50,8 @@ type VMRestoreController struct {
 	PVCInformer               cache.SharedIndexInformer
 	StorageClassInformer      cache.SharedIndexInformer
 
+	VolumeSnapshotProvider VolumeSnapshotProvider
+
 	Recorder record.EventRecorder
 
 	vmRestoreQueue workqueue.RateLimitingInterface

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/golang/mock/gomock"
+	vsv1beta1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -161,6 +162,17 @@ var _ = Describe("Restore controlleer", func() {
 		}
 	}
 
+	createVolumeSnapshot := func(name string, restoreSize resource.Quantity) *vsv1beta1.VolumeSnapshot {
+		return &vsv1beta1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Status: &vsv1beta1.VolumeSnapshotStatus{
+				RestoreSize: &restoreSize,
+			},
+		}
+	}
+
 	Context("One valid Restore controller given", func() {
 
 		var ctrl *gomock.Controller
@@ -195,6 +207,7 @@ var _ = Describe("Restore controlleer", func() {
 		var controller *VMRestoreController
 		var recorder *record.FakeRecorder
 		var mockVMRestoreQueue *testutils.MockWorkQueue
+		var fakeVolumeSnapshotProvider *MockVolumeSnapshotProvider
 
 		var kubevirtClient *kubevirtfake.Clientset
 		var k8sClient *k8sfake.Clientset
@@ -250,6 +263,10 @@ var _ = Describe("Restore controlleer", func() {
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
 
+			fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
+				volumeSnapshots: []*vsv1beta1.VolumeSnapshot{},
+			}
+
 			controller = &VMRestoreController{
 				Client:                    virtClient,
 				VMRestoreInformer:         vmRestoreInformer,
@@ -262,6 +279,7 @@ var _ = Describe("Restore controlleer", func() {
 				DataVolumeInformer:        dataVolumeInformer,
 				Recorder:                  recorder,
 				vmStatusUpdater:           status.NewVMStatusUpdater(virtClient),
+				VolumeSnapshotProvider:    fakeVolumeSnapshotProvider,
 			}
 			controller.Init()
 
@@ -439,8 +457,54 @@ var _ = Describe("Restore controlleer", func() {
 				}
 				vmSource.Add(vm)
 				addVolumeRestores(r)
+				pvcSize := resource.MustParse("2Gi")
+				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
+				fakeVolumeSnapshotProvider.Add(vs)
 				expectUpdateVMRestoreInProgress(vm)
-				expectPVCCreates(k8sClient, r)
+				expectPVCCreates(k8sClient, r, pvcSize)
+				addVirtualMachineRestore(r)
+				controller.processVMRestoreWorkItem()
+			})
+
+			It("should create restore PVC with volume snapshot size if bigger then PVC size", func() {
+				r := createRestoreWithOwner()
+				vm := createModifiedVM()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: &f,
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
+					},
+				}
+				vmSource.Add(vm)
+				addVolumeRestores(r)
+				q := resource.MustParse("3Gi")
+				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
+				fakeVolumeSnapshotProvider.Add(vs)
+				expectUpdateVMRestoreInProgress(vm)
+				expectPVCCreates(k8sClient, r, q)
+				addVirtualMachineRestore(r)
+				controller.processVMRestoreWorkItem()
+			})
+
+			It("should create restore PVC with pvc size if restore size is smaller", func() {
+				r := createRestoreWithOwner()
+				vm := createModifiedVM()
+				r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+					Complete: &f,
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
+						newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
+					},
+				}
+				vmSource.Add(vm)
+				addVolumeRestores(r)
+				q := resource.MustParse("1Gi")
+				vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, q)
+				fakeVolumeSnapshotProvider.Add(vs)
+				expectUpdateVMRestoreInProgress(vm)
+				pvcSize := resource.MustParse("2Gi")
+				expectPVCCreates(k8sClient, r, pvcSize)
 				addVirtualMachineRestore(r)
 				controller.processVMRestoreWorkItem()
 			})
@@ -651,7 +715,7 @@ var _ = Describe("Restore controlleer", func() {
 	})
 })
 
-func expectPVCCreates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMachineRestore) {
+func expectPVCCreates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMachineRestore, expectedSize resource.Quantity) {
 	client.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 		create, ok := action.(testing.CreateAction)
 		Expect(ok).To(BeTrue())
@@ -660,6 +724,7 @@ func expectPVCCreates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMa
 		found := false
 		for _, vr := range vmRestore.Status.Restores {
 			if vr.PersistentVolumeClaimName == createObj.Name {
+				Expect(createObj.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(expectedSize))
 				found = true
 				break
 			}
@@ -718,4 +783,22 @@ func expectDataVolumeDeletes(client *cdifake.Clientset, names []string) {
 
 		return true, nil, nil
 	})
+}
+
+// A mock to implement volumeSnapshotProvider interface
+type MockVolumeSnapshotProvider struct {
+	volumeSnapshots []*vsv1beta1.VolumeSnapshot
+}
+
+func (v *MockVolumeSnapshotProvider) GetVolumeSnapshot(namespace, name string) (*vsv1beta1.VolumeSnapshot, error) {
+	if len(v.volumeSnapshots) == 0 {
+		return nil, nil
+	}
+	vs := v.volumeSnapshots[0]
+	v.volumeSnapshots = v.volumeSnapshots[1:]
+	return vs, nil
+}
+
+func (v *MockVolumeSnapshotProvider) Add(s *vsv1beta1.VolumeSnapshot) {
+	v.volumeSnapshots = append(v.volumeSnapshots, s)
 }

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -223,7 +223,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 
 		vsName := *volumeBackup.VolumeSnapshotName
 
-		volumeSnapshot, err := ctrl.getVolumeSnapshot(content.Namespace, vsName)
+		volumeSnapshot, err := ctrl.GetVolumeSnapshot(content.Namespace, vsName)
 		if err != nil {
 			return 0, err
 		}

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -599,6 +599,43 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}
 			})
 
+			// This test is relevant to provisioner which round up the recieved size of
+			// the PVC. Currently we only test vmsnapshot tests which ceph which has this
+			// behavior. In case of running this test with other provisioner or if ceph
+			// will change this behavior it will fail.
+			It("should restore a vm with restore size bigger then PVC size", func() {
+				vm = tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
+					tests.GetUrl(tests.CirrosHttpUrl),
+					util.NamespaceTestDefault,
+					"#!/bin/bash\necho 'hello'\n",
+					snapshotStorageClass,
+				)
+				quantity, err := resource.ParseQuantity("1528Mi")
+				Expect(err).ToNot(HaveOccurred())
+				vm.Spec.DataVolumeTemplates[0].Spec.PVC.Resources.Requests["storage"] = quantity
+				vm, vmi = createAndStartVM(vm)
+				expectedCapacity, err := resource.ParseQuantity("2Gi")
+				Expect(err).ToNot(HaveOccurred())
+				pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), vm.Spec.DataVolumeTemplates[0].Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pvc.Status.Capacity["storage"]).To(Equal(expectedCapacity))
+
+				doRestore("", console.LoginToCirros, false)
+
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *snapshot.Status.VirtualMachineSnapshotContentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content.Spec.VolumeBackups[0].PersistentVolumeClaim.Spec.Resources.Requests["storage"]).To(Equal(quantity))
+				vs, err := virtClient.KubernetesSnapshotClient().SnapshotV1beta1().VolumeSnapshots(vm.Namespace).Get(context.Background(), *content.Spec.VolumeBackups[0].VolumeSnapshotName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*vs.Status.RestoreSize).To(Equal(expectedCapacity))
+
+				pvc, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.Background(), restore.Status.Restores[0].PersistentVolumeClaimName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pvc.Status.Capacity["storage"]).To(Equal(expectedCapacity))
+				Expect(pvc.Spec.Resources.Requests["storage"]).To(Equal(expectedCapacity))
+
+			})
+
 			It("[test_id:5260]should restore a vm that boots from a datavolumetemplate", func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					tests.GetUrl(tests.CirrosHttpUrl),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherry pick of PR https://github.com/kubevirt/kubevirt/pull/7933

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2101174

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fix vm restore in case of restore size bigger then PVC requested size
```
