### PR TITLE
[Bug-fix]: Windows VM HyperV Reenlightenment enabled fails to migrate

### DIFF
--- a/pkg/virt-api/webhooks/hyperv.go
+++ b/pkg/virt-api/webhooks/hyperv.go
@@ -25,7 +25,6 @@ package webhooks
 
 import (
 	"fmt"
-	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
@@ -179,17 +178,20 @@ func ValidateVirtualMachineInstanceHypervFeatureDependencies(field *k8sfield.Pat
 		}
 	}
 
-	if spec.Domain.Features != nil && spec.Domain.Features.Hyperv != nil && spec.Domain.Features.Hyperv.EVMCS != nil {
-		if spec.Domain.CPU == nil || spec.Domain.CPU.Features == nil || len(spec.Domain.CPU.Features) == 0 {
-			causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Message: "vmx cpu feature is required when evmcs is set", Field: "spec.domain.cpu.features"})
-		} else if spec.Domain.CPU != nil || spec.Domain.CPU.Features != nil {
-			for i, f := range spec.Domain.CPU.Features {
-				if f.Name == nodelabellerutil.VmxFeature {
-					if f.Policy != nodelabellerutil.RequirePolicy {
-						causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueInvalid, Message: "vmx cpu feature has to be set to " + nodelabellerutil.RequirePolicy + " policy", Field: "spec.domain.cpu.features[" + strconv.Itoa(i) + "].policy"})
-					}
-				}
-			}
+	if spec.Domain.Features == nil || spec.Domain.Features.Hyperv == nil || spec.Domain.Features.Hyperv.EVMCS == nil {
+		return causes
+	}
+
+	evmcsDependency := getEVMCSDependency()
+
+	if spec.Domain.CPU == nil || spec.Domain.CPU.Features == nil || len(spec.Domain.CPU.Features) == 0 {
+		causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Message: fmt.Sprintf("%s cpu feature is required when evmcs is set", evmcsDependency.Name), Field: "spec.domain.cpu.features"})
+		return causes
+	}
+
+	for i, existingFeature := range spec.Domain.CPU.Features {
+		if existingFeature.Name == evmcsDependency.Name && existingFeature.Policy != evmcsDependency.Policy {
+			causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueInvalid, Message: fmt.Sprintf("%s cpu feature has to be set to %s policy", evmcsDependency.Name, evmcsDependency.Policy), Field: fmt.Sprintf("spec.domain.cpu.features[%d].policy", i)})
 		}
 	}
 
@@ -229,20 +231,39 @@ func setEVMCSDependency(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.CPU = &v1.CPU{
 			Features: cpuFeatures,
 		}
-	} else if len(vmi.Spec.Domain.CPU.Features) == 0 {
+		return
+	}
+
+	if len(vmi.Spec.Domain.CPU.Features) == 0 {
 		vmi.Spec.Domain.CPU.Features = cpuFeatures
-	} else {
-		vmxFound := false
-		for i, f := range vmi.Spec.Domain.CPU.Features {
-			if f.Name == nodelabellerutil.VmxFeature {
-				vmxFound = true
-				if f.Policy != nodelabellerutil.RequirePolicy {
-					vmi.Spec.Domain.CPU.Features[i].Policy = nodelabellerutil.RequirePolicy
+		return
+	}
+
+	for _, requiredFeature := range cpuFeatures {
+		featureFound := false
+
+		for i, existingFeature := range vmi.Spec.Domain.CPU.Features {
+			if existingFeature.Name == requiredFeature.Name {
+				featureFound = true
+				if existingFeature.Policy != requiredFeature.Policy {
+					vmi.Spec.Domain.CPU.Features[i].Policy = requiredFeature.Policy
 				}
+				break
 			}
 		}
-		if !vmxFound {
-			vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, vmxFeature)
+
+		if !featureFound {
+			vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, requiredFeature)
 		}
 	}
+
+}
+
+func getEVMCSDependency() v1.CPUFeature {
+	vmxFeature := v1.CPUFeature{
+		Name:   nodelabellerutil.VmxFeature,
+		Policy: nodelabellerutil.RequirePolicy,
+	}
+
+	return vmxFeature
 }

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -28,7 +28,7 @@ type topologyHinter struct {
 }
 
 func (t *topologyHinter) TopologyHintsRequiredForVMI(vmi *k6tv1.VirtualMachineInstance) bool {
-	return t.arch == "amd64" && VMIHasInvTSCFeature(vmi)
+	return t.arch == "amd64" && IsManualTSCFrequencyRequired(vmi)
 }
 
 func (t *topologyHinter) TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) (hints *k6tv1.TopologyHints, err error) {

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -3,6 +3,12 @@ package topology_test
 import (
 	"fmt"
 
+	"k8s.io/utils/pointer"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -67,6 +73,28 @@ var _ = Describe("TSC", func() {
 			[]int64{2, 4},
 		),
 	)
+
+	Context("needs to be set when", func() {
+
+		It("invtsc feature exists", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUFeature("invtsc", "require"),
+			)
+
+			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+		})
+
+		It("HyperV reenlightenment is enabled", func() {
+			vmi := libvmi.New()
+			vmi.Spec.Domain.Features = &v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+				},
+			}
+
+			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+		})
+	})
 })
 
 func tscFrequencyLabel(freq int64) string {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -437,7 +437,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			vmiCopy.Status.Phase = virtv1.Failed
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
-			if vmi.Status.TopologyHints == nil && c.topologyHinter.TopologyHintsRequiredForVMI(vmi) {
+			if vmi.Status.TopologyHints == nil {
 				if topologyHints, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedGatherhingClusterTopologyHints, err.Error())
 					return &syncErrorImpl{err, FailedGatherhingClusterTopologyHints}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -210,7 +212,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
-		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
+		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{
+			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
+				MinimumClusterTSCFrequency: pointer.Int64(12345),
+			},
+		}
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
@@ -226,7 +233,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			cdiInformer,
 			cdiConfigInformer,
 			config,
-			topology.NewTopologyHinter(&cache.FakeCustomStore{}, &cache.FakeCustomStore{}, "amd64", nil),
+			topology.NewTopologyHinter(&cache.FakeCustomStore{}, &cache.FakeCustomStore{}, "amd64", config),
 		)
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
@@ -2747,6 +2754,54 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+		})
+	})
+
+	Context("topology hints", func() {
+
+		Context("needs to be set when", func() {
+
+			expectTopologyHintsUpdate := func() {
+				var vmi *virtv1.VirtualMachineInstance
+				vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+					vmi = arg.(*virtv1.VirtualMachineInstance)
+					Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+				}).Return(vmi, nil)
+			}
+
+			runController := func(vmi *virtv1.VirtualMachineInstance) {
+				addVirtualMachine(vmi)
+				shouldExpectPodCreation(vmi.UID)
+				controller.Execute()
+			}
+
+			It("invtsc feature exists", func() {
+				vmi := NewPendingVirtualMachine("testvmi")
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Features: []virtv1.CPUFeature{
+						{
+							Name:   "invtsc",
+							Policy: "require",
+						},
+					},
+				}
+
+				expectTopologyHintsUpdate()
+				runController(vmi)
+			})
+
+			It("HyperV reenlightenment is enabled", func() {
+				vmi := NewPendingVirtualMachine("testvmi")
+				vmi.Spec.Domain.Features = &v1.Features{
+					Hyperv: &v1.FeatureHyperv{
+						Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+					},
+				}
+
+				expectTopologyHintsUpdate()
+				runController(vmi)
+			})
+
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1689,7 +1689,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		// Make use of the tsc frequency topology hint
-		if topology.VMIHasInvTSCFeature(vmi) && vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil {
+		if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
 			freq := *vmi.Status.TopologyHints.TSCFrequency
 			clock := domain.Spec.Clock
 			if clock == nil {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -179,6 +179,7 @@ go_test(
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/device-manager:go_default_library",

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -171,6 +171,19 @@ func WithSEV() Option {
 	}
 }
 
+func WithCPUFeature(featureName, policy string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.CPU == nil {
+			vmi.Spec.Domain.CPU = &v1.CPU{}
+		}
+
+		vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, v1.CPUFeature{
+			Name:   featureName,
+			Policy: policy,
+		})
+	}
+}
+
 func baseVmi(name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewVMIReferenceFromNameWithNS("", name)
 	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"sync"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	"kubevirt.io/api/migrations/v1alpha1"
 
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
@@ -4199,6 +4201,44 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			}, time.Second*30, time.Second*1).Should(BeNumerically("<=", 1))
 		})
+	})
+
+	Context("topology hints", func() {
+
+		Context("needs to be set when", func() {
+
+			expectTopologyHintsToBeSet := func(vmi *v1.VirtualMachineInstance) {
+				EventuallyWithOffset(1, func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					return topology.AreTSCFrequencyTopologyHintsDefined(vmi)
+				}, 90*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("tsc frequency topology hints are expected to exist for vmi %s", vmi.Name))
+			}
+
+			It("invtsc feature exists", func() {
+				vmi := libvmi.New(
+					libvmi.WithResourceMemory("1Mi"),
+					libvmi.WithCPUFeature("invtsc", "require"),
+				)
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				expectTopologyHintsToBeSet(vmi)
+			})
+
+			It("HyperV reenlightenment is enabled", func() {
+				vmi := libvmi.New()
+				vmi.Spec = getWindowsVMISpec()
+				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
+				vmi.Spec.Volumes = []v1.Volume{}
+				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				expectTopologyHintsToBeSet(vmi)
+			})
+
+		})
+
 	})
 })
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -75,6 +75,22 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
+	It("should be able to migrate when HyperV reenlightenment is enabled", func() {
+		var err error
+
+		By("Creating a windows VM")
+		windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
+		Expect(err).ToNot(HaveOccurred())
+		tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+
+		By("Migrating the VM")
+		migration := tests.NewRandomMigration(windowsVMI.Name, windowsVMI.Namespace)
+		migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+
+		By("Checking VMI, confirm migration state")
+		tests.ConfirmVMIPostMigration(virtClient, windowsVMI, migrationUID)
+	})
+
 	Context("with winrm connection", func() {
 		var winrmcliPod *k8sv1.Pod
 		var cli []string


### PR DESCRIPTION
**What this PR does / why we need it**:
## Bug description & overview
A windows VM using HyperV Reenlightenment cannot migrate successfully. An example for such VM:
```yaml
spec:
  domain:
    features:
      hyperv:
        reenlightenment:
          enabled: true
```

(of course, the spec is trimmed down only to the relevant portion.

## Root cause
On [a commit to QEMU](https://gitlab.com/qemu-project/qemu/-/commit/561dbb41b1d752098249128d8462aaadc56fd15d), it says: `"Require 'tsc-frequency=' command line option to be specified for successful migration when re-enlightenment was enabled by the guest."`

IOW, the `tsc-frequency` parameter needs to pass to QEMU if HyperV Reenlightenment is enabled.

In converter.go [1], we're adding a tsc frequency parameter if `vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil`.
In virt-controller [2] we are checking if TopologyHints need to be added to the vmi by calling `TopologyHintsRequiredForVMI()`. There, we are checking if "invtsc" feature exists in vmi's spec (vmi.Spec.Domain.CPU.Features) with a "required" or "force" policy. Only then we add the TopologyHints to the vmi, which will lead (in [1]) to adding this parameter and pass it on to libvirt / QEMU.

[1] https://github.com/kubevirt/kubevirt/blob/v0.54.0/pkg/virt-launcher/virtwrap/converter/converter.go#L1691
[2] https://github.com/kubevirt/kubevirt/blob/v0.54.0/pkg/virt-controller/watch/vmi.go#L438

The reason this error popped up just now is that we bumped up libvirt & QEMU versions (from QEMU 5.2.0 to 6.2.0).

## Fix
As explained above, TopologyHints are added to a vmi if it has the `invtsc` feature and this will eventually cause us to provide 'tsc-frequency=' flag for QEMU [1].

<s>After this PR, invtsc is also considered as a hyperv EVMCS dependency. It's being added automatically via mutating webhooks and validated by validating webhooks.</s>

After this PR, TopologyHints will be added if either `invtsc` is enabled for the vmi (as before) or if the VMI is using HyperV Reenlightenment feature. In other words, after this PR there wouldn't be a need of any user intervention in order to migrate VMs with HyperV Reenlightenment enabled and the lower TSC frequency on the cluster would be automatically set.

## Workaround
<s>Since currently 'tsc-frequency=' flag is passed to QEMU if invtsc feature is enabled, simply add the invtsc feature to the VM's spec:

```yaml
cpu:
  features:
  - name: invtsc
    policy: require
```

After doing so the VM is able to migrate successfully.
</s>

Workaround is not valid since KVM does not support windows + invtsc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2100054
Bugzilla (KBase): https://bugzilla.redhat.com/show_bug.cgi?id=2100629

**Notes for reviewers**
1. Added small refactoring to `hyperv.go`
2. Removed unnecessary call to `TopologyHintsRequiredForVMI()` on virt-controller's `vmi.go`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
[Bug-fix]: Windows VM with WSL2 guest fails to migrate
```
