### PR TITLE
utils, Expose error when update config fails

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2519,7 +2519,7 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 		pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabel})
 
 		if err != nil {
-			return fmt.Errorf("failed to fetch pods. %s", errComponentInfo)
+			return fmt.Errorf("failed to fetch pods: %v, %s", err, errComponentInfo)
 		}
 		for _, pod := range pods.Items {
 			errAdditionalInfo := errComponentInfo + fmt.Sprintf(", pod: \"%s\"", pod.Name)
@@ -2530,12 +2530,12 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 
 			body, err := callUrlOnPod(&pod, "8443", "/healthz")
 			if err != nil {
-				return fmt.Errorf("failed to call healthz endpoint. %s", errAdditionalInfo)
+				return fmt.Errorf("failed to call healthz endpoint: %v, %s", err, errAdditionalInfo)
 			}
 			result := map[string]interface{}{}
 			err = json.Unmarshal(body, &result)
 			if err != nil {
-				return fmt.Errorf("failed to parse response from healthz endpoint. %s", errAdditionalInfo)
+				return fmt.Errorf("failed to parse response from healthz endpoint: %v, %s", err, errAdditionalInfo)
 			}
 
 			if configVersion := result["config-resource-version"].(string); !compareResourceVersions(resourceVersion, configVersion) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR exposes to logs the error when the `WaitForConfigToBePropagatedToComponent()` function fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
