### PR TITLE
Replace NewRandomVMI function with libvmi builder pattern

### DIFF
--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -6,6 +6,8 @@ import (
 	goerrors "errors"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -61,7 +63,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	Context("VM with invalid FlavorMatcher", func() {
 		It("[test_id:TODO] should fail to create VM with non-existing cluster flavor", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Flavor = &v1.FlavorMatcher{
 				Name: "non-existing-cluster-flavor",
@@ -80,7 +82,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should fail to create VM with non-existing namespaced flavor", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Flavor = &v1.FlavorMatcher{
 				Name: "non-existing-flavor",
@@ -102,7 +104,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	Context("VM with invalid PreferenceMatcher", func() {
 		It("[test_id:TODO] should fail to create VM with non-existing cluster preference", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Preference = &v1.PreferenceMatcher{
 				Name: "non-existing-cluster-preference",
@@ -121,7 +123,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should fail to create VM with non-existing namespaced preference", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Preference = &v1.PreferenceMatcher{
 				Name: "non-existing-preference",
@@ -270,7 +272,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should fail if flavor and VM define CPU", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 
 			flavor := newVirtualMachineFlavor(vmi)
 			flavor, err := virtClient.VirtualMachineFlavor(util.NamespaceTestDefault).

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -125,7 +125,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		It("on the controller rate limiter should lead to delayed VMI starts", func() {
 			By("first getting the basetime for a replicaset")
-			replicaset := tests.NewRandomReplicaSetFromVMI(libvmi.NewCirros(libvmi.WithResourceMemory("1Mi")), int32(0))
+			replicaset := tests.NewRandomReplicaSetFromVMI(libvmi.NewCirros(libvmi.With1MiResourceMemory()), int32(0))
 			replicaset, err = virtClient.ReplicaSet(util.NamespaceTestDefault).Create(replicaset)
 			Expect(err).ToNot(HaveOccurred())
 			start := time.Now()
@@ -157,7 +157,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			By("first getting the basetime for a replicaset")
 			targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 			vmi := libvmi.New(
-				libvmi.WithResourceMemory("1Mi"),
+				libvmi.With1MiResourceMemory(),
 				libvmi.WithNodeSelectorFor(&targetNode),
 			)
 
@@ -1120,7 +1120,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					return k8sv1.ConditionUnknown
 				}()).To(Equal(k8sv1.ConditionTrue))
 
-				vmi := tests.NewRandomVMI()
+				vmi := libvmi.New(
+					libvmi.With1MiResourceMemory(),
+				)
 
 				By("Starting a new VirtualMachineInstance")
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -89,7 +89,14 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			virtCli, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
 
-			vm = tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+			vm = tests.NewRandomVirtualMachine(
+				libvmi.New(
+					libvmi.With1MiResourceMemory(),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				),
+				false,
+			)
 			vm, err = virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 			Expect(err).NotTo(HaveOccurred())
 			tests.StartVirtualMachine(vm)

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -20,7 +20,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", func(
 
 	It("should start a SEV VM", func() {
 		const secureBoot = false
-		vmi := libvmi.NewFedora(libvmi.WithUefi(secureBoot), libvmi.WithSEV())
+		vmi := libvmi.NewFedora(libvmi.WithSecureBoot(secureBoot), libvmi.WithSEV())
 		vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
 		By("Expecting the VirtualMachineInstance console")

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -48,7 +48,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		withNonEmptyUserData,
-		WithResourceMemory(cirrosMemory()),
+		WithResourceMemory(CirrosMemory()),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
 	return New(cirrosOpts...)
@@ -56,7 +56,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 
 // NewAlpine instantiates a new Alpine based VMI configuration
 func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	alpineMemory := cirrosMemory
+	alpineMemory := CirrosMemory
 	alpineOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
 		WithResourceMemory(alpineMemory()),
@@ -67,7 +67,7 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 }
 
 func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	alpineMemory := cirrosMemory
+	alpineMemory := CirrosMemory
 	alpineOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
 		WithResourceMemory(alpineMemory()),
@@ -77,7 +77,7 @@ func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return New(alpineOpts...)
 }
 
-func cirrosMemory() string {
+func CirrosMemory() string {
 	if checks.IsARM64(testsuite.Arch) {
 		return "256Mi"
 	}

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -174,3 +174,54 @@ func baseVmi(name string) *v1.VirtualMachineInstance {
 	}
 	return vmi
 }
+
+// WithLabel sets labels with specified values
+func WithLabels(labels map[string]string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Labels == nil {
+			vmi.Labels = labels
+			return
+		}
+		for label, value := range labels {
+			vmi.Labels[label] = value
+		}
+	}
+}
+
+// WithAnnotation adds annotations with specified values
+func WithAnnotations(annotations map[string]string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Annotations == nil {
+			vmi.Annotations = annotations
+			return
+		}
+		for annotation, value := range annotations {
+			vmi.Annotations[annotation] = value
+		}
+	}
+}
+
+func WithClientPassthrough() Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.ClientPassthrough = &v1.ClientPassthroughDevices{}
+	}
+}
+
+// WithResourceMemory specifies the vmi memory resource.
+func With1MiResourceMemory() Option {
+	return WithResourceMemory("1Mi")
+}
+
+// WithMachineType specifies the vmi machine type.
+func WithMachineType(value string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Machine = &v1.Machine{Type: value}
+	}
+}
+
+// WithMachineType specifies the vmi Scheduler.
+func WithScheduler(name string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.SchedulerName = name
+	}
+}

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//tests/clientcmd:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -423,7 +425,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
 			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-controller", metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.With1MiResourceMemory())
 
 			for i := 0; i < 60; i++ {
 				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -446,7 +448,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
 			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-handler", metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.With1MiResourceMemory())
 
 			for i := 0; i < 60; i++ {
 				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//tests/assert:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
-        "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 
 	"kubevirt.io/kubevirt/tests/util"
@@ -38,7 +37,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
@@ -192,17 +190,10 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			setDefaultNetworkInterface("bridge")
 		})
 		It("should reject VMIs with default interface slirp when it's not permitted", func() {
-			var t int64 = 0
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.TerminationGracePeriodSeconds = &t
-			// Reset memory, devices and networks
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
-			vmi.Spec.Domain.Devices = v1.Devices{}
-			vmi.Spec.Networks = nil
-			tests.AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, cd.ContainerDiskFor(cd.ContainerDiskCirros))
-
-			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi := libvmi.New(libvmi.With1MiResourceMemory())
+			_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Slirp"))
 		})
 	})
 })

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -3,6 +3,8 @@ package tests_test
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -48,7 +50,7 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 		It("Fails if can't be tested", func() {
 			Expect(checks.HasFeature(virtconfig.NonRoot)).To(BeTrue())
 
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.With1MiResourceMemory())
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
@@ -109,7 +111,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource", func() {
 		Context("with a restart endpoint", func() {
 			It("[test_id:1304] should restart a VM", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(libvmi.With1MiResourceMemory()), false)
 				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -131,7 +133,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			})
 
 			It("[test_id:1305][posneg:negative] should return an error when VM is not running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
 				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -140,7 +142,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			})
 
 			It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", func() {
-				vmi := tests.NewRandomVMI()
+				vmi := libvmi.New(libvmi.With1MiResourceMemory())
 				tests.RunVMIAndExpectLaunch(vmi, 60)
 
 				err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
@@ -150,7 +152,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 		Context("With manual RunStrategy", func() {
 			It("[test_id:3174]Should not restart when VM is not running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
 				vm.Spec.RunStrategy = &manual
 				vm.Spec.Running = nil
 
@@ -164,7 +166,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			})
 
 			It("[test_id:3175]Should restart when VM is running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(libvmi.With1MiResourceMemory()), false)
 				vm.Spec.RunStrategy = &manual
 				vm.Spec.Running = nil
 
@@ -204,7 +206,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 		Context("With RunStrategy RerunOnFailure", func() {
 			It("[test_id:3176]Should restart the VM", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(libvmi.With1MiResourceMemory()), false)
 				vm.Spec.RunStrategy = &restartOnError
 				vm.Spec.Running = nil
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	"kubevirt.io/kubevirt/tests/framework/checks"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -300,7 +302,7 @@ var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance
 		libstorage.CreatePVC(tests.OSWindowsSysprep, "35Gi", libstorage.Config.StorageClassWindows, true)
 		answerFileWithKey := insertProductKeyToAnswerFileTemplate(answerFileTemplate)
 		tests.CreateConfigMap("sysprepautounattend", map[string]string{"Autounattend.xml": answerFileWithKey, "Unattend.xml": answerFileWithKey})
-		windowsVMI = tests.NewRandomVMI()
+		windowsVMI = libvmi.New()
 		windowsVMI.Spec = getWindowsSysprepVMISpec()
 		tests.AddExplicitPodNetworkInterface(windowsVMI)
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -261,9 +261,12 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {
 			var err error
-			vmi := tests.NewRandomVMI()
-			vmi.Labels = vmiLabels
-			vmi.Annotations = vmiAnnotations
+
+			vmi := libvmi.New(
+				libvmi.With1MiResourceMemory(),
+				libvmi.WithLabels(vmiLabels),
+				libvmi.WithAnnotations(vmiAnnotations),
+			)
 
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil(), "Create VMI successfully")
@@ -1365,7 +1368,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 				By("Creating a VirtualMachineInstance with different namespace")
 				vmi = libvmi.New(
-					libvmi.WithResourceMemory("1Mi"),
+					libvmi.With1MiResourceMemory(),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				)

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -22,9 +22,9 @@ package tests_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/tests/libvmi"
 
 	"kubevirt.io/kubevirt/tests/util"
 
@@ -49,31 +49,10 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 	Context("Disk defaults", func() {
 		BeforeEach(func() {
 			// create VMI with missing disk target
-			vmi = tests.NewRandomVMI()
-			vmi.Spec = v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						Disks: []v1.Disk{
-							{Name: "testdisk"},
-						},
-					},
-					Resources: v1.ResourceRequirements{
-						Requests: k8sv1.ResourceList{
-							k8sv1.ResourceMemory: resource.MustParse("8192Ki"),
-						},
-					},
-				},
-				Volumes: []v1.Volume{
-					{
-						Name: "testdisk",
-						VolumeSource: v1.VolumeSource{
-							ContainerDisk: &v1.ContainerDiskSource{
-								Image: "dummy",
-							},
-						},
-					},
-				},
-			}
+			vmi = libvmi.New(
+				libvmi.WithContainerImage("dummy"),
+				libvmi.WithResourceMemory("8192Ki"),
+			)
 		})
 
 		It("[test_id:4115]Should be applied to VMIs", func() {
@@ -114,7 +93,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 		BeforeEach(func() {
 			// create VMI with missing disk target
-			vmi = tests.NewRandomVMI()
+			vmi = libvmi.New(libvmi.With1MiResourceMemory())
 
 			kv := util.GetCurrentKv(virtClient)
 			kvConfiguration = kv.Spec.Configuration

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,6 +27,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"kubevirt.io/kubevirt/tests/libvmi"
 
 	"github.com/mitchellh/go-vnc"
 
@@ -57,10 +58,11 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 		BeforeEach(func() {
 			virtClient, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
+			vmi = libvmi.New(libvmi.With1MiResourceMemory())
+			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			Expect(err).NotTo(HaveOccurred())
 
-			vmi = tests.NewRandomVMI()
-			Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Error()).To(Succeed())
-			tests.WaitForSuccessfulVMIStart(vmi)
+			vmi = tests.WaitForSuccessfulVMIStart(vmi)
 		})
 
 		Context("with VNC connection", func() {


### PR DESCRIPTION
NewRandomVMI* functions are defined in the 5000-lines long tests/utils.go that is impossible to understand and has repetitious code.
- Replace NewRandomVMI calls in functional tests with libvmi builder pattern and Make functional test more resources efficient.
- Modify libvmi functions to avoid replacing objects in the vmi.spec and change inner fields instead.
- Extend the builder pattern to attach disk to a vmi and verify that a volume is added to the vmi as well in **Compile time**.
- Add functions to libvmi



Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
