### PR TITLE
Remove SRIOVLiveMigration feature-gate

### DIFF
--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -661,5 +661,8 @@ var _ = Describe("test configuration", func() {
 			Expect(clusterConfig.LiveMigrationEnabled()).To(BeTrue())
 		})
 
+		It("SR-IOV live migration feature gate", func() {
+			Expect(clusterConfig.SRIOVLiveMigrationEnabled()).To(BeTrue())
+		})
 	})
 })

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -29,7 +29,7 @@ const (
 	NUMAFeatureGate   = "NUMA"
 	IgnitionGate      = "ExperimentalIgnitionSupport"
 	LiveMigrationGate = "LiveMigration"
-	// SRIOVLiveMigrationGate enable's Live Migration for VM's with SRIOV interfaces.
+	// SRIOVLiveMigrationGate enables Live Migration for VM's with network SR-IOV interfaces.
 	SRIOVLiveMigrationGate     = "SRIOVLiveMigration"
 	CPUNodeDiscoveryGate       = "CPUNodeDiscovery"
 	HypervStrictCheckGate      = "HypervStrictCheck"
@@ -52,6 +52,7 @@ const (
 
 var deprecatedFeatureGates = [...]string{
 	LiveMigrationGate,
+	SRIOVLiveMigrationGate,
 }
 
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2234,11 +2234,6 @@ func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.Vi
 		return fmt.Errorf("cannot migrate VMI which does not use masquerade to connect to the pod network")
 	}
 
-	sriovLiveMigrationEnabled := d.clusterConfig.SRIOVLiveMigrationEnabled()
-	if len(netvmispec.FilterSRIOVInterfaces(ifaces)) > 0 && !sriovLiveMigrationEnabled {
-		return fmt.Errorf("SRIOVLiveMigration feature-gate is closed, can't migrate VMI with SRIOV interfaces")
-	}
-
 	return nil
 }
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2515,58 +2515,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 				err := controller.checkNetworkInterfacesForMigration(vmi)
 				Expect(err).To(HaveOccurred())
 			})
-			It("should block migration for VMI with SRIOV interface when feature-gate SRIOVLiveMigration is off", func() {
-				vmi := api2.NewMinimalVMI("testvmi")
-				sriovInterfaceName := "sriovnet1"
-				vmi.Spec.Networks = []v1.Network{
-					{
-						Name: sriovInterfaceName,
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{
-							NetworkName: "sriov-network1",
-						}},
-					},
-				}
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{
-						Name: sriovInterfaceName,
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{
-							SRIOV: &v1.InterfaceSRIOV{},
-						},
-					},
-				}
-
-				Expect(controller.checkNetworkInterfacesForMigration(vmi)).ShouldNot(Succeed())
-			})
-
-			It("should not block migration for VMI with SRIOV interface when feature-gate SRIOVLiveMigration is on", func() {
-				vmi := api2.NewMinimalVMI("testvmi")
-				sriovInterfaceName := "sriovnet1"
-				vmi.Spec.Networks = []v1.Network{
-					{
-						Name: sriovInterfaceName,
-						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{
-							NetworkName: "sriov-network1",
-						}},
-					},
-				}
-				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{
-						Name: sriovInterfaceName,
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{
-							SRIOV: &v1.InterfaceSRIOV{},
-						},
-					},
-				}
-
-				config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						FeatureGates: []string{virtconfig.SRIOVLiveMigrationGate},
-					},
-				})
-				controller.clusterConfig = config
-
-				Expect(controller.checkNetworkInterfacesForMigration(vmi)).Should(Succeed())
-			})
 
 			It("should not block migration for masquerade binding assigned to the pod network", func() {
 				vmi := api2.NewMinimalVMI("testvmi")

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -333,14 +333,6 @@ var _ = Describe("[Serial]SRIOV", func() {
 				}
 			})
 
-			BeforeEach(func() {
-				tests.EnableFeatureGate(virtconfig.SRIOVLiveMigrationGate)
-			})
-
-			AfterEach(func() {
-				tests.DisableFeatureGate(virtconfig.SRIOVLiveMigrationGate)
-			})
-
 			var vmi *v1.VirtualMachineInstance
 
 			const mac = "de:ad:00:00:be:ef"


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following https://github.com/kubevirt/kubevirt/pull/5558, virt-launcher doesn't execute with the `SYS_RESOURCE` capability anymore, thus `SRIOVLiveMigration` feature-gate is redundant.

~~SR-IOV live migration will be controlled by `LiveMigration` feature-gate similar to non-SR-IOV VMs.~~

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- SRIOVLiveMigration feature gate was introduced by #4874

- `virt-launcher` is no longer executed with `SYS_RESOURCE` capability by #5558

- Once virt-handler pods are upgraded, migrating old SR-IOV VMs will not be blocked by the SRIOVLiveMigration feature-gate anymore.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate SR-IOV live migration feature gate.
```
