### PR TITLE
lint: Add `tests/libnet` to the linter coverage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,10 @@ linters-settings:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  stylecheck:
+    dot-import-whitelist:
+      - "github.com/onsi/ginkgo/v2"
+      - "github.com/onsi/gomega"
 
 linters:
   disable-all: true

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ fmt: format
 lint:
 	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
-	hack/dockerized "golangci-lint run --timeout 3m --verbose \
+	hack/dockerized "golangci-lint run --timeout 10m --verbose \
 	  tests/libvmi/... \
 	  tests/libnet/... \
 	"

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,10 @@ fmt: format
 lint:
 	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
-	hack/dockerized "golangci-lint run --timeout 3m --verbose tests/libvmi/..."
+	hack/dockerized "golangci-lint run --timeout 3m --verbose \
+	  tests/libvmi/... \
+	  tests/libnet/... \
+	"
 
 .PHONY: \
 	build-verify \

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -833,7 +833,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		})
 
 		DescribeTable("should throttle the Prometheus metrics access", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -879,7 +879,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -895,7 +895,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -933,7 +933,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -959,7 +959,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -996,7 +996,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1015,7 +1015,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(controllerMetricIPs, family)
 
@@ -1033,7 +1033,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 		)
 
 		DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1056,7 +1056,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 
 		// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
 		DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1617,7 +1617,7 @@ func validatedHTTPResponses(errorsChan chan error, concurrency int) error {
 }
 
 func getSupportedIP(ips []string, family k8sv1.IPFamily) string {
-	ip := libnet.GetIp(ips, family)
+	ip := libnet.GetIP(ips, family)
 	ExpectWithOffset(1, ip).NotTo(BeEmpty())
 
 	return ip

--- a/tests/libnet/cloudinit.go
+++ b/tests/libnet/cloudinit.go
@@ -153,8 +153,8 @@ type CloudInitInterface struct {
 }
 
 type CloudInitNameservers struct {
-	Search    []string `json:"search,omitempty,flow"`
-	Addresses []string `json:"addresses,omitempty,flow"`
+	Search    []string `json:"search,omitempty"`
+	Addresses []string `json:"addresses,omitempty"`
 }
 
 type CloudInitMatch struct {

--- a/tests/libnet/cluster/cluster.go
+++ b/tests/libnet/cluster/cluster.go
@@ -36,19 +36,19 @@ func DualStack(virtClient kubecli.KubevirtClient) (bool, error) {
 
 func SupportsIpv4(virtClient kubecli.KubevirtClient) (bool, error) {
 	onceIPv4.Do(func() {
-		clusterSupportsIpv4, errIPv4 = clusterAnswersIpCondition(virtClient, netutils.IsIPv4String)
+		clusterSupportsIpv4, errIPv4 = clusterAnswersIPCondition(virtClient, netutils.IsIPv4String)
 	})
 	return clusterSupportsIpv4, errIPv4
 }
 
 func SupportsIpv6(virtClient kubecli.KubevirtClient) (bool, error) {
 	onceIPv6.Do(func() {
-		clusterSupportsIpv6, errIPv6 = clusterAnswersIpCondition(virtClient, netutils.IsIPv6String)
+		clusterSupportsIpv6, errIPv6 = clusterAnswersIPCondition(virtClient, netutils.IsIPv6String)
 	})
 	return clusterSupportsIpv6, errIPv6
 }
 
-func clusterAnswersIpCondition(virtClient kubecli.KubevirtClient, ipCondition func(ip string) bool) (bool, error) {
+func clusterAnswersIPCondition(virtClient kubecli.KubevirtClient, ipCondition func(ip string) bool) (bool, error) {
 	// grab us some neat kubevirt pod; let's say virt-handler is our target.
 	targetPodType := "virt-handler"
 	virtHandlerPod, err := getPodByKubeVirtRole(virtClient, targetPodType)
@@ -66,11 +66,14 @@ func clusterAnswersIpCondition(virtClient kubecli.KubevirtClient, ipCondition fu
 
 func getPodByKubeVirtRole(virtClient kubecli.KubevirtClient, kubevirtPodRole string) (*k8sv1.Pod, error) {
 	labelSelectorValue := fmt.Sprintf("%s = %s", v1.AppLabel, kubevirtPodRole)
-	pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelectorValue})
+	pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(
+		context.Background(),
+		metav1.ListOptions{LabelSelector: labelSelectorValue},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not filter virt-handler pods: %v", err)
 	}
-	if len(pods.Items) <= 0 {
+	if len(pods.Items) == 0 {
 		return nil, fmt.Errorf("could not find virt-handler pods on the system")
 	}
 	return &pods.Items[0], nil

--- a/tests/libnet/dns.go
+++ b/tests/libnet/dns.go
@@ -47,7 +47,9 @@ func ClusterDNSServiceIP() (string, error) {
 		return "", err
 	}
 
-	service, err := virtClient.CoreV1().Services(flags.DNSServiceNamespace).Get(context.Background(), flags.DNSServiceName, metav1.GetOptions{})
+	service, err := virtClient.CoreV1().Services(flags.DNSServiceNamespace).Get(
+		context.Background(), flags.DNSServiceName, metav1.GetOptions{},
+	)
 	if err != nil {
 		prevErr := err
 		service, err = virtClient.CoreV1().Services(openshiftDNSNamespace).Get(context.Background(), openshiftDNSServiceName, metav1.GetOptions{})

--- a/tests/libnet/ipaddress.go
+++ b/tests/libnet/ipaddress.go
@@ -10,19 +10,19 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func GetPodIpByFamily(pod *k8sv1.Pod, family k8sv1.IPFamily) string {
+func GetPodIPByFamily(pod *k8sv1.Pod, family k8sv1.IPFamily) string {
 	var ips []string
 	for _, ip := range pod.Status.PodIPs {
 		ips = append(ips, ip.IP)
 	}
-	return GetIp(ips, family)
+	return GetIP(ips, family)
 }
 
-func GetVmiPrimaryIpByFamily(vmi *v1.VirtualMachineInstance, family k8sv1.IPFamily) string {
-	return GetIp(vmi.Status.Interfaces[0].IPs, family)
+func GetVmiPrimaryIPByFamily(vmi *v1.VirtualMachineInstance, family k8sv1.IPFamily) string {
+	return GetIP(vmi.Status.Interfaces[0].IPs, family)
 }
 
-func GetIp(ips []string, family k8sv1.IPFamily) string {
+func GetIP(ips []string, family k8sv1.IPFamily) string {
 	for _, ip := range ips {
 		if family == getFamily(ip) {
 			return ip
@@ -41,12 +41,11 @@ func getFamily(ip string) k8sv1.IPFamily {
 func GetLoopbackAddress(family k8sv1.IPFamily) string {
 	if family == k8sv1.IPv4Protocol {
 		return "127.0.0.1"
-
 	}
 	return net.IPv6loopback.String()
 }
 
-func GetLoopbackAddressForUrl(family k8sv1.IPFamily) string {
+func GetLoopbackAddressForURL(family k8sv1.IPFamily) string {
 	address := GetLoopbackAddress(family)
 	if family == k8sv1.IPv6Protocol {
 		address = fmt.Sprintf("[%s]", address)

--- a/tests/libnet/namespace.go
+++ b/tests/libnet/namespace.go
@@ -53,15 +53,15 @@ func patchNamespace(client kubecli.KubevirtClient, namespace string, patchFunc f
 		return err
 	}
 
-	new := ns.DeepCopy()
-	patchFunc(new)
+	newNS := ns.DeepCopy()
+	patchFunc(newNS)
 
-	newJson, err := json.Marshal(new)
+	newJSON, err := json.Marshal(newNS)
 	if err != nil {
 		return err
 	}
 
-	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJson, ns)
+	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJSON, ns)
 	if err != nil {
 		return err
 	}

--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -50,7 +50,7 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 
 	err := console.RunCommand(vmi, cmdCheck, maxCommandTimeout)
 	if err != nil {
-		return fmt.Errorf("Failed to ping VMI %s, error: %v", vmi.Name, err)
+		return fmt.Errorf("failed to ping VMI %s, error: %v", vmi.Name, err)
 	}
 	return nil
 }

--- a/tests/libnet/service/service.go
+++ b/tests/libnet/service/service.go
@@ -25,13 +25,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func BuildHeadlessSpec(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service {
+func BuildHeadlessSpec(serviceName string, exposedPort, portToExpose int, selectorKey, selectorValue string) *k8sv1.Service {
 	service := BuildSpec(serviceName, exposedPort, portToExpose, selectorKey, selectorValue)
 	service.Spec.ClusterIP = k8sv1.ClusterIPNone
 	return service
 }
 
-func BuildIPv6Spec(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service {
+func BuildIPv6Spec(serviceName string, exposedPort, portToExpose int, selectorKey, selectorValue string) *k8sv1.Service {
 	service := BuildSpec(serviceName, exposedPort, portToExpose, selectorKey, selectorValue)
 	ipv6Family := k8sv1.IPv6Protocol
 	service.Spec.IPFamilies = []k8sv1.IPFamily{ipv6Family}
@@ -39,7 +39,7 @@ func BuildIPv6Spec(serviceName string, exposedPort int, portToExpose int, select
 	return service
 }
 
-func BuildSpec(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service {
+func BuildSpec(serviceName string, exposedPort, portToExpose int, selectorKey, selectorValue string) *k8sv1.Service {
 	return &k8sv1.Service{
 		ObjectMeta: k8smetav1.ObjectMeta{
 			Name: serviceName,

--- a/tests/libnet/skips.go
+++ b/tests/libnet/skips.go
@@ -34,7 +34,7 @@ func SkipWhenClusterNotSupportIpv6(virtClient kubecli.KubevirtClient) {
 	}
 }
 
-func SkipWhenClusterNotSupportIpFamily(virtClient kubecli.KubevirtClient, ipFamily k8sv1.IPFamily) {
+func SkipWhenClusterNotSupportIPFamily(virtClient kubecli.KubevirtClient, ipFamily k8sv1.IPFamily) {
 	if ipFamily == k8sv1.IPv4Protocol {
 		SkipWhenClusterNotSupportIpv4(virtClient)
 	} else {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -815,8 +815,8 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				vmPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				vmPodIpv4Address := libnet.GetPodIpByFamily(vmPod, k8sv1.IPv4Protocol)
-				vmPodIpv6Address := libnet.GetPodIpByFamily(vmPod, k8sv1.IPv6Protocol)
+				vmPodIpv4Address := libnet.GetPodIPByFamily(vmPod, k8sv1.IPv4Protocol)
+				vmPodIpv6Address := libnet.GetPodIPByFamily(vmPod, k8sv1.IPv6Protocol)
 
 				primaryVmPodAddr, secondaryVmPodAddr := getPrimaryAndSecondaryAddr(vmPodIpv4Address, vmPodIpv6Address)
 

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -63,7 +63,7 @@ var _ = SIGDescribe("Port-forward", func() {
 		)
 
 		setup := func(ipFamily k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
 
 			if ipFamily == k8sv1.IPv6Protocol {
 				Skip(skipIPv6Message)
@@ -172,7 +172,7 @@ func createCirrosVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClien
 }
 
 func testConnectivityThroughLocalPort(ipFamily k8sv1.IPFamily, portNumber int) error {
-	return exec.Command("curl", fmt.Sprintf("%s:%d", libnet.GetLoopbackAddressForUrl(ipFamily), portNumber)).Run()
+	return exec.Command("curl", fmt.Sprintf("%s:%d", libnet.GetLoopbackAddressForURL(ipFamily), portNumber)).Run()
 }
 
 func waitForPortForwardCmd(ipFamily k8sv1.IPFamily, stdout io.ReadCloser, src, dst int) {
@@ -181,7 +181,7 @@ func waitForPortForwardCmd(ipFamily k8sv1.IPFamily, stdout io.ReadCloser, src, d
 		_, err := stdout.Read(tmp)
 		Expect(err).NotTo(HaveOccurred())
 		return string(tmp)
-	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Forwarding from %s:%d -> %d", libnet.GetLoopbackAddressForUrl(ipFamily), src, dst)))
+	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Forwarding from %s:%d -> %d", libnet.GetLoopbackAddressForURL(ipFamily), src, dst)))
 }
 
 func getMasqueradeInternalAddress(ipFamily k8sv1.IPFamily) string {

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -70,7 +70,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		httpProbe := createHTTPProbe(period, initialSeconds, port)
 
 		DescribeTable("should succeed", func(readinessProbe *v1.Probe, ipFamily corev1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
 
 			if ipFamily == corev1.IPv6Protocol {
 				By("Create a support pod which will reply to kubelet's probes ...")
@@ -174,7 +174,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		httpProbe := createHTTPProbe(period, initialSeconds, port)
 
 		DescribeTable("should not fail the VMI", func(livenessProbe *v1.Probe, ipFamily corev1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
 
 			if ipFamily == corev1.IPv6Protocol {
 
@@ -336,7 +336,7 @@ func serverStarter(vmi *v1.VirtualMachineInstance, probe *v1.Probe, port int) {
 }
 
 func pointIpv6ProbeToSupportPod(pod *corev1.Pod, probe *v1.Probe) (*v1.Probe, error) {
-	supportPodIP := libnet.GetPodIpByFamily(pod, corev1.IPv6Protocol)
+	supportPodIP := libnet.GetPodIPByFamily(pod, corev1.IPv6Protocol)
 	if supportPodIP == "" {
 		return nil, fmt.Errorf("pod/%s does not have an IPv6 address", pod.Name)
 	}

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -275,7 +275,7 @@ var _ = SIGDescribe("Services", func() {
 			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
 				By("setting up resources to expose the VMI via a service", func() {
-					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+					libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
 					if ipFamily == k8sv1.IPv6Protocol {
 						serviceName = serviceName + "v6"
 						service = netservice.BuildIPv6Spec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -104,7 +104,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 			By("Getting back the VMI IP")
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			vmiIP := libnet.GetVmiPrimaryIpByFamily(vmi, k8sv1.IPv4Protocol)
+			vmiIP := libnet.GetVmiPrimaryIPByFamily(vmi, k8sv1.IPv4Protocol)
 
 			By("Running job to send a request to the server")
 			return virtClient.BatchV1().Jobs(util.NamespaceTestDefault).Create(
@@ -222,7 +222,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					By("Getting the VMI IP")
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
-					vmiIP := libnet.GetVmiPrimaryIpByFamily(vmi, k8sv1.IPv4Protocol)
+					vmiIP := libnet.GetVmiPrimaryIPByFamily(vmi, k8sv1.IPv4Protocol)
 
 					Expect(
 						checkSSHConnection(bastionVMI, "fedora", vmiIP),
@@ -237,7 +237,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					By("Getting the VMI IP")
 					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
-					vmiIP := libnet.GetVmiPrimaryIpByFamily(vmi, k8sv1.IPv4Protocol)
+					vmiIP := libnet.GetVmiPrimaryIPByFamily(vmi, k8sv1.IPv4Protocol)
 
 					Expect(
 						checkSSHConnection(bastionVMI, "fedora", vmiIP),

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -109,7 +109,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 				bridgeVMI = tests.WaitUntilVMIReady(bridgeVMI, console.LoginToCirros)
 				verifyDummyNicForBridgeNetwork(bridgeVMI)
 
-				vmIP := libnet.GetVmiPrimaryIpByFamily(bridgeVMI, k8sv1.IPv4Protocol)
+				vmIP := libnet.GetVmiPrimaryIPByFamily(bridgeVMI, k8sv1.IPv4Protocol)
 				dadCommand := fmt.Sprintf("sudo /usr/sbin/arping -D -I eth0 -c 2 %s | grep Received | cut -d ' ' -f 2\n", vmIP)
 
 				Expect(console.SafeExpectBatch(bridgeVMI, []expect.Batcher{

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -663,7 +663,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			const cidrWithLeadingZeros = "10.10.010.0/24"
 
 			verifyClientServerConnectivity := func(clientVMI *v1.VirtualMachineInstance, serverVMI *v1.VirtualMachineInstance, tcpPort int, ipFamily k8sv1.IPFamily) error {
-				serverIP := libnet.GetVmiPrimaryIpByFamily(serverVMI, ipFamily)
+				serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
 				err := libnet.PingFromVMConsole(clientVMI, serverIP)
 				if err != nil {
 					return err
@@ -874,7 +874,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Check connectivity")
-				podIP := libnet.GetPodIpByFamily(virtHandlerPod, k8sv1.IPv4Protocol)
+				podIP := libnet.GetPodIPByFamily(virtHandlerPod, k8sv1.IPv4Protocol)
 				Expect(ping(podIP)).To(Succeed())
 
 				By("Execute migration")
@@ -916,7 +916,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).ToNot(HaveOccurred())
 
 				By("Check connectivity")
-				podIP := libnet.GetPodIpByFamily(virtHandlerPod, k8sv1.IPv6Protocol)
+				podIP := libnet.GetPodIPByFamily(virtHandlerPod, k8sv1.IPv6Protocol)
 				Expect(ping(podIP)).To(Succeed())
 
 				By("Execute migration")
@@ -986,7 +986,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 
 			DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
-				libnet.SkipWhenClusterNotSupportIpFamily(virtClient, ipFamily)
+				libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
 
 				By("checking k6t-eth0 MTU inside the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
@@ -1016,7 +1016,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					ipHeaderSize = 40
 				}
 				payloadSize := primaryIfaceMtu - ipHeaderSize - icmpHeaderSize
-				addr := libnet.GetVmiPrimaryIpByFamily(anotherVmi, ipFamily)
+				addr := libnet.GetVmiPrimaryIPByFamily(anotherVmi, ipFamily)
 				Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize), "-M do")).To(Succeed())
 
 				By("checking the VirtualMachineInstance cannot send bigger than MTU sized frames to another VirtualMachineInstance")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -102,7 +102,7 @@ var _ = SIGDescribe("Storage", func() {
 
 			// create a new PV and PVC (PVs can't be reused)
 			By("create a new NFS PV and PVC")
-			nfsIP := libnet.GetPodIpByFamily(nfsPod, ipFamily)
+			nfsIP := libnet.GetPodIPByFamily(nfsPod, ipFamily)
 			ExpectWithOffset(1, nfsIP).NotTo(BeEmpty())
 			os := string(cd.ContainerDiskAlpine)
 			tests.CreateNFSPvAndPvc(pvName, util.NamespaceTestDefault, "1Gi", nfsIP, os)
@@ -258,7 +258,7 @@ var _ = SIGDescribe("Storage", func() {
 					}
 				})
 				DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily, imageOwnedByQEMU bool) {
-					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+					libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 					var nodeName string
 					// Start the VirtualMachineInstance with the PVC attached
@@ -555,7 +555,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
 				DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily) {
-					libnet.SkipWhenClusterNotSupportIpFamily(virtClient, family)
+					libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
 
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -297,7 +297,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 				virtHandlerPod, err := getVirtHandlerPod()
 				Expect(err).ToNot(HaveOccurred())
 
-				virtHandlerPodIP := libnet.GetPodIpByFamily(virtHandlerPod, k8sv1.IPv4Protocol)
+				virtHandlerPodIP := libnet.GetPodIPByFamily(virtHandlerPod, k8sv1.IPv4Protocol)
 
 				command := append(cli, fmt.Sprintf("ping %s", virtHandlerPodIP))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `tests/libnet` package is added to the lint target and required fixed applied.

These are the treated errors:
```
tests/libnet/service/service.go:28:1: paramTypeCombine: func(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service could be replaced with func(serviceName string, exposedPort, portToExpose int, selectorKey, selectorValue string) *k8sv1.Service (gocritic)

tests/libnet/service/service.go:34:1: paramTypeCombine: func(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service could be replaced with func(serviceName string, exposedPort, portToExpose int, selectorKey, selectorValue string) *k8sv1.Service (gocritic)

tests/libnet/service/service.go:42:1: paramTypeCombine: func(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service could be replaced with func(serviceName string, exposedPort, portToExpose int, selectorKey, selectorValue string) *k8sv1.Service (gocritic)

tests/libnet/cluster/cluster.go:73:5: sloppyLen: len(pods.Items) <= 0 can be len(pods.Items) == 0 (gocritic)

tests/libnet/cluster/cluster.go:69: line is 152 characters (lll)
        pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelectorValue})
tests/libnet/cluster/cluster.go:51:6: ST1003: func clusterAnswersIpCondition should be clusterAnswersIPCondition (stylecheck)

tests/libnet/namespace.go:56:2: builtinShadow: shadowing of predeclared identifier: new (gocritic)

tests/libnet/dns.go:50: line is 141 characters (lll)
        service, err := virtClient.CoreV1().Services(flags.DNSServiceNamespace).Get(context.Background(), flags.DNSServiceName, metav1.GetOptions{})
tests/libnet/ipaddress.go:44: unnecessary trailing newline (whitespace)

tests/libnet/cloudinit.go:156:21: SA5008: unknown JSON option "flow" (staticcheck)

tests/libnet/cloudinit.go:157:21: SA5008: unknown JSON option "flow" (staticcheck)

tests/libnet/skips.go:4:2: ST1001: should not use dot imports (stylecheck)

tests/libnet/skips.go:5:2: ST1001: should not use dot imports (stylecheck)

tests/libnet/ping.go:53:10: ST1005: error strings should not be capitalized (stylecheck)

tests/libnet/ipaddress.go:13:6: ST1003: func GetPodIpByFamily should be GetPodIPByFamily (stylecheck)

tests/libnet/ipaddress.go:21:6: ST1003: func GetVmiPrimaryIpByFamily should be GetVmiPrimaryIPByFamily (stylecheck)

tests/libnet/ipaddress.go:25:6: ST1003: func GetIp should be GetIP (stylecheck)

tests/libnet/ipaddress.go:49:6: ST1003: func GetLoopbackAddressForUrl should be GetLoopbackAddressForURL (stylecheck)

tests/libnet/namespace.go:59:2: ST1003: var newJson should be newJSON (stylecheck)

tests/libnet/skips.go:37:6: ST1003: func SkipWhenClusterNotSupportIpFamily should be SkipWhenClusterNotSupportIPFamily (stylecheck)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
