### PR TITLE
lint: Add `tests/console` to the linter coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,9 @@ lint:
 	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 	hack/dockerized "golangci-lint run --timeout 10m --verbose \
-	  tests/libvmi/... \
+	  tests/console/... \
 	  tests/libnet/... \
+	  tests/libvmi/... \
 	"
 
 .PHONY: \

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 
 	expect "github.com/google/goexpect"
 	"google.golang.org/grpc/codes"
@@ -41,6 +41,8 @@ const (
 	PromptExpression = `(\$ |\# )`
 	CRLF             = "\r\n"
 	UTFPosEscape     = "\u001b\\[[0-9]+;[0-9]+H"
+
+	consoleConnectionTimeout = 30 * time.Second
 )
 
 var (
@@ -59,7 +61,7 @@ func ExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, time
 		return err
 	}
 
-	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, consoleConnectionTimeout)
 	if err != nil {
 		return err
 	}
@@ -90,7 +92,7 @@ func SafeExpectBatchWithResponse(vmi *v1.VirtualMachineInstance, expected []expe
 	if err != nil {
 		panic(err)
 	}
-	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, consoleConnectionTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +127,7 @@ func RunCommand(vmi *v1.VirtualMachineInstance, command string, timeout time.Dur
 		}},
 	}, timeout)
 	if err != nil {
-		return fmt.Errorf("Failed to run [%s] at VMI %s, error: %v", command, vmi.Name, err)
+		return fmt.Errorf("failed to run [%s] at VMI %s, error: %v", command, vmi.Name, err)
 	}
 	return nil
 }
@@ -146,18 +148,23 @@ func RunCommandAndStoreOutput(vmi *v1.VirtualMachineInstance, command string, ti
 	conn := stream.AsConn()
 	defer conn.Close()
 
-	_, err = conn.Write([]byte(fmt.Sprintf("%s\n", command)))
+	_, err = fmt.Fprintf(conn, "%s\n", command)
 	if err != nil {
 		return "", err
 	}
 
 	scanner := bufio.NewScanner(conn)
-	// skip our input with the first Scan()
-	// and get the command output with the second one
-	if !scanner.Scan() || !scanner.Scan() {
-		return "", fmt.Errorf("Failed to run [%s] at VMI %s", command, vmi.Name)
+	if !skipInput(scanner) {
+		return "", fmt.Errorf("failed to run [%s] at VMI %s (skip input)", command, vmi.Name)
+	}
+	if !scanner.Scan() {
+		return "", fmt.Errorf("failed to run [%s] at VMI %s", command, vmi.Name)
 	}
 	return scanner.Text(), nil
+}
+
+func skipInput(scanner *bufio.Scanner) bool {
+	return scanner.Scan()
 }
 
 // SecureBootExpecter should be called on a VMI that has EFI enabled
@@ -168,16 +175,15 @@ func SecureBootExpecter(vmi *v1.VirtualMachineInstance) error {
 	if err != nil {
 		return err
 	}
-	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, consoleConnectionTimeout)
 	if err != nil {
 		return err
 	}
 	defer expecter.Close()
 
-	b := append([]expect.Batcher{
-		&expect.BExp{R: "secureboot: Secure boot enabled"},
-	})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
+	b := []expect.Batcher{&expect.BExp{R: "secureboot: Secure boot enabled"}}
+	const expectBatchTimeout = 180 * time.Second
+	res, err := expecter.ExpectBatch(b, expectBatchTimeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Kernel: %+v", res)
 		return err
@@ -194,20 +200,21 @@ func NetBootExpecter(vmi *v1.VirtualMachineInstance) error {
 	if err != nil {
 		return err
 	}
-	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, consoleConnectionTimeout)
 	if err != nil {
 		return err
 	}
 	defer expecter.Close()
 
 	esc := UTFPosEscape
-	b := append([]expect.Batcher{
+	b := []expect.Batcher{
 		// SeaBIOS can use escape (\u001b) combinations for letter placement on screen
 		// The regex below looks for the string "iPXE" and can detect it
 		// even when these escape sequences are present
 		&expect.BExp{R: "i(PXE|" + esc + "P" + esc + "X" + esc + "E)"},
-	})
-	res, err := expecter.ExpectBatch(b, 30*time.Second)
+	}
+	const expectBatchTimeout = 30 * time.Second
+	res, err := expecter.ExpectBatch(b, expectBatchTimeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("BIOS: %+v", res)
 		return err
@@ -217,17 +224,22 @@ func NetBootExpecter(vmi *v1.VirtualMachineInstance) error {
 }
 
 // NewExpecter will connect to an already logged in VMI console and return the generated expecter it will wait `timeout` for the connection.
-func NewExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, timeout time.Duration, opts ...expect.Option) (expect.Expecter, <-chan error, error) {
+func NewExpecter(
+	virtCli kubecli.KubevirtClient,
+	vmi *v1.VirtualMachineInstance,
+	timeout time.Duration,
+	opts ...expect.Option) (expect.Expecter, <-chan error, error) {
 	vmiReader, vmiWriter := io.Pipe()
 	expecterReader, expecterWriter := io.Pipe()
 	resCh := make(chan error)
 
 	startTime := time.Now()
-	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout})
+	serialConsoleOptions := &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout}
+	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, serialConsoleOptions)
 	if err != nil {
 		return nil, nil, err
 	}
-	timeout = timeout - time.Now().Sub(startTime)
+	timeout -= time.Since(startTime)
 
 	go func() {
 		resCh <- con.Stream(kubecli.StreamOptions{
@@ -236,9 +248,7 @@ func NewExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance,
 		})
 	}()
 
-	opts = append(opts, expect.SendTimeout(timeout))
-	opts = append(opts, expect.Verbose(true))
-	opts = append(opts, expect.VerboseWriter(GinkgoWriter))
+	opts = append(opts, expect.SendTimeout(timeout), expect.Verbose(true), expect.VerboseWriter(ginkgo.GinkgoWriter))
 	return expect.SpawnGeneric(&expect.GenOptions{
 		In:  vmiWriter,
 		Out: expecterReader,
@@ -266,15 +276,16 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 	expectFlag := false
 	previousSend := ""
 
-	if len(batch) < 2 {
+	const minimumRequiredBatches = 2
+	if len(batch) < minimumRequiredBatches {
 		return nil, fmt.Errorf("ExpectBatchWithValidatedSend requires at least 2 batchers, supplied %v", batch)
 	}
 
 	for i, batcher := range batch {
 		switch batcher.Cmd() {
 		case expect.BatchExpect:
-			if expectFlag == true {
-				return nil, fmt.Errorf("Two sequential expect.BExp are not allowed")
+			if expectFlag {
+				return nil, fmt.Errorf("two sequential expect.BExp are not allowed")
 			}
 			expectFlag = true
 			sendFlag = false
@@ -282,14 +293,14 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 				return nil, fmt.Errorf("ExpectBatchWithValidatedSend support only expect of type BExp")
 			}
 			bExp, _ := batch[i].(*expect.BExp)
-			previousSend := regexp.QuoteMeta(previousSend)
+			previousSend = regexp.QuoteMeta(previousSend)
 
 			// Remove the \n since it is translated by the console to \r\n.
 			previousSend = strings.TrimSuffix(previousSend, "\n")
 			bExp.R = fmt.Sprintf("%s%s%s", previousSend, "((?s).*)", bExp.R)
 		case expect.BatchSend:
-			if sendFlag == true {
-				return nil, fmt.Errorf("Two sequential expect.BSend are not allowed")
+			if sendFlag {
+				return nil, fmt.Errorf("two sequential expect.BSend are not allowed")
 			}
 			sendFlag = true
 			expectFlag = false
@@ -297,7 +308,7 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 		case expect.BatchSwitchCase:
 			return nil, fmt.Errorf("ExpectBatchWithValidatedSend doesn't support BatchSwitchCase")
 		default:
-			return nil, fmt.Errorf("Unknown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
+			return nil, fmt.Errorf("unknown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
 		}
 	}
 

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -15,6 +15,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 )
 
+const (
+	connectionTimeout = 10 * time.Second
+	promptTimeout     = 5 * time.Second
+)
+
 // LoginToFunction represents any of the LoginTo* functions
 type LoginToFunction func(*v1.VirtualMachineInstance) error
 
@@ -24,7 +29,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 	if err != nil {
 		panic(err)
 	}
-	expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
 	if err != nil {
 		return err
 	}
@@ -36,12 +41,12 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 	if err != nil {
 		return err
 	}
-	_, _, err = expecter.Expect(regexp.MustCompile(`\$`), 5*time.Second)
+	_, _, err = expecter.Expect(regexp.MustCompile(`\$`), promptTimeout)
 	if err == nil {
 		return nil
 	}
 
-	b := append([]expect.Batcher{
+	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "login as 'cirros' user. default password: 'gocubsgo'. use 'sudo' for root."},
 		&expect.BSnd{S: "\n"},
@@ -49,8 +54,10 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 		&expect.BSnd{S: "cirros\n"},
 		&expect.BExp{R: "Password:"},
 		&expect.BSnd{S: "gocubsgo\n"},
-		&expect.BExp{R: PromptExpression}})
-	resp, err := expecter.ExpectBatch(b, 180*time.Second)
+		&expect.BExp{R: PromptExpression},
+	}
+	const loginTimeout = 180 * time.Second
+	resp, err := expecter.ExpectBatch(b, loginTimeout)
 
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", resp)
@@ -71,7 +78,7 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 		panic(err)
 	}
 
-	expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
 	if err != nil {
 		return err
 	}
@@ -85,21 +92,23 @@ func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
 	hostName := dns.SanitizeHostname(vmi)
 
 	// Do not login, if we already logged in
-	b := append([]expect.Batcher{
+	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: fmt.Sprintf(`(localhost|%s):~\# `, hostName)},
-	})
-	_, err = expecter.ExpectBatch(b, 5*time.Second)
+	}
+	_, err = expecter.ExpectBatch(b, promptTimeout)
 	if err == nil {
 		return nil
 	}
 
-	b = append([]expect.Batcher{
+	b = []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: fmt.Sprintf(`(localhost|%s) login: `, hostName)},
 		&expect.BSnd{S: "root\n"},
-		&expect.BExp{R: PromptExpression}})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
+		&expect.BExp{R: PromptExpression},
+	}
+	const loginTimeout = 180 * time.Second
+	res, err := expecter.ExpectBatch(b, loginTimeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Reason(err).Errorf("Login failed: %+v", res)
 		return err
@@ -119,7 +128,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 		panic(err)
 	}
 
-	expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
 	if err != nil {
 		return err
 	}
@@ -131,16 +140,16 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 	}
 
 	// Do not login, if we already logged in
-	b := append([]expect.Batcher{
+	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: fmt.Sprintf(`(\[fedora@(localhost|fedora|%s) ~\]\$ |\[root@(localhost|fedora|%s) fedora\]\# )`, vmi.Name, vmi.Name)},
-	})
-	_, err = expecter.ExpectBatch(b, 5*time.Second)
+	}
+	_, err = expecter.ExpectBatch(b, promptTimeout)
 	if err == nil {
 		return nil
 	}
 
-	b = append([]expect.Batcher{
+	b = []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BSnd{S: "\n"},
 		&expect.BCas{C: []expect.Caser{
@@ -170,15 +179,15 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 		}},
 		&expect.BSnd{S: "sudo su\n"},
 		&expect.BExp{R: PromptExpression},
-	})
-	res, err := expecter.ExpectBatch(b, 2*time.Minute)
+	}
+	const loginTimeout = 2 * time.Minute
+	res, err := expecter.ExpectBatch(b, loginTimeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Reason(err).Errorf("Login attempt failed: %+v", res)
 		// Try once more since sometimes the login prompt is ripped apart by asynchronous daemon updates
-		res, err := expecter.ExpectBatch(b, 1*time.Minute)
-		if err != nil {
-			log.DefaultLogger().Object(vmi).Reason(err).Errorf("Retried login attempt after two minutes failed: %+v", res)
-			return err
+		if retryRes, retryErr := expecter.ExpectBatch(b, 1*time.Minute); retryErr != nil {
+			log.DefaultLogger().Object(vmi).Reason(retryErr).Errorf("Retried login attempt after two minutes failed: %+v", retryRes)
+			return retryErr
 		}
 	}
 
@@ -196,15 +205,16 @@ func OnPrivilegedPrompt(vmi *v1.VirtualMachineInstance, timeout int) bool {
 		panic(err)
 	}
 
-	expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewExpecter(virtClient, vmi, connectionTimeout)
 	if err != nil {
 		return false
 	}
 	defer expecter.Close()
 
-	b := append([]expect.Batcher{
+	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: PromptExpression}})
+		&expect.BExp{R: PromptExpression},
+	}
 	res, err := expecter.ExpectBatch(b, time.Duration(timeout)*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
@@ -219,7 +229,7 @@ func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
 	if shouldSudo {
 		sudoString = "sudo "
 	}
-	batch := append([]expect.Batcher{
+	batch := []expect.Batcher{
 		&expect.BSnd{S: "stty cols 500 rows 500\n"},
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
@@ -227,8 +237,10 @@ func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
 		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")}})
-	resp, err := expecter.ExpectBatch(batch, 30*time.Second)
+		&expect.BExp{R: RetValue("0")},
+	}
+	const configureConsoleTimeout = 30 * time.Second
+	resp, err := expecter.ExpectBatch(batch, configureConsoleTimeout)
 	if err != nil {
 		log.DefaultLogger().Infof("%v", resp)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the `tests/console` folder to the linter coverage.

The following errors are treated:
```
tests/console/console.go:239:2: appendCombine: can combine chain of 3 appends into one (gocritic)
        opts = append(opts, expect.SendTimeout(timeout))
        ^
tests/console/console.go:230:2: assignOp: replace `timeout = timeout - time.Now().Sub(startTime)` with `timeout -= time.Now().Sub(startTime)` (gocritic)
        timeout = timeout - time.Now().Sub(startTime)
        ^
tests/console/console.go:177:7: badCall: no-op append call, probably missing arguments (gocritic)
        b := append([]expect.Batcher{
             ^
tests/console/console.go:204:7: badCall: no-op append call, probably missing arguments (gocritic)
        b := append([]expect.Batcher{
             ^
tests/console/console.go:149:11: preferFprint: fmt.Fprintf(conn, "%s\n", command) should be preferred to the conn.Write([]byte(fmt.Sprintf("%s\n", command))) (gocritic)
        _, err = conn.Write([]byte(fmt.Sprintf("%s\n", command)))
                 ^
tests/console/login.go:44:7: badCall: no-op append call, probably missing arguments (gocritic)
        b := append([]expect.Batcher{
             ^
tests/console/console.go:220: line is 167 characters (lll)
func NewExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, timeout time.Duration, opts ...expect.Option) (expect.Expecter, <-chan error, error) {
tests/console/console.go:226: line is 141 characters (lll)
        con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout})
tests/console/console.go:62:51: mnd: Magic number: 30, in <argument> detected (gomnd)
        expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
                                                         ^
tests/console/console.go:93:51: mnd: Magic number: 30, in <argument> detected (gomnd)
        expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
                                                         ^
tests/console/console.go:171:51: mnd: Magic number: 30, in <argument> detected (gomnd)
        expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
                                                         ^
tests/console/console.go:180:38: mnd: Magic number: 180, in <argument> detected (gomnd)
        res, err := expecter.ExpectBatch(b, 180*time.Second)
                                            ^
tests/console/login.go:27:51: mnd: Magic number: 10, in <argument> detected (gomnd)
        expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
                                                         ^
tests/console/login.go:39:56: mnd: Magic number: 5, in <argument> detected (gomnd)
        _, _, err = expecter.Expect(regexp.MustCompile(`\$`), 5*time.Second)
                                                              ^
tests/console/login.go:53:39: mnd: Magic number: 180, in <argument> detected (gomnd)
        resp, err := expecter.ExpectBatch(b, 180*time.Second)
                                             ^
tests/console/login.go:74:51: mnd: Magic number: 10, in <argument> detected (gomnd)
        expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
                                                         ^
tests/console/login.go:92:35: mnd: Magic number: 5, in <argument> detected (gomnd)
        _, err = expecter.ExpectBatch(b, 5*time.Second)
                                         ^
tests/console/login.go:102:38: mnd: Magic number: 180, in <argument> detected (gomnd)
        res, err := expecter.ExpectBatch(b, 180*time.Second)
                                            ^
tests/console/login.go:122:51: mnd: Magic number: 10, in <argument> detected (gomnd)
        expecter, _, err := NewExpecter(virtClient, vmi, 10*time.Second)
                                                         ^
tests/console/login.go:138:35: mnd: Magic number: 5, in <argument> detected (gomnd)
        _, err = expecter.ExpectBatch(b, 5*time.Second)
                                         ^
tests/console/login.go:174:38: mnd: Magic number: 2, in <argument> detected (gomnd)
        res, err := expecter.ExpectBatch(b, 2*time.Minute)
                                            ^
tests/console/console.go:269:18: mnd: Magic number: 2, in <condition> detected (gomnd)
        if len(batch) < 2 {
                        ^
tests/console/console.go:276:7: S1002: should omit comparison to bool constant, can be simplified to `expectFlag` (gosimple)
                        if expectFlag == true {
                           ^
tests/console/console.go:291:7: S1002: should omit comparison to bool constant, can be simplified to `sendFlag` (gosimple)
                        if sendFlag == true {
                           ^
tests/console/console.go:285:4: shadow: declaration of "previousSend" shadows declaration at line 267 (govet)
                        previousSend := regexp.QuoteMeta(previousSend)
                        ^
tests/console/login.go:178:8: shadow: declaration of "err" shadows declaration at line 117 (govet)
                res, err := expecter.ExpectBatch(b, 1*time.Minute)
                     ^
tests/console/console.go:157:5: SA4000: identical expressions on the left and right side of the '||' operator (staticcheck)
        if !scanner.Scan() || !scanner.Scan() {
           ^
tests/console/console.go:30:2: ST1001: should not use dot imports (stylecheck)
        . "github.com/onsi/ginkgo/v2"
        ^
tests/console/console.go:128:10: ST1005: error strings should not be capitalized (stylecheck)
                return fmt.Errorf("Failed to run [%s] at VMI %s, error: %v", command, vmi.Name, err)
                       ^
tests/console/console.go:158:14: ST1005: error strings should not be capitalized (stylecheck)
                return "", fmt.Errorf("Failed to run [%s] at VMI %s", command, vmi.Name)
                           ^
tests/console/console.go:300:16: ST1005: error strings should not be capitalized (stylecheck)
                        return nil, fmt.Errorf("Unknown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
                                    ^

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
