### PR TITLE
tests: quarantine virt-launcher mem usage test

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2934,7 +2934,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				"the %s process is taking too much RAM! (%s > %s). All processes: %v",
 				process, actual.String(), memoryLimit.String(), processRss)
 		}
-		It("should be lower than allocated size", func() {
+		It("[QUARANTINE]should be lower than allocated size", func() {
 			By("Starting a VirtualMachineInstance")
 			vmi := tests.NewRandomFedoraVMI()
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
This failure rate for this test has consistently been
higher than 5% for the last 2 weeks, putting it into
quarantine according to the quarantine rules.

https://search.ci.kubevirt.io/?search=Configurations+virt-launcher+processes+memory+usage+should+be+lower+than+allocated+size&maxAge=336h&context=1&type=junit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
