### PR TITLE
CI: Run golangci-lint on GitHub Action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,34 @@
+name: checks
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  go-versions:
+    name: Lookup go versions
+    runs-on: ubuntu-latest
+    outputs:
+      minimal: ${{ steps.versions.outputs.minimal }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arnested/go-version-action@v1
+        id: versions
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    needs: go-versions
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.go-versions.outputs.minimal }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46.2
+          args: |
+            --timeout 10m --verbose \
+            tests/libvmi/...


### PR DESCRIPTION
**What this PR does / why we need it**:

Run the golangci-lint using GitHub Actions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This has been tested on a forked repo: https://github.com/EdDev/kubevirt/pull/1

For GitHub actions to operate, they need to be enabled on the repo.

The discussion about the pros & cons of having GitHub Actions alongside Prow jobs should be taken.
I am not sure a PR is the right place to have such a discussion, taking it to a email thread or meeting may fit better.

**Release note**:
```release-note
NONE
```
