### PR TITLE
Refactor node selector

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "multus_annotations_test.go",
+        "nodeselectorrenderer_test.go",
         "rendercontainer_test.go",
         "renderresources_test.go",
         "rendervolumes_test.go",
@@ -71,6 +72,7 @@ go_test(
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "multus_annotations.go",
+        "nodeselectorrenderer.go",
         "rendercontainer.go",
         "renderresources.go",
         "rendervolumes.go",

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -20,8 +20,13 @@ type NodeSelectorRenderer struct {
 
 type NodeSelectorRendererOption func(renderer *NodeSelectorRenderer)
 
-func NewNodeSelectorRenderer(vmiNodeSelectors map[string]string, opts ...NodeSelectorRendererOption) *NodeSelectorRenderer {
+func NewNodeSelectorRenderer(
+	vmiNodeSelectors map[string]string,
+	clusterWideConfNodeSelectors map[string]string,
+	opts ...NodeSelectorRendererOption,
+) *NodeSelectorRenderer {
 	podNodeSelectors := map[string]string{}
+	copySelectors(clusterWideConfNodeSelectors, podNodeSelectors)
 	copySelectors(vmiNodeSelectors, podNodeSelectors)
 
 	nodeSelectorRenderer := &NodeSelectorRenderer{userProvidedSelectors: podNodeSelectors}

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -1,17 +1,40 @@
 package services
 
+import v1 "kubevirt.io/api/core/v1"
+
 type NodeSelectorRenderer struct {
+	hasDedicatedCPU       bool
 	userProvidedSelectors map[string]string
 }
 
-func NewNodeSelectorRenderer(vmiNodeSelectors map[string]string) *NodeSelectorRenderer {
+type NodeSelectorRendererOption func(renderer *NodeSelectorRenderer)
+
+func NewNodeSelectorRenderer(vmiNodeSelectors map[string]string, opts ...NodeSelectorRendererOption) *NodeSelectorRenderer {
 	podNodeSelectors := map[string]string{}
 	copySelectors(vmiNodeSelectors, podNodeSelectors)
-	return &NodeSelectorRenderer{userProvidedSelectors: podNodeSelectors}
+
+	nodeSelectorRenderer := &NodeSelectorRenderer{userProvidedSelectors: podNodeSelectors}
+	for _, opt := range opts {
+		opt(nodeSelectorRenderer)
+	}
+	return nodeSelectorRenderer
 }
 
 func (nsr *NodeSelectorRenderer) Render() map[string]string {
-	return nsr.userProvidedSelectors
+	nodeSelectors := map[string]string{}
+	if nsr.hasDedicatedCPU {
+		nodeSelectors[v1.CPUManager] = "true"
+	}
+	for k, v := range nsr.userProvidedSelectors {
+		nodeSelectors[k] = v
+	}
+	return nodeSelectors
+}
+
+func WithDedicatedCPU() NodeSelectorRendererOption {
+	return func(renderer *NodeSelectorRenderer) {
+		renderer.hasDedicatedCPU = true
+	}
 }
 
 func copySelectors(src map[string]string, dst map[string]string) {

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -1,6 +1,10 @@
 package services
 
-import v1 "kubevirt.io/api/core/v1"
+import (
+	"fmt"
+
+	v1 "kubevirt.io/api/core/v1"
+)
 
 type NodeSelectorRenderer struct {
 	hasDedicatedCPU       bool
@@ -41,4 +45,25 @@ func copySelectors(src map[string]string, dst map[string]string) {
 	for k, v := range src {
 		dst[k] = v
 	}
+}
+
+func CPUModelLabelFromCPUModel(vmi *v1.VirtualMachineInstance) (label string, err error) {
+	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
+		err = fmt.Errorf("Cannot create CPU Model label, vmi spec is mising CPU model")
+		return
+	}
+	label = NFD_CPU_MODEL_PREFIX + vmi.Spec.Domain.CPU.Model
+	return
+}
+
+func CPUFeatureLabelsFromCPUFeatures(vmi *v1.VirtualMachineInstance) []string {
+	var labels []string
+	if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Features != nil {
+		for _, feature := range vmi.Spec.Domain.CPU.Features {
+			if feature.Policy == "" || feature.Policy == "require" {
+				labels = append(labels, NFD_CPU_FEATURE_PREFIX+feature.Name)
+			}
+		}
+	}
+	return labels
 }

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -29,7 +29,7 @@ func NewNodeSelectorRenderer(vmiNodeSelectors map[string]string, opts ...NodeSel
 }
 
 func (nsr *NodeSelectorRenderer) Render() map[string]string {
-	nodeSelectors := map[string]string{}
+	nodeSelectors := map[string]string{v1.NodeSchedulable: "true"}
 	if nsr.hasDedicatedCPU {
 		nodeSelectors[v1.CPUManager] = "true"
 	}

--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -1,0 +1,21 @@
+package services
+
+type NodeSelectorRenderer struct {
+	userProvidedSelectors map[string]string
+}
+
+func NewNodeSelectorRenderer(vmiNodeSelectors map[string]string) *NodeSelectorRenderer {
+	podNodeSelectors := map[string]string{}
+	copySelectors(vmiNodeSelectors, podNodeSelectors)
+	return &NodeSelectorRenderer{userProvidedSelectors: podNodeSelectors}
+}
+
+func (nsr *NodeSelectorRenderer) Render() map[string]string {
+	return nsr.userProvidedSelectors
+}
+
+func copySelectors(src map[string]string, dst map[string]string) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}

--- a/pkg/virt-controller/services/nodeselectorrenderer_test.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer_test.go
@@ -1,0 +1,152 @@
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("Node Selector Renderer", func() {
+	var nsr *NodeSelectorRenderer
+
+	Context("scheduling pods", func() {
+		When("no selectors are defined in the VMI spec", func() {
+			BeforeEach(func() {
+				nsr = NewNodeSelectorRenderer(emptySelectors(), emptySelectors())
+			})
+
+			It("the node requires the KubeVirt schedulable label", func() {
+				Expect(nsr.Render()).To(Equal(map[string]string{"kubevirt.io/schedulable": "true"}))
+			})
+
+			When("the dedicated CPU option is defined", func() {
+				BeforeEach(func() {
+					nsr = NewNodeSelectorRenderer(emptySelectors(), emptySelectors(), WithDedicatedCPU())
+				})
+
+				It("must be scheduled on nodes featuring the `cpumanager` label", func() {
+					Expect(nsr.Render()).To(HaveLabel("cpumanager"))
+				})
+			})
+
+			When("the TSC timer option is defined", func() {
+				var aFewHertzios int64
+
+				BeforeEach(func() {
+					aFewHertzios = 123
+					nsr = NewNodeSelectorRenderer(emptySelectors(), emptySelectors(), WithTSCTimer(&aFewHertzios))
+				})
+
+				It("requires nodes to feature a particular TSC frequency", func() {
+					Expect(nsr.Render()).To(HaveLabel("scheduling.node.kubevirt.io/tsc-frequency-123"))
+				})
+			})
+
+			When("Hyper V is defined", func() {
+				BeforeEach(func() {
+					nsr = NewNodeSelectorRenderer(emptySelectors(), emptySelectors(), WithHyperv(hypervFeatures()))
+				})
+
+				It("must be scheduled on nodes with Intel processor", func() {
+					Expect(nsr.Render()).To(HaveLabel("cpu-vendor.node.kubevirt.io/Intel"))
+				})
+			})
+
+			When("Hyper V is defined, but the features are not correct", func() {
+				BeforeEach(func() {
+					nsr = NewNodeSelectorRenderer(emptySelectors(), emptySelectors(), WithHyperv(kvmFeatures()))
+				})
+
+				It("does not require a particular processor vendor", func() {
+					Expect(nsr.Render()).To(Equal(map[string]string{"kubevirt.io/schedulable": "true"}))
+				})
+			})
+
+			When("specific CPU model and features are requested", func() {
+				const (
+					feature1 = "a-feature"
+					feature2 = "yet-another-feature"
+					model    = "model-t"
+				)
+
+				BeforeEach(func() {
+					nsr = NewNodeSelectorRenderer(
+						emptySelectors(),
+						emptySelectors(),
+						WithModelAndFeatureLabels(model, feature1, feature2))
+				})
+
+				It("requires the node to feature those particular features", func() {
+					Expect(nsr.Render()).To(
+						Equal(map[string]string{
+							"kubevirt.io/schedulable": "true",
+							"model-t":                 "true",
+							"yet-another-feature":     "true",
+							"a-feature":               "true",
+						}))
+				})
+			})
+		})
+
+		When("user defined selectors are present", func() {
+			BeforeEach(func() {
+				nsr = NewNodeSelectorRenderer(selectors(selector{key: "blue-node", value: "true"}), emptySelectors())
+			})
+
+			It("the node requires the user defined selector", func() {
+				Expect(nsr.Render()).To(
+					Equal(map[string]string{
+						"kubevirt.io/schedulable": "true",
+						"blue-node":               "true",
+					}))
+			})
+		})
+
+		When("cluster-wide selectors are present", func() {
+			BeforeEach(func() {
+				nsr = NewNodeSelectorRenderer(
+					emptySelectors(),
+					selectors(selector{key: "all-nodes", value: "must-work"}))
+			})
+
+			It("the node requires the user defined selector", func() {
+				Expect(nsr.Render()).To(
+					Equal(map[string]string{
+						"kubevirt.io/schedulable": "true",
+						"all-nodes":               "must-work",
+					}))
+			})
+		})
+	})
+})
+
+func hypervFeatures() *v1.Features {
+	return &v1.Features{Hyperv: &v1.FeatureHyperv{EVMCS: &v1.FeatureState{}}}
+}
+
+func kvmFeatures() *v1.Features {
+	return &v1.Features{KVM: &v1.FeatureKVM{}}
+}
+
+type selector struct {
+	key   string
+	value string
+}
+
+func emptySelectors() map[string]string {
+	return map[string]string{}
+}
+
+func selectors(userSelectors ...selector) map[string]string {
+	definedSelectors := map[string]string{}
+	for _, s := range userSelectors {
+		definedSelectors[s.key] = s.value
+	}
+	return definedSelectors
+}
+
+func HaveLabel(labelKey string) types.GomegaMatcher {
+	return HaveKeyWithValue(labelKey, "true")
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -422,7 +422,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		}
 	}
 
-	nodeSelector[v1.NodeSchedulable] = "true"
 	nodeSelectors := t.clusterConfig.GetNodeSelectors()
 	for k, v := range nodeSelectors {
 		nodeSelector[k] = v

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -255,27 +255,6 @@ func getHypervNodeSelectors(vmi *v1.VirtualMachineInstance) map[string]string {
 	return nodeSelectors
 }
 
-func CPUModelLabelFromCPUModel(vmi *v1.VirtualMachineInstance) (label string, err error) {
-	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		err = fmt.Errorf("Cannot create CPU Model label, vmi spec is mising CPU model")
-		return
-	}
-	label = NFD_CPU_MODEL_PREFIX + vmi.Spec.Domain.CPU.Model
-	return
-}
-
-func CPUFeatureLabelsFromCPUFeatures(vmi *v1.VirtualMachineInstance) []string {
-	var labels []string
-	if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Features != nil {
-		for _, feature := range vmi.Spec.Domain.CPU.Features {
-			if feature.Policy == "" || feature.Policy == "require" {
-				labels = append(labels, NFD_CPU_FEATURE_PREFIX+feature.Name)
-			}
-		}
-	}
-	return labels
-}
-
 func SetNodeAffinityForForbiddenFeaturePolicy(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
 
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Features == nil {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -385,7 +385,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	precond.MustNotBeNil(vmi)
 	domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
 	namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
-	nodeSelector := map[string]string{}
 
 	var userId int64 = util.RootUser
 
@@ -420,6 +419,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 	resources := resourceRenderer.ResourceRequirements()
 
+	nodeSelector := NewNodeSelectorRenderer(vmi.Spec.NodeSelector).Render()
 	if vmi.IsCPUDedicated() {
 		// schedule only on nodes with a running cpu manager
 		nodeSelector[v1.CPUManager] = "true"
@@ -531,10 +531,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		containers = append(containers, *kernelBootContainer)
 	}
 
-	for k, v := range vmi.Spec.NodeSelector {
-		nodeSelector[k] = v
-
-	}
 	if cpuModelLabel, err := CPUModelLabelFromCPUModel(vmi); err == nil {
 		if vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
 			nodeSelector[cpuModelLabel] = "true"

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1365,6 +1365,36 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
 			})
 
+			It("should add node selector for particular TSC frequency nodes when it is available in the VMI status", func() {
+				config, kvInformer, svc = configFactory(defaultArch)
+
+				var someHertzios int64 = 123123
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								DisableHotplug: true,
+							},
+						},
+					},
+					Status: v1.VirtualMachineInstanceStatus{
+						TopologyHints: &v1.TopologyHints{
+							TSCFrequency: &someHertzios,
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("scheduling.node.kubevirt.io/tsc-frequency-123123", "true"))
+			})
+
 			It("should add default cpu/memory resources to the sidecar container if cpu pinning was requested", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
 				nodeSelector := map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR refactors the virt-controller templating service, introducing a builder pattern to generate the node selector attributes for the pod.

The ad-hoc generation of node selectors for the virt-launcher pod is replaced by a builder pattern, allowing the customization of the launcher spec via options.

It provides a simpler, more explicit way to achieve the same thing - requesting particular requirements from nodes at launcher pod scheduling time becomes easier to write, and a lot easier to read / reason about. 

Finally, the added unit tests are a chance to clearly document how to configure each of the relevant options.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR follows up on PRs:
- #7534 
- #7600 
- #7975 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
