### PR TITLE
tests: performance: update the expected number of created vmis

### DIFF
--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -100,7 +100,7 @@ var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
 				createBatchVMIWithRateControl(virtClient, vmCount)
 
 				By("Waiting a batch of VMIs")
-				waitRunningVMI(virtClient, vmCount, vmBatchStartupLimit)
+				waitRunningVMI(virtClient, vmCount+1, vmBatchStartupLimit)
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The performance test running in the Prow workload cluster is failing:
[https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.21-sig-performance&width=20](https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.21-sig-performance&width=20)
```
   Timed out after 300.003s.
  Expected
      <int>: 101
  to equal
      <int>: 100 
```

After an update in the test that creates one VMI to init the Prometheus database to correctly calculate the counters, the test will create 100 VMIs plus 1. Which is what is failing in the expected value.

This PR updates the expected value to 101.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>