### PR TITLE
Flaky: Improve the test to catch Provisioning

### DIFF
--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -116,10 +116,10 @@ func NewRandomDataVolumeWithPVCSource(sourceNamespace, sourceName, targetNamespa
 	if !exists {
 		ginkgo.Skip("Skip test when Filesystem storage is not present")
 	}
-	return newRandomDataVolumeWithPVCSourceWithStorageClass(sourceNamespace, sourceName, targetNamespace, sc, "1Gi", accessMode)
+	return NewRandomDataVolumeWithPVCSourceWithStorageClass(sourceNamespace, sourceName, targetNamespace, sc, "1Gi", accessMode)
 }
 
-func newRandomDataVolumeWithPVCSourceWithStorageClass(sourceNamespace, sourceName, targetNamespace, storageClass, size string, accessMode v1.PersistentVolumeAccessMode) *v1beta1.DataVolume {
+func NewRandomDataVolumeWithPVCSourceWithStorageClass(sourceNamespace, sourceName, targetNamespace, storageClass, size string, accessMode v1.PersistentVolumeAccessMode) *v1beta1.DataVolume {
 	dataVolumeSource := v1beta1.DataVolumeSource{
 		PVC: &v1beta1.DataVolumeSourcePVC{
 			Namespace: sourceNamespace,

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -47,6 +47,10 @@ const (
 )
 
 func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
+	return RenderPodWithPvcNameAndVolumeMode(name, cmd, args, pvc.GetName(), pvc.Spec.VolumeMode)
+}
+
+func RenderPodWithPvcNameAndVolumeMode(name string, cmd []string, args []string, pvcName string, volumeMode *k8sv1.PersistentVolumeMode) *k8sv1.Pod {
 	volumeName := "disk0"
 	// Change to 'pod := RenderPod(name, cmd, args)' once we have a libpod package
 	pod := &k8sv1.Pod{
@@ -72,7 +76,7 @@ func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.Persi
 					Name: volumeName,
 					VolumeSource: k8sv1.VolumeSource{
 						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-							ClaimName: pvc.GetName(),
+							ClaimName: pvcName,
 						},
 					},
 				},
@@ -80,7 +84,6 @@ func RenderPodWithPVC(name string, cmd []string, args []string, pvc *k8sv1.Persi
 		},
 	}
 
-	volumeMode := pvc.Spec.VolumeMode
 	if volumeMode != nil && *volumeMode == k8sv1.PersistentVolumeBlock {
 		pod.Spec.Containers[0].VolumeDevices = addVolumeDevices(volumeName)
 	} else {


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Changed the logic so that the Provisioning state can be
deterministically enforced by using the source PVC. When the source PVC
is in use the clone can not continue and the status = Provisioning is
easy to observe.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://github.com/kubevirt/kubevirt/pull/7634

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
