### PR TITLE
Increase virt-launcher memory overhead

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -121,11 +121,11 @@ const EXT_LOG_VERBOSITY_THRESHOLD = 5
 const ephemeralStorageOverheadSize = "50M"
 
 const (
-	VirtLauncherMonitorOverhead = "25Mi" // The `ps` RSS for virt-launcher-monitor
-	VirtLauncherOverhead        = "75Mi" // The `ps` RSS for the virt-launcher process
-	VirtlogdOverhead            = "17Mi" // The `ps` RSS for virtlogd
-	LibvirtdOverhead            = "33Mi" // The `ps` RSS for libvirtd
-	QemuOverhead                = "30Mi" // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
+	VirtLauncherMonitorOverhead = "25Mi"  // The `ps` RSS for virt-launcher-monitor
+	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
+	VirtlogdOverhead            = "17Mi"  // The `ps` RSS for virtlogd
+	LibvirtdOverhead            = "33Mi"  // The `ps` RSS for libvirtd
+	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 )
 
 type TemplateService interface {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1651,8 +1651,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1224251237", "2224251237"),
-				Entry("on arm64", "arm64", "1358468965", "2358468965"),
+				Entry("on amd64", "amd64", "1250465637", "2250465637"),
+				Entry("on arm64", "arm64", "1384683365", "2384683365"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1687,8 +1687,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2224251237"),
-				Entry("on arm64", "arm64", "2358468965"),
+				Entry("on amd64", "amd64", "2250465637"),
+				Entry("on arm64", "arm64", "2384683365"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1725,8 +1725,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 304),
-				Entry("on arm64", "arm64", 438),
+				Entry("on amd64", "amd64", 330),
+				Entry("on arm64", "arm64", 464),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1761,12 +1761,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 304),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 304),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 287),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 438),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 438),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 421),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 330),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 330),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 313),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 464),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 464),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 447),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1965,10 +1965,10 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 223),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 223),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 357),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 357),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 249),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 249),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 383),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 383),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -2034,8 +2034,8 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("on amd64", "amd64", 223),
-				Entry("on arm64", "arm64", 357),
+				Entry("on amd64", "amd64", 249),
+				Entry("on arm64", "arm64", 383),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -278,7 +278,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(340)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(366)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Recent tests show that 75Mb is not enough.
virt-launcher memory overhead may vary during execution
depending on many factors, such as when the garbage collector runs.
Increase the virt-launcher overhead to avoid OOM kill.
Here is a report of some collected data
![RSS](https://user-images.githubusercontent.com/4507192/176465240-4ebd2070-3492-4fe8-9ae8-8a22d96c129e.png)

Here is the document where we are collecting data from the current running test:
https://docs.google.com/spreadsheets/d/1Dd_bRffT6hr1fw_rlh7hqOFRFbVQWaCOyU7IZVwGDVo/edit?usp=sharing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase virt-launcher memory overhead
```
