### PR TITLE
[release-0.51] Make names of access tests around test_id:2921 unique

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -404,11 +404,11 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			table.DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 				testAction(resource, action, "no")
 			},
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/pause", "update"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/unpause", "update"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/softreboot", "update"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/console", "get"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/vnc", "get"),
+				table.Entry("[test_id:2921]given a vmi (pause)", "virtualmachineinstances/pause", "update"),
+				table.Entry("[test_id:2921]given a vmi (unpause)", "virtualmachineinstances/unpause", "update"),
+				table.Entry("[test_id:2921]given a vmi (softreboot)", "virtualmachineinstances/softreboot", "update"),
+				table.Entry("[test_id:2921]given a vmi (console)", "virtualmachineinstances/console", "get"),
+				table.Entry("[test_id:2921]given a vmi (vnc)", "virtualmachineinstances/vnc", "get"),
 			)
 		})
 
@@ -445,12 +445,12 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			table.DescribeTable("should verify permissions on resources are correct for subresources", func(resource string, action string) {
 				testAction(resource, action, "yes")
 			},
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/pause", "update"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/unpause", "update"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/softreboot", "update"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/console", "get"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/vnc", "get"),
-				table.Entry("[test_id:2921]given a vmi", "virtualmachineinstances/guestosinfo", "get"),
+				table.Entry("[test_id:2921]given a vmi (pause)", "virtualmachineinstances/pause", "update"),
+				table.Entry("[test_id:2921]given a vmi (unpause)", "virtualmachineinstances/unpause", "update"),
+				table.Entry("[test_id:2921]given a vmi (softreboot)", "virtualmachineinstances/softreboot", "update"),
+				table.Entry("[test_id:2921]given a vmi (console)", "virtualmachineinstances/console", "get"),
+				table.Entry("[test_id:2921]given a vmi (vnc)", "virtualmachineinstances/vnc", "get"),
+				table.Entry("[test_id:2921]given a vmi (guestosinfo)", "virtualmachineinstances/guestosinfo", "get"),
 			)
 		})
 	})


### PR DESCRIPTION
This is a manual cherry-pick of #7673

/assign dhiller

```release-note
NONE
```