### PR TITLE
Add longfile linter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ nogo(
     # that are always correct).
     # You can see the what `go vet` does by running `go doc cmd/vet`.
     deps = [
+        "//tools/analyzers/longfile:go_default_library",
         "//vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/asmdecl:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/assign:go_default_library",

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -125,5 +125,13 @@
       "vendor/": "vendor doesn't pass vet",
       "external/": "externaldoesn't pass vet"
     }
+  },
+  "longfile": {
+    "exclude_files": {
+      "vendor/": "vendor doesn't pass vet",
+      "external/": "externaldoesn't pass vet",
+      "pkg/": "quite some files are big",
+      "staging/": "focus on testing for now"
+    }
   }
 }

--- a/tools/analyzers/longfile/BUILD.bazel
+++ b/tools/analyzers/longfile/BUILD.bazel
@@ -1,0 +1,10 @@
+# gazelle:ignore
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["longfile.go"],
+    importpath = "kubevirt.io/kubevirt/tools/analyzers/longfile",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_tools//go/analysis:go_default_library"],
+)

--- a/tools/analyzers/longfile/longfile.go
+++ b/tools/analyzers/longfile/longfile.go
@@ -1,0 +1,72 @@
+package longfile
+
+import (
+	_ "embed"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var max int
+var exceptions map[string]int
+
+var Analyzer = &analysis.Analyzer{
+	Name: "longfile",
+	Doc:  "detects if source code files are too long",
+	Run:  checkPath,
+}
+
+func init() {
+	max = 1000
+	exceptions = map[string]int{
+		"tests/utils.go":               3500,
+		"tests/reporter/kubernetes.go": 2000,
+	}
+}
+
+func checkPath(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		pos := pass.Fset.Position(file.End())
+		if isGenerated(file, pos) {
+			continue
+		}
+
+		parts := strings.Split(pos.Filename, "execroot/kubevirt/")
+		filename := parts[len(parts)-1]
+
+		fileMax, exists := exceptions[filename]
+		if !exists {
+			fileMax = max
+		}
+
+		if pos.Line > fileMax {
+			pass.Report(analysis.Diagnostic{
+				Pos:     file.End(),
+				Message: fmt.Sprintf("file has a length of %v which is more than %v lines", pos.Line, fileMax),
+			})
+		}
+
+	}
+	return nil, nil
+}
+
+func isGenerated(file *ast.File, pos token.Position) bool {
+	if strings.HasSuffix(pos.Filename, "_generated.go") {
+		return true
+	}
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT.") {
+				return true
+			}
+			if strings.HasPrefix(c.Text, "// Automatically generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT!") {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Demonstrate use of nogo instead of running external (slow) linting code/scripts in extra CI jobs and with extra development commands:

Limit the maximum file length to 1000 in the tests package for now. One
exception for `tests/utils.go` and `tests/reporter/kubernetes.go`
exists.

`pkg` and `staging` are excluded for now.

nogo is used to ensure good developer experience, since it runs all
linters during normal compilation, including caching which makes it
lightweight. Also no dedicated jobs are needed while at the same time
consistent results between CI, the merge queue and local development
environments is guaranteed.

Potential errors look like this:

```
pkg/virt-launcher/virtwrap/live-migration-source.go:1079:2: file has a length of 1079 which is more than 1000 lines (longfile)
pkg/virt-launcher/virtwrap/manager.go:1933:2: file has a length of 1933 which is more than 1000 lines (longfile)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
