### PR TITLE
Add isGarbageCollected to perfscale-load-generator ObjListWatcher

### DIFF
--- a/tools/perfscale-load-generator/watcher/watcher.go
+++ b/tools/perfscale-load-generator/watcher/watcher.go
@@ -22,23 +22,19 @@ package watcher
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"sync"
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-
+	"k8s.io/client-go/tools/cache"
 	kvv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
-
 	"kubevirt.io/kubevirt/pkg/controller"
-
-	"k8s.io/client-go/tools/cache"
-
 	objUtils "kubevirt.io/kubevirt/tools/perfscale-load-generator/object"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This helps in asserting the Delete semantics of the api during
performance testing. It is required that when Delete request is processed
against kubevirt api objects (VMI, VM and VirtualMachineReplicaSet),
kubevirt system is able to observe the complete garbage collection
(from delete request all the way to finalizer being removed and object being
removed from the kube api)

In order to avoid stomping apiserver with get requests from the e2e test suite
a further optimization of introducing a cache is required

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8025 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Wait deletion to succeed all the way till objects are finalized in perfscale tests
```
