### PR TITLE
Let github collapse BUILD.bazel files in certain locations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 vendor/* linguist-vendored
+pkg/**/BUILD.bazel linguist-vendored
+staging/**/BUILD.bazel linguist-vendored
+tests/**/BUILD.bazel linguist-vendored
+tests/conformance/BUILD.bazel linguist-vendored=false


### PR DESCRIPTION
**What this PR does / why we need it**:

BUILD.bazel files in pkg/, staging/ and tests/ are 100% auto-generated
and pretty much 100% of the time not something which need a review.

These paths are also the places where most of the code changes happen.
Let's mark them as dependencies which should be collapsed by default on PR reviews.

In the only case where they are normally an issue and need to be fixed
is when unintended custom modifications were done. In this case CI will
uncover that.

Properties are detected correctly:

```bash
$ git check-attr --all pkg/container-disk/BUILD.bazel
pkg/container-disk/BUILD.bazel: linguist-vendored: set
$ git check-attr --all tests/conformance/
BUILD.bazel     conformance.go  def.bzl         
$ git check-attr --all tests/conformance/
BUILD.bazel     conformance.go  def.bzl         
$ git check-attr --all tests/conformance/BUILD.bazel
tests/conformance/BUILD.bazel: linguist-vendored: false
$ git check-attr --all tests/BUILD.bazel
tests/BUILD.bazel: linguist-vendored: set
$ git check-attr --all staging/src/github.com/BUILD.bazel
staging/src/github.com/BUILD.bazel: linguist-vendored: set
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
