### PR TITLE
virtctl: Add option to wrap local scp client to scp command

### DIFF
--- a/pkg/virtctl/scp/BUILD.bazel
+++ b/pkg/virtctl/scp/BUILD.bazel
@@ -1,10 +1,11 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
         "native.go",
         "scp.go",
+        "wrapped.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/scp",
     visibility = ["//visibility:public"],
@@ -14,5 +15,21 @@ go_library(
         "//vendor/github.com/povsister/scp:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "scp_suite_test.go",
+        "wrapped_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/virtctl/ssh:go_default_library",
+        "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/virtctl/scp/BUILD.bazel
+++ b/pkg/virtctl/scp/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["scp.go"],
+    srcs = [
+        "native.go",
+        "scp.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/scp",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/virtctl/scp/native.go
+++ b/pkg/virtctl/scp/native.go
@@ -1,0 +1,108 @@
+package scp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/povsister/scp"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/ssh"
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+func (o *SCP) nativeSCP(local templates.LocalSCPArgument, remote templates.RemoteSCPArgument, toRemote bool) error {
+	sshClient := ssh.NativeSSHConnection{
+		ClientConfig: o.clientConfig,
+		Options:      o.options,
+	}
+	client, err := sshClient.PrepareSSHClient(remote.Kind, remote.Namespace, remote.Name)
+	if err != nil {
+		return err
+	}
+
+	scpClient, err := scp.NewClientFromExistingSSH(client, &scp.ClientOption{})
+	if err != nil {
+		return err
+	}
+
+	if toRemote {
+		return o.copyToRemote(scpClient, local.Path, remote.Path)
+	}
+	return o.copyFromRemote(scpClient, local.Path, remote.Path)
+}
+
+func (o *SCP) copyToRemote(client *scp.Client, localPath, remotePath string) error {
+	isFile, isDir, exists, err := stat(localPath)
+	if err != nil {
+		return fmt.Errorf("failed reading path %q: %v", localPath, err)
+	}
+
+	if !exists {
+		return fmt.Errorf("local path %q does not exist, can't copy it", localPath)
+	}
+
+	if o.recursive {
+		if isFile {
+			return fmt.Errorf("local path %q is not a directory but '--recursive' was provided", localPath)
+		}
+
+		return client.CopyDirToRemote(localPath, remotePath, &scp.DirTransferOption{PreserveProp: o.preserve})
+	}
+
+	if isDir {
+		return fmt.Errorf("local path %q is a directory but '--recursive' was not provided", localPath)
+	}
+
+	return client.CopyFileToRemote(localPath, remotePath, &scp.FileTransferOption{PreserveProp: o.preserve})
+}
+
+func (o *SCP) copyFromRemote(client *scp.Client, localPath, remotePath string) error {
+	_, isDir, exists, err := stat(localPath)
+	if err != nil {
+		return fmt.Errorf("failed reading path %q: %v", localPath, err)
+	}
+
+	if o.recursive {
+		if exists {
+			if !isDir {
+				return fmt.Errorf("local path %q is a file but '--recursive' was provided", localPath)
+			}
+			localPath = appendRemoteBase(localPath, remotePath)
+		}
+
+		if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
+			return fmt.Errorf("failed ensuring the existence of the local target directory %q: %v", localPath, err)
+		}
+
+		return client.CopyDirFromRemote(remotePath, localPath, &scp.DirTransferOption{PreserveProp: o.preserve})
+	}
+
+	if exists && isDir {
+		localPath = appendRemoteBase(localPath, remotePath)
+	}
+
+	return client.CopyFileFromRemote(remotePath, localPath, &scp.FileTransferOption{PreserveProp: o.preserve})
+}
+
+func stat(path string) (isFile, isDir, exists bool, err error) {
+	s, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, false, false, nil
+	} else if err != nil {
+		return false, false, false, err
+	}
+	return !s.IsDir(), s.IsDir(), true, nil
+}
+
+func appendRemoteBase(localPath, remotePath string) string {
+	remoteBase := filepath.Base(remotePath)
+	switch remoteBase {
+	case "..", ".", "/", "./", "":
+		// no identifiable base name, let's go with the supplied local path
+		return localPath
+	default:
+		// we identified a base location, let's append it to the local path
+		return filepath.Join(localPath, remoteBase)
+	}
+}

--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -20,11 +20,6 @@
 package scp
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/povsister/scp"
 	"github.com/spf13/cobra"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -33,13 +28,15 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
-func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+const (
+	recursiveFlag, recursiveFlagShort = "recursive", "r"
+	preserveFlag                      = "preserve"
+)
 
+func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	c := &SCP{
 		clientConfig: clientConfig,
 		options:      ssh.DefaultSSHOptions(),
-		recursive:    false,
-		preserve:     false,
 	}
 
 	cmd := &cobra.Command{
@@ -51,9 +48,12 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 			return c.Run(cmd, args)
 		},
 	}
-	cmd.Flags().BoolVarP(&c.recursive, "recursive", "r", c.recursive, "Recursively copy entire directories")
-	cmd.Flags().BoolVar(&c.preserve, "preserve", c.preserve, "Preserves modification times, access times, and modes from the original file.")
+
 	ssh.AddCommandlineArgs(cmd.Flags(), &c.options)
+	cmd.Flags().BoolVarP(&c.recursive, recursiveFlag, recursiveFlagShort, c.recursive,
+		"Recursively copy entire directories")
+	cmd.Flags().BoolVar(&c.preserve, preserveFlag, c.preserve,
+		"Preserves modification times, access times, and modes from the original file.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -71,89 +71,8 @@ func (o *SCP) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sshClient := ssh.NativeSSHConnection{
-		ClientConfig: o.clientConfig,
-		Options:      o.options,
-	}
-	client, err := sshClient.PrepareSSHClient(remote.Kind, remote.Namespace, remote.Name)
-	if err != nil {
-		return err
-	}
-	scpClient, err := scp.NewClientFromExistingSSH(client, &scp.ClientOption{})
-	if err != nil {
-		return err
-	}
-	isFile, isDir, exists, err := stat(local.Path)
-	if err != nil {
-		return fmt.Errorf("failed reading path %q: %v", local.Path, err)
-	}
 
-	if toRemote {
-		if !exists {
-			return fmt.Errorf("local path %q does not exist, can't copy it", local.Path)
-		}
-
-		if o.recursive {
-			if isFile {
-				return fmt.Errorf("local path %q is not a direcotry but '--recursive' was provided", local.Path)
-			}
-			err = scpClient.CopyDirToRemote(local.Path, remote.Path, &scp.DirTransferOption{PreserveProp: o.preserve})
-			if err != nil {
-				return err
-			}
-		} else {
-			if isDir {
-				return fmt.Errorf("local path %q is a directory but '--recursive' was not provided", local.Path)
-			}
-			if err = scpClient.CopyFileToRemote(local.Path, remote.Path, &scp.FileTransferOption{PreserveProp: o.preserve}); err != nil {
-				return err
-			}
-		}
-	} else {
-		if o.recursive {
-			if exists {
-				if !isDir {
-					return fmt.Errorf("local path %q is a file but '--recursive' was provided", local.Path)
-				}
-				local.Path = appendRemoteBase(local.Path, remote.Path)
-			}
-
-			if err := os.MkdirAll(local.Path, os.ModePerm); err != nil {
-				return fmt.Errorf("failed ensuring the existence of the local target directory %q: %v", local.Path, err)
-			}
-
-			err = scpClient.CopyDirFromRemote(remote.Path, local.Path, &scp.DirTransferOption{PreserveProp: o.preserve})
-			if err != nil {
-				return err
-			}
-		} else {
-			if exists && isDir {
-				local.Path = appendRemoteBase(local.Path, remote.Path)
-			}
-			err = scpClient.CopyFileFromRemote(remote.Path, local.Path, &scp.FileTransferOption{PreserveProp: o.preserve})
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func usage() string {
-	return `  # Copy a file to the remote home folder of user jdoe
-  {{ProgramName}} scp myfile.bin jdoe@testvmi:myfile.bin
-
-  # Copy a directory to the remote home folder of user jdoe
-  {{ProgramName}} scp --recursive ~/mydir/ jdoe@testvmi:./mydir
-
-  # Copy a file to the remote home folder of user jdoe without specifying a file name on the target
-  {{ProgramName}} scp myfile.bin jdoe@testvmi:.
-
-  # Copy a file to 'testvm' in 'mynamespace' namespace
-  {{ProgramName}} scp myfile.bin jdoe@testvmi.mynamespace:myfile.bin
-
-  # Copy a file from the remote location to a local folder
-  {{ProgramName}} scp jdoe@testvmi:myfile.bin ~/myfile.bin`
+	return o.nativeSCP(local, remote, toRemote)
 }
 
 func PrepareCommand(cmd *cobra.Command, clientConfig clientcmd.ClientConfig, opts *ssh.SSHOptions, args []string) (local templates.LocalSCPArgument, remote templates.RemoteSCPArgument, toRemote bool, err error) {
@@ -176,24 +95,19 @@ func PrepareCommand(cmd *cobra.Command, clientConfig clientcmd.ClientConfig, opt
 	return
 }
 
-func stat(path string) (isFile bool, isDir bool, exists bool, err error) {
-	s, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return false, false, false, nil
-	} else if err != nil {
-		return false, false, false, err
-	}
-	return !s.IsDir(), s.IsDir(), true, nil
-}
+func usage() string {
+	return `  # Copy a file to the remote home folder of user jdoe
+  {{ProgramName}} scp myfile.bin jdoe@testvmi:myfile.bin
 
-func appendRemoteBase(localPath, remotePath string) string {
-	remoteBase := filepath.Base(remotePath)
-	switch remoteBase {
-	case "..", ".", "/", "./", "":
-		// no identifiable base name, let's go with the supplied local path
-		return localPath
-	default:
-		// we identified a base location, let's append it to the local path
-		return filepath.Join(localPath, remoteBase)
-	}
+  # Copy a directory to the remote home folder of user jdoe
+  {{ProgramName}} scp --recursive ~/mydir/ jdoe@testvmi:./mydir
+
+  # Copy a file to the remote home folder of user jdoe without specifying a file name on the target
+  {{ProgramName}} scp myfile.bin jdoe@testvmi:.
+
+  # Copy a file to 'testvm' in 'mynamespace' namespace
+  {{ProgramName}} scp myfile.bin jdoe@testvmi.mynamespace:myfile.bin
+
+  # Copy a file from the remote location to a local folder
+  {{ProgramName}} scp jdoe@testvmi:myfile.bin ~/myfile.bin`
 }

--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -38,6 +38,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		clientConfig: clientConfig,
 		options:      ssh.DefaultSSHOptions(),
 	}
+	c.options.LocalClientName = "scp"
 
 	cmd := &cobra.Command{
 		Use:     "scp (VM|VMI)",
@@ -71,6 +72,10 @@ func (o *SCP) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if o.options.WrapLocalSSH {
+		clientArgs := o.buildSCPTarget(local, remote, toRemote)
+		return ssh.RunLocalClient(remote.Kind, remote.Namespace, remote.Name, &o.options, clientArgs)
+	}
 
 	return o.nativeSCP(local, remote, toRemote)
 }

--- a/pkg/virtctl/scp/scp.go
+++ b/pkg/virtctl/scp/scp.go
@@ -95,7 +95,7 @@ func PrepareCommand(cmd *cobra.Command, clientConfig clientcmd.ClientConfig, opt
 	}
 
 	if len(remote.Username) > 0 {
-		opts.SshUsername = remote.Username
+		opts.SSHUsername = remote.Username
 	}
 	return
 }

--- a/pkg/virtctl/scp/scp_suite_test.go
+++ b/pkg/virtctl/scp/scp_suite_test.go
@@ -1,0 +1,11 @@
+package scp_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestSCP(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/scp/wrapped.go
+++ b/pkg/virtctl/scp/wrapped.go
@@ -1,0 +1,34 @@
+package scp
+
+import (
+	"strings"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+func (o *SCP) buildSCPTarget(local templates.LocalSCPArgument, remote templates.RemoteSCPArgument, toRemote bool) (opts []string) {
+	if o.recursive {
+		opts = append(opts, "-r")
+	}
+	if o.preserve {
+		opts = append(opts, "-p")
+	}
+
+	target := strings.Builder{}
+	if len(o.options.SshUsername) > 0 {
+		target.WriteString(o.options.SshUsername)
+		target.WriteRune('@')
+	}
+	target.WriteString(remote.Name)
+	target.WriteRune('.')
+	target.WriteString(remote.Namespace)
+	target.WriteRune(':')
+	target.WriteString(remote.Path)
+
+	if toRemote {
+		opts = append(opts, local.Path, target.String())
+	} else {
+		opts = append(opts, target.String(), local.Path)
+	}
+	return
+}

--- a/pkg/virtctl/scp/wrapped.go
+++ b/pkg/virtctl/scp/wrapped.go
@@ -15,8 +15,8 @@ func (o *SCP) buildSCPTarget(local templates.LocalSCPArgument, remote templates.
 	}
 
 	target := strings.Builder{}
-	if len(o.options.SshUsername) > 0 {
-		target.WriteString(o.options.SshUsername)
+	if len(o.options.SSHUsername) > 0 {
+		target.WriteString(o.options.SSHUsername)
 		target.WriteRune('@')
 	}
 	target.WriteString(remote.Name)

--- a/pkg/virtctl/scp/wrapped_test.go
+++ b/pkg/virtctl/scp/wrapped_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Wrapped SCP", func() {
 	Context("buildSCPTarget", func() {
 
 		It("with SCP username", func() {
-			scp.options = ssh.SSHOptions{SshUsername: "testuser"}
+			scp.options = ssh.SSHOptions{SSHUsername: "testuser"}
 			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
 			Expect(scpTarget[0]).To(Equal("testuser@fake-name.fake-ns:/remote/fakepath"))
 		})

--- a/pkg/virtctl/scp/wrapped_test.go
+++ b/pkg/virtctl/scp/wrapped_test.go
@@ -1,0 +1,79 @@
+package scp
+
+import (
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/ssh"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+var _ = Describe("Wrapped SCP", func() {
+
+	var fakeLocal templates.LocalSCPArgument
+	var fakeRemote templates.RemoteSCPArgument
+	var fakeToRemote bool
+	var scp SCP
+
+	BeforeEach(func() {
+		fakeLocal = templates.LocalSCPArgument{
+			Path: "/local/fakepath",
+		}
+		fakeRemote = templates.RemoteSCPArgument{
+			Namespace: "fake-ns",
+			Name:      "fake-name",
+			Path:      "/remote/fakepath",
+		}
+		fakeToRemote = false
+		scp = SCP{}
+	})
+
+	Context("buildSCPTarget", func() {
+
+		It("with SCP username", func() {
+			scp.options = ssh.SSHOptions{SshUsername: "testuser"}
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("testuser@fake-name.fake-ns:/remote/fakepath"))
+		})
+
+		It("without SCP username", func() {
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("fake-name.fake-ns:/remote/fakepath"))
+		})
+
+		It("with recursive", func() {
+			scp.recursive = true
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("-r"))
+		})
+
+		It("with preserve", func() {
+			scp.preserve = true
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("-p"))
+		})
+
+		It("with recursive and preserve", func() {
+			scp.recursive = true
+			scp.preserve = true
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("-r"))
+			Expect(scpTarget[1]).To(Equal("-p"))
+		})
+
+		It("toRemote = false", func() {
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("fake-name.fake-ns:/remote/fakepath"))
+			Expect(scpTarget[1]).To(Equal("/local/fakepath"))
+		})
+
+		It("toRemote = true", func() {
+			fakeToRemote = true
+			scpTarget := scp.buildSCPTarget(fakeLocal, fakeRemote, fakeToRemote)
+			Expect(scpTarget[0]).To(Equal("/local/fakepath"))
+			Expect(scpTarget[1]).To(Equal("fake-name.fake-ns:/remote/fakepath"))
+		})
+	})
+})

--- a/pkg/virtctl/ssh/knownhosts.go
+++ b/pkg/virtctl/ssh/knownhosts.go
@@ -76,7 +76,7 @@ Are you sure you want to continue connecting (yes/no)? `,
 	return askToAddHostKey(hostname, remote, key)
 }
 
-func addHostKey(knownHostsFilePath string, hostname string, key ssh.PublicKey) error {
+func addHostKey(knownHostsFilePath, hostname string, key ssh.PublicKey) error {
 	f, err := os.OpenFile(knownHostsFilePath, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err

--- a/pkg/virtctl/ssh/knownhosts_test.go
+++ b/pkg/virtctl/ssh/knownhosts_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Known Hosts", func() {
 })
 
 func newPublicKey() (ssh.PublicKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virtctl/ssh/resize_unix.go
+++ b/pkg/virtctl/ssh/resize_unix.go
@@ -13,16 +13,16 @@ import (
 )
 
 // resizeSessionOnWindowChange watches for SIGWINCH and refreshes the session with the new window size
-func resizeSessionOnWindowChange(session *ssh.Session, fd uintptr) {
+func resizeSessionOnWindowChange(session *ssh.Session, _ uintptr) {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGWINCH)
 
 	for range sigs {
-		session.SendRequest("window-change", false, windowSizePayloadFor(fd))
+		session.SendRequest("window-change", false, windowSizePayloadFor())
 	}
 }
 
-func windowSizePayloadFor(fd uintptr) []byte {
+func windowSizePayloadFor() []byte {
 	w, h, err := term.GetSize(int(os.Stdin.Fd()))
 	if err != nil {
 		return buildWindowSizePayload(80, 24)

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -44,7 +44,6 @@ const (
 )
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-
 	c := &SSH{
 		clientConfig: clientConfig,
 		options:      DefaultSSHOptions(),
@@ -68,13 +67,13 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func AddCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
-	flagset.StringVarP(&opts.SshUsername, usernameFlag, usernameFlagShort, opts.SshUsername,
-		fmt.Sprintf("--%s=%s: Set this to the user you want to open the SSH connection as; If unassigned, this will be empty and the SSH default will apply", usernameFlag, opts.SshUsername))
+	flagset.StringVarP(&opts.SSHUsername, usernameFlag, usernameFlagShort, opts.SSHUsername,
+		fmt.Sprintf("--%s=%s: Set this to the user you want to open the SSH connection as; If unassigned, this will be empty and the SSH default will apply", usernameFlag, opts.SSHUsername))
 	flagset.StringVarP(&opts.IdentityFilePath, IdentityFilePathFlag, identityFilePathFlagShort, opts.IdentityFilePath,
 		fmt.Sprintf("--%s=/home/jdoe/.ssh/id_rsa: Set the path to a private key used for authenticating to the server; If not provided, the client will try to use the local ssh-agent at $SSH_AUTH_SOCK", IdentityFilePathFlag))
 	flagset.StringVar(&opts.KnownHostsFilePath, knownHostsFilePathFlag, opts.KnownHostsFilePathDefault,
 		fmt.Sprintf("--%s=/home/jdoe/.ssh/kubevirt_known_hosts: Set the path to the known_hosts file.", knownHostsFilePathFlag))
-	flagset.IntVarP(&opts.SshPort, portFlag, portFlagShort, opts.SshPort,
+	flagset.IntVarP(&opts.SSHPort, portFlag, portFlagShort, opts.SSHPort,
 		fmt.Sprintf(`--%s=22: Specify a port on the VM to send SSH traffic to`, portFlag))
 	flagset.StringArrayVarP(&opts.AdditionalSSHLocalOptions, additionalOpts, additionalOptsShort, opts.AdditionalSSHLocalOptions,
 		fmt.Sprintf(`--%s="-o StrictHostKeyChecking=no" : Additional options to be passed to the local ssh. This is applied only if local-ssh=true `, commandToExecute))
@@ -88,8 +87,8 @@ func DefaultSSHOptions() SSHOptions {
 		glog.Warningf("failed to determine user home directory: %v", err)
 	}
 	options := SSHOptions{
-		SshPort:                   22,
-		SshUsername:               defaultUsername(),
+		SSHPort:                   22,
+		SSHUsername:               defaultUsername(),
 		IdentityFilePath:          filepath.Join(homeDir, ".ssh", "id_rsa"),
 		IdentityFilePathProvided:  false,
 		KnownHostsFilePath:        "",
@@ -112,8 +111,8 @@ type SSH struct {
 }
 
 type SSHOptions struct {
-	SshPort                   int
-	SshUsername               string
+	SSHPort                   int
+	SSHUsername               string
 	IdentityFilePath          string
 	IdentityFilePathProvided  bool
 	KnownHostsFilePath        string
@@ -153,7 +152,7 @@ func PrepareCommand(cmd *cobra.Command, clientConfig clientcmd.ClientConfig, opt
 	}
 
 	if len(targetUsername) > 0 {
-		opts.SshUsername = targetUsername
+		opts.SSHUsername = targetUsername
 	}
 	return
 }

--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -14,7 +14,7 @@ var runCommand = func(cmd *exec.Cmd) error {
 
 func RunLocalClient(kind, namespace, name string, options *SSHOptions, clientArgs []string) error {
 	args := []string{"-o"}
-	args = append(args, buildProxyCommandOption(kind, namespace, name, options.SshPort))
+	args = append(args, buildProxyCommandOption(kind, namespace, name, options.SSHPort))
 
 	if len(options.AdditionalSSHLocalOptions) > 0 {
 		args = append(args, options.AdditionalSSHLocalOptions...)
@@ -49,8 +49,8 @@ func buildProxyCommandOption(kind, namespace, name string, port int) string {
 
 func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
 	target := strings.Builder{}
-	if len(o.options.SshUsername) > 0 {
-		target.WriteString(o.options.SshUsername)
+	if len(o.options.SSHUsername) > 0 {
+		target.WriteString(o.options.SSHUsername)
 		target.WriteRune('@')
 	}
 	target.WriteString(kind)

--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -12,13 +12,20 @@ var runCommand = func(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-func (o *SSH) runLocalCommandClient(kind, namespace, name string) error {
-
+func RunLocalClient(kind, namespace, name string, options *SSHOptions, clientArgs []string) error {
 	args := []string{"-o"}
-	args = append(args, o.buildProxyCommandOption(kind, namespace, name))
-	args = append(args, o.buildSSHTarget(kind, namespace, name)...)
+	args = append(args, buildProxyCommandOption(kind, namespace, name, options.SshPort))
 
-	cmd := exec.Command("ssh", args...)
+	if len(options.AdditionalSSHLocalOptions) > 0 {
+		args = append(args, options.AdditionalSSHLocalOptions...)
+	}
+	if options.IdentityFilePathProvided {
+		args = append(args, "-i", options.IdentityFilePath)
+	}
+
+	args = append(args, clientArgs...)
+
+	cmd := exec.Command(options.LocalClientName, args...)
 	fmt.Println("running:", cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -27,7 +34,7 @@ func (o *SSH) runLocalCommandClient(kind, namespace, name string) error {
 	return runCommand(cmd)
 }
 
-func (o *SSH) buildProxyCommandOption(kind, namespace, name string) string {
+func buildProxyCommandOption(kind, namespace, name string, port int) string {
 	proxyCommand := strings.Builder{}
 	proxyCommand.WriteString("ProxyCommand=")
 	proxyCommand.WriteString(os.Args[0])
@@ -35,19 +42,13 @@ func (o *SSH) buildProxyCommandOption(kind, namespace, name string) string {
 	proxyCommand.WriteString(fmt.Sprintf("%s/%s.%s", kind, name, namespace))
 	proxyCommand.WriteString(" ")
 
-	proxyCommand.WriteString(strconv.Itoa(o.options.SshPort))
+	proxyCommand.WriteString(strconv.Itoa(port))
 
 	return proxyCommand.String()
 }
 
 func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
 	target := strings.Builder{}
-	if len(o.options.AdditionalSSHLocalOptions) > 0 {
-		opts = append(opts, o.options.AdditionalSSHLocalOptions...)
-	}
-	if o.options.IdentityFilePathProvided {
-		opts = append(opts, "-i", o.options.IdentityFilePath)
-	}
 	if len(o.options.SshUsername) > 0 {
 		target.WriteString(o.options.SshUsername)
 		target.WriteRune('@')
@@ -59,8 +60,8 @@ func (o *SSH) buildSSHTarget(kind, namespace, name string) (opts []string) {
 	target.WriteString(namespace)
 
 	opts = append(opts, target.String())
-	if o.options.Command != "" {
-		opts = append(opts, o.options.Command)
+	if o.command != "" {
+		opts = append(opts, o.command)
 	}
 	return
 }

--- a/pkg/virtctl/ssh/wrapped_test.go
+++ b/pkg/virtctl/ssh/wrapped_test.go
@@ -38,24 +38,26 @@ var _ = Describe("Wrapped SSH", func() {
 
 	It("buildProxyCommandOption", func() {
 		const sshPort = 12345
-		ssh.options = SSHOptions{SshPort: sshPort}
-		proxyCommand := ssh.buildProxyCommandOption(fakeKind, fakeNamespace, fakeName)
+		proxyCommand := buildProxyCommandOption(fakeKind, fakeNamespace, fakeName, sshPort)
 		expected := fmt.Sprintf("port-forward --stdio=true fake-kind/fake-name.fake-ns %d", sshPort)
 		Expect(proxyCommand).To(ContainSubstring(expected))
 	})
 
-	It("runLocalCommandClient", func() {
+	It("RunLocalClient", func() {
 		runCommand = func(cmd *exec.Cmd) error {
 			Expect(cmd).ToNot(BeNil())
 			Expect(cmd.Args).To(HaveLen(4))
 			Expect(cmd.Args[0]).To(Equal("ssh"))
-			Expect(cmd.Args[2]).To(Equal(ssh.buildProxyCommandOption(fakeKind, fakeNamespace, fakeName)))
+			Expect(cmd.Args[2]).To(Equal(buildProxyCommandOption(fakeKind, fakeNamespace, fakeName, ssh.options.SshPort)))
 			Expect(cmd.Args[3]).To(Equal(ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)[0]))
 
 			return nil
 		}
 
-		err := ssh.runLocalCommandClient(fakeKind, fakeNamespace, fakeName)
+		ssh.options = DefaultSSHOptions()
+		ssh.options.SshPort = 12345
+		clientArgs := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
+		err := RunLocalClient(fakeKind, fakeNamespace, fakeName, &ssh.options, clientArgs)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })

--- a/pkg/virtctl/ssh/wrapped_test.go
+++ b/pkg/virtctl/ssh/wrapped_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Wrapped SSH", func() {
 	Context("buildSSHTarget", func() {
 
 		It("with SSH username", func() {
-			ssh.options = SSHOptions{SshUsername: "testuser"}
+			ssh.options = SSHOptions{SSHUsername: "testuser"}
 			sshTarget := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
 			Expect(sshTarget[0]).To(Equal("testuser@fake-kind/fake-name.fake-ns"))
 		})
@@ -48,14 +48,14 @@ var _ = Describe("Wrapped SSH", func() {
 			Expect(cmd).ToNot(BeNil())
 			Expect(cmd.Args).To(HaveLen(4))
 			Expect(cmd.Args[0]).To(Equal("ssh"))
-			Expect(cmd.Args[2]).To(Equal(buildProxyCommandOption(fakeKind, fakeNamespace, fakeName, ssh.options.SshPort)))
+			Expect(cmd.Args[2]).To(Equal(buildProxyCommandOption(fakeKind, fakeNamespace, fakeName, ssh.options.SSHPort)))
 			Expect(cmd.Args[3]).To(Equal(ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)[0]))
 
 			return nil
 		}
 
 		ssh.options = DefaultSSHOptions()
-		ssh.options.SshPort = 12345
+		ssh.options.SSHPort = 12345
 		clientArgs := ssh.buildSSHTarget(fakeKind, fakeNamespace, fakeName)
 		err := RunLocalClient(fakeKind, fakeNamespace, fakeName, &ssh.options, clientArgs)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -23,6 +23,47 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 	var pub ssh.PublicKey
 	var keyFile string
 	var virtClient kubecli.KubevirtClient
+
+	copyNative := func(src, dst string, recursive bool) {
+		args := []string{
+			"scp",
+			"--namespace", util.NamespaceTestDefault,
+			"--username", "cirros",
+			"--identity-file", keyFile,
+			"--known-hosts=",
+		}
+		if recursive {
+			args = append(args, "--recursive")
+		}
+		args = append(args, src, dst)
+
+		Expect(clientcmd.NewRepeatableVirtctlCommand(args...)()).To(Succeed())
+	}
+
+	copyLocal := func(src, dst string, recursive bool) {
+		args := []string{
+			"scp",
+			"--local-ssh=true",
+			"--namespace", util.NamespaceTestDefault,
+			"--username", "cirros",
+			"--identity-file", keyFile,
+			"-t", "-o StrictHostKeyChecking=no",
+			"-t", "-o UserKnownHostsFile=/dev/null",
+			"-t", "-O",
+		}
+		if recursive {
+			args = append(args, "--recursive")
+		}
+		args = append(args, src, dst)
+
+		_, cmd, err := clientcmd.CreateCommandWithNS(util.NamespaceTestDefault, "virtctl", args...)
+		Expect(err).ToNot(HaveOccurred())
+
+		out, err := cmd.CombinedOutput()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(BeEmpty())
+	}
+
 	BeforeEach(func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
@@ -36,7 +77,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 		Expect(DumpPrivateKey(priv, keyFile)).To(Succeed())
 	})
 
-	It("should copy a local file back and forth", func() {
+	DescribeTable("should copy a local file back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmi.NewCirros(
 			libvmi.WithCloudInitNoCloudUserData(renderUserDataWithKey(pub), false))
@@ -46,33 +87,20 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 		vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 		By("copying a file to the VMI")
-		Expect(clientcmd.NewRepeatableVirtctlCommand(
-			"scp",
-			"--namespace", util.NamespaceTestDefault,
-			"--username", "cirros",
-			"--identity-file", keyFile,
-			"--known-hosts=",
-			keyFile,
-			vmi.Name+":"+"./keyfile",
-		)()).To(Succeed())
+		copyFn(keyFile, vmi.Name+":"+"./keyfile", false)
 
 		By("copying the file back")
 		copyBackFile := filepath.Join(GinkgoT().TempDir(), "remote_id_rsa")
-		Expect(clientcmd.NewRepeatableVirtctlCommand(
-			"scp",
-			"--namespace", util.NamespaceTestDefault,
-			"--username", "cirros",
-			"--identity-file", keyFile,
-			"--known-hosts=",
-			vmi.Name+":"+"./keyfile",
-			copyBackFile,
-		)()).To(Succeed())
+		copyFn(vmi.Name+":"+"./keyfile", copyBackFile, false)
 
 		By("comparing the two files")
 		compareFile(keyFile, copyBackFile)
-	})
+	},
+		Entry("using the native scp method", copyNative),
+		Entry("using the local scp method", copyLocal),
+	)
 
-	It("should copy a local directory back and forth", func() {
+	DescribeTable("should copy a local directory back and forth", func(copyFn func(string, string, bool)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmi.NewCirros(
 			libvmi.WithCloudInitNoCloudUserData(renderUserDataWithKey(pub), false))
@@ -90,33 +118,18 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 		Expect(os.WriteFile(filepath.Join(copyFromDir, "file2"), []byte("test1"), 0777)).To(Succeed())
 
 		By("copying a file to the VMI")
-		Expect(clientcmd.NewRepeatableVirtctlCommand(
-			"scp",
-			"--namespace", util.NamespaceTestDefault,
-			"--username", "cirros",
-			"--identity-file", keyFile,
-			"--recursive",
-			"--known-hosts=",
-			copyFromDir,
-			vmi.Name+":"+"./sourcedir",
-		)()).To(Succeed())
+		copyFn(copyFromDir, vmi.Name+":"+"./sourcedir", true)
 
 		By("copying the file back")
-		Expect(clientcmd.NewRepeatableVirtctlCommand(
-			"scp",
-			"--namespace", util.NamespaceTestDefault,
-			"--username", "cirros",
-			"--recursive",
-			"--identity-file", keyFile,
-			"--known-hosts=",
-			vmi.Name+":"+"./sourcedir",
-			copyToDir,
-		)()).To(Succeed())
+		copyFn(vmi.Name+":"+"./sourcedir", copyToDir, true)
 
 		By("comparing the two directories")
 		compareFile(filepath.Join(copyFromDir, "file1"), filepath.Join(copyToDir, "file1"))
 		compareFile(filepath.Join(copyFromDir, "file2"), filepath.Join(copyToDir, "file2"))
-	})
+	},
+		Entry("using the native scp method", copyNative),
+		Entry("using the local scp method", copyLocal),
+	)
 })
 
 func renderUserDataWithKey(key ssh.PublicKey) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds the option to use the local scp client instead of the native go
ssh client for scp operations. Like for the local ssh client virtctl is
used as ProxyCommand for scp.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add option to wrap local scp client to scp command
```
