### PR TITLE
Remove dead virtio cache link

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,7 +126,6 @@ http_file(
     sha256 = "b8a4bc66835c43091a85d35a10b59bd8b1b62b55ea9f02ec754f68bd32e82c0e",
     urls = [
         "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.217-1/virtio-win-0.1.217.iso",
-        "https://storage.googleapis.com/builddeps/b8a4bc66835c43091a85d35a10b59bd8b1b62b55ea9f02ec754f68bd32e82c0e",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The cache link was bumped by accident in a PR without giving the CI bot
a chance to do that automatically. Removing the link so that the bot can
upload the image.

This should help with the virtio disk donwload slowness on initial `make
cluster-sync` calls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
