### PR TITLE
Update orphaned vm alert

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -152,25 +152,28 @@ tests:
         alertname: VirtOperatorDown
         exp_alerts: [ ]
 
-
-    # vmi running on a node with an unready virt-handler pod
+    # Alert to test when there are VMIs running on a node with an unready virt-handler pod
+    # Alert should not fire for node with no running VMIs.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
-        values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="false"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1'
       - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
       - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
 
     alert_rule_test:
       # no alert before 10 minutes
@@ -189,22 +192,29 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
-
-    # vmi running on a node without a virt-handler pod
+    # Alert to test when there are VMIs running on a node without a virt-handler pod
+    # Alert should not fire for node with no running VMIs.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
-        values: '_ _ _ _ _ _ _ _ _ _ _'
       - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
-        values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
       - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+        values: '_ _ _ _ _ _ _ _ _ _ _'
+
 
     alert_rule_test:
       # no alert before 10 minutes
@@ -222,7 +232,6 @@ tests:
               severity: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
-
 
   # Some virt controllers are not ready
   - interval: 1m

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -421,7 +421,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "OrphanedVirtualMachineInstances",
-						Expr:  intstr.FromString("((count by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} * on(pod) group_left(node) kube_pod_info{pod=~'virt-handler.*'})) or (count by (node)(kube_pod_info{pod=~'virt-launcher.*'})*0)) == 0"),
+						Expr:  intstr.FromString("(((sum by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} * on(pod) group_left(node) sum by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0"),
 						For:   "10m",
 						Annotations: map[string]string{
 							"summary":     "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The assumption that the `kube_pod_status_ready` metric with `condition="true"` doesn't return values when the pod is unready was wrong. The metric shows all pods, but pods that are ready has Value=1, non-ready pods - Value=0.
This PR updates the `OrphanedVirtualMachineInstances`  alert when virt-handler pod is unready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2052556
**Special notes for your reviewer**:
The query verifies that the nodes have a virt-handler and that it is in ready state, only for nodes that have running VMs on them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
