### PR TITLE
Add linter for ginkgo checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,10 @@ format:
 
 fmt: format
 
-lint:
+ginkgo_linter:
+	@python3 hack/ginkgo-linter.py $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" ! -path "*/cluster-up/*")
+
+lint: ginkgo_linter
 	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 	hack/dockerized "golangci-lint run --timeout 10m --verbose \

--- a/hack/ginkgo-linter.py
+++ b/hack/ginkgo-linter.py
@@ -1,0 +1,81 @@
+import re
+import sys
+
+wrong_len_equal_check = "(Expect(?:\\(|WithOffset\\(\\d+, ?))len\\(([^)]+)\\)(\\)\\.(?:To|ToNot|NotTo|Should|" \
+                        "ShouldNot)\\((?:Not\\()?)Equal\\(([^\\)]+)\\)(.*$)"
+wrong_len_equal_regex = re.compile(wrong_len_equal_check)
+
+wrong_len_zero_check = "(Expect(?:\\(|WithOffset\\(\\d+, ?))len\\(([^)]+)\\)(\\)\\.(?:To|ToNot|NotTo|Should|" \
+                       "ShouldNot)\\((?:Not\\()?)BeZero\\(\\)(.*)$"
+wrong_len_zero_regex = re.compile(wrong_len_zero_check)
+
+wrong_empty_check = "(Expect(?:\\(|WithOffset\\(\\d+, ?))len\\(([^)]+)\\)(\\)\\.(?:To|ToNot|NotTo|Should|ShouldNot)" \
+                    "\\((?:Not\\()?)BeNumerically\\((?:\">\", 0|\">=\", 1)\\)(.*)$"
+wrong_empty_regex = re.compile(wrong_empty_check)
+
+
+def check_one_file(file_name):
+    found = 0
+    with open(file_name) as f:
+        i = 0
+        for line in f:
+            i = i + 1
+            line = line.strip()
+            found = found + find_wrong_len_equal_check(file_name, i, line)
+            found = found + find_wrong_len_zero_check(file_name, i, line)
+            found = found + find_wrong_empty_check(file_name, i, line)
+    return found
+
+
+def find_wrong_len_equal_check(file_name, i, line):
+    res = wrong_len_equal_regex.search(line)
+    if res:
+        matcher = "BeEmpty()" if res[4].isnumeric() and int(res[4]) == 0 else f"HaveLen({res[4]})"
+        use = f'{res[1]}{res[2]}{res[3]}{matcher}{res[5]}'
+        wrong_length_output(file_name, line, i, use)
+        return 1
+    return 0
+
+
+def find_wrong_len_zero_check(file_name, i, line):
+    res = wrong_len_zero_regex.search(line)
+    if res:
+        use = f"{res[1]}{res[2]}{res[3]}BeEmpty(){res[4]}"
+        wrong_length_output(file_name, line, i, use)
+        return 1
+    return 0
+
+
+def find_wrong_empty_check(file_name, i, line):
+    res = wrong_empty_regex.search(line)
+    if res:
+        use = f"{res[1]}{res[2]}{res[3]}Not(BeEmpty()){res[4]}"
+        wrong_length_output(file_name, line, i, use)
+        return 1
+    return 0
+
+
+def wrong_length_output(file_name, line, line_num, use):
+    print(f'Found problem in {file_name}, line #{line_num}: wrong length check:', file=sys.stderr)
+    print(line, file=sys.stderr)
+    print('~' * len(line), file=sys.stderr)
+    print(f'use `{use}` instead', file=sys.stderr)
+    print("", file=sys.stderr)
+
+
+def main():
+    found_issues = 0
+    found_files = 0
+    if len(sys.argv) > 1:
+        for file in sys.argv[1:]:
+            found_in_one_file = check_one_file(file)
+            if found_in_one_file > 0:
+                found_issues = found_issues + found_in_one_file
+                found_files = found_files + 1
+    if found_issues > 0:
+        print(f'Found {found_issues} issues in {found_files} files', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/hack/ginkgo-linter.py
+++ b/hack/ginkgo-linter.py
@@ -76,6 +76,8 @@ def main():
         print(f'Found {found_issues} issues in {found_files} files', file=sys.stderr)
         sys.exit(1)
 
+    print('Success: ginkgo-linter found no issues.')
+
 
 if __name__ == '__main__':
     main()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3538,7 +3538,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "2Mi"}}
 			vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(BeNumerically(">=", 1))
+			Expect(causes).ToNot(BeEmpty())
 			Expect(causes).To(ContainElement(metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Field: "fake.domain.cpu.dedicatedCpuPlacement", Message: "fake.domain.cpu.dedicatedCpuPlacement must be set to true when fake.domain.cpu.realtime is used"}))
 		})
 		It("should reject the realtime knob when NUMA Guest Mapping Passthrough is not defined", func() {
@@ -4012,7 +4012,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(BeNumerically(">=", 1))
+		Expect(causes).To(Not(BeEmpty()))
 	})
 
 	It("Should validate VMIs with correct hyperv deps", func() {

--- a/pkg/virt-controller/watch/export/export_test.go
+++ b/pkg/virt-controller/watch/export/export_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Export controlleer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pod).ToNot(BeNil())
 		Expect(pod.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
-		Expect(len(pod.Spec.Volumes)).To(Equal(3), "There should be 3 volumes, one pvc, and two secrets (token and certs)")
+		Expect(pod.Spec.Volumes).To(HaveLen(3), "There should be 3 volumes, one pvc, and two secrets (token and certs)")
 		certSecretName := ""
 		for _, volume := range pod.Spec.Volumes {
 			if volume.Name == certificates {
@@ -248,8 +248,8 @@ var _ = Describe("Export controlleer", func() {
 				},
 			},
 		}))
-		Expect(len(pod.Spec.Containers)).To(Equal(1))
-		Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(3))
+		Expect(pod.Spec.Containers).To(HaveLen(1))
+		Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
 		Expect(pod.Spec.Containers[0].VolumeMounts).To(ContainElement(k8sv1.VolumeMount{
 			Name:      "test-pvc",
 			ReadOnly:  true,

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -670,7 +670,7 @@ var _ = Describe("Restore controlleer", func() {
 
 				l, err := cdiClient.CdiV1beta1().DataVolumes("").List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(l.Items)).To(BeZero())
+				Expect(l.Items).To(BeEmpty())
 				testutils.ExpectEvent(recorder, "VirtualMachineRestoreComplete")
 			})
 

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -315,14 +315,14 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 						Expect(numberOfCreatedMDEVs).To(BeZero(), msg)
 					}
 				}
-				Expect(len(desiredDevicesToConfigure)).To(BeZero(), "add types should be created")
+				Expect(desiredDevicesToConfigure).To(BeEmpty(), "add types should be created")
 			}
 
 			By("removing all created mdevs")
 			mdevManager.updateMDEVTypesConfiguration([]string{})
 			files, err := ioutil.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(files)).To(BeZero())
+			Expect(files).To(BeEmpty())
 		},
 			Entry("spread types accoss identical cards", spreadTypesAccossIdenticalCard),
 			Entry("one yype many cards", oneTypeManyCards),
@@ -425,7 +425,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 						Expect(numberOfCreatedMDEVs).To(BeZero(), msg)
 					}
 				}
-				Expect(len(desiredDevicesToConfigure)).To(BeZero(), "add types should be created")
+				Expect(desiredDevicesToConfigure).To(BeEmpty(), "add types should be created")
 			}
 
 			By("removing all created mdevs")
@@ -434,7 +434,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			deviceController.refreshMediatedDevicesTypes()
 			files, err := ioutil.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(files)).To(BeZero())
+			Expect(files).To(BeEmpty())
 		},
 			Entry("configure default mdev types", deafultTypesNotNodeSpecific),
 			Entry("configure mdev types that match all node selectors", matchAllNodeLabels),

--- a/pkg/virt-handler/isolation/isolation_test.go
+++ b/pkg/virt-handler/isolation/isolation_test.go
@@ -23,8 +23,7 @@ var _ = Describe("IsolationResult", func() {
 		It("Should have mounts", func() {
 			mounts, err := isolationResult.Mounts(nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mounts).ToNot(BeNil())
-			Expect(len(mounts)).ToNot(BeZero())
+			Expect(mounts).ToNot(BeEmpty())
 		})
 
 		It("Should have root mounted", func() {
@@ -72,8 +71,7 @@ var _ = Describe("IsolationResult", func() {
 		It("Should have mounts", func() {
 			mounts, err := isolationResult.Mounts(nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mounts).ToNot(BeNil())
-			Expect(len(mounts)).ToNot(BeZero())
+			Expect(mounts).ToNot(BeEmpty())
 		})
 	})
 

--- a/staging/src/kubevirt.io/client-go/api/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/defaults_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Defaults", func() {
 	It("should add interface and pod network by default", func() {
 		vmi := &v1.VirtualMachineInstance{}
 		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).NotTo(BeZero())
-		Expect(len(vmi.Spec.Networks)).NotTo(BeZero())
+		Expect(vmi.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
+		Expect(vmi.Spec.Networks).NotTo(BeEmpty())
 	})
 
 	It("should default to true to all defined features", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -422,7 +422,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				By("finding all kubevirt pods")
 				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
-				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
+				Expect(pods.Items).ToNot(BeEmpty(), "no kubevirt pods found")
 
 				By("finding all schedulable nodes")
 				schedulableNodesList := libnode.GetAllSchedulableNodes(virtClient)


### PR DESCRIPTION
This PR adds a linter for ginkgo checks. For the fist phase, the linter looks for wrong length checks (see below), and suggests alternatives. To ease the usage of the linter, the PR adds the new `ginkgo_linter` Makefile target, and add it to the `lint` target.
   
This PR prevents wrong length check. It forbides the following formats:
    `Expect(len(x)).Should(Equal(1))` ==> `Expect(x).Should(HaveLen(1))`
    `Expect(len(x)).To(Equal(0))` ==> `Expect(x).To(BeEmpty())`
    `Expect(len(x)).NotTo(BeZero())` ==> `Expect(x).NotTo(BeEmpty())`
    `Expect(len(x)).To(BeNumerically(">=", 1))` ==> `Expect(x).To(Not(BeEmpty()))`
    `Expect(len(x)).Should(BeNumerically(">", 0))` ==> `Expect(x).Should(Not(BeEmpty()))`

Also, this PR fixes the new linter warnings in 7 files.

Before the fixes, the linter output was:
```
Found issue in ./pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go, line #3541: wrong length check:
    Expect(len(causes)).To(BeNumerically(">=", 1))
Consider replacing with: 
    Expect(causes).To(Not(BeEmpty()))
================================================================================
Found issue in ./pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go, line #4015: wrong length check:
    Expect(len(causes)).To(BeNumerically(">=", 1))
Consider replacing with: 
    Expect(causes).To(Not(BeEmpty()))
================================================================================
Found issue in ./pkg/virt-controller/watch/snapshot/restore_test.go, line #673: wrong length check:
    Expect(len(l.Items)).To(BeZero())
Consider replacing with: 
    Expect(l.Items).To(BeEmpty())
================================================================================
Found issue in ./pkg/virt-controller/watch/export/export_test.go, line #220: wrong length check:
    Expect(len(pod.Spec.Volumes)).To(Equal(3), "There should be 3 volumes, one pvc, and two secrets (token and certs)")
Consider replacing with: 
    Expect(pod.Spec.Volumes).To(HaveLen(3), "There should be 3 volumes, one pvc, and two secrets (token and certs)")
================================================================================
Found issue in ./pkg/virt-controller/watch/export/export_test.go, line #251: wrong length check:
    Expect(len(pod.Spec.Containers)).To(Equal(1))
Consider replacing with: 
    Expect(pod.Spec.Containers).To(HaveLen(1))
================================================================================
Found issue in ./pkg/virt-controller/watch/export/export_test.go, line #252: wrong length check:
    Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(3))
Consider replacing with: 
    Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
================================================================================
Found issue in ./pkg/virt-handler/device-manager/mediated_devices_types_test.go, line #318: wrong length check:
    Expect(len(desiredDevicesToConfigure)).To(BeZero(), "add types should be created")
Consider replacing with: 
    Expect(desiredDevicesToConfigure).To(BeEmpty(), "add types should be created")
================================================================================
Found issue in ./pkg/virt-handler/device-manager/mediated_devices_types_test.go, line #325: wrong length check:
    Expect(len(files)).To(BeZero())
Consider replacing with: 
    Expect(files).To(BeEmpty())
================================================================================
Found issue in ./pkg/virt-handler/device-manager/mediated_devices_types_test.go, line #428: wrong length check:
    Expect(len(desiredDevicesToConfigure)).To(BeZero(), "add types should be created")
Consider replacing with: 
    Expect(desiredDevicesToConfigure).To(BeEmpty(), "add types should be created")
================================================================================
Found issue in ./pkg/virt-handler/device-manager/mediated_devices_types_test.go, line #437: wrong length check:
    Expect(len(files)).To(BeZero())
Consider replacing with: 
    Expect(files).To(BeEmpty())
================================================================================
Found issue in ./pkg/virt-handler/isolation/isolation_test.go, line #27: wrong length check:
    Expect(len(mounts)).ToNot(BeZero())
Consider replacing with: 
    Expect(mounts).ToNot(BeEmpty())
================================================================================
Found issue in ./pkg/virt-handler/isolation/isolation_test.go, line #76: wrong length check:
    Expect(len(mounts)).ToNot(BeZero())
Consider replacing with: 
    Expect(mounts).ToNot(BeEmpty())
================================================================================
Found issue in ./staging/src/kubevirt.io/client-go/api/defaults_test.go, line #47: wrong length check:
    Expect(len(vmi.Spec.Domain.Devices.Interfaces)).NotTo(BeZero())
Consider replacing with: 
    Expect(vmi.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
================================================================================
Found issue in ./staging/src/kubevirt.io/client-go/api/defaults_test.go, line #48: wrong length check:
    Expect(len(vmi.Spec.Networks)).NotTo(BeZero())
Consider replacing with: 
    Expect(vmi.Spec.Networks).NotTo(BeEmpty())
================================================================================
Found issue in ./tests/infra_test.go, line #425: wrong length check:
    Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
Consider replacing with: 
    Expect(pods.Items).To(Not(BeEmpty()), "no kubevirt pods found")
================================================================================
Found 15 issues in 7 files
```

```release-note
None
```
