### PR TITLE
Deprecate live migration feature gate

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -86,10 +86,6 @@ func (admitter *MigrationCreateAdmitter) Admit(ar *admissionv1.AdmissionReview) 
 		return resp
 	}
 
-	if !admitter.ClusterConfig.LiveMigrationEnabled() {
-		return webhookutils.ToAdmissionResponseError(fmt.Errorf("LiveMigration feature gate is not enabled in kubevirt-config"))
-	}
-
 	causes := ValidateVirtualMachineInstanceMigrationSpec(k8sfield.NewPath("spec"), &migration.Spec)
 	if len(causes) > 0 {
 		return webhookutils.ToAdmissionResponse(causes)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -190,36 +190,6 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
-		It("should reject valid Migration spec on create when feature gate isn't enabled", func() {
-			vmi := api.NewMinimalVMI("testvmimigrate1")
-
-			mockVMIClient.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil).MaxTimes(1)
-
-			migration := v1.VirtualMachineInstanceMigration{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-				},
-				Spec: v1.VirtualMachineInstanceMigrationSpec{
-					VMIName: "testvmimigrate1",
-				},
-			}
-			migrationBytes, _ := json.Marshal(&migration)
-
-			disableFeatureGates()
-
-			ar := &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{
-					Resource: webhooks.MigrationGroupVersionResource,
-					Object: runtime.RawExtension{
-						Raw: migrationBytes,
-					},
-				},
-			}
-
-			resp := migrationCreateAdmitter.Admit(ar)
-			Expect(resp.Allowed).To(BeFalse())
-		})
-
 		It("should accept Migration spec on create when previous VMI migration completed", func() {
 			vmi := api.NewMinimalVMI("testmigratevmi4")
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -24,10 +24,6 @@ type PodEvictionAdmitter struct {
 }
 
 func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	if !admitter.ClusterConfig.LiveMigrationEnabled() {
-		return validating_webhooks.NewPassingAdmissionResponse()
-	}
-
 	launcher, err := admitter.VirtClient.CoreV1().Pods(ar.Request.Namespace).Get(context.Background(), ar.Request.Name, metav1.GetOptions{})
 	if err != nil {
 		return validating_webhooks.NewPassingAdmissionResponse()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -50,26 +50,16 @@ var _ = Describe("Pod eviction admitter", func() {
 	var kubeClient *fake.Clientset
 	var virtClient *kubecli.MockKubevirtClient
 	var vmiClient *kubecli.MockVirtualMachineInstanceInterface
+	var podEvictionAdmitter PodEvictionAdmitter
+	var clusterConfig *virtconfig.ClusterConfig
 
-	newKubeVirtWithFeatureGate := func(featureGate string) *virtv1.KubeVirt {
+	newClusterConfig := func() *virtconfig.ClusterConfig {
 		kv := kubecli.NewMinimalKubeVirt(testns)
 		kv.Namespace = "kubevirt"
 		if kv.Spec.Configuration.DeveloperConfiguration == nil {
 			kv.Spec.Configuration.DeveloperConfiguration = &virtv1.DeveloperConfiguration{}
 		}
-		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		return kv
-	}
 
-	newClusterConfigWithFeatureGate := func(featureGate string) *virtconfig.ClusterConfig {
-		kv := newKubeVirtWithFeatureGate(featureGate)
-		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
-		return clusterConfig
-	}
-
-	newClusterConfigWithEvictionStrategy := func(evictionStrategy virtv1.EvictionStrategy) *virtconfig.ClusterConfig {
-		kv := newKubeVirtWithFeatureGate(virtconfig.LiveMigrationGate)
-		kv.Spec.Configuration.EvictionStrategy = &evictionStrategy
 		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
 		return clusterConfig
 	}
@@ -81,6 +71,11 @@ var _ = Describe("Pod eviction admitter", func() {
 		kubeClient = fake.NewSimpleClientset()
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(testns).Return(vmiClient).AnyTimes()
+		clusterConfig = newClusterConfig()
+		podEvictionAdmitter = PodEvictionAdmitter{
+			ClusterConfig: clusterConfig,
+			VirtClient:    virtClient,
+		}
 
 		// Make sure that any unexpected call to the client will fail
 		kubeClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
@@ -89,25 +84,205 @@ var _ = Describe("Pod eviction admitter", func() {
 		})
 	})
 
-	Context("Live migration enabled", func() {
+	Context("Migratable and evictable VMI", func() {
 
-		var podEvictionAdmitter PodEvictionAdmitter
+		var vmi *virtv1.VirtualMachineInstance
+		liveMigrateStrategy := virtv1.EvictionStrategyLiveMigrate
+		nodeName := "node01"
 
 		BeforeEach(func() {
-			clusterConfig := newClusterConfigWithFeatureGate(virtconfig.LiveMigrationGate)
-			podEvictionAdmitter = PodEvictionAdmitter{
-				ClusterConfig: clusterConfig,
-				VirtClient:    virtClient,
+			vmi = &virtv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testns,
+					Name:      "testvmi",
+				},
+				Status: virtv1.VirtualMachineInstanceStatus{
+					Conditions: []virtv1.VirtualMachineInstanceCondition{
+						{
+							Type:   virtv1.VirtualMachineInstanceIsMigratable,
+							Status: k8sv1.ConditionTrue,
+						},
+					},
+					NodeName: nodeName,
+				},
+				Spec: virtv1.VirtualMachineInstanceSpec{
+					EvictionStrategy: &liveMigrateStrategy,
+				},
 			}
 		})
 
-		Context("Migratable and evictable VMI", func() {
+		It("Should deny review requests when updating the VMI fails", func() {
 
+			By("Composing a dummy admission request on a virt-launcher pod")
+			pod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: testns,
+					Annotations: map[string]string{
+						virtv1.DomainAnnotation: vmi.Name,
+					},
+					Labels: map[string]string{
+						virtv1.AppLabel: "virt-launcher",
+					},
+				},
+				Spec: k8sv1.PodSpec{
+					NodeName: nodeName,
+				},
+				Status: k8sv1.PodStatus{},
+			}
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				},
+			}
+
+			kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				get, ok := action.(testing.GetAction)
+				Expect(ok).To(BeTrue())
+				Expect(pod.Namespace).To(Equal(get.GetNamespace()))
+				Expect(pod.Name).To(Equal(get.GetName()))
+				return true, pod, nil
+			})
+
+			vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
+
+			data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
+			vmiClient.
+				EXPECT().
+				Patch(vmi.Name,
+					types.JSONPatchType,
+					[]byte(data),
+					&metav1.PatchOptions{}).
+				Return(nil, fmt.Errorf("err"))
+
+			resp := podEvictionAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Code).To(Equal(int32(http.StatusTooManyRequests)))
+			Expect(kubeClient.Fake.Actions()).To(HaveLen(1))
+		})
+
+		It("Should allow review requests when eviction strategy is not configured", func() {
+
+			By("Removing eviction strategy from the VMI")
+			vmi.Spec.EvictionStrategy = nil
+
+			By("Composing a dummy admission request on a virt-launcher pod")
+			pod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: testns,
+					Annotations: map[string]string{
+						virtv1.DomainAnnotation: vmi.Name,
+					},
+					Labels: map[string]string{
+						virtv1.AppLabel: "virt-launcher",
+					},
+				},
+				Spec: k8sv1.PodSpec{
+					NodeName: nodeName,
+				},
+				Status: k8sv1.PodStatus{},
+			}
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				},
+			}
+
+			kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				get, ok := action.(testing.GetAction)
+				Expect(ok).To(BeTrue())
+				Expect(pod.Namespace).To(Equal(get.GetNamespace()))
+				Expect(pod.Name).To(Equal(get.GetName()))
+				return true, pod, nil
+			})
+
+			vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
+
+			data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
+			vmiClient.
+				EXPECT().
+				Patch(vmi.Name,
+					types.JSONPatchType,
+					[]byte(data),
+					&metav1.PatchOptions{}).
+				Return(nil, fmt.Errorf("err")).AnyTimes()
+
+			resp := podEvictionAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(kubeClient.Fake.Actions()).To(HaveLen(1))
+		})
+
+		DescribeTable("Should allow  review requests that are on a virt-launcher pod", func(dryRun bool) {
+			By("Composing a dummy admission request on a virt-launcher pod")
+			pod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testpod",
+					Namespace: testns,
+					Annotations: map[string]string{
+						virtv1.DomainAnnotation: vmi.Name,
+					},
+					Labels: map[string]string{
+						virtv1.AppLabel: "virt-launcher",
+					},
+				},
+				Spec: k8sv1.PodSpec{
+					NodeName: nodeName,
+				},
+				Status: k8sv1.PodStatus{},
+			}
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+					DryRun:    &dryRun,
+				},
+			}
+
+			kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				get, ok := action.(testing.GetAction)
+				Expect(ok).To(BeTrue())
+				Expect(pod.Namespace).To(Equal(get.GetNamespace()))
+				Expect(pod.Name).To(Equal(get.GetName()))
+				return true, pod, nil
+			})
+
+			if !dryRun {
+				data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
+				vmiClient.
+					EXPECT().
+					Patch(vmi.Name,
+						types.JSONPatchType,
+						[]byte(data),
+						&metav1.PatchOptions{}).
+					Return(nil, nil)
+			}
+			vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
+
+			resp := podEvictionAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeTrue())
+			actions := kubeClient.Fake.Actions()
+			Expect(actions).To(HaveLen(1))
+		},
+			Entry("and should mark the VMI when not in dry-run mode", false),
+			Entry("and should not mark the VMI when in dry-run mode", true),
+		)
+
+		Context("With EvictionStrategy cluster setting set to 'LiveMigrate'", func() {
 			var vmi *virtv1.VirtualMachineInstance
-			liveMigrateStrategy := virtv1.EvictionStrategyLiveMigrate
-			nodeName := "node01"
 
 			BeforeEach(func() {
+				//clusterConfig := newClusterConfigWithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate)
+				podEvictionAdmitter = PodEvictionAdmitter{
+					ClusterConfig: clusterConfig,
+					VirtClient:    virtClient,
+				}
+
 				vmi = &virtv1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testns,
@@ -120,15 +295,13 @@ var _ = Describe("Pod eviction admitter", func() {
 								Status: k8sv1.ConditionTrue,
 							},
 						},
-						NodeName: nodeName,
 					},
-					Spec: virtv1.VirtualMachineInstanceSpec{
-						EvictionStrategy: &liveMigrateStrategy,
-					},
+					Spec: virtv1.VirtualMachineInstanceSpec{},
 				}
 			})
 
-			It("Should deny review requests when updating the VMI fails", func() {
+			DescribeTable("Should allow review requests", func(markVMI bool, vmiEvictionStrategy virtv1.EvictionStrategy) {
+				vmi.Spec.EvictionStrategy = &vmiEvictionStrategy
 
 				By("Composing a dummy admission request on a virt-launcher pod")
 				pod := &k8sv1.Pod{
@@ -142,9 +315,7 @@ var _ = Describe("Pod eviction admitter", func() {
 							virtv1.AppLabel: "virt-launcher",
 						},
 					},
-					Spec: k8sv1.PodSpec{
-						NodeName: nodeName,
-					},
+					Spec:   k8sv1.PodSpec{},
 					Status: k8sv1.PodStatus{},
 				}
 
@@ -165,255 +336,59 @@ var _ = Describe("Pod eviction admitter", func() {
 
 				vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
 
-				data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
-				vmiClient.
-					EXPECT().
-					Patch(vmi.Name,
-						types.JSONPatchType,
-						[]byte(data),
-						&metav1.PatchOptions{}).
-					Return(nil, fmt.Errorf("err"))
-
-				resp := podEvictionAdmitter.Admit(ar)
-				Expect(resp.Allowed).To(BeFalse())
-				Expect(resp.Result.Code).To(Equal(int32(http.StatusTooManyRequests)))
-				Expect(kubeClient.Fake.Actions()).To(HaveLen(1))
-			})
-
-			It("Should allow review requests when eviction strategy is not configured", func() {
-
-				By("Removing eviction strategy from the VMI")
-				vmi.Spec.EvictionStrategy = nil
-
-				By("Composing a dummy admission request on a virt-launcher pod")
-				pod := &k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "testpod",
-						Namespace: testns,
-						Annotations: map[string]string{
-							virtv1.DomainAnnotation: vmi.Name,
-						},
-						Labels: map[string]string{
-							virtv1.AppLabel: "virt-launcher",
-						},
-					},
-					Spec: k8sv1.PodSpec{
-						NodeName: nodeName,
-					},
-					Status: k8sv1.PodStatus{},
+				if markVMI {
+					vmiClient.EXPECT().Update(gomock.Any()).Return(nil, nil).AnyTimes()
 				}
-
-				ar := &admissionv1.AdmissionReview{
-					Request: &admissionv1.AdmissionRequest{
-						Name:      pod.Name,
-						Namespace: pod.Namespace,
-					},
-				}
-
-				kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-					get, ok := action.(testing.GetAction)
-					Expect(ok).To(BeTrue())
-					Expect(pod.Namespace).To(Equal(get.GetNamespace()))
-					Expect(pod.Name).To(Equal(get.GetName()))
-					return true, pod, nil
-				})
-
-				vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
-
-				data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
-				vmiClient.
-					EXPECT().
-					Patch(vmi.Name,
-						types.JSONPatchType,
-						[]byte(data),
-						&metav1.PatchOptions{}).
-					Return(nil, fmt.Errorf("err")).AnyTimes()
 
 				resp := podEvictionAdmitter.Admit(ar)
 				Expect(resp.Allowed).To(BeTrue())
 				Expect(kubeClient.Fake.Actions()).To(HaveLen(1))
-			})
-
-			DescribeTable("Should allow  review requests that are on a virt-launcher pod", func(dryRun bool) {
-				By("Composing a dummy admission request on a virt-launcher pod")
-				pod := &k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "testpod",
-						Namespace: testns,
-						Annotations: map[string]string{
-							virtv1.DomainAnnotation: vmi.Name,
-						},
-						Labels: map[string]string{
-							virtv1.AppLabel: "virt-launcher",
-						},
-					},
-					Spec: k8sv1.PodSpec{
-						NodeName: nodeName,
-					},
-					Status: k8sv1.PodStatus{},
-				}
-
-				ar := &admissionv1.AdmissionReview{
-					Request: &admissionv1.AdmissionRequest{
-						Name:      pod.Name,
-						Namespace: pod.Namespace,
-						DryRun:    &dryRun,
-					},
-				}
-
-				kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-					get, ok := action.(testing.GetAction)
-					Expect(ok).To(BeTrue())
-					Expect(pod.Namespace).To(Equal(get.GetNamespace()))
-					Expect(pod.Name).To(Equal(get.GetName()))
-					return true, pod, nil
-				})
-
-				if !dryRun {
-					data := fmt.Sprintf(`[{ "op": "add", "path": "/status/evacuationNodeName", "value": "%s" }]`, nodeName)
-					vmiClient.
-						EXPECT().
-						Patch(vmi.Name,
-							types.JSONPatchType,
-							[]byte(data),
-							&metav1.PatchOptions{}).
-						Return(nil, nil)
-				}
-				vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
-
-				resp := podEvictionAdmitter.Admit(ar)
-				Expect(resp.Allowed).To(BeTrue())
-				actions := kubeClient.Fake.Actions()
-				Expect(actions).To(HaveLen(1))
 			},
-				Entry("and should mark the VMI when not in dry-run mode", false),
-				Entry("and should not mark the VMI when in dry-run mode", true),
+				Entry("and should mark the VMI", true, nil),
+				Entry("and should not mark the VMI", false, virtv1.EvictionStrategyNone),
 			)
+		})
+	})
 
-			Context("With EvictionStrategy cluster setting set to 'LiveMigrate'", func() {
-				var vmi *virtv1.VirtualMachineInstance
+	Context("Not a virt launcher pod", func() {
 
-				BeforeEach(func() {
-					clusterConfig := newClusterConfigWithEvictionStrategy(virtv1.EvictionStrategyLiveMigrate)
-					podEvictionAdmitter = PodEvictionAdmitter{
-						ClusterConfig: clusterConfig,
-						VirtClient:    virtClient,
-					}
+		It("Should allow any review requests", func() {
 
-					vmi = &virtv1.VirtualMachineInstance{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: testns,
-							Name:      "testvmi",
-						},
-						Status: virtv1.VirtualMachineInstanceStatus{
-							Conditions: []virtv1.VirtualMachineInstanceCondition{
-								{
-									Type:   virtv1.VirtualMachineInstanceIsMigratable,
-									Status: k8sv1.ConditionTrue,
-								},
-							},
-						},
-						Spec: virtv1.VirtualMachineInstanceSpec{},
-					}
-				})
-
-				DescribeTable("Should allow review requests", func(markVMI bool, vmiEvictionStrategy virtv1.EvictionStrategy) {
-					vmi.Spec.EvictionStrategy = &vmiEvictionStrategy
-
-					By("Composing a dummy admission request on a virt-launcher pod")
-					pod := &k8sv1.Pod{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "testpod",
-							Namespace: testns,
-							Annotations: map[string]string{
-								virtv1.DomainAnnotation: vmi.Name,
-							},
-							Labels: map[string]string{
-								virtv1.AppLabel: "virt-launcher",
-							},
-						},
-						Spec:   k8sv1.PodSpec{},
-						Status: k8sv1.PodStatus{},
-					}
-
-					ar := &admissionv1.AdmissionReview{
-						Request: &admissionv1.AdmissionRequest{
-							Name:      pod.Name,
-							Namespace: pod.Namespace,
-						},
-					}
-
-					kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-						get, ok := action.(testing.GetAction)
-						Expect(ok).To(BeTrue())
-						Expect(pod.Namespace).To(Equal(get.GetNamespace()))
-						Expect(pod.Name).To(Equal(get.GetName()))
-						return true, pod, nil
-					})
-
-					vmiClient.EXPECT().Get(vmi.Name, &metav1.GetOptions{}).Return(vmi, nil)
-
-					if markVMI {
-						vmiClient.EXPECT().Update(gomock.Any()).Return(nil, nil).AnyTimes()
-					}
-
-					resp := podEvictionAdmitter.Admit(ar)
-					Expect(resp.Allowed).To(BeTrue())
-					Expect(kubeClient.Fake.Actions()).To(HaveLen(1))
+			By("Composing a dummy admission request on a virt-launcher pod")
+			pod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testns,
+					Name:      "foo",
 				},
-					Entry("and should mark the VMI", true, nil),
-					Entry("and should not mark the VMI", false, virtv1.EvictionStrategyNone),
-				)
+			}
+
+			ar := &admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Name:      pod.Name,
+					Namespace: pod.Namespace,
+				},
+			}
+
+			kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				get, ok := action.(testing.GetAction)
+				Expect(ok).To(BeTrue())
+				Expect(pod.Namespace).To(Equal(get.GetNamespace()))
+				Expect(pod.Name).To(Equal(get.GetName()))
+				return true, pod, nil
 			})
+
+			resp := podEvictionAdmitter.Admit(ar)
+			Expect(resp.Allowed).To(BeTrue())
 		})
-
-		Context("Not a virt launcher pod", func() {
-
-			It("Should allow any review requests", func() {
-
-				By("Composing a dummy admission request on a virt-launcher pod")
-				pod := &k8sv1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: testns,
-						Name:      "foo",
-					},
-				}
-
-				ar := &admissionv1.AdmissionReview{
-					Request: &admissionv1.AdmissionRequest{
-						Name:      pod.Name,
-						Namespace: pod.Namespace,
-					},
-				}
-
-				kubeClient.Fake.PrependReactor("get", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-					get, ok := action.(testing.GetAction)
-					Expect(ok).To(BeTrue())
-					Expect(pod.Namespace).To(Equal(get.GetNamespace()))
-					Expect(pod.Name).To(Equal(get.GetName()))
-					return true, pod, nil
-				})
-
-				resp := podEvictionAdmitter.Admit(ar)
-				Expect(resp.Allowed).To(BeTrue())
-			})
-		})
-
 	})
 
 	Context("Eviction strategy external", func() {
 
-		var podEvictionAdmitter PodEvictionAdmitter
 		var vmi *virtv1.VirtualMachineInstance
 		externalMigrateStrategy := virtv1.EvictionStrategyExternal
 		nodeName := "node01"
 
 		BeforeEach(func() {
-			clusterConfig := newClusterConfigWithFeatureGate(virtconfig.LiveMigrationGate)
-			podEvictionAdmitter = PodEvictionAdmitter{
-				ClusterConfig: clusterConfig,
-				VirtClient:    virtClient,
-			}
 			vmi = &virtv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testns,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -401,20 +401,6 @@ var _ = Describe("Pod eviction admitter", func() {
 
 	})
 
-	Context("Live migration disabled", func() {
-		kv := kubecli.NewMinimalKubeVirt(testns)
-		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
-		podEvictionAdmitter := PodEvictionAdmitter{
-			ClusterConfig: clusterConfig,
-		}
-
-		It("Should allow any review request", func() {
-			resp := podEvictionAdmitter.Admit(&admissionv1.AdmissionReview{})
-			Expect(resp.Allowed).To(BeTrue())
-		})
-
-	})
-
 	Context("Eviction strategy external", func() {
 
 		var podEvictionAdmitter PodEvictionAdmitter

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -754,15 +754,7 @@ func validateLiveMigration(field *k8sfield.Path, spec *v1.VirtualMachineInstance
 	if spec.EvictionStrategy != nil {
 		evictionStrategy = spec.EvictionStrategy
 	}
-	if !config.LiveMigrationEnabled() &&
-		evictionStrategy != nil &&
-		*evictionStrategy == v1.EvictionStrategyLiveMigrate {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "LiveMigration feature gate is not enabled",
-			Field:   field.Child("evictionStrategy").String(),
-		})
-	} else if !isValidEvictionStrategy(evictionStrategy) {
+	if !isValidEvictionStrategy(evictionStrategy) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s is set with an unrecognized option: %s", field.Child("evictionStrategy").String(), *spec.EvictionStrategy),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -160,13 +160,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("migration policy to be set nil", nil),
 		)
 
-		It("should block setting eviction policies if the feature gate is disabled", func() {
-			disableFeatureGates()
-			vmi.Spec.EvictionStrategy = &policyMigrate
-			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(resp[0].Message).To(ContainSubstring("LiveMigration feature gate is not enabled"))
-		})
-
 		It("should allow no eviction policy to be set", func() {
 			vmi.Spec.EvictionStrategy = nil
 			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -645,4 +645,21 @@ var _ = Describe("test configuration", func() {
 		Entry("ClusterProfiler feature gate enabled should result in cluster profiler being enabled",
 			[]string{virtconfig.ClusterProfiler}, true),
 	)
+
+	Context("deprecated feature gates should always be considered as enabled", func() {
+		var clusterConfig *virtconfig.ClusterConfig
+
+		BeforeEach(func() {
+			clusterConfig, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+				DeveloperConfiguration: &v1.DeveloperConfiguration{
+					FeatureGates: nil,
+				},
+			})
+		})
+
+		It("live migration feature gate", func() {
+			Expect(clusterConfig.LiveMigrationEnabled()).To(BeTrue())
+		})
+
+	})
 })

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -645,24 +645,4 @@ var _ = Describe("test configuration", func() {
 		Entry("ClusterProfiler feature gate enabled should result in cluster profiler being enabled",
 			[]string{virtconfig.ClusterProfiler}, true),
 	)
-
-	DescribeTable("when feature-gate", func(fgs []string, isLiveMigrationEnabled, isSRIOVLiveMigrationEnabled bool) {
-		clusterConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: fgs,
-			},
-		})
-
-		Expect(clusterConfig.LiveMigrationEnabled()).To(Equal(isLiveMigrationEnabled))
-		Expect(clusterConfig.SRIOVLiveMigrationEnabled()).To(Equal(isSRIOVLiveMigrationEnabled))
-	},
-		Entry("LiveMigration and SRIOVLiveMigration are closed, both should be closed",
-			[]string{}, false, false),
-		Entry("LiveMigration and SRIOVLiveMigration are open, both should be open",
-			[]string{virtconfig.LiveMigrationGate, virtconfig.SRIOVLiveMigrationGate}, true, true),
-		Entry("SRIOVLiveMigration is open, LiveMigration should be open",
-			[]string{virtconfig.SRIOVLiveMigrationGate}, true, true),
-		Entry("LiveMigration is open, SRIOVLiveMigration should be close",
-			[]string{virtconfig.LiveMigrationGate}, true, false),
-	)
 })

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -49,12 +49,32 @@ const (
 	WorkloadEncryptionSEV      = "WorkloadEncryptionSEV"
 )
 
+var deprecatedFeatureGates = [...]string{
+	LiveMigrationGate,
+}
+
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
+	if c.IsFeatureGateDeprecated(featureGate) {
+		// Deprecated feature gates are considered enabled and no-op.
+		// For more info about deprecation policy: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md
+		return true
+	}
+
 	for _, fg := range c.GetConfig().DeveloperConfiguration.FeatureGates {
 		if fg == featureGate {
 			return true
 		}
 	}
+	return false
+}
+
+func (c *ClusterConfig) IsFeatureGateDeprecated(featureGate string) bool {
+	for _, deprecatedFeatureGate := range deprecatedFeatureGates {
+		if featureGate == deprecatedFeatureGate {
+			return true
+		}
+	}
+
 	return false
 }
 
@@ -79,8 +99,7 @@ func (config *ClusterConfig) IgnitionEnabled() bool {
 }
 
 func (config *ClusterConfig) LiveMigrationEnabled() bool {
-	return config.isFeatureGateEnabled(LiveMigrationGate) ||
-		config.isFeatureGateEnabled(SRIOVLiveMigrationGate)
+	return config.isFeatureGateEnabled(LiveMigrationGate)
 }
 
 func (config *ClusterConfig) SRIOVLiveMigrationEnabled() bool {

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -369,7 +369,7 @@ func (app *VirtOperatorApp) Run() {
 		validating_webhooks.Serve(w, r, operator_webhooks.NewKubeVirtDeletionAdmitter(app.clientSet))
 	}))
 	mux.HandleFunc(components.KubeVirtUpdateValidatePath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		validating_webhooks.Serve(w, r, operator_webhooks.NewKubeVirtUpdateAdmitter(app.clientSet))
+		validating_webhooks.Serve(w, r, operator_webhooks.NewKubeVirtUpdateAdmitter(app.clientSet, app.clusterConfig))
 	}))
 	webhookServer.Handler = &mux
 	go func() {

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/util/webhooks:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -33,7 +32,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -11,9 +11,11 @@ go_library(
     deps = [
         "//pkg/util/webhooks:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -37,7 +37,6 @@ import (
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
 )
 
@@ -85,10 +84,6 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *
 
 	if newKV.Spec.Infra != nil {
 		results = append(results, validateInfraReplicas(newKV.Spec.Infra.Replicas)...)
-	}
-
-	if len(newKV.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods) > 0 {
-		results = append(results, validateWorkloadUpdateMethods(&currKV.Spec, &newKV.Spec)...)
 	}
 
 	return validating_webhooks.NewAdmissionResponse(results)
@@ -313,44 +308,5 @@ func validateInfraReplicas(replicas *uint8) []metav1.StatusCause {
 		})
 	}
 
-	return statuses
-}
-
-func validateWorkloadUpdateMethods(oldKVSpec, newKVSpec *v1.KubeVirtSpec) []metav1.StatusCause {
-	statuses := []metav1.StatusCause{}
-
-	isLiveMigrateMethodEnabled := func(kvSpec *v1.KubeVirtSpec) bool {
-		for _, method := range kvSpec.WorkloadUpdateStrategy.WorkloadUpdateMethods {
-			if method == v1.WorkloadUpdateMethodLiveMigrate {
-				return true
-			}
-		}
-		return false
-	}
-
-	isLiveMigrationFGEnabled := func(kvSpec *v1.KubeVirtSpec) bool {
-		if newKVSpec.Configuration.DeveloperConfiguration != nil {
-			for _, fg := range newKVSpec.Configuration.DeveloperConfiguration.FeatureGates {
-				if fg == virtconfig.LiveMigrationGate {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
-	// do not return an error if the misconfiguration was already there, otherwise
-	// we risk to block any operation on the KV CR right from the start if the
-	// CR got created this way.
-	if isLiveMigrateMethodEnabled(oldKVSpec) && !isLiveMigrationFGEnabled(oldKVSpec) {
-		return statuses
-	}
-
-	if isLiveMigrateMethodEnabled(newKVSpec) && !isLiveMigrationFGEnabled(newKVSpec) {
-		statuses = append(statuses, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "the LiveMigration feature gate must be enabled to have LiveMigrate as a workload update method",
-		})
-	}
 	return statuses
 }

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -24,8 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
@@ -65,46 +63,6 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			},
 		}, 0),
 	)
-
-	DescribeTable("should accept the WorkloadUpdateMethods", func(oldSpec, newSpec *v1.KubeVirtSpec) {
-		causes := validateWorkloadUpdateMethods(oldSpec, newSpec)
-		Expect(causes).To(BeEmpty())
-	},
-		Entry("should accept LiveMigrate feature gate enabled and workloadUpdateMethod LiveMigrate",
-			newKubeVirtSpec(),
-			newKubeVirtSpec(
-				withFeatureGate(virtconfig.LiveMigrationGate),
-				withWorkloadUpdateMethod(v1.WorkloadUpdateMethodLiveMigrate),
-			),
-		),
-		Entry("should accept LiveMigrate feature gate enabled and no workloadUpdateMethod",
-			newKubeVirtSpec(),
-			newKubeVirtSpec(
-				withFeatureGate(virtconfig.LiveMigrationGate),
-			),
-		),
-		Entry("should accept LiveMigrate feature gate disabled and no workloadUpdateMethod",
-			newKubeVirtSpec(),
-			newKubeVirtSpec(),
-		),
-		Entry("should accept if the misconfiguration was already present",
-			newKubeVirtSpec(
-				withWorkloadUpdateMethod(v1.WorkloadUpdateMethodLiveMigrate),
-			),
-			newKubeVirtSpec(
-				withWorkloadUpdateMethod(v1.WorkloadUpdateMethodLiveMigrate),
-			),
-		),
-	)
-
-	It("should reject LiveMigrate feature gate disabled and workloadUpdateMethod LiveMigrate", func() {
-		causes := validateWorkloadUpdateMethods(
-			newKubeVirtSpec(),
-			newKubeVirtSpec(
-				withWorkloadUpdateMethod(v1.WorkloadUpdateMethodLiveMigrate),
-			))
-		Expect(causes).NotTo(BeEmpty())
-	})
 })
 
 type kubevirtSpecOption func(*v1.KubeVirtSpec)

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -219,10 +219,6 @@ func SkipIfOpenShift4(message string) {
 }
 
 func SkipIfMigrationIsNotPossible() {
-	if !HasLiveMigration() {
-		ginkgo.Skip("LiveMigration feature gate is not enabled in kubevirt-config")
-	}
-
 	if !HasAtLeastTwoNodes() {
 		ginkgo.Skip("Migration tests require at least 2 nodes")
 	}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1474,7 +1474,7 @@ spec:
 
 			// This test should run fine on single-node setups as long as no VM is created pre-update
 			createVMs := true
-			if !checks.HasLiveMigration() || !checks.HasAtLeastTwoNodes() {
+			if !checks.HasAtLeastTwoNodes() {
 				createVMs = false
 			}
 
@@ -1801,7 +1801,7 @@ spec:
 			// This ensures that we can remove kubevirt while workloads are running
 			By("Starting some vmis")
 			var vmis []*v1.VirtualMachineInstance
-			if checks.HasLiveMigration() && checks.HasAtLeastTwoNodes() {
+			if checks.HasAtLeastTwoNodes() {
 				vmis = generateMigratableVMIs(2)
 				startAllVMIs(vmis)
 			}
@@ -1972,7 +1972,7 @@ spec:
 			}
 
 			var vmis []*v1.VirtualMachineInstance
-			if checks.HasLiveMigration() && checks.HasAtLeastTwoNodes() {
+			if checks.HasAtLeastTwoNodes() {
 				vmis = generateMigratableVMIs(2)
 			}
 			vmisNonMigratable := generateNonMigratableVMIs(2)


### PR DESCRIPTION
**What this PR does / why we need it**:
Finally - the moment we've all been waiting for... :smiley: 

When live migration feature was first presented to Kubevirt, it was immature and unstable. Over time, the situation had drastically changed.

Currently, Live migration is a mature and stable feature. Therefore, it shouldn't be guarded by a feature gate anymore. Now, that we have a [deprecation policy for feature gates](https://github.com/kubevirt/kubevirt/pull/7791), it's time to deprecate this feature gate.

For more information, take a look at the new deprecation policy here: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate live migration feature gate
```
