### PR TITLE
guestfs: set the RunAsNonRoot

### DIFF
--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -366,8 +366,6 @@ func (client *K8sClient) getPodsForPVC(pvcName, ns string) ([]corev1.Pod, error)
 }
 
 func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock bool) *corev1.Pod {
-	var rootUid int64
-	rootUid = 0
 	var resources corev1.ResourceRequirements
 	podName = fmt.Sprintf("%s-%s", podNamePrefix, pvc)
 	if kvm {
@@ -377,12 +375,18 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 			},
 		}
 	}
-	var securityContext *corev1.PodSecurityContext
+	nonRoot := true
+	var uidRoot int64 = 0
+	var uid *int64
 	if root {
-		securityContext = &corev1.PodSecurityContext{
-			RunAsUser: &rootUid,
-		}
+		nonRoot = false
+		uid = &uidRoot
 	}
+	securityContext := &corev1.PodSecurityContext{
+		RunAsNonRoot: &nonRoot,
+		RunAsUser:    uid,
+	}
+
 	c := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,


### PR DESCRIPTION
Set the RunAsNonRoot to false by default

Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set RunAsNonRoot as default for the guestfs pod
```