### PR TITLE
goimports: Adjust the local prefix to include the project

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,7 +40,7 @@ goimports(
         "./.git/*",
         "./_ci-configs/*",
     ],
-    local = ["kubevirt.io"],
+    local = ["kubevirt.io/kubevirt"],
     prefix = "kubevirt.io/kubevirt",
     write = True,
 )

--- a/cmd/example-cloudinit-hook-sidecar/cloudinit.go
+++ b/cmd/example-cloudinit-hook-sidecar/cloudinit.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	hooks "kubevirt.io/kubevirt/pkg/hooks"
 	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"

--- a/cmd/example-hook-sidecar/smbios.go
+++ b/cmd/example-hook-sidecar/smbios.go
@@ -33,6 +33,7 @@ import (
 
 	vmSchema "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
 	hooksV1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	klog "kubevirt.io/client-go/log"
+
 	_ "kubevirt.io/kubevirt/pkg/monitoring/client/prometheus"    // import for prometheus metrics
 	_ "kubevirt.io/kubevirt/pkg/monitoring/reflector/prometheus" // import for prometheus metrics
 	_ "kubevirt.io/kubevirt/pkg/monitoring/workqueue/prometheus" // import for prometheus metrics

--- a/cmd/virt-exportproxy/virt-exportproxy.go
+++ b/cmd/virt-exportproxy/virt-exportproxy.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	clientutil "kubevirt.io/client-go/util"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/service"

--- a/cmd/virt-exportserver/virt-exportserver.go
+++ b/cmd/virt-exportserver/virt-exportserver.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/service"
 
 	exportServer "kubevirt.io/kubevirt/pkg/virt-exportserver"

--- a/cmd/virt-freezer/main.go
+++ b/cmd/virt-freezer/main.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -59,6 +59,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	clientutil "kubevirt.io/client-go/util"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -39,6 +39,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/config"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"

--- a/cmd/virt-probe/virt-probe.go
+++ b/cmd/virt-probe/virt-probe.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"kubevirt.io/client-go/log"
+
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 

--- a/pkg/certificates/bootstrap/cert-manager_test.go
+++ b/pkg/certificates/bootstrap/cert-manager_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 )

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -36,6 +36,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"

--- a/pkg/cloud-init/cloudinit_suite_test.go
+++ b/pkg/cloud-init/cloudinit_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"kubevirt.io/client-go/testutils"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/config/config-map.go
+++ b/pkg/config/config-map.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"kubevirt.io/client-go/testutils"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/config/downwardapi.go
+++ b/pkg/config/downwardapi.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/config/service-account.go
+++ b/pkg/config/service-account.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/config/sysprep.go
+++ b/pkg/config/sysprep.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -36,6 +36,7 @@ import (
 	ephemeraldisk "kubevirt.io/kubevirt/pkg/ephemeral-disk"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 )

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -61,6 +61,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/downwardmetrics/downwardmetrics.go
+++ b/pkg/downwardmetrics/downwardmetrics.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd"
 )

--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 )

--- a/pkg/emptydisk/emptydisk_suite_test.go
+++ b/pkg/emptydisk/emptydisk_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"kubevirt.io/client-go/testutils"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/ephemeral-disk/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/ephemeral-disk.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"kubevirt.io/client-go/testutils"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/ephemeral-disk/ephemeral-disk_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_test.go
@@ -31,6 +31,7 @@ import (
 	api2 "kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/ephemeral-disk/fake/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/fake/ephemeral-disk.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/flavor/flavor.go
+++ b/pkg/flavor/flavor.go
@@ -21,6 +21,7 @@ import (
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 )
 

--- a/pkg/flavor/flavor_test.go
+++ b/pkg/flavor/flavor_test.go
@@ -22,6 +22,7 @@ import (
 
 	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/flavor"
 
 	v1 "kubevirt.io/api/core/v1"

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 )
 

--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
 	hooksV1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -27,12 +27,14 @@ import (
 	"syscall"
 
 	"kubevirt.io/client-go/log"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/types"
 )

--- a/pkg/host-disk/host-disk_test.go
+++ b/pkg/host-disk/host-disk_test.go
@@ -39,6 +39,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/host-disk/host_disk_suite_test.go
+++ b/pkg/host-disk/host_disk_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"kubevirt.io/client-go/testutils"
+
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -26,6 +26,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 )

--- a/pkg/inotify-informer/inotify.go
+++ b/pkg/inotify-informer/inotify.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/monitoring/domainstats/collector.go
+++ b/pkg/monitoring/domainstats/collector.go
@@ -25,6 +25,7 @@ import (
 
 	k6tv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 

--- a/pkg/monitoring/domainstats/downwardmetrics/hostmetrics.go
+++ b/pkg/monitoring/domainstats/downwardmetrics/hostmetrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/c9s/goprocinfo/linux"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd/api"
 	metricspkg "kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd/metrics"
 )

--- a/pkg/monitoring/domainstats/downwardmetrics/scraper.go
+++ b/pkg/monitoring/domainstats/downwardmetrics/scraper.go
@@ -11,6 +11,7 @@ import (
 
 	k6sv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/downwardmetrics"
 	"kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd"
 	"kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd/api"

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -36,6 +36,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/version"
+
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	k6tv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 

--- a/pkg/monitoring/profiler/profile-manager.go
+++ b/pkg/monitoring/profiler/profile-manager.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	restful "github.com/emicklei/go-restful"

--- a/pkg/monitoring/profiler/profile-manager_test.go
+++ b/pkg/monitoring/profiler/profile-manager_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/monitoring/vmistats/collector.go
+++ b/pkg/monitoring/vmistats/collector.go
@@ -29,6 +29,7 @@ import (
 
 	k6tv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/monitoring/vmistats/collector_test.go
+++ b/pkg/monitoring/vmistats/collector_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	k6tv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/network/cache/podinterface.go
+++ b/pkg/network/cache/podinterface.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/util"
 )
 

--- a/pkg/network/dhcp/bridge.go
+++ b/pkg/network/dhcp/bridge.go
@@ -4,6 +4,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"

--- a/pkg/network/dhcp/bridge_test.go
+++ b/pkg/network/dhcp/bridge_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"

--- a/pkg/network/dhcp/configurator.go
+++ b/pkg/network/dhcp/configurator.go
@@ -26,6 +26,7 @@ import (
 	"os"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )

--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )

--- a/pkg/network/dhcp/generated_mock_configurator.go
+++ b/pkg/network/dhcp/generated_mock_configurator.go
@@ -5,8 +5,8 @@ package dhcp
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
 	v1 "kubevirt.io/api/core/v1"
+
 	cache "kubevirt.io/kubevirt/pkg/network/cache"
 )
 

--- a/pkg/network/dhcp/masquerade.go
+++ b/pkg/network/dhcp/masquerade.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"

--- a/pkg/network/dhcp/masquerade_test.go
+++ b/pkg/network/dhcp/masquerade_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )

--- a/pkg/network/dhcp/server/server.go
+++ b/pkg/network/dhcp/server/server.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/network/dns"
 )
 

--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -6,6 +6,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	api2 "kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/testutils"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/network/domainspec/generators.go
+++ b/pkg/network/domainspec/generators.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	dhcpserver "kubevirt.io/kubevirt/pkg/network/dhcp/server"
 	dhcpserverv6 "kubevirt.io/kubevirt/pkg/network/dhcp/serverv6"

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -9,8 +9,8 @@ import (
 	iptables "github.com/coreos/go-iptables/iptables"
 	gomock "github.com/golang/mock/gomock"
 	netlink "github.com/vishvananda/netlink"
-
 	v1 "kubevirt.io/api/core/v1"
+
 	cache "kubevirt.io/kubevirt/pkg/network/cache"
 )
 

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"

--- a/pkg/network/infraconfigurators/bridge_test.go
+++ b/pkg/network/infraconfigurators/bridge_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -26,6 +26,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 )

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -11,6 +11,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/network/istio"

--- a/pkg/network/infraconfigurators/masquerade_test.go
+++ b/pkg/network/infraconfigurators/masquerade_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/network/istio"

--- a/pkg/network/link/address.go
+++ b/pkg/network/link/address.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )

--- a/pkg/network/link/address_test.go
+++ b/pkg/network/link/address_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 )
 

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -26,6 +26,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/netns"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 )
 

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 )

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/sriov"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	netsriov "kubevirt.io/kubevirt/pkg/network/sriov"

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	api2 "kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/testutils"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	api2 "kubevirt.io/client-go/api"
+
 	"kubevirt.io/kubevirt/pkg/network/infraconfigurators"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -28,6 +28,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	dhcpconfigurator "kubevirt.io/kubevirt/pkg/network/dhcp"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -11,6 +11,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	api2 "kubevirt.io/client-go/api"
+
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/dhcp"

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 

--- a/pkg/testutils/domain.go
+++ b/pkg/testutils/domain.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -11,6 +11,7 @@ import (
 	k8score "k8s.io/api/core/v1"
 
 	KVv1 "kubevirt.io/api/core/v1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 

--- a/pkg/testutils/mock_flavor.go
+++ b/pkg/testutils/mock_flavor.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
+
 	"kubevirt.io/kubevirt/pkg/flavor"
 )
 

--- a/pkg/testutils/mock_queue.go
+++ b/pkg/testutils/mock_queue.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 

--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 )
 

--- a/pkg/util/openapi/openapi_test.go
+++ b/pkg/util/openapi/openapi_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/util/openapi"
 )
 

--- a/pkg/util/webhooks/ca-manager.go
+++ b/pkg/util/webhooks/ca-manager.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/util/cert"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )

--- a/pkg/util/webhooks/webhooks.go
+++ b/pkg/util/webhooks/webhooks.go
@@ -13,6 +13,7 @@ import (
 
 	v12 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
 

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -50,6 +50,7 @@ import (
 	"kubevirt.io/client-go/log"
 	clientutil "kubevirt.io/client-go/util"
 	virtversion "kubevirt.io/client-go/version"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/healthz"

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-api/rest"
 )
 

--- a/pkg/virt-api/rest/console.go
+++ b/pkg/virt-api/rest/console.go
@@ -9,6 +9,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	apimetrics "kubevirt.io/kubevirt/pkg/monitoring/api"
 )
 

--- a/pkg/virt-api/rest/definitions.go
+++ b/pkg/virt-api/rest/definitions.go
@@ -44,6 +44,7 @@ import (
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	poolv1alpha1 "kubevirt.io/api/pool/v1alpha1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
+
 	mime "kubevirt.io/kubevirt/pkg/rest"
 )
 

--- a/pkg/virt-api/rest/portforward.go
+++ b/pkg/virt-api/rest/portforward.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	apimetrics "kubevirt.io/kubevirt/pkg/monitoring/api"
 )

--- a/pkg/virt-api/rest/profiler_test.go
+++ b/pkg/virt-api/rest/profiler_test.go
@@ -44,6 +44,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -46,6 +46,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	k6ttypes "kubevirt.io/kubevirt/pkg/util/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -56,6 +56,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )

--- a/pkg/virt-api/rest/usbredir.go
+++ b/pkg/virt-api/rest/usbredir.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	apimetrics "kubevirt.io/kubevirt/pkg/monitoring/api"
 )
 

--- a/pkg/virt-api/rest/vnc.go
+++ b/pkg/virt-api/rest/vnc.go
@@ -9,6 +9,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	apimetrics "kubevirt.io/kubevirt/pkg/monitoring/api"
 )
 

--- a/pkg/virt-api/webhooks/hyperv.go
+++ b/pkg/virt-api/webhooks/hyperv.go
@@ -31,6 +31,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"kubevirt.io/client-go/log"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/mutating-webhook/mutators"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator.go
@@ -31,6 +31,7 @@ import (
 
 	"kubevirt.io/api/clone"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
+
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/clone-create-mutator_test.go
@@ -16,6 +16,7 @@ import (
 	"kubevirt.io/api/clone"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 )
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -26,6 +26,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 )
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
@@ -33,6 +33,7 @@ import (
 	"kubevirt.io/api/core"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -29,6 +29,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	apiflavor "kubevirt.io/api/flavor"
 	"kubevirt.io/client-go/log"
+
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	apiflavor "kubevirt.io/api/flavor"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -28,10 +28,12 @@ import (
 
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 
 	v1 "kubevirt.io/api/core/v1"
 	clientutil "kubevirt.io/client-go/util"
+
 	"kubevirt.io/kubevirt/pkg/util/openapi"
 	"kubevirt.io/kubevirt/pkg/virt-api/rest"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/flavor-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/flavor-admitter.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter_test.go
@@ -37,6 +37,7 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/preference-admitter.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/util"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter.go
@@ -29,6 +29,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	exportv1 "kubevirt.io/api/export/v1alpha1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmexport-admitter_test.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -34,6 +34,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/network/link"
 	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"kubevirt.io/client-go/api"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,6 +42,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter.go
@@ -28,6 +28,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-preset-admitter_test.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -31,6 +31,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter.go
@@ -29,6 +29,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
@@ -31,6 +31,7 @@ import (
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
@@ -31,6 +31,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter.go
@@ -38,6 +38,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmrestore-admitter_test.go
@@ -39,6 +39,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -38,6 +38,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiclone "kubevirt.io/containerized-data-importer/pkg/clone"
+
 	"kubevirt.io/kubevirt/pkg/flavor"
 	typesutil "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -45,6 +45,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/flavor"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter.go
@@ -33,6 +33,7 @@ import (
 
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmsnapshot-admitter_test.go
@@ -36,6 +36,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"kubevirt.io/client-go/kubecli"
+
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -6,6 +6,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/util"
 )
 

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -10,6 +10,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/network/istio"

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"kubevirt.io/client-go/api"
+
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 
 	"github.com/golang/mock/gomock"
@@ -46,6 +47,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/network/istio"
 	"kubevirt.io/kubevirt/pkg/testutils"

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/monitoring/migration"
 
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/clone"
 
 	"kubevirt.io/kubevirt/pkg/flavor"
@@ -63,6 +64,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	clientutil "kubevirt.io/client-go/util"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/clone"
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
@@ -53,6 +54,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/rest"
 	testutils "kubevirt.io/kubevirt/pkg/testutils"

--- a/pkg/virt-controller/watch/clone/clone_base.go
+++ b/pkg/virt-controller/watch/clone/clone_base.go
@@ -16,6 +16,7 @@ import (
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util/status"
 )
 

--- a/pkg/virt-controller/watch/clone/clone_test.go
+++ b/pkg/virt-controller/watch/clone/clone_test.go
@@ -43,6 +43,7 @@ import (
 	snapshotv1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -19,6 +19,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/pkg/util/pdbs"

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	ctrl_util "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -20,6 +20,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -17,6 +17,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation"
 

--- a/pkg/virt-controller/watch/export/export.go
+++ b/pkg/virt-controller/watch/export/export.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"

--- a/pkg/virt-controller/watch/export/export_test.go
+++ b/pkg/virt-controller/watch/export/export_test.go
@@ -47,6 +47,7 @@ import (
 	exportv1 "kubevirt.io/api/export/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -55,6 +55,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/migration"
 	kubevirttypes "kubevirt.io/kubevirt/pkg/util/types"

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 
@@ -59,6 +60,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+
 	migrations "kubevirt.io/kubevirt/pkg/monitoring/migration"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	utiltype "kubevirt.io/kubevirt/pkg/util/types"

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -19,6 +19,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/lookup"
 	k6ttypes "kubevirt.io/kubevirt/pkg/util/types"

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -26,6 +26,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/virt-controller/watch/pool.go
+++ b/pkg/virt-controller/watch/pool.go
@@ -31,6 +31,7 @@ import (
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	traceUtils "kubevirt.io/kubevirt/pkg/util/trace"
 )

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/client-go/api"
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	testutils "kubevirt.io/kubevirt/pkg/testutils"
 )

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -38,6 +38,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )

--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -37,6 +37,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 

--- a/pkg/virt-controller/watch/snapshot/restore_base.go
+++ b/pkg/virt-controller/watch/snapshot/restore_base.go
@@ -34,6 +34,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util/status"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 )

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -26,6 +26,7 @@ import (
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/util/status"

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -36,6 +36,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 

--- a/pkg/virt-controller/watch/snapshot/snapshot_base.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_base.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/status"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -31,6 +31,7 @@ import (
 	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/util/status"

--- a/pkg/virt-controller/watch/snapshot/source.go
+++ b/pkg/virt-controller/watch/snapshot/source.go
@@ -32,6 +32,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
 	launcherapi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/virt-controller/watch/topology/filter_test.go
+++ b/pkg/virt-controller/watch/topology/filter_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 )
 

--- a/pkg/virt-controller/watch/topology/generated_mock_hinter.go
+++ b/pkg/virt-controller/watch/topology/generated_mock_hinter.go
@@ -5,7 +5,6 @@ package topology
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
 	v1 "kubevirt.io/api/core/v1"
 )
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdiclone "kubevirt.io/containerized-data-importer/pkg/clone"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/flavor"
 	"kubevirt.io/kubevirt/pkg/util"

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/flavor"
 	"kubevirt.io/kubevirt/pkg/testutils"

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	kubevirttypes "kubevirt.io/kubevirt/pkg/util/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -50,6 +50,7 @@ import (
 	fakenetworkclient "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	kvcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -28,6 +28,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/status"
 )

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 

--- a/pkg/virt-exportserver/exportserver.go
+++ b/pkg/virt-exportserver/exportserver.go
@@ -35,6 +35,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/service"
 )
 

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/log"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"

--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	virtutil "kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -46,6 +46,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	com "kubevirt.io/kubevirt/pkg/handler-launcher-com"
 	"kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/info"

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 )
 

--- a/pkg/virt-handler/cmd-client/generated_mock_client.go
+++ b/pkg/virt-handler/cmd-client/generated_mock_client.go
@@ -5,8 +5,8 @@ package cmdclient
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
 	v1 "kubevirt.io/api/core/v1"
+
 	v10 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	stats "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"

--- a/pkg/virt-handler/container-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/container-disk/generated_mock_mount.go
@@ -7,8 +7,8 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-
 	v1 "kubevirt.io/api/core/v1"
+
 	container_disk "kubevirt.io/kubevirt/pkg/container-disk"
 )
 

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -14,6 +14,7 @@ import (
 	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
 
 	"kubevirt.io/client-go/log"
+
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"kubevirt.io/client-go/api"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 

--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
 )

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -31,6 +31,7 @@ import (
 	k8scli "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"kubevirt.io/client-go/log"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 

--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )

--- a/pkg/virt-handler/device-manager/mediated_device.go
+++ b/pkg/virt-handler/device-manager/mediated_device.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/testing"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
 )

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	virtutil "kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"

--- a/pkg/virt-handler/heartbeat/heartbeat_test.go
+++ b/pkg/virt-handler/heartbeat/heartbeat_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	virtv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"

--- a/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
@@ -6,7 +6,6 @@ package hotplug_volume
 import (
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
-
 	v1 "kubevirt.io/api/core/v1"
 )
 

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"

--- a/pkg/virt-handler/isolation/detector_test.go
+++ b/pkg/virt-handler/isolation/detector_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mitchellh/go-ps"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 

--- a/pkg/virt-handler/isolation/generated_mock_detector.go
+++ b/pkg/virt-handler/isolation/generated_mock_detector.go
@@ -5,7 +5,6 @@ package isolation
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
 	v1 "kubevirt.io/api/core/v1"
 )
 

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -35,6 +35,7 @@ import (
 	mount "github.com/moby/sys/mountinfo"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 )
 

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 
 	"kubevirt.io/client-go/log"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/ip"

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/certificates"
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/testutils"

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
 
 	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -34,6 +34,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )

--- a/pkg/virt-handler/node-labeller/kvm-caps-info-plugin_amd64.go
+++ b/pkg/virt-handler/node-labeller/kvm-caps-info-plugin_amd64.go
@@ -56,6 +56,7 @@ import (
 	"unsafe"
 
 	"kubevirt.io/client-go/log"
+
 	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -37,6 +37,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	utiltype "kubevirt.io/kubevirt/pkg/util/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -37,6 +37,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -11,6 +11,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/util/types"

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -37,6 +37,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	notifyv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/v1"
 	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/virt-handler/options.go
+++ b/pkg/virt-handler/options.go
@@ -2,6 +2,7 @@ package virthandler
 
 import (
 	v1 "kubevirt.io/api/core/v1"
+
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -36,6 +36,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 

--- a/pkg/virt-handler/rest/lifecycle.go
+++ b/pkg/virt-handler/rest/lifecycle.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -68,6 +68,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -38,6 +38,7 @@ import (
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 
 	api2 "kubevirt.io/client-go/api"
+
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -67,6 +68,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/precond"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"kubevirt.io/client-go/log"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
 )

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -20,6 +20,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	com "kubevirt.io/kubevirt/pkg/handler-launcher-com"
 	"kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/info"

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/handler-launcher-com/notify/info"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -41,6 +41,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -8,6 +8,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )

--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -23,7 +23,6 @@ package api
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -32,6 +32,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/info"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -51,6 +51,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/config"
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -49,6 +49,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	kvapi "kubevirt.io/client-go/api"
+
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 )
 

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 
 	"kubevirt.io/kubevirt/pkg/network/dns"

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/addresspool.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool.go
@@ -21,6 +21,7 @@ package generic
 
 import (
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/addresspool_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/generic"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/generic"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool.go
@@ -21,6 +21,7 @@ package gpu
 
 import (
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/addresspool_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/gpu"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/gpu"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hotplug.go
@@ -28,6 +28,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/network/sriov"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -32,6 +32,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	netsriov "kubevirt.io/kubevirt/pkg/network/sriov"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/pcipool_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"
 )
 

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -5,8 +5,8 @@ package virtwrap
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
 	v1 "kubevirt.io/api/core/v1"
+
 	v10 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	cmd_client "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -40,6 +40,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	virtutil "kubevirt.io/kubevirt/pkg/util"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/hooks"

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -59,6 +59,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/config"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -46,6 +46,7 @@ import (
 	api2 "kubevirt.io/client-go/api"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/ephemeral-disk/fake"

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -19,6 +19,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	kubevirtlog "kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -54,6 +54,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	clientutil "kubevirt.io/client-go/util"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/monitoring/profiler"
 	"kubevirt.io/kubevirt/pkg/service"

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -43,6 +43,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/status"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -66,6 +66,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/version"
+
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	kubecontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -48,6 +48,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"

--- a/pkg/virt-operator/resource/apply/crds_test.go
+++ b/pkg/virt-operator/resource/apply/crds_test.go
@@ -18,6 +18,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 

--- a/pkg/virt-operator/resource/apply/delete.go
+++ b/pkg/virt-operator/resource/apply/delete.go
@@ -41,6 +41,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/install"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"

--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/install"
 )

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
 

--- a/pkg/virt-operator/resource/apply/pdb_test.go
+++ b/pkg/virt-operator/resource/apply/pdb_test.go
@@ -18,6 +18,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )

--- a/pkg/virt-operator/resource/apply/prometheus_test.go
+++ b/pkg/virt-operator/resource/apply/prometheus_test.go
@@ -7,6 +7,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 
 	promclientfake "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/fake"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 
 	"github.com/golang/mock/gomock"
@@ -20,6 +21,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 

--- a/pkg/virt-operator/resource/apply/rbac.go
+++ b/pkg/virt-operator/resource/apply/rbac.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 )
 

--- a/pkg/virt-operator/resource/apply/rbac_test.go
+++ b/pkg/virt-operator/resource/apply/rbac_test.go
@@ -36,6 +36,7 @@ import (
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -44,6 +44,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/controller"

--- a/pkg/virt-operator/resource/apply/routes.go
+++ b/pkg/virt-operator/resource/apply/routes.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )

--- a/pkg/virt-operator/resource/apply/scc_test.go
+++ b/pkg/virt-operator/resource/apply/scc_test.go
@@ -16,6 +16,7 @@ import (
 
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"

--- a/pkg/virt-operator/resource/apply/ssc.go
+++ b/pkg/virt-operator/resource/apply/ssc.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 )
 

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	virtv1 "kubevirt.io/api/core/v1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	virtv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 )

--- a/pkg/virt-operator/resource/generate/components/secrets.go
+++ b/pkg/virt-operator/resource/generate/components/secrets.go
@@ -15,6 +15,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"

--- a/pkg/virt-operator/resource/generate/csv/csv.go
+++ b/pkg/virt-operator/resource/generate/csv/csv.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 )

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -51,6 +51,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 

--- a/pkg/virt-operator/webhooks/webhook.go
+++ b/pkg/virt-operator/webhooks/webhook.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 )

--- a/pkg/virtctl/configuration/configuration.go
+++ b/pkg/virtctl/configuration/configuration.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 	"kubevirt.io/kubevirt/pkg/virtctl/utils"
 )

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -20,6 +20,7 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/testing"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
 
 	virtctlcmd "kubevirt.io/kubevirt/tests/clientcmd"

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -47,6 +47,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadcdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -26,6 +26,7 @@ import (
 	fakecdiclient "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/imageupload"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"

--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -32,6 +32,7 @@ import (
 	kubevirtV1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/pause/pause_test.go
+++ b/pkg/virtctl/pause/pause_test.go
@@ -12,6 +12,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/pause"
 
 	"kubevirt.io/kubevirt/tests/clientcmd"

--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -12,6 +12,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/configuration"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"

--- a/pkg/virtctl/softreboot/softreboot.go
+++ b/pkg/virtctl/softreboot/softreboot.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/softreboot/softreboot_test.go
+++ b/pkg/virtctl/softreboot/softreboot_test.go
@@ -10,6 +10,7 @@ import (
 
 	"kubevirt.io/client-go/api"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/softreboot"
 )
 

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -10,6 +10,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 

--- a/pkg/virtctl/usbredir/usbredir.go
+++ b/pkg/virtctl/usbredir/usbredir.go
@@ -33,6 +33,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -11,6 +11,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/version"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/version/version_test.go
+++ b/pkg/virtctl/version/version_test.go
@@ -12,6 +12,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	virt_version "kubevirt.io/client-go/version"
+
 	"kubevirt.io/kubevirt/pkg/virtctl"
 	"kubevirt.io/kubevirt/pkg/virtctl/version"
 )

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -29,6 +29,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/api/flavor/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/flavor/v1alpha1/deepcopy_generated.go
@@ -23,7 +23,6 @@ package v1alpha1
 
 import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
-
 	v1 "kubevirt.io/api/core/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/clientset.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/clientset.go
@@ -24,7 +24,6 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-
 	cdiv1beta1 "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1"
 	uploadv1beta1 "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake/clientset_generated.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-
 	clientset "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned"
 	cdiv1beta1 "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1"
 	fakecdiv1beta1 "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake"

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake/register.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake/register.go
@@ -24,7 +24,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme/register.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme/register.go
@@ -24,7 +24,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	uploadv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/cdi.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/cdi.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/cdiconfig.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/cdiconfig.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/core_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/core_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	"kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/dataimportcron.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/dataimportcron.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/datasource.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/datasource.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/datavolume.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/datavolume.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_cdi.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_cdi.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_cdiconfig.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_cdiconfig.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_core_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_core_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_dataimportcron.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_dataimportcron.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_datasource.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_datasource.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_datavolume.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_datavolume.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_objecttransfer.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_objecttransfer.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_storageprofile.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/fake/fake_storageprofile.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/objecttransfer.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/objecttransfer.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/storageprofile.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/core/v1beta1/storageprofile.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/fake/fake_upload_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/fake/fake_upload_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/fake/fake_uploadtokenrequest.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/fake/fake_uploadtokenrequest.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/upload_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/upload_client.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	"kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/uploadtokenrequest.go
+++ b/staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/typed/upload/v1beta1/uploadtokenrequest.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/scheme"
 	v1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/upload/v1beta1"
 )

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/clientset.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/clientset.go
@@ -24,7 +24,6 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-
 	snapshotv1 "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/fake/clientset_generated.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-
 	clientset "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned"
 	snapshotv1 "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1"
 	fakesnapshotv1 "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/fake"

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/fake/fake_volumesnapshot_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/fake/fake_volumesnapshot_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1 "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshot.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshot.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshot_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshot_client.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	rest "k8s.io/client-go/rest"
-
 	"kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshotclass.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshotclass.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshotcontent.go
+++ b/staging/src/kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/volumesnapshot/v1/volumesnapshotcontent.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/clientset.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/clientset.go
@@ -24,7 +24,6 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-
 	clonev1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1"
 	exportv1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1"
 	flavorv1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1"

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake/clientset_generated.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-
 	clientset "kubevirt.io/client-go/generated/kubevirt/clientset/versioned"
 	clonev1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1"
 	fakeclonev1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake"

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake/register.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake/register.go
@@ -24,7 +24,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	exportv1alpha1 "kubevirt.io/api/export/v1alpha1"
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme/register.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme/register.go
@@ -24,7 +24,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	exportv1alpha1 "kubevirt.io/api/export/v1alpha1"
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/clone_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/clone_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake/fake_clone_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake/fake_clone_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake/fake_virtualmachineclone.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake/fake_virtualmachineclone.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/clone/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/virtualmachineclone.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/virtualmachineclone.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/export_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/export_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/export/v1alpha1"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/fake/fake_export_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/fake/fake_export_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/fake/fake_virtualmachineexport.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/fake/fake_virtualmachineexport.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/export/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/virtualmachineexport.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/virtualmachineexport.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/export/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_flavor_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_flavor_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachineclusterflavor.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachineclusterflavor.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachineclusterpreference.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachineclusterpreference.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachineflavor.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachineflavor.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachinepreference.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/fake/fake_virtualmachinepreference.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/flavor_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/flavor_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachineclusterflavor.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachineclusterflavor.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachineclusterpreference.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachineclusterpreference.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachineflavor.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachineflavor.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachinepreference.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1/virtualmachinepreference.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/fake/fake_migrationpolicy.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/fake/fake_migrationpolicy.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/migrations/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/fake/fake_migrations_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/fake/fake_migrations_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/migrationpolicy.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/migrationpolicy.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/migrations/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/migrations_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/migrations/v1alpha1/migrations_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/migrations/v1alpha1"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/fake/fake_pool_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/fake/fake_pool_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/fake/fake_virtualmachinepool.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/fake/fake_virtualmachinepool.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/pool/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/pool_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/pool_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/virtualmachinepool.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/pool/v1alpha1/virtualmachinepool.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/pool/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_snapshot_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_snapshot_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_virtualmachinerestore.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_virtualmachinerestore.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_virtualmachinesnapshot.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_virtualmachinesnapshot.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_virtualmachinesnapshotcontent.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/fake/fake_virtualmachinesnapshotcontent.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/snapshot_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/snapshot_client.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/virtualmachinerestore.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/virtualmachinerestore.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/virtualmachinesnapshot.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/virtualmachinesnapshot.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/virtualmachinesnapshotcontent.go
+++ b/staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/snapshot/v1alpha1/virtualmachinesnapshotcontent.go
@@ -26,7 +26,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	v1alpha1 "kubevirt.io/api/snapshot/v1alpha1"
 	scheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
 )

--- a/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/clientset.go
+++ b/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/clientset.go
@@ -24,7 +24,6 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-
 	k8scnicncfiov1 "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake/clientset_generated.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-
 	clientset "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned"
 	k8scnicncfiov1 "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	fakek8scnicncfiov1 "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake"

--- a/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake/fake_k8s.cni.cncf.io_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/fake/fake_k8s.cni.cncf.io_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1 "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/k8s.cni.cncf.io_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/k8s.cni.cncf.io_client.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	rest "k8s.io/client-go/rest"
-
 	"kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
+++ b/staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/typed/k8s.cni.cncf.io/v1/networkattachmentdefinition.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/clientset.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/clientset.go
@@ -24,7 +24,6 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-
 	monitoringv1 "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/fake/clientset_generated.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-
 	clientset "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned"
 	monitoringv1 "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1"
 	fakemonitoringv1 "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/fake"

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/alertmanager.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/alertmanager.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/fake/fake_monitoring_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/fake/fake_monitoring_client.go
@@ -21,7 +21,6 @@ package fake
 import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
 	v1 "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/monitoring_client.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/monitoring_client.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	rest "k8s.io/client-go/rest"
-
 	"kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/podmonitor.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/podmonitor.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/prometheus.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/prometheus.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/prometheusrule.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/prometheusrule.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/servicemonitor.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/servicemonitor.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/thanosruler.go
+++ b/staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/typed/monitoring/v1/thanosruler.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
 	scheme "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/scheme"
 )
 

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -63,7 +63,6 @@ import (
 	v1alpha14 "k8s.io/client-go/kubernetes/typed/storage/v1alpha1"
 	v1beta115 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 	rest "k8s.io/client-go/rest"
-
 	v120 "kubevirt.io/api/core/v1"
 	versioned "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned"
 	versioned0 "kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned"

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/util"
 

--- a/tests/clientcmd/command.go
+++ b/tests/clientcmd/command.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/util"
 )

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -34,6 +34,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -37,6 +37,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -36,6 +36,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -38,6 +38,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/flavor_test.go
+++ b/tests/flavor_test.go
@@ -20,6 +20,7 @@ import (
 	flavorapi "kubevirt.io/api/flavor"
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	flavorpkg "kubevirt.io/kubevirt/pkg/flavor"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -12,6 +12,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/cluster"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/util"
 
 	v12 "kubevirt.io/api/core/v1"

--- a/tests/framework/checks/skips.go
+++ b/tests/framework/checks/skips.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	"kubevirt.io/kubevirt/tests/libnode"

--- a/tests/framework/matcher/phase_test.go
+++ b/tests/framework/matcher/phase_test.go
@@ -10,6 +10,7 @@ import (
 
 	v13 "kubevirt.io/api/core/v1"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
 )
 

--- a/tests/framework/storage/nfs.go
+++ b/tests/framework/storage/nfs.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 )

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -68,6 +68,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 	"kubevirt.io/kubevirt/pkg/virt-controller/leaderelectionconfig"
 	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/flags"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 )
 

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -39,6 +39,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 

--- a/tests/libreplicaset/replicaset.go
+++ b/tests/libreplicaset/replicaset.go
@@ -10,6 +10,7 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"
 )

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/util/net/ip"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 
 	"kubevirt.io/api/migrations/v1alpha1"
+
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
 
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
@@ -75,6 +76,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/util/cluster"

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -7,6 +7,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet/cluster"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/flags"
 )
 

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/clientcmd"

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -15,6 +15,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -37,6 +37,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -36,6 +36,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/util/hardware"

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -33,6 +33,7 @@ import (
 	kvirtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/libvmi"

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -45,6 +45,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/network/istio"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -36,6 +36,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -41,6 +41,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -46,6 +46,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -35,6 +35,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/checks"

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -17,6 +17,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/flags"

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -41,6 +41,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -33,11 +33,13 @@ import (
 	metric_client "kubevirt.io/kubevirt/tools/perfscale-audit/metric-client"
 
 	kvv1 "kubevirt.io/api/core/v1"
+
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"
 )

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -15,6 +15,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -39,6 +39,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"
 )

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -13,6 +13,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -45,6 +45,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	apicdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/scale/virt-api.go
+++ b/tests/scale/virt-api.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/tests/util"
 )

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/softreboot_test.go
+++ b/tests/softreboot_test.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtctlpause "kubevirt.io/kubevirt/pkg/virtctl/pause"
 	virtctlsoftreboot "kubevirt.io/kubevirt/pkg/virtctl/softreboot"
 	"kubevirt.io/kubevirt/tests"

--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -25,6 +26,7 @@ import (
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -41,6 +41,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -32,6 +32,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 )
 

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/guestfs"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -45,6 +45,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -21,6 +21,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/flags"

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -40,6 +40,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/libvmi"

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -27,6 +27,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -24,6 +24,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -49,6 +49,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -36,6 +36,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/testsuite"

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/util"
 )
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libstorage"

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libstorage"

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -36,6 +36,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"

--- a/tests/testsuite/manifest.go
+++ b/tests/testsuite/manifest.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/util"
 )
 

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 
 	"kubevirt.io/kubevirt/tests/flags"

--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/util"
 )

--- a/tests/util/util.go
+++ b/tests/util/util.go
@@ -8,6 +8,7 @@ import (
 
 	k6sv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests/flags"
 )
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -82,6 +82,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	kutil "kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -36,6 +36,7 @@ import (
 
 	k6sv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -48,6 +48,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virtctl/vm"
 	"kubevirt.io/kubevirt/tests"

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -41,6 +41,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 
@@ -54,6 +55,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	kubevirt_hooks_v1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/util/cluster"

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	"kubevirt.io/kubevirt/tests"

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -17,6 +17,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	hwutil "kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/hooks"
 	hooksv1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"
 	hooksv1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -36,6 +36,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -44,6 +44,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 )

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/vmi_servers.go
+++ b/tests/vmi_servers.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/tests/console"
 )
 

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -29,6 +29,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 )

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -40,6 +40,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -43,6 +43,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/subresources"
+
 	"kubevirt.io/kubevirt/tests"
 )
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -40,6 +40,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/pkg/network/dns"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/tests"

--- a/tools/doc-generator/fakeCollector.go
+++ b/tools/doc-generator/fakeCollector.go
@@ -7,6 +7,7 @@ import (
 	domainstats "kubevirt.io/kubevirt/pkg/monitoring/domainstats/prometheus"
 
 	k6tv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/statsconv"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/statsconv/util"

--- a/tools/openapispec/openapispec.go
+++ b/tools/openapispec/openapispec.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 
 	klog "kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/pkg/util/openapi"
 	virt_api "kubevirt.io/kubevirt/pkg/virt-api"
 	"kubevirt.io/kubevirt/pkg/virt-api/rest"

--- a/tools/perfscale-load-generator/api/api.go
+++ b/tools/perfscale-load-generator/api/api.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/config"
 )
 

--- a/tools/perfscale-load-generator/burst/burst.go
+++ b/tools/perfscale-load-generator/burst/burst.go
@@ -26,6 +26,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/config"
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/flags"
 	objUtil "kubevirt.io/kubevirt/tools/perfscale-load-generator/object"

--- a/tools/perfscale-load-generator/config/config.go
+++ b/tools/perfscale-load-generator/config/config.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/client-go/kubecli"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/flags"
 )
 

--- a/tools/perfscale-load-generator/load-generator.go
+++ b/tools/perfscale-load-generator/load-generator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/api"
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/burst"
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/config"

--- a/tools/perfscale-load-generator/object/template.go
+++ b/tools/perfscale-load-generator/object/template.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	kvv1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/config"
 )
 

--- a/tools/perfscale-load-generator/object/utils.go
+++ b/tools/perfscale-load-generator/object/utils.go
@@ -27,6 +27,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/config"
 )
 

--- a/tools/perfscale-load-generator/steady-state/steady-state.go
+++ b/tools/perfscale-load-generator/steady-state/steady-state.go
@@ -26,6 +26,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/config"
 	objUtil "kubevirt.io/kubevirt/tools/perfscale-load-generator/object"
 	"kubevirt.io/kubevirt/tools/perfscale-load-generator/watcher"

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -36,6 +36,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	flavorv1alpha1 "kubevirt.io/api/flavor/v1alpha1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	validating_webhook "kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters"
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"


### PR DESCRIPTION
**What this PR does / why we need it**:

The current goimports local prefix covered the kubevirt organization
and not the kubevirt/kubevirt project itself.

It is useful to see in the source files the dependencies which come from
outside the project. Therefore, updating the local prefix allows
the imports to be structured correctly into blocks that exposes local
and non-local dependencies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a huge PR due to the inability to split the auto-format coverage.
Luckily, it does a simple operation with no manual intervention.

This is an alternative to #8033 .

**Release note**:
```release-note
NONE
```
