### PR TITLE
Add ginkgo linter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ nogo(
     # that are always correct).
     # You can see the what `go vet` does by running `go doc cmd/vet`.
     deps = [
+        "//tools/analyzers/ginkgolinter:go_default_library",
         "//vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/asmdecl:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/assign:go_default_library",

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
+	golang.org/x/tools v0.1.9
 	google.golang.org/grpc v1.40.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.4.0
@@ -138,7 +139,6 @@ require (
 	go.mongodb.org/mongo-driver v1.8.4 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.1.9 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -125,5 +125,11 @@
       "vendor/": "vendor doesn't pass vet",
       "external/": "externaldoesn't pass vet"
     }
+  },
+  "ginkgolinter": {
+    "exclude_files": {
+      "vendor/": "vendor doesn't pass vet",
+      "external/": "externaldoesn't pass vet"
+    }
   }
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3538,7 +3538,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "2Mi"}}
 			vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(BeNumerically(">=", 1))
+			Expect(causes).ToNot(BeEmpty())
 			Expect(causes).To(ContainElement(metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Field: "fake.domain.cpu.dedicatedCpuPlacement", Message: "fake.domain.cpu.dedicatedCpuPlacement must be set to true when fake.domain.cpu.realtime is used"}))
 		})
 		It("should reject the realtime knob when NUMA Guest Mapping Passthrough is not defined", func() {
@@ -4012,7 +4012,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		path := k8sfield.NewPath("spec")
 		causes := webhooks.ValidateVirtualMachineInstanceHypervFeatureDependencies(path, &vmi.Spec)
-		Expect(len(causes)).To(BeNumerically(">=", 1))
+		Expect(causes).ToNot(BeEmpty())
 	})
 
 	It("Should validate VMIs with correct hyperv deps", func() {

--- a/pkg/virt-controller/watch/export/export_test.go
+++ b/pkg/virt-controller/watch/export/export_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Export controlleer", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pod).ToNot(BeNil())
 		Expect(pod.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
-		Expect(len(pod.Spec.Volumes)).To(Equal(3), "There should be 3 volumes, one pvc, and two secrets (token and certs)")
+		Expect(pod.Spec.Volumes).To(HaveLen(3), "There should be 3 volumes, one pvc, and two secrets (token and certs)")
 		certSecretName := ""
 		for _, volume := range pod.Spec.Volumes {
 			if volume.Name == certificates {
@@ -248,8 +248,8 @@ var _ = Describe("Export controlleer", func() {
 				},
 			},
 		}))
-		Expect(len(pod.Spec.Containers)).To(Equal(1))
-		Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(3))
+		Expect(pod.Spec.Containers).To(HaveLen(1))
+		Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
 		Expect(pod.Spec.Containers[0].VolumeMounts).To(ContainElement(k8sv1.VolumeMount{
 			Name:      "test-pvc",
 			ReadOnly:  true,

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -670,7 +670,7 @@ var _ = Describe("Restore controlleer", func() {
 
 				l, err := cdiClient.CdiV1beta1().DataVolumes("").List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(l.Items)).To(BeZero())
+				Expect(l.Items).To(BeEmpty())
 				testutils.ExpectEvent(recorder, "VirtualMachineRestoreComplete")
 			})
 

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -315,14 +315,14 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 						Expect(numberOfCreatedMDEVs).To(BeZero(), msg)
 					}
 				}
-				Expect(len(desiredDevicesToConfigure)).To(BeZero(), "add types should be created")
+				Expect(desiredDevicesToConfigure).To(BeEmpty(), "add types should be created")
 			}
 
 			By("removing all created mdevs")
 			mdevManager.updateMDEVTypesConfiguration([]string{})
 			files, err := ioutil.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(files)).To(BeZero())
+			Expect(files).To(BeEmpty())
 		},
 			Entry("spread types accoss identical cards", spreadTypesAccossIdenticalCard),
 			Entry("one yype many cards", oneTypeManyCards),
@@ -425,7 +425,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 						Expect(numberOfCreatedMDEVs).To(BeZero(), msg)
 					}
 				}
-				Expect(len(desiredDevicesToConfigure)).To(BeZero(), "add types should be created")
+				Expect(desiredDevicesToConfigure).To(BeEmpty(), "add types should be created")
 			}
 
 			By("removing all created mdevs")
@@ -434,7 +434,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			deviceController.refreshMediatedDevicesTypes()
 			files, err := ioutil.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(files)).To(BeZero())
+			Expect(files).To(BeEmpty())
 		},
 			Entry("configure default mdev types", deafultTypesNotNodeSpecific),
 			Entry("configure mdev types that match all node selectors", matchAllNodeLabels),

--- a/pkg/virt-handler/isolation/isolation_test.go
+++ b/pkg/virt-handler/isolation/isolation_test.go
@@ -23,8 +23,7 @@ var _ = Describe("IsolationResult", func() {
 		It("Should have mounts", func() {
 			mounts, err := isolationResult.Mounts(nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mounts).ToNot(BeNil())
-			Expect(len(mounts)).ToNot(BeZero())
+			Expect(mounts).ToNot(BeEmpty())
 		})
 
 		It("Should have root mounted", func() {
@@ -72,8 +71,7 @@ var _ = Describe("IsolationResult", func() {
 		It("Should have mounts", func() {
 			mounts, err := isolationResult.Mounts(nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(mounts).ToNot(BeNil())
-			Expect(len(mounts)).ToNot(BeZero())
+			Expect(mounts).ToNot(BeEmpty())
 		})
 	})
 

--- a/staging/src/kubevirt.io/client-go/api/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/defaults_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Defaults", func() {
 	It("should add interface and pod network by default", func() {
 		vmi := &v1.VirtualMachineInstance{}
 		v1.SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).NotTo(BeZero())
-		Expect(len(vmi.Spec.Networks)).NotTo(BeZero())
+		Expect(vmi.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
+		Expect(vmi.Spec.Networks).NotTo(BeEmpty())
 	})
 
 	It("should default to true to all defined features", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -423,6 +423,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
 				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
+				Expect(pods.Items).ToNot(BeEmpty(), "no kubevirt pods found")
 
 				By("finding all schedulable nodes")
 				schedulableNodesList := libnode.GetAllSchedulableNodes(virtClient)

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -422,7 +422,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				By("finding all kubevirt pods")
 				pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{})
 				Expect(err).ShouldNot(HaveOccurred(), "failed listing kubevirt pods")
-				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
 				Expect(pods.Items).ToNot(BeEmpty(), "no kubevirt pods found")
 
 				By("finding all schedulable nodes")

--- a/tools/analyzers/ginkgolinter/BUILD.bazel
+++ b/tools/analyzers/ginkgolinter/BUILD.bazel
@@ -1,0 +1,10 @@
+# gazelle:ignore
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ginkgo_linter.go"],
+    importpath = "kubevirt.io/kubevirt/tools/analyzers/ginkgolinter",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_tools//go/analysis:go_default_library"],
+)

--- a/tools/analyzers/ginkgolinter/BUILD.bazel
+++ b/tools/analyzers/ginkgolinter/BUILD.bazel
@@ -1,4 +1,3 @@
-# gazelle:ignore
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/tools/analyzers/ginkgolinter/README.md
+++ b/tools/analyzers/ginkgolinter/README.md
@@ -1,0 +1,39 @@
+# ginkgo-linter
+
+This is a golang linter to check usage of the ginkgo and gomega packages.
+
+ginkgo is a testing framework and gomega is its assertion package.
+
+## Linter Checks
+### Wrong Length checks
+The linter finds usage of the golang built-in `len` function, and then all kind of matchers, while there are already gomega matchers for these usecases.
+
+There are several wrong patterns:
+```go
+Expect(len(x)).To(Equal(0)) // should be Expect(x).To(BeEmpty())
+Expect(len(x)).To(BeZero()) // should be Expect(x).To(BeEmpty())
+Expect(len(x)).To(BeNumerically(">", 0)) // should be Expect(x).ToNot(BeEmpty())
+Expect(len(x)).To(BeNumerically(">=", 1)) // should be Expect(x).ToNot(BeEmpty())
+Expect(len(x)).To(BeNumerically("==", 0)) // should be Expect(x).To(BeEmpty())
+Expect(len(x)).To(BeNumerically("!=", 0)) // should be Expect(x).ToNot(BeEmpty())
+
+Expect(len(x)).To(Equal(1)) // should be Expect(x).To(HaveLen(1))
+Expect(len(x)).To(BeNumerically("==", 2)) // should be Expect(x).To(HaveLen(2))
+Expect(len(x)).To(BeNumerically("!=", 3)) // should be Expect(x).ToNot(HaveLen(3))
+```
+
+The linter supports the `Expect`, `ExpectWithOffset` and the `Ω` functions, with the `Should`, `ShouldNot`, `To`, `ToNot` and `NotTo` assertion functions.
+
+It also supports the embedded `Not()` function; e.g.
+
+`Ω(len(x)).Should(Not(Equal(4)))` => `Ω(x).ShouldNot(HaveLen(4))`
+
+Or even (double negative):
+
+`Ω(len(x)).To(Not(BeNumerically(">", 0)))` => `Ω(x).To(BeEmpty())`
+
+The linter output looks like this:
+```
+pkg/virt-handler/isolation/isolation_test.go:27:4: ginkgo-linter: wrong length check; consider using Expect(mounts).ToNot(BeEmpty()) instead (ginkgolinter)
+pkg/virt-handler/isolation/isolation_test.go:76:4: ginkgo-linter: wrong length check; consider using Expect(mounts).ToNot(BeEmpty()) instead (ginkgolinter)
+```

--- a/tools/analyzers/ginkgolinter/ginkgo_linter.go
+++ b/tools/analyzers/ginkgolinter/ginkgo_linter.go
@@ -37,7 +37,7 @@ This should be replaced with:
 
 const (
 	linterName                 = "ginkgo-linter"
-	wrongLengthWarningTemplate = "wrong length check; consider using %s instead"
+	wrongLengthWarningTemplate = "wrong length check; consider using `%s` instead"
 	not                        = "Not"
 	beEmpty                    = "BeEmpty"
 	haveLen                    = "HaveLen"

--- a/tools/analyzers/ginkgolinter/ginkgo_linter.go
+++ b/tools/analyzers/ginkgolinter/ginkgo_linter.go
@@ -1,0 +1,133 @@
+package ginkgolinter
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Analyzer is the package interface with nogo
+var Analyzer = &analysis.Analyzer{
+	Name: "ginkgolinter",
+	Doc: `enforces standards of using ginkgo and gomega
+currently, the linter searches for wrong length checks; e.g.
+	Expect(len(x).Should(Equal(1))
+This should be replaced with:
+	Expect(x).Should(HavelLen(1)`,
+	Run: run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			// search for function calls
+			exp, ok := n.(*ast.CallExpr)
+			if ok {
+				selected, ok := exp.Fun.(*ast.SelectorExpr)
+				if ok {
+					if !isCheckFunc(selected.Sel.Name) {
+						return true
+					}
+
+					caller, ok := selected.X.(*ast.CallExpr)
+					if ok {
+						callerFunc, ok := caller.Fun.(*ast.Ident)
+						if ok {
+							arg := getActualArg(callerFunc, caller.Args)
+							if arg == nil {
+								return true
+							}
+
+							// check that the "actual" is a function call
+							lenArgExp, ok := arg.(*ast.CallExpr)
+							if ok {
+								lenFunc, ok := lenArgExp.Fun.(*ast.Ident)
+								// check that the "actual" function is the built-in len() function
+								if ok && lenFunc.Name == "len" {
+									return checkMatcher(exp, pass)
+								}
+							}
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func checkMatcher(exp *ast.CallExpr, pass *analysis.Pass) bool {
+	matcher, ok := exp.Args[0].(*ast.CallExpr)
+	if ok {
+		matcherFunc, ok := matcher.Fun.(*ast.Ident)
+		if ok {
+			switch matcherFunc.Name {
+			case "Equal":
+				handleEqualMatcher(matcher, pass, exp)
+				return false
+			case "BeZero":
+				pass.Reportf(exp.Pos(), "ginkgo-linter: wrong length check; consider using BeEmpty() instead")
+				return false
+			case "BeNumerically":
+				return handleBeNumerically(matcher, pass, exp)
+			}
+		}
+	}
+	return false
+}
+
+func getActualArg(callerFunc *ast.Ident, callerArgs []ast.Expr) ast.Expr {
+	switch callerFunc.Name {
+	case "Expect", "Ω":
+		return callerArgs[0]
+	case "ExpectWithOffset":
+		return callerArgs[1]
+	default:
+		return nil
+	}
+}
+
+func handleBeNumerically(matcher *ast.CallExpr, pass *analysis.Pass, exp *ast.CallExpr) bool {
+	op, ok1 := matcher.Args[0].(*ast.BasicLit)
+	val, ok2 := matcher.Args[1].(*ast.BasicLit)
+
+	if ok1 && ok2 {
+		if (op.Value == `">"` && val.Value == "0") || (op.Value == `">="` && val.Value == "1") {
+			pass.Reportf(exp.Pos(), "ginkgo-linter: wrong length check; consider using Not(BeEmpty()) instead")
+			return false
+		} else if op.Value == `"=="` {
+			pass.Reportf(exp.Pos(), "ginkgo-linter: wrong length check; consider using HaveLen() instead")
+			return false
+		}
+	}
+	return true
+}
+
+func handleEqualMatcher(matcher *ast.CallExpr, pass *analysis.Pass, exp *ast.CallExpr) {
+	suggest := "HaveLen()"
+
+	equalTo, ok := matcher.Args[0].(*ast.BasicLit)
+	if ok && equalTo.Kind == token.INT {
+		val, err := strconv.Atoi(equalTo.Value)
+		if err != nil {
+			// should never get here; this is just for case
+			pass.Reportf(exp.Pos(), "ginkgo-linter: wrong data. '%s' should be integer", equalTo.Value)
+			return
+		} else if val == 0 {
+			suggest = "BeEmpty()"
+		}
+	}
+
+	pass.Reportf(exp.Pos(), "ginkgo-linter: wrong length check; consider using %s instead", suggest)
+}
+
+func isCheckFunc(name string) bool {
+	switch name {
+	case "To", "ToNot", "NotTo", "Should", "ShouldNot":
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This PR adds a linter for ginkgo checks. For the first phase, the linter looks for wrong length checks (see below), and suggests alternatives.

This is a golang linter to check usage of the ginkgo and gomega packages.

ginkgo is a testing framework and gomega is its assertion package.

## Linter Checks
### Wrong Length checks
The linter finds usage of the golang built-in `len` function, and then all kind of matchers, while there are already gomega matchers for these usecases.

There are several wrong patterns:
```go
Expect(len(x)).To(Equal(0)) // should be Expect(x).To(BeEmpty())
Expect(len(x)).To(BeZero()) // should be Expect(x).To(BeEmpty())
Expect(len(x)).To(BeNumerically(">", 0)) // should be Expect(x).ToNot(BeEmpty())
Expect(len(x)).To(BeNumerically(">=", 1)) // should be Expect(x).ToNot(BeEmpty())
Expect(len(x)).To(BeNumerically("==", 0)) // should be Expect(x).To(BeEmpty())
Expect(len(x)).To(BeNumerically("!=", 0)) // should be Expect(x).ToNot(BeEmpty())

Expect(len(x)).To(Equal(1)) // should be Expect(x).To(HaveLen(1))
Expect(len(x)).To(BeNumerically("==", 2)) // should be Expect(x).To(HaveLen(2))
Expect(len(x)).To(BeNumerically("!=", 3)) // should be Expect(x).ToNot(HaveLen(3))
```

The linter supports the `Expect`, `ExpectWithOffset` and the `Ω` function, and the `Should`, `ShouldNot`, `To`, `ToNot` and `NotTo` assertion functions.

It also supports the embedded `Not()` function; e.g.

`Ω(len(x)).Should(Not(Equal(4)))` => `Ω(x).ShouldNot(HaveLen(4))`

Or even (double negative):

`Ω(len(x)).To(Not(BeNumerically(">", 0)))` => `Ω(x).To(BeEmpty())`

The linter output looks like this:
```
pkg/virt-handler/isolation/isolation_test.go:27:4: ginkgo-linter: wrong length check; consider using Expect(mounts).ToNot(BeEmpty()) instead (ginkgolinter)
pkg/virt-handler/isolation/isolation_test.go:76:4: ginkgo-linter: wrong length check; consider using Expect(mounts).ToNot(BeEmpty()) instead (ginkgolinter)
```

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```
