### PR TITLE
Support DV garbage collection

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -21,6 +21,9 @@ set -ex pipefail
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 KUBEVIRT_DEPLOY_CDI=${KUBEVIRT_DEPLOY_CDI:-true}
+##### DO NOT APPROVE #####
+# FIXME: default should be false, as we want to cover the existing no-GC flows
+CDI_DV_GC=${CDI_DV_GC:-0}
 
 source hack/common.sh
 # shellcheck disable=SC1090
@@ -55,6 +58,11 @@ function _ensure_cdi_deployment() {
     host_port=$(${KUBEVIRT_PATH}cluster-up/cli.sh ports uploadproxy | xargs)
     override="https://127.0.0.1:$host_port"
     _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"uploadProxyURLOverride": "'"$override"'"}}}'
+
+    # Enable succeeded DataVolume garbage collection
+    if [[ $CDI_DV_GC != "false" ]]; then
+        _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"dataVolumeTTLSeconds": '"$CDI_DV_GC"'}}}'
+    fi
 }
 
 function configure_prometheus() {

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -409,6 +409,9 @@ func GetVMIInformerIndexers() cache.Indexers {
 				if vol.PersistentVolumeClaim != nil {
 					pvcs = append(pvcs, fmt.Sprintf("%s/%s", vmi.Namespace, vol.PersistentVolumeClaim.ClaimName))
 				}
+				if vol.DataVolume != nil {
+					pvcs = append(pvcs, fmt.Sprintf("%s/%s", vmi.Namespace, vol.DataVolume.Name))
+				}
 			}
 			return pvcs, nil
 		},
@@ -529,6 +532,9 @@ func GetVirtualMachineInformerIndexers() cache.Indexers {
 			for _, vol := range vm.Spec.Template.Spec.Volumes {
 				if vol.PersistentVolumeClaim != nil {
 					pvcs = append(pvcs, fmt.Sprintf("%s/%s", vm.Namespace, vol.PersistentVolumeClaim.ClaimName))
+				}
+				if vol.DataVolume != nil {
+					pvcs = append(pvcs, fmt.Sprintf("%s/%s", vm.Namespace, vol.DataVolume.Name))
 				}
 			}
 			return pvcs, nil

--- a/pkg/virt-controller/watch/export/export.go
+++ b/pkg/virt-controller/watch/export/export.go
@@ -693,7 +693,8 @@ func (ctrl *VMExportController) isKubevirtContentType(pvc *corev1.PersistentVolu
 	if pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == corev1.PersistentVolumeBlock {
 		return true
 	}
-	isKubevirt := pvc.Annotations[annContentType] == string(cdiv1.DataVolumeKubeVirt)
+	contentType, ok := pvc.Annotations[annContentType]
+	isKubevirt := ok && (contentType == string(cdiv1.DataVolumeKubeVirt) || contentType == "")
 	if isKubevirt {
 		return true
 	}

--- a/pkg/virt-controller/watch/export/export_test.go
+++ b/pkg/virt-controller/watch/export/export_test.go
@@ -651,7 +651,7 @@ var _ = Describe("Export controlleer", func() {
 		Expect(res).To(Equal(expectedRes))
 	},
 		Entry("missing content-type", "something", "something", false),
-		Entry("blank content-type", annContentType, "", false),
+		Entry("blank content-type", annContentType, "", true),
 		Entry("kubevirt content-type", annContentType, string(cdiv1.DataVolumeKubeVirt), true),
 		Entry("archive content-type", annContentType, string(cdiv1.DataVolumeArchive), false),
 	)

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -479,7 +479,7 @@ func (ctrl *VMSnapshotController) createContent(vmSnapshot *snapshotv1.VirtualMa
 		}
 
 		if pvc == nil {
-			log.Log.Warningf("No VolumeSnapshotClass for %s/%s", vmSnapshot.Namespace, pvcName)
+			log.Log.Warningf("No snapshot PVC for %s/%s", vmSnapshot.Namespace, pvcName)
 			continue
 		}
 
@@ -794,7 +794,14 @@ func (ctrl *VMSnapshotController) getVolumeStorageClass(namespace string, volume
 	if volume.VolumeSource.DataVolume != nil {
 		storageClassName, err := ctrl.getStorageClassNameForDV(namespace, volume.VolumeSource.DataVolume.Name)
 		if err != nil {
-			return "", err
+			//FIXME: only if GC, nicify
+			pvcKey := cacheKeyFunc(namespace, volume.VolumeSource.DataVolume.Name)
+			storageClassName, err = ctrl.getStorageClassNameForPVC(pvcKey)
+			if err != nil {
+				return "", err
+			}
+			return storageClassName, nil
+			//return "", err
 		}
 		return storageClassName, nil
 	}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -26,12 +26,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
@@ -188,8 +191,13 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		newPool := newPersistentStorageVirtualMachinePool()
 		doScale(newPool.ObjectMeta.Name, 2)
 
-		var err error
-		var vms *v1.VirtualMachineList
+		var (
+			err       error
+			vms       *v1.VirtualMachineList
+			dvs       *cdiv1.DataVolumeList
+			pvcs      *corev1.PersistentVolumeClaimList
+			dvOrigUID types.UID
+		)
 
 		By("Waiting until all VMs are created")
 		Eventually(func() int {
@@ -201,20 +209,40 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		By("Waiting until all VMIs are created and online")
 		waitForVMIs(newPool.Namespace, 2)
 
-		By("Ensure DataVolumes are created")
-		dvs, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(newPool.Namespace).List(context.Background(), metav1.ListOptions{})
-		Expect(dvs.Items).To(HaveLen(2))
-
-		// Select a VM to delete, and record the VM and DV UIDs associated with the VM.
+		// Select a VM to delete, and record the VM and DV/PVC UIDs associated with the VM.
 		origUID := vms.Items[0].UID
 		name := vms.Items[0].Name
 		dvName := vms.Items[0].Spec.DataVolumeTemplates[0].ObjectMeta.Name
-		var dvOrigUID types.UID
-		for _, dv := range dvs.Items {
-			if dv.Name == dvName {
-				dvOrigUID = dv.UID
+		dvName1 := vms.Items[1].Spec.DataVolumeTemplates[0].ObjectMeta.Name
+		Expect(dvName).ToNot(Equal(dvName1))
+
+		dvTTL := tests.GetDataVolumeTTLSeconds(virtClient)
+		if dvTTL == nil {
+			By("Ensure DataVolumes are created")
+			dvs, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(newPool.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dvs.Items).To(HaveLen(2))
+			for _, dv := range dvs.Items {
+				if dv.Name == dvName {
+					dvOrigUID = dv.UID
+				}
 			}
+		} else {
+			By("Ensure PVCs are created")
+			pvcs, err = virtClient.CoreV1().PersistentVolumeClaims(newPool.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			pvcCount := 0
+			for _, pvc := range pvcs.Items {
+				if pvc.Name == dvName || pvc.Name == dvName1 {
+					pvcCount++
+					if pvc.Name == dvName {
+						dvOrigUID = pvc.UID
+					}
+				}
+			}
+			Expect(pvcCount).To(Equal(2))
 		}
+
 		Expect(string(dvOrigUID)).ToNot(Equal(""))
 
 		By("deleting a VM")
@@ -249,13 +277,29 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		By("Waiting until all VMIs are created and online again")
 		waitForVMIs(newPool.Namespace, 2)
 
-		By("Verify datavolume count after VM replacement")
-		dvs, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(newPool.Namespace).List(context.Background(), metav1.ListOptions{})
-		Expect(dvs.Items).To(HaveLen(2))
+		if dvTTL == nil {
+			By("Verify datavolume count after VM replacement")
+			dvs, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(newPool.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(dvs.Items).To(HaveLen(2))
 
-		By("Verify datavolume for deleted VM is replaced")
-		for _, dv := range dvs.Items {
-			Expect(dv.UID).ToNot(Equal(dvOrigUID))
+			By("Verify datavolume for deleted VM is replaced")
+			for _, dv := range dvs.Items {
+				Expect(dv.UID).ToNot(Equal(dvOrigUID))
+			}
+		} else {
+			pvcs, err = virtClient.CoreV1().PersistentVolumeClaims(newPool.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verify pvc for deleted VM is replaced")
+			pvcCount := 0
+			for _, pvc := range pvcs.Items {
+				if pvc.Name == dvName || pvc.Name == dvName1 {
+					Expect(pvc.UID).ToNot(Equal(dvOrigUID))
+					pvcCount++
+				}
+			}
+			By("Verify pvc count after VM replacement")
+			Expect(pvcCount).To(Equal(2))
 		}
 	})
 

--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -8,10 +8,6 @@ import (
 
 	"github.com/onsi/gomega/format"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -28,6 +24,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -382,15 +379,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				for _, dvt := range sourceVM.Spec.DataVolumeTemplates {
-					Eventually(func() bool {
-						dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(sourceVM.Namespace).Get(context.Background(), dvt.Name, v1.GetOptions{})
-						if errors.IsNotFound(err) {
-							return false
-						}
-						Expect(err).ToNot(HaveOccurred())
-						Expect(dv.Status.Phase).ShouldNot(Equal(cdiv1.Failed))
-						return dv.Status.Phase == cdiv1.Succeeded
-					}, 180*time.Second, time.Second).Should(BeTrue())
+					tests.EventuallyDVWith(sourceVM.Namespace, dvt.Name, 180, HaveSucceeded())
 				}
 			})
 

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -43,7 +43,6 @@ import (
 	exportv1 "kubevirt.io/api/export/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -51,6 +50,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/util"
 
@@ -322,13 +322,7 @@ var _ = SIGDescribe("Export", func() {
 		ensurePVCBound(pvc)
 
 		By("Making sure the DV is successful")
-		Eventually(func() cdiv1.DataVolumePhase {
-			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-			if !errors.IsNotFound(err) {
-				Expect(err).ToNot(HaveOccurred())
-			}
-			return dv.Status.Phase
-		}, 90*time.Second, 1*time.Second).Should(Equal(cdiv1.Succeeded))
+		tests.EventuallyDV(dv, 90, HaveSucceeded())
 
 		pod := createSourcePodChecker(pvc)
 
@@ -748,13 +742,8 @@ var _ = SIGDescribe("Export", func() {
 		ensurePVCBound(pvc)
 
 		By("Making sure the DV is successful")
-		Eventually(func() cdiv1.DataVolumePhase {
-			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-			if !errors.IsNotFound(err) {
-				Expect(err).ToNot(HaveOccurred())
-			}
-			return dv.Status.Phase
-		}, 90*time.Second, 1*time.Second).Should(Equal(cdiv1.Succeeded))
+		tests.EventuallyDV(dv, 90, HaveSucceeded())
+
 		By("Making sure the export becomes ready")
 		Eventually(func() bool {
 			export, err = virtClient.VirtualMachineExport(pvc.Namespace).Get(context.Background(), export.Name, metav1.GetOptions{})

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -468,7 +468,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		dvBlock := libstorage.NewRandomBlankDataVolume(util.NamespaceTestDefault, sc, "64Mi", accessMode, volumeMode)
 		_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dvBlock.Namespace).Create(context.Background(), dvBlock, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
-		Eventually(ThisDV(dvBlock), 240).Should(HaveSucceeded())
+		tests.EventuallyDV(dvBlock, 240, HaveSucceeded())
 		return dvBlock
 	}
 

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -79,6 +79,11 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 	})
 
 	validateDataVolume := func(targetName string, _ string) {
+		if tests.GetDataVolumeTTLSeconds(virtClient) != nil {
+			_, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Get(context.Background(), targetName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return
+		}
 		By(getDataVolume)
 		_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Get(context.Background(), targetName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -117,6 +122,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 	deleteDataVolume := func(targetName string) {
 		err := virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Delete(context.Background(), targetName, metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
+			deletePVC(targetName)
 			return
 		}
 		Expect(err).ToNot(HaveOccurred())
@@ -189,6 +195,9 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 	})
 
 	validateDataVolumeForceBind := func(targetName string) {
+		if tests.GetDataVolumeTTLSeconds(virtClient) != nil {
+			return
+		}
 		By(getDataVolume)
 		dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Get(context.Background(), targetName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -250,11 +259,13 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 
 		validateArchiveUpload := func(targetName string, uploadDV bool) {
 			if uploadDV {
-				By(getDataVolume)
-				dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Get(context.Background(), targetName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				if tests.GetDataVolumeTTLSeconds(virtClient) == nil {
+					By(getDataVolume)
+					dv, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Get(context.Background(), targetName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(dv.Spec.ContentType).To(Equal(cdiv1.DataVolumeArchive))
+					Expect(dv.Spec.ContentType).To(Equal(cdiv1.DataVolumeArchive))
+				}
 			} else {
 				By("Validate no DataVolume")
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Get(context.Background(), targetName, metav1.GetOptions{})

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -472,8 +472,7 @@ var _ = SIGDescribe("Storage", func() {
 				dataVolume = libstorage.NewRandomDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 			})
 			AfterEach(func() {
-				err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				tests.DeleteDataVolume(dataVolume)
 			})
 
 			It("should be successfully started and virtiofs could be accessed", func() {
@@ -1049,12 +1048,11 @@ var _ = SIGDescribe("Storage", func() {
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				tests.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 			})
 
 			AfterEach(func() {
-				err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				tests.DeleteDataVolume(dataVolume)
 			})
 
 			// Not a candidate for NFS because local volumes are used in test
@@ -1196,13 +1194,12 @@ var _ = SIGDescribe("Storage", func() {
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+				tests.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 				vmi = nil
 			})
 
 			AfterEach(func() {
-				err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				tests.DeleteDataVolume(dataVolume)
 			})
 
 			It("should generate the block backingstore disk within the domain", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -191,13 +191,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			return tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, corev1.ReadWriteOnce)
 		}
 
-		deleteDataVolume := func(dv *cdiv1.DataVolume) {
-			if dv != nil {
-				By("Deleting the DataVolume")
-				ExpectWithOffset(1, virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
-			}
-		}
-
 		createVirtualMachine := func(running bool, template *v1.VirtualMachineInstance) *v1.VirtualMachine {
 			By("Creating VirtualMachine")
 			vm := tests.NewRandomVirtualMachine(template, running)
@@ -411,7 +404,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		DescribeTable("[test_id:1520]should update VirtualMachine once VMIs are up", func(createTemplate vmiBuilder) {
 			template, dv := createTemplate()
-			defer deleteDataVolume(dv)
+			defer tests.DeleteDataVolume(dv)
 			newVM := createVirtualMachine(true, template)
 			Eventually(func() bool {
 				vm, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Get(newVM.Name, &k8smetav1.GetOptions{})
@@ -426,7 +419,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", func(createTemplate vmiBuilder) {
 			template, dv := createTemplate()
-			defer deleteDataVolume(dv)
+			defer tests.DeleteDataVolume(dv)
 			newVM := createVirtualMachine(true, template)
 			// Delete it
 			Expect(virtClient.VirtualMachine(newVM.Namespace).Delete(newVM.Name, &k8smetav1.DeleteOptions{})).To(Succeed())
@@ -556,7 +549,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		DescribeTable("[test_id:1525]should stop VirtualMachineInstance if running set to false", func(createTemplate vmiBuilder) {
 			template, dv := createTemplate()
-			defer deleteDataVolume(dv)
+			defer tests.DeleteDataVolume(dv)
 			vm := createVirtualMachine(false, template)
 			vm = startVM(vm)
 			stopVM(vm)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1930,12 +1930,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			tests.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 		})
 
 		AfterEach(func() {
-			err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			tests.DeleteDataVolume(dataVolume)
 		})
 
 		It("[test_id:1681]should set appropriate cache modes", func() {
@@ -2062,7 +2061,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			tests.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 
 			vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 
@@ -2099,7 +2098,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(ThisDV(dataVolume), 240).Should(Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
+			tests.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), BeInPhase(cdiv1.WaitForFirstConsumer)))
 
 			vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
 


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
CDI added support for [garbage collection of completed DVs](https://github.com/kubevirt/containerized-data-importer/pull/2233).
Here we add KubeVirt support for it, and adapt tests accordingly, so in case GC is enabled DV won't be referred. 

See design [here](https://github.com/kubevirt/community/blob/main/design-proposals/garbage-collect-completed-dvs.md).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Support DataVolume garbage collection
```
