### PR TITLE
Let nogo linters use the right golang.org/x/tools dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,6 +82,7 @@ nogo(
 
 # gazelle:prefix kubevirt.io/kubevirt
 # gazelle:build_tags selinux
+# gazelle:resolve go golang.org/x/tools/go/analysis @org_golang_x_tools//go/analysis:go_default_library
 gazelle(
     name = "gazelle",
     build_tags = ["selinux"],

--- a/hack/bazel-generate.sh
+++ b/hack/bazel-generate.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
 
-# first ensure this file, so that sandbox bootstrapping has a working nogo setup
-# without this sourcing hack/bootstraph.sh will fail
-cat >vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign/BUILD.bazel <<EOT
-# gazelle:ignore
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
-go_library(
-    name = "go_default_library",
-    srcs = ["ineffassign.go"],
-    importmap = "kubevirt.io/kubevirt/vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign",
-    importpath = "github.com/gordonklaus/ineffassign/pkg/ineffassign",
-    visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_tools//go/analysis:go_default_library"],
-)
-EOT
-
 source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -39,6 +39,9 @@ function kubevirt::bootstrap::regenerate() {
         cd ${KUBEVIRT_DIR}
         rm ${SANDBOX_DIR} -rf
         rm .bazeldnf/sandbox.bazelrc -f
+        # Run gazelle to ensure that nogo has all build files resolved and that we can bootstrap the env.
+        # This is necessary since some steps remove the vendor build files and nogo would be broken then.
+        KUBEVIRT_BOOTSTRAPPING=true bazel run --config=${ARCHITECTURE} //:gazelle -- -exclude vendor/google.golang.org/grpc --exclude cluster-up
         KUBEVIRT_BOOTSTRAPPING=true bazel run --config ${HOST_ARCHITECTURE} //rpm:sandbox_${1}
         bazel clean
 

--- a/tools/analyzers/BUILD.bazel
+++ b/tools/analyzers/BUILD.bazel
@@ -1,12 +1,9 @@
-# gazelle:ignore
-load("@io_bazel_rules_go//go:def.bzl", "go_tool_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-go_tool_library(
-    name = "ineffassign",
+go_library(
+    name = "go_default_library",
     srcs = ["analyzer.go"],
-    importpath = "kubevirt.io/kubevirt/analyzer",
+    importpath = "kubevirt.io/kubevirt/tools/analyzers",
     visibility = ["//visibility:public"],
-    deps = [
-        "//vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign:go_tool_library",
-    ],
+    deps = ["//vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign:go_default_library"],
 )

--- a/vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign/BUILD.bazel
+++ b/vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign/BUILD.bazel
@@ -1,4 +1,3 @@
-# gazelle:ignore
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1087,6 +1087,8 @@ k8s.io/utils/pointer
 k8s.io/utils/trace
 # kubevirt.io/api v0.0.0-00010101000000-000000000000 => ./staging/src/kubevirt.io/api
 ## explicit; go 1.17
+kubevirt.io/api/clone
+kubevirt.io/api/clone/v1alpha1
 kubevirt.io/api/core
 kubevirt.io/api/core/v1
 kubevirt.io/api/export
@@ -1117,6 +1119,8 @@ kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/v
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme
+kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1
+kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/fake
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:

Instruct gazelle with an explicit mapping directive to use the right
golang.org/x/tools dependency for the Analyzer interface which is also
used by nogo to load the custom analyzers.

Since gazelle now does the correct mapping, all special handling of
files with a `#gazelle: ignore` annotation is no longer necessary.

The BUILD.bazel files for analyzers are now generated like all the other
build files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
