### PR TITLE
virt-controller: Pass Multus network-status Annotation to VMI

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/util:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a pod is connected to secondary networks using Multus [1],
it will be annotated with "k8s.v1.cni.cncf.io/networks-status" [2].

This is a preparation step before introducing the PR that fixes mapping between VM SR-IOV interfaces and the underlying VFs
before assigning them to the domain [#6351 ](https://github.com/kubevirt/kubevirt/issues/7444).

[1] https://github.com/k8snetworkplumbingwg/multus-cni/blob/v3.9/docs/quickstart.md#creating-a-pod-that-attaches-an-additional-interface
[2] https://github.com/k8snetworkplumbingwg/multus-cni/blob/v3.9/docs/quickstart.md#network-status-annotations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Or Mergi <ormergi@redhat.com>
