### PR TITLE
trivial: Increase timeout of device controller tests

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Device Controller", func() {
 			go deviceController.Run(stop)
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
-			}, 500*time.Millisecond).Should(BeNumerically(">=", 1))
+			}, 5*time.Second).Should(BeNumerically(">=", 1))
 			Expect(deviceController.Initialized()).To(BeTrue())
 		})
 
@@ -172,11 +172,11 @@ var _ = Describe("Device Controller", func() {
 
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin1.Starts))
-			}).Should(BeNumerically(">=", 1))
+			}, 5*time.Second).Should(BeNumerically(">=", 1))
 
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
-			}).Should(BeNumerically(">=", 1))
+			}, 5*time.Second).Should(BeNumerically(">=", 1))
 		})
 
 		It("should remove all device plugins if permittedHostDevices is removed from the CR", func() {
@@ -194,7 +194,7 @@ var _ = Describe("Device Controller", func() {
 				_, exists1 := deviceController.startedPlugins[deviceName1]
 				_, exists2 := deviceController.startedPlugins[deviceName2]
 				return exists1 || exists2
-			}).Should(BeFalse())
+			}, 5*time.Second).Should(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8006/pull-kubevirt-unit-test/1542490796945575936

```
{ Failure pkg/virt-handler/device-manager/device_controller_test.go:182
Timed out after 1.001s.
Expected
    <bool>: true
to be false
pkg/virt-handler/device-manager/device_controller_test.go:197}
```

For now this change increases the Eventually timeout used by various
tests to hopefully avoid this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
