### PR TITLE
[Clone API]: Fix race between VM and restore readiness

### DIFF
--- a/pkg/virt-controller/watch/clone/BUILD.bazel
+++ b/pkg/virt-controller/watch/clone/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/status:go_default_library",
+        "//pkg/virt-controller/watch/snapshot:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -87,7 +87,7 @@ func restoreDVName(vmRestore *snapshotv1.VirtualMachineRestore, name string) str
 	return restorePVCName(vmRestore, name)
 }
 
-func vmRestoreProgressing(vmRestore *snapshotv1.VirtualMachineRestore) bool {
+func VmRestoreProgressing(vmRestore *snapshotv1.VirtualMachineRestore) bool {
 	return vmRestore.Status == nil || vmRestore.Status.Complete == nil || !*vmRestore.Status.Complete
 }
 
@@ -111,7 +111,7 @@ func (ctrl *VMRestoreController) updateVMRestore(vmRestoreIn *snapshotv1.Virtual
 		return 0, ctrl.doUpdateError(vmRestoreOut, err)
 	}
 
-	if !vmRestoreProgressing(vmRestoreIn) && target != nil {
+	if !VmRestoreProgressing(vmRestoreIn) && target != nil {
 		//update the vm if Done restore
 		if updated, err := target.UpdateDoneRestore(); updated || err != nil {
 			return 0, err
@@ -626,7 +626,7 @@ func (ctrl *VMRestoreController) getSnapshotContent(vmRestore *snapshotv1.Virtua
 	}
 
 	vms := obj.(*snapshotv1.VirtualMachineSnapshot).DeepCopy()
-	if !vmSnapshotReady(vms) {
+	if !VmSnapshotReady(vms) {
 		return nil, fmt.Errorf("VMSnapshot %s not ready", objKey)
 	}
 

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -62,7 +62,7 @@ const (
 	snapshotRetryInterval = 5 * time.Second
 )
 
-func vmSnapshotReady(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
+func VmSnapshotReady(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
 	return vmSnapshot.Status != nil && vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse
 }
 
@@ -86,7 +86,7 @@ func vmSnapshotSucceeded(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
 }
 
 func vmSnapshotProgressing(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
-	return vmSnapshotError(vmSnapshot) == nil && !vmSnapshotReady(vmSnapshot) &&
+	return vmSnapshotError(vmSnapshot) == nil && !VmSnapshotReady(vmSnapshot) &&
 		!vmSnapshotFailed(vmSnapshot) && !vmSnapshotSucceeded(vmSnapshot)
 }
 
@@ -661,7 +661,7 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 	} else if vmSnapshotError(vmSnapshotCpy) != nil {
 		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "In error state"))
 		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionFalse, "Error"))
-	} else if vmSnapshotReady(vmSnapshotCpy) {
+	} else if VmSnapshotReady(vmSnapshotCpy) {
 		vmSnapshotCpy.Status.Phase = snapshotv1.Succeeded
 		updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "Operation complete"))
 		updateSnapshotCondition(vmSnapshotCpy, newReadyCondition(corev1.ConditionTrue, "Operation complete"))

--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -95,6 +95,17 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 
 			return vmClone.Status.Phase
 		}, 3*time.Minute, 3*time.Second).Should(Equal(clonev1alpha1.Succeeded), "clone should finish successfully")
+
+		// TODO: Clone should not depend on target VM's status. This should be fixed in restore controller.
+		// For more info: https://github.com/kubevirt/kubevirt/pull/8059#discussion_r917762046
+		targetVmName := vmClone.Spec.Target.Name
+		By(fmt.Sprintf("Waiting for target VM %s to be ready", targetVmName))
+		Eventually(func() (isRestoreInProgress bool) {
+			targetVm, err := virtClient.VirtualMachine(vmClone.Namespace).Get(targetVmName, &v1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			return targetVm.Status.RestoreInProgress != nil
+		}, 90*time.Second, 1*time.Second).Should(BeFalse(), "target VM is expected to be ready")
 	}
 
 	expectVMRunnable := func(vm *virtv1.VirtualMachine, login loginFunction) *virtv1.VirtualMachine {


### PR DESCRIPTION
**What this PR does / why we need it**:
The new cloning API [was merged](https://github.com/kubevirt/kubevirt/pull/7336) [1] recently. Since then, we're seeing some CI failures (e.g. [this one](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.23-sig-storage/1544549474116833280) [2]).

### The bug

The failures are coming from validating webhooks [3]. These webhooks don't allow VMs to start if a restore is still in progress.

The cloning API is making sure the restore object states that it's ready [4], but it doesn't check the VM's status.

Essentially, this is the current flow:
- Restore is complete. Its status is changed to reflect it.
- Then, these two things happen in parallel:
  - Cloning controller moves to "Succeeded" and considers the VM as ready
  - The VM updates its status to refrect it's ready

This race introduces flakieness, as in the test we:
- Wait for the clone to be finished
- Run the VM
- The VM is being rejected by webhooks since allegedly it isn't ready yet.

### The Fix

<del>In order to fix this, the cloning controller would wait for both the restore and the VM to be ready. This should resolve the flakieness.</del>

Following one of the [discussions in this PR](https://github.com/kubevirt/kubevirt/pull/8059#discussion_r917762046), we will solve this temporarily by waiting for `targetVm.Status.RestoreInProgress` to be nil in the clone controller functional tests.

The reason for this decision is that the clone controller should not depend on the target VM's status - but only on the restore object's status. To save CI lanes from being flaky we introduce a temporary dependency between the functional tests and the target VM's status. In the near future we will make sure the restore object is ready only when the target VM is ready.

---------

[1] https://github.com/kubevirt/kubevirt/pull/7336
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.23-sig-storage/1544549474116833280
[3] https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go#L533
[4] https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/watch/clone/clone.go#L238

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
