### PR TITLE
Alert if there are multiple VMIs in scheduling state

### DIFF
--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -525,6 +525,18 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					vmStuckInStatusRule("starting"),
 					vmStuckInStatusRule("migrating"),
 					vmStuckInStatusRule("error"),
+					{
+						Alert: "KubeVirtMultipleSchedulingVMI",
+						Expr:  intstr.FromString("sum(kubevirt_vmi_phase_count{phase='scheduling'}) > 15"),
+						For:   "5m",
+						Annotations: map[string]string{
+							"summary":     "More than 15 Virtual Machine Instances are in scheduling state",
+							"runbook_url": runbookUrlBasePath + "KubeVirtMultipleSchedulingVMI",
+						},
+						Labels: map[string]string{
+							severityAlertLabelKey: "warning",
+						},
+					},
 				},
 			},
 		},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -263,6 +263,7 @@ func DeleteSecret(name string) {
 		util2.PanicOnError(err)
 	}
 }
+
 func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
 	By(StartingVMInstance)
 	virtCli, err := kubecli.GetKubevirtClient()
@@ -271,6 +272,22 @@ func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInsta
 	var obj *v1.VirtualMachineInstance
 	Eventually(func() error {
 		obj, err = virtCli.VirtualMachineInstance(util2.NamespaceTestDefault).Create(vmi)
+		return err
+	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
+	return obj
+}
+
+func DeleteVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
+	By("Deleting a VirtualMachineInstance")
+	virtCli, err := kubecli.GetKubevirtClient()
+	util2.PanicOnError(err)
+
+	var obj *v1.VirtualMachineInstance
+	Eventually(func() error {
+		err = virtCli.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
 	return obj


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Alert if there are multiple VMIs in scheduling state
```
