### PR TITLE
[e2e tests]: improve the `config_test.go` suite

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", func() {
+var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]Config", func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1053,12 +1053,6 @@ func NewRandomVMIWithWatchdog() *v1.VirtualMachineInstance {
 	return vmi
 }
 
-func NewRandomVMIWithConfigMap(configMapName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithPVC(DiskAlpineHostPath)
-	AddConfigMapDisk(vmi, configMapName, configMapName)
-	return vmi
-}
-
 func AddConfigMapDisk(vmi *v1.VirtualMachineInstance, configMapName string, volumeName string) {
 	AddConfigMapDiskWithCustomLabel(vmi, configMapName, volumeName, "")
 
@@ -1078,12 +1072,6 @@ func AddConfigMapDiskWithCustomLabel(vmi *v1.VirtualMachineInstance, configMapNa
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: volumeName,
 	})
-}
-
-func NewRandomVMIWithSecret(secretName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithPVC(DiskAlpineHostPath)
-	AddSecretDisk(vmi, secretName, secretName)
-	return vmi
 }
 
 func AddSecretDisk(vmi *v1.VirtualMachineInstance, secretName string, volumeName string) {
@@ -1143,12 +1131,6 @@ func AddDownwardMetricsVolume(vmi *v1.VirtualMachineInstance, volumeName string)
 			},
 		},
 	})
-}
-
-func NewRandomVMIWithServiceAccount(serviceAccountName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithPVC(DiskAlpineHostPath)
-	AddServiceAccountDisk(vmi, serviceAccountName)
-	return vmi
 }
 
 func AddServiceAccountDisk(vmi *v1.VirtualMachineInstance, serviceAccountName string) {


### PR DESCRIPTION
Following are the improvements:

- Replace usage of host-path Alpine with a container-disk based VM disk, that should reduce the VM launch time.
- Adapt the suite to use `libvmi` thus reducing the content of `utils.go`
- Run the suite in parallel manner.

**What this PR does / why we need it**:

**Special notes for your reviewer**:
Perhaps more refactoring can be done i.e. merge the suite to the `vmi_configuration_test.go` suite
I wanted to reduce the complexity of the PR thus decided to start with these changes.

**Release note**:
```release-note
NONE
```
