### PR TITLE
Sync kubevirt dependencies

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1087,6 +1087,8 @@ k8s.io/utils/pointer
 k8s.io/utils/trace
 # kubevirt.io/api v0.0.0-00010101000000-000000000000 => ./staging/src/kubevirt.io/api
 ## explicit; go 1.17
+kubevirt.io/api/clone
+kubevirt.io/api/clone/v1alpha1
 kubevirt.io/api/core
 kubevirt.io/api/core/v1
 kubevirt.io/api/export
@@ -1117,6 +1119,8 @@ kubevirt.io/client-go/generated/external-snapshotter/clientset/versioned/typed/v
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme
+kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1
+kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/clone/v1alpha1/fake
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/export/v1alpha1/fake
 kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/flavor/v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
`pull-kubevirt-verify-go-mod` lane is failing. This PR is the result of running `make deps-sync` so that the lane would pass.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
