### PR TITLE
tests, storage, snapshot: Retry a flaky VMI Update

### DIFF
--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:

The test is flaky with the following error:
```
{ Failure tests/storage/snapshot.go:383
Unexpected error:
    <*errors.StatusError | 0xc0057a4320>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "Operation cannot be fulfilled on
virtualmachines.kubevirt.io \"testvmi-kz6kb\": the object has been
modified; please apply your changes to the latest version and try again",
            Reason: "Conflict",
            Details: {
                Name: "testvmi-kz6kb",
                Group: "kubevirt.io",
                Kind: "virtualmachines",
                UID: "",
                Causes: nil,
                RetryAfterSeconds: 0,
            },
            Code: 409,
        },
    }
tests/storage/snapshot.go:446}
```

Update operations may fail in case the resource is updated on the API
server and it is common to retry the operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
