### PR TITLE
tests, libvmi: Do not override dependent spec sub trees

### DIFF
--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -118,6 +118,16 @@ func WithUefi(secureBoot bool) Option {
 			vmi.Spec.Domain.Firmware.Bootloader.EFI = &v1.EFI{}
 		}
 		vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.Bool(secureBoot)
+		// secureBoot Requires SMM to be enabled
+		if secureBoot {
+			if vmi.Spec.Domain.Features == nil {
+				vmi.Spec.Domain.Features = &v1.Features{}
+			}
+			if vmi.Spec.Domain.Features.SMM == nil {
+				vmi.Spec.Domain.Features.SMM = &v1.FeatureState{}
+			}
+			vmi.Spec.Domain.Features.SMM.Enabled = pointer.Bool(secureBoot)
+		}
 	}
 }
 

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -88,9 +88,10 @@ func WithRng() Option {
 // WithResourceMemory specifies the vmi memory resource.
 func WithResourceMemory(value string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-			k8sv1.ResourceMemory: resource.MustParse(value),
+		if vmi.Spec.Domain.Resources.Requests == nil {
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 		}
+		vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(value)
 	}
 }
 
@@ -107,22 +108,26 @@ func WithNodeSelectorFor(node *k8sv1.Node) Option {
 // WithUefi configures EFI bootloader and SecureBoot.
 func WithUefi(secureBoot bool) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Firmware = &v1.Firmware{
-			Bootloader: &v1.Bootloader{
-				EFI: &v1.EFI{
-					SecureBoot: pointer.BoolPtr(secureBoot),
-				},
-			},
+		if vmi.Spec.Domain.Firmware == nil {
+			vmi.Spec.Domain.Firmware = &v1.Firmware{}
 		}
+		if vmi.Spec.Domain.Firmware.Bootloader == nil {
+			vmi.Spec.Domain.Firmware.Bootloader = &v1.Bootloader{}
+		}
+		if vmi.Spec.Domain.Firmware.Bootloader.EFI == nil {
+			vmi.Spec.Domain.Firmware.Bootloader.EFI = &v1.EFI{}
+		}
+		vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.Bool(secureBoot)
 	}
 }
 
 // WithSEV adds `launchSecurity` with `sev`.
 func WithSEV() Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{
-			SEV: &v1.SEV{},
+		if vmi.Spec.Domain.LaunchSecurity == nil {
+			vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
 		}
+		vmi.Spec.Domain.LaunchSecurity.SEV = &v1.SEV{}
 	}
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -605,43 +605,6 @@ func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataHighMemory(containerImag
 	return vmi
 }
 
-func NewRandomVMIWithEFIBootloader() *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-
-	// EFI needs more memory than other images
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
-	vmi.Spec.Domain.Firmware = &v1.Firmware{
-		Bootloader: &v1.Bootloader{
-			EFI: &v1.EFI{
-				SecureBoot: NewBool(false),
-			},
-		},
-	}
-
-	return vmi
-
-}
-
-func NewRandomVMIWithSecureBoot() *v1.VirtualMachineInstance {
-	vmi := NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
-
-	// EFI needs more memory than other images
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
-	vmi.Spec.Domain.Features = &v1.Features{
-		SMM: &v1.FeatureState{
-			Enabled: NewBool(true),
-		},
-	}
-	vmi.Spec.Domain.Firmware = &v1.Firmware{
-		Bootloader: &v1.Bootloader{
-			EFI: &v1.EFI{}, // SecureBoot should default to true
-		},
-	}
-
-	return vmi
-
-}
-
 func NewRandomMigration(vmiName string, namespace string) *v1.VirtualMachineInstanceMigration {
 	return &v1.VirtualMachineInstanceMigration{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Replacing spec's objects might mislead and surprise the users.
We should change only the field that the function refer to instead.

Changing `WithUefi` function to  enable `SMM` when secureBoot is `true` as the  required settings
of secure boot include enabling `Uefi` and `SMM` feature as well  :
http://kubevirt.io/api-reference/master/definitions.html  ( v1.EFI )
 
Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
