### PR TITLE
virt-api: relax networkInterfaceMultiqueue semantics, introduce queueCount

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18354,6 +18354,11 @@
      "name": {
       "description": "Name of the interface, corresponds to name of the network assigned to the interface",
       "type": "string"
+     },
+     "queueCount": {
+      "description": "Specifies how many queues are allocated by MultiQueue",
+      "type": "integer",
+      "format": "int32"
      }
     }
    },

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -34,6 +34,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	DefaultInterfaceQueueCount = 1
+	UnknownInterfaceQueueCount = 0
+)
+
 type NetStat struct {
 	cacheCreator cacheCreator
 
@@ -165,9 +170,18 @@ func ifacesStatusFromDomainInterfaces(domainSpecIfaces []api.Interface) []v1.Vir
 			Name:       domainSpecIface.Alias.GetName(),
 			MAC:        domainSpecIface.MAC.MAC,
 			InfoSource: netvmispec.InfoSourceDomain,
+			QueueCount: domainInterfaceQueues(domainSpecIface.Driver),
 		})
 	}
 	return vmiStatusIfaces
+}
+
+func domainInterfaceQueues(driver *api.InterfaceDriver) int32 {
+	if driver != nil && driver.Queues != nil {
+		return int32(*driver.Queues)
+	}
+
+	return DefaultInterfaceQueueCount
 }
 
 func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfacesSpecByName map[string]v1.Interface) []v1.VirtualMachineInstanceNetworkInterface {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1997,31 +1997,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should reject vmi with a network multiqueue, with only non virtio nics", func() {
-			vmi := api.NewMinimalVMI("testvm")
-			nic := *v1.DefaultBridgeNetworkInterface()
-			nic.Model = "e1000"
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{nic}
-			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
-		})
-
-		DescribeTable("VMI with network multiqueue", func(updateSpec func(vmi *v1.VirtualMachineInstance)) {
-			vmi := api.NewMinimalVMI("testvm")
-			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
-			updateSpec(vmi)
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(BeEmpty())
-		},
-			Entry("should accept vmi with autoattached interfaces as the default", func(*v1.VirtualMachineInstance) {}),
-			Entry("should accept vmi with autoattached interfaces enabled", enableAutoattachPodInterface),
-			Entry("should accept vmi with autoattached interfaces disabled", disableAutoattachPodInterface),
-		)
-
 		It("should allow BlockMultiQueue with CPU settings", func() {
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.Bool(true)
@@ -4165,11 +4140,3 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		Expect(causes).To(BeEmpty())
 	})
 })
-
-func enableAutoattachPodInterface(vmi *v1.VirtualMachineInstance) {
-	vmi.Spec.Domain.Devices.AutoattachPodInterface = pointer.Bool(true)
-}
-
-func disableAutoattachPodInterface(vmi *v1.VirtualMachineInstance) {
-	vmi.Spec.Domain.Devices.AutoattachPodInterface = pointer.Bool(false)
-}

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -10482,6 +10482,10 @@ var CRDsValidation map[string]string = map[string]string{
                 description: Name of the interface, corresponds to name of the network
                   assigned to the interface
                 type: string
+              queueCount:
+                description: Specifies how many queues are allocated by MultiQueue
+                format: int32
+                type: integer
             type: object
           type: array
         launcherContainerImageVersion:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -552,6 +552,8 @@ type VirtualMachineInstanceNetworkInterface struct {
 	InterfaceName string `json:"interfaceName,omitempty"`
 	// Specifies the origin of the interface data collected. values: domain, guest-agent, or both
 	InfoSource string `json:"infoSource,omitempty"`
+	// Specifies how many queues are allocated by MultiQueue
+	QueueCount int32 `json:"queueCount,omitempty"`
 }
 
 type VirtualMachineInstanceGuestOSInfo struct {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -144,6 +144,7 @@ func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface",
 		"interfaceName": "The interface name inside the Virtual Machine",
 		"infoSource":    "Specifies the origin of the interface data collected. values: domain, guest-agent, or both",
+		"queueCount":    "Specifies how many queues are allocated by MultiQueue",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21190,6 +21190,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceNetworkInterface(ref co
 							Format:      "",
 						},
 					},
+					"queueCount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies how many queues are allocated by MultiQueue",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//pkg/cloud-init:go_default_library",
         "//pkg/network/istio:go_default_library",
+        "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -34,6 +34,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
+	network "kubevirt.io/kubevirt/pkg/network/setup"
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/libvmi"
@@ -98,27 +99,32 @@ var _ = SIGDescribe("Infosource", func() {
 					InfoSource: netvmispec.InfoSourceDomain,
 					MAC:        primaryInterfaceMac,
 					Name:       primaryNetwork,
+					QueueCount: network.DefaultInterfaceQueueCount,
 				},
 				{
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					InterfaceName: "eth1",
 					MAC:           secondaryInterface1Mac,
 					Name:          secondaryInterface1Name,
+					QueueCount:    network.DefaultInterfaceQueueCount,
 				},
 				{
 					InfoSource: netvmispec.InfoSourceDomain,
 					MAC:        secondaryInterface2Mac,
 					Name:       secondaryInterface2Name,
+					QueueCount: network.DefaultInterfaceQueueCount,
 				},
 				{
 					InfoSource:    netvmispec.InfoSourceGuestAgent,
 					InterfaceName: "eth0",
 					MAC:           primaryInterfaceNewMac,
+					QueueCount:    network.UnknownInterfaceQueueCount,
 				},
 				{
 					InfoSource:    netvmispec.InfoSourceGuestAgent,
 					InterfaceName: dummyInterfaceName,
 					MAC:           dummyInterfaceMac,
+					QueueCount:    network.UnknownInterfaceQueueCount,
 				},
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Multi queue will configure only virtio interfaces.
Kubevirt won't reject VMs without virtio interfaces when multi queue is configured.
It is now best effort, i.e enable multi queue when it makes sense instead
enable it at all costs.

In order to expose what is the actual configuration per interface,
add `queueCount` field to vmi.status.interfaces.
The field specifies how many queues are configured per interface
if it can be determined.
It can't determine it for interfaces that are reported by guest-agent only.
In this case it will be omitted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/7671

**Special notes for your reviewer**:
User guide https://github.com/kubevirt/user-guide/pull/560

**Release note**:
```release-note
Relax networkInterfaceMultiqueue semantics: multi queue will configure only what it can (virtio interfaces).
Kubevirt won't reject VMs without virtio interfaces when multi queue is configured.
Add queueCount field to vmi.status.interfaces (per interface).
The field specifies how many queues are configured, omitted if can't be determined (i.e interface reported by guest-agent only).
```
