### PR TITLE
virt-launcher: Deprecate MarkedForGracefulShutdown (libvirt metadata field)

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -418,9 +418,8 @@ func main() {
 	cmdServerDone := startCmdServer(cmdclient.UninitializedSocketOnGuest(), domainManager, stopChan, options)
 
 	gracefulShutdownCallback := func() {
-		err := domainManager.MarkGracefulShutdownVMI(vmi)
-		if err != nil {
-			log.Log.Reason(err).Errorf("Unable to signal graceful shutdown")
+		if err := domainManager.SignalShutdownVMI(vmi); err != nil {
+			log.Log.Object(vmi).Reason(err).Errorf("Failed to signal shutdown for vmi")
 		} else {
 			log.Log.Object(vmi).Info("Successfully signaled graceful shutdown")
 		}

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"libvirt.org/go/libvirt"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -419,18 +418,9 @@ func main() {
 	cmdServerDone := startCmdServer(cmdclient.UninitializedSocketOnGuest(), domainManager, stopChan, options)
 
 	gracefulShutdownCallback := func() {
-		err := wait.PollImmediate(time.Second, 15*time.Second, func() (bool, error) {
-			err := domainManager.MarkGracefulShutdownVMI(vmi)
-			if err != nil {
-				log.Log.Reason(err).Errorf("Unable to signal graceful shutdown")
-				return false, err
-			}
-
-			return true, nil
-		})
-
+		err := domainManager.MarkGracefulShutdownVMI(vmi)
 		if err != nil {
-			log.Log.Reason(err).Errorf("Gave up attempting to signal graceful shutdown")
+			log.Log.Reason(err).Errorf("Unable to signal graceful shutdown")
 		} else {
 			log.Log.Object(vmi).Info("Successfully signaled graceful shutdown")
 		}

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -383,7 +383,9 @@ type MigrationMetadata struct {
 type GracePeriodMetadata struct {
 	DeletionGracePeriodSeconds int64        `xml:"deletionGracePeriodSeconds"`
 	DeletionTimestamp          *metav1.Time `xml:"deletionTimestamp,omitempty"`
-	MarkedForGracefulShutdown  *bool        `xml:"markedForGracefulShutdown,omitempty"`
+
+	// Deprecated: Should not be used anymore. It is kept for backward compatibility.
+	MarkedForGracefulShutdown *bool `xml:"markedForGracefulShutdown,omitempty"`
 }
 
 type Commandline struct {

--- a/pkg/virt-launcher/virtwrap/errors/errors.go
+++ b/pkg/virt-launcher/virtwrap/errors/errors.go
@@ -26,7 +26,10 @@ import (
 	"libvirt.org/go/libvirt"
 )
 
-var MigrationAbortInProgressError = errors.New("Migration abort is in progress")
+var (
+	MigrationAbortInProgressError = errors.New("Migration abort is in progress")
+	ShutdownACPIDisabledError     = errors.New("ACPI is disabled, unable to execute graceful shutdown")
+)
 
 func checkError(err error, expectedError libvirt.ErrorNumber) bool {
 	libvirtError, ok := err.(libvirt.Error)

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -125,16 +125,6 @@ func (_mr *_MockDomainManagerRecorder) SignalShutdownVMI(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignalShutdownVMI", arg0)
 }
 
-func (_m *MockDomainManager) MarkGracefulShutdownVMI(_param0 *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "MarkGracefulShutdownVMI", _param0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockDomainManagerRecorder) MarkGracefulShutdownVMI(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MarkGracefulShutdownVMI", arg0)
-}
-
 func (_m *MockDomainManager) ListAllDomains() ([]*api.Domain, error) {
 	ret := _m.ctrl.Call(_m, "ListAllDomains")
 	ret0, _ := ret[0].([]*api.Domain)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -109,7 +109,6 @@ type DomainManager interface {
 	KillVMI(*v1.VirtualMachineInstance) error
 	DeleteVMI(*v1.VirtualMachineInstance) error
 	SignalShutdownVMI(*v1.VirtualMachineInstance) error
-	MarkGracefulShutdownVMI(*v1.VirtualMachineInstance) error
 	ListAllDomains() ([]*api.Domain, error)
 	MigrateVMI(*v1.VirtualMachineInstance, *cmdclient.MigrationOptions) error
 	PrepareMigrationTarget(*v1.VirtualMachineInstance, bool, *cmdv1.VirtualMachineOptions) error
@@ -1482,46 +1481,6 @@ func (l *LibvirtDomainManager) SoftRebootVMI(vmi *v1.VirtualMachineInstance) err
 	return nil
 }
 
-func (l *LibvirtDomainManager) MarkGracefulShutdownVMI(vmi *v1.VirtualMachineInstance) error {
-	l.domainModifyLock.Lock()
-	defer l.domainModifyLock.Unlock()
-
-	domName := api.VMINamespaceKeyFunc(vmi)
-	dom, err := l.virConn.LookupDomainByName(domName)
-	if err != nil {
-		log.Log.Object(vmi).Reason(err).Error("Getting the domain for shutdown failed.")
-		return err
-	}
-
-	defer dom.Free()
-	domainSpec, err := l.getDomainSpec(dom)
-	if err != nil {
-		return err
-	}
-
-	t := true
-
-	if domainSpec.Metadata.KubeVirt.GracePeriod == nil {
-		domainSpec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{
-			MarkedForGracefulShutdown: &t,
-		}
-	} else if domainSpec.Metadata.KubeVirt.GracePeriod.MarkedForGracefulShutdown != nil &&
-		*domainSpec.Metadata.KubeVirt.GracePeriod.MarkedForGracefulShutdown == true {
-		// already marked, nothing to do
-		return nil
-	} else {
-		domainSpec.Metadata.KubeVirt.GracePeriod.MarkedForGracefulShutdown = &t
-	}
-
-	d, err := l.setDomainSpecWithHooks(vmi, domainSpec)
-	if err != nil {
-		return err
-	}
-	defer d.Free()
-	return nil
-
-}
-
 func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance) error {
 	l.domainModifyLock.Lock()
 	defer l.domainModifyLock.Unlock()
@@ -1550,6 +1509,10 @@ func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance)
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Error("Unable to retrieve domain xml")
 			return err
+		}
+
+		if domSpec.Features.ACPI == nil {
+			return domainerrors.ShutdownACPIDisabledError
 		}
 
 		err = dom.ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1030,34 +1030,6 @@ var _ = Describe("Manager", func() {
 		})
 	})
 	Context("test marking graceful shutdown", func() {
-		It("Should set metadata when calling MarkGracefulShutdown api", func() {
-			mockDomain.EXPECT().Free().AnyTimes()
-
-			vmi := newVMI(testNamespace, testVmName)
-			domainSpec := expectedDomainFor(vmi)
-
-			oldXML, err := xml.MarshalIndent(domainSpec, "", "\t")
-			Expect(err).ToNot(HaveOccurred())
-
-			t := true
-			domainSpec.Metadata.KubeVirt.GracePeriod = &api.GracePeriodMetadata{MarkedForGracefulShutdown: &t}
-
-			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
-			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
-			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(oldXML), nil)
-			mockDomain.EXPECT().
-				GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).
-				AnyTimes().
-				Return("<kubevirt></kubevirt>", nil)
-			mockConn.EXPECT().DomainDefineXML(gomock.Any()).DoAndReturn(func(xml string) (cli.VirDomain, error) {
-				Expect(strings.Contains(xml, "<markedForGracefulShutdown>true</markedForGracefulShutdown>")).To(BeTrue())
-				return mockDomain, nil
-			})
-			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock)
-
-			manager.MarkGracefulShutdownVMI(vmi)
-		})
-
 		It("Should signal graceful shutdown after marked for shutdown", func() {
 			mockDomain.EXPECT().Free().AnyTimes()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Stop using the MarkedForGracefulShutdown flag from libvirt metadata.

It has been used to signal virt-hanlder to initiate a graceful shutdown.
Triggered from the virt-launcher, when catching an OS signal.

This change suggests to drop the marking and perform the graceful
shutdown directly. virt-handler will be notified of the action through
the regular domain changes flow.

The field and its usage at the virt-handler side is kept for backward
compatibility with older virt-launchers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Implements: https://gist.github.com/EdDev/17076e37bb53b27ca2729b313ee2011c#remove-the-graceful-shutdown-mark

I think the tests that covers this scenario is `should be stopped and have Failed phase`, in e2e tests, `vmi_filecycle`.

**Release note**:
```release-note
NONE
```
