### PR TITLE
code cleanup: Use libvmi builder pattern instead of NewRandomVMI functions.

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1873,8 +1873,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 	Context("with a custom scheduler", func() {
 		It("[test_id:4631]should set the custom scheduler on the pod", func() {
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.SchedulerName = "my-custom-scheduler"
+			vmi := libvmi.New(
+				libvmi.WithResourceMemory("32Mi"),
+				WithSchedulerName("my-custom-scheduler"),
+			)
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 			launcherPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
 			Expect(launcherPod.Spec.SchedulerName).To(Equal("my-custom-scheduler"))
@@ -3060,5 +3062,11 @@ func overcommitGuestOverhead() libvmi.Option {
 func withMachineType(machineType string) libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Machine = &v1.Machine{Type: machineType}
+	}
+}
+
+func WithSchedulerName(schedulerName string) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.SchedulerName = schedulerName
 	}
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1819,9 +1819,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[test_id:3124]should set machine type from VMI spec", func() {
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine = &v1.Machine{Type: "pc"}
-			tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi := libvmi.New(
+				libvmi.WithResourceMemory("32Mi"),
+				withMachineType("pc"),
+			)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -1840,9 +1842,12 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		It("[test_id:6964]should allow creating VM defined with Machine with an empty Type", func() {
 			// This is needed to provide backward compatibility since our example VMIs used to be defined in this way
-			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine = &v1.Machine{Type: ""}
-			tests.RunVMIAndExpectLaunch(vmi, 30)
+			vmi := libvmi.New(
+				libvmi.WithResourceMemory("32Mi"),
+				withMachineType(""),
+			)
+
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -3049,5 +3054,11 @@ func withNoRng() libvmi.Option {
 func overcommitGuestOverhead() libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+	}
+}
+
+func withMachineType(machineType string) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Machine = &v1.Machine{Type: machineType}
 	}
 }

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -261,9 +261,16 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		DescribeTable("log libvirtd debug logs should be", func(vmiLabels, vmiAnnotations map[string]string, expectDebugLogs bool) {
 			var err error
-			vmi := tests.NewRandomVMI()
-			vmi.Labels = vmiLabels
-			vmi.Annotations = vmiAnnotations
+			options := []libvmi.Option{libvmi.WithResourceMemory("32Mi")}
+			for k, v := range vmiLabels {
+				options = append(options, libvmi.WithLabel(k, v))
+			}
+
+			for k, v := range vmiAnnotations {
+				options = append(options, libvmi.WithAnnotation(k, v))
+			}
+
+			vmi := libvmi.New(options...)
 
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil(), "Create VMI successfully")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Using libvmi instead of NewRandomVMI functions.
Add options to libvmi in order to use libvmi builder pattern in functional tests instead of NewRandomVMI functions.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
