### PR TITLE
Must clear "cloneRequest" annotation on restore of PVC

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -77,6 +77,8 @@ var restoreAnnotationsToDelete = []string{
 	"volume.beta.kubernetes.io",
 	"cdi.kubevirt.io",
 	"volume.kubernetes.io",
+	"k8s.io/CloneRequest",
+	"k8s.io/CloneOf",
 }
 
 func restorePVCName(vmRestore *snapshotv1.VirtualMachineRestore, name string) string {

--- a/tests/libstorage/BUILD.bazel
+++ b/tests/libstorage/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -188,7 +188,7 @@ func HasCDI() bool {
 }
 
 func GoldenImageRBAC(namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
-	name := "golden-rabc-" + rand.String(12)
+	name := "golden-rbac-" + rand.String(12)
 	role := &rbacv1.Role{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      name,

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -27,7 +27,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -161,6 +160,14 @@ func AddDataVolumeTemplate(vm *v13.VirtualMachine, dataVolume *v1beta1.DataVolum
 	vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
 }
 
+func SetDataVolumePVCStorageClass(dv *v1beta1.DataVolume, storageClass string) {
+	dv.Spec.PVC.StorageClassName = &storageClass
+}
+
+func SetDataVolumePVCSize(dv *v1beta1.DataVolume, size string) {
+	dv.Spec.PVC.Resources.Requests[v1.ResourceStorage] = resource.MustParse(size)
+}
+
 func HasDataVolumeCRD() bool {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
@@ -183,7 +190,7 @@ func HasCDI() bool {
 func GoldenImageRBAC(namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
 	name := "golden-rabc-" + rand.String(12)
 	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v12.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
@@ -202,7 +209,7 @@ func GoldenImageRBAC(namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
 		},
 	}
 	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: v12.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/host-disk:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -24,6 +24,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	typesutil "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -1564,15 +1565,24 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					}
 				}
 
-				DescribeTable("should restore a vm that boots from a network cloned datavolumetemplate", func(restoreToNewVM bool) {
-					vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeCloneSourceAndUserData(
+				createVMFromSource := func() *v1.VirtualMachine {
+					dataVolume := libstorage.NewRandomDataVolumeWithPVCSource(
 						sourceDV.Namespace,
 						sourceDV.Name,
 						util.NamespaceTestDefault,
-						bashHelloScript,
-						snapshotStorageClass,
 						corev1.ReadWriteOnce,
-					))
+					)
+					libstorage.SetDataVolumePVCStorageClass(dataVolume, snapshotStorageClass)
+					libstorage.SetDataVolumePVCSize(dataVolume, "6Gi")
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+					tests.AddUserData(vmi, "cloud-init", bashHelloScript)
+					vm := tests.NewRandomVirtualMachine(vmi, false)
+					libstorage.AddDataVolumeTemplate(vm, dataVolume)
+					return vm
+				}
+
+				DescribeTable("should restore a vm that boots from a network cloned datavolumetemplate", func(restoreToNewVM bool) {
+					vm, vmi = createAndStartVM(createVMFromSource())
 
 					checkCloneAnnotations(vm, true)
 					doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
@@ -1583,14 +1593,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				)
 
 				DescribeTable("should restore a vm that boots from a network cloned datavolume (not template)", func(restoreToNewVM bool) {
-					vm = tests.NewRandomVMWithDataVolumeCloneSourceAndUserData(
-						sourceDV.Namespace,
-						sourceDV.Name,
-						util.NamespaceTestDefault,
-						bashHelloScript,
-						snapshotStorageClass,
-						corev1.ReadWriteOnce,
-					)
+					vm = createVMFromSource()
 
 					dvt := &vm.Spec.DataVolumeTemplates[0]
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -24,7 +24,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-
+	typesutil "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -1547,15 +1547,13 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					}
 				})
 
-				checkNoCloneAnnotations := func(vm *v1.VirtualMachine, shouldExist bool) {
+				checkCloneAnnotations := func(vm *v1.VirtualMachine, shouldExist bool) {
 					pvcName := ""
 					for _, v := range vm.Spec.Template.Spec.Volumes {
-						if v.DataVolume != nil {
+						n := typesutil.PVCNameFromVirtVolume(&v)
+						if n != "" {
 							Expect(pvcName).Should(Equal(""))
-							pvcName = v.DataVolume.Name
-						} else if v.PersistentVolumeClaim != nil {
-							Expect(pvcName).Should(Equal(""))
-							pvcName = v.PersistentVolumeClaim.ClaimName
+							pvcName = n
 						}
 					}
 					pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
@@ -1576,9 +1574,9 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						corev1.ReadWriteOnce,
 					))
 
-					checkNoCloneAnnotations(vm, true)
+					checkCloneAnnotations(vm, true)
 					doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
-					checkNoCloneAnnotations(getTargetVM(restoreToNewVM), false)
+					checkCloneAnnotations(getTargetVM(restoreToNewVM), false)
 				},
 					Entry("to the same VM", false),
 					Entry("to a new VM", true),
@@ -1604,17 +1602,17 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 					dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					dv = waitDVReady(dv)
 					defer func() {
 						err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Delete(context.TODO(), dv.Name, metav1.DeleteOptions{})
 						Expect(err).ToNot(HaveOccurred())
 					}()
+					dv = waitDVReady(dv)
 
 					vm, vmi = createAndStartVM(vm)
 
-					checkNoCloneAnnotations(vm, true)
+					checkCloneAnnotations(vm, true)
 					doRestore("", console.LoginToCirros, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
-					checkNoCloneAnnotations(getTargetVM(restoreToNewVM), false)
+					checkCloneAnnotations(getTargetVM(restoreToNewVM), false)
 				},
 					Entry("to the same VM", false),
 					Entry("to a new VM", true),

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -551,6 +551,18 @@ func NewRandomVMWithDataVolumeWithRegistryImport(imageUrl, namespace, storageCla
 	return vm
 }
 
+func NewRandomVMWithDataVolumeCloneSourceAndUserData(sourceNamespace, sourceName, namespace, userData, storageClass string, accessMode k8sv1.PersistentVolumeAccessMode) *v1.VirtualMachine {
+	dataVolume := libstorage.NewRandomDataVolumeWithPVCSource(sourceNamespace, sourceName, namespace, accessMode)
+	dataVolume.Spec.PVC.StorageClassName = &storageClass
+	dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("6Gi")
+	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
+	AddUserData(vmi, "cloud-init", userData)
+	vm := NewRandomVirtualMachine(vmi, false)
+
+	libstorage.AddDataVolumeTemplate(vm, dataVolume)
+	return vm
+}
+
 func NewRandomVMWithDataVolume(imageUrl string, namespace string) *v1.VirtualMachine {
 	dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(imageUrl, namespace, k8sv1.ReadWriteOnce)
 	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -551,18 +551,6 @@ func NewRandomVMWithDataVolumeWithRegistryImport(imageUrl, namespace, storageCla
 	return vm
 }
 
-func NewRandomVMWithDataVolumeCloneSourceAndUserData(sourceNamespace, sourceName, namespace, userData, storageClass string, accessMode k8sv1.PersistentVolumeAccessMode) *v1.VirtualMachine {
-	dataVolume := libstorage.NewRandomDataVolumeWithPVCSource(sourceNamespace, sourceName, namespace, accessMode)
-	dataVolume.Spec.PVC.StorageClassName = &storageClass
-	dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("6Gi")
-	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
-	AddUserData(vmi, "cloud-init", userData)
-	vm := NewRandomVirtualMachine(vmi, false)
-
-	libstorage.AddDataVolumeTemplate(vm, dataVolume)
-	return vm
-}
-
 func NewRandomVMWithDataVolume(imageUrl string, namespace string) *v1.VirtualMachine {
 	dataVolume := libstorage.NewRandomDataVolumeWithRegistryImport(imageUrl, namespace, k8sv1.ReadWriteOnce)
 	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)


### PR DESCRIPTION
BugId:  2070366

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If a VM disk is originally created by network clone, then snapshotted, the "cloneRequest" annotation must be cleared from the new PVC.  Otherwise, CDI network cloning will be initiated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

BugId: https://bugzilla.redhat.com/show_bug.cgi?id=2070366

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
