### PR TITLE
golangci-lint: Increase timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ fmt: format
 lint:
 	if [ $$(wc -l < tests/utils.go) -gt 3565 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
-	hack/dockerized "golangci-lint run --timeout 10m --verbose \
+	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/network/domainspec/... \
 	  tests/console/... \
 	  tests/libnet/... \


### PR DESCRIPTION
**What this PR does / why we need it**:

The time it takes for the linters to run seem to have a large
fluctuation range, between 4sec to over 10sec.

As there are no guarantees given for such jobs (e.g. CPU time), we are
left with increasing the timeout period.

This is mainly triggered by the instability (timeouts) on CI runs.
A possible alternative is to define resource requirements for jobs,
reducing the inconsistent run duration results.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
