### PR TITLE
[e2e tests]: fix test 6987 in operator suite

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1374,6 +1374,9 @@ spec:
 			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
 			Expect(err).ToNot(HaveOccurred())
 
+			By("Waiting for virt-operator to apply changes to component")
+			waitForKvWithTimeout(kv, 120)
+
 			By("Test that patch was applied to DaemonSet")
 			Eventually(fetchVirtHandlerCommand, 60*time.Second, 5*time.Second).Should(ContainSubstring(maxDevicesCommandArgument))
 
@@ -1384,6 +1387,9 @@ spec:
 			kv.Spec.Configuration.VirtualMachineInstancesPerNode = nil
 			kv, err = virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Update(kv)
 			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for virt-operator to apply changes to component")
+			waitForKvWithTimeout(kv, 120)
 
 			By("Test that patch was removed from DaemonSet")
 			Eventually(fetchVirtHandlerCommand, 60*time.Second, 5*time.Second).ShouldNot(ContainSubstring(maxDevicesCommandArgument))


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The test aims to verify that virt-handler is being updated
with the configured maximum amount of devices. The test was
missing the validation of Kubevirt status, whether deployment of new
configuration has finished. It also missed checking that all the virt-handler
pods are ready after the rollout.

This caused flakes in the subsequent tests i.e. `test_id:4744` was failed on timeout waiting for the patch 
to be propogated.

**Release note**:
```release-note
NONE
```
