### PR TITLE
Add longfile linter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,6 +55,7 @@ nogo(
     # You can see the what `go vet` does by running `go doc cmd/vet`.
     deps = [
         "//vendor/github.com/nunnatsa/ginkgolinter:go_default_library",
+        "//tools/analyzers/longfile:go_default_library",
         "//vendor/github.com/gordonklaus/ineffassign/pkg/ineffassign:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/asmdecl:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/assign:go_default_library",

--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,6 @@ format:
 fmt: format
 
 lint:
-	if [ $$(wc -l < tests/utils.go) -gt 2813 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
-
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
 	  pkg/network/domainspec/... \
 	  tests/console/... \

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -138,6 +138,9 @@
       "external/": "externaldoesn't pass vet",
       "pkg/": "quite some files are big",
       "staging/": "focus on testing for now"
+    },
+    "analyzer_flags": {
+      "exceptions": "tests/utils.go:2776,tests/infra_test.go:1686,tests/migration_test.go:4382,tests/operator_test.go:2990,tests/vm_test.go:2301,tests/vmi_configuration_test.go:3053,tests/vmi_lifecycle_test.go:1900,tests/storage/restore.go:1621"
     }
   }
 }

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -140,7 +140,9 @@
       "staging/": "focus on testing for now"
     },
     "analyzer_flags": {
-      "exceptions": "tests/utils.go:2776,tests/infra_test.go:1686,tests/migration_test.go:4382,tests/operator_test.go:2990,tests/vm_test.go:2301,tests/vmi_configuration_test.go:3053,tests/vmi_lifecycle_test.go:1900,tests/storage/restore.go:1621"
+      "exceptions": "tests/infra_test.go:1686,tests/migration_test.go:4382,tests/operator_test.go:2990,tests/storage/restore.go:1621,tests/utils.go:2776,tests/vm_test.go:2301,tests/vmi_configuration_test.go:3053,tests/vmi_lifecycle_test.go:1900,tools/vms-generator/utils/utils.go:1423",
+      "max-file-length": 1000,
+      "max-test-file-length": 1500
     }
   }
 }

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -131,5 +131,13 @@
       "vendor/": "vendor doesn't pass vet",
       "external/": "externaldoesn't pass vet"
     }
+  },
+  "longfile": {
+    "exclude_files": {
+      "vendor/": "vendor doesn't pass vet",
+      "external/": "externaldoesn't pass vet",
+      "pkg/": "quite some files are big",
+      "staging/": "focus on testing for now"
+    }
   }
 }

--- a/tools/analyzers/longfile/BUILD.bazel
+++ b/tools/analyzers/longfile/BUILD.bazel
@@ -1,0 +1,10 @@
+# gazelle:ignore
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["longfile.go"],
+    importpath = "kubevirt.io/kubevirt/tools/analyzers/longfile",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_tools//go/analysis:go_default_library"],
+)

--- a/tools/analyzers/longfile/longfile.go
+++ b/tools/analyzers/longfile/longfile.go
@@ -2,42 +2,104 @@ package longfile
 
 import (
 	_ "embed"
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/token"
+	"strconv"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
 
-var max int
-var exceptions map[string]int
+var max = 1500
 
-var Analyzer = &analysis.Analyzer{
-	Name: "longfile",
-	Doc:  "detects if source code files are too long",
-	Run:  checkPath,
-}
+const (
+	exceptionDoc = "comma separated list of files with size greater than the default." +
+		" each item in the list is with this format: <file name>:<number of lines>"
+)
 
-func init() {
-	max = 1000
-	exceptions = map[string]int{
-		"tests/utils.go":               3500,
-		"tests/reporter/kubernetes.go": 2000,
+var Analyzer = newAnalyzer()
+
+func newAnalyzer() *analysis.Analyzer {
+	l := &longFileCfg{
+		// todo: once in rules_go version v0.32.0 or higher, nogo should send the command
+		//       line arguments (analyzer_flags field in nogo_configuration.json);
+		//       then we can replace this initialization by: `exceptions: make(longFileExceptions)`
+		// todo: try to reduce the size of each one of these files
+		exceptions: longFileExceptions{
+			"tests/storage/restore.go":        1621,
+			"tests/infra_test.go":             1686,
+			"tests/migration_test.go":         4382,
+			"tests/operator_test.go":          2990,
+			"tests/utils.go":                  2776,
+			"tests/vm_test.go":                2301,
+			"tests/vmi_configuration_test.go": 3053,
+			"tests/vmi_lifecycle_test.go":     1900,
+		},
 	}
+	a := &analysis.Analyzer{
+		Name:             "longfile",
+		Doc:              "detects if source code files are too long",
+		Run:              l.checkPath,
+		RunDespiteErrors: true,
+	}
+
+	a.Flags.Init("longfiles", flag.ExitOnError)
+	a.Flags.Var(&l.exceptions, "exceptions", exceptionDoc)
+	return a
 }
 
-func checkPath(pass *analysis.Pass) (interface{}, error) {
+type longFileExceptions map[string]int
+
+// implement the flag.Value interface
+func (e longFileExceptions) String() string {
+	b := strings.Builder{}
+	b.WriteRune('[')
+	for k, v := range e {
+		b.WriteString(fmt.Sprintf(`{%q: %d},`, k, v))
+	}
+	b.WriteRune(']')
+
+	return b.String()
+}
+
+func (e longFileExceptions) Set(value string) error {
+	items := strings.Split(value, ",")
+	for _, item := range items {
+		file := strings.Split(item, ":")
+		if len(file) != 2 {
+			return fmt.Errorf("can't parsr the file '%s'; it should be in format of <file name>:<number of lines>", item)
+		}
+		name := strings.TrimSpace(file[0])
+		lines, err := strconv.Atoi(strings.TrimSpace(file[1]))
+		if err != nil {
+			return fmt.Errorf("can't parse number of lines from %s; %w", item, err)
+		}
+		e[name] = lines
+	}
+
+	return nil
+}
+
+type longFileCfg struct {
+	exceptions longFileExceptions
+}
+
+func (l longFileCfg) checkPath(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
 		pos := pass.Fset.Position(file.End())
 		if isGenerated(file, pos) {
 			continue
 		}
 
-		parts := strings.Split(pos.Filename, "execroot/kubevirt/")
-		filename := parts[len(parts)-1]
+		fileName := pos.Filename
+		if strings.Contains(fileName, "execroot/kubevirt/") {
+			parts := strings.Split(pos.Filename, "execroot/kubevirt/")
+			fileName = parts[len(parts)-1]
+		}
 
-		fileMax, exists := exceptions[filename]
+		fileMax, exists := l.exceptions[fileName]
 		if !exists {
 			fileMax = max
 		}
@@ -45,10 +107,9 @@ func checkPath(pass *analysis.Pass) (interface{}, error) {
 		if pos.Line > fileMax {
 			pass.Report(analysis.Diagnostic{
 				Pos:     file.End(),
-				Message: fmt.Sprintf("file has a length of %v which is more than %v lines", pos.Line, fileMax),
+				Message: fmt.Sprintf("file has a length of %v which is more than %v lines; file name: %s", pos.Line, fileMax, pos.Filename),
 			})
 		}
-
 	}
 	return nil, nil
 }

--- a/tools/analyzers/longfile/longfile.go
+++ b/tools/analyzers/longfile/longfile.go
@@ -35,10 +35,10 @@ func newAnalyzer() *analysis.Analyzer {
 		// todo: try to reduce the size of each one of these files
 		exceptions: longFileExceptions{
 			"tests/infra_test.go":                1686,
-			"tests/migration_test.go":            4382,
-			"tests/operator_test.go":             3000,
+			"tests/migration_test.go":            4371,
+			"tests/operator_test.go":             3100,
 			"tests/storage/restore.go":           1621,
-			"tests/utils.go":                     2758,
+			"tests/utils.go":                     2733,
 			"tests/vm_test.go":                   2301,
 			"tests/vmi_configuration_test.go":    3053,
 			"tests/vmi_lifecycle_test.go":        1900,
@@ -127,9 +127,7 @@ func (l longFileCfg) checkPath(pass *analysis.Pass) (interface{}, error) {
 func (l longFileCfg) maxAllowedFileLength(fileName string) int {
 	fileMax, exists := l.exceptions[fileName]
 	if !exists {
-		if strings.HasPrefix(fileName, "tests/") ||
-			strings.Contains(fileName, "/tests/") ||
-			strings.HasSuffix(fileName, "_test.go") {
+		if isTestFile(fileName) {
 			fileMax = l.maxTestFileLength
 		} else {
 			fileMax = l.maxFileLength
@@ -137,6 +135,12 @@ func (l longFileCfg) maxAllowedFileLength(fileName string) int {
 	}
 
 	return fileMax
+}
+
+func isTestFile(fileName string) bool {
+	return strings.HasPrefix(fileName, "tests/") ||
+		strings.Contains(fileName, "/tests/") ||
+		strings.HasSuffix(fileName, "_test.go")
 }
 
 func isGenerated(file *ast.File, pos token.Position) bool {

--- a/tools/analyzers/longfile/longfile.go
+++ b/tools/analyzers/longfile/longfile.go
@@ -1,0 +1,72 @@
+package longfile
+
+import (
+	_ "embed"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var max int
+var exceptions map[string]int
+
+var Analyzer = &analysis.Analyzer{
+	Name: "longfile",
+	Doc:  "detects if source code files are too long",
+	Run:  checkPath,
+}
+
+func init() {
+	max = 1000
+	exceptions = map[string]int{
+		"tests/utils.go":               3500,
+		"tests/reporter/kubernetes.go": 2000,
+	}
+}
+
+func checkPath(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		pos := pass.Fset.Position(file.End())
+		if isGenerated(file, pos) {
+			continue
+		}
+
+		parts := strings.Split(pos.Filename, "execroot/kubevirt/")
+		filename := parts[len(parts)-1]
+
+		fileMax, exists := exceptions[filename]
+		if !exists {
+			fileMax = max
+		}
+
+		if pos.Line > fileMax {
+			pass.Report(analysis.Diagnostic{
+				Pos:     file.End(),
+				Message: fmt.Sprintf("file has a length of %v which is more than %v lines", pos.Line, fileMax),
+			})
+		}
+
+	}
+	return nil, nil
+}
+
+func isGenerated(file *ast.File, pos token.Position) bool {
+	if strings.HasSuffix(pos.Filename, "_generated.go") {
+		return true
+	}
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT.") {
+				return true
+			}
+			if strings.HasPrefix(c.Text, "// Automatically generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT!") {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Originally done at #8016 

Limit the maximum file length to 1500 lines in the tests package for now. One
exception for `tests/utils.go` and `tests/reporter/kubernetes.go`
exists.

`pkg` and `staging` are excluded for now.

nogo is used to ensure good developer experience, since it runs all
linters during normal compilation, including caching which makes it
lightweight. Also no dedicated jobs are needed while at the same time
consistent results between CI, the merge queue and local development
environments is guaranteed.

Potential errors look like this:

```
pkg/virt-launcher/virtwrap/live-migration-source.go:1079:2: file has a length of 1079 which is more than 1000 lines (longfile)
pkg/virt-launcher/virtwrap/manager.go:1933:2: file has a length of 1933 which is more than 1000 lines (longfile)
```

Signed-off-by: Roman Mohr <rmohr@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
