### PR TITLE
tests: Windows tests small cleanup

### DIFF
--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -122,13 +122,12 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 }
 
 var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
-	var err error
 	var virtClient kubecli.KubevirtClient
-
 	var windowsVMI *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
 		const OSWindows = "windows"
+		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 		checks.SkipIfMissingRequiredImage(virtClient, tests.DiskWindows)
@@ -142,7 +141,6 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	Context("with winrm connection", func() {
 		var winrmcliPod *k8sv1.Pod
 		var cli []string
-		var output string
 
 		BeforeEach(func() {
 			By("Creating winrm-cli pod for the future use")
@@ -159,6 +157,8 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 					},
 				},
 			}
+
+			var err error
 			winrmcliPod, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), winrmcliPod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -167,6 +167,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 
 			BeforeEach(func() {
 				By("Starting the windows VirtualMachineInstance")
+				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 				Expect(err).To(BeNil())
 				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
@@ -177,7 +178,9 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			It("[test_id:240]should have correct UUID", func() {
 				command := append(cli, "wmic csproduct get \"UUID\"")
 				By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
+				var output string
 				Eventually(func() error {
+					var err error
 					output, err = tests.ExecuteCommandOnPod(
 						virtClient,
 						winrmcliPod,
@@ -193,7 +196,9 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			It("[test_id:3159]should have default masquerade IP", func() {
 				command := append(cli, "ipconfig /all")
 				By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
+				var output string
 				Eventually(func() error {
+					var err error
 					output, err = tests.ExecuteCommandOnPod(
 						virtClient,
 						winrmcliPod,
@@ -224,6 +229,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 				windowsVMI.Spec.Subdomain = "subdomain"
 
 				By("Starting the windows VirtualMachineInstance with subdomain")
+				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
@@ -248,6 +254,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			BeforeEach(func() {
 				By("Starting Windows VirtualMachineInstance with bridge binding")
 				windowsVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName)}
+				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 420)
@@ -259,6 +266,7 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 
 				By("Pinging virt-handler Pod from Windows VMI")
 
+				var err error
 				windowsVMI, err = virtClient.VirtualMachineInstance(windowsVMI.Namespace).Get(windowsVMI.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -139,23 +139,6 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
-	It("[test_id:487]should succeed to start a vmi", func() {
-		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
-		Expect(err).To(BeNil())
-		tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
-	})
-
-	It("[test_id:488]should succeed to stop a running vmi", func() {
-		By("Starting the vmi")
-		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
-		Expect(err).To(BeNil())
-		tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
-
-		By("Stopping the vmi")
-		err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
-		Expect(err).To(BeNil())
-	})
-
 	Context("with winrm connection", func() {
 		var winrmcliPod *k8sv1.Pod
 		var cli []string

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -58,69 +58,6 @@ const (
 	winrmCliCmd = "winrm-cli"
 )
 
-var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
-	gracePeriod := int64(0)
-	spinlocks := uint32(8191)
-	firmware := types.UID(windowsFirmware)
-	_false := false
-	return v1.VirtualMachineInstanceSpec{
-		TerminationGracePeriodSeconds: &gracePeriod,
-		Domain: v1.DomainSpec{
-			CPU: &v1.CPU{Cores: 2},
-			Features: &v1.Features{
-				ACPI: v1.FeatureState{},
-				APIC: &v1.FeatureAPIC{},
-				Hyperv: &v1.FeatureHyperv{
-					Relaxed:    &v1.FeatureState{},
-					SyNICTimer: &v1.SyNICTimer{Direct: &v1.FeatureState{}},
-					VAPIC:      &v1.FeatureState{},
-					Spinlocks:  &v1.FeatureSpinlocks{Retries: &spinlocks},
-				},
-			},
-			Clock: &v1.Clock{
-				ClockOffset: v1.ClockOffset{UTC: &v1.ClockOffsetUTC{}},
-				Timer: &v1.Timer{
-					HPET:   &v1.HPETTimer{Enabled: &_false},
-					PIT:    &v1.PITTimer{TickPolicy: v1.PITTickPolicyDelay},
-					RTC:    &v1.RTCTimer{TickPolicy: v1.RTCTickPolicyCatchup},
-					Hyperv: &v1.HypervTimer{},
-				},
-			},
-			Firmware: &v1.Firmware{UUID: firmware},
-			Resources: v1.ResourceRequirements{
-				Requests: k8sv1.ResourceList{
-					k8sv1.ResourceMemory: resource.MustParse("2048Mi"),
-				},
-			},
-			Devices: v1.Devices{
-				Disks: []v1.Disk{
-					{
-						Name: windowsDisk,
-						DiskDevice: v1.DiskDevice{
-							Disk: &v1.DiskTarget{
-								Bus: v1.DiskBusSATA,
-							},
-						},
-					},
-				},
-			},
-		},
-		Volumes: []v1.Volume{
-			{
-				Name: windowsDisk,
-				VolumeSource: v1.VolumeSource{
-					Ephemeral: &v1.EphemeralVolumeSource{
-						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-							ClaimName: tests.DiskWindows,
-						},
-					},
-				},
-			},
-		},
-	}
-
-}
-
 var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	var virtClient kubecli.KubevirtClient
 	var windowsVMI *v1.VirtualMachineInstance
@@ -302,6 +239,68 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		})
 	})
 })
+
+func getWindowsVMISpec() v1.VirtualMachineInstanceSpec {
+	gracePeriod := int64(0)
+	spinlocks := uint32(8191)
+	firmware := types.UID(windowsFirmware)
+	_false := false
+	return v1.VirtualMachineInstanceSpec{
+		TerminationGracePeriodSeconds: &gracePeriod,
+		Domain: v1.DomainSpec{
+			CPU: &v1.CPU{Cores: 2},
+			Features: &v1.Features{
+				ACPI: v1.FeatureState{},
+				APIC: &v1.FeatureAPIC{},
+				Hyperv: &v1.FeatureHyperv{
+					Relaxed:    &v1.FeatureState{},
+					SyNICTimer: &v1.SyNICTimer{Direct: &v1.FeatureState{}},
+					VAPIC:      &v1.FeatureState{},
+					Spinlocks:  &v1.FeatureSpinlocks{Retries: &spinlocks},
+				},
+			},
+			Clock: &v1.Clock{
+				ClockOffset: v1.ClockOffset{UTC: &v1.ClockOffsetUTC{}},
+				Timer: &v1.Timer{
+					HPET:   &v1.HPETTimer{Enabled: &_false},
+					PIT:    &v1.PITTimer{TickPolicy: v1.PITTickPolicyDelay},
+					RTC:    &v1.RTCTimer{TickPolicy: v1.RTCTickPolicyCatchup},
+					Hyperv: &v1.HypervTimer{},
+				},
+			},
+			Firmware: &v1.Firmware{UUID: firmware},
+			Resources: v1.ResourceRequirements{
+				Requests: k8sv1.ResourceList{
+					k8sv1.ResourceMemory: resource.MustParse("2048Mi"),
+				},
+			},
+			Devices: v1.Devices{
+				Disks: []v1.Disk{
+					{
+						Name: windowsDisk,
+						DiskDevice: v1.DiskDevice{
+							Disk: &v1.DiskTarget{
+								Bus: v1.DiskBusSATA,
+							},
+						},
+					},
+				},
+			},
+		},
+		Volumes: []v1.Volume{
+			{
+				Name: windowsDisk,
+				VolumeSource: v1.VolumeSource{
+					Ephemeral: &v1.EphemeralVolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: tests.DiskWindows,
+						},
+					},
+				},
+			},
+		},
+	}
+}
 
 func winrnLoginCommand(virtClient kubecli.KubevirtClient, windowsVMI *v1.VirtualMachineInstance) []string {
 	var err error


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up windows test code:
- Removes tests checking `kubectl` - it is not windows specific
- Removes tests that check VM start and stop - also not windows specific
- Simplify test code

**Release note**:
```release-note
None
```
