### PR TITLE
Quarantine flaky operator replicas test

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2632,7 +2632,7 @@ spec:
 				}
 			}
 		})
-		It("should update new single-replica CRs with a finalizer and be stable", func() {
+		It("[QUARANTINE] should update new single-replica CRs with a finalizer and be stable", func() {
 			By("copying the original kv CR")
 			kvOrig := copyOriginalKv()
 			kv := copyOriginalKv()


### PR DESCRIPTION


**What this PR does / why we need it**:

Quarantine flaky operator replicas test:
[- [Serial][sig-operator]Operator Replicas should update new single-replica CRs with a finalizer and be stable](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-07-12-168h.html#row1)

Test is failing regularly in periodic and presubmit lanes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @jean-edouard 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
