### PR TITLE
Bump memory requests for virt-(api|controller|operator)

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1175,7 +1175,7 @@ spec:
                 resources:
                   requests:
                     cpu: 10m
-                    memory: 150Mi
+                    memory: 250Mi
                 volumeMounts:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -365,7 +365,7 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("150Mi"),
+			corev1.ResourceMemory: resource.MustParse("250Mi"),
 		},
 	}
 
@@ -449,7 +449,7 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("150Mi"),
+			corev1.ResourceMemory: resource.MustParse("250Mi"),
 		},
 	}
 
@@ -559,7 +559,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("150Mi"),
+									corev1.ResourceMemory: resource.MustParse("250Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
When prometheus is enabled, we keep getting KubeVirtComponentExceedsRequestedMemory alerts.
These are legitimate, since virt-api, virt-controller and virt-operator routinely exceed
their 150Mi memory request. Local tests even showed a virt-operator reaching 230Mi.
This is usually fine (aside from the constant alerts...), since k8s will let containers use
more memory than requested as long as nodes have enough memory to spare.
However, this could become a critical issue on a memory-constrained node.
As usual with memory limits, we don't have a way to know what the maximum amount processes
may consume...
Bumping the memory request for all 3 from 150Mi to 250Mi seems to me like a good compromise

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
