### PR TITLE
add nodeSelector kubernetes.io/os: linux to virt-operator csv

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1104,6 +1104,8 @@ spec:
                   readOnly: true
                 - mountPath: /profile-data
                   name: profile-data
+              nodeSelector:
+                kubernetes.io/os: linux
               priorityClassName: kubevirt-cluster-critical
               securityContext:
                 runAsNonRoot: true

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -424,6 +424,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 	kubeVirtVersionEnv string, virtApiShaEnv string, virtControllerShaEnv string,
 	virtHandlerShaEnv string, virtLauncherShaEnv string, gsShaEnv string) (*appsv1.Deployment, error) {
 
+	const kubernetesOSLinux = "linux"
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, kubernetesHostnameTopologyKey, metav1.LabelSelectorOpIn, []string{VirtOperatorName})
 	version = AddVersionSeparatorPrefix(version)
 	image := fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, VirtOperatorName, version)
@@ -464,6 +465,9 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 					Tolerations:        criticalAddonsToleration(),
 					Affinity:           podAntiAffinity,
 					ServiceAccountName: "kubevirt-operator",
+					NodeSelector: map[string]string{
+						corev1.LabelOSStable: kubernetesOSLinux,
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            VirtOperatorName,


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR adds kubernetes.io/os: linux nodeSelector to virt-operator.
All other components already have this nodeSelector and virt-operator
was missing it

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
Add nodeSelector kubernetes.io/os: linux to virt-operator csv manifest

```
