### PR TITLE
Fix a launcher unresponsive detection race between virt-handler and the kubelet

### DIFF
--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -196,6 +196,12 @@ func SocketMonitoringEnabled(socket string) bool {
 }
 
 func IsSocketUnresponsive(socket string) bool {
+	if exists, _ := diskutils.FileExists(filepath.Dir(socket)); !exists {
+		// If the sockets directory does not exist the kubelet already started unmounting
+		// since the sockets directory is a mountpoint.
+		return true
+	}
+
 	file := filepath.Join(filepath.Dir(socket), StandardLauncherUnresponsiveFileName)
 	exists, _ := diskutils.FileExists(file)
 	// if the unresponsive socket monitor marked this socket
@@ -214,6 +220,11 @@ func IsSocketUnresponsive(socket string) bool {
 }
 
 func MarkSocketUnresponsive(socket string) error {
+	if exists, _ := diskutils.FileExists(filepath.Dir(socket)); !exists {
+		// If the sockets directory does not exist the kubelet already started unmounting
+		// since the sockets directory is a mountpoint. Don't try to create a file at an inexistent location.
+		return nil
+	}
 	file := filepath.Join(filepath.Dir(socket), StandardLauncherUnresponsiveFileName)
 	f, err := os.Create(file)
 	if err != nil {

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -143,6 +143,17 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(unresponsive).To(BeTrue())
 		})
 
+		It("should be able to detect unresponsive launchers when the kubelet removed the sockets base directory already", func() {
+			sock, err := FindSocketOnHost(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			socketsDir := filepath.Dir(sock)
+			Expect(os.RemoveAll(socketsDir)).To(Succeed())
+
+			Expect(MarkSocketUnresponsive(sock)).To(Succeed())
+			Expect(IsSocketUnresponsive(sock)).To(BeTrue())
+		})
+
 		It("Determine legacy sockets vs new socket paths", func() {
 			legacy := IsLegacySocket("/some/path/something_sock")
 			Expect(legacy).To(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:

Once all processes in the virt-launcher pod are gone, the kubelet will
start unmounting all volumes. One of these is the `sockets` volume.
virt-handler on the other hand uses this volume to mark launchers as
unresponsive. If virt-handler tries to mark a launcher as unresponsive
after the unmount of the sockets volume, it has to consider that this
directory may not exist anymore and implicitly assume that the launcher
is not responsive anymore at this point.
This is safe. There is no risk that virt-launcher is in a startup phase
at this moment, since virt-handler only ever acts on launcher which were
ready in the past and the kubelet will only start unmounting if all processes of the pods have stopped.

Without this, virt-handler may run repeatedly into this error:

```
{"component":"virt-handler","level":"error","msg":"Unable to mark vmi as unresponsive socket //pods/e6cc43c8-dbde-4af3-96c8-e6ab88fabb07/volumes/kubernetes.io~empty-dir/sockets/launcher-sock","pos":"cache.go:485","reason":"open /pods/e6cc43c8-dbde-4af3-96c8-e6ab88fabb07/volumes/kubernetes.io~empty-dir/sockets/launcher-unresponsive: no such file or directory","timestamp":"2022-07-14T06:11:59.919964Z"}
```

and the VMI cleanup can be significantly delayed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-handler can now better deal with already partially unmounted volumes during VMI cleanups when the launcher is unresponsive and the kubelet started the cleanup already.
```
