### PR TITLE
Respect the feature gate when exposing SEV device

### DIFF
--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Mediated Device", func() {
 
 			By("creating an empty device controller")
 			var noDevices []Device
-			deviceController := NewDeviceController("master", noDevices, fakeClusterConfig, clientTest.CoreV1())
+			deviceController := NewDeviceController("master", 100, "rw", noDevices, fakeClusterConfig, clientTest.CoreV1())
 
 			By("adding a host device to the cluster config")
 			kvConfig := kv.DeepCopy()

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -400,7 +400,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 
 			By("creating an empty device controller")
 			var noDevices []Device
-			deviceController := NewDeviceController("master", noDevices, fakeClusterConfig, clientTest.CoreV1())
+			deviceController := NewDeviceController("master", 100, "rw", noDevices, fakeClusterConfig, clientTest.CoreV1())
 			deviceController.refreshMediatedDevicesTypes()
 			By("creating the desired mdev types")
 			desiredDevicesToConfigure := make(map[string]struct{})

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -129,7 +129,7 @@ pciHostDevices:
 
 		By("creating an empty device controller")
 		var noDevices []Device
-		deviceController := NewDeviceController("master", noDevices, fakeClusterConfig, clientTest.CoreV1())
+		deviceController := NewDeviceController("master", 100, "rw", noDevices, fakeClusterConfig, clientTest.CoreV1())
 
 		By("adding a host device to the cluster config")
 		kvConfig := kv.DeepCopy()

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -252,7 +252,13 @@ func NewController(
 		permissions = "rwm"
 	}
 
-	c.deviceManagerController = device_manager.NewDeviceController(c.host, device_manager.PermanentHostDevicePlugins(maxDevices, permissions), clusterConfig, clientset.CoreV1())
+	c.deviceManagerController = device_manager.NewDeviceController(
+		c.host,
+		maxDevices,
+		permissions,
+		device_manager.PermanentHostDevicePlugins(maxDevices, permissions),
+		clusterConfig,
+		clientset.CoreV1())
 	c.heartBeat = heartbeat.NewHeartBeat(clientset.CoreV1(), c.deviceManagerController, clusterConfig, host)
 
 	return c

--- a/tests/launchsecurity/BUILD.bazel
+++ b/tests/launchsecurity/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virt-config:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/console:go_default_library",
         "//tests/framework/checks:go_default_library",
@@ -14,5 +15,6 @@ go_library(
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -1,9 +1,16 @@
 package launchsecurity
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
@@ -15,26 +22,88 @@ import (
 var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", func() {
 	BeforeEach(func() {
 		checks.SkipTestIfNoFeatureGate(virtconfig.WorkloadEncryptionSEV)
-		checks.SkipTestIfNotSEVCapable()
 	})
 
-	It("should start a SEV VM", func() {
-		const secureBoot = false
-		vmi := libvmi.NewFedora(libvmi.WithUefi(secureBoot), libvmi.WithSEV())
-		vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+	Context("[Serial]device management", func() {
+		var (
+			virtClient      kubecli.KubevirtClient
+			nodeName        string
+			isDevicePresent bool
+			err             error
+		)
 
-		By("Expecting the VirtualMachineInstance console")
-		Expect(console.LoginToFedora(vmi)).To(Succeed())
+		BeforeEach(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			Expect(err).ToNot(HaveOccurred())
 
-		By("Verifying that SEV is enabled in the guest")
-		err := console.SafeExpectBatch(vmi, []expect.Batcher{
-			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: "dmesg | grep --color=never SEV\n"},
-			&expect.BExp{R: "AMD Memory Encryption Features active: SEV"},
-			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: console.PromptExpression},
-		}, 30)
-		Expect(err).ToNot(HaveOccurred())
+			nodeName = tests.NodeNameWithHandler()
+			Expect(nodeName).ToNot(BeEmpty())
+
+			checkCmd := []string{"ls", "/dev/sev"}
+			_, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, checkCmd)
+			isDevicePresent = (err == nil)
+
+			if !isDevicePresent {
+				// Create a fake SEV device
+				mknodCmd := []string{"mknod", "/dev/sev", "c", "10", "124"}
+				_, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, mknodCmd)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			Eventually(func() bool {
+				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				val, ok := node.Status.Capacity["devices.kubevirt.io/sev"]
+				return ok && !val.IsZero()
+			}, 30*time.Second, 1*time.Second).Should(BeTrue(), "SEV capacity should not be zero")
+		})
+
+		AfterEach(func() {
+			if !isDevicePresent {
+				// Remove the fake SEV device
+				rmCmd := []string{"rm", "-f", "/dev/sev"}
+				_, err = tests.ExecuteCommandInVirtHandlerPod(nodeName, rmCmd)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			tests.EnableFeatureGate(virtconfig.WorkloadEncryptionSEV)
+		})
+
+		It("should reset SEV capacity when the feature gate is disabled", func() {
+			By(fmt.Sprintf("Disabling %s feature gate", virtconfig.WorkloadEncryptionSEV))
+			tests.DisableFeatureGate(virtconfig.WorkloadEncryptionSEV)
+			Eventually(func() bool {
+				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				val, ok := node.Status.Capacity["devices.kubevirt.io/sev"]
+				return !ok || val.IsZero()
+			}, 30*time.Second, 1*time.Second).Should(BeTrue(), "SEV capacity should be zero")
+		})
+	})
+
+	Context("lifecycle", func() {
+		BeforeEach(func() {
+			checks.SkipTestIfNotSEVCapable()
+		})
+
+		It("should start a SEV VM", func() {
+			const secureBoot = false
+			vmi := libvmi.NewFedora(libvmi.WithUefi(secureBoot), libvmi.WithSEV())
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Expecting the VirtualMachineInstance console")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+			By("Verifying that SEV is enabled in the guest")
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "dmesg | grep --color=never SEV\n"},
+				&expect.BExp{R: "AMD Memory Encryption Features active: SEV"},
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: console.PromptExpression},
+			}, 30)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Having `/dev/sev` in the list of permanently available devices may impose
a security risk as it can be requested and accessed by an arbitrary pod.
Stop advertizing the device when the corresponding feature gate is
disabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
