### PR TITLE
migration_test: drop redundant user data

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -246,7 +246,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			withKernelBoot(),
 			withSecret(secretName),
 			withConfigMap(configMapName),
-			libvmi.WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n", true),
 		)
 	}
 
@@ -1640,7 +1639,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 
-				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\n echo hello\n")
 				vmi = runVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
 
 				By("Checking guest agent")
@@ -2603,7 +2601,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(ThisDV(dv), 600).Should(HaveSucceeded())
 				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
-				tests.AddUserData(vmi, "disk1", "#!/bin/bash\n echo hello\n")
 				return vmi
 			}
 


### PR DESCRIPTION
The "echo hello" user data is helpful only in making Cirros boot faster.
It has no use in a Fedora VM defition and only confuses the reader.

```release-note
NONE
```
