### PR TITLE
Use libvmi package to create VMIs in perf density.go test

### DIFF
--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//tests/util:go_default_library",
         "//tools/perfscale-audit/api:go_default_library",
         "//tools/perfscale-audit/metric-client:go_default_library",

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -167,15 +167,6 @@ func createBatchVMIWithRateControl(virtClient kubecli.KubevirtClient, vmCount in
 	}
 }
 
-func createVMISpecWithResources(virtClient kubecli.KubevirtClient) *kvv1.VirtualMachineInstance {
-	cpuLimit := "100m"
-	memLimit := "90Mi"
-	return libvmi.NewCirros(
-		withResourcesLimits(memLimit, cpuLimit),
-		withResourcesRequests(memLimit, cpuLimit),
-	)
-}
-
 func waitRunningVMI(virtClient kubecli.KubevirtClient, vmiCount int, timeout time.Duration) {
 	Eventually(func() int {
 		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&metav1.ListOptions{})
@@ -190,8 +181,6 @@ func waitRunningVMI(virtClient kubecli.KubevirtClient, vmiCount int, timeout tim
 	}, timeout, 10*time.Second).Should(Equal(vmiCount))
 }
 
-<<<<<<< Updated upstream
-=======
 func createVMISpecWithResources(virtClient kubecli.KubevirtClient) *kvv1.VirtualMachineInstance {
 	cpuLimit := "100m"
 	memLimit := "90Mi"
@@ -203,7 +192,6 @@ func createVMISpecWithResources(virtClient kubecli.KubevirtClient) *kvv1.Virtual
 	)
 }
 
->>>>>>> Stashed changes
 func withResourcesLimits(memLimit, cpuLimit string) libvmi.Option {
 	return func(vmi *kvv1.VirtualMachineInstance) {
 		vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR
- uses libvmi to build VMI.
- moves implementation of  `createVMISpecWithResources` so that implementations of the called libmi builder options
  follow right after it


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
