### PR TITLE
Quarantine flaky test for clone of more complicated VM

### DIFF
--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -394,7 +394,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 				}
 			})
 
-			It("with a simple clone", func() {
+			It("[QUARANTINE] with a simple clone", func() {
 				vmClone = generateClone()
 
 				createCloneAndWaitForFinish(vmClone)


### PR DESCRIPTION
**What this PR does / why we need it**:
The simple clone test still looks to be flaky after the fix was merged (https://github.com/kubevirt/kubevirt/pull/8059)
[VirtualMachineClone Tests VM clone with more complicated VM with a simple clone](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8099/pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot/1547967495300714496)

CI Search link:
https://search.ci.kubevirt.io/?search=VirtualMachineClone&maxAge=6h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
