### PR TITLE
podman: Use kubevirtci's KUBEVIRTCI_PODMAN_SOCKET

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
+export KUBEVIRTCI_PODMAN_SOCKET=${KUBEVIRTCI_PODMAN_SOCKET:-"/run/podman/podman.sock"}
+
 detect_podman() {
-    if curl --unix-socket "/run/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-        echo "podman --remote --url=unix:///run/podman/podman.sock"
-    elif curl --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-        echo "podman --remote --url=unix://${XDG_RUNTIME_DIR}/podman/podman.sock"
+    if curl --unix-socket "${KUBEVIRTCI_PODMAN_SOCKET}" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+        echo "podman --remote --url=unix://${KUBEVIRTCI_PODMAN_SOCKET}"
     fi
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to make the code easier to maintain
and agnostic of custom socket path,
use `KUBEVIRTCI_PODMAN_SOCKET`.

See https://github.com/kubevirt/kubevirtci/pull/833
for more details.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
