### PR TITLE
tests: Replace `Update` with `Patch`

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -311,11 +311,6 @@ func GeneratePatchBytes(ops []string) []byte {
 	return []byte(fmt.Sprintf("[%s]", strings.Join(ops, ", ")))
 }
 
-func EscapeJSONPointer(ptr string) string {
-	s := strings.ReplaceAll(ptr, "~", "~0")
-	return strings.ReplaceAll(s, "/", "~1")
-}
-
 func SetVMIPhaseTransitionTimestamp(oldVMI *v1.VirtualMachineInstance, newVMI *v1.VirtualMachineInstance) {
 	if oldVMI.Status.Phase != newVMI.Status.Phase {
 		for _, transitionTimeStamp := range newVMI.Status.PhaseTransitionTimestamps {

--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -22,6 +22,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type PatchOperation struct {
@@ -69,4 +70,9 @@ func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
 	err := json.Unmarshal(patch, &p)
 
 	return p, err
+}
+
+func EscapeJSONPointer(ptr string) string {
+	s := strings.ReplaceAll(ptr, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
 }

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/pdbs:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -34,8 +35,8 @@ go_test(
     ],
     deps = [
         ":go_default_library",
-        "//pkg/controller:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/pkg/util/pdbs"
+	kubevirttypes "kubevirt.io/kubevirt/pkg/util/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
@@ -451,7 +452,7 @@ func (c *DisruptionBudgetController) deletePDB(key string, pdb *policyv1.PodDisr
 func (c *DisruptionBudgetController) shrinkPDB(vmi *virtv1.VirtualMachineInstance, pdb *policyv1.PodDisruptionBudget) error {
 	if pdb != nil && pdb.DeletionTimestamp == nil && pdb.Spec.MinAvailable.IntValue() != 1 {
 		patch := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/minAvailable", "value": 1 }, { "op": "remove", "path": "/metadata/labels/%s" }]`,
-			controller.EscapeJSONPointer(virtv1.MigrationNameLabel)))
+			kubevirttypes.EscapeJSONPointer(virtv1.MigrationNameLabel)))
 
 		_, err := c.clientset.PolicyV1().PodDisruptionBudgets(pdb.Namespace).Patch(context.Background(), pdb.Name, types.JSONPatchType, patch, v1.PatchOptions{})
 		if err != nil {

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -23,8 +23,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	ctrl_util "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	kubevirttypes "kubevirt.io/kubevirt/pkg/util/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
 )
@@ -111,7 +111,7 @@ var _ = Describe("Disruptionbudget", func() {
 			Expect(patch.GetPatchType()).To(Equal(types.JSONPatchType))
 
 			expectedPatch := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/minAvailable", "value": 1 }, { "op": "remove", "path": "/metadata/labels/%s" }]`,
-				ctrl_util.EscapeJSONPointer(v1.MigrationNameLabel))
+				kubevirttypes.EscapeJSONPointer(v1.MigrationNameLabel))
 			Expect(string(patch.GetPatch())).To(Equal(expectedPatch))
 			return true, &policyv1.PodDisruptionBudget{}, nil
 		})

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -1116,7 +1116,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 				if vmi.Annotations == nil {
 					patches = append(patches, fmt.Sprintf(`{ "op": "add", "path": "/metadata/annotations", "value":  { "%s": "true"} }`, virtv1.DeprecatedNonRootVMIAnnotation))
 				} else if _, ok := vmi.Annotations[virtv1.DeprecatedNonRootVMIAnnotation]; !ok {
-					patches = append(patches, fmt.Sprintf(`{ "op": "add", "path": "/metadata/annotations/%s", "value": "true"}`, controller.EscapeJSONPointer(virtv1.DeprecatedNonRootVMIAnnotation)))
+					patches = append(patches, fmt.Sprintf(`{ "op": "add", "path": "/metadata/annotations/%s", "value": "true"}`, kubevirttypes.EscapeJSONPointer(virtv1.DeprecatedNonRootVMIAnnotation)))
 				}
 			} else {
 				// The cluster is configured for root VMs, ensure the VMI is root.
@@ -1127,7 +1127,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 
 				if vmi.Annotations != nil {
 					if _, ok := vmi.Annotations[virtv1.DeprecatedNonRootVMIAnnotation]; ok {
-						patches = append(patches, fmt.Sprintf(`{ "op": "remove", "path": "/metadata/annotations/%s"}`, controller.EscapeJSONPointer(virtv1.DeprecatedNonRootVMIAnnotation)))
+						patches = append(patches, fmt.Sprintf(`{ "op": "remove", "path": "/metadata/annotations/%s"}`, kubevirttypes.EscapeJSONPointer(virtv1.DeprecatedNonRootVMIAnnotation)))
 					}
 				}
 			}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -175,6 +175,7 @@ go_test(
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/dns:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -406,12 +406,9 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 								taints = append(taints, taint)
 							}
 						}
+						selectedNode.Spec.Taints = taints
 
-						nodeCopy := selectedNode.DeepCopy()
-						nodeCopy.ResourceVersion = ""
-						nodeCopy.Spec.Taints = taints
-
-						_, err = virtClient.CoreV1().Nodes().Update(context.Background(), nodeCopy, metav1.UpdateOptions{})
+						_, err = virtClient.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{})
 						return err
 					})
 					Expect(err).ShouldNot(HaveOccurred())
@@ -496,14 +493,13 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 						return err
 					}
 
-					selectedNodeCopy := selectedNode.DeepCopy()
-					selectedNodeCopy.Spec.Taints = append(selectedNodeCopy.Spec.Taints, k8sv1.Taint{
+					selectedNode.Spec.Taints = append(selectedNode.Spec.Taints, k8sv1.Taint{
 						Key:    "CriticalAddonsOnly",
 						Value:  "",
 						Effect: k8sv1.TaintEffectNoExecute,
 					})
 
-					_, err = virtClient.CoreV1().Nodes().Update(context.Background(), selectedNodeCopy, metav1.UpdateOptions{})
+					_, err = virtClient.CoreV1().Nodes().Update(context.Background(), selectedNode, metav1.UpdateOptions{})
 					return err
 				})
 				Expect(err).ShouldNot(HaveOccurred())

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -47,6 +47,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/controller"
+	k6ttypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -339,8 +340,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		// set new replica count while still being paused
 		By("Updating the number of replicas")
-		rs.Spec.Replicas = tests.NewInt32(2)
-		_, err = virtClient.ReplicaSet(rs.ObjectMeta.Namespace).Update(rs)
+		patchData, err := k6ttypes.GenerateTestReplacePatch("/spec/replicas", rs.Spec.Replicas, tests.NewInt32(2))
+		Expect(err).ToNot(HaveOccurred())
+		rs, err = virtClient.ReplicaSet(rs.Namespace).Patch(rs.Name, types.JSONPatchType, patchData)
 		Expect(err).ToNot(HaveOccurred())
 
 		// make sure that we don't scale up

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -66,7 +66,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
-        "//vendor/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:
The execution of the e2e tests are producing a large amount of conflict errors [1].

There are two methods for updating an object manifest on the API server:
- Update
- Patch

Update is used to change the whole object and can detect conflicts when using the `resourceVersion`.
Patch is used to change only a subset of the object and comes in several flavors.

This change suggests replacing all `Update` operations with `Patch` ones in the e2e tests.
It should reduce the conflict/collisions experienced as the tests will no longer race with various controllers that touch the objects being changed. When using `Update`, a conflict may manifest itself even when the test changes a spec value and a controller in parallel changes a status value.

Using `Patch` such conflicts are unlikely to occur and in some cases which require it, can be asserted against (the `test` JSON-patch operation type).

In order to perform the migration to `Patch` some small refactoring had to be applied in tests.

1. https://search.ci.kubevirt.io/?search=the+object+has+been+modified%3B+please+apply+your+changes+to+the+latest+version+and+try+again&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Not all `Update` operations have been replaced with `Patch`.

**Release note**:
```release-note
NONE
```
