### PR TITLE
Code clean: Use libvmi builder pattern in tests/instancetype_test.go

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -61,7 +61,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	Context("VM with invalid InstancetypeMatcher", func() {
 		It("[test_id:TODO] should fail to create VM with non-existing cluster instancetype", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Instancetype = &v1.InstancetypeMatcher{
 				Name: "non-existing-cluster-instancetype",
@@ -80,7 +80,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should fail to create VM with non-existing namespaced instancetype", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Instancetype = &v1.InstancetypeMatcher{
 				Name: "non-existing-instancetype",
@@ -102,7 +102,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	Context("VM with invalid PreferenceMatcher", func() {
 		It("[test_id:TODO] should fail to create VM with non-existing cluster preference", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Preference = &v1.PreferenceMatcher{
 				Name: "non-existing-cluster-preference",
@@ -121,7 +121,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should fail to create VM with non-existing namespaced preference", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 			vm := tests.NewRandomVirtualMachine(vmi, false)
 			vm.Spec.Preference = &v1.PreferenceMatcher{
 				Name: "non-existing-preference",
@@ -270,7 +270,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should fail if instancetype and VM define CPU", func() {
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 
 			instancetype := newVirtualMachineInstancetype(vmi)
 			instancetype, err := virtClient.VirtualMachineInstancetype(util.NamespaceTestDefault).
@@ -418,7 +418,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				preferenceRevision   *appsv1.ControllerRevision
 			)
 
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New()
 
 			By("Creating a VirtualMachineInstancetype")
 			instancetype := newVirtualMachineInstancetype(vmi)
@@ -518,8 +518,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(vmi.Spec.Domain.CPU.Sockets).To(Equal(originalInstancetypeCPUGuest))
 
 			By("Creating a second VirtualMachine using the now updated VirtualMachineInstancetype and original VirtualMachinePreference")
-			newVMI := tests.NewRandomVMI()
-			removeResourcesAndPreferencesFromVMI(newVMI)
+			newVMI := libvmi.New()
 			newVM := tests.NewRandomVirtualMachine(newVMI, false)
 			newVM.Spec.Instancetype = &v1.InstancetypeMatcher{
 				Name: instancetype.Name,


### PR DESCRIPTION
Use libvmi builder pattern in tests/instancetype_test.go.
Use less resources in the test to be more resources efficiency.

Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
