### PR TITLE
Get VM clone test out of quarantine

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -334,12 +334,6 @@ func (ctrl *VMRestoreController) getBindingMode(pvc *corev1.PersistentVolumeClai
 }
 
 func (t *vmRestoreTarget) UpdateDoneRestore() (bool, error) {
-	/* this should never be true
-	if !t.doesTargetVMExist() {
-		return true, nil
-	}
-	*/
-
 	if t.vm.Status.RestoreInProgress == nil || *t.vm.Status.RestoreInProgress != t.vmRestore.Name {
 		return false, nil
 	}
@@ -554,9 +548,6 @@ func (t *vmRestoreTarget) Reconcile() (bool, error) {
 	}
 	newVM.Spec.DataVolumeTemplates = newTemplates
 	newVM.Spec.Template.Spec.Volumes = newVolumes
-	if newVM.Annotations == nil {
-		newVM.Annotations = make(map[string]string)
-	}
 	setLastRestoreAnnotation(t.vmRestore, newVM)
 
 	newVM, err = patchVM(newVM, t.vmRestore.Spec.Patches)

--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -95,17 +95,6 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 
 			return vmClone.Status.Phase
 		}, 3*time.Minute, 3*time.Second).Should(Equal(clonev1alpha1.Succeeded), "clone should finish successfully")
-
-		// TODO: Clone should not depend on target VM's status. This should be fixed in restore controller.
-		// For more info: https://github.com/kubevirt/kubevirt/pull/8059#discussion_r917762046
-		targetVmName := vmClone.Spec.Target.Name
-		By(fmt.Sprintf("Waiting for target VM %s to be ready", targetVmName))
-		Eventually(func() (isRestoreInProgress bool) {
-			targetVm, err := virtClient.VirtualMachine(vmClone.Namespace).Get(targetVmName, &v1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			return targetVm.Status.RestoreInProgress != nil
-		}, 90*time.Second, 1*time.Second).Should(BeFalse(), "target VM is expected to be ready")
 	}
 
 	expectVMRunnable := func(vm *virtv1.VirtualMachine, login loginFunction) *virtv1.VirtualMachine {
@@ -394,7 +383,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 				}
 			})
 
-			It("[QUARANTINE] with a simple clone", func() {
+			It("with a simple clone", func() {
 				vmClone = generateClone()
 
 				createCloneAndWaitForFinish(vmClone)

--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -383,7 +383,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 				}
 			})
 
-			It("with a simple clone", func() {
+			It("[QUARANTINE] with a simple clone", func() {
 				vmClone = generateClone()
 
 				createCloneAndWaitForFinish(vmClone)


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently a VM clone test is in quarantine.  The issue is that the VirtualMachineRestore resource is deleted before the VM restore controller clears the VM `status.restoreInProgress`.  Fix is to clear restoreInProgrress before marking the restore complete.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
