### PR TITLE
Rancher proxy uris

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
@@ -21,6 +21,7 @@ package kubecli
 
 import (
 	"context"
+	"path"
 
 	"encoding/json"
 	"fmt"
@@ -40,19 +41,26 @@ type GuestfsInfo struct {
 func (k *kubevirt) GuestfsVersion() *GuestfsVersion {
 	return &GuestfsVersion{
 		restClient: k.restClient,
+		config:     k.config,
 		resource:   "guestfs",
 	}
 }
 
 type GuestfsVersion struct {
 	restClient *rest.RESTClient
+	config     *rest.Config
 	resource   string
 }
 
 func (v *GuestfsVersion) Get() (*GuestfsInfo, error) {
 	var group metav1.APIGroup
 	// First, find out which version to query
-	uri := ApiGroupName
+	u, err := url.Parse(v.config.Host)
+	if err != nil {
+		return nil, err
+	}
+	uri := path.Join(u.Path, ApiGroupName)
+
 	result := v.restClient.Get().RequestURI(uri).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
@@ -67,7 +75,8 @@ func (v *GuestfsVersion) Get() (*GuestfsInfo, error) {
 	}
 
 	// Now, query the preferred version
-	uri = fmt.Sprintf("/apis/%s/guestfs", group.PreferredVersion.GroupVersion)
+	uri = fmt.Sprintf("%s/apis/%s/guestfs", u.Path, group.PreferredVersion.GroupVersion)
+
 	var info GuestfsInfo
 
 	result = v.restClient.Get().RequestURI(uri).Do(context.Background())

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -24,6 +24,8 @@ import (
 
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"path"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,6 +69,15 @@ func (v *vm) Create(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
 	newVm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 
 	return newVm, err
+}
+
+// Compute URI based on host path
+func (v *vm) adaptUriForHostPath(uri string) string {
+	u, err := url.Parse(v.config.Host)
+	if err != nil {
+		return uri
+	}
+	return path.Join(u.Path, uri)
 }
 
 // Get the Virtual machine from the cluster by its name and namespace
@@ -179,7 +190,7 @@ func (v *vm) Restart(name string, restartOptions *v1.RestartOptions) error {
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
 	}
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "restart")
-	return v.restClient.Put().RequestURI(uri).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vm) ForceRestart(name string, restartOptions *v1.RestartOptions) error {
@@ -188,7 +199,7 @@ func (v *vm) ForceRestart(name string, restartOptions *v1.RestartOptions) error 
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
 	}
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "restart")
-	return v.restClient.Put().RequestURI(uri).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vm) Start(name string, startOptions *v1.StartOptions) error {
@@ -198,7 +209,7 @@ func (v *vm) Start(name string, startOptions *v1.StartOptions) error {
 	if err != nil {
 		return err
 	}
-	return v.restClient.Put().RequestURI(uri).Body(optsJson).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(optsJson).Do(context.Background()).Error()
 }
 
 func (v *vm) Stop(name string, stopOptions *v1.StopOptions) error {
@@ -207,7 +218,7 @@ func (v *vm) Stop(name string, stopOptions *v1.StopOptions) error {
 	if err != nil {
 		return err
 	}
-	return v.restClient.Put().RequestURI(uri).Body(optsJson).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(optsJson).Do(context.Background()).Error()
 }
 
 func (v *vm) ForceStop(name string, stopOptions *v1.StopOptions) error {
@@ -216,7 +227,7 @@ func (v *vm) ForceStop(name string, stopOptions *v1.StopOptions) error {
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
 	}
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "stop")
-	return v.restClient.Put().RequestURI(uri).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vm) Migrate(name string, migrateOptions *v1.MigrateOptions) error {
@@ -225,7 +236,7 @@ func (v *vm) Migrate(name string, migrateOptions *v1.MigrateOptions) error {
 	if err != nil {
 		return err
 	}
-	return v.restClient.Put().RequestURI(uri).Body(optsJson).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(optsJson).Do(context.Background()).Error()
 }
 
 func (v *vm) MemoryDump(name string, memoryDumpRequest *v1.VirtualMachineMemoryDumpRequest) error {
@@ -236,13 +247,13 @@ func (v *vm) MemoryDump(name string, memoryDumpRequest *v1.VirtualMachineMemoryD
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(uri).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vm) RemoveMemoryDump(name string) error {
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "removememorydump")
 
-	return v.restClient.Put().RequestURI(uri).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Error()
 }
 
 func (v *vm) AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) error {
@@ -254,7 +265,7 @@ func (v *vm) AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) error
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(uri).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vm) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
@@ -266,7 +277,7 @@ func (v *vm) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptio
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(uri).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vm) PortForward(name string, port int, protocol string) (StreamInterface, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -173,6 +173,15 @@ func (v *vmis) PortForward(name string, port int, protocol string) (StreamInterf
 	return asyncSubresourceHelper(v.config, v.resource, v.namespace, name, buildPortForwardResourcePath(port, protocol))
 }
 
+// Compute URI based on host path
+func (v *vmis) adaptUriForHostPath(uri string) string {
+	u, err := url.Parse(v.config.Host)
+	if err != nil {
+		return uri
+	}
+	return path.Join(u.Path, uri)
+}
+
 func buildPortForwardResourcePath(port int, protocol string) string {
 	resource := strings.Builder{}
 	resource.WriteString("portforward/")
@@ -253,19 +262,19 @@ func (v *vmis) Freeze(name string, unfreezeTimeout time.Duration) error {
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(uri).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vmis) Unfreeze(name string) error {
 	log.Log.Infof("Unfreeze VMI %s", name)
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "unfreeze")
-	return v.restClient.Put().RequestURI(uri).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Error()
 }
 
 func (v *vmis) SoftReboot(name string) error {
 	log.Log.Infof("SoftReboot VMI")
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "softreboot")
-	return v.restClient.Put().RequestURI(uri).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Error()
 }
 
 func (v *vmis) Pause(name string, pauseOptions *v1.PauseOptions) error {
@@ -274,7 +283,7 @@ func (v *vmis) Pause(name string, pauseOptions *v1.PauseOptions) error {
 		return fmt.Errorf("Cannot Marshal to json: %s", err)
 	}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "pause")
-	return v.restClient.Put().RequestURI(uri).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vmis) Unpause(name string, unpauseOptions *v1.UnpauseOptions) error {
@@ -283,7 +292,7 @@ func (v *vmis) Unpause(name string, unpauseOptions *v1.UnpauseOptions) error {
 		return fmt.Errorf("Cannot Marshal to json: %s", err)
 	}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "unpause")
-	return v.restClient.Put().RequestURI(uri).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vmis) Get(name string, options *k8smetav1.GetOptions) (vmi *v1.VirtualMachineInstance, err error) {
@@ -423,7 +432,7 @@ func (v *vmis) GuestOsInfo(name string) (v1.VirtualMachineInstanceGuestAgentInfo
 	// this issue should be solved.
 	// This workaround can go away once the least supported k8s version is the working one.
 	// The issue has been described in: https://github.com/kubevirt/kubevirt/issues/3059
-	res := v.restClient.Get().RequestURI(uri).Do(context.Background())
+	res := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background())
 	rawInfo, err := res.Raw()
 	if err != nil {
 		log.Log.Errorf("Cannot retrieve GuestOSInfo: %s", err.Error())
@@ -441,14 +450,14 @@ func (v *vmis) GuestOsInfo(name string) (v1.VirtualMachineInstanceGuestAgentInfo
 func (v *vmis) UserList(name string) (v1.VirtualMachineInstanceGuestOSUserList, error) {
 	userList := v1.VirtualMachineInstanceGuestOSUserList{}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "userlist")
-	err := v.restClient.Get().RequestURI(uri).Do(context.Background()).Into(&userList)
+	err := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Into(&userList)
 	return userList, err
 }
 
 func (v *vmis) FilesystemList(name string) (v1.VirtualMachineInstanceFileSystemList, error) {
 	fsList := v1.VirtualMachineInstanceFileSystemList{}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "filesystemlist")
-	err := v.restClient.Get().RequestURI(uri).Do(context.Background()).Into(&fsList)
+	err := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Into(&fsList)
 	return fsList, err
 }
 
@@ -461,7 +470,7 @@ func (v *vmis) AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) err
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(uri).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vmis) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
@@ -473,5 +482,5 @@ func (v *vmis) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOpt
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(uri).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR relates to `virtctl` and its unability to use kubeconfigs provided by RANCHER. The underlying reason is that a RANCHER cluster URL will typically have a path describing the proxied cluster in the querystring (e.g. : `https://rancher-url/k8s/clusters/c-m-someid`) whereas Kubernetes cluster URLs typically have no path (e.g. : `https://192.168.3.3:6443
`)

As a consequence, using `virtctl` on RANCHER proxied clusters typically wrongly defines the URIs to use to call Kubernetes APIs. For example, calling `virtctl start xxx` on a RANCHER cluster would hit `https://rancher-url/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachines/xxx/start` instead of `https://rancher-url//k8s/clusters/c-m-someid/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachines/xxx/start`.

This pull requests aims at computing the URIs to use correctly so that `virtctl` can also work on RANCHER clusters.

It further extends fixing https://github.com/kubevirt/kubevirt/issues/3760

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes virtctl to support connection to clusters proxied by RANCHER or having special paths
```