### PR TITLE
[e2e tests]: improve operator test 4744

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1436,13 +1436,6 @@ spec:
 			By("Waiting for virt-operator to apply changes to component")
 			waitForKvWithTimeout(kv, 120)
 
-			Consistently(func() string {
-				vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				return vc.Spec.Template.ObjectMeta.Annotations[annotationPatchKey]
-			}, 30*time.Second, 5*time.Second).Should(Equal(annotationPatchValue))
-
 			By("Check that KubeVirt CR generation does not get updated when applying patch")
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(originalKv.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1426,7 +1426,8 @@ spec:
 				vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vc.Annotations[v1.KubeVirtGenerationAnnotation]
-			}, 60*time.Second, 5*time.Second).Should(Equal(strconv.FormatInt(generation, 10)))
+			}, 90*time.Second, 5*time.Second).Should(Equal(strconv.FormatInt(generation, 10)),
+				"Rsource generation numbers should be identical on both the Kubevirt CR and the virt-controller resource")
 
 			By("Test that patch was applied to deployment")
 			vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
@@ -1452,7 +1453,8 @@ spec:
 				vc, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vc.Annotations[v1.KubeVirtGenerationAnnotation]
-			}, 60*time.Second, 5*time.Second).Should(Equal(strconv.FormatInt(generation, 10)))
+			}, 90*time.Second, 5*time.Second).Should(Equal(strconv.FormatInt(generation, 10)),
+				"Rsource generation numbers should be identical on both the Kubevirt CR and the virt-controller resource")
 
 			By("Test that patch was removed from deployment")
 			vc, err = virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), "virt-controller", metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
the test verifies successful component patching using the customize
components configuration from Kubevirt CR. A proper verification would be:

- To compare the generation numbers between the CR and the component under test
- Verify the changes on the component.
- In this test case verify successful roll-out of the component.

**Special notes for your reviewer**:
My assumption was that if we aim to check only if the patch was applied to the resource we could do so 
in unit tests, I think that in e2e we should check the health of the subject under test, such as a successful roll-out
in our case.

**Release note**:
```release-note
NONE
```
