### PR TITLE
Fix cgroups unit tests: mock out underlying runc cgroup manager

### DIFF
--- a/pkg/virt-handler/cgroup/cgroup.go
+++ b/pkg/virt-handler/cgroup/cgroup.go
@@ -58,6 +58,11 @@ type Manager interface {
 	GetCpuSet() (string, error)
 }
 
+// This is here so that mockgen would create a mock out of it. That way we would have a mocked runc manager.
+type runcManager interface {
+	runc_cgroups.Manager
+}
+
 // NewManagerFromPid initializes a new cgroup manager from VMI's pid.
 // The pid is expected to VMI's pid from the host's viewpoint.
 func NewManagerFromPid(pid int) (manager Manager, err error) {

--- a/pkg/virt-handler/cgroup/cgroup_v1_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v1_manager.go
@@ -24,19 +24,19 @@ type v1Manager struct {
 }
 
 func newV1Manager(config *runc_configs.Cgroup, controllerPaths map[string]string) (Manager, error) {
-	return newCustomizedV1Manager(config, controllerPaths, execVirtChrootCgroups, getCurrentlyDefinedRules)
-}
-
-func newCustomizedV1Manager(config *runc_configs.Cgroup, controllerPaths map[string]string,
-	execVirtChroot execVirtChrootFunc, getCurrentlyDefinedRules getCurrentlyDefinedRulesFunc) (Manager, error) {
 	runcManager, err := runc_fs.NewManager(config, controllerPaths)
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize new cgroup manager. err: %v", err)
 	}
+	return newCustomizedV1Manager(runcManager, config.Rootless, execVirtChrootCgroups, getCurrentlyDefinedRules)
+}
+
+func newCustomizedV1Manager(runcManager runc_cgroups.Manager, isRootless bool,
+	execVirtChroot execVirtChrootFunc, getCurrentlyDefinedRules getCurrentlyDefinedRulesFunc) (Manager, error) {
 	manager := v1Manager{
 		runcManager,
-		controllerPaths,
-		config.Rootless,
+		runcManager.GetPaths(),
+		isRootless,
 		execVirtChroot,
 		getCurrentlyDefinedRules,
 	}

--- a/pkg/virt-handler/cgroup/cgroup_v2_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v2_manager.go
@@ -17,19 +17,23 @@ type v2Manager struct {
 }
 
 func newV2Manager(config *runc_configs.Cgroup, dirPath string) (Manager, error) {
-	return newCustomizedV2Manager(config, dirPath, execVirtChrootCgroups)
+	runcManager, err := runc_fs.NewManager(config, dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return newCustomizedV2Manager(runcManager, config.Rootless, execVirtChrootCgroups)
 }
 
-func newCustomizedV2Manager(config *runc_configs.Cgroup, dirPath string, execVirtChroot execVirtChrootFunc) (Manager, error) {
-	runcManager, err := runc_fs.NewManager(config, dirPath)
+func newCustomizedV2Manager(runcManager runc_cgroups.Manager, isRootless bool, execVirtChroot execVirtChrootFunc) (Manager, error) {
 	manager := v2Manager{
 		runcManager,
-		dirPath,
-		config.Rootless,
+		runcManager.GetPaths()[""],
+		isRootless,
 		execVirtChroot,
 	}
 
-	return &manager, err
+	return &manager, nil
 }
 
 func (v *v2Manager) GetBasePathToHostSubsystem(_ string) (string, error) {

--- a/pkg/virt-handler/cgroup/generated_mock_cgroup.go
+++ b/pkg/virt-handler/cgroup/generated_mock_cgroup.go
@@ -5,6 +5,7 @@ package cgroup
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	cgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	configs "github.com/opencontainers/runc/libcontainer/configs"
 )
 
@@ -69,4 +70,161 @@ func (_m *MockManager) GetCpuSet() (string, error) {
 
 func (_mr *_MockManagerRecorder) GetCpuSet() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCpuSet")
+}
+
+// Mock of runcManager interface
+type MockruncManager struct {
+	ctrl     *gomock.Controller
+	recorder *_MockruncManagerRecorder
+}
+
+// Recorder for MockruncManager (not exported)
+type _MockruncManagerRecorder struct {
+	mock *MockruncManager
+}
+
+func NewMockruncManager(ctrl *gomock.Controller) *MockruncManager {
+	mock := &MockruncManager{ctrl: ctrl}
+	mock.recorder = &_MockruncManagerRecorder{mock}
+	return mock
+}
+
+func (_m *MockruncManager) EXPECT() *_MockruncManagerRecorder {
+	return _m.recorder
+}
+
+func (_m *MockruncManager) Apply(pid int) error {
+	ret := _m.ctrl.Call(_m, "Apply", pid)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) Apply(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Apply", arg0)
+}
+
+func (_m *MockruncManager) GetPids() ([]int, error) {
+	ret := _m.ctrl.Call(_m, "GetPids")
+	ret0, _ := ret[0].([]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockruncManagerRecorder) GetPids() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPids")
+}
+
+func (_m *MockruncManager) GetAllPids() ([]int, error) {
+	ret := _m.ctrl.Call(_m, "GetAllPids")
+	ret0, _ := ret[0].([]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockruncManagerRecorder) GetAllPids() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllPids")
+}
+
+func (_m *MockruncManager) GetStats() (*cgroups.Stats, error) {
+	ret := _m.ctrl.Call(_m, "GetStats")
+	ret0, _ := ret[0].(*cgroups.Stats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockruncManagerRecorder) GetStats() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetStats")
+}
+
+func (_m *MockruncManager) Freeze(state configs.FreezerState) error {
+	ret := _m.ctrl.Call(_m, "Freeze", state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) Freeze(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Freeze", arg0)
+}
+
+func (_m *MockruncManager) Destroy() error {
+	ret := _m.ctrl.Call(_m, "Destroy")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) Destroy() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Destroy")
+}
+
+func (_m *MockruncManager) Path(_param0 string) string {
+	ret := _m.ctrl.Call(_m, "Path", _param0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) Path(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Path", arg0)
+}
+
+func (_m *MockruncManager) Set(r *configs.Resources) error {
+	ret := _m.ctrl.Call(_m, "Set", r)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) Set(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Set", arg0)
+}
+
+func (_m *MockruncManager) GetPaths() map[string]string {
+	ret := _m.ctrl.Call(_m, "GetPaths")
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) GetPaths() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPaths")
+}
+
+func (_m *MockruncManager) GetCgroups() (*configs.Cgroup, error) {
+	ret := _m.ctrl.Call(_m, "GetCgroups")
+	ret0, _ := ret[0].(*configs.Cgroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockruncManagerRecorder) GetCgroups() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCgroups")
+}
+
+func (_m *MockruncManager) GetFreezerState() (configs.FreezerState, error) {
+	ret := _m.ctrl.Call(_m, "GetFreezerState")
+	ret0, _ := ret[0].(configs.FreezerState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockruncManagerRecorder) GetFreezerState() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetFreezerState")
+}
+
+func (_m *MockruncManager) Exists() bool {
+	ret := _m.ctrl.Call(_m, "Exists")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockruncManagerRecorder) Exists() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Exists")
+}
+
+func (_m *MockruncManager) OOMKillCount() (uint64, error) {
+	ret := _m.ctrl.Call(_m, "OOMKillCount")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockruncManagerRecorder) OOMKillCount() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "OOMKillCount")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to adress this issue https://github.com/kubevirt/kubevirt/issues/8122 that was introduced after this PR https://github.com/kubevirt/kubevirt/pull/8073.

Essentially, our cgroup package wraps runc's cgroup `Manager` interface. This underlying manager was not mocked properly, therefore causing errors when a v2 environment was trying to run v1 tests locally.

Now the underlying interface is properly mocked.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubevirt/kubevirt/issues/8122

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cgroups unit tests: mock out underlying runc cgroup manager
```
