### PR TITLE
Tests: Fix flaky io error

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -228,7 +228,7 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 
-				_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil(), failedCreateVMI)
 
 				tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)


### PR DESCRIPTION
**What this PR does / why we need it**:
Not assigning vmi from Create call causes
that the vmi is missing namespace.
Namespace is required for helper in our test suite
causing 100% failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
