### PR TITLE
Remove "should pause on IO error" test from quarantine

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -138,7 +138,7 @@ var _ = SIGDescribe("Storage", func() {
 				tests.RemoveSCSIDisk(nodeName, address)
 			})
 
-			It("[QUARANTINE] should pause VMI on IO error", func() {
+			It("should pause VMI with error disk on IO error", func() {
 				By("Creating VMI with faulty disk")
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi = tests.AddPVCDisk(vmi, "pvc-disk", v1.DiskBusVirtio, pvc.Name)


### PR DESCRIPTION
There are two very similarly named tests - one "with faulty disk"
which is currently failing and #8140 is aiming to fix it, another
["with error disk" that hasn't failed in 2 weeks except in release
lanes.](https://search.ci.kubevirt.io/?search=with+error+disk&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)

While here, give it a slightly different name so it isn't confused
as easily.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
