### PR TITLE
cmd, dump: Publish k8s reporter dump

### DIFF
--- a/automation/release.sh
+++ b/automation/release.sh
@@ -64,6 +64,7 @@ function update_github_release() {
         _out/tests/tests.test \
         _out/manifests/release/conformance.yaml \
         _out/manifests/testing/*
+        _out/cmd/dump/dump*
 }
 
 function upload_testing_manifests() {


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of the tests suites publish on the release the dump binary so
reporter can be used by other projects that consume kubevirt too.

**Release note**:
```release-note
NONE
```
