### PR TITLE
tests: reuse GetComputeContainerOfPod

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -4332,22 +4332,11 @@ func wakeNodeLabellerUp(virtClient kubecli.KubevirtClient) {
 
 func libvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
 	vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-	found := false
-	containerIdx := 0
-	for idx, container := range vmiPod.Spec.Containers {
-		if container.Name == "compute" {
-			containerIdx = idx
-			found = true
-		}
-	}
-	if !found {
-		return false, fmt.Errorf(tests.CouldNotFindComputeContainer)
-	}
 
 	stdout, stderr, err := tests.ExecuteCommandOnPodV2(
 		virtClient,
 		vmiPod,
-		vmiPod.Spec.Containers[containerIdx].Name,
+		tests.GetComputeContainerOfPod(vmiPod).Name,
 		[]string{"virsh", "--quiet", "list", "--persistent", "--name"},
 	)
 	if err != nil {


### PR DESCRIPTION
The use of a public constant CouldNotFindComputeContainer exposes that
we had three reimplemenations of GetComputeContainerOfPod. Let us reuse
that function instead, to shorten our code and to make it more readable.

```release-note
NONE
```
