### PR TITLE
slow tests: adding cloud init network data to alpine VM

### DIFF
--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -50,9 +50,11 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 
 		networkData, err = libnet.NewNetworkData(
 			libnet.WithEthernet("eth0",
+				libnet.WithDHCP4Enabled(),
 				libnet.WithDHCP6Enabled(),
 			),
 		)
+		util.PanicOnError(err)
 	})
 
 	Context("VirtualMachineInstance with passt binding mechanism", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As part of the passt effort all the istio tests were moved to use Alpine.
The alpine VM was created without cloud-init network data which caused the VM startup to be very slow (it added ~2 hours per
network lane).
Adding network data to the alpine VMs to workaround the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
