### PR TITLE
Drop RunAsGroup from the exporter pod manifest

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -628,7 +628,6 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 	podManifest.ObjectMeta.Labels = map[string]string{exportServiceLabel: vmExport.Name}
 	podManifest.Spec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: pointer.Bool(true),
-		RunAsGroup:   pointer.Int64Ptr(kvm),
 		FSGroup:      pointer.Int64Ptr(kvm),
 	}
 	for i, pvc := range pvcs {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This fixes the following container runtime error:

>  failed to generate user string: user group "107" is specified without user

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Faced this error on `rke2` cluster (uses `containerd`). Not sure why the error is not reproducible in the CI. Maybe a different container runtime?

UPD: `containerd` explicitly validates the user/group combination in: https://github.com/containerd/containerd/blob/db3ecb286bd5f082d13ae9d5646f189a7d284805/pkg/cri/server/container_create_linux.go#L592

UPD2: https://github.com/kubernetes/cri-api/blob/2b5244cefaeace624cb160d6b3d85dd3fd14baea/pkg/apis/runtime/v1/api.proto#L307-L309:

> run_as_group should only be specified when run_as_user is specified; otherwise, the runtime MUST error


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
