### PR TITLE
slow AlpineWithTestTooling startup

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -67,9 +67,12 @@ func NewAlpine(opts ...Option) *kvirtv1.VirtualMachineInstance {
 }
 
 func NewAlpineWithTestTooling(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	// Supplied with no user data, AlpimeWithTestTooling image takes more than 200s to allow login
+	withNonEmptyUserData := WithCloudInitNoCloudUserData("#!/bin/bash\necho hello\n", true)
 	alpineMemory := cirrosMemory
 	alpineOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskAlpineTestTooling)),
+		withNonEmptyUserData,
 		WithResourceMemory(alpineMemory()),
 		WithRng(),
 	}

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -483,7 +483,7 @@ func newVMIWithIstioSidecar(ports []v1.Port, vmType VmType) (*v1.VirtualMachineI
 		return createMasqueradeVm(ports)
 	}
 	if vmType == Passt {
-		return createPasstVm(ports)
+		return createPasstVm(ports), nil
 	}
 	return nil, nil
 }
@@ -500,22 +500,15 @@ func createMasqueradeVm(ports []v1.Port) (*v1.VirtualMachineInstance, error) {
 	return vmi, err
 }
 
-func createPasstVm(ports []v1.Port) (*v1.VirtualMachineInstance, error) {
-	networkData, err := libnet.NewNetworkData(
-		libnet.WithEthernet("eth0",
-			libnet.WithDHCP4Enabled(),
-			libnet.WithDHCP6Enabled(),
-		),
-	)
+func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
 	vmi := libvmi.NewAlpineWithTestTooling(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
 		withPasstExtendedResourceMemory(ports...),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)
-	return vmi, err
+	return vmi
 }
 
 func generateIstioCNINetworkAttachmentDefinition() *k8snetworkplumbingwgv1.NetworkAttachmentDefinition {

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -42,18 +42,9 @@ import (
 var _ = SIGDescribe("[Serial] Passt", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
-	var networkData string
 
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
-		networkData, err = libnet.NewNetworkData(
-			libnet.WithEthernet("eth0",
-				libnet.WithDHCP4Enabled(),
-				libnet.WithDHCP6Enabled(),
-			),
-		)
 		util.PanicOnError(err)
 	})
 
@@ -63,7 +54,6 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 			vmi := libvmi.NewAlpineWithTestTooling(
 				withPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 			)
 
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -85,7 +75,6 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 						libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(ports...)),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						withPasstExtendedResourceMemory(ports...),
-						libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 					)
 
 					serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
@@ -133,7 +122,6 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 						clientVMI = libvmi.NewAlpineWithTestTooling(
 							withPasstInterfaceWithPort(),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-							libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 						)
 
 						clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
@@ -220,7 +208,6 @@ EOL`, inetSuffix, serverIP, serverPort)
 							libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding()),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							withPasstExtendedResourceMemory(),
-							libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 						)
 						clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
 						Expect(err).ToNot(HaveOccurred())
@@ -258,7 +245,6 @@ EOL`, inetSuffix, serverIP, serverPort)
 				vmi := libvmi.NewAlpineWithTestTooling(
 					withPasstInterfaceWithPort(),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 				)
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -283,7 +269,6 @@ EOL`, inetSuffix, serverIP, serverPort)
 				vmi := libvmi.NewAlpineWithTestTooling(
 					withPasstInterfaceWithPort(),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 				)
 				Expect(err).ToNot(HaveOccurred())
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When AlpineWithTestTooling supplied with no user data, it takes the image more than 200s to allow login.
Adding default empty user data to speed up the startup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
