### PR TITLE
VM Clone validation - make sure all PVCs snapshot-able

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -24,21 +24,18 @@ import (
 	"fmt"
 	"strings"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	"kubevirt.io/api/clone"
 	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
-
-	admissionv1 "k8s.io/api/admission/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 // VirtualMachineCloneAdmitter validates VirtualMachineClones
@@ -220,7 +217,7 @@ func doesSliceContainStr(slice []string, str string) (isFound bool) {
 }
 
 func verifySourceExists(client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
-	_, err := client.VirtualMachine(namespace).Get(name, &metav1.GetOptions{})
+	vm, err := client.VirtualMachine(namespace).Get(name, &metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return []metav1.StatusCause{
 			{
@@ -239,5 +236,46 @@ func verifySourceExists(client kubecli.KubevirtClient, name, namespace string, s
 		}
 	}
 
-	return nil
+	// currently, cloning leverages vm snapshot/restore to copy volumes
+	// snapshot/restore requires that volumes support CSI snapshots
+	// this limitation should be removed eventually
+	// probably by leveraging CDI cloning
+	return verifyVolumesSupportSnapshot(vm, sourceField)
+}
+
+func verifyVolumesSupportSnapshot(vm *v1.VirtualMachine, sourceField *k8sfield.Path) []metav1.StatusCause {
+	var result []metav1.StatusCause
+
+	// should never happen, but don't want to NPE
+	if vm.Spec.Template == nil {
+		return result
+	}
+
+	for _, v := range vm.Spec.Template.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil || v.DataVolume != nil {
+			found := false
+			for _, vss := range vm.Status.VolumeSnapshotStatuses {
+				if v.Name == vss.Name {
+					if !vss.Enabled {
+						result = append(result, metav1.StatusCause{
+							Type:    metav1.CauseTypeFieldValueInvalid,
+							Message: fmt.Sprintf("Virtual Machine volume %s does not support snapshots", v.Name),
+							Field:   sourceField.String(),
+						})
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				result = append(result, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("Virtual Machine volume %s snapshot support unknown", v.Name),
+					Field:   sourceField.String(),
+				})
+			}
+		}
+	}
+
+	return result
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -177,7 +177,13 @@ func validateSource(client kubecli.KubevirtClient, vmClone *clonev1alpha1.Virtua
 		}}
 		return causes
 	}
-
+	if source.APIGroup == nil || *source.APIGroup == "" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Source's APIGroup cannot be empty",
+			Field:   sourceField.Child("Source").Child("APIGroup").String(),
+		})
+	}
 	if source.Kind == "" {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
@@ -191,17 +197,19 @@ func validateSource(client kubecli.KubevirtClient, vmClone *clonev1alpha1.Virtua
 			Message: "Source's name cannot be empty",
 			Field:   sourceField.Child("Source").Child("Name").String(),
 		})
-	} else {
-		causes = append(causes, verifySourceExists(client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
 	}
-	if source.APIGroup == nil || *source.APIGroup == "" {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Source's APIGroup cannot be empty",
-			Field:   sourceField.Child("Source").Child("APIGroup").String(),
-		})
+	if source.Kind != "" && source.Name != "" {
+		switch source.Kind {
+		case "VirtualMachine":
+			causes = append(causes, validateCloneSourceVM(client, source.Name, vmClone.Namespace, sourceField.Child("Source"))...)
+		default:
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Source's Kind is invalid",
+				Field:   sourceField.Child("Source").String(),
+			})
+		}
 	}
-
 	return causes
 }
 
@@ -216,7 +224,7 @@ func doesSliceContainStr(slice []string, str string) (isFound bool) {
 	return isFound
 }
 
-func verifySourceExists(client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
+func validateCloneSourceVM(client kubecli.KubevirtClient, name, namespace string, sourceField *k8sfield.Path) []metav1.StatusCause {
 	vm, err := client.VirtualMachine(namespace).Get(name, &metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return []metav1.StatusCause{
@@ -240,10 +248,10 @@ func verifySourceExists(client kubecli.KubevirtClient, name, namespace string, s
 	// snapshot/restore requires that volumes support CSI snapshots
 	// this limitation should be removed eventually
 	// probably by leveraging CDI cloning
-	return verifyVolumesSupportSnapshot(vm, sourceField)
+	return validateCloneVolumeSnapshotSupportVM(vm, sourceField)
 }
 
-func verifyVolumesSupportSnapshot(vm *v1.VirtualMachine, sourceField *k8sfield.Path) []metav1.StatusCause {
+func validateCloneVolumeSnapshotSupportVM(vm *v1.VirtualMachine, sourceField *k8sfield.Path) []metav1.StatusCause {
 	var result []metav1.StatusCause
 
 	// should never happen, but don't want to NPE

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -168,6 +168,11 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			source.APIGroup = pointer.String("")
 			return source
 		}),
+		Entry("Source with bad kind", func() *k8sv1.TypedLocalObjectReference {
+			source := newValidObjReference()
+			source.Kind = "Foobar"
+			return source
+		}),
 	)
 
 	It("Should reject unknown source type", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -23,28 +23,27 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/client-go/tools/cache"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
+	"github.com/golang/mock/gomock"
+	admissionv1 "k8s.io/api/admission/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+
+	"kubevirt.io/api/clone"
+	clonev1lpha1 "kubevirt.io/api/clone/v1alpha1"
+	"kubevirt.io/api/core"
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests/util"
-
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	admissionv1 "k8s.io/api/admission/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"kubevirt.io/api/clone"
-	clonev1lpha1 "kubevirt.io/api/clone/v1alpha1"
-	"kubevirt.io/client-go/kubecli"
 )
 
 var _ = Describe("Validating VirtualMachineClone Admitter", func() {
@@ -55,6 +54,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 	var config *virtconfig.ClusterConfig
 	var kvInformer cache.SharedIndexInformer
 	var vmInterface *kubecli.MockVirtualMachineInterface
+	var vm *v1.VirtualMachine
 
 	enableFeatureGate := func(featureGate string) {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
@@ -80,6 +80,47 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		})
 	}
 
+	newValidVM := func(namespace, name string) *v1.VirtualMachine {
+		return &v1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+			},
+			Spec: v1.VirtualMachineSpec{
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: v1.VirtualMachineInstanceSpec{
+						Volumes: []v1.Volume{
+							{
+								Name: "dvVol",
+								VolumeSource: v1.VolumeSource{
+									DataVolume: &v1.DataVolumeSource{},
+								},
+							},
+							{
+								Name: "pvcVol",
+								VolumeSource: v1.VolumeSource{
+									PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: v1.VirtualMachineStatus{
+				VolumeSnapshotStatuses: []v1.VolumeSnapshotStatus{
+					{
+						Name:    "dvVol",
+						Enabled: true,
+					},
+					{
+						Name:    "pvcVol",
+						Enabled: true,
+					},
+				},
+			},
+		}
+	}
+
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
@@ -89,7 +130,8 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 
 		admitter = &VirtualMachineCloneAdmitter{Config: config, Client: virtClient}
 		vmClone = newValidClone()
-		vmInterface.EXPECT().Get(vmClone.Spec.Source.Name, gomock.Any()).Return(&v1.VirtualMachine{}, nil).AnyTimes()
+		vm = newValidVM(vmClone.Namespace, vmClone.Spec.Source.Name)
+		vmInterface.EXPECT().Get(vmClone.Spec.Source.Name, gomock.Any()).Return(vm, nil).AnyTimes()
 		vmInterface.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("does-not-exist")).AnyTimes()
 		enableFeatureGate("Snapshot")
 	})
@@ -147,6 +189,14 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 		disableFeatureGates()
 		admitter.admitAndExpect(vmClone, false)
 	})
+
+	DescribeTable("Should reject a source volume not Snapshot-able", func(index int) {
+		vm.Status.VolumeSnapshotStatuses[index].Enabled = false
+		admitter.admitAndExpect(vmClone, false)
+	},
+		Entry("DataVolume", 0),
+		Entry("PersistentVolumeClaim", 1),
+	)
 
 	Context("Annotations and labels filters", func() {
 		testFilter := func(filter string, expectAllowed bool) {
@@ -214,7 +264,7 @@ func newValidClone() *clonev1lpha1.VirtualMachineClone {
 
 func newValidObjReference() *k8sv1.TypedLocalObjectReference {
 	return &k8sv1.TypedLocalObjectReference{
-		APIGroup: pointer.String(clone.GroupName),
+		APIGroup: pointer.String(core.GroupName),
 		Kind:     "VirtualMachine",
 		Name:     "clone-source-vm",
 	}

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1251,14 +1251,14 @@ func getSnapshotStorageClass(client kubecli.KubevirtClient) (string, error) {
 		return "", err
 	}
 
-	hasV1beta1 := false
+	hasV1 := false
 	for _, v := range crd.Spec.Versions {
-		if v.Name == "v1beta1" && v.Served {
-			hasV1beta1 = true
+		if v.Name == "v1" && v.Served {
+			hasV1 = true
 		}
 	}
 
-	if !hasV1beta1 {
+	if !hasV1 {
 		return "", nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

VM clone webhook should make sure all PVCs support snapshots.  Otherwise the clone target will refer to the same PVC as the source.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
