### PR TITLE
Add scale OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -60,3 +60,7 @@ aliases:
       - rhrazdil
   network-approvers:
       - AlonaKaplan
+  scale-approvers:
+      - rthallisey
+  scale-reviewers:
+      - rthallisey

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - scale-reviewers
+approvers:
+  - scale-approvers
+labels:
+  - sig/scale

--- a/pkg/monitoring/perfscale/OWNERS
+++ b/pkg/monitoring/perfscale/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - scale-reviewers
+approvers:
+  - scale-approvers
+labels:
+  - sig/scale

--- a/tests/performance/OWNERS
+++ b/tests/performance/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - scale-reviewers
+approvers:
+  - scale-approvers
+labels:
+  - sig/scale

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - scale-reviewers
+approvers:
+  - scale-approvers
+labels:
+  - sig/scale


### PR DESCRIPTION
SIG-scale maintains tooling in /hack /tools and /tests/performance and some code in /pkg/monitoring/perfscale.  Add approvers and reviewers for this code to the owners file.

```release-note
NONE
```