### PR TITLE
executor: Introduce a new timeout executor

### DIFF
--- a/pkg/executor/timeout/BUILD.bazel
+++ b/pkg/executor/timeout/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "timeoutexecutor.go",
+        "timeoutpool.go",
+        "timer.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/pkg/executor/timeout",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "timeout_suite_test.go",
+        "timeout_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)

--- a/pkg/executor/timeout/timeout_suite_test.go
+++ b/pkg/executor/timeout/timeout_suite_test.go
@@ -1,0 +1,11 @@
+package timeout_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestExecutorTimeout(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/executor/timeout/timeout_test.go
+++ b/pkg/executor/timeout/timeout_test.go
@@ -1,0 +1,89 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package timeout_test
+
+import (
+	"errors"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/executor/timeout"
+)
+
+var _ = Describe("executor", func() {
+	It("should execute successful command before timeout", func() {
+		executed := false
+		executor := timeout.NewExecutor(timeout.NewTimer(time.Minute))
+		Expect(executor.Exec(func() error {
+			executed = true
+			return nil
+		})).To(Succeed())
+		Expect(executed).To(BeTrue())
+	})
+
+	It("should execute failing command before timeout", func() {
+		testError := errors.New("test")
+		executor := timeout.NewExecutor(timeout.NewTimer(time.Minute))
+		Expect(executor.Exec(func() error {
+			return testError
+		})).To(MatchError(testError))
+	})
+
+	It("should not execute command after timeout", func() {
+		executor := timeout.NewExecutor(timeout.NewTimer(0))
+		Expect(executor.Exec(func() error {
+			return errors.New("test")
+		})).To(Succeed())
+	})
+})
+
+var _ = Describe("executor pool", func() {
+
+	const (
+		key1 = types.UID("20007000")
+		key2 = types.UID("20006000")
+	)
+
+	var pool *timeout.ExecutorPool
+
+	BeforeEach(func() {
+		pool = timeout.NewExecutorPool(timeout.NewTimerCreator(time.Minute))
+	})
+
+	It("should not override data element if key exists", func() {
+		initialElement := pool.LoadOrStore(key1)
+		Expect(initialElement).To(BeIdenticalTo(pool.LoadOrStore(key1)))
+	})
+
+	It("should delete element if key exists", func() {
+		initialElement := pool.LoadOrStore(key1)
+		pool.Delete(key1)
+		Expect(initialElement).ToNot(Equal(pool.LoadOrStore(key1)))
+	})
+
+	It("should create unique elements", func() {
+		element1 := pool.LoadOrStore(key1)
+		Expect(element1).ToNot(Equal(pool.LoadOrStore(key2)))
+	})
+})

--- a/pkg/executor/timeout/timeoutexecutor.go
+++ b/pkg/executor/timeout/timeoutexecutor.go
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package timeout
+
+type timer interface {
+	Expired() bool
+}
+
+type Executor struct {
+	timer timer
+}
+
+func NewExecutor(timer timer) Executor {
+	return Executor{timer: timer}
+}
+
+// Exec will execute the given func when the underlying timer has not expired.
+// In case the timer expired, the command is not executed and nil is returned.
+func (t Executor) Exec(command func() error) error {
+	if t.timer.Expired() {
+		return nil
+	}
+	return command()
+}

--- a/pkg/executor/timeout/timeoutpool.go
+++ b/pkg/executor/timeout/timeoutpool.go
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package timeout
+
+import (
+	"sync"
+)
+
+type ExecutorPool struct {
+	sync.Map
+	creator TimerCreator
+}
+
+func NewExecutorPool(creator TimerCreator) *ExecutorPool {
+	return &ExecutorPool{
+		Map:     sync.Map{},
+		creator: creator,
+	}
+}
+
+// LoadOrStore returns the existing executor for the key if present.
+// Otherwise, it will create a new timeout executor, store and return it.
+func (c *ExecutorPool) LoadOrStore(key interface{}) Executor {
+	newTimer := c.creator.New()
+	executor, _ := c.Map.LoadOrStore(key, NewExecutor(newTimer))
+	return executor.(Executor)
+}

--- a/pkg/executor/timeout/timer.go
+++ b/pkg/executor/timeout/timer.go
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package timeout
+
+import (
+	"time"
+)
+
+type Timer struct {
+	expirationTime time.Time
+}
+
+func NewTimer(duration time.Duration) Timer {
+	now := time.Now()
+	return Timer{expirationTime: now.Add(duration)}
+}
+
+func (t Timer) Expired() bool {
+	now := time.Now()
+	return now.After(t.expirationTime)
+}
+
+type TimerCreator struct {
+	timeout time.Duration
+}
+
+func NewTimerCreator(timeout time.Duration) TimerCreator {
+	return TimerCreator{timeout: timeout}
+}
+
+func (t TimerCreator) New() Timer {
+	return NewTimer(t.timeout)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The new executor uses a timeout to determine if the command it is
instructed to execute should run or not.

There are 3 scenarios that are supported:
- Run successful command before timeout is reached.
- Run failing command before timeout is reached.
- Silently skip running command after timeout is reached.

An error is expected to be returned only for the 2nd scenario above.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```