### PR TITLE
executor: Refactor package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ lint:
 	if [ $$(wc -l < tests/utils.go) -gt 2813 ]; then echo >&2 "do not make tests/utils longer"; exit 1; fi
 
 	hack/dockerized "golangci-lint run --timeout 20m --verbose \
+	  pkg/executor/... \
 	  pkg/network/domainspec/... \
 	  tests/console/... \
 	  tests/libnet/... \

--- a/pkg/executor/ratelimit/BUILD.bazel
+++ b/pkg/executor/ratelimit/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "executor.go",
         "pool.go",
     ],
-    importpath = "kubevirt.io/kubevirt/pkg/executor",
+    importpath = "kubevirt.io/kubevirt/pkg/executor/ratelimit",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",

--- a/pkg/executor/ratelimit/backoff.go
+++ b/pkg/executor/ratelimit/backoff.go
@@ -17,7 +17,7 @@
  *
  */
 
-package executor
+package ratelimit
 
 import (
 	"math"

--- a/pkg/executor/ratelimit/backoff_test.go
+++ b/pkg/executor/ratelimit/backoff_test.go
@@ -17,27 +17,27 @@
  *
  */
 
-package executor_test
+package ratelimit_test
 
 import (
 	"time"
+
+	"kubevirt.io/kubevirt/pkg/executor/ratelimit"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/clock"
-
-	"kubevirt.io/kubevirt/pkg/executor"
 )
 
 var _ = Describe("exponential limited backoff", func() {
 
 	var testsClock *clock.FakeClock
-	var backoff executor.LimitedBackoff
+	var backoff ratelimit.LimitedBackoff
 
 	BeforeEach(func() {
 		testsClock = clock.NewFakeClock(time.Time{})
-		backoff = executor.NewExponentialLimitedBackoffWithClock(executor.DefaultMaxStep, testsClock)
+		backoff = ratelimit.NewExponentialLimitedBackoffWithClock(ratelimit.DefaultMaxStep, testsClock)
 
 		testsClock.Step(time.Nanosecond)
 	})
@@ -53,8 +53,8 @@ var _ = Describe("exponential limited backoff", func() {
 	})
 
 	It("should be ready after step end time passed", func() {
-		firstStepDuration := executor.DefaultDuration + time.Nanosecond
-		secondStepDuration := time.Duration(float64(firstStepDuration)*executor.DefaultFactor) + time.Nanosecond
+		firstStepDuration := ratelimit.DefaultDuration + time.Nanosecond
+		secondStepDuration := time.Duration(float64(firstStepDuration)*ratelimit.DefaultFactor) + time.Nanosecond
 
 		Expect(backoff.Ready()).To(BeTrue())
 		backoff.Step()
@@ -72,7 +72,7 @@ var _ = Describe("exponential limited backoff", func() {
 	})
 
 	It("should not be ready after max time is passed", func() {
-		testsClock.Step(executor.DefaultMaxStep + time.Nanosecond)
+		testsClock.Step(ratelimit.DefaultMaxStep + time.Nanosecond)
 
 		Expect(backoff.Ready()).To(BeFalse())
 		backoff.Step()

--- a/pkg/executor/ratelimit/executor.go
+++ b/pkg/executor/ratelimit/executor.go
@@ -17,7 +17,7 @@
  *
  */
 
-package executor
+package ratelimit
 
 type rateLimiter interface {
 	Step()

--- a/pkg/executor/ratelimit/executor.go
+++ b/pkg/executor/ratelimit/executor.go
@@ -24,21 +24,21 @@ type rateLimiter interface {
 	Ready() bool
 }
 
-// RateLimitedExecutor provides self-contained entity that enables rate-limiting a given func
+// Executor provides self-contained entity that enables rate-limiting a given func
 // execution (e.g: with an exponential backoff) without blocking the goroutine it runs on.
-type RateLimitedExecutor struct {
+type Executor struct {
 	rateLimiter rateLimiter
 }
 
-func NewRateLimitedExecutor(rateLimiter rateLimiter) *RateLimitedExecutor {
-	return &RateLimitedExecutor{
+func NewExecutor(rateLimiter rateLimiter) *Executor {
+	return &Executor{
 		rateLimiter: rateLimiter,
 	}
 }
 
 // Exec will execute the given func when the underlying rate-limiter
 // is not blocking; rate-limiter's end time is passed and limit is not reached.
-func (c *RateLimitedExecutor) Exec(command func() error) error {
+func (c *Executor) Exec(command func() error) error {
 	if !c.rateLimiter.Ready() {
 		return nil
 	}

--- a/pkg/executor/ratelimit/executor_suite_test.go
+++ b/pkg/executor/ratelimit/executor_suite_test.go
@@ -1,4 +1,4 @@
-package executor_test
+package ratelimit_test
 
 import (
 	"fmt"

--- a/pkg/executor/ratelimit/executor_suite_test.go
+++ b/pkg/executor/ratelimit/executor_suite_test.go
@@ -11,10 +11,10 @@ func TestExecutor(t *testing.T) {
 	testutils.KubeVirtTestSuiteSetup(t)
 }
 
-var testsExecError = fmt.Errorf("error occurred")
+var errTestsExec = fmt.Errorf("error occurred")
 
 func failingCommandStub() func() error {
 	return func() error {
-		return testsExecError
+		return errTestsExec
 	}
 }

--- a/pkg/executor/ratelimit/executor_test.go
+++ b/pkg/executor/ratelimit/executor_test.go
@@ -17,34 +17,34 @@
  *
  */
 
-package executor_test
+package ratelimit_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/pkg/executor"
+	"kubevirt.io/kubevirt/pkg/executor/ratelimit"
 )
 
 var _ = Describe("rate limited executor", func() {
 	It("should execute command when the underlying rate-limiter is not blocking", func() {
-		executor := executor.NewRateLimitedExecutor(&rateLimiterStub{block: false})
+		executor := ratelimit.NewRateLimitedExecutor(&rateLimiterStub{block: false})
 		expectCommandExec(executor)
 		expectCommandExec(executor)
 	})
 
 	It("should not execute command when the underlying rate-limiter is blocking", func() {
-		executor := executor.NewRateLimitedExecutor(&rateLimiterStub{block: true})
+		executor := ratelimit.NewRateLimitedExecutor(&rateLimiterStub{block: true})
 		expectSkipCommandExec(executor)
 		expectSkipCommandExec(executor)
 	})
 })
 
-func expectCommandExec(executor *executor.RateLimitedExecutor) {
+func expectCommandExec(executor *ratelimit.RateLimitedExecutor) {
 	ExpectWithOffset(1, executor.Exec(failingCommandStub())).To(MatchError(testsExecError))
 }
 
-func expectSkipCommandExec(executor *executor.RateLimitedExecutor) {
+func expectSkipCommandExec(executor *ratelimit.RateLimitedExecutor) {
 	ExpectWithOffset(1, executor.Exec(failingCommandStub())).To(Succeed())
 }
 

--- a/pkg/executor/ratelimit/executor_test.go
+++ b/pkg/executor/ratelimit/executor_test.go
@@ -28,23 +28,23 @@ import (
 
 var _ = Describe("rate limited executor", func() {
 	It("should execute command when the underlying rate-limiter is not blocking", func() {
-		executor := ratelimit.NewRateLimitedExecutor(&rateLimiterStub{block: false})
+		executor := ratelimit.NewExecutor(&rateLimiterStub{block: false})
 		expectCommandExec(executor)
 		expectCommandExec(executor)
 	})
 
 	It("should not execute command when the underlying rate-limiter is blocking", func() {
-		executor := ratelimit.NewRateLimitedExecutor(&rateLimiterStub{block: true})
+		executor := ratelimit.NewExecutor(&rateLimiterStub{block: true})
 		expectSkipCommandExec(executor)
 		expectSkipCommandExec(executor)
 	})
 })
 
-func expectCommandExec(executor *ratelimit.RateLimitedExecutor) {
+func expectCommandExec(executor *ratelimit.Executor) {
 	ExpectWithOffset(1, executor.Exec(failingCommandStub())).To(MatchError(testsExecError))
 }
 
-func expectSkipCommandExec(executor *ratelimit.RateLimitedExecutor) {
+func expectSkipCommandExec(executor *ratelimit.Executor) {
 	ExpectWithOffset(1, executor.Exec(failingCommandStub())).To(Succeed())
 }
 

--- a/pkg/executor/ratelimit/executor_test.go
+++ b/pkg/executor/ratelimit/executor_test.go
@@ -41,7 +41,7 @@ var _ = Describe("rate limited executor", func() {
 })
 
 func expectCommandExec(executor *ratelimit.Executor) {
-	ExpectWithOffset(1, executor.Exec(failingCommandStub())).To(MatchError(testsExecError))
+	ExpectWithOffset(1, executor.Exec(failingCommandStub())).To(MatchError(errTestsExec))
 }
 
 func expectSkipCommandExec(executor *ratelimit.Executor) {

--- a/pkg/executor/ratelimit/pool.go
+++ b/pkg/executor/ratelimit/pool.go
@@ -23,25 +23,25 @@ import (
 	"sync"
 )
 
-// RateLimitedExecutorPool aggregates RateLimiterExecutor's by keys,
+// ExecutorPool aggregates RateLimiterExecutor's by keys,
 // each key element is self-contained and have its own rate-limiter.
 // Each element rate-limiter is created by the given creator.
-type RateLimitedExecutorPool struct {
+type ExecutorPool struct {
 	sync.Map
 	creator LimitedBackoffCreator
 }
 
-func NewRateLimitedExecutorPool(creator LimitedBackoffCreator) *RateLimitedExecutorPool {
-	return &RateLimitedExecutorPool{
+func NewExecutorPool(creator LimitedBackoffCreator) *ExecutorPool {
+	return &ExecutorPool{
 		Map:     sync.Map{},
 		creator: creator,
 	}
 }
 
-// LoadOrStore returns the existing RateLimitedExecutor for the key if present.
-// Otherwise, it will create new RateLimitedExecutor with a new underlying rate-limiter, store and return it.
-func (c *RateLimitedExecutorPool) LoadOrStore(key interface{}) *RateLimitedExecutor {
+// LoadOrStore returns the existing Executor for the key if present.
+// Otherwise, it will create new Executor with a new underlying rate-limiter, store and return it.
+func (c *ExecutorPool) LoadOrStore(key interface{}) *Executor {
 	rateLimit := c.creator.New()
-	element, _ := c.Map.LoadOrStore(key, NewRateLimitedExecutor(&rateLimit))
-	return element.(*RateLimitedExecutor)
+	element, _ := c.Map.LoadOrStore(key, NewExecutor(&rateLimit))
+	return element.(*Executor)
 }

--- a/pkg/executor/ratelimit/pool.go
+++ b/pkg/executor/ratelimit/pool.go
@@ -17,7 +17,7 @@
  *
  */
 
-package executor
+package ratelimit
 
 import (
 	"sync"

--- a/pkg/executor/ratelimit/pool_test.go
+++ b/pkg/executor/ratelimit/pool_test.go
@@ -17,15 +17,15 @@
  *
  */
 
-package executor_test
+package ratelimit_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/types"
+	"kubevirt.io/kubevirt/pkg/executor/ratelimit"
 
-	"kubevirt.io/kubevirt/pkg/executor"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("rate limited executor pool", func() {
@@ -35,10 +35,10 @@ var _ = Describe("rate limited executor pool", func() {
 		key2 = types.UID("20006000")
 	)
 
-	var pool *executor.RateLimitedExecutorPool
+	var pool *ratelimit.RateLimitedExecutorPool
 
 	BeforeEach(func() {
-		pool = executor.NewRateLimitedExecutorPool(executor.NewExponentialLimitedBackoffCreator())
+		pool = ratelimit.NewRateLimitedExecutorPool(ratelimit.NewExponentialLimitedBackoffCreator())
 	})
 
 	It("should not override pool element if key exists", func() {

--- a/pkg/executor/ratelimit/pool_test.go
+++ b/pkg/executor/ratelimit/pool_test.go
@@ -45,7 +45,7 @@ var _ = Describe("rate limited executor pool", func() {
 		initialElement := pool.LoadOrStore(key1)
 		Expect(initialElement).To(BeIdenticalTo(pool.LoadOrStore(key1)))
 		// mutate the element
-		Expect(initialElement.Exec(failingCommandStub())).To(MatchError(testsExecError))
+		Expect(initialElement.Exec(failingCommandStub())).To(MatchError(errTestsExec))
 		Expect(initialElement).To(BeIdenticalTo(pool.LoadOrStore(key1)))
 	})
 

--- a/pkg/executor/ratelimit/pool_test.go
+++ b/pkg/executor/ratelimit/pool_test.go
@@ -35,10 +35,10 @@ var _ = Describe("rate limited executor pool", func() {
 		key2 = types.UID("20006000")
 	)
 
-	var pool *ratelimit.RateLimitedExecutorPool
+	var pool *ratelimit.ExecutorPool
 
 	BeforeEach(func() {
-		pool = ratelimit.NewRateLimitedExecutorPool(ratelimit.NewExponentialLimitedBackoffCreator())
+		pool = ratelimit.NewExecutorPool(ratelimit.NewExponentialLimitedBackoffCreator())
 	})
 
 	It("should not override pool element if key exists", func() {

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
         "//pkg/container-disk:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
-        "//pkg/executor:go_default_library",
+        "//pkg/executor/ratelimit:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/hotplug-disk:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -72,7 +72,7 @@ import (
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/controller"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
-	"kubevirt.io/kubevirt/pkg/executor"
+	rlexecutor "kubevirt.io/kubevirt/pkg/executor/ratelimit"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 	virtutil "kubevirt.io/kubevirt/pkg/util"
@@ -206,7 +206,7 @@ func NewController(
 		capabilities:                capabilities,
 		hostCpuModel:                hostCpuModel,
 		vmiExpectations:             controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		sriovHotplugExecutorPool:    executor.NewRateLimitedExecutorPool(executor.NewExponentialLimitedBackoffCreator()),
+		sriovHotplugExecutorPool:    rlexecutor.NewRateLimitedExecutorPool(rlexecutor.NewExponentialLimitedBackoffCreator()),
 	}
 
 	vmiSourceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -285,7 +285,7 @@ type VirtualMachineController struct {
 	containerDiskMounter     container_disk.Mounter
 	hotplugVolumeMounter     hotplug_volume.VolumeMounter
 	clusterConfig            *virtconfig.ClusterConfig
-	sriovHotplugExecutorPool *executor.RateLimitedExecutorPool
+	sriovHotplugExecutorPool *rlexecutor.RateLimitedExecutorPool
 
 	netConf netconf
 	netStat netstat

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -206,7 +206,7 @@ func NewController(
 		capabilities:                capabilities,
 		hostCpuModel:                hostCpuModel,
 		vmiExpectations:             controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
-		sriovHotplugExecutorPool:    rlexecutor.NewRateLimitedExecutorPool(rlexecutor.NewExponentialLimitedBackoffCreator()),
+		sriovHotplugExecutorPool:    rlexecutor.NewExecutorPool(rlexecutor.NewExponentialLimitedBackoffCreator()),
 	}
 
 	vmiSourceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -285,7 +285,7 @@ type VirtualMachineController struct {
 	containerDiskMounter     container_disk.Mounter
 	hotplugVolumeMounter     hotplug_volume.VolumeMounter
 	clusterConfig            *virtconfig.ClusterConfig
-	sriovHotplugExecutorPool *rlexecutor.RateLimitedExecutorPool
+	sriovHotplugExecutorPool *rlexecutor.ExecutorPool
 
 	netConf netconf
 	netStat netstat


### PR DESCRIPTION
**What this PR does / why we need it**:

Perform several refactoring changes on the executor package:
- Simplify the pool by embedding the map.
- Move the executor files to a `ratelimit` package. Allowing new executor types to be added later without cluttering the package.
- Rename functions/types, adjusting them with the new package name.
- Add the executor package to the lint coverage (comes with a small fix).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
