### PR TITLE
libvmi: Split performance.go into cpu.go and memory.go

### DIFF
--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -4,9 +4,10 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cloudinit.go",
+        "cpu.go",
         "factory.go",
+        "memory.go",
         "network.go",
-        "performance.go",
         "status.go",
         "storage.go",
         "vmi.go",

--- a/tests/libvmi/cpu.go
+++ b/tests/libvmi/cpu.go
@@ -20,7 +20,6 @@
 package libvmi
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -57,24 +56,5 @@ func WithNUMAGuestMappingPassthrough() Option {
 			vmi.Spec.Domain.CPU = &v1.CPU{}
 		}
 		vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}}
-	}
-}
-
-func WithHugepages(pageSize string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		if vmi.Spec.Domain.Memory == nil {
-			vmi.Spec.Domain.Memory = &v1.Memory{}
-		}
-		vmi.Spec.Domain.Memory.Hugepages = &v1.Hugepages{PageSize: pageSize}
-	}
-}
-
-func WithGuestMemory(memory string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		if vmi.Spec.Domain.Memory == nil {
-			vmi.Spec.Domain.Memory = &v1.Memory{}
-		}
-		quantity := resource.MustParse(memory)
-		vmi.Spec.Domain.Memory.Guest = &quantity
 	}
 }

--- a/tests/libvmi/memory.go
+++ b/tests/libvmi/memory.go
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package libvmi
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+func WithHugepages(pageSize string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.Memory == nil {
+			vmi.Spec.Domain.Memory = &v1.Memory{}
+		}
+		vmi.Spec.Domain.Memory.Hugepages = &v1.Hugepages{PageSize: pageSize}
+	}
+}
+
+func WithGuestMemory(memory string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.Memory == nil {
+			vmi.Spec.Domain.Memory = &v1.Memory{}
+		}
+		quantity := resource.MustParse(memory)
+		vmi.Spec.Domain.Memory.Guest = &quantity
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Split performance.go into cpu.go and memory.go to be more specific.

**Special notes for your reviewer**:

Follow up to #8161 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
