### PR TITLE
Test: Remove unnecessary error

### DIFF
--- a/tests/libnet/cloudinit.go
+++ b/tests/libnet/cloudinit.go
@@ -184,13 +184,16 @@ const (
 // for the Cloud-Init Network Data, in version 2 format.
 // The default configuration sets dynamic IPv4 (DHCP) and static IPv6 addresses,
 // inclusing DNS settings of the cluster nameserver IP and search domains.
-func CreateDefaultCloudInitNetworkData() (string, error) {
-	return NewNetworkData(
+func CreateDefaultCloudInitNetworkData() string {
+	data, err := NewNetworkData(
 		WithEthernet("eth0",
 			WithDHCP4Enabled(),
 			WithAddresses(DefaultIPv6CIDR),
 			WithGateway6(DefaultIPv6Gateway),
 			WithNameserverFromCluster(),
-		),
-	)
+		))
+	if err != nil {
+		panic(err)
+	}
+	return data
 }

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -44,7 +44,7 @@ func WithNetwork(network *kvirtv1.Network) Option {
 }
 
 func WithMasqueradeNetworking(ports ...kvirtv1.Port) []Option {
-	networkData, _ := libnet.CreateDefaultCloudInitNetworkData()
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 	return []Option{
 		WithInterface(InterfaceDeviceWithMasqueradeBinding(ports...)),
 		WithNetwork(kvirtv1.DefaultPodNetwork()),

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -183,10 +183,7 @@ func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance)
 }
 
 func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.VirtualMachineInstance, error) {
-	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-	if err != nil {
-		return nil, err
-	}
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 
 	vmi := libvmi.NewFedora(
 		libvmi.WithInterface(iface),

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -671,8 +671,7 @@ func validatePodKubevirtResourceNameByVMI(virtClient kubecli.KubevirtClient, vmi
 }
 
 func defaultCloudInitNetworkData() string {
-	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should successfully create default cloud init network data for SRIOV")
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 	return networkData
 }
 

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -347,8 +347,8 @@ var istioTests = func(vmType VmType) {
 			}
 
 			BeforeEach(func() {
-				networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-				Expect(err).ToNot(HaveOccurred())
+				networkData := libnet.CreateDefaultCloudInitNetworkData()
+
 				serverVMI = libvmi.NewAlpineWithTestTooling(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
@@ -480,7 +480,8 @@ func istioServiceMeshDeployed() bool {
 
 func newVMIWithIstioSidecar(ports []v1.Port, vmType VmType) (*v1.VirtualMachineInstance, error) {
 	if vmType == Masquerade {
-		return createMasqueradeVm(ports)
+		return createMasqueradeVm(ports), nil
+
 	}
 	if vmType == Passt {
 		return createPasstVm(ports)
@@ -488,8 +489,8 @@ func newVMIWithIstioSidecar(ports []v1.Port, vmType VmType) (*v1.VirtualMachineI
 	return nil, nil
 }
 
-func createMasqueradeVm(ports []v1.Port) (*v1.VirtualMachineInstance, error) {
-	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
+func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 	vmi := libvmi.NewAlpineWithTestTooling(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
@@ -497,7 +498,7 @@ func createMasqueradeVm(ports []v1.Port) (*v1.VirtualMachineInstance, error) {
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)
-	return vmi, err
+	return vmi
 }
 
 func createPasstVm(ports []v1.Port) (*v1.VirtualMachineInstance, error) {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -344,8 +344,8 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			By(checkingEth0MACAddr)
 			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 			masqIface.MacAddress = "de:ad:00:00:be:af"
-			networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-			Expect(err).NotTo(HaveOccurred())
+			networkData := libnet.CreateDefaultCloudInitNetworkData()
+
 			deadbeafVMI := libvmi.NewAlpineWithTestTooling(
 				libvmi.WithInterface(masqIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -961,8 +961,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				var err error
 
 				By("Create masquerade VMI")
-				networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-				Expect(err).NotTo(HaveOccurred())
+				networkData := libnet.CreateDefaultCloudInitNetworkData()
 
 				vmi = libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -691,8 +691,7 @@ func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus v1.DiskB
 }
 
 func NewRandomFedoraVMI() *v1.VirtualMachineInstance {
-	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-	Expect(err).NotTo(HaveOccurred())
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 
 	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -702,8 +701,7 @@ func NewRandomFedoraVMI() *v1.VirtualMachineInstance {
 }
 
 func NewRandomFedoraVMIWithGuestAgent() *v1.VirtualMachineInstance {
-	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-	Expect(err).NotTo(HaveOccurred())
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 
 	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -713,8 +711,7 @@ func NewRandomFedoraVMIWithGuestAgent() *v1.VirtualMachineInstance {
 }
 
 func NewRandomFedoraVMIWithBlacklistGuestAgent(commands string) *v1.VirtualMachineInstance {
-	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
-	Expect(err).NotTo(HaveOccurred())
+	networkData := libnet.CreateDefaultCloudInitNetworkData()
 
 	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),


### PR DESCRIPTION
**What this PR does / why we need it**:
`CreateDefaultCloudInitNetworkData` returns an error that needs to be handled. There is mostly no better action than panic so let's just do it and reduce the awkward error handling. This will also differ from normal test failure.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
