### PR TITLE
De-quarantine simple clone functest

### DIFF
--- a/tests/storage/clone.go
+++ b/tests/storage/clone.go
@@ -412,7 +412,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineClone Tests", func() {
 				return candidates[0]
 			}
 
-			It("[QUARANTINE] with a simple clone", func() {
+			It("with a simple clone", func() {
 				snapshotStorageClass, err := getSnapshotStorageClass(virtClient)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR https://github.com/kubevirt/kubevirt/pull/8120 solved flakieness of "simple clone" functest.

Following [this process](https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md), since 3 days passed without failures, we can remove the quarantine.

**Useful links:**
Test grid: https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.24-sig-storage&width=20&show-stale-tests=

CI search: https://search.ci.kubevirt.io/?search=.*with+a+simple+clone.*&maxAge=48h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
