### PR TITLE
Differentiate between different components' Kubevirt generation annotation

### DIFF
--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -977,24 +977,6 @@ func (c *KubeVirtController) checkForActiveInstall(kv *v1.KubeVirt) error {
 	return nil
 }
 
-func isUpdating(kv *v1.KubeVirt) bool {
-
-	// first check to see if any version has been observed yet.
-	// If no version is observed, this means no version has been
-	// installed yet, so we can't be updating.
-	if kv.Status.ObservedDeploymentID == "" {
-		return false
-	}
-
-	// At this point we know an observed version exists.
-	// if observed doesn't match target in anyway then we are updating.
-	if kv.Status.ObservedDeploymentID != kv.Status.TargetDeploymentID {
-		return true
-	}
-
-	return false
-}
-
 func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 	var targetStrategy *install.Strategy
 	var targetPending bool
@@ -1021,7 +1003,7 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 		kv.Status.Phase = v1.KubeVirtPhaseDeploying
 	}
 
-	if isUpdating(kv) {
+	if apply.IsUpdating(kv) {
 		util.UpdateConditionsUpdating(kv)
 	} else {
 		util.UpdateConditionsDeploying(kv)

--- a/pkg/virt-operator/resource/apply/admissionregistration.go
+++ b/pkg/virt-operator/resource/apply/admissionregistration.go
@@ -218,6 +218,8 @@ func (r *Reconciler) createOrUpdateValidatingWebhookConfiguration(webhook *admis
 		return nil
 	}
 
+	r.bumpKubevirtGeneration(&webhook.ObjectMeta)
+
 	// Patch if old version
 	ops := []string{
 		fmt.Sprintf(testGenerationJSONPatchTemplate, cachedWebhook.ObjectMeta.Generation),
@@ -322,6 +324,8 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 		log.Log.V(4).Infof("mutating webhook configuration %v is up-to-date", webhook.GetName())
 		return nil
 	}
+
+	r.bumpKubevirtGeneration(&webhook.ObjectMeta)
 
 	// Patch if old version
 	ops := []string{

--- a/pkg/virt-operator/resource/apply/apiservices.go
+++ b/pkg/virt-operator/resource/apply/apiservices.go
@@ -72,6 +72,8 @@ func (r *Reconciler) createOrUpdateAPIService(apiService *apiregv1.APIService, c
 		return nil
 	}
 
+	r.bumpKubevirtGeneration(&apiService.ObjectMeta)
+
 	spec, err := json.Marshal(apiService.Spec)
 	if err != nil {
 		return err

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -100,6 +100,8 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 		return deployment, nil
 	}
 
+	r.bumpKubevirtGeneration(&deployment.ObjectMeta)
+
 	newSpec, err := json.Marshal(deployment.Spec)
 	if err != nil {
 		return nil, err
@@ -311,6 +313,8 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 		return true, nil
 	}
 
+	r.bumpKubevirtGeneration(&daemonSet.ObjectMeta)
+
 	// canary pod upgrade
 	// first update virt-handler with maxUnavailable=1
 	// patch daemonSet with new version
@@ -379,6 +383,8 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 		log.Log.V(4).Infof("poddisruptionbudget %v is up-to-date", cachedPodDisruptionBudget.GetName())
 		return nil
 	}
+
+	r.bumpKubevirtGeneration(&podDisruptionBudget.ObjectMeta)
 
 	// Add Spec Patch
 	newSpec, err := json.Marshal(podDisruptionBudget.Spec)

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -89,6 +89,7 @@ func (r *Reconciler) syncDeployment(origDeployment *appsv1.Deployment) (*appsv1.
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := cachedDeployment.DeepCopy()
 	expectedGeneration := GetExpectedGeneration(deployment, kv.Status.Generations)
+	deployment.Annotations[v1.KubeVirtGenerationAnnotation] = existingCopy.Annotations[v1.KubeVirtGenerationAnnotation]
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, deployment.ObjectMeta)
 
@@ -305,6 +306,7 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := cachedDaemonSet.DeepCopy()
 	expectedGeneration := GetExpectedGeneration(daemonSet, kv.Status.Generations)
+	daemonSet.Annotations[v1.KubeVirtGenerationAnnotation] = existingCopy.Annotations[v1.KubeVirtGenerationAnnotation]
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, daemonSet.ObjectMeta)
 	// there was no change to metadata, the generation was right
@@ -374,6 +376,7 @@ func (r *Reconciler) syncPodDisruptionBudgetForDeployment(deployment *appsv1.Dep
 	modified := resourcemerge.BoolPtr(false)
 	existingCopy := cachedPodDisruptionBudget.DeepCopy()
 	expectedGeneration := GetExpectedGeneration(podDisruptionBudget, kv.Status.Generations)
+	podDisruptionBudget.Annotations[v1.KubeVirtGenerationAnnotation] = existingCopy.Annotations[v1.KubeVirtGenerationAnnotation]
 
 	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, podDisruptionBudget.ObjectMeta)
 	// there was no change to metadata or minAvailable, the generation was right

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -265,6 +265,8 @@ func (r *Reconciler) createOrUpdateCertificateSecret(queue workqueue.RateLimitin
 		return crt, nil
 	}
 
+	r.bumpKubevirtGeneration(&secret.ObjectMeta)
+
 	ops, err := createSecretPatch(secret)
 	if err != nil {
 		return nil, err
@@ -480,6 +482,8 @@ func (r *Reconciler) createOrUpdateServiceAccount(sa *corev1.ServiceAccount) err
 		return nil
 	}
 
+	r.bumpKubevirtGeneration(&sa.ObjectMeta)
+
 	// Patch Labels and Annotations
 	labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&sa.ObjectMeta)
 	if err != nil {
@@ -620,6 +624,8 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.RateLimit
 		log.Log.V(4).Infof("configMap %v is up-to-date", configMap.GetName())
 		return []byte(configMap.Data[components.CABundleKey]), nil
 	}
+
+	r.bumpKubevirtGeneration(&configMap.ObjectMeta)
 
 	ops, err := createConfigMapPatch(configMap)
 	if err != nil {

--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -106,6 +106,8 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 		return nil
 	}
 
+	r.bumpKubevirtGeneration(&crd.ObjectMeta)
+
 	// Patch if old version
 	for i := range crd.Spec.Versions {
 		if needsSubresourceStatusDisable(&crd.Spec.Versions[i], cachedCrd) {

--- a/pkg/virt-operator/resource/apply/prometheus.go
+++ b/pkg/virt-operator/resource/apply/prometheus.go
@@ -64,6 +64,8 @@ func (r *Reconciler) createOrUpdateServiceMonitor(serviceMonitor *promv1.Service
 		return nil
 	}
 
+	r.bumpKubevirtGeneration(&serviceMonitor.ObjectMeta)
+
 	// Add Spec Patch
 	newSpec, err := json.Marshal(serviceMonitor.Spec)
 	if err != nil {
@@ -141,6 +143,8 @@ func (r *Reconciler) createOrUpdatePrometheusRule(prometheusRule *promv1.Prometh
 		log.Log.V(4).Infof("PrometheusRule %v is up-to-date", prometheusRule.GetName())
 		return nil
 	}
+
+	r.bumpKubevirtGeneration(&prometheusRule.ObjectMeta)
 
 	// Add Spec Patch
 	newSpec, err := json.Marshal(prometheusRule.Spec)

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -140,6 +140,7 @@ func IsUpdating(kv *v1.KubeVirt) bool {
 }
 
 func (r *Reconciler) bumpKubevirtGeneration(objectMeta *metav1.ObjectMeta) {
+	// TODO ihol3: I don't think this is needed.
 	if !IsUpdating(r.kv) {
 		util.UpdateConditionsDeploying(r.kv)
 	}

--- a/pkg/virt-operator/resource/apply/routes.go
+++ b/pkg/virt-operator/resource/apply/routes.go
@@ -77,6 +77,8 @@ func (r *Reconciler) syncRoute(route *routev1.Route, caBundle []byte) error {
 		return nil
 	}
 
+	r.bumpKubevirtGeneration(&route.ObjectMeta)
+
 	spec, err := json.Marshal(route.Spec)
 	if err != nil {
 		return err

--- a/pkg/virt-operator/resource/apply/ssc.go
+++ b/pkg/virt-operator/resource/apply/ssc.go
@@ -44,6 +44,7 @@ func (r *Reconciler) createOrUpdateSCC() error {
 		} else if !objectMatchesVersion(&cachedSCC.ObjectMeta, version, imageRegistry, id, r.kv.GetGeneration()) {
 			scc.ObjectMeta = *cachedSCC.ObjectMeta.DeepCopy()
 			injectOperatorMetadata(r.kv, &scc.ObjectMeta, version, imageRegistry, id, true)
+			r.bumpKubevirtGeneration(&scc.ObjectMeta)
 			_, err := sec.SecurityContextConstraints().Update(context.Background(), scc, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("Unable to update %s SecurityContextConstraints", scc.Name)

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -251,6 +251,9 @@ func newBaseDeployment(deploymentName string, imageName string, namespace string
 				virtv1.AppLabel:     deploymentName,
 				virtv1.AppNameLabel: deploymentName,
 			},
+			Annotations: map[string]string{
+				virtv1.KubeVirtGenerationAnnotation: "1",
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: int32Ptr(2),
@@ -733,7 +736,9 @@ func NewPodDisruptionBudgetForDeployment(deployment *appsv1.Deployment) *policyv
 			Namespace: deployment.Namespace,
 			Name:      pdbName,
 			Labels: map[string]string{
-				virtv1.AppLabel: pdbName,
+				virtv1.AppLabel:        pdbName,
+				virtv1.AppNameLabel:    pdbName,
+				virtv1.AppVersionLabel: deployment.Labels[virtv1.AppVersionLabel],
 			},
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
@@ -741,5 +746,6 @@ func NewPodDisruptionBudgetForDeployment(deployment *appsv1.Deployment) *policyv
 			Selector:     selector,
 		},
 	}
+
 	return podDisruptionBudget
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1111,34 +1111,47 @@ spec:
 		crdName := "virtualmachines.kubevirt.io"
 		shortNameAdded := "new"
 
+		getKubevirtGeneration := func(o metav1.Object) int {
+			annotations := o.GetAnnotations()
+			Expect(annotations).ToNot(BeNil())
+
+			generationStr := annotations[v1.KubeVirtGenerationAnnotation]
+			generationInt, err := strconv.Atoi(generationStr)
+			Expect(err).ToNot(HaveOccurred())
+
+			return generationInt
+		}
+
 		DescribeTable("checking updating resource is reverted to original state for ", func(changeResource func(), getResource func() runtime.Object, compareResource func() bool) {
 			resource := getResource()
 			By("Updating KubeVirt Object")
 			changeResource()
 
-			var generation int64
+			var k8sGeneration int64
+			var k6tGeneration int
 			By("Test that the added envvar was removed")
 			Eventually(func() bool {
 				equal := compareResource()
 				if equal {
 					r := getResource()
 					o := r.(metav1.Object)
-					generation = o.GetGeneration()
+					k8sGeneration = o.GetGeneration()
+					k6tGeneration = getKubevirtGeneration(o)
 				}
 
 				return equal
 			}, 120*time.Second, 5*time.Second).Should(BeTrue(), "waiting for deployment to revert to original state")
 
+			By("Test that the expected k8s generation is as expected")
 			Eventually(func() int64 {
 				currentKV := util2.GetCurrentKv(virtClient)
 				return apply.GetExpectedGeneration(resource, currentKV.Status.Generations)
-			}, 60*time.Second, 5*time.Second).Should(Equal(generation), "reverted deployment generation should be set on KV resource")
+			}, 60*time.Second, 5*time.Second).Should(Equal(k8sGeneration), "reverted deployment generation should be set on KV resource")
 
-			By("Test that the expected generation is unchanged")
-			Consistently(func() int64 {
-				currentKV := util2.GetCurrentKv(virtClient)
-				return apply.GetExpectedGeneration(resource, currentKV.Status.Generations)
-			}, 30*time.Second, 5*time.Second).Should(Equal(generation))
+			By("Test that the expected kubevirt generation is unchanged")
+			Consistently(func() int {
+				return getKubevirtGeneration(getResource().(metav1.Object))
+			}, 30*time.Second, 5*time.Second).Should(Equal(k6tGeneration))
 		},
 
 			Entry("[test_id:6254] deployments",


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue is well explained here in issue https://github.com/kubevirt/kubevirt/issues/8031. I will try to briefly summarize it here as well:

<ins>The problem</ins>
When Kubevirt's configuration is changed, it comes "unready" (that is, with false ready condition at its status). The reason is that deployment is in progress. After a very short period (~1-2 seconds) Kubevirt becomes ready again.

For the most part, the problem will affect automations that watch the kubevirt and might fail when Kubevirt is no longer ready.

<ins>The root cause</ins>
The `kubevirt.io/generation` annotation is explained in detail [here](https://github.com/kubevirt/kubevirt/issues/8031).
In essence, this annotation is made to help debug and track changes to our components.

In the current implementation, whenever Kubevirt's configuration is updated, the generation is incremented. This implementation is problematic for two reasons:
* The fact that a config was changed automatically means that all component's annotation is updated. This includes deployments (e.g. virt-api, virt-controller), daemon sets (e.g. virt-handler), CRDs, PDBs, and many more. Even though it's only one annotation change, the underlying (deployments, daemon sets, etc) are taking some time to be ready. This enforces virt-operator to make Kubevirt unready, execute another control loop, and make it ready again.
* It's confusing to add a generation to virt-api's deployment because the cluster's migration settings have changed - what does virt-api care? In other words, while the mechanism eases to debug and track Kubevirt, it does not provide a way to track specific components of it.

<ins>The solution</ins>
In order to fix the problem explained above, the current implementation assigns a different generation for each component.

For example:
* If Kubevirt updates its default CPU model - nothing happens.
* If Kubevirt updates the number of instances of virt-api - **only** virt-api's deployment's generation is bumped.

This won't only keep Kubevirt in a ready condition (unless there's a real reason not to) and save some computing time, it will also enhance the ability to debug and track different components separately

**Which issue(s) this PR fixes**:
Fixes #8031 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2079916

**Special notes for your reviewer**:
In the functional tests I've added, I use the client to "get" Kubevirt every half a second. Unfortunately, currently Kubevirt client does not support watching.
I've opened [an issue](https://github.com/kubevirt/kubevirt/issues/8200) on that manner and address it as a follow-up to this PR. It might also grant a performance boost for our CI as a bonus.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Differentiate between different components' Kubevirt generation annotation
```
