### PR TITLE
[e2e tests] improvements in the VM pool suite

### DIFF
--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -132,8 +132,8 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		doScale(newPool.ObjectMeta.Name, int32(stopScale))
 		doScale(newPool.ObjectMeta.Name, int32(0))
 	},
-		Entry("[QUARANTINE]to three, to two and then to zero replicas", 3, 2),
-		Entry("[QUARANTINE]to five, to six and then to zero replicas", 5, 6),
+		Entry("to three, to two and then to zero replicas", 3, 2),
+		Entry("to five, to six and then to zero replicas", 5, 6),
 	)
 
 	It("should be rejected on POST if spec is invalid", func() {

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -115,7 +115,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 
 	newVirtualMachinePool := func() *poolv1.VirtualMachinePool {
 		By("Create a new VirtualMachinePool")
-		pool := newPoolFromVMI(libvmi.NewCirros())
+		pool := newPoolFromVMI(libvmi.New(libvmi.WithResourceMemory("2Mi")))
 		running := true
 		pool.Spec.VirtualMachineTemplate.Spec.Running = &running
 		return createVirtualMachinePool(pool)
@@ -131,7 +131,6 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		doScale(newPool.ObjectMeta.Name, int32(startScale))
 		doScale(newPool.ObjectMeta.Name, int32(stopScale))
 		doScale(newPool.ObjectMeta.Name, int32(0))
-
 	},
 		Entry("[QUARANTINE]to three, to two and then to zero replicas", 3, 2),
 		Entry("[QUARANTINE]to five, to six and then to zero replicas", 5, 6),


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>


**What this PR does / why we need it**:
* Taking the VM pool scale tests out of quarantine - according to Testgrid these tests were passing the periodic lanes for a couple of weeks, hence taking them back as they proved to be stable.

* Improving the time it takes to run some of the VM pool tests -  the VM pool suite contains tests with running VMs. These tests only observe the statuses of the VMIs and the VM pool resources. They don't interact directly with the guest OS. Therefore we can use a diskless approach when a VM runs the "no bootable device" phase. It will save the time it takes to setup the container-disk.

**Special notes for the reviewer**:
* The minimum amount of RAM required to run SeaBIOS is 1M, I've decided to put 2Mi to be on the safe side.
* changes were tested on a local 1.23 based setup, I've ran them w/o the quarantine label, and also using `gmeasure` to
run them in a loop for 100 times in a row.

**Release note**:
```release-note
NONE
```
