### PR TITLE
Fixing the error message when guestfs digest and tag are missing and …

### DIFF
--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -220,7 +220,7 @@ func setImage(virtClient kubecli.KubevirtClient) error {
 	} else if info.Tag != "" {
 		imageName = fmt.Sprintf("%s:%s", imageName, info.Tag)
 	} else {
-		return fmt.Errorf("Either the digest or the tag for the image have been specified")
+		return fmt.Errorf("Neither the digest nor the tag for the image has been specified")
 	}
 
 	// Set the registry


### PR DESCRIPTION
Align error message with the guestfs logic when neither Digest nor Tag could be determined

Signed-off-by: Arnaud Aubert <aaubert@magesi.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Clarifies error message for guestfs command

**Special notes for your reviewer**:
I simply encountered this misleading error message and wanted to clarify it

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
