### PR TITLE
build-go.sh: Introduce KUBEVIRT_GO_BUILD_TAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ client-python:
 	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} ./hack/gen-client-python/generate.sh"
 
 go-build:
-	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
+	hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
 
 gosec:
 	hack/dockerized "GOSEC=${GOSEC} ARTIFACTS=${ARTIFACTS} ./hack/gosec.sh"
@@ -66,7 +66,7 @@ goveralls:
 	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN_FILE=${COVERALLS_TOKEN_FILE} COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BRANCH=${PULL_BASE_REF} CI_PR_NUMBER=${PULL_NUMBER} GIT_ID=${PULL_PULL_SHA} PROW_JOB_ID=${PROW_JOB_ID} ./hack/bazel-goveralls.sh"
 
 go-test: go-build
-	SYNC_OUT=false hack/dockerized "export KUBEVIRT_NO_BAZEL=true && ./hack/build-go.sh test ${WHAT}"
+	SYNC_OUT=false hack/dockerized "export KUBEVIRT_NO_BAZEL=true && KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} ./hack/build-go.sh test ${WHAT}"
 
 test: bazel-test
 

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -57,18 +57,18 @@ if [ $# -eq 0 ]; then
     if [ "${target}" = "test" ]; then
         (
             # Ignoring container-disk-v2alpha since it is written in C, not in go
-            go ${target} -v --ignore=container-disk-v2alpha ./cmd/...
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" --ignore=container-disk-v2alpha ./cmd/...
         )
         (
-            go ${target} -v -race ./pkg/...
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race ./pkg/...
         )
     else
         (
-            go $target -tags selinux ./pkg/...
-            GO111MODULE=off go $target ./staging/src/kubevirt.io/...
+            go $target -tags "${KUBEVIRT_GO_BUILD_TAGS}" ./pkg/...
+            GO111MODULE=off go $target -tags "${KUBEVIRT_GO_BUILD_TAGS}" ./staging/src/kubevirt.io/...
         )
         (
-            go $target ./tests/...
+            go $target -tags "${KUBEVIRT_GO_BUILD_TAGS}" ./tests/...
         )
     fi
 fi
@@ -101,7 +101,7 @@ fi
 for arg in $args; do
     if [ "${target}" = "test" ]; then
         (
-            go ${target} -v ./$arg/...
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" ./$arg/...
         )
     elif [ "${target}" = "install" ]; then
         eval "$(go env)"
@@ -117,7 +117,7 @@ for arg in $args; do
             LINUX_NAME=${ARCH_BASENAME}-linux-${ARCH}
 
             echo "building dynamic binary $BIN_NAME"
-            GOOS=linux GOARCH=${ARCH} go_build -tags selinux -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux ${ARCH})
+            GOOS=linux GOARCH=${ARCH} go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux ${ARCH})
 
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
 
@@ -126,8 +126,8 @@ for arg in $args; do
 
             # build virtctl also for darwin and windows on amd64
             if [ "${BIN_NAME}" = "virtctl" -a "${ARCH}" = "amd64" -a -z "${LINUX_ONLY}" ]; then
-                GOOS=darwin GOARCH=amd64 go_build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
-                GOOS=windows GOARCH=amd64 go_build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
+                GOOS=darwin GOARCH=amd64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
+                GOOS=windows GOARCH=amd64 go_build -tags "${KUBEVIRT_GO_BUILD_TAGS}" -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
                 # Create symlinks to the latest binary of each architecture
                 (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-darwin-amd64 ${BIN_NAME}-darwin)
                 (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-windows-amd64.exe ${BIN_NAME}-windows.exe)

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -83,6 +83,14 @@ function build_func_tests_image() {
 # Useful for cross-compilation where the default -pkdir for cross-builds may not be writable
 #KUBEVIRT_GO_BASE_PKGDIR="${GOPATH}/crossbuild-cache-root/"
 
+# Use this environment variable to specify additional tags for the go build in hack/build-go.sh.
+# To specify tags in the bazel build modify/overwrite the build target in .bazelrc instead.
+if [ -z "$KUBEVIRT_GO_BUILD_TAGS" ]; then
+    KUBEVIRT_GO_BUILD_TAGS="selinux"
+else
+    KUBEVIRT_GO_BUILD_TAGS="selinux,${KUBEVIRT_GO_BUILD_TAGS}"
+fi
+
 # Populate an environment variable with the version info needed.
 # It should be used for everything which needs a version when building (not generating)
 # IMPORTANT:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds env variable KUBEVIRT_GO_BUILD_TAGS to hack/common.sh and
hack/build-go.sh, which allows to specify additonal go build tags when
not building with bazel. The tag 'selinux' is always present.

Example for adding additional tags to the default build:
export KUBEVIRT_GO_BUILD_TAGS=additionaltag1,additionaltag2

Resulting tags during build:
KUBEVIRT_GO_BUILD_TAGS=selinux,additionaltag1,additionaltag2

**Special notes for your reviewer**:

This is useful for e.g. https://github.com/kubevirt/kubevirt/pull/8193

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
