### PR TITLE
virtctl: Add build tag to allow excluding native SSH

### DIFF
--- a/pkg/virtctl/scp/BUILD.bazel
+++ b/pkg/virtctl/scp/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "native.go",
+        "native_unsupported.go",
         "scp.go",
         "wrapped.go",
     ],

--- a/pkg/virtctl/scp/native.go
+++ b/pkg/virtctl/scp/native.go
@@ -1,3 +1,5 @@
+//go:build !excludenative
+
 package scp
 
 import (

--- a/pkg/virtctl/scp/native_unsupported.go
+++ b/pkg/virtctl/scp/native_unsupported.go
@@ -1,0 +1,11 @@
+//go:build excludenative
+
+package scp
+
+import (
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+func (o *SCP) nativeSCP(_ templates.LocalSCPArgument, _ templates.RemoteSCPArgument, _ bool) error {
+	panic("Native SCP is unsupported in this build!")
+}

--- a/pkg/virtctl/ssh/BUILD.bazel
+++ b/pkg/virtctl/ssh/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "knownhosts.go",
         "native.go",
+        "native_unsupported.go",
         "resize_unix.go",
         "resize_windows.go",
         "ssh.go",

--- a/pkg/virtctl/ssh/knownhosts.go
+++ b/pkg/virtctl/ssh/knownhosts.go
@@ -1,3 +1,5 @@
+//go:build !excludenative
+
 package ssh
 
 import (

--- a/pkg/virtctl/ssh/knownhosts_test.go
+++ b/pkg/virtctl/ssh/knownhosts_test.go
@@ -1,3 +1,5 @@
+//go:build !excludenative
+
 package ssh
 
 import (

--- a/pkg/virtctl/ssh/native.go
+++ b/pkg/virtctl/ssh/native.go
@@ -1,3 +1,5 @@
+//go:build !excludenative
+
 package ssh
 
 import (
@@ -6,6 +8,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/term"
@@ -14,6 +17,25 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 )
+
+const (
+	wrapLocalSSHDefault = false
+)
+
+func additionalUsage() string {
+	return fmt.Sprintf(`
+	# Connect to 'testvmi' using the local ssh binary found in $PATH:
+	{{ProgramName}} ssh --%s=true jdoe@testvmi`,
+		wrapLocalSSHFlag,
+	)
+}
+
+func addAdditionalCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
+	flagset.StringArrayVarP(&opts.AdditionalSSHLocalOptions, additionalOpts, additionalOptsShort, opts.AdditionalSSHLocalOptions,
+		fmt.Sprintf(`--%s="-o StrictHostKeyChecking=no" : Additional options to be passed to the local ssh. This is applied only if local-ssh=true`, additionalOpts))
+	flagset.BoolVar(&opts.WrapLocalSSH, wrapLocalSSHFlag, opts.WrapLocalSSH,
+		fmt.Sprintf("--%s=true: Set this to true to use the SSH/SCP client available on your system by using this command as ProxyCommand; If set to false, this will establish a SSH/SCP connection with limited capabilities provided by this client", wrapLocalSSHFlag))
+}
 
 type NativeSSHConnection struct {
 	ClientConfig clientcmd.ClientConfig

--- a/pkg/virtctl/ssh/native_unsupported.go
+++ b/pkg/virtctl/ssh/native_unsupported.go
@@ -1,0 +1,26 @@
+//go:build excludenative
+
+package ssh
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	wrapLocalSSHDefault = true
+)
+
+func additionalUsage() string {
+	return ""
+}
+
+func addAdditionalCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
+	flagset.StringArrayVarP(&opts.AdditionalSSHLocalOptions, additionalOpts, additionalOptsShort, opts.AdditionalSSHLocalOptions,
+		fmt.Sprintf(`--%s="-o StrictHostKeyChecking=no" : Additional options to be passed to the local ssh`, additionalOpts))
+}
+
+func (o *SSH) nativeSSH(_, _, _ string) error {
+	panic("Native SSH is unsupported in this build!")
+}

--- a/pkg/virtctl/ssh/resize_unix.go
+++ b/pkg/virtctl/ssh/resize_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !excludenative
 
 package ssh
 

--- a/pkg/virtctl/ssh/resize_windows.go
+++ b/pkg/virtctl/ssh/resize_windows.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && !excludenative
 
 package ssh
 

--- a/pkg/virtctl/ssh/ssh.go
+++ b/pkg/virtctl/ssh/ssh.go
@@ -75,10 +75,8 @@ func AddCommandlineArgs(flagset *pflag.FlagSet, opts *SSHOptions) {
 		fmt.Sprintf("--%s=/home/jdoe/.ssh/kubevirt_known_hosts: Set the path to the known_hosts file.", knownHostsFilePathFlag))
 	flagset.IntVarP(&opts.SSHPort, portFlag, portFlagShort, opts.SSHPort,
 		fmt.Sprintf(`--%s=22: Specify a port on the VM to send SSH traffic to`, portFlag))
-	flagset.StringArrayVarP(&opts.AdditionalSSHLocalOptions, additionalOpts, additionalOptsShort, opts.AdditionalSSHLocalOptions,
-		fmt.Sprintf(`--%s="-o StrictHostKeyChecking=no" : Additional options to be passed to the local ssh. This is applied only if local-ssh=true `, commandToExecute))
-	flagset.BoolVar(&opts.WrapLocalSSH, wrapLocalSSHFlag, opts.WrapLocalSSH,
-		fmt.Sprintf("--%s=true: Set this to true to use the SSH/SCP client available on your system by using this command as ProxyCommand; If set to false, this will establish a SSH/SCP connection with limited capabilities provided by this client", wrapLocalSSHFlag))
+
+	addAdditionalCommandlineArgs(flagset, opts)
 }
 
 func DefaultSSHOptions() SSHOptions {
@@ -94,7 +92,7 @@ func DefaultSSHOptions() SSHOptions {
 		KnownHostsFilePath:        "",
 		KnownHostsFilePathDefault: "",
 		AdditionalSSHLocalOptions: []string{},
-		WrapLocalSSH:              false,
+		WrapLocalSSH:              wrapLocalSSHDefault,
 		LocalClientName:           "ssh",
 	}
 
@@ -165,15 +163,11 @@ func usage() string {
   {{ProgramName}} ssh jdoe@vm/testvm.mynamespace [--%s]
 
   # Specify a username and namespace:
-  {{ProgramName}} ssh --namespace=mynamespace --%s=jdoe testvmi
- 
-  # Connect to 'testvmi' using the local ssh binary found in $PATH:
-  {{ProgramName}} ssh --%s=true jdoe@testvmi`,
+  {{ProgramName}} ssh --namespace=mynamespace --%s=jdoe testvmi`,
 		IdentityFilePathFlag,
 		IdentityFilePathFlag,
 		usernameFlag,
-		wrapLocalSSHFlag,
-	)
+	) + additionalUsage()
 }
 
 func defaultUsername() string {


### PR DESCRIPTION
**What this PR does / why we need it**:

By specifying the go build tag 'excludenative' the native ssh client in
virtctl is excluded from the build and the wrapped local ssh client is
always used instead.

**Special notes for your reviewer**:

https://github.com/kubevirt/kubevirt/pull/8192 is needed to be able to define the tag when building without bazel.
When building with bazel the build target in `.bazelrc` can be modified.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
