### PR TITLE
[release-0.53] [Bug-fix]: Windows VM HyperV Reenlightenment enabled fails to migrate

### DIFF
--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -28,7 +28,7 @@ type topologyHinter struct {
 }
 
 func (t *topologyHinter) TopologyHintsRequiredForVMI(vmi *k6tv1.VirtualMachineInstance) bool {
-	return t.arch == "amd64" && VMIHasInvTSCFeature(vmi)
+	return t.arch == "amd64" && IsManualTSCFrequencyRequired(vmi)
 }
 
 func (t *topologyHinter) TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) (hints *k6tv1.TopologyHints, err error) {

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -77,15 +77,16 @@ var _ = Describe("TSC", func() {
 	Context("needs to be set when", func() {
 
 		It("invtsc feature exists", func() {
-			vmi := libvmi.New(
-				libvmi.WithCPUFeature("invtsc", "require"),
-			)
+			vmi := libvmi.New("test-vmi")
+			vmi.Spec.Domain.CPU = &v1.CPU{Features: []v1.CPUFeature{
+				{Name: "invtsc", Policy: "require"},
+			}}
 
 			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
 		})
 
 		It("HyperV reenlightenment is enabled", func() {
-			vmi := libvmi.New()
+			vmi := libvmi.New("test-vmi")
 			vmi.Spec.Domain.Features = &v1.Features{
 				Hyperv: &v1.FeatureHyperv{
 					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -3,6 +3,12 @@ package topology_test
 import (
 	"fmt"
 
+	"k8s.io/utils/pointer"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -67,6 +73,28 @@ var _ = Describe("TSC", func() {
 			[]int64{2, 4},
 		),
 	)
+
+	Context("needs to be set when", func() {
+
+		It("invtsc feature exists", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUFeature("invtsc", "require"),
+			)
+
+			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+		})
+
+		It("HyperV reenlightenment is enabled", func() {
+			vmi := libvmi.New()
+			vmi.Spec.Domain.Features = &v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+				},
+			}
+
+			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+		})
+	})
 })
 
 func tscFrequencyLabel(freq int64) string {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -435,7 +435,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			vmiCopy.Status.Phase = virtv1.Failed
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
-			if vmi.Status.TopologyHints == nil && c.topologyHinter.TopologyHintsRequiredForVMI(vmi) {
+			if vmi.Status.TopologyHints == nil {
 				if topologyHints, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedGatherhingClusterTopologyHints, err.Error())
 					return &syncErrorImpl{err, FailedGatherhingClusterTopologyHints}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1697,7 +1697,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		// Make use of the tsc frequency topology hint
-		if topology.VMIHasInvTSCFeature(vmi) && vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil {
+		if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
 			freq := *vmi.Status.TopologyHints.TSCFrequency
 			clock := domain.Spec.Clock
 			if clock == nil {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -186,6 +186,7 @@ go_test(
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/device-manager:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"sync"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	"kubevirt.io/api/migrations/v1alpha1"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
 
@@ -4161,6 +4163,44 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			}, time.Second*30, time.Second*1).Should(BeNumerically("<=", 1))
 		})
+	})
+
+	Context("topology hints", func() {
+
+		Context("needs to be set when", func() {
+
+			expectTopologyHintsToBeSet := func(vmi *v1.VirtualMachineInstance) {
+				EventuallyWithOffset(1, func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					return topology.AreTSCFrequencyTopologyHintsDefined(vmi)
+				}, 90*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("tsc frequency topology hints are expected to exist for vmi %s", vmi.Name))
+			}
+
+			It("invtsc feature exists", func() {
+				vmi := libvmi.New(
+					libvmi.WithResourceMemory("1Mi"),
+					libvmi.WithCPUFeature("invtsc", "require"),
+				)
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				expectTopologyHintsToBeSet(vmi)
+			})
+
+			It("HyperV reenlightenment is enabled", func() {
+				vmi := libvmi.New()
+				vmi.Spec = getWindowsVMISpec()
+				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
+				vmi.Spec.Volumes = []v1.Volume{}
+				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				expectTopologyHintsToBeSet(vmi)
+			})
+
+		})
+
 	})
 })
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -4179,17 +4179,19 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			It("invtsc feature exists", func() {
-				vmi := libvmi.New(
+				vmi := libvmi.New("test-vmi",
 					libvmi.WithResourceMemory("1Mi"),
-					libvmi.WithCPUFeature("invtsc", "require"),
 				)
+				vmi.Spec.Domain.CPU = &v1.CPU{Features: []v1.CPUFeature{
+					{Name: "invtsc", Policy: "require"},
+				}}
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				expectTopologyHintsToBeSet(vmi)
 			})
 
 			It("HyperV reenlightenment is enabled", func() {
-				vmi := libvmi.New()
+				vmi := libvmi.New("test-vmi")
 				vmi.Spec = getWindowsVMISpec()
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
 				vmi.Spec.Volumes = []v1.Volume{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of this PR: https://github.com/kubevirt/kubevirt/pull/7986.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bug-fix]: Windows VM with WSL2 guest fails to migrate
```
