### PR TITLE
Corrected issue with external boot which only kernelPath is specified without initrd path

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2387,6 +2387,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					createKernelBoot(validKernelArgs, invalidInitrd, validKernel, validImage), false),
 				Entry("with kernel args, with container that has initrd and kernel defined but without image - should reject",
 					createKernelBoot(validKernelArgs, validInitrd, validKernel, withoutImage), false),
+				Entry("with kernel args, with container that has only kernel defined - should approve",
+					createKernelBoot(validKernelArgs, withoutInitrd, validKernel, validImage), false),
 			)
 		})
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2387,8 +2387,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					createKernelBoot(validKernelArgs, invalidInitrd, validKernel, validImage), false),
 				Entry("with kernel args, with container that has initrd and kernel defined but without image - should reject",
 					createKernelBoot(validKernelArgs, validInitrd, validKernel, withoutImage), false),
-				Entry("with kernel args, with container that has only kernel defined - should approve",
-					createKernelBoot(validKernelArgs, withoutInitrd, validKernel, validImage), false),
 			)
 		})
 

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -444,19 +444,30 @@ func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 
 	nodeRes := isolation.NodeIsolationResult()
 
-	if err := safepath.TouchAtNoFollow(targetDir, filepath.Base(kb.InitrdPath), 0655); err != nil && !os.IsExist(err) {
-		return err
+	var targetInitrdPath *safepath.Path
+	var targetKernelPath *safepath.Path
+
+	if kb.InitrdPath != "" {
+
+		if err := safepath.TouchAtNoFollow(targetDir, filepath.Base(kb.InitrdPath), 0655); err != nil && !os.IsExist(err) {
+			return err
+		}
+
+		targetInitrdPath, err = safepath.JoinNoFollow(targetDir, filepath.Base(kb.InitrdPath))
+		if err != nil {
+			return err
+		}
 	}
-	if err := safepath.TouchAtNoFollow(targetDir, filepath.Base(kb.KernelPath), 0655); err != nil && !os.IsExist(err) {
-		return err
-	}
-	targetInitrdPath, err := safepath.JoinNoFollow(targetDir, filepath.Base(kb.InitrdPath))
-	if err != nil {
-		return err
-	}
-	targetKernelPath, err := safepath.JoinNoFollow(targetDir, filepath.Base(kb.KernelPath))
-	if err != nil {
-		return err
+
+	if kb.KernelPath != "" {
+		if err := safepath.TouchAtNoFollow(targetDir, filepath.Base(kb.KernelPath), 0655); err != nil && !os.IsExist(err) {
+			return err
+		}
+
+		targetKernelPath, err = safepath.JoinNoFollow(targetDir, filepath.Base(kb.KernelPath))
+		if err != nil {
+			return err
+		}
 	}
 
 	areKernelArtifactsMounted := func(artifactsDir *safepath.Path, artifactFiles ...*safepath.Path) (bool, error) {

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -448,7 +448,6 @@ func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 	var targetKernelPath *safepath.Path
 
 	if kb.InitrdPath != "" {
-
 		if err := safepath.TouchAtNoFollow(targetDir, filepath.Base(kb.InitrdPath), 0655); err != nil && !os.IsExist(err) {
 			return err
 		}
@@ -510,12 +509,18 @@ func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 			return nil
 		}
 
-		if err = mount(kb.InitrdPath, targetInitrdPath); err != nil {
-			return err
+		if kb.InitrdPath != "" {
+			if err = mount(kb.InitrdPath, targetInitrdPath); err != nil {
+				return err
+			}
 		}
-		if err = mount(kb.KernelPath, targetKernelPath); err != nil {
-			return err
+
+		if kb.KernelPath != "" {
+			if err = mount(kb.KernelPath, targetKernelPath); err != nil {
+				return err
+			}
 		}
+
 	}
 
 	if verify {

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -101,9 +101,11 @@ func IsMounted(mountPoint *safepath.Path) (isMounted bool, err error) {
 // If error occurs, the first error is returned.
 func (r *RealIsolationResult) AreMounted(mountPoints ...*safepath.Path) (isMounted bool, err error) {
 	for _, mountPoint := range mountPoints {
-		isMounted, err = IsMounted(mountPoint)
-		if !isMounted || err != nil {
-			return
+		if mountPoint != nil {
+			isMounted, err = IsMounted(mountPoint)
+			if !isMounted || err != nil {
+				return
+			}
 		}
 	}
 

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libvmi"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR aims to resolve an issue that was discovered involving booting from external source functionality. Currently, Kubevirt provides the ability for the user to specify options for booting directly from a kernel/initrd as part of the VM spec. An issue was identified in which scenarios where the user opts to boot from a kernel (`kernelPath` argument provided) but does not have a need to specify a path for initrd, the verification of kernel artifact mount success will fail. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
fixes #8191

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
