### PR TITLE
Simplify template service

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -613,12 +613,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		}
 	}
 
-	readinessGates := []k8sv1.PodReadinessGate{
-		{
-			ConditionType: v1.VirtualMachineUnpaused,
-		},
-	}
-
 	hostName := dns.SanitizeHostname(vmi)
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -644,7 +638,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			ImagePullSecrets:              imagePullSecrets,
 			DNSConfig:                     vmi.Spec.DNSConfig,
 			DNSPolicy:                     vmi.Spec.DNSPolicy,
-			ReadinessGates:                readinessGates,
+			ReadinessGates:                readinessGates(),
 		},
 	}
 
@@ -1395,4 +1389,12 @@ func podLabels(vmi *v1.VirtualMachineInstance, hostName string) map[string]strin
 	labels[v1.CreatedByLabel] = string(vmi.UID)
 	labels[v1.VirtualMachineNameLabel] = hostName
 	return labels
+}
+
+func readinessGates() []k8sv1.PodReadinessGate {
+	return []k8sv1.PodReadinessGate{
+		{
+			ConditionType: v1.VirtualMachineUnpaused,
+		},
+	}
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -433,8 +433,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		nodeSelector[v1.CPUManager] = "true"
 	}
 
-	ovmfPath := t.clusterConfig.GetOVMFPath()
-
 	// Read requested hookSidecars from VMI meta
 	requestedHookSidecarList, err := hooks.UnmarshalHookSidecarList(vmi)
 	if err != nil {
@@ -459,7 +457,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			"--container-disk-dir", t.containerDiskDir,
 			"--grace-period-seconds", strconv.Itoa(int(gracePeriodSeconds)),
 			"--hook-sidecars", strconv.Itoa(len(requestedHookSidecarList)),
-			"--ovmf-path", ovmfPath,
+			"--ovmf-path", t.clusterConfig.GetOVMFPath(),
 		}
 		if nonRoot {
 			command = append(command, "--run-as-nonroot")

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -614,6 +614,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	hostName := dns.SanitizeHostname(vmi)
+	enableServiceLinks := false
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "virt-launcher-" + domain + "-",
@@ -639,6 +640,9 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			DNSConfig:                     vmi.Spec.DNSConfig,
 			DNSPolicy:                     vmi.Spec.DNSPolicy,
 			ReadinessGates:                readinessGates(),
+			EnableServiceLinks:            &enableServiceLinks,
+			SchedulerName:                 vmi.Spec.SchedulerName,
+			Tolerations:                   vmi.Spec.Tolerations,
 		},
 	}
 
@@ -671,13 +675,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	SetNodeAffinityForForbiddenFeaturePolicy(vmi, &pod)
-
-	pod.Spec.Tolerations = vmi.Spec.Tolerations
-
-	pod.Spec.SchedulerName = vmi.Spec.SchedulerName
-
-	enableServiceLinks := false
-	pod.Spec.EnableServiceLinks = &enableServiceLinks
 
 	serviceAccountName := serviceAccount(vmi.Spec.Volumes...)
 	if len(serviceAccountName) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This code simplifies the `templateService` `renderLaunchManifest` receiver function by doing two things:
- exports code into functions that will be called inline
- creates the `Pod.Spec` with as much info as possible, instead of initializing it with some, then update it with other

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
