### PR TITLE
add validation for vmi.spec.affinity

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -745,19 +745,19 @@ func (app *virtAPIApp) prepareCertManager() {
 func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers) {
 
 	http.HandleFunc(components.VMICreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMICreate(w, r, app.clusterConfig)
+		validating_webhook.ServeVMICreate(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig)
+		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers)
 	})
 	http.HandleFunc(components.VMIRSValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)
+		validating_webhook.ServeVMIRS(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.VMPoolValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMPool(w, r, app.clusterConfig)
+		validating_webhook.ServeVMPool(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.VMIPresetValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIPreset(w, r)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -470,15 +470,15 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		presentVolumeName := "present-vol"
 		missingVolumeName := "missing-vol"
 		vmi.Spec.Domain.Devices.Disks = []v1.Disk{
-			v1.Disk{
+			{
 				Name: presentVolumeName,
 			},
 		}
 		vmi.Spec.Volumes = []v1.Volume{
-			v1.Volume{
+			{
 				Name: presentVolumeName,
 			},
-			v1.Volume{
+			{
 				Name: missingVolumeName,
 			},
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		DescribeTable("it should allow", func(policy *v1.EvictionStrategy) {
 			vmi.Spec.EvictionStrategy = policy
-			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(resp).To(BeEmpty())
 		},
 			Entry("migration policy to be set to LiveMigrate", &policyMigrate),
@@ -177,14 +177,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should allow no eviction policy to be set", func() {
 			vmi.Spec.EvictionStrategy = nil
-			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(resp).To(BeEmpty())
 		})
 
 		It("should  not allow unknown eviction policies", func() {
 			policy := v1.EvictionStrategy("fantasy")
 			vmi.Spec.EvictionStrategy = &policy
-			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			resp := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(resp).To(HaveLen(1))
 			Expect(resp[0].Message).To(Equal("fake.evictionStrategy is set with an unrecognized option: fantasy"))
 		})
@@ -476,14 +476,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi.Spec.Domain.Machine = &v1.Machine{Type: "q35"}
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid machine type", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Machine = &v1.Machine{Type: "test"}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.domain.machine.type"))
@@ -494,14 +494,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Hostname = "test"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid hostname", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Hostname = "test+bad"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.hostname"))
@@ -511,14 +511,14 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Subdomain = "testsubdomain"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid subdomain name", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.Subdomain = "bad+domain"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.subdomain"))
 		})
@@ -538,7 +538,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject disk lists greater than max element length", func() {
@@ -551,7 +551,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			// if this is processed correctly, it should result in a single error
 			// If multiple causes occurred, then the spec was processed too far.
 			Expect(causes).To(HaveLen(1))
@@ -570,7 +570,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			// if this is processed correctly, it should result in a single error
 			// If multiple causes occurred, then the spec was processed too far.
 			Expect(causes).To(HaveLen(1))
@@ -583,7 +583,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk",
 			})
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].name"))
 		})
@@ -596,7 +596,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Name:  "audio-device",
 					Model: deviceName,
 				}
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(BeEmpty())
 			}
 		})
@@ -608,7 +608,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Model: "aNotSupportedDevice",
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.Sound"))
 		})
@@ -619,7 +619,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Sound = &v1.SoundDevice{
 				Model: supportedAudioDevice,
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.Sound"))
 		})
@@ -654,7 +654,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					ContainerDisk: testutils.NewFakeContainerDiskSource(),
 				},
 			})
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].name"))
 		})
@@ -671,7 +671,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			// missing volume and multiple targets set. should result in 2 causes
 			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].name"))
@@ -682,7 +682,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			func(input v1.Input, expectedErrors int, expectedErrorTypes []string, expectMessage string) {
 				vmi := api.NewMinimalVMI("testvmi")
 				vmi.Spec.Domain.Devices.Inputs = append(vmi.Spec.Domain.Devices.Inputs, input)
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(HaveLen(expectedErrors), fmt.Sprintf("Expect %d errors", expectedErrors))
 				for i, errorType := range expectedErrorTypes {
 					Expect(causes[i].Field).To(Equal(errorType), expectMessage)
@@ -738,7 +738,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("-200m"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.cpu"))
 		})
@@ -749,7 +749,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("-3"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.cpu"))
 		})
@@ -763,7 +763,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("500m"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.cpu"))
 		})
@@ -777,7 +777,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU: resource.MustParse("2"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -788,7 +788,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("-64Mi"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
@@ -799,7 +799,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("64m"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
@@ -810,7 +810,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("-65Mi"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.memory"))
 		})
@@ -824,7 +824,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
@@ -838,7 +838,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceMemory: resource.MustParse("65Mi"),
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject incorrect hugepages size format", func() {
@@ -850,7 +850,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{}}
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2ab"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.hugepages.size"))
 		})
@@ -863,7 +863,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{}}
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "1Gi"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
@@ -876,7 +876,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject bigger guest memory than the memory limit", func() {
@@ -888,7 +888,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
 		})
@@ -904,7 +904,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should allow setting guest memory when no limit is set", func() {
@@ -916,7 +916,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject not divisable by hugepages.size requests.memory", func() {
@@ -928,7 +928,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{}}
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Gi"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
@@ -941,7 +941,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{}}
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject incorrect memory and hugepages size values", func() {
@@ -953,7 +953,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{}}
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "10Mi"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
@@ -974,7 +974,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		DescribeTable("should verify LUN is mapped to PVC volume",
@@ -988,7 +988,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				})
 				vmi.Spec.Volumes = append(vmi.Spec.Volumes, *volume)
 
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(HaveLen(expectedErrors))
 			},
 			Entry("and reject non PVC sources",
@@ -1011,7 +1011,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -1031,7 +1031,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					v1.Network{Name: networkName, NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{NetworkName: networkName}}})
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject interface lists greater than max element length", func() {
@@ -1044,7 +1044,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 						InterfaceBindingMethod: v1.InterfaceBindingMethod{
 							Bridge: &v1.InterfaceBridge{}}})
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.domain.devices.interfaces "+
 				"list exceeds the %d element limit in length", arrayLenMax)))
@@ -1058,7 +1058,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					v1.Network{Name: networkName, NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{NetworkName: networkName}}})
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.networks "+
 				"list exceeds the %d element limit in length", arrayLenMax)))
@@ -1078,7 +1078,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				{Name: "testvolume2", VolumeSource: v1.VolumeSource{
 					ContainerDisk: testutils.NewFakeContainerDiskSource()}}}...)
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].bootOrder"))
 			Expect(causes[0].Message).To(Equal("Boot order for " +
@@ -1091,7 +1091,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				*v1.DefaultBridgeNetworkInterface()}
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			// if this is processed correctly, it should result an error
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
@@ -1102,7 +1102,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				{Name: "default2", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 			vm.Spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
 				{Name: "default2", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			// if this is processed correctly, it should result an error only about duplicate pod network configuration
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
@@ -1115,7 +1115,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			for model := range validInterfaceModels {
 				vmi.Spec.Domain.Devices.Interfaces[0].Model = model
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				// if this is processed correctly, it should not result in any error
 				Expect(causes).To(BeEmpty())
 			}
@@ -1126,7 +1126,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmi.Spec.Domain.Devices.Interfaces[0].Model = "invalid_model"
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -1142,7 +1142,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 			Expect(causes[1].Field).To(Equal("fake.networks[0].name"))
@@ -1159,7 +1159,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[0].name"))
 		})
@@ -1181,7 +1181,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[1].name"))
 			Expect(causes[0].Message).To(Equal("Network with name \"default\" already exists, every network must have a unique name"))
@@ -1205,7 +1205,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 			Expect(causes[0].Message).To(Equal("Network interface name can only contain alphabetical characters, numbers, dashes (-) or underscores (_)"))
@@ -1228,7 +1228,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[1].name"))
 		})
@@ -1242,7 +1242,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should accept networks with a multus network source and bridge interface", func() {
@@ -1257,7 +1257,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject when multiple types defined for a CNI network", func() {
@@ -1273,7 +1273,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[0]"))
 		})
@@ -1308,7 +1308,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should allow single multus network with a multus default", func() {
@@ -1326,7 +1326,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject multiple multus networks with a multus default", func() {
@@ -1352,7 +1352,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.networks"))
@@ -1380,7 +1380,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.networks"))
@@ -1398,7 +1398,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.networks[0]"))
 		})
@@ -1419,7 +1419,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 		It("should accept networks with a pod network source and slirp interface", func() {
@@ -1438,7 +1438,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject networks with a passt interface and passt feature gate diabled", func() {
@@ -1457,7 +1457,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 		It("should reject networks with a multus network source and passt interface", func() {
@@ -1477,7 +1477,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 		It("should accept networks with a pod network source and passt interface", func() {
@@ -1496,7 +1496,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject vmis where passt is not a single interface", func() {
@@ -1527,7 +1527,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 		It("should accept networks with a pod network source and slirp interface with port", func() {
@@ -1547,7 +1547,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject networks with a pod network source and slirp interface without specific port", func() {
@@ -1567,7 +1567,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0]"))
 		})
@@ -1587,7 +1587,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 		})
@@ -1608,7 +1608,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal("The requested MAC address is reserved for the in-pod bridge. Please choose another one."))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].macAddress"))
@@ -1617,7 +1617,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm := api.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject a bridge interface on a pod network when it is not permitted", func() {
@@ -1625,7 +1625,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			disableBridgeOnPodNetwork()
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 		})
@@ -1644,7 +1644,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1), "unexpected number of errors")
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0].name"))
 		})
@@ -1665,7 +1665,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0].protocol"))
 		})
@@ -1686,7 +1686,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject a macvtap interface on a network different than multus", func() {
@@ -1706,7 +1706,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			enableFeatureGate(virtconfig.MacvtapGate)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 			Expect(causes[0].Message).To(Equal("Macvtap interface only implemented with Multus network"))
@@ -1727,7 +1727,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 			Expect(causes[0].Message).To(Equal("Macvtap feature gate is not enabled"))
@@ -1749,7 +1749,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 
 			enableFeatureGate(virtconfig.MacvtapGate)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject port out of range", func() {
@@ -1769,7 +1769,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0]"))
 		})
@@ -1790,7 +1790,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[1].name"))
 		})
@@ -1817,7 +1817,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(2))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
 			Expect(causes[1].Field).To(Equal("fake.domain.devices.interfaces[1].ports[0].name"))
@@ -1839,7 +1839,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject specs with multiple pod interfaces", func() {
@@ -1857,7 +1857,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vm.Spec.Networks = append(vm.Spec.Networks, *net)
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.interfaces"))
 		})
@@ -1868,7 +1868,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			for _, macAddress := range []string{"de:ad:00:00:be:af", "de-ad-00-00-be-af"} {
 				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress // missing octet
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				// if this is processed correctly, it should not result in any error
 				Expect(causes).To(BeEmpty())
 			}
@@ -1880,7 +1880,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			for _, macAddress := range []string{"de:ad:00:00:be", "de-ad-00-00-be", "de:ad:00:00:be:af:be:af"} {
 				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].macAddress"))
 			}
@@ -1891,7 +1891,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			for _, pciAddress := range []string{"0000:81:11.1", "0001:02:00.0"} {
 				vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				// if this is processed correctly, it should not result in any error
 				Expect(causes).To(BeEmpty())
 			}
@@ -1903,7 +1903,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			for _, pciAddress := range []string{"0000:80.10.1", "0000:80:80:1.0", "0000:80:11.15"} {
 				vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].pciAddress"))
 			}
@@ -1916,7 +1916,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].DHCPOptions = &v1.DHCPOptions{
 				NTPServers: []string{"127.0.0.1", "127.0.0.2"},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -1927,7 +1927,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].DHCPOptions = &v1.DHCPOptions{
 				NTPServers: []string{"::1", "hostname"},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(2))
 		})
 
@@ -1938,7 +1938,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].DHCPOptions = &v1.DHCPOptions{
 				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "extra.options.kubevirt.io"}},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -1949,7 +1949,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].DHCPOptions = &v1.DHCPOptions{
 				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 223, Value: "extra.options.kubevirt.io"}},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -1962,7 +1962,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					{Option: 240, Value: "extra.options.kubevirt.io"},
 					{Option: 240, Value: "sameextra.options.kubevirt.io"}},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -1975,7 +1975,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					{Option: 240, Value: "extra.options.kubevirt.io"},
 					{Option: 241, Value: "sameextra.options.kubevirt.io"}},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2004,7 +2004,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{nic}
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
 		})
@@ -2014,7 +2014,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
 			updateSpec(vmi)
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		},
 			Entry("should accept vmi with autoattached interfaces as the default", func(*v1.VirtualMachineInstance) {}),
@@ -2028,7 +2028,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{}
 			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("5")
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2036,7 +2036,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.Bool(false)
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2045,7 +2045,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			var ioThreadPolicy v1.IOThreadsPolicy
 			ioThreadPolicy = "auto"
 			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2054,7 +2054,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			var ioThreadPolicy v1.IOThreadsPolicy
 			ioThreadPolicy = "bad"
 			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("Invalid IOThreadsPolicy (%s)", ioThreadPolicy)))
 		})
@@ -2068,7 +2068,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.GPUs"))
 		})
@@ -2091,7 +2091,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.Filesystems"))
 		})
@@ -2116,7 +2116,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
@@ -2131,7 +2131,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					DeviceName: "example.org/deadbeef",
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should accept permitted GPU devices", func() {
@@ -2154,7 +2154,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					DeviceName: "example.org/deadbeef",
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject host devices when feature gate is disabled", func() {
@@ -2166,7 +2166,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.HostDevices"))
 		})
@@ -2189,7 +2189,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					DeviceName: "example.org/deadbeef1",
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should accept permitted host devices", func() {
@@ -2211,7 +2211,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					DeviceName: "example.org/deadbeef",
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		DescribeTable("Should accept valid DNSPolicy and DNSConfig",
@@ -2219,7 +2219,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi := api.NewMinimalVMI("testvmi")
 				vmi.Spec.DNSPolicy = dnsPolicy
 				vmi.Spec.DNSConfig = dnsConfig
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(BeEmpty())
 			},
 			Entry("with DNSPolicy ClusterFirstWithHostNet", k8sv1.DNSClusterFirstWithHostNet, &k8sv1.PodDNSConfig{}),
@@ -2242,7 +2242,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				vmi := api.NewMinimalVMI("testvmi")
 				vmi.Spec.DNSPolicy = dnsPolicy
 				vmi.Spec.DNSConfig = dnsConfig
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(HaveLen(causeCount))
 				for i := 0; i < causeCount; i++ {
 					Expect(causes[i].Message).To(Equal(causeMessage[i]))
@@ -2284,13 +2284,13 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			strategy := v1.StartStrategyPaused
 			vmi.Spec.StartStrategy = &strategy
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should allow no start strategy to be set", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 			vmi.Spec.StartStrategy = nil
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject invalid start strategy", func() {
@@ -2298,7 +2298,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			strategy := v1.StartStrategy("invalid")
 			vmi.Spec.StartStrategy = &strategy
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.startStrategy"))
@@ -2317,7 +2317,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
 			Expect(causes[0].Field).To(Equal("fake.startStrategy"))
@@ -2407,7 +2407,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			spec.Volumes = []v1.Volume{volume}
 			spec.Domain.Devices.Disks = []v1.Disk{disk}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 	})
@@ -2424,7 +2424,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "2Mi"}}
 			vmi.Spec.Domain.CPU.Cores = 4
 			vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.numa.guestMappingPassthrough"))
 			Expect(causes[0].Message).To(ContainSubstring("NUMA feature gate"))
@@ -2433,7 +2433,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}}
 			vmi.Spec.Domain.CPU.DedicatedCPUPlacement = false
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "2Mi"}}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.numa.guestMappingPassthrough"))
 		})
@@ -2445,7 +2445,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			}
 			vmi.Spec.Domain.CPU.DedicatedCPUPlacement = true
 			vmi.Spec.Domain.Memory = memory
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.numa.guestMappingPassthrough"))
 		},
@@ -2459,7 +2459,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
 				k8sv1.ResourceCPU: resource.MustParse("4"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 		It("should reject specs with more than two threads", func() {
@@ -2470,12 +2470,12 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
 				k8sv1.ResourceCPU: resource.MustParse("12"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("Not more than two threads must be provided at fake.domain.cpu.threads (got 3) when DedicatedCPUPlacement is true"))
 		})
 		It("should reject specs without cpu reqirements", func() {
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.dedicatedCpuPlacement"))
 		})
@@ -2485,7 +2485,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				DedicatedCPUPlacement: false,
 				IsolateEmulatorThread: true,
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.isolateEmulatorThread"))
 		})
@@ -2494,7 +2494,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
 				k8sv1.ResourceCPU: resource.MustParse("2"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.dedicatedCpuPlacement"))
 		})
@@ -2502,7 +2502,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
 				k8sv1.ResourceCPU: resource.MustParse("800m"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.cpu"))
 		})
@@ -2511,7 +2511,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU:    resource.MustParse("800m"),
 				k8sv1.ResourceMemory: resource.MustParse("8Mi"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.cpu"))
 		})
@@ -2524,7 +2524,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU:    resource.MustParse("2"),
 				k8sv1.ResourceMemory: resource.MustParse("8Mi"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.cpu.dedicatedCpuPlacement"))
 		})
@@ -2535,7 +2535,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
 				k8sv1.ResourceCPU: resource.MustParse("4"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.limits.memory"))
 		})
@@ -2548,7 +2548,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				k8sv1.ResourceCPU:    resource.MustParse("1"),
 				k8sv1.ResourceMemory: resource.MustParse("4Mi"),
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
@@ -2581,7 +2581,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2604,7 +2604,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2625,7 +2625,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -2656,7 +2656,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 		It("should reject a ssh access credential without a source", func() {
@@ -2680,7 +2680,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -2700,7 +2700,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -2715,7 +2715,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 
 			Expect(causes).To(HaveLen(1))
 		})
@@ -2743,7 +2743,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -2760,7 +2760,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 	})
@@ -2778,7 +2778,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			for policy := range validCPUFeaturePolicies {
 				vmi.Spec.Domain.CPU.Features[0].Policy = policy
-				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 				Expect(causes).To(BeEmpty())
 			}
 		})
@@ -2793,7 +2793,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					},
 				},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 	})
@@ -2930,7 +2930,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			})
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].cdrom.bus"))
 			Expect(causes[0].Message).To(Equal("Bus type virtio is invalid for CD-ROM device"))
@@ -3502,7 +3502,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Bootloader: nil,
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -3516,7 +3516,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -3535,7 +3535,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -3549,7 +3549,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -3565,7 +3565,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
@@ -3585,7 +3585,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 		})
 
@@ -3663,21 +3663,21 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		It("should reject the realtime knob without DedicatedCPUPlacement", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "2Mi"}}
 			vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{GuestMappingPassthrough: &v1.NUMAGuestMappingPassthrough{}}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).ToNot(BeEmpty())
 			Expect(causes).To(ContainElement(metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Field: "fake.domain.cpu.dedicatedCpuPlacement", Message: "fake.domain.cpu.dedicatedCpuPlacement must be set to true when fake.domain.cpu.realtime is used"}))
 		})
 		It("should reject the realtime knob when NUMA Guest Mapping Passthrough is not defined", func() {
 			vmi.Spec.Domain.CPU.DedicatedCPUPlacement = true
 			vmi.Spec.Domain.CPU.NUMA = &v1.NUMA{}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes).To(ContainElement(metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Field: "fake.domain.cpu.numa.guestMappingPassthrough", Message: "fake.domain.cpu.numa.guestMappingPassthrough must be defined when fake.domain.cpu.realtime is used"}))
 		})
 		It("should reject the realtime knob when NUMA is nil", func() {
 			vmi.Spec.Domain.CPU.DedicatedCPUPlacement = true
 			vmi.Spec.Domain.CPU.NUMA = nil
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes).To(ContainElement(metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Field: "fake.domain.cpu.numa.guestMappingPassthrough", Message: "fake.domain.cpu.numa.guestMappingPassthrough must be defined when fake.domain.cpu.realtime is used"}))
 		})
@@ -3702,28 +3702,28 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept when the feature gate is enabled and OVMF is configured", func() {
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(BeEmpty())
 		})
 
 		It("should reject when the feature gate is disabled", func() {
 			disableFeatureGates()
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", virtconfig.WorkloadEncryptionSEV)))
 		})
 
 		It("should reject when UEFI is not configured", func() {
 			vmi.Spec.Domain.Firmware.Bootloader.EFI = nil
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("SEV requires OVMF"))
 			vmi.Spec.Domain.Firmware.Bootloader = nil
-			causes = ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes = ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("SEV requires OVMF"))
 			vmi.Spec.Domain.Firmware = nil
-			causes = ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes = ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("SEV requires OVMF"))
 		})
@@ -3735,11 +3735,11 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.Bool(true)
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("SEV does not work along with SecureBoot"))
 			vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = nil
-			causes = ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes = ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("SEV does not work along with SecureBoot"))
 		})
@@ -3748,9 +3748,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			bootOrder := uint(1)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				v1.Interface{Name: vmi.Spec.Networks[0].Name, BootOrder: &bootOrder},
+				{Name: vmi.Spec.Networks[0].Name, BootOrder: &bootOrder},
 			}
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config, nil, "")
 			Expect(causes).To(HaveLen(len(vmi.Spec.Domain.Devices.Interfaces)))
 		})
 	})
@@ -3825,7 +3825,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		iface1 := v1.Interface{Name: net1.Name}
 		spec.Networks = []v1.Network{net1}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(HaveLen(1))
 	})
 	It("should reject when more than one network source is configured", func() {
@@ -3840,7 +3840,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		iface1 := v1.Interface{Name: net1.Name}
 		spec.Networks = []v1.Network{net1}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(HaveLen(1))
 	})
 	It("should work when boot order is given to interfaces", func() {
@@ -3855,7 +3855,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		iface := v1.Interface{Name: net.Name, BootOrder: &order}
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(BeEmpty())
 	})
 	It("should fail when invalid boot order is given to interface", func() {
@@ -3870,7 +3870,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		iface := v1.Interface{Name: net.Name, BootOrder: &order}
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Field).To(Equal("fake[0].bootOrder"))
 	})
@@ -3905,7 +3905,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 		spec.Volumes = []v1.Volume{volume}
 		spec.Domain.Devices.Disks = []v1.Disk{disk}
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(BeEmpty())
 	})
 	It("should fail when same boot order is given to more than one device", func() {
@@ -3937,7 +3937,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		}
 		spec.Volumes = []v1.Volume{volume}
 
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Field).To(ContainSubstring("bootOrder"))
 	})
@@ -3947,7 +3947,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
 
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Field).To(ContainSubstring("serial"))
 	})
@@ -3957,7 +3957,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
 
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Field).To(ContainSubstring("serial"))
 	})
@@ -3967,7 +3967,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
 
-		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config, nil, "")
 		Expect(causes).To(BeEmpty())
 	})
 

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -30,25 +30,24 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig})
+func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMICreateAdmitter(clusterConfig, client))
 }
 
-func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMIUpdateAdmitter{ClusterConfig: clusterConfig})
+func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMIUpdateAdmitter(clusterConfig, client))
 }
 
 func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
-
 	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers))
 }
 
-func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMIRSAdmitter{ClusterConfig: clusterConfig})
+func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMIRSAdmitter(clusterConfig, client))
 }
 
-func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMPoolAdmitter{ClusterConfig: clusterConfig})
+func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMPoolAdmitter(clusterConfig, client))
 }
 
 func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -181,13 +181,13 @@ func main() {
 
 	// Having no generics is lots of fun
 	for name, obj := range vms {
-		causes := validating_webhook.ValidateVirtualMachineSpec(k8sfield.NewPath("spec"), &obj.Spec, config, "user-account")
+		causes := validating_webhook.ValidateVirtualMachineSpec(k8sfield.NewPath("spec"), &obj.Spec, config, "user-account", nil, "")
 		handleCauses(causes, name, "vm")
 		handleError(dumpObject(name, *obj))
 	}
 
 	for name, obj := range vmis {
-		causes := validating_webhook.ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &obj.Spec, config)
+		causes := validating_webhook.ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &obj.Spec, config, nil, "")
 		handleCauses(causes, name, "vmi")
 		handleError(dumpObject(name, *obj))
 	}
@@ -205,7 +205,7 @@ func main() {
 	}
 
 	for name, obj := range vmireplicasets {
-		causes := validating_webhook.ValidateVMIRSSpec(k8sfield.NewPath("spec"), &obj.Spec, config)
+		causes := validating_webhook.ValidateVMIRSSpec(k8sfield.NewPath("spec"), &obj.Spec, config, nil, "")
 		handleCauses(causes, name, "vmi replica set")
 		handleError(dumpObject(name, *obj))
 	}
@@ -220,7 +220,7 @@ func main() {
 				Operation: admissionv1.Create,
 			},
 		}
-		causes := validating_webhook.ValidateVMPoolSpec(ar, k8sfield.NewPath("spec"), obj, config)
+		causes := validating_webhook.ValidateVMPoolSpec(ar, k8sfield.NewPath("spec"), obj, config, nil, "")
 		handleCauses(causes, name, "vm pool")
 		handleError(dumpObject(name, *obj))
 	}


### PR DESCRIPTION
Signed-off-by: Simon Yang <yang.chenjun@99cloud.net>


**What this PR does / why we need it**:
So far vmi validation webhook does not validate spec.affinity fo vmi template

**Which issue(s) this PR fixes**
Fixes #<https://github.com/kubevirt/kubevirt/issues/8100>

**Special notes for your reviewer**:

**Release note**:
```release-note
Support validation for spec.affinity of vmi template
```
