### PR TITLE
Update SMBios: assign KVM Virtual Machine to product

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -58,7 +58,7 @@ const (
 	DefaultPermitSlirpInterface                     = false
 	SmbiosConfigDefaultFamily                       = "KubeVirt"
 	SmbiosConfigDefaultManufacturer                 = "KubeVirt"
-	SmbiosConfigDefaultProduct                      = "None"
+	SmbiosConfigDefaultProduct                      = "KVM Virtual Machine"
 	DefaultPermitBridgeInterfaceOnPodNetwork        = true
 	DefaultSELinuxLauncherType                      = "virt_launcher.process"
 	SupportedGuestAgentVersions                     = "2.*,3.*,4.*,5.*"

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2728,7 +2728,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<entry name='family'>KubeVirt</entry>"))
-			Expect(domXml).To(ContainSubstring("<entry name='product'>None</entry>"))
+			Expect(domXml).To(ContainSubstring("<entry name='product'>KVM Virtual Machine</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
 
 			By("Expecting console")


### PR DESCRIPTION
The current product value for SMBios is None, but this causes problem
when using `systemd-ditect-virt` command to differentiate the current
virtualization environment on arm virtual machines. As this command
reads /sys/class/dmi/id/product_name to get the real value.

Considering kubevirt is currently technically based on KVM (but not
xen yet[1]), let's fix this by assigning 'KVM Virtual Machine'
to 'product'.

[1] https://groups.google.com/g/kubevirt-dev/c/C6cUgzTOsVg

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
