### PR TITLE
virt-freezer exit 0 if no guest agent

### DIFF
--- a/cmd/virt-freezer/main.go
+++ b/cmd/virt-freezer/main.go
@@ -82,11 +82,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Log.Infof("Guest agent version is %s", info.GAVersion)
 	if info.GAVersion == "" {
 		log.Log.Info("No guest agent, exiting")
 		os.Exit(0)
 	}
+
+	log.Log.Infof("Guest agent version is %s", info.GAVersion)
 
 	if *freeze {
 		err = client.FreezeVirtualMachine(vmi, *unfreezeTimeoutSeconds)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -750,7 +750,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			})
 
 			It("Calling Velero hooks should not error if no guest agent", func() {
-				const noGuestAgentString = "Guest agent not connected"
+				const noGuestAgentString = "No guest agent, exiting"
 				By("Creating VM")
 				var vmi *v1.VirtualMachineInstance
 				running := false


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, velero will consider backups partially failed if a VM does not contain a guest agent.  Not very user friendly, especially when you consider that always add the hook annotations to virt-launcher pods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7750

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
