### PR TITLE
multi queue: Fix VMI creation in case non virtio interface present and multi vCPU

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1192,7 +1192,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						PreferredLunBus:         v1.DiskBusSATA,
 						PreferredInputBus:       v1.InputBusVirtio,
 						PreferredInputType:      v1.InputTypeTablet,
-						PreferredInterfaceModel: "virtio",
+						PreferredInterfaceModel: v1.VirtIO,
 						PreferredSoundModel:     "ac97",
 						PreferredRng:            &v1.Rng{},
 						PreferredTPM:            &v1.TPMDevice{},

--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -62,7 +62,7 @@ func NewDomainWithMacvtapInterface(macvtapName string) *api.Domain {
 	domain.Spec.Devices.Interfaces = []api.Interface{{
 		Alias: api.NewUserDefinedAlias(macvtapName),
 		Model: &api.Model{
-			Type: "virtio",
+			Type: v1.VirtIO,
 		},
 		Type: "ethernet",
 	}}

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Pod Network", func() {
 			It("Should create an interface in the qemu command line, remove it from the interfaces and leave the other interfaces inplace", func() {
 				domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, api.Interface{
 					Model: &api.Model{
-						Type: "virtio",
+						Type: v1.VirtIO,
 					},
 					Type: "bridge",
 					Source: api.InterfaceSource{

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -15,6 +15,7 @@ import (
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 )
 
 type BridgePodNetworkConfigurator struct {
@@ -134,7 +135,9 @@ func (b *BridgePodNetworkConfigurator) PreparePodNetworkInterface() error {
 	if util.IsNonRootVMI(b.vmi) {
 		tapOwner = strconv.Itoa(util.NonRootUID)
 	}
-	err := createAndBindTapToBridge(b.handler, b.tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, tapOwner, b.vmi)
+
+	queues := converter.CalculateNetworkQueues(b.vmi, converter.GetInterfaceType(b.vmiSpecIface))
+	err := createAndBindTapToBridge(b.handler, b.tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, tapOwner, queues)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", b.tapDeviceName)
 		return err

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -25,10 +25,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
-	v1 "kubevirt.io/api/core/v1"
-
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 )
 
 type PodNetworkInfraConfigurator interface {
@@ -39,22 +36,10 @@ type PodNetworkInfraConfigurator interface {
 	GenerateNonRecoverableDHCPConfig() *cache.DHCPConfig
 }
 
-func createAndBindTapToBridge(handler netdriver.NetworkHandler, deviceName string, bridgeIfaceName string, launcherPID int, mtu int, tapOwner string, vmi *v1.VirtualMachineInstance) error {
-	err := handler.CreateTapDevice(deviceName, calculateNetworkQueues(vmi), launcherPID, mtu, tapOwner)
+func createAndBindTapToBridge(handler netdriver.NetworkHandler, deviceName string, bridgeIfaceName string, launcherPID int, mtu int, tapOwner string, queues uint32) error {
+	err := handler.CreateTapDevice(deviceName, queues, launcherPID, mtu, tapOwner)
 	if err != nil {
 		return err
 	}
 	return handler.BindTapDeviceToBridge(deviceName, bridgeIfaceName)
-}
-
-func calculateNetworkQueues(vmi *v1.VirtualMachineInstance) uint32 {
-	if isMultiqueue(vmi) {
-		return converter.CalculateNetworkQueues(vmi)
-	}
-	return 0
-}
-
-func isMultiqueue(vmi *v1.VirtualMachineInstance) bool {
-	return (vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue != nil) &&
-		(*vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue)
 }

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -19,6 +19,7 @@ import (
 	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 )
 
 const (
@@ -124,7 +125,9 @@ func (b *MasqueradePodNetworkConfigurator) PreparePodNetworkInterface() error {
 		tapOwner = strconv.Itoa(util.NonRootUID)
 	}
 	tapDeviceName := virtnetlink.GenerateTapDeviceName(b.podNicLink.Attrs().Name)
-	err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, tapOwner, b.vmi)
+
+	queues := converter.CalculateNetworkQueues(b.vmi, converter.GetInterfaceType(b.vmiSpecIface))
+	err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, tapOwner, queues)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -42,7 +42,7 @@ func NewDomainWithBridgeInterface() *api.Domain {
 	domain := &api.Domain{}
 	domain.Spec.Devices.Interfaces = []api.Interface{{
 		Model: &api.Model{
-			Type: "virtio",
+			Type: v1.VirtIO,
 		},
 		Type: "bridge",
 		Source: api.InterfaceSource{

--- a/pkg/testutils/domain.go
+++ b/pkg/testutils/domain.go
@@ -24,7 +24,7 @@ func ExpectVirtioTransitionalOnly(dom *api.DomainSpec) {
 
 	hit = false
 	for _, ifc := range dom.Devices.Interfaces {
-		if strings.HasPrefix(ifc.Model.Type, "virtio") {
+		if strings.HasPrefix(ifc.Model.Type, v1.VirtIO) {
 			ExpectWithOffset(1, ifc.Model.Type).To(Equal(virtioTrans))
 			hit = true
 		}
@@ -33,9 +33,9 @@ func ExpectVirtioTransitionalOnly(dom *api.DomainSpec) {
 
 	hit = false
 	for _, input := range dom.Devices.Inputs {
-		if strings.HasPrefix(input.Model, "virtio") {
+		if strings.HasPrefix(input.Model, v1.VirtIO) {
 			// All our input types only exist only as virtio 1.0 and only accept virtio
-			ExpectWithOffset(1, input.Model).To(Equal("virtio"))
+			ExpectWithOffset(1, input.Model).To(Equal(v1.VirtIO))
 			hit = true
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -107,7 +107,7 @@ func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Model == "" || iface.Model == "virtio" {
+		if iface.Model == "" || iface.Model == v1.VirtIO {
 			return true
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -64,7 +64,7 @@ const (
 	maxDNSSearchListChars = 256
 )
 
-var validInterfaceModels = map[string]*struct{}{"e1000": nil, "e1000e": nil, "ne2k_pci": nil, "pcnet": nil, "rtl8139": nil, "virtio": nil}
+var validInterfaceModels = map[string]*struct{}{"e1000": nil, "e1000e": nil, "ne2k_pci": nil, "pcnet": nil, "rtl8139": nil, v1.VirtIO: nil}
 var validIOThreadsPolicies = []v1.IOThreadsPolicy{v1.IOThreadsPolicyShared, v1.IOThreadsPolicyAuto}
 var validCPUFeaturePolicies = map[string]*struct{}{"": nil, "force": nil, "require": nil, "optional": nil, "disable": nil, "forbid": nil}
 

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -26,6 +26,8 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var exampleXMLwithNoneMemballoon string
@@ -333,7 +335,7 @@ var _ = ginkgo.Describe("Schema", func() {
 		exampleDomain.Spec.Devices.Inputs = []Input{
 			{
 				Type:  "tablet",
-				Bus:   "virtio",
+				Bus:   v1.VirtIO,
 				Alias: NewUserDefinedAlias("tablet0"),
 			},
 		}
@@ -352,7 +354,7 @@ var _ = ginkgo.Describe("Schema", func() {
 			Alias:  NewUserDefinedAlias("mywatchdog"),
 		}
 		exampleDomain.Spec.Devices.Rng = &Rng{
-			Model:   "virtio",
+			Model:   v1.VirtIO,
 			Backend: &RngBackend{Source: "/dev/urandom", Model: "random"},
 		}
 		exampleDomain.Spec.Devices.Controllers = []Controller{
@@ -403,7 +405,7 @@ var _ = ginkgo.Describe("Schema", func() {
 		exampleDomain.Spec.Metadata.KubeVirt.GracePeriod = &GracePeriodMetadata{}
 		exampleDomain.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds = 5
 		exampleDomain.Spec.IOThreads = &IOThreads{IOThreads: 2}
-		exampleDomain.Spec.Devices.Ballooning = &MemBalloon{Model: "virtio", Stats: &Stats{Period: 10}}
+		exampleDomain.Spec.Devices.Ballooning = &MemBalloon{Model: v1.VirtIO, Stats: &Stats{Period: 10}}
 		exampleDomainWithMemballonDevice = exampleDomain.DeepCopy()
 		exampleDomainWithMemballonDevice.Spec.Devices.Ballooning = &MemBalloon{Model: "none"}
 	})

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -169,7 +169,7 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 			disk.Address = addr
 		}
 		if diskDevice.Disk.Bus == v1.DiskBusVirtio {
-			disk.Model = translateModel(c, "virtio")
+			disk.Model = translateModel(c, v1.VirtIO)
 		}
 		disk.ReadOnly = toApiReadOnly(diskDevice.Disk.ReadOnly)
 		disk.Serial = diskDevice.Serial
@@ -564,7 +564,7 @@ func Add_Agent_To_api_Channel() (channel api.Channel) {
 	channel.Source = nil
 	channel.Target = &api.ChannelTarget{
 		Name: "org.qemu.guest_agent.0",
-		Type: "virtio",
+		Type: v1.VirtIO,
 	}
 
 	return
@@ -807,7 +807,7 @@ func Convert_v1_DownwardMetricSource_To_api_Disk(disk *api.Disk, c *ConverterCon
 		Name: "qemu",
 	}
 	// This disk always needs `virtio`. Validation ensures that bus is unset or is already virtio
-	disk.Model = translateModel(c, "virtio")
+	disk.Model = translateModel(c, v1.VirtIO)
 	disk.Source = api.DiskSource{
 		File: config.DownwardMetricDisk,
 	}
@@ -895,7 +895,7 @@ func Convert_v1_Watchdog_To_api_Watchdog(source *v1.Watchdog, watchdog *api.Watc
 func Convert_v1_Rng_To_api_Rng(_ *v1.Rng, rng *api.Rng, c *ConverterContext) error {
 
 	// default rng model for KVM/QEMU virtualization
-	rng.Model = translateModel(c, "virtio")
+	rng.Model = translateModel(c, v1.VirtIO)
 
 	// default backend model, random
 	rng.Backend = &api.RngBackend{
@@ -982,7 +982,7 @@ func Convert_v1_Input_To_api_InputDevice(input *v1.Input, inputDevice *api.Input
 	inputDevice.Alias = api.NewUserDefinedAlias(input.Name)
 
 	if input.Bus == v1.InputBusVirtio {
-		inputDevice.Model = "virtio"
+		inputDevice.Model = v1.VirtIO
 	}
 	return nil
 }
@@ -1131,7 +1131,7 @@ func ConvertV1ToAPIBalloning(source *v1.Devices, ballooning *api.MemBalloon, c *
 		ballooning.Model = "none"
 		ballooning.Stats = nil
 	} else {
-		ballooning.Model = translateModel(c, "virtio")
+		ballooning.Model = translateModel(c, v1.VirtIO)
 		if c.MemBalloonStatsPeriod != 0 {
 			ballooning.Stats = &api.Stats{Period: c.MemBalloonStatsPeriod}
 		}
@@ -1616,7 +1616,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		scsiController := api.Controller{
 			Type:   "scsi",
 			Index:  "0",
-			Model:  translateModel(c, "virtio"),
+			Model:  translateModel(c, v1.VirtIO),
 			Driver: controllerDriver,
 		}
 		if useIOThreads {
@@ -1704,7 +1704,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
 			Type:   "virtio-serial",
 			Index:  "0",
-			Model:  translateModel(c, "virtio"),
+			Model:  translateModel(c, v1.VirtIO),
 			Driver: controllerDriver,
 		})
 
@@ -1743,7 +1743,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			domain.Spec.Devices.Video = []api.Video{
 				{
 					Model: api.VideoModel{
-						Type:  "virtio",
+						Type:  v1.VirtIO,
 						Heads: &heads,
 					},
 				},
@@ -1931,7 +1931,7 @@ func newDeviceNamer(volumeStatuses []v1.VolumeStatus, disks []v1.Disk) map[strin
 
 func translateModel(ctx *ConverterContext, bus string) string {
 	switch bus {
-	case "virtio":
+	case v1.VirtIO:
 		if ctx.UseVirtioTransitional {
 			return "virtio-transitional"
 		} else {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Converter", func() {
 			v1Disk := v1.Disk{
 				Name: "myvolume",
 				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{Bus: "virtio"},
+					Disk: &v1.DiskTarget{Bus: v1.VirtIO},
 				},
 			}
 			apiDisk := api.Disk{}
@@ -145,7 +145,7 @@ var _ = Describe("Converter", func() {
 				BootOrder: &order,
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.VirtIO,
 					},
 				},
 			}
@@ -191,7 +191,7 @@ var _ = Describe("Converter", func() {
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.VirtIO,
 					},
 				},
 			}
@@ -231,7 +231,7 @@ var _ = Describe("Converter", func() {
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.VirtIO,
 					},
 				},
 				Shareable: True(),
@@ -326,7 +326,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.DisableHotplug = true
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 				{
-					Bus:  "virtio",
+					Bus:  v1.VirtIO,
 					Type: "tablet",
 					Name: "tablet0",
 				},
@@ -336,7 +336,7 @@ var _ = Describe("Converter", func() {
 					Name: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.VirtIO,
 						},
 					},
 					DedicatedIOThread: True(),
@@ -345,7 +345,7 @@ var _ = Describe("Converter", func() {
 					Name: "nocloud",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.VirtIO,
 						},
 					},
 					DedicatedIOThread: True(),
@@ -2351,7 +2351,7 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Graphics).To(HaveLen(devices))
 
 			if isARM64(arch) && (autoAttach == nil || *autoAttach) {
-				Expect(domain.Spec.Devices.Video[0].Model.Type).To(Equal("virtio"))
+				Expect(domain.Spec.Devices.Video[0].Model.Type).To(Equal(v1.VirtIO))
 				Expect(domain.Spec.Devices.Inputs[0].Type).To(Equal(v1.InputTypeTablet))
 				Expect(domain.Spec.Devices.Inputs[1].Type).To(Equal(v1.InputTypeKeyboard))
 			}
@@ -2481,7 +2481,7 @@ var _ = Describe("Converter", func() {
 									Name: "dedicated",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 									DedicatedIOThread: True(),
@@ -2490,7 +2490,7 @@ var _ = Describe("Converter", func() {
 									Name: "shared",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 									DedicatedIOThread: False(),
@@ -2499,7 +2499,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted1",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 								},
@@ -2507,7 +2507,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted2",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 								},
@@ -2515,7 +2515,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted3",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 								},
@@ -2523,7 +2523,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted4",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 								},
@@ -2531,7 +2531,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted5",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.VirtIO,
 										},
 									},
 								},
@@ -2651,7 +2651,7 @@ var _ = Describe("Converter", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.VirtIO,
 						},
 					},
 				},
@@ -2681,7 +2681,7 @@ var _ = Describe("Converter", func() {
 
 			v1Disk := v1.Disk{
 				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{Bus: "virtio"},
+					Disk: &v1.DiskTarget{Bus: v1.VirtIO},
 				},
 			}
 			apiDisk := api.Disk{}
@@ -3335,23 +3335,23 @@ var _ = Describe("disk device naming", func() {
 
 	It("makeDeviceName should generate proper name", func() {
 		prefixMap := make(map[string]deviceNamer)
-		res, index := makeDeviceName("test1", "virtio", prefixMap)
+		res, index := makeDeviceName("test1", v1.VirtIO, prefixMap)
 		Expect(res).To(Equal("vda"))
 		Expect(index).To(Equal(0))
 		for i := 2; i < 10; i++ {
-			makeDeviceName(fmt.Sprintf("test%d", i), "virtio", prefixMap)
+			makeDeviceName(fmt.Sprintf("test%d", i), v1.VirtIO, prefixMap)
 		}
-		prefix := getPrefixFromBus("virtio")
+		prefix := getPrefixFromBus(v1.VirtIO)
 		delete(prefixMap[prefix].usedDeviceMap, "vdd")
 		By("Verifying next value is vdd")
-		res, index = makeDeviceName("something", "virtio", prefixMap)
+		res, index = makeDeviceName("something", v1.VirtIO, prefixMap)
 		Expect(index).To(Equal(3))
 		Expect(res).To(Equal("vdd"))
-		res, index = makeDeviceName("something_else", "virtio", prefixMap)
+		res, index = makeDeviceName("something_else", v1.VirtIO, prefixMap)
 		Expect(res).To(Equal("vdj"))
 		Expect(index).To(Equal(9))
 		By("verifying existing returns correct value")
-		res, index = makeDeviceName("something", "virtio", prefixMap)
+		res, index = makeDeviceName("something", v1.VirtIO, prefixMap)
 		Expect(res).To(Equal("vdd"))
 		Expect(index).To(Equal(3))
 		By("Verifying a new bus returns from start")

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -65,7 +65,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 
 		// if AllowEmulation unset and at least one NIC model is virtio,
 		// /dev/vhost-net must be present as we should have asked for it.
-		if ifaceType == "virtio" && virtioNetProhibited {
+		if ifaceType == v1.VirtIO && virtioNetProhibited {
 			return nil, fmt.Errorf("In-kernel virtio-net device emulation '/dev/vhost-net' not present")
 		}
 
@@ -124,7 +124,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 		if c.UseLaunchSecurity {
 			// It's necessary to disable the iPXE option ROM as iPXE is not aware of SEV
 			domainIface.Rom = &api.Rom{Enabled: "no"}
-			if ifaceType == "virtio" {
+			if ifaceType == v1.VirtIO {
 				if domainIface.Driver != nil {
 					domainIface.Driver.IOMMU = "on"
 				} else {
@@ -150,7 +150,7 @@ func GetInterfaceType(iface *v1.Interface) string {
 	if iface.Model != "" {
 		return iface.Model
 	}
-	return "virtio"
+	return v1.VirtIO
 }
 
 func validateNetworksTypes(networks []v1.Network) error {
@@ -198,7 +198,7 @@ func createSlirpNetwork(iface v1.Interface, network v1.Network, domain *api.Doma
 }
 
 func CalculateNetworkQueues(vmi *v1.VirtualMachineInstance, ifaceType string) uint32 {
-	if !isTrue(vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue) || ifaceType != "virtio" {
+	if !isTrue(vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue) || ifaceType != v1.VirtIO {
 		return 0
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -55,7 +55,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 			continue
 		}
 
-		ifaceType := getInterfaceType(&vmi.Spec.Domain.Devices.Interfaces[i])
+		ifaceType := GetInterfaceType(&vmi.Spec.Domain.Devices.Interfaces[i])
 		domainIface := api.Interface{
 			Model: &api.Model{
 				Type: translateModel(c, ifaceType),
@@ -65,14 +65,11 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 
 		// if AllowEmulation unset and at least one NIC model is virtio,
 		// /dev/vhost-net must be present as we should have asked for it.
-		var virtioNetMQRequested bool
-		if mq := vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue; mq != nil {
-			virtioNetMQRequested = *mq
-		}
 		if ifaceType == "virtio" && virtioNetProhibited {
 			return nil, fmt.Errorf("In-kernel virtio-net device emulation '/dev/vhost-net' not present")
-		} else if ifaceType == "virtio" && virtioNetMQRequested {
-			queueCount := uint(CalculateNetworkQueues(vmi))
+		}
+
+		if queueCount := uint(CalculateNetworkQueues(vmi, ifaceType)); queueCount != 0 {
 			domainIface.Driver = &api.InterfaceDriver{Name: "vhost", Queues: &queueCount}
 		}
 
@@ -141,7 +138,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 	return domainInterfaces, nil
 }
 
-func getInterfaceType(iface *v1.Interface) string {
+func GetInterfaceType(iface *v1.Interface) string {
 	if iface.Slirp != nil {
 		// Slirp configuration works only with e1000 or rtl8139
 		if iface.Model != "e1000" && iface.Model != "rtl8139" {
@@ -200,7 +197,11 @@ func createSlirpNetwork(iface v1.Interface, network v1.Network, domain *api.Doma
 	return nil
 }
 
-func CalculateNetworkQueues(vmi *v1.VirtualMachineInstance) uint32 {
+func CalculateNetworkQueues(vmi *v1.VirtualMachineInstance, ifaceType string) uint32 {
+	if !isTrue(vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue) || ifaceType != "virtio" {
+		return 0
+	}
+
 	cpuTopology := vcpu.GetCPUTopology(vmi)
 	queueNumber := vcpu.CalculateRequestedVCPUs(cpuTopology)
 
@@ -209,6 +210,10 @@ func CalculateNetworkQueues(vmi *v1.VirtualMachineInstance) uint32 {
 		queueNumber = multiQueueMaxQueues
 	}
 	return queueNumber
+}
+
+func isTrue(networkInterfaceMultiQueue *bool) bool {
+	return (networkInterfaceMultiQueue != nil) && (*networkInterfaceMultiQueue)
 }
 
 func configPortForward(qemuArg *api.Arg, iface v1.Interface) error {

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -45,7 +45,7 @@ func PlacePCIDevicesOnRootComplex(spec *api.DomainSpec) (err error) {
 		}
 	}
 	for i, input := range spec.Devices.Inputs {
-		if input.Bus != "virtio" {
+		if input.Bus != v1.VirtIO {
 			continue
 		}
 		spec.Devices.Inputs[i].Address, err = assigner.PlacePCIDeviceAtNextSlot(input.Address)

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -628,7 +628,7 @@ type DiskBus string
 const (
 	DiskBusSCSI   DiskBus = "scsi"
 	DiskBusSATA   DiskBus = "sata"
-	DiskBusVirtio DiskBus = "virtio"
+	DiskBusVirtio DiskBus = VirtIO
 	DiskBusUSB    DiskBus = "usb"
 )
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -819,6 +819,8 @@ const (
 	// This label represents vendor of cpu model on the node
 	CPUModelVendorLabel = "cpu-vendor.node.kubevirt.io/"
 
+	VirtIO = "virtio"
+
 	// This label represents the host model CPU name
 	HostModelCPULabel = "host-model-cpu.node.kubevirt.io/"
 	// This label represents the host model required features

--- a/staging/src/kubevirt.io/client-go/api/schema_test.go
+++ b/staging/src/kubevirt.io/client-go/api/schema_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Schema", func() {
 				Name: "disk0",
 				DiskDevice: v12.DiskDevice{
 					Disk: &v12.DiskTarget{
-						Bus:      "virtio",
+						Bus:      v12.VirtIO,
 						ReadOnly: false,
 					},
 				},
@@ -261,7 +261,7 @@ var _ = Describe("Schema", func() {
 				Name: "cdrom0",
 				DiskDevice: v12.DiskDevice{
 					CDRom: &v12.CDRomTarget{
-						Bus:      "virtio",
+						Bus:      v12.VirtIO,
 						ReadOnly: pointer.BoolPtr(true),
 						Tray:     "open",
 					},
@@ -271,7 +271,7 @@ var _ = Describe("Schema", func() {
 				Name: "lun0",
 				DiskDevice: v12.DiskDevice{
 					LUN: &v12.LunTarget{
-						Bus:      "virtio",
+						Bus:      v12.VirtIO,
 						ReadOnly: true,
 					},
 				},
@@ -281,7 +281,7 @@ var _ = Describe("Schema", func() {
 				Serial: "sn-11223344",
 				DiskDevice: v12.DiskDevice{
 					Disk: &v12.DiskTarget{
-						Bus:      "virtio",
+						Bus:      v12.VirtIO,
 						ReadOnly: false,
 					},
 				},
@@ -291,7 +291,7 @@ var _ = Describe("Schema", func() {
 		exampleVMI.Spec.Domain.Devices.Rng = &v12.Rng{}
 		exampleVMI.Spec.Domain.Devices.Inputs = []v12.Input{
 			{
-				Bus:  "virtio",
+				Bus:  v12.VirtIO,
 				Type: "tablet",
 				Name: "tablet0",
 			},

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -726,7 +726,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			// TODO: introspect the VMI and get the device name of this
 			// block device?
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			tests.AppendEmptyDisk(vmi, "testdisk", "virtio", "1Gi")
+			tests.AppendEmptyDisk(vmi, "testdisk", v1.VirtIO, "1Gi")
 
 			if preferredNodeName != "" {
 				pinVMIOnNode(vmi, preferredNodeName)

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -386,7 +386,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			clusterPreference := newVirtualMachineClusterPreference()
 			clusterPreference.Spec.Devices = &instancetypev1alpha2.DevicePreferences{
-				PreferredInterfaceModel: "virtio",
+				PreferredInterfaceModel: v1.VirtIO,
 			}
 
 			clusterPreference, err := virtClient.VirtualMachineClusterPreference().

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1575,7 +1575,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// Start the VirtualMachineInstance with PVC and Ephemeral Disks
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				image := cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-				tests.AddEphemeralDisk(vmi, "myephemeral", "virtio", image)
+				tests.AddEphemeralDisk(vmi, "myephemeral", v1.VirtIO, image)
 
 				By("Starting the VirtualMachineInstance")
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -116,7 +116,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
 				libvmi.WithRng(),
 			)
-			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -135,7 +135,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	Context("when requesting virtio-transitional models", func() {
 		It("[test_id:6957]should start and run the guest", func() {
 			vmi := libvmi.NewCirros(libvmi.WithRng())
-			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.BoolPtr(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
@@ -857,7 +857,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					{
 						Name: "tablet0",
 						Type: "keyboard",
-						Bus:  "virtio",
+						Bus:  v1.VirtIO,
 					},
 				}
 				By("Starting a VirtualMachineInstance")
@@ -885,7 +885,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					{
 						Name: "tablet0",
 						Type: "tablet",
-						Bus:  "virtio",
+						Bus:  v1.VirtIO,
 					},
 				}
 				By("Starting a VirtualMachineInstance")

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -83,7 +83,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			By("Checking QueueCount has the expected value")
 			Expect(vmi.Status.Interfaces[0].QueueCount).To(Equal(expectedQueueCount))
 		},
-			Entry("[test_id:4599] with default virtio interface", "virtio", numCpus),
+			Entry("[test_id:4599] with default virtio interface", v1.VirtIO, numCpus),
 			Entry("with e1000 interface", "e1000", int32(1)),
 		)
 

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -55,23 +55,25 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 
 	Context("MultiQueue Behavior", func() {
 		var availableCPUs int
+		const numCpus int32 = 3
 
 		BeforeEach(func() {
 			availableCPUs = libnode.GetHighestCPUNumberAmongNodes(virtClient)
 		})
-		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", func() {
+
+		DescribeTable("should be able to successfully boot fedora to the login prompt with multi-queue without being blocked by selinux", func(interfaceModel string, expectedQueueCount int32) {
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
-			var numCpus int32 = 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
 			)
 			cpuReq := resource.MustParse(fmt.Sprintf("%d", numCpus))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = cpuReq
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = pointer.Bool(true)
-			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+
+			vmi.Spec.Domain.Devices.Interfaces[0].Model = interfaceModel
 
 			By("Creating and starting the VMI")
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			vmi = tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 
@@ -79,12 +81,14 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 			By("Checking QueueCount has the expected value")
-			Expect(vmi.Status.Interfaces[0].QueueCount).To(Equal(numCpus))
-		})
+			Expect(vmi.Status.Interfaces[0].QueueCount).To(Equal(expectedQueueCount))
+		},
+			Entry("[test_id:4599] with default virtio interface", "virtio", numCpus),
+			Entry("with e1000 interface", "e1000", int32(1)),
+		)
 
 		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			numCpus := 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
 			)
@@ -111,7 +115,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 
 			By("Verifying VMI")
 			newCpuReq := newVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU]
-			Expect(int(newCpuReq.Value())).To(Equal(numCpus))
+			Expect(int32(newCpuReq.Value())).To(Equal(numCpus))
 			Expect(*newVMI.Spec.Domain.Devices.BlockMultiQueue).To(BeTrue())
 
 			By("Fetching Domain XML from running pod")
@@ -122,7 +126,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 
 			By("Ensuring each disk has three queues assigned")
 			for _, disk := range domSpec.Devices.Disks {
-				Expect(int(*disk.Driver.Queues)).To(Equal(numCpus))
+				Expect(int32(*disk.Driver.Queues)).To(Equal(numCpus))
 			}
 		})
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -86,7 +86,7 @@ const (
 	VirtualMachineInstancetypeComputeSmall              = "csmall"
 	VirtualMachineClusterInstancetypeComputeSmall       = "cluster-csmall"
 	VirtualMachineInstancetypeComputeLarge              = "clarge"
-	VirtualMachinePreferenceVirtio                      = "virtio"
+	VirtualMachinePreferenceVirtio                      = v1.VirtIO
 	VirtualMachinePreferenceWindows                     = "windows"
 	VmCirrosInstancetypeComputeSmall                    = "vm-cirros-csmall"
 	VmCirrosClusterInstancetypeComputeSmall             = "vm-cirros-cluster-csmall"
@@ -121,7 +121,7 @@ const (
 const windowsFirmware = "5d307ca9-b3ef-428c-8861-06e72d69f223"
 const defaultInterfaceName = "default"
 const enableNetworkInterfaceMultiqueueForTemplate = true
-const EthernetAdaptorModelToEnableMultiqueue = "virtio"
+const EthernetAdaptorModelToEnableMultiqueue = v1.VirtIO
 
 const (
 	cloudConfigHeader = "#cloud-config"
@@ -1298,8 +1298,8 @@ func GetVirtualMachinePreferenceVirtio() *instancetypev1alpha2.VirtualMachinePre
 		},
 		Spec: instancetypev1alpha2.VirtualMachinePreferenceSpec{
 			Devices: &instancetypev1alpha2.DevicePreferences{
-				PreferredDiskBus:        "virtio",
-				PreferredInterfaceModel: "virtio",
+				PreferredDiskBus:        v1.VirtIO,
+				PreferredInterfaceModel: v1.VirtIO,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
In case the following happen together:
1. Multi queue is enabled
2. There is more than one vCPU
3. There is at least one non virtio interface,

the VMI would fail to be created with the following error:
`"LibvirtError(Code=38, Domain=0, Message='Unable to create tap device tap0: Invalid argument')"`

Multi queue is only implemented for virtio interfaces.
The tap device which is created, didn't take into account the
interface model when calculating the number of queues.
This caused the problem for non virtio interfaces.
Fix it by taking into account the interface model.

`vmi.Spec.Domain.Devices.Rng` is removed from the test because it
is already included in `libvmi.NewFedora` which is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Note: this is not a regression of https://github.com/kubevirt/kubevirt/pull/8071

We might want to introduce NAD lib in order to reuse code.

**Release note**:
```release-note
None
```
