### PR TITLE
virt-controller, vmi: Move VMI object modification out of status update

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -598,6 +598,11 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		return fmt.Errorf("unknown vmi phase %v", vmi.Status.Phase)
 	}
 
+	err = c.modifyVMIOnAPIServer(vmi, vmiCopy, syncErr, conditionManager)
+	return err
+}
+
+func (c *VMIController) modifyVMIOnAPIServer(vmi *virtv1.VirtualMachineInstance, vmiCopy *virtv1.VirtualMachineInstance, syncErr syncError, conditionManager *controller.VirtualMachineInstanceConditionManager) error {
 	// VMI is owned by virt-handler, so patch instead of update
 	if vmi.IsRunning() || vmi.IsScheduled() {
 		patchBytes, err := prepareVMIPatch(vmi, vmiCopy)
@@ -637,7 +642,6 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			return err
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The VMI controller reconciling execution has two steps which have been
separated by methods: sync and status-update.
The sync is suppose to mutate the VMI metadata and spec, while the
status-update is suppose to mutate the status section.

There is a 3rd step, where the VMI is being actually updated against the
API server. This step was part of the status-update, until this change.

Updating the VMI object on the API server is now placed at the same
level as the sync and status-update calls.
It should be now clearer what is done at each step.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
