### PR TITLE
Address some parallel testing complications that cause flakes

### DIFF
--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -288,7 +289,7 @@ func CreateHostPathPvWithSizeAndStorageClass(osName, hostPath, size, sc string) 
 
 	hostPathType := k8sv1.HostPathDirectoryOrCreate
 
-	name := fmt.Sprintf("%s-disk-for-tests", osName)
+	name := fmt.Sprintf("%s-disk-for-tests-%s", osName, rand.String(12))
 	pv := &k8sv1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", name, util.NamespaceTestDefault),

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -143,6 +143,8 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logNamespaces(virtCli)
 	r.logPVCs(virtCli)
 	r.logPVs(virtCli)
+	r.logStorageClasses(virtCli)
+	r.logCSIDrivers(virtCli)
 	r.logAPIServices(virtCli)
 	r.logServices(virtCli)
 	r.logEndpoints(virtCli)
@@ -660,6 +662,26 @@ func (r *KubernetesReporter) logPVs(virtCli kubecli.KubevirtClient) {
 	}
 
 	r.logObjects(virtCli, pvs, "pvs")
+}
+
+func (r *KubernetesReporter) logStorageClasses(virtCli kubecli.KubevirtClient) {
+	storageClasses, err := virtCli.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch storageclasses: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, storageClasses, "storageclasses")
+}
+
+func (r *KubernetesReporter) logCSIDrivers(virtCli kubecli.KubevirtClient) {
+	csiDrivers, err := virtCli.StorageV1().CSIDrivers().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch csidrivers: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, csiDrivers, "csidrivers")
 }
 
 func (r *KubernetesReporter) logPVCs(virtCli kubecli.KubevirtClient) {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -90,9 +90,9 @@ func TestTests(t *testing.T) {
 	RunSpecs(t, "Tests Suite")
 }
 
-var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite.BeforeTestSuitSetup)
+var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite.BeforeTestSuiteSetup)
 
-var _ = SynchronizedAfterSuite(testsuite.AfterTestSuitCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
+var _ = SynchronizedAfterSuite(testsuite.AfterTestSuiteCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
 
 var _ = AfterEach(func() {
 	tests.TestCleanup()

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -67,14 +67,11 @@ func SynchronizedAfterTestSuiteCleanup() {
 	libnode.CleanNodes()
 }
 
-func AfterTestSuitCleanup() {
+func AfterTestSuiteCleanup() {
 
 	cleanupServiceAccounts()
 	CleanNamespaces()
 
-	if flags.DeployTestingInfrastructureFlag {
-		WipeTestingInfrastructure()
-	}
 	removeNamespaces()
 }
 
@@ -98,7 +95,7 @@ func SynchronizedBeforeTestSetup() []byte {
 	return nil
 }
 
-func BeforeTestSuitSetup(_ []byte) {
+func BeforeTestSuiteSetup(_ []byte) {
 
 	worker := GinkgoParallelProcess()
 	rand.Seed(int64(worker))

--- a/tests/testsuite/manifest.go
+++ b/tests/testsuite/manifest.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -114,6 +115,7 @@ func DeleteRawManifest(object unstructured.Unstructured) error {
 	policy := metav1.DeletePropagationBackground
 	options := &metav1.DeleteOptions{PropagationPolicy: &policy}
 
+	log.DefaultLogger().Infof("Calling DELETE on testing manifest: %s", uri)
 	result := virtCli.CoreV1().RESTClient().Delete().RequestURI(uri).Body(options).Do(context.Background())
 	if err = result.Error(); err != nil && !k8serrors.IsNotFound(err) {
 		panic(fmt.Errorf("ERROR: Can not delete %s err: %#v %s\n", object.GetName(), err, object))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Add storage class/csidriver logging
- Avoid deleting test manifests on all ginkgo nodes
`SynchronizedAfterSuite` takes two function arguments. The first func runs on all nodes; the second runs only on parallel node 1,
and only after all other nodes have finished and exited.
We only want to delete manifests such as `disks-images-provider` in the second function we pass.
- Random PV name to avoid AlreadyExist in recreation
`TestCleanup()` is cleaning up PVs. A potential issue is that when we recreate PVs, we'll back off if they AlreadyExist;
Consider the following:
1. DELETE is called on alpine-host-path-disk-for-tests-ns1.
2. PV sticks around for a few extra seconds (Terminating phase)
3. CREATE attempt of alpine-host-path-disk-for-tests-ns1 results in AlreadyExists
4. We back out and continue as usual
5. PV is eventually deleted without being replaced with a new one, tests fail to bind PVCs to PVs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
