### PR TITLE
vmi_ignition_test: shorten and improve

### DIFF
--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -20,60 +20,35 @@
 package tests_test
 
 import (
-	"context"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]IgnitionData", func() {
 
-	var err error
-	var virtClient kubecli.KubevirtClient
-
-	var LaunchVMI func(*v1.VirtualMachineInstance)
-
 	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		util.PanicOnError(err)
-
 		if !checks.HasFeature("ExperimentalIgnitionSupport") {
 			Skip("ExperimentalIgnitionSupport feature gate is not enabled in kubevirt-config")
 		}
 	})
 
-	LaunchVMI = func(vmi *v1.VirtualMachineInstance) {
-		By("Starting a VirtualMachineInstance")
-		obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Waiting the VirtualMachineInstance start")
-		_, ok := obj.(*v1.VirtualMachineInstance)
-		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-		Expect(tests.WaitForSuccessfulVMIStart(obj).Status.NodeName).ToNot(BeEmpty())
-	}
-
 	Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		Context("with IgnitionData annotation", func() {
 			Context("with injected data", func() {
 				It("[test_id:1616]should have injected data under firmware directory", func() {
-					vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
-
 					ignitionData := "ignition injected"
-					vmi.Annotations = map[string]string{v1.IgnitionAnnotation: ignitionData}
-
-					LaunchVMI(vmi)
+					vmi := tests.RunVMIAndExpectLaunch(
+						libvmi.NewFedora(libvmi.WithAnnotation(v1.IgnitionAnnotation, ignitionData)),
+						240)
 
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -52,8 +52,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					Expect(console.LoginToFedora(vmi)).To(Succeed())
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-						&expect.BSnd{S: "ls /sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config\n"},
-						&expect.BExp{R: "raw"},
+						&expect.BSnd{S: "cat /sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw\n"},
+						&expect.BExp{R: ignitionData},
 					}, 300)).To(Succeed())
 				})
 			})

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -50,13 +50,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						libvmi.NewFedora(libvmi.WithAnnotation(v1.IgnitionAnnotation, ignitionData)),
 						240)
 
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-						&expect.BSnd{S: "\n"},
-						&expect.BExp{R: "login:"},
-						&expect.BSnd{S: "fedora\n"},
-						&expect.BExp{R: "Password:"},
-						&expect.BSnd{S: "fedora" + "\n"},
-						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: "ls /sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config\n"},
 						&expect.BExp{R: "raw"},
 					}, 300)).To(Succeed())


### PR DESCRIPTION
Make vmi_ignition_test shorter and clearer by using `libvmi` to define a VM and by reusing `RunVMIAndExpectLaunch` instead of re-implementing it.
Furthermore, have the test verify that the requested ignition data exists in `/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw`

```release-note
NONE
```
