### PR TITLE
console_test: drop unrelated tests and simplify others

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -34,7 +34,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -98,29 +97,6 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 						"Welcome to",
 					)
 				})
-			})
-
-			Context("with an alpine image", func() {
-				type vmiBuilder func() *v1.VirtualMachineInstance
-
-				newVirtualMachineInstanceWithAlpineFileDisk := func() *v1.VirtualMachineInstance {
-					vmi, _ := tests.NewRandomVirtualMachineInstanceWithFileDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					return vmi
-				}
-
-				newVirtualMachineInstanceWithAlpineBlockDisk := func() *v1.VirtualMachineInstance {
-					vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
-					return vmi
-				}
-
-				DescribeTable("should return that we are running alpine", func(createVMI vmiBuilder) {
-					vmi := createVMI()
-					vmi = tests.RunVMIAndExpectLaunch(vmi, 120)
-					expectConsoleOutput(vmi, "login")
-				},
-					Entry("[test_id:4637][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithAlpineFileDisk),
-					Entry("[test_id:4638][storage-req]with Block Disk", newVirtualMachineInstanceWithAlpineBlockDisk),
-				)
 			})
 
 			It("[test_id:1590]should be able to reconnect to console multiple times", func() {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -134,24 +134,18 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 			})
 
 			It("[test_id:1592]should wait until the virtual machine is in running state and return a stream interface", func() {
-				vmi := libvmi.NewAlpine()
-				By("Creating a new VirtualMachineInstance")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				vmi := tests.RunVMIAndExpectLaunch(libvmi.NewAlpine(), 240)
 
 				By("and connecting to it very quickly. Hopefully the VM is not yet up")
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
+				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("[test_id:1593]should not be connected if scheduled to non-existing host", func() {
 				vmi := libvmi.NewAlpine(withNodeAffinityTo("kubernetes.io/hostname", "nonexistent"))
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
-				By("Creating a new VirtualMachineInstance")
-				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
+				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
 			})


### PR DESCRIPTION
This is a follow-up to https://github.com/kubevirt/kubevirt/pull/7114/files#r797663204 ; I believe that now it is possible to drop the two remaining storage-related cases from the console test. console_test should test only console functionality, not storage's.

/cc @kbidarkar @brybacki 
/sig code-quality

```release-note
NONE
```
