### PR TITLE
Patching node set kubevirt.io/schedulable to false upon exiting heartbeat

### DIFF
--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -71,6 +71,22 @@ func (h *HeartBeat) heartBeat(heartBeatInterval time.Duration, stopCh chan struc
 	// 1 minute with a 1.2 jitter + the time it takes for the heartbeat function to run (sliding == true).
 	// So the amount of time between heartbeats randomly varies between 1min and 2min12sec + the heartbeat function execution time.
 	wait.JitterUntil(h.do, heartBeatInterval, 1.2, true, stopCh)
+	now, err := json.Marshal(metav1.Now())
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Can't determine date")
+		return
+	}
+	var data []byte
+	data = []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "%s", "%s": "%t"}, "annotations": {"%s": %s}}}`,
+		v1.NodeSchedulable, "false",
+		v1.CPUManager, false,
+		v1.VirtHandlerHeartbeat, string(now),
+	))
+	_, err = h.clientset.Nodes().Patch(context.Background(), h.host, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Can't patch node %s", h.host)
+		return
+	}
 }
 
 // waitForDevicePlugins gives the device plugins additional time to successfully connect to the kubelet.

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -51,6 +51,9 @@ func (h *HeartBeat) Run(heartBeatInterval time.Duration, stopCh chan struct{}) (
 	done = make(chan struct{})
 	go func() {
 		h.heartBeat(heartBeatInterval, stopCh)
+		//ensure that the node is getting marked as unschedulable when removed
+		labelNodeDone := h.labelNodeUnschedulable()
+		<-labelNodeDone
 		close(done)
 	}()
 	return done
@@ -71,9 +74,6 @@ func (h *HeartBeat) heartBeat(heartBeatInterval time.Duration, stopCh chan struc
 	// 1 minute with a 1.2 jitter + the time it takes for the heartbeat function to run (sliding == true).
 	// So the amount of time between heartbeats randomly varies between 1min and 2min12sec + the heartbeat function execution time.
 	wait.JitterUntil(h.do, heartBeatInterval, 1.2, true, stopCh)
-
-	//ensure that the node is getting marked as unschedulable when removed
-	h.labelNodeUnschedulable()
 }
 
 func (h *HeartBeat) labelNodeUnschedulable() (done chan struct{}) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1417,8 +1417,9 @@ func (c *VirtualMachineController) Run(threadiness int, stopCh chan struct{}) {
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}
-	<-heartBeatDone
+
 	<-stopCh
+	<-heartBeatDone
 	log.Log.Info("Stopping virt-handler controller.")
 }
 


### PR DESCRIPTION
Signed-off-by: prnaraya <prnaraya@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This aims to address an issue in which making master nodes schedulable and then unschedulable results in a mismatch between the daemonset state and the pods state, with the master nodes still showing up as schedulable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
