### PR TITLE
Kernelboot fix unmount

### DIFF
--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -614,5 +614,6 @@ func (m *mounter) legacyUnmountKernelArtifacts(vmi *v1.VirtualMachineInstance) e
 		return nil
 	}
 
-	return fmt.Errorf("kernel artifacts record wasn't found")
+	log.Log.Object(vmi).Info("Kernel artifacts record wasn't found for legacy unmount")
+	return nil
 }

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -401,12 +401,12 @@ func (m *mounter) ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitial
 func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bool) error {
 	const kernelBootName = containerdisk.KernelBootName
 
-	log.Log.Object(vmi).Infof("mounting kernel artifacts")
-
 	if !util.HasKernelBootContainerImage(vmi) {
-		log.Log.Object(vmi).Infof("kernel boot not defined - nothing to mount")
+		log.Log.Object(vmi).Info("kernel boot not defined - nothing to mount")
 		return nil
 	}
+
+	log.Log.Object(vmi).Info("mounting kernel artifacts")
 
 	kb := vmi.Spec.Domain.Firmware.KernelBoot.Container
 
@@ -543,8 +543,6 @@ func (m *mounter) unmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
 		return nil
 	}
 
-	log.DefaultLogger().Object(vmi).Infof("unmounting kernel artifacts")
-
 	kb := vmi.Spec.Domain.Firmware.KernelBoot.Container
 
 	record, err := m.getMountTargetRecord(vmi)
@@ -554,6 +552,8 @@ func (m *mounter) unmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
 		log.DefaultLogger().Object(vmi).Warning("Cannot find kernel-boot entries to unmount")
 		return nil
 	}
+
+	log.DefaultLogger().Object(vmi).Info("unmounting kernel artifacts")
 
 	unmount := func(targetDir *safepath.Path, artifactPaths ...string) error {
 		for _, artifactPath := range artifactPaths {

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -334,7 +334,7 @@ func (m *mounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 		return nil
 	}
 
-	err := m.unmountKernelArtifacts(vmi)
+	err := m.legacyUnmountKernelArtifacts(vmi)
 	if err != nil {
 		return fmt.Errorf("error unmounting kernel artifacts: %v", err)
 	}
@@ -544,7 +544,9 @@ func (m *mounter) mountKernelArtifacts(vmi *v1.VirtualMachineInstance, verify bo
 	return nil
 }
 
-func (m *mounter) unmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
+// Deprecated: Do not edit. Unmount of KernelArtifacts should be handled by generic container disk code.
+// This is kept here for compatibility with VMs started by older handlers
+func (m *mounter) legacyUnmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
 	if !util.HasKernelBootContainerImage(vmi) {
 		return nil
 	}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1833,7 +1833,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				Entry("with CD + CloudInit + SA + ConfigMap + Secret + DownwardAPI + Kernel Boot", func() *v1.VirtualMachineInstance {
 					return prepareVMIWithAllVolumeSources()
-				}, console.LoginToFedora),
+					//We need new login func for this case
+				}, func(*v1.VirtualMachineInstance) error { return nil }),
 
 				Entry("with PVC", func() *v1.VirtualMachineInstance {
 					dv = createDataVolumePVCAndChangeDiskImgPermissions(size)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -129,7 +129,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		return func(vmi *v1.VirtualMachineInstance) {
 			kernelBootFirmware := utils.GetVMIKernelBoot().Spec.Domain.Firmware
 			if vmiFirmware := vmi.Spec.Domain.Firmware; vmiFirmware == nil {
-				vmiFirmware = kernelBootFirmware
+				vmi.Spec.Domain.Firmware = kernelBootFirmware
 			} else {
 				vmiFirmware.KernelBoot = kernelBootFirmware.KernelBoot
 			}
@@ -3118,7 +3118,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			// check VMI, confirm migration state
 			tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
 
-			// delete VMI
+			// Keep this here! This can reproduce clean up issue where vmi will disappear from cache on source code before
+			// clean up happened
 			By("Deleting the VMI")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In some rare cases, it can happen that VMI will be removed from the cache before clean-up is called. In this case, it is necessary we are able to remove all mounts to let Pod properly terminate(and of course don't block Kubevirt functionality).
This PR reuse "generic" container disk logic for unmount of KernelBoot.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
An alternative solution to leaving the unmountKernelArtifacts function is to populate mounts on the startup of the handler. I don't see any advantage but stating it here for others.

I recommend reviewing commit by commit.

**Release note**:
```release-note
Bug fix: Properly clean up KernelBoot mounts
```
