### PR TITLE
Stop including all [storage-req] tests in lanes

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -394,16 +394,6 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
   else
     export KUBEVIRT_E2E_SKIP="Multus|SRIOV|GPU|Macvtap|MediatedDevices"
   fi
-
-  if ! [[ $TARGET =~ sig-storage ]]; then
-    if [[ "$KUBEVIRT_STORAGE" == "rook-ceph-default" ]]; then
-        if [[ -z $KUBEVIRT_E2E_FOCUS ]]; then
-          export KUBEVIRT_E2E_FOCUS="\\[storage-req\\]"
-        else
-          export KUBEVIRT_E2E_FOCUS="$KUBEVIRT_E2E_FOCUS|\\[storage-req\\]"
-        fi
-    fi
-  fi
 fi
 
 if [[ $KUBEVIRT_NONROOT =~ true ]]; then

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,9 @@ Additional suggestions:
  * The `[Disruptive]` tag is recognized by the test suite but is not yet
    mandatory. Feel free to set it on destructive tests.
  * Conformance tests need to be marked with a `[Conformance]` tag.
+ * We try to mark tests that require advanced/special storage capabilities with `[storage-req]`,  
+   So they are easy to skip when lanes with new storage solutions are introduced.  
+   At the point of writing this we use `rook-ceph-block` which certainly qualifies for running them.
 
 ## Test Namespaces
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1425,8 +1425,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Shutoff reason Destroyed","name":"%s"`, vmi.GetObjectMeta().GetName()), // Domain was destroyed because the launcher pod is gone
 				), "Logs should confirm pod deletion")
 			},
-				Entry("[test_id:1641]"+util.NamespaceTestDefault, &util.NamespaceTestDefault),
-				Entry("[test_id:1642]"+testsuite.NamespaceTestAlternative, &testsuite.NamespaceTestAlternative),
+				Entry("[test_id:1641]Default test namespace", &util.NamespaceTestDefault),
+				Entry("[test_id:1642]Alternative test namespace", &testsuite.NamespaceTestAlternative),
 			)
 		})
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Tests that require advanced/special storage capabilities are marked with `[storage-req]`;
Currently, [storage-req] tests from all SIGs are added to each lane that uses rook-ceph.
We might want to revisit that, as it does not make much sense for sig-migrations (for example)
to run sig-storage tests.
The sig-migrations tests which have [storage-req] will continue to run as these are a subset.

If and when we introduce other less "advanced" storage lanes
we could capitalize on [storage-req] to skip these.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
