### PR TITLE
Revert "Merge pull request #7986 from iholder-redhat/fix/MigrationFor…

### DIFF
--- a/pkg/virt-api/webhooks/hyperv.go
+++ b/pkg/virt-api/webhooks/hyperv.go
@@ -25,6 +25,7 @@ package webhooks
 
 import (
 	"fmt"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
@@ -178,20 +179,17 @@ func ValidateVirtualMachineInstanceHypervFeatureDependencies(field *k8sfield.Pat
 		}
 	}
 
-	if spec.Domain.Features == nil || spec.Domain.Features.Hyperv == nil || spec.Domain.Features.Hyperv.EVMCS == nil {
-		return causes
-	}
-
-	evmcsDependency := getEVMCSDependency()
-
-	if spec.Domain.CPU == nil || spec.Domain.CPU.Features == nil || len(spec.Domain.CPU.Features) == 0 {
-		causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Message: fmt.Sprintf("%s cpu feature is required when evmcs is set", evmcsDependency.Name), Field: "spec.domain.cpu.features"})
-		return causes
-	}
-
-	for i, existingFeature := range spec.Domain.CPU.Features {
-		if existingFeature.Name == evmcsDependency.Name && existingFeature.Policy != evmcsDependency.Policy {
-			causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueInvalid, Message: fmt.Sprintf("%s cpu feature has to be set to %s policy", evmcsDependency.Name, evmcsDependency.Policy), Field: fmt.Sprintf("spec.domain.cpu.features[%d].policy", i)})
+	if spec.Domain.Features != nil && spec.Domain.Features.Hyperv != nil && spec.Domain.Features.Hyperv.EVMCS != nil {
+		if spec.Domain.CPU == nil || spec.Domain.CPU.Features == nil || len(spec.Domain.CPU.Features) == 0 {
+			causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Message: "vmx cpu feature is required when evmcs is set", Field: "spec.domain.cpu.features"})
+		} else if spec.Domain.CPU != nil || spec.Domain.CPU.Features != nil {
+			for i, f := range spec.Domain.CPU.Features {
+				if f.Name == nodelabellerutil.VmxFeature {
+					if f.Policy != nodelabellerutil.RequirePolicy {
+						causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueInvalid, Message: "vmx cpu feature has to be set to " + nodelabellerutil.RequirePolicy + " policy", Field: "spec.domain.cpu.features[" + strconv.Itoa(i) + "].policy"})
+					}
+				}
+			}
 		}
 	}
 
@@ -231,39 +229,20 @@ func setEVMCSDependency(vmi *v1.VirtualMachineInstance) {
 		vmi.Spec.Domain.CPU = &v1.CPU{
 			Features: cpuFeatures,
 		}
-		return
-	}
-
-	if len(vmi.Spec.Domain.CPU.Features) == 0 {
+	} else if len(vmi.Spec.Domain.CPU.Features) == 0 {
 		vmi.Spec.Domain.CPU.Features = cpuFeatures
-		return
-	}
-
-	for _, requiredFeature := range cpuFeatures {
-		featureFound := false
-
-		for i, existingFeature := range vmi.Spec.Domain.CPU.Features {
-			if existingFeature.Name == requiredFeature.Name {
-				featureFound = true
-				if existingFeature.Policy != requiredFeature.Policy {
-					vmi.Spec.Domain.CPU.Features[i].Policy = requiredFeature.Policy
+	} else {
+		vmxFound := false
+		for i, f := range vmi.Spec.Domain.CPU.Features {
+			if f.Name == nodelabellerutil.VmxFeature {
+				vmxFound = true
+				if f.Policy != nodelabellerutil.RequirePolicy {
+					vmi.Spec.Domain.CPU.Features[i].Policy = nodelabellerutil.RequirePolicy
 				}
-				break
 			}
 		}
-
-		if !featureFound {
-			vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, requiredFeature)
+		if !vmxFound {
+			vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, vmxFeature)
 		}
 	}
-
-}
-
-func getEVMCSDependency() v1.CPUFeature {
-	vmxFeature := v1.CPUFeature{
-		Name:   nodelabellerutil.VmxFeature,
-		Policy: nodelabellerutil.RequirePolicy,
-	}
-
-	return vmxFeature
 }

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
-        "//tests/libvmi:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -28,7 +28,7 @@ type topologyHinter struct {
 }
 
 func (t *topologyHinter) TopologyHintsRequiredForVMI(vmi *k6tv1.VirtualMachineInstance) bool {
-	return t.arch == "amd64" && IsManualTSCFrequencyRequired(vmi)
+	return t.arch == "amd64" && VMIHasInvTSCFeature(vmi)
 }
 
 func (t *topologyHinter) TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) (hints *k6tv1.TopologyHints, err error) {

--- a/pkg/virt-controller/watch/topology/tsc.go
+++ b/pkg/virt-controller/watch/topology/tsc.go
@@ -107,15 +107,7 @@ func ToTSCSchedulableLabel(frequency int64) string {
 	return fmt.Sprintf("%s-%d", TSCFrequencySchedulingLabel, frequency)
 }
 
-func AreTSCFrequencyTopologyHintsDefined(vmi *k6tv1.VirtualMachineInstance) bool {
-	return vmi != nil && vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil
-}
-
-func IsManualTSCFrequencyRequired(vmi *k6tv1.VirtualMachineInstance) bool {
-	return isVmiUsingHyperVReenlightenment(vmi) || vmiHasInvTSCFeature(vmi)
-}
-
-func vmiHasInvTSCFeature(vmi *k6tv1.VirtualMachineInstance) bool {
+func VMIHasInvTSCFeature(vmi *k6tv1.VirtualMachineInstance) bool {
 	if cpu := vmi.Spec.Domain.CPU; cpu != nil {
 		for _, f := range cpu.Features {
 			if f.Name != "invtsc" {
@@ -128,15 +120,4 @@ func vmiHasInvTSCFeature(vmi *k6tv1.VirtualMachineInstance) bool {
 		}
 	}
 	return false
-}
-
-func isVmiUsingHyperVReenlightenment(vmi *k6tv1.VirtualMachineInstance) bool {
-	if vmi == nil {
-		return false
-	}
-
-	domainFeatures := vmi.Spec.Domain.Features
-
-	return domainFeatures != nil && domainFeatures.Hyperv != nil && domainFeatures.Hyperv.Reenlightenment != nil &&
-		domainFeatures.Hyperv.Reenlightenment.Enabled != nil && *domainFeatures.Hyperv.Reenlightenment.Enabled
 }

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -3,12 +3,6 @@ package topology_test
 import (
 	"fmt"
 
-	"k8s.io/utils/pointer"
-
-	v1 "kubevirt.io/api/core/v1"
-
-	"kubevirt.io/kubevirt/tests/libvmi"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -73,28 +67,6 @@ var _ = Describe("TSC", func() {
 			[]int64{2, 4},
 		),
 	)
-
-	Context("needs to be set when", func() {
-
-		It("invtsc feature exists", func() {
-			vmi := libvmi.New(
-				libvmi.WithCPUFeature("invtsc", "require"),
-			)
-
-			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
-		})
-
-		It("HyperV reenlightenment is enabled", func() {
-			vmi := libvmi.New()
-			vmi.Spec.Domain.Features = &v1.Features{
-				Hyperv: &v1.FeatureHyperv{
-					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
-				},
-			}
-
-			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
-		})
-	})
 })
 
 func tscFrequencyLabel(freq int64) string {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -437,7 +437,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			vmiCopy.Status.Phase = virtv1.Failed
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
-			if vmi.Status.TopologyHints == nil {
+			if vmi.Status.TopologyHints == nil && c.topologyHinter.TopologyHintsRequiredForVMI(vmi) {
 				if topologyHints, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedGatherhingClusterTopologyHints, err.Error())
 					return &syncErrorImpl{err, FailedGatherhingClusterTopologyHints}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -212,12 +210,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
-		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{
-			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-				MinimumClusterTSCFrequency: pointer.Int64(12345),
-			},
-		}
-		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
@@ -233,7 +226,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			cdiInformer,
 			cdiConfigInformer,
 			config,
-			topology.NewTopologyHinter(&cache.FakeCustomStore{}, &cache.FakeCustomStore{}, "amd64", config),
+			topology.NewTopologyHinter(&cache.FakeCustomStore{}, &cache.FakeCustomStore{}, "amd64", nil),
 		)
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
@@ -2754,54 +2747,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
-		})
-	})
-
-	Context("topology hints", func() {
-
-		Context("needs to be set when", func() {
-
-			expectTopologyHintsUpdate := func() {
-				var vmi *virtv1.VirtualMachineInstance
-				vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-					vmi = arg.(*virtv1.VirtualMachineInstance)
-					Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
-				}).Return(vmi, nil)
-			}
-
-			runController := func(vmi *virtv1.VirtualMachineInstance) {
-				addVirtualMachine(vmi)
-				shouldExpectPodCreation(vmi.UID)
-				controller.Execute()
-			}
-
-			It("invtsc feature exists", func() {
-				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Features: []virtv1.CPUFeature{
-						{
-							Name:   "invtsc",
-							Policy: "require",
-						},
-					},
-				}
-
-				expectTopologyHintsUpdate()
-				runController(vmi)
-			})
-
-			It("HyperV reenlightenment is enabled", func() {
-				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Spec.Domain.Features = &v1.Features{
-					Hyperv: &v1.FeatureHyperv{
-						Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
-					},
-				}
-
-				expectTopologyHintsUpdate()
-				runController(vmi)
-			})
-
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1689,7 +1689,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		// Make use of the tsc frequency topology hint
-		if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
+		if topology.VMIHasInvTSCFeature(vmi) && vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil {
 			freq := *vmi.Status.TopologyHints.TSCFrequency
 			clock := domain.Spec.Clock
 			if clock == nil {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -180,7 +180,6 @@ go_test(
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch:go_default_library",
-        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/device-manager:go_default_library",

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -171,19 +171,6 @@ func WithSEV() Option {
 	}
 }
 
-func WithCPUFeature(featureName, policy string) Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		if vmi.Spec.Domain.CPU == nil {
-			vmi.Spec.Domain.CPU = &v1.CPU{}
-		}
-
-		vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, v1.CPUFeature{
-			Name:   featureName,
-			Policy: policy,
-		})
-	}
-}
-
 func baseVmi(name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewVMIReferenceFromNameWithNS("", name)
 	vmi.Spec = v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -29,8 +29,6 @@ import (
 	"strings"
 	"sync"
 
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-
 	"kubevirt.io/api/migrations/v1alpha1"
 
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
@@ -4344,44 +4342,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			}, time.Second*30, time.Second*1).Should(BeNumerically("<=", 1))
 		})
-	})
-
-	Context("topology hints", func() {
-
-		Context("needs to be set when", func() {
-
-			expectTopologyHintsToBeSet := func(vmi *v1.VirtualMachineInstance) {
-				EventuallyWithOffset(1, func() bool {
-					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					return topology.AreTSCFrequencyTopologyHintsDefined(vmi)
-				}, 90*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("tsc frequency topology hints are expected to exist for vmi %s", vmi.Name))
-			}
-
-			It("invtsc feature exists", func() {
-				vmi := libvmi.New(
-					libvmi.WithResourceMemory("1Mi"),
-					libvmi.WithCPUFeature("invtsc", "require"),
-				)
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
-
-				expectTopologyHintsToBeSet(vmi)
-			})
-
-			It("HyperV reenlightenment is enabled", func() {
-				vmi := libvmi.New()
-				vmi.Spec = getWindowsVMISpec()
-				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
-				vmi.Spec.Volumes = []v1.Volume{}
-				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
-				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
-
-				expectTopologyHintsToBeSet(vmi)
-			})
-
-		})
-
 	})
 })
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -75,22 +75,6 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
-	It("should be able to migrate when HyperV reenlightenment is enabled", func() {
-		var err error
-
-		By("Creating a windows VM")
-		windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
-		Expect(err).ToNot(HaveOccurred())
-		tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
-
-		By("Migrating the VM")
-		migration := tests.NewRandomMigration(windowsVMI.Name, windowsVMI.Namespace)
-		migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
-
-		By("Checking VMI, confirm migration state")
-		tests.ConfirmVMIPostMigration(virtClient, windowsVMI, migrationUID)
-	})
-
 	Context("with winrm connection", func() {
 		var winrmcliPod *k8sv1.Pod
 		var cli []string


### PR DESCRIPTION
…VMX"

This reverts commit f963215842eb86dce271d1ae4bfc320e97079915, reversing
changes made to 9b9848d90d6da884e253e0280a2b68973562adac.

Reverting as this patch requires at least 1 node to have
the <counter name='tsc' /> capability to start a Windows VM
with Hyper-V re-enlightenment enabled, this is a regression
as before this patch this was required only on migration.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the start of Windows VMs with Hyper-V enlightenments on nodes without the 'tsc' counter capability.
```
