### PR TITLE
Bump virtlogd memory requirement to 18Mi and libvirtd to 35Mi

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -120,7 +120,7 @@ const ephemeralStorageOverheadSize = "50M"
 const (
 	VirtLauncherMonitorOverhead = "25Mi"  // The `ps` RSS for virt-launcher-monitor
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
-	VirtlogdOverhead            = "17Mi"  // The `ps` RSS for virtlogd
+	VirtlogdOverhead            = "18Mi"  // The `ps` RSS for virtlogd
 	LibvirtdOverhead            = "33Mi"  // The `ps` RSS for libvirtd
 	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 )

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -121,7 +121,7 @@ const (
 	VirtLauncherMonitorOverhead = "25Mi"  // The `ps` RSS for virt-launcher-monitor
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
 	VirtlogdOverhead            = "18Mi"  // The `ps` RSS for virtlogd
-	LibvirtdOverhead            = "33Mi"  // The `ps` RSS for libvirtd
+	LibvirtdOverhead            = "35Mi"  // The `ps` RSS for libvirtd
 	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 )
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1683,8 +1683,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1250465637", "2250465637"),
-				Entry("on arm64", "arm64", "1384683365", "2384683365"),
+				Entry("on amd64", "amd64", "1251514213", "2251514213"),
+				Entry("on arm64", "arm64", "1385731941", "2385731941"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1719,8 +1719,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2250465637"),
-				Entry("on arm64", "arm64", "2384683365"),
+				Entry("on amd64", "amd64", "2251514213"),
+				Entry("on arm64", "arm64", "2385731941"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1757,8 +1757,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 330),
-				Entry("on arm64", "arm64", 464),
+				Entry("on amd64", "amd64", 331),
+				Entry("on arm64", "arm64", 465),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1793,12 +1793,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 330),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 330),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 313),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 464),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 464),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 447),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 331),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 331),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 314),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 465),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 465),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 448),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1997,10 +1997,10 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 249),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 249),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 383),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 383),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 250),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 250),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 384),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 384),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -2066,8 +2066,8 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("on amd64", "amd64", 249),
-				Entry("on arm64", "arm64", 383),
+				Entry("on amd64", "amd64", 250),
+				Entry("on arm64", "arm64", 384),
 			)
 		})
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1683,8 +1683,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1251514213", "2251514213"),
-				Entry("on arm64", "arm64", "1385731941", "2385731941"),
+				Entry("on amd64", "amd64", "1253611365", "2253611365"),
+				Entry("on arm64", "arm64", "1387829093", "2387829093"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1719,8 +1719,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2251514213"),
-				Entry("on arm64", "arm64", "2385731941"),
+				Entry("on amd64", "amd64", "2253611365"),
+				Entry("on arm64", "arm64", "2387829093"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1757,8 +1757,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 331),
-				Entry("on arm64", "arm64", 465),
+				Entry("on amd64", "amd64", 333),
+				Entry("on arm64", "arm64", 467),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1793,12 +1793,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 331),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 331),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 314),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 465),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 465),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 448),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 333),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 333),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 316),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 467),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 467),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 451),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1997,10 +1997,10 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 250),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 250),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 384),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 384),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 252),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 252),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 387),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 387),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -2066,8 +2066,8 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("on amd64", "amd64", 250),
-				Entry("on arm64", "arm64", 384),
+				Entry("on amd64", "amd64", 252),
+				Entry("on arm64", "arm64", 387),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -288,7 +288,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(367)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(369)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -288,7 +288,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(366)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(367)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
In some deployment, virtlogd was seen using just a bit more than 17Mi (17468Ki).
Bumping its overhead to the next Mi should address that, with some room to grow.

Testing on this PR revealed that libvirtd can reach 35400Ki.
Added a commit to bump its overhead to 35Mi.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes RHBZ#2111794

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
