### PR TITLE
Tests: Handle various names of the qemu binary

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2992,14 +2992,18 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(len(fields)).To(BeNumerically(">=", 2))
 				rss := fields[0]
 				command := filepath.Base(fields[1])
+				// Handle the qemu binary: e.g. qemu-kvm or qemu-system-x86_64
+				if command == "qemu-kvm" || strings.HasPrefix(command, "qemu-system-") {
+					command = "qemu"
+				}
 				switch command {
-				case "virt-launcher-monitor", "virt-launcher", "virtlogd", "libvirtd", "qemu-kvm":
+				case "virt-launcher-monitor", "virt-launcher", "virtlogd", "libvirtd", "qemu":
 					Expect(processRss).ToNot(HaveKey(command), "multiple %s processes found", command)
 					value := resource.MustParse(rss + "Ki")
 					processRss[command] = value
 				}
 			}
-			for _, process := range []string{"virt-launcher-monitor", "virt-launcher", "virtlogd", "libvirtd", "qemu-kvm"} {
+			for _, process := range []string{"virt-launcher-monitor", "virt-launcher", "virtlogd", "libvirtd", "qemu"} {
 				Expect(processRss).To(HaveKey(process), "no %s process found", process)
 			}
 
@@ -3010,7 +3014,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			doesntExceedMemoryUsage(&processRss, "libvirtd", resource.MustParse(services.LibvirtdOverhead))
 			qemuExpected := resource.MustParse(services.QemuOverhead)
 			qemuExpected.Add(vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory])
-			doesntExceedMemoryUsage(&processRss, "qemu-kvm", qemuExpected)
+			doesntExceedMemoryUsage(&processRss, "qemu", qemuExpected)
 		})
 	})
 })


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Qemu binary may have different names depending on the base container
image used by virt-launcher. E.g. qemu-kvm or qemu-system-x86_64. Try
to handle that by considering also the qemu-system-* prefix when looking
through the list of running processes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This test currently fails in our downstream CI because the qemu proccess has different name.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
