### PR TITLE
code cleanup:Replace NewRandomVMI calls with libvmi builder pattern

### DIFF
--- a/tests/usbredir_test.go
+++ b/tests/usbredir_test.go
@@ -56,7 +56,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 	var err error
 	var virtClient kubecli.KubevirtClient
-	const enoughMemForSafeBiosEmulation = "32Mi"
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -78,9 +78,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	var virtClient kubecli.KubevirtClient
 
 	const (
-		cgroupV1MemoryUsagePath       = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
-		cgroupV2MemoryUsagePath       = "/sys/fs/cgroup/memory.current"
-		enoughMemForSafeBiosEmulation = "32Mi"
+		cgroupV1MemoryUsagePath = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+		cgroupV2MemoryUsagePath = "/sys/fs/cgroup/memory.current"
 	)
 
 	getPodMemoryUsage := func(pod *kubev1.Pod) (output string, err error) {

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -34,6 +34,8 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
+const enoughMemForSafeBiosEmulation = "32Mi"
+
 var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -89,7 +91,6 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 	Context("MemBalloon defaults", func() {
 		var kvConfiguration v1.KubeVirtConfiguration
-		const enoughMemForSafeBiosEmulation = "32Mi"
 		BeforeEach(func() {
 			// create VMI with missing disk target
 			vmi = libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -22,19 +22,16 @@ package tests_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	"kubevirt.io/kubevirt/tests/libvmi"
-	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
@@ -51,31 +48,10 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 	Context("Disk defaults", func() {
 		BeforeEach(func() {
 			// create VMI with missing disk target
-			vmi = tests.NewRandomVMI()
-			vmi.Spec = v1.VirtualMachineInstanceSpec{
-				Domain: v1.DomainSpec{
-					Devices: v1.Devices{
-						Disks: []v1.Disk{
-							{Name: "testdisk"},
-						},
-					},
-					Resources: v1.ResourceRequirements{
-						Requests: k8sv1.ResourceList{
-							k8sv1.ResourceMemory: resource.MustParse("8192Ki"),
-						},
-					},
-				},
-				Volumes: []v1.Volume{
-					{
-						Name: "testdisk",
-						VolumeSource: v1.VolumeSource{
-							ContainerDisk: &v1.ContainerDiskSource{
-								Image: "dummy",
-							},
-						},
-					},
-				},
-			}
+			vmi = libvmi.New(
+				libvmi.WithContainerImage("dummy"),
+				libvmi.WithResourceMemory("8192Ki"),
+			)
 		})
 
 		It("[test_id:4115]Should be applied to VMIs", func() {
@@ -113,10 +89,10 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
 
 	Context("MemBalloon defaults", func() {
 		var kvConfiguration v1.KubeVirtConfiguration
-
+		const enoughMemForSafeBiosEmulation = "32Mi"
 		BeforeEach(func() {
 			// create VMI with missing disk target
-			vmi = tests.NewRandomVMI()
+			vmi = libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
 
 			kv := util.GetCurrentKv(virtClient)
 			kvConfiguration = kv.Spec.Configuration

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -55,7 +55,6 @@ var _ = Describe("[rfe_id:127][crit:medium][arm64][vendor:cnv-qe@redhat.com][lev
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var vmi *v1.VirtualMachineInstance
-	const enoughMemForSafeBiosEmulation = "32Mi"
 
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		BeforeEach(func() {

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -76,9 +76,10 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 		util.PanicOnError(err)
 		checks.SkipIfMissingRequiredImage(virtClient, tests.DiskWindows)
 		libstorage.CreatePVC(OSWindows, "30Gi", libstorage.Config.StorageClassWindows, true)
-		windowsVMI = tests.NewRandomVMI()
+		windowsVMI = libvmi.New()
 		windowsVMI.Spec = getWindowsVMISpec()
 		tests.AddExplicitPodNetworkInterface(windowsVMI)
+		windowsVMI.Namespace = util.NamespaceTestDefault
 		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
NewRandomVMI* functions are defined in tests/utils.go that is impossible to understand and has repetitious code.
Replace NewRandomVMI calls in functional tests with libvmi builder pattern and Make functional test more resources efficient.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
