### PR TITLE
code cleanup:Replace NewRandomVMI calls with libvmi builder pattern

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1149,6 +1149,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 	Describe("Start a VirtualMachineInstance", func() {
 		Context("when the controller pod is not running and an election happens", func() {
 			It("[test_id:4642]should succeed afterwards", func() {
+				const enoughMemForSafeBiosEmulation = "32Mi"
+
 				// This test needs at least 2 controller pods. Skip on single-replica.
 				checks.SkipIfSingleReplica(virtClient)
 
@@ -1183,7 +1185,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					return k8sv1.ConditionUnknown
 				}()).To(Equal(k8sv1.ConditionTrue))
 
-				vmi := tests.NewRandomVMI()
+				vmi := libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
 
 				By("Starting a new VirtualMachineInstance")
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(util.NamespaceTestDefault).Body(vmi).Do(context.Background()).Get()

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -88,8 +88,16 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 		BeforeEach(func() {
 			virtCli, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
+			const enoughMemForSafeBiosEmulation = "32Mi"
 
-			vm = tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+			vm = tests.NewRandomVirtualMachine(
+				libvmi.New(
+					libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				),
+				false,
+			)
 			vm, err = virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 			Expect(err).NotTo(HaveOccurred())
 			tests.StartVirtualMachine(vm)

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -369,6 +369,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
 
 	Context("Errors metrics", func() {
 		var crb *rbacv1.ClusterRoleBinding
+		const enoughMemForSafeBiosEmulation = "32Mi"
 
 		BeforeEach(func() {
 			virtClient, err = kubecli.GetKubevirtClient()
@@ -438,7 +439,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
 			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-controller", metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
 
 			for i := 0; i < 60; i++ {
 				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -461,7 +462,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
 			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-handler", metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi := tests.NewRandomVMI()
+			vmi := libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
 
 			for i := 0; i < 60; i++ {
 				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -43,7 +43,6 @@ go_library(
         "//tests/assert:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
-        "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/matcher:go_default_library",

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -9,6 +9,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -25,8 +26,8 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 	Context("[verify-nonroot] NonRoot feature", func() {
 		It("Fails if can't be tested", func() {
 			Expect(checks.HasFeature(virtconfig.NonRoot)).To(BeTrue())
-
-			vmi := tests.NewRandomVMI()
+			const enoughMemForSafeBiosEmulation = "32Mi"
+			vmi := libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -51,6 +51,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 	var err error
 	var virtCli kubecli.KubevirtClient
 
+	const enoughMemForSafeBiosEmulation = "32Mi"
 	manual := v1.RunStrategyManual
 	restartOnError := v1.RunStrategyRerunOnFailure
 
@@ -113,7 +114,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource", func() {
 		Context("with a restart endpoint", func() {
 			It("[test_id:1304] should restart a VM", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation)), false)
 				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -135,7 +136,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			})
 
 			It("[test_id:1305][posneg:negative] should return an error when VM is not running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
 				vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -144,7 +145,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			})
 
 			It("[test_id:2265][posneg:negative] should return an error when VM has not been found but VMI is running", func() {
-				vmi := tests.NewRandomVMI()
+				vmi := libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation))
 				tests.RunVMIAndExpectLaunch(vmi, 60)
 
 				err := virtCli.VirtualMachine(util.NamespaceTestDefault).Restart(vmi.Name, &v1.RestartOptions{})
@@ -154,7 +155,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 		Context("With manual RunStrategy", func() {
 			It("[test_id:3174]Should not restart when VM is not running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
 				vm.Spec.RunStrategy = &manual
 				vm.Spec.Running = nil
 
@@ -168,7 +169,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 			})
 
 			It("[test_id:3175]Should restart when VM is running", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation)), false)
 				vm.Spec.RunStrategy = &manual
 				vm.Spec.Running = nil
 
@@ -208,7 +209,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 		Context("With RunStrategy RerunOnFailure", func() {
 			It("[test_id:3176]Should restart the VM", func() {
-				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+				vm := tests.NewRandomVirtualMachine(libvmi.New(libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation)), false)
 				vm.Spec.RunStrategy = &restartOnError
 				vm.Spec.Running = nil
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1007,14 +1007,14 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			It("Should force stop a VMI", func() {
-
+				const enoughMemForSafeBiosEmulation = "32Mi"
 				By("getting a VM with high TerminationGracePeriod")
-				newVMI := tests.NewRandomVMI()
-				gracePeriod := int64(1600)
-				newVMI.Spec.TerminationGracePeriodSeconds = &gracePeriod
-
+				newVMI := libvmi.New(
+					libvmi.WithResourceMemory(enoughMemForSafeBiosEmulation),
+					libvmi.WithTerminationGracePeriod(1600),
+				)
 				newVM := tests.NewRandomVirtualMachine(newVMI, true)
-				_, err := virtClient.VirtualMachine(newVM.Namespace).Create(newVM)
+				newVM, err := virtClient.VirtualMachine(util.NamespaceTestDefault).Create(newVM)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VM to be ready")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
NewRandomVMI* functions are defined in the long tests/utils.go file that is impossible to understand and has repetitious code.
Replace NewRandomVMI calls in functional tests with libvmi builder pattern and Make functional test more resources efficient.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
