### PR TITLE
libnet: avoid WithCloudInitNoCloudNetworkData's boolean arg

### DIFF
--- a/tests/libvmi/cloudinit.go
+++ b/tests/libvmi/cloudinit.go
@@ -45,17 +45,12 @@ func WithCloudInitNoCloudUserData(data string, b64Encoding bool) Option {
 }
 
 // WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
-func WithCloudInitNoCloudNetworkData(data string, b64Encoding bool) Option {
+func WithCloudInitNoCloudNetworkData(data string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		addDiskVolumeWithCloudInitNoCloud(vmi, cloudInitDiskName, v1.DiskBusVirtio)
 
 		volume := getVolume(vmi, cloudInitDiskName)
-		if b64Encoding {
-			encodedData := base64.StdEncoding.EncodeToString([]byte(data))
-			volume.CloudInitNoCloud.NetworkDataBase64 = encodedData
-		} else {
-			volume.CloudInitNoCloud.NetworkData = data
-		}
+		volume.CloudInitNoCloud.NetworkData = data
 	}
 }
 

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -48,7 +48,7 @@ func WithMasqueradeNetworking(ports ...kvirtv1.Port) []Option {
 	return []Option{
 		WithInterface(InterfaceDeviceWithMasqueradeBinding(ports...)),
 		WithNetwork(kvirtv1.DefaultPodNetwork()),
-		WithCloudInitNoCloudNetworkData(networkData, false),
+		WithCloudInitNoCloudNetworkData(networkData),
 	}
 }
 

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -191,7 +191,7 @@ func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.Virtual
 	vmi := libvmi.NewFedora(
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
 	return vmi, nil
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -100,7 +100,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			}
 			if cloudInitNetworkData != "" {
-				cloudinitOption := libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkData, false)
+				cloudinitOption := libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkData)
 				withVmiOptions = append(withVmiOptions, cloudinitOption)
 			}
 			// sriov network interfaces

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -354,7 +354,7 @@ var istioTests = func(vmType VmType) {
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
 					libvmi.WithLabel("version", "v1"),
 					libvmi.WithLabel(vmiAppSelectorKey, vmiServerAppSelectorValue),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+					libvmi.WithCloudInitNoCloudNetworkData(networkData),
 				)
 				serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
 				Expect(err).ToNot(HaveOccurred())
@@ -495,7 +495,7 @@ func createMasqueradeVm(ports []v1.Port) (*v1.VirtualMachineInstance, error) {
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
 	return vmi, err
 }

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -202,7 +202,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmi.NewAlpineWithTestTooling(
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+					libvmi.WithCloudInitNoCloudNetworkData(networkData),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
@@ -222,7 +222,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				checks.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmi.NewAlpineWithTestTooling(
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+					libvmi.WithCloudInitNoCloudNetworkData(networkData),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
@@ -286,7 +286,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 				detachedVMI := libvmi.NewAlpineWithTestTooling(
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+					libvmi.WithCloudInitNoCloudNetworkData(networkData),
 				)
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
@@ -439,7 +439,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ptpSubnetIP2+ptpSubnetMask), false))
+					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", ptpSubnetIP2+ptpSubnetMask)))
 				vmiTwo = tests.CreateVmiOnNode(vmiTwo, nodes.Items[0].Name)
 
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
@@ -450,7 +450,7 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask), false))
+					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, ptpSubnetIP1+ptpSubnetMask)))
 				vmiOne = tests.CreateVmiOnNode(vmiOne, nodes.Items[0].Name)
 
 				vmiOne = tests.WaitUntilVMIReady(vmiOne, console.LoginToFedora)
@@ -618,14 +618,14 @@ var _ = SIGDescribe("[Serial]Multus", func() {
 				vmiUnderTest := libvmi.NewFedora(
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask), false))
+					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, linuxBridgeInterfaceWithCustomMac.MacAddress, vmUnderTestIPAddress+bridgeSubnetMask)))
 				vmiUnderTest = tests.CreateVmiOnNode(vmiUnderTest, nodes.Items[0].Name)
 
 				By("Creating a target VM with Linux bridge CNI network interface and default MAC address.")
 				targetVmi := libvmi.NewFedora(
 					libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
 					libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
-					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth0", targetVMIPAddress+bridgeSubnetMask), false))
+					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth0", targetVMIPAddress+bridgeSubnetMask)))
 				targetVmi = tests.CreateVmiOnNode(targetVmi, nodes.Items[0].Name)
 
 				vmiUnderTest = tests.WaitUntilVMIReady(vmiUnderTest, console.LoginToFedora)

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -349,7 +349,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			deadbeafVMI := libvmi.NewAlpineWithTestTooling(
 				libvmi.WithInterface(masqIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+				libvmi.WithCloudInitNoCloudNetworkData(networkData),
 			)
 			deadbeafVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(deadbeafVMI)
 			Expect(err).ToNot(HaveOccurred())
@@ -623,7 +623,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			vmi := libvmi.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 				libvmi.WithNetwork(net),
-				libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+				libvmi.WithCloudInitNoCloudNetworkData(networkData),
 			)
 
 			return vmi, nil
@@ -967,7 +967,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				vmi = libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+					libvmi.WithCloudInitNoCloudNetworkData(networkData),
 				)
 
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -697,7 +697,7 @@ func NewRandomFedoraVMI() *v1.VirtualMachineInstance {
 	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
 }
 
@@ -708,7 +708,7 @@ func NewRandomFedoraVMIWithGuestAgent() *v1.VirtualMachineInstance {
 	return libvmi.NewFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
 }
 
@@ -720,7 +720,7 @@ func NewRandomFedoraVMIWithBlacklistGuestAgent(commands string) *v1.VirtualMachi
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithCloudInitNoCloudUserData(GetFedoraToolsGuestAgentBlacklistUserData(commands), false),
-		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+		libvmi.WithCloudInitNoCloudNetworkData(networkData),
 	)
 }
 


### PR DESCRIPTION
A casual reader finds it hard to understand what is "false" in
    WithCloudInitNoCloudNetworkData(networkData, false)
This can be solved by introducing a named argument or even an
enumeration for encoding. However, none of our tests wants to set the
"true" value, so let us just drop the b64Encoding argument and make the
function and its users simpler.

```release-note
NONE
```
