### PR TITLE
Add vm export vm

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -566,7 +566,7 @@ func GetVirtualMachineExportInformerIndexers() cache.Indexers {
 			}
 
 			if export.Spec.Source.APIGroup != nil &&
-				*export.Spec.Source.APIGroup == core.GroupName &&
+				*export.Spec.Source.APIGroup == snapshotv1.SchemeGroupVersion.Group &&
 				export.Spec.Source.Kind == "VirtualMachineSnapshot" {
 				return []string{fmt.Sprintf("%s/%s", export.Namespace, export.Spec.Source.Name)}, nil
 			}

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -573,6 +573,20 @@ func GetVirtualMachineExportInformerIndexers() cache.Indexers {
 
 			return nil, nil
 		},
+		"vm": func(obj interface{}) ([]string, error) {
+			export, ok := obj.(*exportv1.VirtualMachineExport)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			if export.Spec.Source.APIGroup != nil &&
+				*export.Spec.Source.APIGroup == core.GroupName &&
+				export.Spec.Source.Kind == "VirtualMachine" {
+				return []string{fmt.Sprintf("%s/%s", export.Namespace, export.Spec.Source.Name)}, nil
+			}
+
+			return nil, nil
+		},
 	}
 }
 

--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -2,7 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["export.go"],
+    srcs = [
+        "export.go",
+        "links.go",
+        "pvc-source.go",
+        "vm-source.go",
+        "vmsnapshot-source.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/storage/export/export",
     visibility = ["//visibility:public"],
     deps = [
@@ -47,6 +53,9 @@ go_test(
     srcs = [
         "export_suite_test.go",
         "export_test.go",
+        "pvc-source_test.go",
+        "vm-source_test.go",
+        "vmsnapshot-source_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -1419,6 +1419,24 @@ func createSnapshotVMExport() *exportv1.VirtualMachineExport {
 	}
 }
 
+func createSnapshotVMExport() *exportv1.VirtualMachineExport {
+	return &exportv1.VirtualMachineExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: testNamespace,
+			UID:       "11111-22222-33333",
+		},
+		Spec: exportv1.VirtualMachineExportSpec{
+			Source: k8sv1.TypedLocalObjectReference{
+				APIGroup: &snapshotv1.SchemeGroupVersion.Group,
+				Kind:     "VirtualMachineSnapshot",
+				Name:     testVmsnapshotName,
+			},
+			TokenSecretRef: "token",
+		},
+	}
+}
+
 func expectExporterCreate(k8sClient *k8sfake.Clientset, phase k8sv1.PodPhase) {
 	k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 		create, ok := action.(testing.CreateAction)

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -426,9 +426,8 @@ var _ = Describe("Export controller", func() {
 			},
 		}
 		syncCaches(stop)
-		mockVMExportQueue.ExpectAdds(2)
-		vmExportSource.Add(vmExport)
-		controller.processVMExportWorkItem()
+		mockVMExportQueue.ExpectAdds(1)
+		vmExportInformer.GetStore().Add(vmExport)
 		vmInformer.GetStore().Add(vm)
 		controller.handleVMI(vmi)
 		mockVMExportQueue.Wait()
@@ -466,7 +465,6 @@ var _ = Describe("Export controller", func() {
 		syncCaches(stop)
 		mockVMExportQueue.ExpectAdds(1)
 		vmExportSource.Add(vmExport)
-		controller.processVMExportWorkItem()
 		vmInformer.GetStore().Add(vm)
 		controller.handleVMI(vmi)
 		mockVMExportQueue.Wait()
@@ -483,7 +481,6 @@ var _ = Describe("Export controller", func() {
 		syncCaches(stop)
 		mockVMExportQueue.ExpectAdds(1)
 		vmExportSource.Add(vmExport)
-		controller.processVMExportWorkItem()
 		controller.handleVMI(vmi)
 		mockVMExportQueue.Wait()
 	})

--- a/pkg/storage/export/export/links.go
+++ b/pkg/storage/export/export/links.go
@@ -1,0 +1,271 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package export
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"path"
+	"strings"
+	"unicode"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+
+	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
+	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+)
+
+const (
+	caBundle             = "ca-bundle"
+	routeCAConfigMapName = "kube-root-ca.crt"
+	routeCaKey           = "ca.crt"
+	subjectAltNameId     = "2.5.29.17"
+
+	apiGroup              = "export.kubevirt.io"
+	apiVersion            = "v1alpha1"
+	exportResourceName    = "virtualmachineexports"
+	gv                    = apiGroup + "/" + apiVersion
+	externalUrlLinkFormat = "/api/" + gv + "/namespaces/%s/" + exportResourceName + "/%s"
+)
+
+func (ctrl *VMExportController) getInteralLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, service *corev1.Service) (*exportv1.VirtualMachineExportLink, error) {
+	internalCert, err := ctrl.internalExportCa()
+	if err != nil {
+		return nil, err
+	}
+	host := fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace)
+	return ctrl.getLinks(pvcs, exporterPod, host, internalCert)
+}
+
+func (ctrl *VMExportController) getExternalLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, export *exportv1.VirtualMachineExport) (*exportv1.VirtualMachineExportLink, error) {
+	urlPath := fmt.Sprintf(externalUrlLinkFormat, export.Namespace, export.Name)
+	externalLinkHost, cert := ctrl.getExternalLinkHostAndCert()
+	if externalLinkHost != "" {
+		hostAndBase := path.Join(externalLinkHost, urlPath)
+		return ctrl.getLinks(pvcs, exporterPod, hostAndBase, cert)
+	}
+	return nil, nil
+}
+
+func (ctrl *VMExportController) getLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, hostAndBase, cert string) (*exportv1.VirtualMachineExportLink, error) {
+	exportLink := &exportv1.VirtualMachineExportLink{
+		Volumes: []exportv1.VirtualMachineExportVolume{},
+		Cert:    cert,
+	}
+	for _, pvc := range pvcs {
+		if pvc != nil && exporterPod != nil && exporterPod.Status.Phase == corev1.PodRunning {
+			const scheme = "https://"
+
+			if ctrl.isKubevirtContentType(pvc) {
+				exportLink.Volumes = append(exportLink.Volumes, exportv1.VirtualMachineExportVolume{
+					Name: pvc.Name,
+					Formats: []exportv1.VirtualMachineExportVolumeFormat{
+						{
+							Format: exportv1.KubeVirtRaw,
+							Url:    scheme + path.Join(hostAndBase, rawURI(pvc)),
+						},
+						{
+							Format: exportv1.KubeVirtGz,
+							Url:    scheme + path.Join(hostAndBase, rawGzipURI(pvc)),
+						},
+					},
+				})
+			} else {
+				exportLink.Volumes = append(exportLink.Volumes, exportv1.VirtualMachineExportVolume{
+					Name: pvc.Name,
+					Formats: []exportv1.VirtualMachineExportVolumeFormat{
+						{
+							Format: exportv1.Dir,
+							Url:    scheme + path.Join(hostAndBase, dirURI(pvc)),
+						},
+						{
+							Format: exportv1.ArchiveGz,
+							Url:    scheme + path.Join(hostAndBase, archiveURI(pvc)),
+						},
+					},
+				})
+			}
+		}
+	}
+	return exportLink, nil
+}
+
+func (ctrl *VMExportController) internalExportCa() (string, error) {
+	key := controller.NamespacedKey(ctrl.KubevirtNamespace, components.KubeVirtExportCASecretName)
+	ctrl.ConfigMapInformer.GetStore().GetByKey(key)
+	obj, exists, err := ctrl.ConfigMapInformer.GetStore().GetByKey(key)
+	if err != nil || !exists {
+		return "", err
+	}
+	cm := obj.(*corev1.ConfigMap).DeepCopy()
+	bundle := cm.Data[caBundle]
+	return strings.TrimSpace(bundle), nil
+}
+
+func (ctrl *VMExportController) getExternalLinkHostAndCert() (string, string) {
+	for _, obj := range ctrl.IngressCache.List() {
+		if ingress, ok := obj.(*networkingv1.Ingress); ok {
+			if host := getHostFromIngress(ingress); host != "" {
+				cert, _ := ctrl.getIngressCert(host, ingress)
+				return host, cert
+			}
+		}
+	}
+	for _, obj := range ctrl.RouteCache.List() {
+		if route, ok := obj.(*routev1.Route); ok {
+			if host := getHostFromRoute(route); host != "" {
+				cert, _ := ctrl.getRouteCert(host)
+				return host, cert
+			}
+		}
+	}
+	return "", ""
+}
+
+func (ctrl *VMExportController) getIngressCert(hostName string, ing *networkingv1.Ingress) (string, error) {
+	secretName := ""
+	for _, tls := range ing.Spec.TLS {
+		if tls.SecretName != "" {
+			secretName = tls.SecretName
+			break
+		}
+	}
+	key := controller.NamespacedKey(ctrl.KubevirtNamespace, secretName)
+	obj, exists, err := ctrl.SecretInformer.GetStore().GetByKey(key)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", nil
+	}
+	if secret, ok := obj.(*corev1.Secret); ok {
+		return ctrl.getIngressCertFromSecret(secret, hostName)
+	}
+	return "", nil
+}
+
+func (ctrl *VMExportController) getIngressCertFromSecret(secret *corev1.Secret, hostName string) (string, error) {
+	certBytes := secret.Data["tls.crt"]
+	certs, err := cert.ParseCertsPEM(certBytes)
+	if err != nil {
+		return "", err
+	}
+	return ctrl.findCertByHostName(hostName, certs)
+}
+
+func (ctrl *VMExportController) getRouteCert(hostName string) (string, error) {
+	key := controller.NamespacedKey(ctrl.KubevirtNamespace, routeCAConfigMapName)
+	obj, exists, err := ctrl.RouteConfigMapInformer.GetStore().GetByKey(key)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", nil
+	}
+	if cm, ok := obj.(*corev1.ConfigMap); ok {
+		cmString := cm.Data[routeCaKey]
+		certs, err := cert.ParseCertsPEM([]byte(cmString))
+		if err != nil {
+			return "", err
+		}
+		return ctrl.findCertByHostName(hostName, certs)
+	}
+	return "", fmt.Errorf("not a config map")
+}
+
+func (ctrl *VMExportController) findCertByHostName(hostName string, certs []*x509.Certificate) (string, error) {
+	for _, cert := range certs {
+		if ctrl.matchesOrWildCard(hostName, cert.Subject.CommonName) {
+			return buildPemFromCert(cert), nil
+		}
+		for _, extension := range cert.Extensions {
+			if extension.Id.String() == subjectAltNameId {
+				value := strings.Map(func(r rune) rune {
+					if unicode.IsPrint(r) && r <= unicode.MaxASCII {
+						return r
+					}
+					return ' '
+				}, string(extension.Value))
+				names := strings.Split(value, " ")
+				for _, name := range names {
+					if ctrl.matchesOrWildCard(hostName, name) {
+						return buildPemFromCert(cert), nil
+					}
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+func buildPemFromCert(cert *x509.Certificate) string {
+	pemOut := strings.Builder{}
+	pem.Encode(&pemOut, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	return strings.TrimSpace(pemOut.String())
+}
+
+func (ctrl *VMExportController) matchesOrWildCard(hostName, compare string) bool {
+	wildCard := fmt.Sprintf("*.%s", getDomainFromHost(hostName))
+	return hostName == compare || wildCard == compare
+}
+
+func getDomainFromHost(host string) string {
+	if index := strings.Index(host, "."); index != -1 {
+		return host[index+1:]
+	}
+	return host
+}
+
+func getHostFromRoute(route *routev1.Route) string {
+	if route.Spec.To.Name == components.VirtExportProxyServiceName {
+		if len(route.Status.Ingress) > 0 {
+			return route.Status.Ingress[0].Host
+		}
+	}
+	return ""
+}
+
+func getHostFromIngress(ing *networkingv1.Ingress) string {
+	if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+		if ing.Spec.DefaultBackend.Service.Name != components.VirtExportProxyServiceName {
+			return ""
+		}
+		return ing.Spec.Rules[0].Host
+	}
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.Service != nil && path.Backend.Service.Name == components.VirtExportProxyServiceName {
+				if rule.Host != "" {
+					return rule.Host
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/storage/export/export/pvc-source.go
+++ b/pkg/storage/export/export/pvc-source.go
@@ -1,0 +1,157 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package export
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
+)
+
+func (ctrl *VMExportController) handlePVC(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+		key, _ := cache.MetaNamespaceKeyFunc(pvc)
+		log.Log.V(3).Infof("Processing PVC %s", key)
+		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("pvc", key)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+
+		for _, key := range keys {
+			ctrl.vmExportQueue.Add(key)
+		}
+	}
+}
+
+func (ctrl *VMExportController) isSourcePvc(source *exportv1.VirtualMachineExportSpec) bool {
+	return source != nil && (source.Source.APIGroup == nil || *source.Source.APIGroup == corev1.SchemeGroupVersion.Group) && source.Source.Kind == "PersistentVolumeClaim"
+}
+
+func (ctrl *VMExportController) getPvc(namespace, name string) (*corev1.PersistentVolumeClaim, bool, error) {
+	key := controller.NamespacedKey(namespace, name)
+	obj, exists, err := ctrl.PVCInformer.GetStore().GetByKey(key)
+	if err != nil || !exists {
+		return nil, exists, err
+	}
+	return obj.(*corev1.PersistentVolumeClaim).DeepCopy(), true, nil
+}
+
+func (ctrl *VMExportController) isSourceAvailablePVC(vmExport *exportv1.VirtualMachineExport, pvc *corev1.PersistentVolumeClaim) (bool, string, error) {
+	availableMessage := ""
+	sourceAvailable, err := ctrl.isPVCPopulated(pvc)
+	if err != nil {
+		return false, "", err
+	}
+	if sourceAvailable {
+		inUse, err := ctrl.isPVCInUse(vmExport, pvc)
+		if err != nil {
+			return false, "", err
+		}
+		if inUse {
+			availableMessage = fmt.Sprintf("pvc %s/%s is in use", pvc.Namespace, pvc.Name)
+		}
+		sourceAvailable = sourceAvailable && !inUse
+	} else {
+		availableMessage = fmt.Sprintf("pvc %s/%s is not populated", pvc.Namespace, pvc.Name)
+	}
+	return sourceAvailable, availableMessage, nil
+}
+
+func (ctrl *VMExportController) getPVCFromSourcePVC(vmExport *exportv1.VirtualMachineExport) (*sourceVolumes, error) {
+	pvc, pvcExists, err := ctrl.getPvc(vmExport.Namespace, vmExport.Spec.Source.Name)
+	if err != nil {
+		return &sourceVolumes{}, err
+	}
+	if !pvcExists {
+		return &sourceVolumes{
+			volumes:          nil,
+			sourceAvailable:  true,
+			availableMessage: fmt.Sprintf("pvc %s/%s not found", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
+	}
+
+	sourceAvailable, availableMessage, err := ctrl.isSourceAvailablePVC(vmExport, pvc)
+	if err != nil {
+		return &sourceVolumes{}, err
+	}
+	return &sourceVolumes{
+		volumes:          []*corev1.PersistentVolumeClaim{pvc},
+		sourceAvailable:  sourceAvailable,
+		availableMessage: availableMessage}, nil
+}
+
+func (ctrl *VMExportController) isPVCInUse(vmExport *exportv1.VirtualMachineExport, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	if pvc == nil {
+		return false, nil
+	}
+	pvcSet := sets.NewString(pvc.Name)
+	if usedPods, err := watchutil.PodsUsingPVCs(ctrl.PodInformer, pvc.Namespace, pvcSet); err != nil {
+		return false, err
+	} else {
+		for _, pod := range usedPods {
+			if !metav1.IsControlledBy(&pod, vmExport) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}
+
+func (ctrl *VMExportController) updateVMExportPvcStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, sourceVolumes *sourceVolumes) (time.Duration, error) {
+	var requeue time.Duration
+
+	if !sourceVolumes.sourceAvailable {
+		log.Log.V(4).Infof("Source is not available %s, requeuing", sourceVolumes.availableMessage)
+		requeue = requeueTime
+	}
+
+	vmExportCopy := vmExport.DeepCopy()
+
+	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
+		return requeue, err
+	}
+
+	if len(sourceVolumes.volumes) == 0 {
+		log.Log.V(3).Info("PVC(s) not found, updating status to not found")
+		updateCondition(vmExportCopy.Status.Conditions, newPvcCondition(corev1.ConditionFalse, pvcNotFoundReason, sourceVolumes.availableMessage))
+	} else {
+		updateCondition(vmExportCopy.Status.Conditions, ctrl.pvcConditionFromPVC(sourceVolumes.volumes))
+	}
+
+	if err := ctrl.updateVMExportStatus(vmExport, vmExportCopy); err != nil {
+		return requeue, err
+	}
+	return requeue, nil
+}

--- a/pkg/storage/export/export/pvc-source.go
+++ b/pkg/storage/export/export/pvc-source.go
@@ -42,15 +42,15 @@ func (ctrl *VMExportController) handlePVC(obj interface{}) {
 	}
 
 	if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
-		key, _ := cache.MetaNamespaceKeyFunc(pvc)
-		log.Log.V(3).Infof("Processing PVC %s", key)
-		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("pvc", key)
+		pvcKey, _ := cache.MetaNamespaceKeyFunc(pvc)
+		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("pvc", pvcKey)
 		if err != nil {
 			utilruntime.HandleError(err)
 			return
 		}
 
 		for _, key := range keys {
+			log.Log.V(3).Infof("Adding VMExport due to pvc %s", pvcKey)
 			ctrl.vmExportQueue.Add(key)
 		}
 	}

--- a/pkg/storage/export/export/pvc-source_test.go
+++ b/pkg/storage/export/export/pvc-source_test.go
@@ -1,0 +1,375 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+package export
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8sv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
+	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
+	"kubevirt.io/client-go/kubecli"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+)
+
+const (
+	testPVCName = "test-pvc"
+)
+
+var _ = Describe("PVC source", func() {
+	var (
+		ctrl                       *gomock.Controller
+		controller                 *VMExportController
+		recorder                   *record.FakeRecorder
+		pvcInformer                cache.SharedIndexInformer
+		podInformer                cache.SharedIndexInformer
+		cmInformer                 cache.SharedIndexInformer
+		vmExportInformer           cache.SharedIndexInformer
+		serviceInformer            cache.SharedIndexInformer
+		dvInformer                 cache.SharedIndexInformer
+		vmSnapshotInformer         cache.SharedIndexInformer
+		vmSnapshotContentInformer  cache.SharedIndexInformer
+		secretInformer             cache.SharedIndexInformer
+		vmInformer                 cache.SharedIndexInformer
+		vmiInformer                cache.SharedIndexInformer
+		k8sClient                  *k8sfake.Clientset
+		vmExportClient             *kubevirtfake.Clientset
+		fakeVolumeSnapshotProvider *MockVolumeSnapshotProvider
+		mockVMExportQueue          *testutils.MockWorkQueue
+		routeCache                 cache.Store
+		ingressCache               cache.Store
+		certDir                    string
+		certFilePath               string
+		keyFilePath                string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		var err error
+		certDir, err = ioutil.TempDir("", "certs")
+		Expect(err).ToNot(HaveOccurred())
+		certFilePath = filepath.Join(certDir, "tls.crt")
+		keyFilePath = filepath.Join(certDir, "tls.key")
+		writeCertsToDir(certDir)
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
+		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
+		vmExportInformer, _ = testutils.NewFakeInformerWithIndexersFor(&exportv1.VirtualMachineExport{}, virtcontroller.GetVirtualMachineExportInformerIndexers())
+		dvInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+		vmSnapshotInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
+		vmSnapshotContentInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
+		vmInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+		vmiInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
+		routeInformer, _ := testutils.NewFakeInformerFor(&routev1.Route{})
+		routeCache = routeInformer.GetStore()
+		ingressInformer, _ := testutils.NewFakeInformerFor(&networkingv1.Ingress{})
+		ingressCache = ingressInformer.GetStore()
+		secretInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Secret{})
+		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
+			volumeSnapshots: []*vsv1.VolumeSnapshot{},
+		}
+
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
+		k8sClient = k8sfake.NewSimpleClientset()
+		vmExportClient = kubevirtfake.NewSimpleClientset()
+		recorder = record.NewFakeRecorder(100)
+
+		virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+		virtClient.EXPECT().VirtualMachineExport(testNamespace).
+			Return(vmExportClient.ExportV1alpha1().VirtualMachineExports(testNamespace)).AnyTimes()
+
+		controller = &VMExportController{
+			Client:                    virtClient,
+			Recorder:                  recorder,
+			PVCInformer:               pvcInformer,
+			PodInformer:               podInformer,
+			ConfigMapInformer:         cmInformer,
+			VMExportInformer:          vmExportInformer,
+			ServiceInformer:           serviceInformer,
+			DataVolumeInformer:        dvInformer,
+			KubevirtNamespace:         "kubevirt",
+			TemplateService:           services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			caCertManager:             bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
+			RouteCache:                routeCache,
+			IngressCache:              ingressCache,
+			RouteConfigMapInformer:    cmInformer,
+			SecretInformer:            secretInformer,
+			VMSnapshotInformer:        vmSnapshotInformer,
+			VMSnapshotContentInformer: vmSnapshotContentInformer,
+			VolumeSnapshotProvider:    fakeVolumeSnapshotProvider,
+			VMInformer:                vmInformer,
+			VMIInformer:               vmiInformer,
+		}
+		initCert = func(ctrl *VMExportController) {
+			go controller.caCertManager.Start()
+			// Give the thread time to read the certs.
+			Eventually(func() *tls.Certificate {
+				return controller.caCertManager.Current()
+			}, time.Second, time.Millisecond).ShouldNot(BeNil())
+		}
+
+		controller.Init()
+		mockVMExportQueue = testutils.NewMockWorkQueue(controller.vmExportQueue)
+		controller.vmExportQueue = mockVMExportQueue
+
+		cmInformer.GetStore().Add(&k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controller.KubevirtNamespace,
+				Name:      components.KubeVirtExportCASecretName,
+			},
+			Data: map[string]string{
+				"ca-bundle": "replace me with ca cert",
+			},
+		})
+	})
+
+	AfterEach(func() {
+		controller.caCertManager.Stop()
+		os.RemoveAll(certDir)
+	})
+
+	It("Should properly update VMExport status with a valid token and no pvc", func() {
+		testVMExport := createPVCVMExport()
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			return true, vmExport, nil
+		})
+
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	It("Should properly update VMExport status with a valid token and archive pvc no route", func() {
+		testVMExport := createPVCVMExport()
+		pvcInformer.GetStore().Add(createPVC(testPVCName, "archive"))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			Expect(vmExport.Status).ToNot(BeNil())
+			Expect(vmExport.Status.Links).ToNot(BeNil())
+			Expect(vmExport.Status.Links.External).To(BeNil())
+			verifyArchiveInternal(vmExport, vmExport.Name, testNamespace, testVMExport.Spec.Source.Name)
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	It("Should properly update VMExport status with a valid token and kubevirt pvc with route", func() {
+		testVMExport := createPVCVMExport()
+		pvcInformer.GetStore().Add(createPVC(testPVCName, "kubevirt"))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		controller.RouteCache.Add(routeToHostAndService(components.VirtExportProxyServiceName))
+
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyKubevirtInternal(vmExport, vmExport.Name, testNamespace, testVMExport.Spec.Source.Name)
+			verifyKubevirtExternal(vmExport, vmExport.Name, testNamespace, testVMExport.Spec.Source.Name)
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	It("Should properly update VMExport status with a valid token and no pvc, pending pod", func() {
+		testVMExport := createPVCVMExport()
+		expectExporterCreate(k8sClient, k8sv1.PodPending)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	It("Should retry if PVC is in use by other pod", func() {
+		testVMExport := createPVCVMExport()
+		pod := &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "inuse-pod",
+				Namespace: testNamespace,
+			},
+			Spec: k8sv1.PodSpec{
+				Volumes: []k8sv1.Volume{
+					{
+						VolumeSource: k8sv1.VolumeSource{
+							PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: testPVCName,
+							},
+						},
+					},
+				},
+			},
+		}
+		pvc := &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPVCName,
+				Namespace: testNamespace,
+			},
+			Status: k8sv1.PersistentVolumeClaimStatus{
+				Phase: k8sv1.ClaimBound,
+			},
+		}
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			return true, vmExport, nil
+		})
+		controller.PodInformer.GetStore().Add(pod)
+		controller.PVCInformer.GetStore().Add(pvc)
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(requeueTime))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	DescribeTable("should detect content type properly", func(key, contentType string, expectedRes bool) {
+		pvc := &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					key: contentType,
+				},
+			},
+		}
+		res := controller.isKubevirtContentType(pvc)
+		Expect(res).To(Equal(expectedRes))
+	},
+		Entry("missing content-type", "something", "something", false),
+		Entry("blank content-type", annContentType, "", true),
+		Entry("kubevirt content-type", annContentType, string(cdiv1.DataVolumeKubeVirt), true),
+		Entry("archive content-type", annContentType, string(cdiv1.DataVolumeArchive), false),
+	)
+
+	DescribeTable("should detect kubevirt content type if a datavolume exists that is kubevirt", func(contentType cdiv1.DataVolumeContentType, expected bool) {
+		dv := &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dv",
+				Namespace: testNamespace,
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				ContentType: contentType,
+			},
+		}
+		controller.DataVolumeInformer.GetStore().Add(dv)
+		pvc := &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dv",
+				Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(dv, schema.GroupVersionKind{
+						Group:   cdiv1.SchemeGroupVersion.Group,
+						Version: cdiv1.SchemeGroupVersion.Version,
+						Kind:    "DataVolume",
+					}),
+				},
+			},
+		}
+		res := controller.isKubevirtContentType(pvc)
+		Expect(res).To(Equal(expected))
+	},
+		Entry("missing content-type", cdiv1.DataVolumeContentType(""), true),
+		Entry("content-type kubevirt", cdiv1.DataVolumeKubeVirt, true),
+		Entry("content-type archive", cdiv1.DataVolumeArchive, false),
+	)
+
+	DescribeTable("should create proper condition from PVC", func(phase k8sv1.PersistentVolumeClaimPhase, status k8sv1.ConditionStatus, reason, message string) {
+		pvc := &k8sv1.PersistentVolumeClaim{
+			Status: k8sv1.PersistentVolumeClaimStatus{
+				Phase: phase,
+			},
+		}
+		expectedCond := newPvcCondition(status, reason, message)
+		condRes := controller.pvcConditionFromPVC([]*k8sv1.PersistentVolumeClaim{pvc})
+		Expect(condRes.Type).To(Equal(expectedCond.Type))
+		Expect(condRes.Status).To(Equal(expectedCond.Status))
+		Expect(condRes.Reason).To(Equal(expectedCond.Reason))
+		Expect(condRes.Message).To(Equal(message))
+	},
+		Entry("PVC bound", k8sv1.ClaimBound, k8sv1.ConditionTrue, pvcBoundReason, ""),
+		Entry("PVC claim lost", k8sv1.ClaimLost, k8sv1.ConditionFalse, unknownReason, ""),
+		Entry("PVC pending", k8sv1.ClaimPending, k8sv1.ConditionFalse, pvcPendingReason, ""),
+	)
+})

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -1,0 +1,244 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package export
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+
+	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
+)
+
+const (
+	noVolumeVMReason = "VMNoVolumes"
+)
+
+func (ctrl *VMExportController) handleVMExport(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	if vmExport, ok := obj.(*exportv1.VirtualMachineExport); ok {
+		objName, err := cache.DeletionHandlingMetaNamespaceKeyFunc(vmExport)
+		if err != nil {
+			log.Log.Errorf(failedKeyFromObjectFmt, err, vmExport)
+			return
+		}
+		log.Log.V(3).Infof(enqueuedForSyncFmt, objName)
+		ctrl.vmExportQueue.Add(objName)
+	}
+}
+
+func (ctrl *VMExportController) handleVM(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	if vm, ok := obj.(*virtv1.VirtualMachine); ok {
+		key, _ := cache.MetaNamespaceKeyFunc(vm)
+		log.Log.V(3).Infof("Processing VM %s", key)
+		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("vm", key)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		for _, key := range keys {
+			ctrl.vmExportQueue.Add(key)
+		}
+	}
+}
+
+func (ctrl *VMExportController) handleVMI(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	if vmi, ok := obj.(*virtv1.VirtualMachineInstance); ok {
+		vm := ctrl.getVMFromVMI(vmi)
+		if vm != nil {
+			key, _ := cache.MetaNamespaceKeyFunc(vm)
+			log.Log.V(3).Infof("Processing VM %s", key)
+			keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("vm", key)
+			if err != nil {
+				utilruntime.HandleError(err)
+				return
+			}
+			for _, key := range keys {
+				ctrl.vmExportQueue.Add(key)
+			}
+			return
+		}
+		pvcs := ctrl.getPVCsFromVMI(vmi)
+		for _, pvc := range pvcs {
+			ctrl.handlePVC(pvc)
+		}
+	}
+}
+
+func (ctrl *VMExportController) getPVCsFromVMI(vmi *virtv1.VirtualMachineInstance) []*corev1.PersistentVolumeClaim {
+	var pvcs []*corev1.PersistentVolumeClaim
+	for _, volume := range vmi.Spec.Volumes {
+		pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
+		if pvc := ctrl.getPVCsFromName(vmi.Namespace, pvcName); pvc != nil {
+			pvcs = append(pvcs, pvc)
+		}
+	}
+	return pvcs
+}
+
+func (ctrl *VMExportController) getOwnerVMexportKey(obj metav1.Object) string {
+	ownerRef := metav1.GetControllerOf(obj)
+	var key string
+	if ownerRef != nil {
+		if ownerRef.Kind == exportGVK.Kind && ownerRef.APIVersion == exportGVK.GroupVersion().String() {
+			key = controller.NamespacedKey(obj.GetNamespace(), ownerRef.Name)
+		}
+	}
+	return key
+}
+
+func (ctrl *VMExportController) getVMFromVMI(vmi *virtv1.VirtualMachineInstance) *virtv1.VirtualMachine {
+	ownerRef := metav1.GetControllerOf(vmi)
+	if ownerRef != nil {
+		if ownerRef.Kind == "VirtualMachine" && ownerRef.APIVersion == virtv1.GroupVersion.String() {
+			if vm, exists, err := ctrl.getVm(vmi.Namespace, ownerRef.Name); !exists || err != nil {
+				log.Log.V(3).Infof("Unable to get owner VM %s/%s for VMI %s/%s", vmi.Namespace, ownerRef.Name, vmi.Namespace, vmi.Name)
+			} else {
+				return vm
+			}
+		}
+	}
+	return nil
+}
+
+func (ctrl *VMExportController) isSourceAvailableVM(vmExport *exportv1.VirtualMachineExport) (bool, string, error) {
+	vmi, exists, err := ctrl.getVmi(vmExport.Namespace, vmExport.Spec.Source.Name)
+	if err != nil {
+		return false, "", err
+	}
+	if exists {
+		return false, fmt.Sprintf("Virtual Machine %s/%s is running", vmi.Namespace, vmi.Name), nil
+	}
+	return true, "", nil
+}
+
+func (ctrl *VMExportController) getPVCFromSourceVM(vmExport *exportv1.VirtualMachineExport) (*sourceVolumes, error) {
+	pvcs, allPopulated, err := ctrl.getPVCsFromVM(vmExport.Namespace, vmExport.Spec.Source.Name)
+	if err != nil {
+		return &sourceVolumes{}, err
+	}
+	if pvcs != nil && !allPopulated {
+		return &sourceVolumes{
+			volumes:          pvcs,
+			sourceAvailable:  allPopulated,
+			availableMessage: fmt.Sprintf("Not all volumes in the Virtual Machine %s/%s are populated", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
+	}
+	sourceAvailable, availableMessage, err := ctrl.isSourceAvailableVM(vmExport)
+	if err != nil {
+		return &sourceVolumes{}, err
+	}
+	return &sourceVolumes{
+		volumes:          pvcs,
+		sourceAvailable:  sourceAvailable,
+		availableMessage: availableMessage}, nil
+}
+
+func (ctrl *VMExportController) getPVCsFromVM(vmNamespace, vmName string) ([]*corev1.PersistentVolumeClaim, bool, error) {
+	var pvcs []*corev1.PersistentVolumeClaim
+	vm, exists, err := ctrl.getVm(vmNamespace, vmName)
+	if err != nil {
+		return nil, false, err
+	}
+	if !exists {
+		return nil, false, nil
+	}
+	allPopulated := true
+	for _, volume := range vm.Spec.Template.Spec.Volumes {
+		pvcName := storagetypes.PVCNameFromVirtVolume(&volume)
+		if pvcName == "" {
+			continue
+		}
+		pvc, exists, err := ctrl.getPvc(vmNamespace, pvcName)
+		if err != nil {
+			return nil, false, nil
+		}
+		if exists {
+			populated, err := ctrl.isPVCPopulated(pvc)
+			if err != nil {
+				return nil, false, err
+			}
+			if populated {
+				pvcs = append(pvcs, pvc)
+			} else {
+				allPopulated = false
+			}
+		}
+	}
+	return pvcs, allPopulated, nil
+}
+
+func (ctrl *VMExportController) updateVMExportVMStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, sourceVolumes *sourceVolumes) (time.Duration, error) {
+	vmExportCopy := vmExport.DeepCopy()
+
+	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
+		return 0, err
+	}
+	if len(sourceVolumes.volumes) == 0 {
+		vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newReadyCondition(corev1.ConditionFalse, noVolumeVMReason, sourceVolumes.availableMessage))
+		vmExportCopy.Status.Phase = exportv1.Skipped
+	}
+	if err := ctrl.updateVMExportStatus(vmExport, vmExportCopy); err != nil {
+		return 0, err
+	}
+	return 0, nil
+}
+
+func (ctrl *VMExportController) isSourceVM(source *exportv1.VirtualMachineExportSpec) bool {
+	return source != nil && source.Source.APIGroup != nil && *source.Source.APIGroup == virtv1.SchemeGroupVersion.Group && source.Source.Kind == "VirtualMachine"
+}
+
+func (ctrl *VMExportController) getVm(namespace, name string) (*virtv1.VirtualMachine, bool, error) {
+	key := controller.NamespacedKey(namespace, name)
+	obj, exists, err := ctrl.VMInformer.GetStore().GetByKey(key)
+	if err != nil || !exists {
+		return nil, exists, err
+	}
+	return obj.(*virtv1.VirtualMachine).DeepCopy(), true, nil
+}
+
+func (ctrl *VMExportController) getVmi(namespace, name string) (*virtv1.VirtualMachineInstance, bool, error) {
+	key := controller.NamespacedKey(namespace, name)
+	obj, exists, err := ctrl.VMIInformer.GetStore().GetByKey(key)
+	if err != nil || !exists {
+		return nil, exists, err
+	}
+	return obj.(*virtv1.VirtualMachineInstance).DeepCopy(), true, nil
+}

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -203,6 +203,13 @@ func (ctrl *VMExportController) getPVCsFromVM(vmNamespace, vmName string) ([]*co
 			if !populated {
 				allPopulated = false
 			}
+			continue
+		}
+		if volume.DataVolume != nil {
+			// PVC has not been created yet, otherwise exist would be true. Setting allPopulated to false will
+			// trigger a requeue
+			log.Log.V(2).Infof("Found data volume %s but PVC does not exist yet", volume.DataVolume.Name)
+			allPopulated = false
 		}
 	}
 	return pvcs, allPopulated, nil

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -1,0 +1,513 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+package export
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+
+	k8sv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
+	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
+	"kubevirt.io/client-go/kubecli"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+)
+
+const (
+	testVmName = "test-vm"
+)
+
+var _ = Describe("PVC source", func() {
+	var (
+		ctrl                       *gomock.Controller
+		controller                 *VMExportController
+		recorder                   *record.FakeRecorder
+		pvcInformer                cache.SharedIndexInformer
+		podInformer                cache.SharedIndexInformer
+		cmInformer                 cache.SharedIndexInformer
+		vmExportInformer           cache.SharedIndexInformer
+		serviceInformer            cache.SharedIndexInformer
+		dvInformer                 cache.SharedIndexInformer
+		vmSnapshotInformer         cache.SharedIndexInformer
+		vmSnapshotContentInformer  cache.SharedIndexInformer
+		secretInformer             cache.SharedIndexInformer
+		vmInformer                 cache.SharedIndexInformer
+		vmiInformer                cache.SharedIndexInformer
+		k8sClient                  *k8sfake.Clientset
+		vmExportClient             *kubevirtfake.Clientset
+		fakeVolumeSnapshotProvider *MockVolumeSnapshotProvider
+		mockVMExportQueue          *testutils.MockWorkQueue
+		routeCache                 cache.Store
+		ingressCache               cache.Store
+		certDir                    string
+		certFilePath               string
+		keyFilePath                string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		var err error
+		certDir, err = ioutil.TempDir("", "certs")
+		Expect(err).ToNot(HaveOccurred())
+		certFilePath = filepath.Join(certDir, "tls.crt")
+		keyFilePath = filepath.Join(certDir, "tls.key")
+		writeCertsToDir(certDir)
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
+		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
+		vmExportInformer, _ = testutils.NewFakeInformerWithIndexersFor(&exportv1.VirtualMachineExport{}, virtcontroller.GetVirtualMachineExportInformerIndexers())
+		dvInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+		vmSnapshotInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
+		vmSnapshotContentInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
+		vmInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+		vmiInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
+		routeInformer, _ := testutils.NewFakeInformerFor(&routev1.Route{})
+		routeCache = routeInformer.GetStore()
+		ingressInformer, _ := testutils.NewFakeInformerFor(&networkingv1.Ingress{})
+		ingressCache = ingressInformer.GetStore()
+		secretInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Secret{})
+		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
+			volumeSnapshots: []*vsv1.VolumeSnapshot{},
+		}
+
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
+		k8sClient = k8sfake.NewSimpleClientset()
+		vmExportClient = kubevirtfake.NewSimpleClientset()
+		recorder = record.NewFakeRecorder(100)
+
+		virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+		virtClient.EXPECT().VirtualMachineExport(testNamespace).
+			Return(vmExportClient.ExportV1alpha1().VirtualMachineExports(testNamespace)).AnyTimes()
+
+		controller = &VMExportController{
+			Client:                    virtClient,
+			Recorder:                  recorder,
+			PVCInformer:               pvcInformer,
+			PodInformer:               podInformer,
+			ConfigMapInformer:         cmInformer,
+			VMExportInformer:          vmExportInformer,
+			ServiceInformer:           serviceInformer,
+			DataVolumeInformer:        dvInformer,
+			KubevirtNamespace:         "kubevirt",
+			TemplateService:           services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			caCertManager:             bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
+			RouteCache:                routeCache,
+			IngressCache:              ingressCache,
+			RouteConfigMapInformer:    cmInformer,
+			SecretInformer:            secretInformer,
+			VMSnapshotInformer:        vmSnapshotInformer,
+			VMSnapshotContentInformer: vmSnapshotContentInformer,
+			VolumeSnapshotProvider:    fakeVolumeSnapshotProvider,
+			VMInformer:                vmInformer,
+			VMIInformer:               vmiInformer,
+		}
+		initCert = func(ctrl *VMExportController) {
+			go controller.caCertManager.Start()
+			// Give the thread time to read the certs.
+			Eventually(func() *tls.Certificate {
+				return controller.caCertManager.Current()
+			}, time.Second, time.Millisecond).ShouldNot(BeNil())
+		}
+
+		controller.Init()
+		mockVMExportQueue = testutils.NewMockWorkQueue(controller.vmExportQueue)
+		controller.vmExportQueue = mockVMExportQueue
+
+		cmInformer.GetStore().Add(&k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controller.KubevirtNamespace,
+				Name:      components.KubeVirtExportCASecretName,
+			},
+			Data: map[string]string{
+				"ca-bundle": "replace me with ca cert",
+			},
+		})
+	})
+
+	AfterEach(func() {
+		controller.caCertManager.Stop()
+		os.RemoveAll(certDir)
+	})
+
+	createExporterPod := func(name string, phase k8sv1.PodPhase) *k8sv1.Pod {
+		return &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Status: k8sv1.PodStatus{
+				Phase: phase,
+			},
+		}
+	}
+
+	createVMWithoutVolumes := func() *virtv1.VirtualMachine {
+		return &virtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmName,
+				Namespace: testNamespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{
+						Volumes: []virtv1.Volume{},
+					},
+				},
+			},
+		}
+	}
+
+	createVMWithDataVolumes := func() *virtv1.VirtualMachine {
+		vm := createVMWithoutVolumes()
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume1",
+			VolumeSource: virtv1.VolumeSource{
+				DataVolume: &virtv1.DataVolumeSource{
+					Name: "volume1",
+				},
+			},
+		})
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume2",
+			VolumeSource: virtv1.VolumeSource{
+				DataVolume: &virtv1.DataVolumeSource{
+					Name: "volume2",
+				},
+			},
+		})
+		return vm
+	}
+
+	createVMWithPVCs := func() *virtv1.VirtualMachine {
+		vm := createVMWithoutVolumes()
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume1",
+			VolumeSource: virtv1.VolumeSource{
+				PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "volume1",
+					},
+				},
+			},
+		})
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume2",
+			VolumeSource: virtv1.VolumeSource{
+				PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "volume2",
+					},
+				},
+			},
+		})
+		return vm
+	}
+
+	createVMWithPVCandMemoryDump := func() *virtv1.VirtualMachine {
+		vm := createVMWithoutVolumes()
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume1",
+			VolumeSource: virtv1.VolumeSource{
+				PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "volume1",
+					},
+				},
+			},
+		})
+		vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+			Name: "volume2",
+			VolumeSource: virtv1.VolumeSource{
+				MemoryDump: &virtv1.MemoryDumpVolumeSource{
+					PersistentVolumeClaimVolumeSource: virtv1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "volume2",
+						},
+					},
+				},
+			},
+		})
+		return vm
+	}
+
+	createVMIWithDataVolumes := func() *virtv1.VirtualMachineInstance {
+		return &virtv1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmName,
+				Namespace: testNamespace,
+			},
+			Spec: virtv1.VirtualMachineInstanceSpec{
+				Volumes: []virtv1.Volume{
+					{
+						Name: "volume1",
+						VolumeSource: virtv1.VolumeSource{
+							DataVolume: &virtv1.DataVolumeSource{
+								Name: "volume1",
+							},
+						},
+					},
+					{
+						Name: "volume2",
+						VolumeSource: virtv1.VolumeSource{
+							DataVolume: &virtv1.DataVolumeSource{
+								Name: "volume2",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	verifyMixedInternal := func(vmExport *exportv1.VirtualMachineExport, exportName, namespace string, volumeNames ...string) {
+		exportVolumeFormats := make([]exportv1.VirtualMachineExportVolumeFormat, 0)
+		exportVolumeFormats = append(exportVolumeFormats, exportv1.VirtualMachineExportVolumeFormat{
+			Format: exportv1.KubeVirtRaw,
+			Url:    fmt.Sprintf("https://%s.%s.svc/volumes/%s/disk.img", fmt.Sprintf("%s-%s", exportPrefix, exportName), namespace, volumeNames[0]),
+		})
+		exportVolumeFormats = append(exportVolumeFormats, exportv1.VirtualMachineExportVolumeFormat{
+			Format: exportv1.KubeVirtGz,
+			Url:    fmt.Sprintf("https://%s.%s.svc/volumes/%s/disk.img.gz", fmt.Sprintf("%s-%s", exportPrefix, exportName), namespace, volumeNames[0]),
+		})
+		exportVolumeFormats = append(exportVolumeFormats, exportv1.VirtualMachineExportVolumeFormat{
+			Format: exportv1.Dir,
+			Url:    fmt.Sprintf("https://%s.%s.svc/volumes/%s/dir", fmt.Sprintf("%s-%s", exportPrefix, exportName), namespace, volumeNames[1]),
+		})
+		exportVolumeFormats = append(exportVolumeFormats, exportv1.VirtualMachineExportVolumeFormat{
+			Format: exportv1.ArchiveGz,
+			Url:    fmt.Sprintf("https://%s.%s.svc/volumes/%s/disk.tar.gz", fmt.Sprintf("%s-%s", exportPrefix, exportName), namespace, volumeNames[1]),
+		})
+		verifyLinksInternal(vmExport, exportVolumeFormats...)
+	}
+
+	DescribeTable("Should create VM export, when VM is stopped", func(createVMFunc func() *virtv1.VirtualMachine, contentType1, contentType2 string, verifyFunc func(vmExport *exportv1.VirtualMachineExport, exportName, namespace string, volumeNames ...string)) {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMFunc())
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", contentType1))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", contentType2))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyFunc(vmExport, vmExport.Name, testNamespace, "volume1", "volume2")
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(podReadyReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	},
+		Entry("DataVolumes", createVMWithDataVolumes, "kubevirt", "kubevirt", verifyKubevirtInternal),
+		Entry("PVCs", createVMWithPVCs, "kubevirt", "kubevirt", verifyKubevirtInternal),
+		Entry("Memorydump and pvc", createVMWithPVCandMemoryDump, "kubevirt", "archive", verifyMixedInternal),
+	)
+
+	It("Should NOT create VM export, when VM is started", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithDataVolumes())
+		vmi := createVMIWithDataVolumes()
+		controller.VMIInformer.GetStore().Add(vmi)
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(inUseReason))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("Virtual Machine %s/%s is running", vmi.Namespace, vmi.Name)))
+				}
+			}
+			return true, vmExport, nil
+		})
+
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	})
+
+	createPopulatingDataVolume := func(name string) *cdiv1.DataVolume {
+		return &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Status: cdiv1.DataVolumeStatus{
+				Progress: "50%",
+				Phase:    cdiv1.ImportInProgress,
+			},
+		}
+	}
+
+	It("Should NOT create VM export, when DV is not complete", func() {
+		testVMExport := createVMVMExport()
+		vm := createVMWithDataVolumes()
+		controller.VMInformer.GetStore().Add(vm)
+		dv := createPopulatingDataVolume("volume1")
+		pvc1 := createPVC("volume1", "kubevirt")
+		ownerRef := metav1.NewControllerRef(dv, datavolumeGVK)
+		pvc1.GetObjectMeta().SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
+		controller.PVCInformer.GetStore().Add(pvc1)
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		controller.DataVolumeInformer.GetStore().Add(dv)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(inUseReason))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("Not all volumes in the Virtual Machine %s/%s are populated", vm.Namespace, vm.Name)))
+				}
+			}
+			return true, vmExport, nil
+		})
+
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+	})
+
+	It("Should stop running VM export, when VM is started", func() {
+		testVMExport := createVMVMExport()
+		podName := controller.getExportPodName(testVMExport)
+		controller.PodInformer.GetStore().Add(createExporterPod(podName, k8sv1.PodRunning))
+		controller.VMInformer.GetStore().Add(createVMWithDataVolumes())
+		vmi := createVMIWithDataVolumes()
+		controller.VMIInformer.GetStore().Add(vmi)
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		expectExporterDelete(k8sClient, podName)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(inUseReason))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("Virtual Machine %s/%s is running", vmi.Namespace, vmi.Name)), "%v", vmExport.Status.Conditions)
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+		testutils.ExpectEvent(recorder, ExportPaused)
+	})
+
+	It("Should be in skipped phase when VM has no volumes", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithoutVolumes())
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(noVolumeVMReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+	})
+
+	It("Should handle failed exporter pod", func() {
+		testVMExport := createVMVMExport()
+		podName := controller.getExportPodName(testVMExport)
+		controller.PodInformer.GetStore().Add(createExporterPod(podName, k8sv1.PodFailed))
+		controller.VMInformer.GetStore().Add(createVMWithDataVolumes())
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(unknownReason))
+				}
+			}
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		testutils.ExpectEvent(recorder, serviceCreatedEvent)
+		testutils.ExpectEvent(recorder, exporterPodFailedOrCompletedEvent)
+	})
+})

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -425,7 +425,7 @@ var _ = Describe("PVC source", func() {
 
 		retry, err := controller.updateVMExport(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(retry).To(BeEquivalentTo(0))
+		Expect(retry).To(BeEquivalentTo(requeueTime))
 		testutils.ExpectEvent(recorder, serviceCreatedEvent)
 	})
 

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -75,7 +75,8 @@ func (ctrl *VMExportController) getPVCFromSourceVMSnapshot(vmExport *exportv1.Vi
 	if !exists {
 		return &sourceVolumes{
 			volumes:          nil,
-			sourceAvailable:  false,
+			inUse:            false,
+			isPopulated:      false,
 			availableMessage: fmt.Sprintf("VirtualMachineSnapshot %s/%s does not exist", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
 	}
 	if vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse {
@@ -86,23 +87,27 @@ func (ctrl *VMExportController) getPVCFromSourceVMSnapshot(vmExport *exportv1.Vi
 		if len(pvcs) == restoreableSnapshots && restoreableSnapshots > 0 {
 			return &sourceVolumes{
 				volumes:          pvcs,
-				sourceAvailable:  true,
+				inUse:            false,
+				isPopulated:      true,
 				availableMessage: ""}, nil
 		}
 		if restoreableSnapshots == 0 {
 			return &sourceVolumes{
 				volumes:          nil,
-				sourceAvailable:  false,
+				inUse:            false,
+				isPopulated:      false,
 				availableMessage: fmt.Sprintf("VirtualMachineSnapshot %s/%s does not contain any volume snapshots", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
 		}
 		return &sourceVolumes{
 			volumes:          nil,
-			sourceAvailable:  false,
+			inUse:            false,
+			isPopulated:      false,
 			availableMessage: "Not all PVCs have been successfully restored"}, nil
 	}
 	return &sourceVolumes{
 		volumes:          nil,
-		sourceAvailable:  false,
+		inUse:            false,
+		isPopulated:      false,
 		availableMessage: fmt.Sprintf("VirtualMachineSnapshot %s/%s is not ready to use", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
 }
 

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -1,0 +1,268 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package export
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
+	"kubevirt.io/client-go/log"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+
+	"kubevirt.io/kubevirt/pkg/storage/snapshot"
+)
+
+const (
+	noVolumeSnapshotReason = "VMSnapshotNoVolumes"
+
+	notAllPVCsCreated = "NotAllPVCsCreated"
+	allPVCsReady      = "AllPVCsReady"
+	notAllPVCsReady   = "NotAllPVCsReady"
+)
+
+func (ctrl *VMExportController) handleVMSnapshot(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
+
+	if snapshot, ok := obj.(*snapshotv1.VirtualMachineSnapshot); ok {
+		key, _ := cache.MetaNamespaceKeyFunc(snapshot)
+		log.Log.V(3).Infof("Processing VirtualMachineSnapshot %s", key)
+		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("vmsnapshot", key)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		for _, key := range keys {
+			ctrl.vmExportQueue.Add(key)
+		}
+	}
+}
+
+func (ctrl *VMExportController) getPVCFromSourceVMSnapshot(vmExport *exportv1.VirtualMachineExport) (*sourceVolumes, error) {
+	vmSnapshot, exists, err := ctrl.getVmSnapshot(vmExport.Namespace, vmExport.Spec.Source.Name)
+	if err != nil {
+		return &sourceVolumes{}, err
+	}
+	if !exists {
+		return &sourceVolumes{
+			volumes:          nil,
+			sourceAvailable:  false,
+			availableMessage: fmt.Sprintf("VirtualMachineSnapshot %s/%s does not exist", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
+	}
+	if vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse {
+		pvcs, restoreableSnapshots, err := ctrl.handlePVCsForVirtualMachineSnapshot(vmExport, vmSnapshot)
+		if err != nil {
+			return &sourceVolumes{}, err
+		}
+		if len(pvcs) == restoreableSnapshots && restoreableSnapshots > 0 {
+			return &sourceVolumes{
+				volumes:          pvcs,
+				sourceAvailable:  true,
+				availableMessage: ""}, nil
+		}
+		if restoreableSnapshots == 0 {
+			return &sourceVolumes{
+				volumes:          nil,
+				sourceAvailable:  false,
+				availableMessage: fmt.Sprintf("VirtualMachineSnapshot %s/%s does not contain any volume snapshots", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
+		}
+		return &sourceVolumes{
+			volumes:          nil,
+			sourceAvailable:  false,
+			availableMessage: "Not all PVCs have been successfully restored"}, nil
+	}
+	return &sourceVolumes{
+		volumes:          nil,
+		sourceAvailable:  false,
+		availableMessage: fmt.Sprintf("VirtualMachineSnapshot %s/%s is not ready to use", vmExport.Namespace, vmExport.Spec.Source.Name)}, nil
+}
+
+func (ctrl *VMExportController) handlePVCsForVirtualMachineSnapshot(vmExport *exportv1.VirtualMachineExport, vmSnapshot *snapshotv1.VirtualMachineSnapshot) ([]*corev1.PersistentVolumeClaim, int, error) {
+	var content *snapshotv1.VirtualMachineSnapshotContent
+	var err error
+	var pvcs []*corev1.PersistentVolumeClaim
+	exists := false
+	totalVolumes := 0
+
+	if vmSnapshot.Status.VirtualMachineSnapshotContentName != nil && *vmSnapshot.Status.VirtualMachineSnapshotContentName != "" {
+		content, exists, err = ctrl.getVmSnapshotContent(vmSnapshot.Namespace, *vmSnapshot.Status.VirtualMachineSnapshotContentName)
+		if err != nil {
+			return nil, 0, err
+		}
+		if exists {
+			sourceVm := content.Spec.Source.VirtualMachine
+			totalVolumes = len(content.Status.VolumeSnapshotStatus)
+			for _, volumeBackup := range content.Spec.VolumeBackups {
+				if pvc, err := ctrl.getOrCreatePVCFromSnapshot(vmExport, &volumeBackup, sourceVm); err != nil {
+					return nil, 0, err
+				} else {
+					pvcs = append(pvcs, pvc)
+				}
+			}
+		}
+	}
+	return pvcs, totalVolumes, err
+}
+
+func (ctrl *VMExportController) getOrCreatePVCFromSnapshot(vmExport *exportv1.VirtualMachineExport, volumeBackup *snapshotv1.VolumeBackup, sourceVm *snapshotv1.VirtualMachine) (*corev1.PersistentVolumeClaim, error) {
+	if volumeBackup.VolumeSnapshotName == nil {
+		log.Log.Errorf("VolumeSnapshot name missing %+v", volumeBackup)
+		return nil, fmt.Errorf("missing VolumeSnapshot name")
+	}
+	restorePVCName := fmt.Sprintf("%s-%s", vmExport.Name, volumeBackup.PersistentVolumeClaim.Name)
+
+	if pvc, exists, err := ctrl.getPvc(vmExport.Namespace, restorePVCName); err != nil {
+		return nil, err
+	} else if exists {
+		return pvc, nil
+	}
+
+	volumeSnapshot, err := ctrl.VolumeSnapshotProvider.GetVolumeSnapshot(vmExport.Namespace, *volumeBackup.VolumeSnapshotName)
+	if err != nil {
+		return nil, err
+	}
+
+	// leaving source name and namespace blank because we don't care in this context
+	pvc := snapshot.CreateRestorePVCDef(restorePVCName, volumeSnapshot, volumeBackup)
+	if volumeBackupIsKubeVirtContent(volumeBackup, sourceVm) {
+		if len(pvc.GetAnnotations()) == 0 {
+			pvc.SetAnnotations(make(map[string]string))
+		}
+		pvc.Annotations[annContentType] = string(cdiv1.DataVolumeKubeVirt)
+	}
+	pvc.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion:         apiVersion,
+			Kind:               "VirtualMachineExport",
+			Name:               vmExport.Name,
+			UID:                vmExport.UID,
+			Controller:         pointer.BoolPtr(true),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
+		},
+	})
+
+	pvc, err = ctrl.Client.CoreV1().PersistentVolumeClaims(vmExport.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pvc, nil
+}
+
+func (ctrl *VMExportController) updateVMExporVMSnapshotStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, sourceVolumes *sourceVolumes) (time.Duration, error) {
+	vmExportCopy := vmExport.DeepCopy()
+
+	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
+		return 0, err
+	}
+
+	if err := ctrl.updateVMSnapshotExportStatusConditions(vmExportCopy, sourceVolumes.volumes, sourceVolumes.availableMessage); err != nil {
+		return 0, err
+	}
+
+	if err := ctrl.updateVMExportStatus(vmExport, vmExportCopy); err != nil {
+		return 0, err
+	}
+	return 0, nil
+}
+
+func (ctrl *VMExportController) updateVMSnapshotExportStatusConditions(vmExportCopy *exportv1.VirtualMachineExport, pvcs []*corev1.PersistentVolumeClaim, availableMessage string) error {
+	vmSnapshot, exists, err := ctrl.getVmSnapshot(vmExportCopy.Namespace, vmExportCopy.Spec.Source.Name)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newReadyCondition(corev1.ConditionFalse, initializingReason, ""))
+		return nil
+	}
+	if vmSnapshot.Status.VirtualMachineSnapshotContentName != nil && *vmSnapshot.Status.VirtualMachineSnapshotContentName != "" {
+		content, exists, err := ctrl.getVmSnapshotContent(vmSnapshot.Namespace, *vmSnapshot.Status.VirtualMachineSnapshotContentName)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if len(content.Status.VolumeSnapshotStatus) == 0 {
+				vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newVolumesCreatedCondition(corev1.ConditionFalse, noVolumeSnapshotReason, availableMessage))
+				vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newReadyCondition(corev1.ConditionFalse, initializingReason, ""))
+				vmExportCopy.Status.Phase = exportv1.Skipped
+			} else if len(content.Status.VolumeSnapshotStatus) != len(pvcs) {
+				vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newVolumesCreatedCondition(corev1.ConditionFalse, notAllPVCsCreated, availableMessage))
+			} else {
+				readyCount := 0
+				for _, pvc := range pvcs {
+					if pvc.Status.Phase == corev1.ClaimBound {
+						readyCount++
+					}
+				}
+				if readyCount == len(pvcs) {
+					vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newVolumesCreatedCondition(corev1.ConditionTrue, allPVCsReady, availableMessage))
+				} else {
+					vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, newVolumesCreatedCondition(corev1.ConditionFalse, notAllPVCsReady, "Not all PVCs are ready"))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (ctrl *VMExportController) isSourceVMSnapshot(source *exportv1.VirtualMachineExportSpec) bool {
+	return source != nil && source.Source.APIGroup != nil && *source.Source.APIGroup == snapshotv1.SchemeGroupVersion.Group && source.Source.Kind == "VirtualMachineSnapshot"
+}
+
+func (ctrl *VMExportController) getVmSnapshot(namespace, name string) (*snapshotv1.VirtualMachineSnapshot, bool, error) {
+	key := controller.NamespacedKey(namespace, name)
+	obj, exists, err := ctrl.VMSnapshotInformer.GetStore().GetByKey(key)
+	if err != nil || !exists {
+		return nil, exists, err
+	}
+	return obj.(*snapshotv1.VirtualMachineSnapshot).DeepCopy(), true, nil
+}
+
+func (ctrl *VMExportController) getVmSnapshotContent(namespace, name string) (*snapshotv1.VirtualMachineSnapshotContent, bool, error) {
+	key := controller.NamespacedKey(namespace, name)
+	obj, exists, err := ctrl.VMSnapshotContentInformer.GetStore().GetByKey(key)
+	if err != nil || !exists {
+		return nil, exists, err
+	}
+	return obj.(*snapshotv1.VirtualMachineSnapshotContent).DeepCopy(), true, nil
+}
+
+func volumeBackupIsKubeVirtContent(volumeBackup *snapshotv1.VolumeBackup, sourceVm *snapshotv1.VirtualMachine) bool {
+	if sourceVm != nil && sourceVm.Spec.Template != nil {
+		for _, volume := range sourceVm.Spec.Template.Spec.Volumes {
+			if volume.Name == volumeBackup.VolumeName && (volume.DataVolume != nil || volume.PersistentVolumeClaim != nil) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -54,14 +54,14 @@ func (ctrl *VMExportController) handleVMSnapshot(obj interface{}) {
 	}
 
 	if snapshot, ok := obj.(*snapshotv1.VirtualMachineSnapshot); ok {
-		key, _ := cache.MetaNamespaceKeyFunc(snapshot)
-		log.Log.V(3).Infof("Processing VirtualMachineSnapshot %s", key)
-		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("vmsnapshot", key)
+		snapshotKey, _ := cache.MetaNamespaceKeyFunc(snapshot)
+		keys, err := ctrl.VMExportInformer.GetIndexer().IndexKeys("vmsnapshot", snapshotKey)
 		if err != nil {
 			utilruntime.HandleError(err)
 			return
 		}
 		for _, key := range keys {
+			log.Log.V(3).Infof("Adding VMExport due to VMSnapshot %s", snapshotKey)
 			ctrl.vmExportQueue.Add(key)
 		}
 	}

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -1,0 +1,637 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+package export
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+
+	k8sv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+
+	virtv1 "kubevirt.io/api/core/v1"
+	exportv1 "kubevirt.io/api/export/v1alpha1"
+	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
+	kubevirtfake "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
+	"kubevirt.io/client-go/kubecli"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
+	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+)
+
+const (
+	testVmsnapshotName     = "test-vmsnapshot"
+	testVolumesnapshotName = "test-snapshot"
+)
+
+var _ = Describe("VMSnapshot source", func() {
+	var (
+		ctrl                       *gomock.Controller
+		controller                 *VMExportController
+		recorder                   *record.FakeRecorder
+		pvcInformer                cache.SharedIndexInformer
+		podInformer                cache.SharedIndexInformer
+		cmInformer                 cache.SharedIndexInformer
+		vmExportInformer           cache.SharedIndexInformer
+		serviceInformer            cache.SharedIndexInformer
+		dvInformer                 cache.SharedIndexInformer
+		vmSnapshotInformer         cache.SharedIndexInformer
+		vmSnapshotContentInformer  cache.SharedIndexInformer
+		secretInformer             cache.SharedIndexInformer
+		vmInformer                 cache.SharedIndexInformer
+		vmiInformer                cache.SharedIndexInformer
+		k8sClient                  *k8sfake.Clientset
+		vmExportClient             *kubevirtfake.Clientset
+		fakeVolumeSnapshotProvider *MockVolumeSnapshotProvider
+		mockVMExportQueue          *testutils.MockWorkQueue
+		routeCache                 cache.Store
+		ingressCache               cache.Store
+		certDir                    string
+		certFilePath               string
+		keyFilePath                string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		var err error
+		certDir, err = ioutil.TempDir("", "certs")
+		Expect(err).ToNot(HaveOccurred())
+		certFilePath = filepath.Join(certDir, "tls.crt")
+		keyFilePath = filepath.Join(certDir, "tls.key")
+		writeCertsToDir(certDir)
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		podInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+		cmInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
+		serviceInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Service{})
+		vmExportInformer, _ = testutils.NewFakeInformerWithIndexersFor(&exportv1.VirtualMachineExport{}, virtcontroller.GetVirtualMachineExportInformerIndexers())
+		dvInformer, _ = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
+		vmSnapshotInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshot{})
+		vmSnapshotContentInformer, _ = testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineSnapshotContent{})
+		vmInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachine{})
+		vmiInformer, _ = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
+		routeInformer, _ := testutils.NewFakeInformerFor(&routev1.Route{})
+		routeCache = routeInformer.GetStore()
+		ingressInformer, _ := testutils.NewFakeInformerFor(&networkingv1.Ingress{})
+		ingressCache = ingressInformer.GetStore()
+		secretInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Secret{})
+		fakeVolumeSnapshotProvider = &MockVolumeSnapshotProvider{
+			volumeSnapshots: []*vsv1.VolumeSnapshot{},
+		}
+
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
+		k8sClient = k8sfake.NewSimpleClientset()
+		vmExportClient = kubevirtfake.NewSimpleClientset()
+		recorder = record.NewFakeRecorder(100)
+
+		virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+		virtClient.EXPECT().VirtualMachineExport(testNamespace).
+			Return(vmExportClient.ExportV1alpha1().VirtualMachineExports(testNamespace)).AnyTimes()
+
+		controller = &VMExportController{
+			Client:                    virtClient,
+			Recorder:                  recorder,
+			PVCInformer:               pvcInformer,
+			PodInformer:               podInformer,
+			ConfigMapInformer:         cmInformer,
+			VMExportInformer:          vmExportInformer,
+			ServiceInformer:           serviceInformer,
+			DataVolumeInformer:        dvInformer,
+			KubevirtNamespace:         "kubevirt",
+			TemplateService:           services.NewTemplateService("a", 240, "b", "c", "d", "e", "f", "g", pvcInformer.GetStore(), virtClient, config, qemuGid, "h"),
+			caCertManager:             bootstrap.NewFileCertificateManager(certFilePath, keyFilePath),
+			RouteCache:                routeCache,
+			IngressCache:              ingressCache,
+			RouteConfigMapInformer:    cmInformer,
+			SecretInformer:            secretInformer,
+			VMSnapshotInformer:        vmSnapshotInformer,
+			VMSnapshotContentInformer: vmSnapshotContentInformer,
+			VolumeSnapshotProvider:    fakeVolumeSnapshotProvider,
+			VMInformer:                vmInformer,
+			VMIInformer:               vmiInformer,
+		}
+		initCert = func(ctrl *VMExportController) {
+			go controller.caCertManager.Start()
+			// Give the thread time to read the certs.
+			Eventually(func() *tls.Certificate {
+				return controller.caCertManager.Current()
+			}, time.Second, time.Millisecond).ShouldNot(BeNil())
+		}
+
+		controller.Init()
+		mockVMExportQueue = testutils.NewMockWorkQueue(controller.vmExportQueue)
+		controller.vmExportQueue = mockVMExportQueue
+
+		cmInformer.GetStore().Add(&k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controller.KubevirtNamespace,
+				Name:      components.KubeVirtExportCASecretName,
+			},
+			Data: map[string]string{
+				"ca-bundle": "replace me with ca cert",
+			},
+		})
+	})
+
+	AfterEach(func() {
+		controller.caCertManager.Stop()
+		os.RemoveAll(certDir)
+	})
+
+	createTestVMSnapshot := func(ready bool) *snapshotv1.VirtualMachineSnapshot {
+		return &snapshotv1.VirtualMachineSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmsnapshotName,
+				Namespace: testNamespace,
+			},
+			Spec: snapshotv1.VirtualMachineSnapshotSpec{},
+			Status: &snapshotv1.VirtualMachineSnapshotStatus{
+				VirtualMachineSnapshotContentName: pointer.StringPtr("snapshot-content"),
+				ReadyToUse:                        pointer.BoolPtr(ready),
+			},
+		}
+	}
+
+	createTestVMSnapshotContent := func(name string) *snapshotv1.VirtualMachineSnapshotContent {
+		return &snapshotv1.VirtualMachineSnapshotContent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Spec: snapshotv1.VirtualMachineSnapshotContentSpec{
+				VolumeBackups: []snapshotv1.VolumeBackup{
+					{
+						VolumeName: "test-volume",
+						PersistentVolumeClaim: snapshotv1.PersistentVolumeClaim{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-snapshot",
+							},
+							Spec: k8sv1.PersistentVolumeClaimSpec{
+								Resources: k8sv1.ResourceRequirements{
+									Requests: k8sv1.ResourceList{},
+								},
+							},
+						},
+						VolumeSnapshotName: pointer.StringPtr(testVolumesnapshotName),
+					},
+				},
+				Source: snapshotv1.SourceSpec{
+					VirtualMachine: &snapshotv1.VirtualMachine{
+						Spec: virtv1.VirtualMachineSpec{
+							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+								Spec: virtv1.VirtualMachineInstanceSpec{
+									Volumes: []virtv1.Volume{
+										{
+											Name: "test-volume",
+											VolumeSource: virtv1.VolumeSource{
+												DataVolume: &virtv1.DataVolumeSource{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: &snapshotv1.VirtualMachineSnapshotContentStatus{
+				VolumeSnapshotStatus: []snapshotv1.VolumeSnapshotStatus{
+					{
+						VolumeSnapshotName: testVolumesnapshotName,
+						ReadyToUse:         pointer.BoolPtr(true),
+					},
+				},
+			},
+		}
+	}
+
+	createTestVMSnapshotContentNoVolumes := func(name string) *snapshotv1.VirtualMachineSnapshotContent {
+		return &snapshotv1.VirtualMachineSnapshotContent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Spec: snapshotv1.VirtualMachineSnapshotContentSpec{
+				VolumeBackups: []snapshotv1.VolumeBackup{},
+				Source: snapshotv1.SourceSpec{
+					VirtualMachine: &snapshotv1.VirtualMachine{
+						Spec: virtv1.VirtualMachineSpec{
+							Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+								Spec: virtv1.VirtualMachineInstanceSpec{
+									Volumes: []virtv1.Volume{
+										{
+											Name: "test-volume",
+											VolumeSource: virtv1.VolumeSource{
+												DataVolume: &virtv1.DataVolumeSource{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: &snapshotv1.VirtualMachineSnapshotContentStatus{
+				VolumeSnapshotStatus: []snapshotv1.VolumeSnapshotStatus{},
+			},
+		}
+	}
+
+	createTestVolumeSnapshot := func(name string) *vsv1.VolumeSnapshot {
+		size := resource.MustParse("1Gi")
+		return &vsv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Spec: vsv1.VolumeSnapshotSpec{},
+			Status: &vsv1.VolumeSnapshotStatus{
+				RestoreSize: &size,
+			},
+		}
+	}
+
+	createRestoredPVC := func(name string) *k8sv1.PersistentVolumeClaim {
+		return &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			Spec: k8sv1.PersistentVolumeClaimSpec{
+				Resources: k8sv1.ResourceRequirements{
+					Requests: k8sv1.ResourceList{
+						k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+				DataSource: &k8sv1.TypedLocalObjectReference{
+					APIGroup: pointer.StringPtr(vsv1.GroupName),
+					Kind:     "VolumeSnapshot",
+					Name:     testVolumesnapshotName,
+				},
+			},
+			Status: k8sv1.PersistentVolumeClaimStatus{
+				Phase: k8sv1.ClaimBound,
+			},
+		}
+	}
+
+	It("Should properly update VMExport status with a valid token and no VMSnapshot", func() {
+		testVMExport := createSnapshotVMExport()
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(initializingReason))
+					Expect(condition.Message).To(Equal(""))
+				}
+				if condition.Type == exportv1.ConditionVolumesCreated {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(noVolumeSnapshotReason))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("VirtualMachineSnapshot %s/%s does not contain any volume snapshots", vmExport.Namespace, vmExport.Spec.Source.Name)))
+				}
+			}
+			return true, vmExport, nil
+		})
+
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	It("Should properly update VMExport status with a valid token with VMSnapshot without volumes", func() {
+		testVMExport := createSnapshotVMExport()
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			volumeCreateConditionSet := false
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(initializingReason))
+					Expect(condition.Message).To(Equal(""))
+				}
+				if condition.Type == exportv1.ConditionVolumesCreated {
+					volumeCreateConditionSet = true
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(noVolumeSnapshotReason))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("VirtualMachineSnapshot %s/%s does not contain any volume snapshots", vmExport.Namespace, vmExport.Spec.Source.Name)))
+				}
+			}
+			Expect(volumeCreateConditionSet).To(BeTrue())
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Skipped))
+			return true, vmExport, nil
+		})
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(true))
+		vmSnapshotContentInformer.GetStore().Add(createTestVMSnapshotContentNoVolumes("snapshot-content"))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		service, err := k8sClient.CoreV1().Services(testNamespace).Get(context.Background(), fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service.Name).To(Equal(fmt.Sprintf("%s-%s", exportPrefix, testVMExport.Name)))
+	})
+
+	It("Should create restored PVCs from VMSnapshot", func() {
+		testVMExport := createSnapshotVMExport()
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			volumeCreateConditionSet := false
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(podPendingReason))
+					Expect(condition.Message).To(Equal(""))
+				}
+				if condition.Type == exportv1.ConditionVolumesCreated {
+					volumeCreateConditionSet = true
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(notAllPVCsReady))
+					Expect(condition.Message).To(Equal("Not all PVCs are ready"))
+				}
+			}
+			Expect(volumeCreateConditionSet).To(BeTrue())
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Pending))
+			return true, vmExport, nil
+		})
+
+		k8sClient.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			pvc, ok := create.GetObject().(*k8sv1.PersistentVolumeClaim)
+			Expect(ok).To(BeTrue())
+			Expect(pvc.Name).To(Equal("test-test-snapshot"))
+			Expect(pvc.Spec.DataSource).ToNot(BeNil())
+			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
+			Expect(pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+			Expect(pvc.Spec.DataSource).To(Equal(&k8sv1.TypedLocalObjectReference{
+				APIGroup: pointer.StringPtr(vsv1.GroupName),
+				Kind:     "VolumeSnapshot",
+				Name:     testVolumesnapshotName,
+			}))
+			By("Ensuring the PVC is owned by the vmExport")
+			Expect(pvc.OwnerReferences).To(HaveLen(1))
+			Expect(pvc.OwnerReferences[0]).To(Equal(metav1.OwnerReference{
+				APIVersion:         apiVersion,
+				Kind:               "VirtualMachineExport",
+				Name:               testVMExport.Name,
+				UID:                testVMExport.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			}))
+			return true, pvc, nil
+		})
+		expectExporterCreate(k8sClient, k8sv1.PodPending)
+
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(true))
+		vmSnapshotContentInformer.GetStore().Add(createTestVMSnapshotContent("snapshot-content"))
+		fakeVolumeSnapshotProvider.Add(createTestVolumeSnapshot(testVolumesnapshotName))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+	})
+
+	It("Should not re-create restored PVCs from VMSnapshot if pvc already exists", func() {
+		testVMExport := createSnapshotVMExport()
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			volumeCreateConditionSet := false
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(podPendingReason))
+					Expect(condition.Message).To(Equal(""))
+				}
+				if condition.Type == exportv1.ConditionVolumesCreated {
+					volumeCreateConditionSet = true
+					Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+					Expect(condition.Reason).To(Equal(allPVCsReady))
+					Expect(condition.Message).To(Equal(""))
+				}
+			}
+			Expect(volumeCreateConditionSet).To(BeTrue())
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Pending))
+			return true, vmExport, nil
+		})
+
+		k8sClient.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			_, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			Fail("unexpected create persistentvolumeclaims called")
+			return true, nil, nil
+		})
+		expectExporterCreate(k8sClient, k8sv1.PodPending)
+		pvcInformer.GetStore().Add(createRestoredPVC("test-test-snapshot"))
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(true))
+		vmSnapshotContentInformer.GetStore().Add(createTestVMSnapshotContent("snapshot-content"))
+		fakeVolumeSnapshotProvider.Add(createTestVolumeSnapshot(testVolumesnapshotName))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+	})
+
+	It("Should update status with correct links from snapshot with kubevirt content type", func() {
+		testVMExport := createSnapshotVMExport()
+		restoreName := fmt.Sprintf("%s-%s", testVMExport.Name, testVolumesnapshotName)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyKubevirtInternal(vmExport, vmExport.Name, testNamespace, restoreName)
+			verifyKubevirtExternal(vmExport, vmExport.Name, testNamespace, restoreName)
+			return true, vmExport, nil
+		})
+
+		k8sClient.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			pvc, ok := create.GetObject().(*k8sv1.PersistentVolumeClaim)
+			Expect(ok).To(BeTrue())
+			Expect(pvc.Name).To(Equal("test-test-snapshot"))
+			Expect(pvc.Spec.DataSource).ToNot(BeNil())
+			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
+			Expect(pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+			Expect(pvc.Spec.DataSource).To(Equal(&k8sv1.TypedLocalObjectReference{
+				APIGroup: pointer.StringPtr(vsv1.GroupName),
+				Kind:     "VolumeSnapshot",
+				Name:     testVolumesnapshotName,
+			}))
+			By("Ensuring the PVC is owned by the vmExport")
+			Expect(pvc.OwnerReferences).To(HaveLen(1))
+			Expect(pvc.OwnerReferences[0]).To(Equal(metav1.OwnerReference{
+				APIVersion:         apiVersion,
+				Kind:               "VirtualMachineExport",
+				Name:               testVMExport.Name,
+				UID:                testVMExport.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			}))
+			Expect(pvc.GetAnnotations()).ToNot(BeEmpty())
+			Expect(pvc.GetAnnotations()[annContentType]).To(BeEquivalentTo(cdiv1.DataVolumeKubeVirt))
+			return true, pvc, nil
+		})
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		controller.RouteCache.Add(routeToHostAndService(components.VirtExportProxyServiceName))
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(true))
+		vmSnapshotContentInformer.GetStore().Add(createTestVMSnapshotContent("snapshot-content"))
+		fakeVolumeSnapshotProvider.Add(createTestVolumeSnapshot(testVolumesnapshotName))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+	})
+
+	It("Should update status with correct links from snapshot with other content type", func() {
+		testVMExport := createSnapshotVMExport()
+		restoreName := fmt.Sprintf("%s-%s", testVMExport.Name, testVolumesnapshotName)
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyArchiveInternal(vmExport, vmExport.Name, testNamespace, restoreName)
+			verifyArchiveExternal(vmExport, vmExport.Name, testNamespace, restoreName)
+			return true, vmExport, nil
+		})
+
+		k8sClient.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			pvc, ok := create.GetObject().(*k8sv1.PersistentVolumeClaim)
+			Expect(ok).To(BeTrue())
+			Expect(pvc.Name).To(Equal("test-test-snapshot"))
+			Expect(pvc.Spec.DataSource).ToNot(BeNil())
+			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
+			Expect(pvc.Spec.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+			Expect(pvc.Spec.DataSource).To(Equal(&k8sv1.TypedLocalObjectReference{
+				APIGroup: pointer.StringPtr(vsv1.GroupName),
+				Kind:     "VolumeSnapshot",
+				Name:     testVolumesnapshotName,
+			}))
+			By("Ensuring the PVC is owned by the vmExport")
+			Expect(pvc.OwnerReferences).To(HaveLen(1))
+			Expect(pvc.OwnerReferences[0]).To(Equal(metav1.OwnerReference{
+				APIVersion:         apiVersion,
+				Kind:               "VirtualMachineExport",
+				Name:               testVMExport.Name,
+				UID:                testVMExport.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			}))
+			Expect(pvc.GetAnnotations()[annContentType]).To(BeEmpty())
+			return true, pvc, nil
+		})
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		controller.RouteCache.Add(routeToHostAndService(components.VirtExportProxyServiceName))
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(true))
+		content := createTestVMSnapshotContent("snapshot-content")
+		content.Spec.Source.VirtualMachine.Spec.Template.Spec.Volumes[0].DataVolume = nil
+		content.Spec.Source.VirtualMachine.Spec.Template.Spec.Volumes[0].MemoryDump = &virtv1.MemoryDumpVolumeSource{}
+		vmSnapshotContentInformer.GetStore().Add(content)
+		fakeVolumeSnapshotProvider.Add(createTestVolumeSnapshot(testVolumesnapshotName))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+	})
+
+	It("Should update status with no links and not ready if snapshot is not ready", func() {
+		testVMExport := createSnapshotVMExport()
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			volumeCreateConditionSet := false
+			for _, condition := range vmExport.Status.Conditions {
+				if condition.Type == exportv1.ConditionReady {
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(inUseReason))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("VirtualMachineSnapshot %s/%s is not ready to use", vmExport.Namespace, vmExport.Spec.Source.Name)))
+				}
+				if condition.Type == exportv1.ConditionVolumesCreated {
+					volumeCreateConditionSet = true
+					Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+					Expect(condition.Reason).To(Equal(notAllPVCsCreated))
+					Expect(condition.Message).To(Equal(fmt.Sprintf("VirtualMachineSnapshot %s/%s is not ready to use", vmExport.Namespace, vmExport.Spec.Source.Name)))
+				}
+			}
+			Expect(volumeCreateConditionSet).To(BeTrue())
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Pending))
+			return true, vmExport, nil
+		})
+
+		k8sClient.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			_, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			Fail("Should not create PVCs")
+			return true, nil, nil
+		})
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(false))
+		content := createTestVMSnapshotContent("snapshot-content")
+		vmSnapshotContentInformer.GetStore().Add(content)
+		fakeVolumeSnapshotProvider.Add(createTestVolumeSnapshot(testVolumesnapshotName))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+	})
+
+})

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -737,6 +737,8 @@ func (vca *VirtControllerApp) initExportController() {
 		VolumeSnapshotProvider:    vca.snapshotController,
 		VMSnapshotInformer:        vca.vmSnapshotInformer,
 		VMSnapshotContentInformer: vca.vmSnapshotContentInformer,
+		VMInformer:                vca.vmInformer,
+		VMIInformer:               vca.vmiInformer,
 	}
 	vca.exportController.Init()
 }

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -201,6 +201,8 @@ var _ = Describe("Application", func() {
 			SecretInformer:            secretInformer,
 			VMSnapshotInformer:        vmSnapshotInformer,
 			VMSnapshotContentInformer: vmSnapshotContentInformer,
+			VMInformer:                vmInformer,
+			VMIInformer:               vmiInformer,
 		}
 		app.exportController.Init()
 		app.persistentVolumeClaimInformer = pvcInformer

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -166,6 +166,25 @@ func AddDataVolumeTemplate(vm *v13.VirtualMachine, dataVolume *v1beta1.DataVolum
 	vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
 }
 
+func AddDataVolume(vm *v13.VirtualMachine, diskName string, dataVolume *v1beta1.DataVolume) {
+	vm.Spec.Template.Spec.Domain.Devices.Disks = append(vm.Spec.Template.Spec.Domain.Devices.Disks, v13.Disk{
+		Name: diskName,
+		DiskDevice: v13.DiskDevice{
+			Disk: &v13.DiskTarget{
+				Bus: v13.DiskBusVirtio,
+			},
+		},
+	})
+	vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v13.Volume{
+		Name: diskName,
+		VolumeSource: v13.VolumeSource{
+			DataVolume: &v13.DataVolumeSource{
+				Name: dataVolume.Name,
+			},
+		},
+	})
+}
+
 func SetDataVolumePVCStorageClass(dv *v1beta1.DataVolume, storageClass string) {
 	dv.Spec.PVC.StorageClassName = &storageClass
 }

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onsi/gomega/format"
 	gomegatypes "github.com/onsi/gomega/types"
 
+	corev1 "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -42,6 +43,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 
+<<<<<<< HEAD
+=======
+	v1 "kubevirt.io/api/core/v1"
+>>>>>>> 7f88d1c42 (Add export of VMSnapshot volumes)
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
@@ -643,6 +648,25 @@ var _ = SIGDescribe("Export", func() {
 		export, err := virtClient.VirtualMachineExport(namespace).Create(context.Background(), vmExport, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return export
+	}
+
+	createRunningPVCExport := func(sc string, volumeMode k8sv1.PersistentVolumeMode) *exportv1.VirtualMachineExport {
+		pvc, _ := populateKubeVirtContent(sc, volumeMode)
+		By("Creating the export token, we can export volumes using this token")
+		// For testing the token is the name of the source pvc.
+		token := createExportTokenSecret(pvc.Name, pvc.Namespace)
+
+		export := createPVCExportObject(pvc.Name, pvc.Namespace, token)
+
+		return waitForReadyExport(export)
+	}
+
+	createRunningVMSnapshotExport := func(snapshot *snapshotv1.VirtualMachineSnapshot) *exportv1.VirtualMachineExport {
+		// For testing the token is the name of the source snapshot.
+		token := createExportTokenSecret(snapshot.Name, snapshot.Namespace)
+
+		export := createVMSnapshotExportObject(snapshot.Name, snapshot.Namespace, token)
+		return waitForReadyExport(export)
 	}
 
 	createRunningPVCExport := func(sc string, volumeMode k8sv1.PersistentVolumeMode) *exportv1.VirtualMachineExport {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1057,13 +1057,16 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	stopVM := func(vm *virtv1.VirtualMachine) *virtv1.VirtualMachine {
+		vmName := vm.Name
+		vmNamespace := vm.Namespace
+		var err error
 		Eventually(func() error {
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vm, err = virtClient.VirtualMachine(vmNamespace).Get(vmName, &metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			vm.Spec.Running = pointer.BoolPtr(false)
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
+			vm, err = virtClient.VirtualMachine(vmNamespace).Update(vm)
 			return err
 		}, 15*time.Second, time.Second).Should(BeNil())
 		return vm
@@ -1416,7 +1419,7 @@ var _ = SIGDescribe("Export", func() {
 			// start the VM which triggers the populating, and then it should become ready.
 			waitForExportPhase(export, exportv1.Pending)
 			waitForExportCondition(export, expectedPVCPopulatingCondition(vm.Name, vm.Namespace), "export should report PVCs in VM populating")
-			startVM(vm)
+			vm = startVM(vm)
 			waitForDisksComplete(vm)
 			stopVM(vm)
 			waitForExportPhase(export, exportv1.Ready)

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -33,7 +33,6 @@ import (
 	"github.com/onsi/gomega/format"
 	gomegatypes "github.com/onsi/gomega/types"
 
-	corev1 "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -43,10 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 
-<<<<<<< HEAD
-=======
-	v1 "kubevirt.io/api/core/v1"
->>>>>>> 7f88d1c42 (Add export of VMSnapshot volumes)
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
 	snapshotv1 "kubevirt.io/api/snapshot/v1alpha1"
@@ -648,25 +643,6 @@ var _ = SIGDescribe("Export", func() {
 		export, err := virtClient.VirtualMachineExport(namespace).Create(context.Background(), vmExport, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return export
-	}
-
-	createRunningPVCExport := func(sc string, volumeMode k8sv1.PersistentVolumeMode) *exportv1.VirtualMachineExport {
-		pvc, _ := populateKubeVirtContent(sc, volumeMode)
-		By("Creating the export token, we can export volumes using this token")
-		// For testing the token is the name of the source pvc.
-		token := createExportTokenSecret(pvc.Name, pvc.Namespace)
-
-		export := createPVCExportObject(pvc.Name, pvc.Namespace, token)
-
-		return waitForReadyExport(export)
-	}
-
-	createRunningVMSnapshotExport := func(snapshot *snapshotv1.VirtualMachineSnapshot) *exportv1.VirtualMachineExport {
-		// For testing the token is the name of the source snapshot.
-		token := createExportTokenSecret(snapshot.Name, snapshot.Namespace)
-
-		export := createVMSnapshotExportObject(snapshot.Name, snapshot.Namespace, token)
-		return waitForReadyExport(export)
 	}
 
 	createRunningPVCExport := func(sc string, volumeMode k8sv1.PersistentVolumeMode) *exportv1.VirtualMachineExport {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -907,7 +907,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 				By(creatingSnapshot)
 				snapshot = createSnapshot(vm)
-
 				for i := 0; i < 2; i++ {
 					By(fmt.Sprintf("Restoring VM iteration %d", i))
 					restore = createRestoreDef(vm.Name, snapshot.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add VM source type to VMExport object CRD, including all needed code to support it in the controller and admission webhooks. The export will not start if a running VM is detected (VMI exists) and will be stopped if a VMI is detected associated with the VM after the export started.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Addressed the style comment noted in the VMSnapshot PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VirtualMachineExport now supports VM export source type.
```
