### PR TITLE
e2e tests, libnode: only uncordon node once

### DIFF
--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//tests/clientcmd:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/cleanup:go_default_library",
         "//tests/util:go_default_library",

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -45,7 +45,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/util"
@@ -60,17 +59,9 @@ func CleanNodes() {
 	clusterDrainKey := GetNodeDrainKey()
 
 	for _, node := range GetAllSchedulableNodes(virtCli).Items {
-
 		old, err := json.Marshal(node)
 		Expect(err).ToNot(HaveOccurred())
 		new := node.DeepCopy()
-
-		k8sClient := clientcmd.GetK8sCmdClient()
-		if k8sClient == "oc" {
-			_, _, _ = clientcmd.RunCommandWithNS("", k8sClient, "adm", "uncordon", node.Name)
-		} else {
-			_, _, _ = clientcmd.RunCommandWithNS("", k8sClient, "uncordon", node.Name)
-		}
 
 		found := false
 		taints := []k8sv1.Taint{}

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -56,11 +56,10 @@ var SchedulableNode = ""
 func CleanNodes() {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
-	nodes := GetAllSchedulableNodes(virtCli).Items
 
 	clusterDrainKey := GetNodeDrainKey()
 
-	for _, node := range nodes {
+	for _, node := range GetAllSchedulableNodes(virtCli).Items {
 
 		old, err := json.Marshal(node)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3334,7 +3334,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			Context("[Serial] with node tainted during node drain", func() {
-
 				BeforeEach(func() {
 					// Taints defined by k8s are special and can't be applied manually.
 					// Temporarily configure KubeVirt to use something else for the duration of these tests.
@@ -3366,6 +3365,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 					// Drain node.
 					node := vmi.Status.NodeName
+					libnode.Taint(node, libnode.GetNodeDrainKey(), k8sv1.TaintEffectNoSchedule)
 					drainNode(node)
 
 					// verify VMI migrated and lives on another node now.

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3346,10 +3346,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					setMastersUnschedulable(true)
 				})
 
-				AfterEach(func() {
-					libnode.CleanNodes()
-				})
-
 				It("[test_id:6982]should migrate a VMI only one time", func() {
 					checks.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:   
`libnode` is relying on `kubectl uncordon` to make the node
schedulable again - this fails on the conformance lanes executed on the
kubevirtci project, since the sonobuoy container where the conformance
tests are executed do **not** have the kubectl binary.
    
Uncordoning a node is, quite literaly, making it schedulable - something
which is achieving by setting the `node.Spec.Unschedulable` flag to
false - which is already being done in the stategic-merge patch command
being sent to the API [some lines below](https://github.com/kubevirt/kubevirt/blob/cdbc0a94a93ec5a758cde487edc62499ae2ff84f/tests/libnode/node.go#L107).

Furthermore, one of the tests - `test_id:6982` - was missing tainting the node with
`NoSchedule` effect, which would cause the test teardown framework to restore
the node spec to its original. This PR addresses this, thus enabling the framework
to properly cleanup the node.

Finally, this PR removes the redundant `AfterEach` block that triggers node deletion
for the migration tests - it is [done automatically as part of each test](https://github.com/kubevirt/kubevirt/blob/dc593644cd5dcdd8586c03177b0b308c2f39a35f/tests/tests_suite_test.go#L98) teardown.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
