### PR TITLE
paast, e2e, Skip if featureGate is disabled

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -47,6 +47,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/network/istio"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -98,6 +99,12 @@ var istioTests = func(vmType VmType) {
 			{Port: sshPort},
 		}
 	)
+	BeforeEach(func() {
+		if vmType == Passt {
+			checks.SkipTestIfNoFeatureGate(virtconfig.PasstGate)
+		}
+	})
+
 	BeforeEach(func() {
 		if !istioServiceMeshDeployed() {
 			Skip("Istio service mesh is required for service-mesh tests to run")

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -31,9 +31,11 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
@@ -42,6 +44,10 @@ import (
 var _ = SIGDescribe("[Serial] Passt", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		checks.SkipTestIfNoFeatureGate(virtconfig.PasstGate)
+	})
 
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips Paast e2e tests if the Passt featureGate is disabled.
This skip also affects tier1 tests running on d/s clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
