### PR TITLE
Fix minCPUModel in node-labeller

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -69,9 +69,12 @@ func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []
 
 func (n *NodeLabeller) getSupportedCpuFeatures() cpuFeatures {
 	supportedCpuFeatures := make(cpuFeatures)
+	basicFeaturesMap := n.getMinCpuFeature()
 
 	for _, feature := range n.supportedFeatures {
-		supportedCpuFeatures[feature] = true
+		if _, exist := basicFeaturesMap[feature]; !exist {
+			supportedCpuFeatures[feature] = true
+		}
 	}
 
 	return supportedCpuFeatures
@@ -81,7 +84,7 @@ func (n *NodeLabeller) GetHostCpuModel() hostCPUModel {
 	return n.hostCPUModel
 }
 
-//loadDomCapabilities loads info about cpu models, which can host emulate
+// loadDomCapabilities loads info about cpu models, which can host emulate
 func (n *NodeLabeller) loadDomCapabilities() error {
 	hostDomCapabilities, err := n.getDomCapabilities()
 	if err != nil {
@@ -122,7 +125,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 	return nil
 }
 
-//loadHostSupportedFeatures loads supported features
+// loadHostSupportedFeatures loads supported features
 func (n *NodeLabeller) loadHostSupportedFeatures() error {
 	featuresFile := filepath.Join(n.volumePath, supportedFeaturesXml)
 
@@ -155,7 +158,7 @@ func (n *NodeLabeller) loadHostCapabilities() error {
 	return nil
 }
 
-//loadCPUInfo load info about all cpu models
+// loadCPUInfo load info about all cpu models
 func (n *NodeLabeller) loadCPUInfo() error {
 	files, err := os.ReadDir(filepath.Join(n.volumePath, "cpu_map"))
 	if err != nil {
@@ -188,7 +191,7 @@ func (n *NodeLabeller) getDomCapabilities() (HostDomCapabilities, error) {
 	return hostDomCapabilities, err
 }
 
-//LoadFeatures loads features for given cpu name
+// LoadFeatures loads features for given cpu name
 func (n *NodeLabeller) loadFeatures(fileName string) (cpuFeatures, error) {
 	if fileName == "" {
 		return nil, fmt.Errorf("file name can't be empty")
@@ -208,13 +211,13 @@ func (n *NodeLabeller) loadFeatures(fileName string) (cpuFeatures, error) {
 	return modelFeatures, nil
 }
 
-//getPathCPUFeatures creates path where folder with cpu models is
+// getPathCPUFeatures creates path where folder with cpu models is
 func getPathCPUFeatures(volumePath string, name string) string {
 	return filepath.Join(volumePath, "cpu_map", name)
 }
 
-//GetStructureFromXMLFile load data from xml file and unmarshals them into given structure
-//Given structure has to be pointer
+// GetStructureFromXMLFile load data from xml file and unmarshals them into given structure
+// Given structure has to be pointer
 func (n *NodeLabeller) getStructureFromXMLFile(path string, structure interface{}) error {
 	rawFile, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Node-labeller config", func() {
 
 	})
 
-	It("should return correct cpu models, features and tsc freqnency", func() {
+	It("should return correct cpu models, features and tsc frequency", func() {
 		err := nlController.loadDomCapabilities()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -114,7 +114,7 @@ var _ = Describe("Node-labeller config", func() {
 
 		Expect(cpuModels).To(HaveLen(3), "number of models must match")
 
-		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
+		Expect(cpuFeatures).To(HaveLen(2), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(counter).ToNot(BeNil())
@@ -135,7 +135,7 @@ var _ = Describe("Node-labeller config", func() {
 
 		Expect(cpuModels).To(BeEmpty(), "no CPU models are expected to be supported")
 
-		Expect(cpuFeatures).To(HaveLen(4), "number of features doesn't match")
+		Expect(cpuFeatures).To(HaveLen(2), "number of features doesn't match")
 	})
 
 	Context("should return correct host cpu", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`getMinCpuFeature` is never called in node-labeller.
This means `minCPUModel` in the KubeVirt spec is never read.
This change adds back the `getMinCpuFeature` call
in the same way it was used previously.

This reduces the number of node labels as described here: https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#labeling-nodes-with-cpu-models-and-cpu-features

Reference: https://github.com/jrcichra/kubevirt/commit/6d36b2566982d09aded5c626a2ac2e736af081cf#diff-e5f7c7eba691f55f6aec1002653b484c6b4ac728df85b61315d402a31eb643afR75

Signed-off-by: Justin Cichra <jcichra@cloudflare.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed minCPUModel configuration option from being ignored in node-labeller
```
