### PR TITLE
Bump timeout in cleanup, remove "should pause on IO error" from quarantine

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -220,7 +220,7 @@ var _ = SIGDescribe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[QUARANTINE] should pause VMI on IO error", func() {
+			It("should pause VMI on IO error", func() {
 				By("Creating VMI with faulty disk")
 				vmi := libvmi.New(
 					libvmi.WithPersistentVolumeClaim("disk0", pvc.Name),


### PR DESCRIPTION
This test only failed once [on a periodic](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sig-storage/1555312797280112640) in the past 14 days.
It failed with a timeout in the cleanup after the test.
Let's bump that timeout from the low 30 seconds (might be too low for a very busy cluster) and remove it from quarantine.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
