### PR TITLE
manifests: avoid empty infra section in kubevirt-cr

### DIFF
--- a/manifests/generated/kubevirt-cr.yaml.in
+++ b/manifests/generated/kubevirt-cr.yaml.in
@@ -13,7 +13,7 @@ spec:
       - {{.}}
       {{- end}}{{else}} []{{end}}
   customizeComponents: {}
-  imagePullPolicy: {{.ImagePullPolicy}}
-  infra:{{if .InfraReplicas}}
+  imagePullPolicy: {{.ImagePullPolicy}}{{if .InfraReplicas}}
+  infra:
     replicas: {{.InfraReplicas}}{{end}}
   workloadUpdateStrategy: {}

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -125,9 +125,10 @@ $1{{- end}}{{else}} []{{end}}`)
 	if strings.HasPrefix(*infraReplicasFlag, "{{") {
 		infraReplicasVar := strings.TrimPrefix(*infraReplicasFlag, "{{")
 		infraReplicasVar = strings.TrimSuffix(infraReplicasVar, "}}")
-		re := regexp.MustCompile(`(?m)\n([ \t]+)replicas: ` + fmt.Sprintf("%d", infraReplicasPlaceholder))
+		re := regexp.MustCompile(`(?m)\n([ \t]+)infra:\n([ \t]+)replicas: ` + fmt.Sprintf("%d", infraReplicasPlaceholder))
 		cr = re.ReplaceAllString(cr, `{{if `+infraReplicasVar+`}}
-${1}replicas: {{`+infraReplicasVar+`}}{{end}}`)
+${1}infra:
+${2}replicas: {{`+infraReplicasVar+`}}{{end}}`)
 	}
 
 	fmt.Print(cr)


### PR DESCRIPTION
**What this PR does / why we need it**:
When `KUBEVIRT_INFRA_REPLICAS` is not set, we currently create an empty infra section in kubevirt-cr, which is incompatible with some versions of kubectl (see linked issue)
This PR fixes the issue by only creating an infra section when needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8251 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
No more empty section in the kubevirt-cr manifest
```
