### PR TITLE
Pod Security Admission/Standards

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1197,6 +1197,8 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  seccompProfile:
+                    type: RuntimeDefault
                 volumeMounts:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs
@@ -1208,6 +1210,8 @@ spec:
               priorityClassName: kubevirt-cluster-critical
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: kubevirt-operator
               tolerations:
               - key: CriticalAddonsOnly

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1194,6 +1194,9 @@ spec:
                     memory: 250Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
                 volumeMounts:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1192,6 +1192,8 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 250Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
                 volumeMounts:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -320,7 +320,8 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = rbac.ApiServiceAccountName
 	pod.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: boolPtr(true),
+		RunAsNonRoot:   boolPtr(true),
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 
 	container := &deployment.Spec.Template.Spec.Containers[0]
@@ -370,11 +371,13 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 		},
 	}
 
-	container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
-	container.SecurityContext.Capabilities = &corev1.Capabilities{
-		Drop: []corev1.Capability{"ALL"},
+	container.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
-
 	return deployment, nil
 }
 
@@ -391,7 +394,8 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = rbac.ControllerServiceAccountName
 	pod.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: boolPtr(true),
+		RunAsNonRoot:   boolPtr(true),
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 
 	launcherVersion = AddVersionSeparatorPrefix(launcherVersion)
@@ -459,11 +463,13 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 		},
 	}
 
-	container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
-	container.SecurityContext.Capabilities = &corev1.Capabilities{
-		Drop: []corev1.Capability{"ALL"},
+	container.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
-
 	return deployment, nil
 }
 
@@ -582,11 +588,13 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
+								SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 							},
 						},
 					},
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: boolPtr(true),
+						RunAsNonRoot:   boolPtr(true),
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				},
 			},

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/pointer"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -369,6 +370,8 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 		},
 	}
 
+	container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
+
 	return deployment, nil
 }
 
@@ -452,6 +455,8 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 			corev1.ResourceMemory: resource.MustParse("250Mi"),
 		},
 	}
+
+	container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
 
 	return deployment, nil
 }
@@ -565,6 +570,9 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 									corev1.ResourceCPU:    resource.MustParse("10m"),
 									corev1.ResourceMemory: resource.MustParse("250Mi"),
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 						},
 					},

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -371,6 +371,9 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	}
 
 	container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
+	container.SecurityContext.Capabilities = &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	}
 
 	return deployment, nil
 }
@@ -457,6 +460,9 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 	}
 
 	container.SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
+	container.SecurityContext.Capabilities = &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	}
 
 	return deployment, nil
 }
@@ -573,6 +579,9 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: pointer.Bool(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjust components to satisfy PSA. Not all components can be adjusted. The primary problem is virt-handler that is by design privileged and therefore the installed namespace will never satisfy the restricted policy. It is still good practice for our components to try to satisfy these policies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
