### PR TITLE
instancetype: Move remaining functional tests to libvmi

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -26,7 +26,6 @@ import (
 	instancetypepkg "kubevirt.io/kubevirt/pkg/instancetype"
 	k6ttypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -188,9 +187,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	Context("Instancetype and preference application", func() {
 
 		It("[test_id:TODO] should find and apply cluster instancetype and preferences when kind isn't provided", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(
-				cd.ContainerDiskFor(cd.ContainerDiskCirros),
-			)
+			vmi := libvmi.NewCirros()
+
 			instancetype := newVirtualMachineClusterInstancetype(vmi)
 			instancetype, err := virtClient.VirtualMachineClusterInstancetype().
 				Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -225,9 +223,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should apply instancetype and preferences to VMI", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(
-				cd.ContainerDiskFor(cd.ContainerDiskCirros),
-			)
+			vmi := libvmi.NewCirros()
 
 			instancetype := newVirtualMachineInstancetype(vmi)
 			instancetype, err := virtClient.VirtualMachineInstancetype(util.NamespaceTestDefault).
@@ -344,8 +340,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		DescribeTable("[test_id:TODO] should fail if the VirtualMachine has ", func(resources virtv1.ResourceRequirements, expectedField string) {
+			vmi := libvmi.New()
 
-			vmi := libvmi.NewCirros(libvmi.WithResourceMemory("1Mi"))
 			instancetype := newVirtualMachineInstancetype(vmi)
 			instancetype, err := virtClient.VirtualMachineInstancetype(util.NamespaceTestDefault).
 				Create(context.Background(), instancetype, metav1.CreateOptions{})
@@ -393,9 +389,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		)
 
 		It("[test_id:TODO] should apply preferences to default network interface", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(
-				cd.ContainerDiskFor(cd.ContainerDiskCirros),
-			)
+			vmi := libvmi.New()
 
 			preference := newVirtualMachineClusterPreference()
 			preference.Spec.Devices = &instancetypev1alpha1.DevicePreferences{
@@ -423,9 +417,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 
 		It("[test_id:TODO] should apply preferences to default volume disks", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(
-				cd.ContainerDiskFor(cd.ContainerDiskCirros),
-			)
+			vmi := libvmi.NewCirros()
 
 			preference := newVirtualMachineClusterPreference()
 			preference.Spec.Devices = &instancetypev1alpha1.DevicePreferences{
@@ -462,7 +454,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				preferenceRevision   *appsv1.ControllerRevision
 			)
 
-			vmi := libvmi.New()
+			vmi := libvmi.NewCirros()
 
 			By("Creating a VirtualMachineInstancetype")
 			instancetype := newVirtualMachineInstancetype(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

b5131c3cdbad7b315383df25c53ec7a43e189e52 previously missed a few uses of
NewRandomVMIWithEphemeralDisk, move these to libvmi only using NewCirros
when an actual disk is required.

Additionally some negative tests were given VMIs with limited resources
when the test would replace these requests with its own anyway. Remove
these and allow the test to control the resource requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
