### PR TITLE
WIP: guestfs test

### DIFF
--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -82,15 +82,14 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		// Waiting until the libguestfs pod is running
 		Eventually(func() bool {
 			pod, _ := virtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), podName, metav1.GetOptions{})
-			ready := false
 			for _, status := range pod.Status.ContainerStatuses {
 				if status.State.Running != nil {
 					return true
 				}
 			}
-			return ready
+			return false
 
-		}, 90*time.Second, 2*time.Second).Should(BeTrue())
+		}, 180*time.Second, 2*time.Second).Should(BeTrue())
 		// Verify that the appliance has been extracted before running any tests by checking the done file
 		Eventually(func() bool {
 			_, _, err := execCommandLibguestfsPod(podName, []string{"ls", "/usr/local/lib/guestfs/appliance/done"})

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -89,7 +89,7 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 			}
 			return false
 
-		}, 180*time.Second, 2*time.Second).Should(BeTrue())
+		}, 90*time.Second, 2*time.Second).Should(BeTrue())
 		// Verify that the appliance has been extracted before running any tests by checking the done file
 		Eventually(func() bool {
 			_, _, err := execCommandLibguestfsPod(podName, []string{"ls", "/usr/local/lib/guestfs/appliance/done"})


### PR DESCRIPTION
Increase timeout as the libguestfs image needs to be pulled and might require more
time.

Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
