### PR TITLE
[e2e]: Fix a panic call in BeforeSuite

### DIFF
--- a/tests/testsuite/manifest.go
+++ b/tests/testsuite/manifest.go
@@ -115,10 +115,11 @@ func DeleteRawManifest(object unstructured.Unstructured) error {
 	options := &metav1.DeleteOptions{PropagationPolicy: &policy}
 
 	result := virtCli.CoreV1().RESTClient().Delete().RequestURI(uri).Body(options).Do(context.Background())
-	if result.Error() != nil && !k8serrors.IsNotFound(result.Error()) {
-		fmt.Printf(fmt.Sprintf("ERROR: Can not delete %s err: %#v %s\n", object.GetName(), result.Error(), object))
-		panic(err)
+	if err = result.Error(); err != nil && !k8serrors.IsNotFound(err) {
+		panic(fmt.Errorf("ERROR: Can not delete %s err: %#v %s\n", object.GetName(), err, object))
+
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
We had a situation in e2e where we hit the 'Test Panicked'
assertion but without a stack trace or an error message.
The reason was that panic(err) was called with err being nil.

This patch fixes the err assignment

**Fixes #**
Situations that lack stack trace i.e.:
```
tests/tests_suite_test.go:92
Test Panicked
tests/util/util.go:19

```

**Release note**:
```release-note
NONE
```
