### PR TITLE
Use libvmi in tests/storage

### DIFF
--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -20,6 +20,8 @@
 package libvmi
 
 import (
+	"fmt"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -67,6 +69,22 @@ func WithCDRom(cdRomName string, bus v1.DiskBus, claimName string) Option {
 	}
 }
 
+// WithFilesystemPVC specifies a filesystem backed by a PVC to be used.
+func WithFilesystemPVC(claimName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addFilesystem(vmi, newFilesystem(claimName))
+		addVolume(vmi, newPersistentVolumeClaimVolume(claimName, claimName))
+	}
+}
+
+// WithFilesystemDV specifies a filesystem backed by a DV to be used.
+func WithFilesystemDV(dataVolumeName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addFilesystem(vmi, newFilesystem(dataVolumeName))
+		addVolume(vmi, newDataVolume(dataVolumeName, dataVolumeName))
+	}
+}
+
 func addDisk(vmi *v1.VirtualMachineInstance, disk v1.Disk) {
 	if !diskExists(vmi, disk) {
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
@@ -77,6 +95,14 @@ func addVolume(vmi *v1.VirtualMachineInstance, volume v1.Volume) {
 	if !volumeExists(vmi, volume) {
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
 	}
+}
+
+func addFilesystem(vmi *v1.VirtualMachineInstance, filesystem v1.Filesystem) {
+	if filesystemExists(vmi, filesystem) {
+		panic(fmt.Errorf("filesystem %s already exists", filesystem.Name))
+	}
+
+	vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, filesystem)
 }
 
 func getVolume(vmi *v1.VirtualMachineInstance, name string) *v1.Volume {
@@ -106,6 +132,15 @@ func volumeExists(vmi *v1.VirtualMachineInstance, volume v1.Volume) bool {
 	return false
 }
 
+func filesystemExists(vmi *v1.VirtualMachineInstance, filesystem v1.Filesystem) bool {
+	for _, f := range vmi.Spec.Domain.Devices.Filesystems {
+		if f.Name == filesystem.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func newDisk(name string, bus v1.DiskBus) v1.Disk {
 	return v1.Disk{
 		Name: name,
@@ -125,6 +160,13 @@ func newCDRom(name string, bus v1.DiskBus) v1.Disk {
 				Bus: bus,
 			},
 		},
+	}
+}
+
+func newFilesystem(name string) v1.Filesystem {
+	return v1.Filesystem{
+		Name:     name,
+		Virtiofs: &v1.FilesystemVirtiofs{},
 	}
 }
 

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -59,6 +59,14 @@ func WithEmptyDisk(diskName string, bus v1.DiskBus, capacity resource.Quantity) 
 	}
 }
 
+// WithCDRom specifies a CDRom drive backed by a PVC to be used.
+func WithCDRom(cdRomName string, bus v1.DiskBus, claimName string) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		addDisk(vmi, newCDRom(cdRomName, bus))
+		addVolume(vmi, newPersistentVolumeClaimVolume(cdRomName, claimName))
+	}
+}
+
 func addDisk(vmi *v1.VirtualMachineInstance, disk v1.Disk) {
 	if !diskExists(vmi, disk) {
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
@@ -103,6 +111,17 @@ func newDisk(name string, bus v1.DiskBus) v1.Disk {
 		Name: name,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
+				Bus: bus,
+			},
+		},
+	}
+}
+
+func newCDRom(name string, bus v1.DiskBus) v1.Disk {
+	return v1.Disk{
+		Name: name,
+		DiskDevice: v1.DiskDevice{
+			CDRom: &v1.CDRomTarget{
 				Bus: bus,
 			},
 		},

--- a/tests/nonroot_test.go
+++ b/tests/nonroot_test.go
@@ -3,6 +3,8 @@ package tests_test
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -36,7 +38,7 @@ var _ = Describe("[sig-compute]NonRoot feature", func() {
 				Skip(fmt.Sprintf("Missing %s, enable %s featureGate.", virtconfig.VirtIOFSGate, virtconfig.VirtIOFSGate))
 			}
 
-			vmi := tests.NewRandomVMIWithPVCFS("test")
+			vmi := libvmi.New(libvmi.WithFilesystemPVC("test"))
 			_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(And(ContainSubstring("VirtioFS"), ContainSubstring("nonroot")))

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -454,9 +454,8 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 			It("should fail restoring to a different VM that already exists", func() {
 				By("Creating a new VM")
-				newVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), bashHelloScript)
-				newVM := tests.NewRandomVirtualMachine(newVMI, false)
-				newVM, err = virtClient.VirtualMachine(newVM.Namespace).Create(newVM)
+				newVM := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+				newVM, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(newVM)
 				Expect(err).ToNot(HaveOccurred())
 				defer deleteVM(newVM)
 
@@ -1090,11 +1089,12 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			DescribeTable("should restore a vm with containerdisk and blank datavolume", func(restoreToNewVM bool) {
 				quantity, err := resource.ParseQuantity("1Gi")
 				Expect(err).ToNot(HaveOccurred())
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(
-					cd.ContainerDiskFor(cd.ContainerDiskCirros),
-					bashHelloScript,
+				vmi = libvmi.NewCirros(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
 				vm = tests.NewRandomVirtualMachine(vmi, false)
+				vm.Namespace = util.NamespaceTestDefault
 
 				dvName := "dv-" + vm.Name
 				vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -67,10 +67,13 @@ const (
 	failedCreateVMI              = "Failed to create vmi"
 	failedDeleteVMI              = "Failed to delete VMI"
 	checkingVMInstanceConsoleOut = "Checking that the VirtualMachineInstance console has expected output"
-	cloudInitName                = "cloud-init"
 	startingVMInstance           = "Starting VirtualMachineInstance"
 	hostDiskName                 = "host-disk"
 	diskImgName                  = "disk.img"
+
+	// Without cloud init user data Cirros takes long time to boot,
+	// so provide this dummy data to make it boot faster
+	cirrosUserData = "#!/bin/bash\necho 'hello'\n"
 )
 
 const (
@@ -140,8 +143,7 @@ var _ = SIGDescribe("Storage", func() {
 
 			It("should pause VMI on IO error", func() {
 				By("Creating VMI with faulty disk")
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi = tests.AddPVCDisk(vmi, "pvc-disk", v1.DiskBusVirtio, pvc.Name)
+				vmi := libvmi.NewAlpine(libvmi.WithPersistentVolumeClaim("pvc-disk", pvc.Name))
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
@@ -260,6 +262,12 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithResourceMemory("256Mi"),
 					libvmi.WithRng())
 			}
+			newRandomVMIWithCDRom := func(claimName string) *virtv1.VirtualMachineInstance {
+				return libvmi.New(
+					libvmi.WithCDRom("disk0", v1.DiskBusSATA, claimName),
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithRng())
+			}
 
 			Context("should be successfully", func() {
 				var pvName string
@@ -296,7 +304,7 @@ var _ = SIGDescribe("Storage", func() {
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				},
 					Entry("[test_id:3130]with Disk PVC", newRandomVMIWithPVC, "", nil, true),
-					Entry("[test_id:3131]with CDRom PVC", tests.NewRandomVMIWithCDRom, "", nil, true),
+					Entry("[test_id:3131]with CDRom PVC", newRandomVMIWithCDRom, "", nil, true),
 					Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
 					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
 					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
@@ -324,7 +332,7 @@ var _ = SIGDescribe("Storage", func() {
 				}
 			},
 				Entry("[test_id:3132]with Disk PVC", newRandomVMIWithPVC),
-				Entry("[test_id:3133]with CDRom PVC", tests.NewRandomVMIWithCDRom),
+				Entry("[test_id:3133]with CDRom PVC", newRandomVMIWithCDRom),
 			)
 		})
 
@@ -333,23 +341,10 @@ var _ = SIGDescribe("Storage", func() {
 			It("[test_id:3134]should create a writeable emptyDisk with the right capacity", func() {
 
 				// Start the VirtualMachineInstance with the empty disk attached
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
-					Name: "emptydisk1",
-					DiskDevice: virtv1.DiskDevice{
-						Disk: &virtv1.DiskTarget{
-							Bus: v1.DiskBusVirtio,
-						},
-					},
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
-					Name: "emptydisk1",
-					VolumeSource: virtv1.VolumeSource{
-						EmptyDisk: &virtv1.EmptyDiskSource{
-							Capacity: resource.MustParse("1G"),
-						},
-					},
-				})
+				vmi = libvmi.NewCirros(
+					libvmi.WithResourceMemory("512M"),
+					libvmi.WithEmptyDisk("emptydisk1", v1.DiskBusVirtio, resource.MustParse("1G")),
+				)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -426,21 +421,18 @@ var _ = SIGDescribe("Storage", func() {
 
 			It("should be successfully started and virtiofs could be accessed", func() {
 				pvcName := fmt.Sprintf("disk-%s", pvc)
-				vmi := tests.NewRandomVMIWithPVCFS(pvcName)
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
-				vmi.Spec.Domain.Devices.Rng = &virtv1.Rng{}
-
-				// add userdata for guest agent and mount virtio-fs
-				fs := vmi.Spec.Domain.Devices.Filesystems[0]
-				virtiofsMountPath := fmt.Sprintf("/mnt/virtiof_%s", fs.Name)
+				virtiofsMountPath := fmt.Sprintf("/mnt/virtiofs_%s", pvcName)
 				virtiofsTestFile := fmt.Sprintf("%s/virtiofs_test", virtiofsMountPath)
 				mountVirtiofsCommands := fmt.Sprintf(`#!/bin/bash
                                    mkdir %s
                                    mount -t virtiofs %s %s
                                    touch %s
-                           `, virtiofsMountPath, fs.Name, virtiofsMountPath, virtiofsTestFile)
-				tests.AddUserData(vmi, cloudInitName, mountVirtiofsCommands)
+                           `, virtiofsMountPath, pvcName, virtiofsMountPath, virtiofsTestFile)
 
+				vmi = libvmi.NewFedora(
+					libvmi.WithCloudInitNoCloudUserData(mountVirtiofsCommands, true),
+					libvmi.WithFilesystemPVC(pvcName),
+				)
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 
 				// Wait for cloud init to finish and start the agent inside the vmi.
@@ -449,7 +441,7 @@ var _ = SIGDescribe("Storage", func() {
 				By(checkingVMInstanceConsoleOut)
 				Expect(console.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
-				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", fs.Name)
+				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", pvcName)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				podVirtioFsFileExist, err := tests.ExecuteCommandOnPod(
 					virtClient,
@@ -476,28 +468,25 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 			It("should be successfully started and virtiofs could be accessed", func() {
-				vmi := tests.NewRandomVMIWithFSFromDataVolume(dataVolume.Name)
 				_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				By("Waiting until the DataVolume is ready")
 				if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(libstorage.Config.StorageRWOFileSystem) {
 					Eventually(ThisDV(dataVolume), 30).Should(BeInPhase(cdiv1.WaitForFirstConsumer))
 				}
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
 
-				vmi.Spec.Domain.Devices.Rng = &virtv1.Rng{}
-
-				// add userdata for guest agent and mount virtio-fs
-				fs := vmi.Spec.Domain.Devices.Filesystems[0]
-				virtiofsMountPath := fmt.Sprintf("/mnt/virtiof_%s", fs.Name)
+				virtiofsMountPath := fmt.Sprintf("/mnt/virtiofs_%s", dataVolume.Name)
 				virtiofsTestFile := fmt.Sprintf("%s/virtiofs_test", virtiofsMountPath)
 				mountVirtiofsCommands := fmt.Sprintf(`#!/bin/bash
                                        mkdir %s
                                        mount -t virtiofs %s %s
                                        touch %s
-                               `, virtiofsMountPath, fs.Name, virtiofsMountPath, virtiofsTestFile)
-				tests.AddUserData(vmi, cloudInitName, mountVirtiofsCommands)
+                               `, virtiofsMountPath, dataVolume.Name, virtiofsMountPath, virtiofsTestFile)
 
+				vmi = libvmi.NewFedora(
+					libvmi.WithCloudInitNoCloudUserData(mountVirtiofsCommands, true),
+					libvmi.WithFilesystemDV(dataVolume.Name),
+				)
 				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
 				// import and start
 				vmi = tests.RunVMIAndExpectLaunchWithDataVolume(vmi, dataVolume, 500)
@@ -515,7 +504,7 @@ var _ = SIGDescribe("Storage", func() {
 					&expect.BExp{R: console.RetValue("1")},
 				}, 30*time.Second)).To(Succeed(), "Should be able to access the mounted virtiofs file")
 
-				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", fs.Name)
+				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", dataVolume.Name)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				podVirtioFsFileExist, err := tests.ExecuteCommandOnPod(
 					virtClient,
@@ -700,7 +689,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 			It("VirtioFS, it should fail to start a VMI", func() {
 				tests.DisableFeatureGate(virtconfig.VirtIOFSGate)
-				vmi := tests.NewRandomVMIWithFSFromDataVolume("something")
+				vmi := libvmi.NewFedora(libvmi.WithFilesystemDV("something"))
 				virtClient, err := kubecli.GetKubevirtClient()
 				Expect(err).ToNot(HaveOccurred())
 				_, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -911,8 +900,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithPersistentVolumeClaim("disk0", fmt.Sprintf("disk-%s", pvc)),
 							libvmi.WithResourceMemory("256Mi"),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
-						vmi.Spec.NodeSelector = nodeSelector
+							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithNodeSelectorFor(&k8sv1.Node{ObjectMeta: metav1.ObjectMeta{Name: node}}))
 						tests.RunVMIAndExpectLaunch(vmi, 90)
 
 						By("Checking if disk.img exists")
@@ -1056,10 +1045,12 @@ var _ = SIGDescribe("Storage", func() {
 			// Not a candidate for NFS because local volumes are used in test
 			It("[test_id:1015]should be successfully started", func() {
 				// Start the VirtualMachineInstance with the PVC attached
-				vmi = tests.NewRandomVMIWithPVC(dataVolume.Name)
 				// Without userdata the hostname isn't set correctly and the login expecter fails...
-				tests.AddUserData(vmi, cloudInitName, "#!/bin/bash\necho 'hello'\n")
-
+				vmi = libvmi.New(
+					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithPersistentVolumeClaim("disk0", dataVolume.Name),
+					libvmi.WithCloudInitNoCloudUserData(cirrosUserData, true),
+				)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				By(checkingVMInstanceConsoleOut)
@@ -1086,9 +1077,11 @@ var _ = SIGDescribe("Storage", func() {
 			It("[test_id:1040] should get unschedulable condition", func() {
 				// Start the VirtualMachineInstance
 				pvcName := "nonExistingPVC"
-				vmi = tests.NewRandomVMIWithPVC(pvcName)
-
-				tests.RunVMI(vmi, 10)
+				vmi = libvmi.New(
+					libvmi.WithResourceMemory("128Mi"),
+					libvmi.WithPersistentVolumeClaim("disk0", pvcName),
+				)
+				vmi = tests.RunVMI(vmi, 10)
 
 				virtClient, err := kubecli.GetKubevirtClient()
 				Expect(err).ToNot(HaveOccurred())
@@ -1130,40 +1123,10 @@ var _ = SIGDescribe("Storage", func() {
 		Context("With both SCSI and SATA devices", func() {
 			It("should successfully start with distinct device names", func() {
 
-				// Start the VirtualMachineInstance with two empty disks attached, one per bus
-				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
-					Name: "emptydisk1",
-					DiskDevice: virtv1.DiskDevice{
-						Disk: &virtv1.DiskTarget{
-							Bus: v1.DiskBusSCSI,
-						},
-					},
-				})
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, virtv1.Disk{
-					Name: "emptydisk2",
-					DiskDevice: virtv1.DiskDevice{
-						Disk: &virtv1.DiskTarget{
-							Bus: v1.DiskBusSATA,
-						},
-					},
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
-					Name: "emptydisk1",
-					VolumeSource: virtv1.VolumeSource{
-						EmptyDisk: &virtv1.EmptyDiskSource{
-							Capacity: resource.MustParse("1Gi"),
-						},
-					},
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, virtv1.Volume{
-					Name: "emptydisk2",
-					VolumeSource: virtv1.VolumeSource{
-						EmptyDisk: &virtv1.EmptyDiskSource{
-							Capacity: resource.MustParse("1Gi"),
-						},
-					},
-				})
+				vmi = libvmi.NewAlpine(
+					libvmi.WithEmptyDisk("emptydisk1", v1.DiskBusSCSI, resource.MustParse("1Gi")),
+					libvmi.WithEmptyDisk("emptydisk2", v1.DiskBusSATA, resource.MustParse("1Gi")),
+				)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
@@ -1309,9 +1272,10 @@ var _ = SIGDescribe("Storage", func() {
 		})
 		Context("write and read data from a shared disk", func() {
 			It("should successfully write and read data", func() {
-				vmi1 := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				vmi2 := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-				labelKey := "testshareablekey"
+				const diskName = "disk1"
+				const pvcClaim = "pvc-test-disk1"
+				const labelKey = "testshareablekey"
+
 				labels := map[string]string{
 					labelKey: "",
 				}
@@ -1337,24 +1301,23 @@ var _ = SIGDescribe("Storage", func() {
 						},
 					},
 				}
+
+				vmi1 := libvmi.NewAlpine(libvmi.WithPersistentVolumeClaim(diskName, pvcClaim))
+				vmi2 := libvmi.NewAlpine(libvmi.WithPersistentVolumeClaim(diskName, pvcClaim))
+
 				vmi1.Labels = labels
 				vmi2.Labels = labels
 
 				vmi1.Spec.Affinity = affinityRule
 				vmi2.Spec.Affinity = affinityRule
 
-				diskName := "disk1"
-				pvcClaim := "pvc-test-disk1"
 				libstorage.CreateBlockPVC(pvcClaim, "500Mi")
-				tests.AddPVCDisk(vmi1, diskName, v1.DiskBusVirtio, pvcClaim)
-				tests.AddPVCDisk(vmi2, diskName, v1.DiskBusVirtio, pvcClaim)
-
 				setShareable(vmi1, diskName)
 				setShareable(vmi2, diskName)
 
 				By("Starting the VirtualMachineInstances")
-				tests.RunVMIAndExpectLaunch(vmi1, 500)
-				tests.RunVMIAndExpectLaunch(vmi2, 500)
+				vmi1 = tests.RunVMIAndExpectLaunch(vmi1, 500)
+				vmi2 = tests.RunVMIAndExpectLaunch(vmi2, 500)
 				By("Write data from the first VMI")
 				Expect(console.LoginToAlpine(vmi1)).To(Succeed())
 
@@ -1416,9 +1379,9 @@ var _ = SIGDescribe("Storage", func() {
 
 			It("should run the VMI", func() {
 				By("Creating VMI with LUN disk")
-				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi := libvmi.NewAlpine()
 				addPVCLunDisk(vmi, "lun0", pvc.ObjectMeta.Name)
-				_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)
 
 				tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 180)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -912,8 +912,6 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithResourceMemory("256Mi"),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
-
-						vmi = tests.NewRandomVMIWithPVC(fmt.Sprintf("disk-%s", pvc))
 						vmi.Spec.NodeSelector = nodeSelector
 						tests.RunVMIAndExpectLaunch(vmi, 90)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -726,51 +726,6 @@ func NewRandomFedoraVMIWithBlacklistGuestAgent(commands string) *v1.VirtualMachi
 	)
 }
 
-func AddPVCFS(vmi *v1.VirtualMachineInstance, name string, claimName string) *v1.VirtualMachineInstance {
-	vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
-		Name:     name,
-		Virtiofs: &v1.FilesystemVirtiofs{},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: name,
-		VolumeSource: v1.VolumeSource{
-			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-				ClaimName: claimName,
-			}},
-		},
-	})
-
-	return vmi
-}
-
-func NewRandomVMIWithFSFromDataVolume(dataVolumeName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMI()
-	containerImage := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-	AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, containerImage)
-	vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
-		Name:     "disk1",
-		Virtiofs: &v1.FilesystemVirtiofs{},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: "disk1",
-		VolumeSource: v1.VolumeSource{
-			DataVolume: &v1.DataVolumeSource{
-				Name: dataVolumeName,
-			},
-		},
-	})
-	return vmi
-}
-
-func NewRandomVMIWithPVCFS(claimName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMI()
-
-	containerImage := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-	AddEphemeralDisk(vmi, "disk0", v1.DiskBusVirtio, containerImage)
-	vmi = AddPVCFS(vmi, "disk1", claimName)
-	return vmi
-}
-
 func NewRandomFedoraVMIWithDmidecode() *v1.VirtualMachineInstance {
 	vmi := NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling))
 	return vmi
@@ -890,30 +845,6 @@ func DeletePvAndPvc(name string) {
 	if !errors.IsNotFound(err) {
 		util2.PanicOnError(err)
 	}
-}
-
-func NewRandomVMIWithCDRom(claimName string) *v1.VirtualMachineInstance {
-	vmi := NewRandomVMI()
-
-	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name: "disk0",
-		DiskDevice: v1.DiskDevice{
-			CDRom: &v1.CDRomTarget{
-				// Do not specify ReadOnly flag so that
-				// default behavior can be tested
-				Bus: v1.DiskBusSATA,
-			},
-		},
-	})
-	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: "disk0",
-		VolumeSource: v1.VolumeSource{
-			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-				ClaimName: claimName,
-			}},
-		},
-	})
-	return vmi
 }
 
 func NewRandomVMIWithEphemeralPVC(claimName string) *v1.VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR introduces new functions to libvmi and
changes the tests in tests/storage to use libvmi.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
