### PR TITLE
[release-0.44] Fix `KubeVirtComponentExceedsRequestedMemory` alert on duplicate series

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -32,7 +32,7 @@ tests:
   # Pod is using more memory than expected
   - interval: 1m
     input_series:
-      - series: 'container_memory_usage_bytes{namespace="ci",container="virt-controller",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
+      - series: 'container_memory_working_set_bytes{namespace="ci",container="",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: "157286400 157286400 157286400 157286400 157286400 157286400 157286400 157286400"
       - series: 'kube_pod_container_resource_requests{namespace="ci",container="virt-controller",resource="memory",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: "118325248 118325248 118325248 118325248 118325248 118325248 118325248 118325248"

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -936,7 +936,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "KubeVirtComponentExceedsRequestedMemory",
-						Expr:  intstr.FromString(fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_usage_bytes{namespace="%s"}) < 0`, ns, ns)),
+						Expr:  intstr.FromString(fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="%s"}) < 0`, ns, ns)),
 						For:   "5m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage exceeds the memory requested",


### PR DESCRIPTION
This is a manual cherry-pick of #7372 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2118317

/assign @enp0s3 

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

```release-note
NONE
```
