### PR TITLE
Fix possible race when deleting unready vmsnapshot and the vm remaining frozen

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -599,6 +599,19 @@ func GetVirtualMachineSnapshotInformerIndexers() cache.Indexers {
 
 			return nil, nil
 		},
+		"vmSnapshotContent": func(obj interface{}) ([]string, error) {
+			vms, ok := obj.(*snapshotv1.VirtualMachineSnapshot)
+			if !ok {
+				return nil, unexpectedObjectError
+			}
+
+			if vms.Status != nil &&
+				vms.Status.VirtualMachineSnapshotContentName != nil {
+				return []string{fmt.Sprintf("%s/%s", vms.Namespace, *vms.Status.VirtualMachineSnapshotContentName)}, nil
+			}
+
+			return nil, nil
+		},
 	}
 }
 

--- a/pkg/storage/snapshot/snapshot_base.go
+++ b/pkg/storage/snapshot/snapshot_base.go
@@ -136,6 +136,7 @@ func (ctrl *VMSnapshotController) Init() {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    ctrl.handleVMSnapshotContent,
 			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handleVMSnapshotContent(newObj) },
+			DeleteFunc: ctrl.handleVMSnapshotContent,
 		},
 		ctrl.ResyncPeriod,
 	)
@@ -395,9 +396,13 @@ func (ctrl *VMSnapshotController) handleVMSnapshotContent(obj interface{}) {
 			log.Log.Errorf(failedKeyFromObjectFmt, err, content)
 			return
 		}
+		keys, err := ctrl.VMSnapshotInformer.GetIndexer().IndexKeys("vmSnapshotContent", objName)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
 
-		if content.Spec.VirtualMachineSnapshotName != nil {
-			k := cacheKeyFunc(content.Namespace, *content.Spec.VirtualMachineSnapshotName)
+		for _, k := range keys {
 			log.Log.V(5).Infof("enqueued vmsnapshot %q for sync", k)
 			ctrl.vmSnapshotQueue.Add(k)
 		}

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -151,6 +151,18 @@ var _ = Describe("Snapshot controlleer", func() {
 		return createVirtualMachineSnapshotContent(vmSnapshot, vm, pvcs)
 	}
 
+	createReadyVMSnapshotContent := func() *snapshotv1.VirtualMachineSnapshotContent {
+		vmSnapshot := createVMSnapshotInProgress()
+		vm := createLockedVM()
+		pvcs := createPersistentVolumeClaims()
+		content := createVirtualMachineSnapshotContent(vmSnapshot, vm, pvcs)
+		content.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+			ReadyToUse:   &t,
+			CreationTime: timeFunc(),
+		}
+		return content
+	}
+
 	createStorageClass := func() *storagev1.StorageClass {
 		return &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -494,6 +506,27 @@ var _ = Describe("Snapshot controlleer", func() {
 				controller.processVMSnapshotWorkItem()
 			})
 
+			It("shouldn't unlock if snapshot deleting before completed and content not deleted", func() {
+				vmSnapshot := createVMSnapshotInProgress()
+				vmSnapshot.DeletionTimestamp = timeFunc()
+				vm := createLockedVM()
+				vmSource.Add(vm)
+				content := createVMSnapshotContent()
+				vmSnapshotContentSource.Add(content)
+				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.ResourceVersion = "1"
+				updatedSnapshot.Status.Phase = snapshotv1.Deleting
+				updatedSnapshot.Status.Indications = []snapshotv1.Indication{}
+				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionFalse, "VM snapshot is deleting"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
+				}
+				addVirtualMachineSnapshot(vmSnapshot)
+				expectVMSnapshotContentDelete(vmSnapshotClient, content.Name)
+				expectVMSnapshotUpdate(vmSnapshotClient, updatedSnapshot)
+				controller.processVMSnapshotWorkItem()
+			})
+
 			It("should finish unlock source VirtualMachine", func() {
 				vmSnapshot := createVMSnapshotSuccess()
 				vm := createLockedVM()
@@ -527,7 +560,27 @@ var _ = Describe("Snapshot controlleer", func() {
 				controller.processVMSnapshotWorkItem()
 			})
 
-			It("cleanup when VirtualMachineSnapshot is deleted and retain if necessary", func() {
+			It("should not delete content when VirtualMachineSnapshot is deleted, content ready and retain policy", func() {
+				vmSnapshot := createVMSnapshotSuccess()
+				vmSnapshot.DeletionTimestamp = timeFunc()
+				vmSnapshot.Spec.DeletionPolicy = &retain
+				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.ResourceVersion = "1"
+				updatedSnapshot.Finalizers = []string{}
+
+				content := createReadyVMSnapshotContent()
+				updatedContent := content.DeepCopy()
+				updatedContent.ResourceVersion = "1"
+				updatedContent.Finalizers = []string{}
+
+				vmSnapshotContentSource.Add(content)
+				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
+				expectVMSnapshotUpdate(vmSnapshotClient, updatedSnapshot)
+				addVirtualMachineSnapshot(vmSnapshot)
+				controller.processVMSnapshotWorkItem()
+			})
+
+			It("should delete content when VirtualMachineSnapshot is deleted, content not ready even if retain policy", func() {
 				vmSnapshot := createVMSnapshotSuccess()
 				vmSnapshot.DeletionTimestamp = timeFunc()
 				vmSnapshot.Spec.DeletionPolicy = &retain
@@ -542,6 +595,7 @@ var _ = Describe("Snapshot controlleer", func() {
 
 				vmSnapshotContentSource.Add(content)
 				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
+				expectVMSnapshotContentDelete(vmSnapshotClient, updatedContent.Name)
 				expectVMSnapshotUpdate(vmSnapshotClient, updatedSnapshot)
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotWorkItem()
@@ -1341,10 +1395,9 @@ var _ = Describe("Snapshot controlleer", func() {
 				controller.processVMSnapshotContentWorkItem()
 			})
 
-			It("should unfreeze before unlock if vmsnapshot was taken with guest agent", func() {
+			It("should unfreeze vm with and remove content finalizer if vmsnapshot deleting", func() {
 				vm := createLockedVM()
 				vmSource.Add(vm)
-
 				vmi := createVMI(vm)
 				agentCondition := v1.VirtualMachineInstanceCondition{
 					Type:          v1.VirtualMachineInstanceAgentConnected,
@@ -1354,20 +1407,24 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 				vmiSource.Add(vmi)
 
-				vmSnapshot := createVMSnapshotSuccess()
-				vmSnapshot.Status.Indications = append(vmSnapshot.Status.Indications, snapshotv1.VMSnapshotOnlineSnapshotIndication)
-				vmSnapshot.Status.Indications = append(vmSnapshot.Status.Indications, snapshotv1.VMSnapshotGuestAgentIndication)
+				vmSnapshot := createVMSnapshotInProgress()
+				vmSnapshot.DeletionTimestamp = timeFunc()
+				vmSnapshotContent := createVMSnapshotContent()
+				vmSnapshotContent.UID = contentUID
+				vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					ReadyToUse: &f,
+				}
+
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+
+				updatedContent := vmSnapshotContent.DeepCopy()
+				updatedContent.ResourceVersion = "1"
+				updatedContent.Finalizers = []string{}
 
 				vmiInterface.EXPECT().Unfreeze(vm.Name).Return(nil)
-				updatedVM := vm.DeepCopy()
-				updatedVM.Finalizers = []string{}
-				updatedVM.ResourceVersion = "1"
-				vmInterface.EXPECT().Update(updatedVM).Return(updatedVM, nil).Times(1)
-				statusUpdate := updatedVM.DeepCopy()
-				statusUpdate.Status.SnapshotInProgress = nil
-				vmInterface.EXPECT().UpdateStatus(updatedVM).Return(updatedVM, nil).Times(1)
+				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
 				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
+				controller.processVMSnapshotContentWorkItem()
 			})
 
 			DescribeTable("should delete informer", func(crdName string) {
@@ -1944,6 +2001,13 @@ func expectVMSnapshotContentUpdate(client *kubevirtfake.Clientset, content *snap
 		Expect(ok).To(BeTrue())
 
 		updateObj := update.GetObject().(*snapshotv1.VirtualMachineSnapshotContent)
+		Expect(updateObj.ObjectMeta).To(Equal(content.ObjectMeta))
+		Expect(updateObj.Spec.Source).To(Equal(content.Spec.Source))
+		Expect(*updateObj.Spec.VirtualMachineSnapshotName).To(Equal(*content.Spec.VirtualMachineSnapshotName))
+		Expect(updateObj.Spec.VolumeBackups).To(ConsistOf(content.Spec.VolumeBackups))
+		updateObj.Spec.VolumeBackups = []snapshotv1.VolumeBackup{}
+		content.Spec.VolumeBackups = []snapshotv1.VolumeBackup{}
+		Expect(updateObj.Status).To(Equal(content.Status))
 		Expect(updateObj).To(Equal(content))
 
 		return true, update.GetObject(), nil

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -507,40 +507,6 @@ var _ = Describe("Snapshot controlleer", func() {
 				controller.processVMSnapshotWorkItem()
 			})
 
-			It("should be status error when VM snapshot deleted while in progress", func() {
-				vmSnapshot := createVMSnapshotInProgress()
-				vmSnapshot.DeletionTimestamp = timeFunc()
-				vm := createLockedVM()
-				updatedVM := vm.DeepCopy()
-				updatedVM.ResourceVersion = "2"
-				updatedVM.Finalizers = []string{}
-				vmInterface.EXPECT().Update(updatedVM).Return(updatedVM, nil).Times(1)
-				statusUpdate := updatedVM.DeepCopy()
-				statusUpdate.Status.SnapshotInProgress = nil
-				vmInterface.EXPECT().UpdateStatus(statusUpdate).Return(statusUpdate, nil).Times(1)
-				vmSource.Add(vm)
-				updatedSnapshot := vmSnapshot.DeepCopy()
-				updatedSnapshot.ResourceVersion = "1"
-				updatedSnapshot.Finalizers = []string{}
-				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
-					newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
-					newReadyCondition(corev1.ConditionFalse, "Not ready"),
-				}
-				updatedSnapshot.Status.Indications = []snapshotv1.Indication{}
-				content := createVMSnapshotContent()
-				updatedContent := content.DeepCopy()
-				updatedContent.ResourceVersion = "1"
-				updatedContent.Finalizers = []string{}
-
-				vmSnapshotContentSource.Add(content)
-				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
-				expectVMSnapshotContentDelete(vmSnapshotClient, updatedContent.Name)
-				expectVMSnapshotUpdate(vmSnapshotClient, updatedSnapshot)
-				vmSource.Add(vm)
-				addVirtualMachineSnapshot(vmSnapshot)
-				controller.processVMSnapshotWorkItem()
-			})
-
 			It("cleanup when VirtualMachineSnapshot is deleted", func() {
 				vmSnapshot := createVMSnapshotSuccess()
 				vmSnapshot.DeletionTimestamp = timeFunc()

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -90,6 +90,7 @@ const (
 	InProgress VirtualMachineSnapshotPhase = "InProgress"
 	Succeeded  VirtualMachineSnapshotPhase = "Succeeded"
 	Failed     VirtualMachineSnapshotPhase = "Failed"
+	Deleting   VirtualMachineSnapshotPhase = "Deleting"
 	Unknown    VirtualMachineSnapshotPhase = "Unknown"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This should fix flakiness in test: [test_id:6837]delete snapshot after freeze, expect vm unfreeze
The issue presented there was:
deleting vmsnapshot-> deleting vmsnapshot content while the update content reconcile loop was during a wait for a call to the freeze source api command. In the CI it seems that sometimes the call can take longer time(~1s) to return. Once return there is the attempt to create the volumesnapshot that test added a fake webhook to make that call fail, hence the call returns error the reconcile loop is exited and when needing to call it again the content is already deleted.
In order to fix this issue we moved the remove of the content finalizer from the vmsnapshot reconcile to the vmsnapshotcontent reconcile which happens only after unfreezing the vm. We are not allowing the vmsnapshot to be deleted incase the process was not completed successfully (possible that the vm will still get frozen) until the content is deleted first (makes sure there will be no other call to freeze).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix possible race when deleting unready vmsnapshot and the vm remaining frozen
```
