### PR TITLE
[e2e tests]: Less large PVCs during parallel testing

### DIFF
--- a/tests/libstorage/BUILD.bazel
+++ b/tests/libstorage/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util/net/ip:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/containerdisk:go_default_library",
         "//tests/errorhandling:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/cleanup:go_default_library",

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -99,9 +99,12 @@ func newDataVolume(namespace, storageClass string, size string, accessMode v1.Pe
 
 func NewDataVolumeWithRegistryImportInStorageClass(imageUrl, namespace, storageClass string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode) *v1beta1.DataVolume {
 	size := "512Mi"
+	// Uses node cache, does not require extra scratch space PVC
+	pullMethod := v1beta1.RegistryPullNode
 	dataVolumeSource := v1beta1.DataVolumeSource{
 		Registry: &v1beta1.DataVolumeSourceRegistry{
-			URL: &imageUrl,
+			URL:        &imageUrl,
+			PullMethod: &pullMethod,
 		},
 	}
 	return newDataVolume(namespace, storageClass, size, accessMode, volumeMode, dataVolumeSource)

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -98,7 +99,13 @@ func newDataVolume(namespace, storageClass string, size string, accessMode v1.Pe
 }
 
 func NewDataVolumeWithRegistryImportInStorageClass(imageUrl, namespace, storageClass string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode) *v1beta1.DataVolume {
-	size := "512Mi"
+	var size string
+	switch imageUrl {
+	case cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraRealtime):
+		size = cd.FedoraVolumeSize
+	default:
+		size = "512Mi"
+	}
 	// Uses node cache, does not require extra scratch space PVC
 	pullMethod := v1beta1.RegistryPullNode
 	dataVolumeSource := v1beta1.DataVolumeSource{

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2573,7 +2573,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 
-				quantity, err := resource.ParseQuantity("5Gi")
+				quantity, err := resource.ParseQuantity(cd.FedoraVolumeSize)
 				Expect(err).ToNot(HaveOccurred())
 
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -391,8 +391,10 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume", func() {
 		Context("using DataVolume with invalid URL", func() {
-			It("shold be possible to stop VM if datavolume is crashing", func() {
+			It("should be possible to stop VM if datavolume is crashing", func() {
 				dataVolume := libstorage.NewDataVolumeWithRegistryImport(InvalidDataVolumeUrl, util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				pullMethod := cdiv1.RegistryPullPod
+				dataVolume.Spec.Source.Registry.PullMethod = &pullMethod
 				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
 				vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{
 					{
@@ -448,6 +450,8 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 					util.NamespaceTestDefault,
 					k8sv1.ReadWriteOnce,
 				)
+				pullMethod := cdiv1.RegistryPullPod
+				dataVolume.Spec.Source.Registry.PullMethod = &pullMethod
 				defer libstorage.DeleteDataVolume(&dataVolume)
 
 				By("Creating DataVolume with invalid URL")

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -38,7 +38,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -1358,7 +1357,6 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		dataVolume := libstorage.NewDataVolumeWithRegistryImportInStorageClass(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
-		dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("6Gi")
 		dataVolume = createDataVolume(dataVolume)
 		vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 		vmi = createVMI(vmi)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1616,7 +1616,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						corev1.ReadWriteOnce,
 					)
 					libstorage.SetDataVolumePVCStorageClass(dataVolume, snapshotStorageClass)
-					libstorage.SetDataVolumePVCSize(dataVolume, "6Gi")
 					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 					tests.AddUserData(vmi, "cloud-init", bashHelloScript)
 					vm := tests.NewRandomVirtualMachine(vmi, false)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -532,7 +532,6 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 
 func NewRandomVMWithDataVolumeWithRegistryImport(imageUrl, namespace, storageClass string, accessMode k8sv1.PersistentVolumeAccessMode) *v1.VirtualMachine {
 	dataVolume := libstorage.NewDataVolumeWithRegistryImportInStorageClass(imageUrl, namespace, storageClass, accessMode, k8sv1.PersistentVolumeFilesystem)
-	dataVolume.Spec.PVC.Resources.Requests[k8sv1.ResourceStorage] = resource.MustParse("6Gi")
 	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
 	vm := NewRandomVirtualMachine(vmi, false)
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- The node pull method is basically taking advantage of pulling images
the same way k8s would if you specified them in a pod's `container.image`:
https://github.com/kubevirt/containerized-data-importer/blob/main/doc/image-from-registry.md#import-registry-image-into-a-data-volume-using-node-docker-cache
It does not require scratch space so we should not see situations in CI
where there are 6 PVCs of 6Gi size each:
https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7549/pull-kubevirt-e2e-k8s-1.23-sig-storage/1554905217219170304/artifacts/k8s-reporter/2/1_pvcs.log
Potentially exhausting all ceph capacity.

- Attempt to not use huge DV sizes where they are not needed. for example 6Gi for an alpine DV is not necessary and can cause ceph to run out of its capacity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
