### PR TITLE
Update example files to use a remote images repository

### DIFF
--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -20,7 +20,7 @@ spec:
         storageClassName: local
       source:
         http:
-          url: docker://registry:5000/kubevirt/alpine-container-disk-demo:devel
+          url: docker://quay.io/kubevirt/alpine-container-disk-demo:devel
   running: false
   template:
     metadata:

--- a/examples/vm-cirros-clarge-virtio.yaml
+++ b/examples/vm-cirros-clarge-virtio.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-cirros-clarge-windows.yaml
+++ b/examples/vm-cirros-clarge-windows.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-cirros-clarge.yaml
+++ b/examples/vm-cirros-clarge.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   instancetype:
     kind: VirtualMachineClusterInstancetype
-    name: csmall
+    name: cluster-csmall
   running: false
   template:
     metadata:
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-cirros-csmall.yaml
+++ b/examples/vm-cirros-csmall.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-cirros-sata.yaml
+++ b/examples/vm-cirros-sata.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-pool-cirros.yaml
+++ b/examples/vm-pool-cirros.yaml
@@ -33,5 +33,5 @@ spec:
           terminationGracePeriodSeconds: 0
           volumes:
           - containerDisk:
-              image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+              image: quay.io/kubevirt/cirros-container-disk-demo:devel
             name: containerdisk

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk
       - cloudInitNoCloud:
           userData: |

--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -60,7 +60,7 @@ objects:
               chpasswd: { expire: False }
           name: cloudinitdisk
         - containerDisk:
-            image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+            image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
           name: containerdisk
   status: {}
 parameters:

--- a/examples/vmi-alpine-efi.yaml
+++ b/examples/vmi-alpine-efi.yaml
@@ -22,5 +22,5 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/alpine-container-disk-demo:devel
+      image: quay.io/kubevirt/alpine-container-disk-demo:devel
     name: containerdisk

--- a/examples/vmi-arm.yaml
+++ b/examples/vmi-arm.yaml
@@ -24,7 +24,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+      image: quay.io/kubevirt/cirros-container-disk-demo:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |

--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -18,5 +18,5 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+      image: quay.io/kubevirt/cirros-container-disk-demo:devel
     name: containerdisk

--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -22,7 +22,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-

--- a/examples/vmi-gpu.yaml
+++ b/examples/vmi-gpu.yaml
@@ -25,7 +25,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-

--- a/examples/vmi-kernel-boot.yaml
+++ b/examples/vmi-kernel-boot.yaml
@@ -11,7 +11,7 @@ spec:
     firmware:
       kernelBoot:
         container:
-          image: registry:5000/kubevirt/alpine-ext-kernel-boot-demo:devel
+          image: quay.io/kubevirt/alpine-ext-kernel-boot-demo:devel
           initrdPath: /boot/initramfs-virt
           kernelPath: /boot/vmlinuz-virt
         kernelArgs: console=ttyS0

--- a/examples/vmi-macvtap.yaml
+++ b/examples/vmi-macvtap.yaml
@@ -29,7 +29,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -32,7 +32,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       networkData: |

--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -24,5 +24,5 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/alpine-container-disk-demo:devel
+      image: quay.io/kubevirt/alpine-container-disk-demo:devel
     name: containerdisk

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -33,7 +33,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       networkData: |

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -29,7 +29,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-

--- a/examples/vmi-nocloud.yaml
+++ b/examples/vmi-nocloud.yaml
@@ -24,7 +24,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+      image: quay.io/kubevirt/cirros-container-disk-demo:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |

--- a/examples/vmi-replicaset-cirros.yaml
+++ b/examples/vmi-replicaset-cirros.yaml
@@ -25,5 +25,5 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:
-          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+          image: quay.io/kubevirt/cirros-container-disk-demo:devel
         name: containerdisk

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -14,5 +14,5 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+      image: quay.io/kubevirt/cirros-container-disk-demo:devel
     name: containerdisk

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -26,5 +26,5 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk

--- a/examples/vmi-slirp.yaml
+++ b/examples/vmi-slirp.yaml
@@ -32,7 +32,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -33,7 +33,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       networkData: |

--- a/examples/vmi-with-sidecar-hook.yaml
+++ b/examples/vmi-with-sidecar-hook.yaml
@@ -4,7 +4,7 @@ kind: VirtualMachineInstance
 metadata:
   annotations:
     hooks.kubevirt.io/hookSidecars: '[{"args": ["--version", "v1alpha2"], "image":
-      "registry:5000/kubevirt/example-hook-sidecar:devel"}]'
+      "quay.io/kubevirt/example-hook-sidecar:devel"}]'
     smbios.vm.kubevirt.io/baseBoardManufacturer: Radical Edward
   labels:
     special: vmi-with-sidecar-hook
@@ -26,7 +26,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-with-test-tooling-container-disk:devel
+      image: quay.io/kubevirt/fedora-with-test-tooling-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
       userData: |-


### PR DESCRIPTION
**What this PR does / why we need it**:
Example files pull images from the local repository which does not allow users to run them on a real cluster (not kubevirtci).
The image files required by the examples are now pulled from https://quay.io/organization/kubevirt

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
