### PR TITLE
e2e, istio: Wait for VMI to launch before Logging in

### DIFF
--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -356,15 +356,15 @@ var istioTests = func(vmType VmType) {
 					libvmi.WithLabel(vmiAppSelectorKey, vmiServerAppSelectorValue),
 					libvmi.WithCloudInitNoCloudNetworkData(networkData),
 				)
-				serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
-				Expect(err).ToNot(HaveOccurred())
+				By("Starting VirtualMachineInstance")
+				serverVMI = tests.RunVMIAndExpectLaunch(serverVMI, 240)
 
 				serverVMIService := netservice.BuildSpec("vmi-server", vmiServerTestPort, vmiServerTestPort, vmiAppSelectorKey, vmiServerAppSelectorValue)
 				_, err = virtClient.CoreV1().Services(util.NamespaceTestDefault).Create(context.Background(), serverVMIService, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
 				By("Starting HTTP Server")
+				Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
 				tests.StartPythonHttpServer(serverVMI, vmiServerTestPort)
 
 				By("Creating Istio VirtualService")


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This commit uses tests.RunVMIAndExpectLaunch function to
create VMI and wait for it to be running, before calling console.LoginToAlpine, because attempting to log in the VMI
causes flakes when the VMI isn't running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes flake: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7007/pull-kubevirt-e2e-k8s-1.22-sig-network/1559831970916077568


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
