### PR TITLE
istio,handler: enable ipv4 route_localnet for k6t-eth0

### DIFF
--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -51,6 +51,7 @@ const (
 	randomMacGenerationAttempts = 10
 	allowForwarding             = "1"
 	LibvirtUserAndGroupId       = "0"
+	allowRouteLocalNet          = "1"
 )
 
 type NetworkHandler interface {
@@ -75,6 +76,7 @@ type NetworkHandler interface {
 	HasIPv6GlobalUnicastAddress(interfaceName string) (bool, error)
 	IsIpv4Primary() (bool, error)
 	ConfigureIpForwarding(proto iptables.Protocol) error
+	ConfigureRouteLocalNet(string) error
 	ConfigureIpv4ArpIgnore() error
 	ConfigurePingGroupRange() error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
@@ -168,6 +170,12 @@ func (h *NetworkUtilsHandler) ConfigureIpForwarding(proto iptables.Protocol) err
 
 func (h *NetworkUtilsHandler) ConfigurePingGroupRange() error {
 	err := sysctl.New().SetSysctl(sysctl.PingGroupRange, "107 107")
+	return err
+}
+
+func (h *NetworkUtilsHandler) ConfigureRouteLocalNet(iface string) error {
+	routeLocalNetForIface := fmt.Sprintf(sysctl.IPv4RouteLocalNet, iface)
+	err := sysctl.New().SetSysctl(routeLocalNetForIface, allowRouteLocalNet)
 	return err
 }
 

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -254,6 +254,16 @@ func (_mr *_MockNetworkHandlerRecorder) ConfigureIpForwarding(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpForwarding", arg0)
 }
 
+func (_m *MockNetworkHandler) ConfigureRouteLocalNet(_param0 string) error {
+	ret := _m.ctrl.Call(_m, "ConfigureRouteLocalNet", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) ConfigureRouteLocalNet(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureRouteLocalNet", arg0)
+}
+
 func (_m *MockNetworkHandler) ConfigureIpv4ArpIgnore() error {
 	ret := _m.ctrl.Call(_m, "ConfigureIpv4ArpIgnore")
 	ret0, _ := ret[0].(error)

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -136,6 +136,11 @@ func (b *MasqueradePodNetworkConfigurator) PreparePodNetworkInterface() error {
 		return err
 	}
 	if ipv4Enabled {
+		err = b.handler.ConfigureRouteLocalNet(api.DefaultBridgeName)
+		if err != nil {
+			log.Log.Reason(err).Errorf("failed to configure routing of local addresses for %s", api.DefaultBridgeName)
+			return err
+		}
 		err = b.createNatRules(iptables.ProtocolIPv4)
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to create ipv4 nat rules for vm error: %v", err)

--- a/pkg/network/infraconfigurators/masquerade_test.go
+++ b/pkg/network/infraconfigurators/masquerade_test.go
@@ -448,6 +448,7 @@ func mockNATNetfilterRules(configurator MasqueradePodNetworkConfigurator, dhcpCo
 		if proto == iptables.ProtocolIPv4 {
 			vmIP = dhcpConfig.IP.IP.String()
 			gwIP = dhcpConfig.AdvertisingIPAddr.String()
+			handler.EXPECT().ConfigureRouteLocalNet("k6t-eth0").Return(nil)
 		}
 
 		if proto == iptables.ProtocolIPv6 {

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -30,6 +30,7 @@ const (
 	NetIPv4Forwarding = "net/ipv4/ip_forward"
 	Ipv4ArpIgnoreAll  = "net/ipv4/conf/all/arp_ignore"
 	PingGroupRange    = "net/ipv4/ping_group_range"
+	IPv4RouteLocalNet = "net/ipv4/conf/%s/route_localnet"
 )
 
 // Interface is an injectable interface for running sysctl commands.


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This commit adds handler method for enabling route_localnet
sysctl option. This option enables/disables routing of
127.0.0.0/8 traffic.

This option is required in the following scenario for VMs with masquerade interface:
- kubectl port-forward
- Istio service mesh

Since we only need to enable this for the in-pod bridge, enabling
this option doesn't allow martian traffic to leave the virt-launcher
pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2081306

**Special notes for your reviewer**:

IPv6 doesn't have an alternative to route_localnet

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Enable route_localnet sysctl option for masquerade binding at virt-handler
```
