### PR TITLE
virtctl: Do not log wrapped ssh command by default

### DIFF
--- a/pkg/virtctl/ssh/wrapped.go
+++ b/pkg/virtctl/ssh/wrapped.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 var runCommand = func(cmd *exec.Cmd) error {
@@ -26,7 +28,7 @@ func RunLocalClient(kind, namespace, name string, options *SSHOptions, clientArg
 	args = append(args, clientArgs...)
 
 	cmd := exec.Command(options.LocalClientName, args...)
-	fmt.Println("running:", cmd)
+	glog.V(3).Info("running: ", cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This changes the verbosity of the wrapped ssh command to 3 so it is no
longer logged by default.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: Do not log wrapped ssh command by default
```
