### PR TITLE
Legacy GAVersion matching did not report a reason for failure

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -991,6 +991,9 @@ func (d *VirtualMachineController) updateGuestAgentConditions(vmi *v1.VirtualMac
 			for _, version := range d.clusterConfig.GetSupportedAgentVersions() {
 				supported = supported || regexp.MustCompile(version).MatchString(guestInfo.GAVersion)
 			}
+			if !supported {
+				reason = fmt.Sprintf("Guest agent version '%s' is not supported", guestInfo.GAVersion)
+			}
 		}
 
 		if !supported {


### PR DESCRIPTION
Signed-off-by: Stu Gott <sgott@redhat.com>

**What this PR does / why we need it**:

When using legacy matching for Guest Agent compatibility, if a matching version is not found, the status condition didn't specify a reason why it was applied.

**Release note**:
```release-note
NONE
```
