### PR TITLE
virt-launcher: add opt-in feature gate for docker bug workaround

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -48,6 +48,8 @@ const (
 	NonRoot                    = "NonRoot"
 	ClusterProfiler            = "ClusterProfiler"
 	WorkloadEncryptionSEV      = "WorkloadEncryptionSEV"
+	// DockerSELinuxMCSWorkaround sets the SELinux level of all the non-compute virt-launcher containers to "s0".
+	DockerSELinuxMCSWorkaround = "DockerSELinuxMCSWorkaround"
 )
 
 var deprecatedFeatureGates = [...]string{
@@ -166,4 +168,8 @@ func (config *ClusterConfig) ClusterProfilerEnabled() bool {
 
 func (config *ClusterConfig) WorkloadEncryptionSEVEnabled() bool {
 	return config.isFeatureGateEnabled(WorkloadEncryptionSEV)
+}
+
+func (config *ClusterConfig) DockerSELinuxMCSWorkaroundEnabled() bool {
+	return config.isFeatureGateEnabled(DockerSELinuxMCSWorkaround)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A bug in docker (https://github.com/moby/moby/issues/41370) forces
us to implement a workaround in the SELinux options of virt-launcher.
This workaround (disabling categories on non-compute containers)
weakens the security of the project for all when it is only needed
for a very specific use-case: deployments on clusters
that have docker nodes with SELinux enforced on the system and
enabled in the docker configuration (it is disabled by default).

That bug was filed more than 2 years ago, so it is time to disable
the workaround by default, with a feature gate for those who need it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Important: If you use docker with SELinux enabled, set the `DockerSELinuxMCSWorkaround` feature gate before upgrading
```
