### PR TITLE
guestfs: flag to set uid and gid

### DIFF
--- a/cmd/libguestfs/BUILD.bazel
+++ b/cmd/libguestfs/BUILD.bazel
@@ -27,6 +27,7 @@ container_image(
         "//:get-version",
     ],
     tars = [
+        "//:passwd-tar",
         "//rpm:libguestfs-tools",
         ":appliance_layer",
         ":entrypoint",

--- a/pkg/virtctl/guestfs/BUILD.bazel
+++ b/pkg/virtctl/guestfs/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -53,7 +53,7 @@ var (
 	kvm           bool
 	podName       string
 	root          bool
-	group         string
+	fsGroup       string
 )
 
 type guestfsCommand struct {
@@ -78,7 +78,7 @@ func NewGuestfsShellCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 	cmd.PersistentFlags().BoolVar(&kvm, "kvm", true, "Use kvm for the libguestfs-tools container")
 	cmd.PersistentFlags().BoolVar(&root, "root", false, "Set uid 0 for the libguestfs-tool container")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
-	cmd.PersistentFlags().StringVar(&group, "group", "", "Set the gid and fsgroup for the libguestfs-tool container")
+	cmd.PersistentFlags().StringVar(&fsGroup, "fsGroup", "", "Set the fsgroup for the libguestfs-tool container")
 
 	return cmd
 }
@@ -369,11 +369,11 @@ func (client *K8sClient) getPodsForPVC(pvcName, ns string) ([]corev1.Pod, error)
 }
 
 func setGroupLibguestfs() (*int64, error) {
-	if root && group != "" {
-		return nil, fmt.Errorf("cannot set group id with root")
+	if root && fsGroup != "" {
+		return nil, fmt.Errorf("cannot set fsGroup id with root")
 	}
-	if group != "" {
-		n, err := strconv.ParseInt(group, 10, 64)
+	if fsGroup != "" {
+		n, err := strconv.ParseInt(fsGroup, 10, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -418,7 +418,6 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 	securityContext := &corev1.PodSecurityContext{
 		RunAsNonRoot: &nonRoot,
 		RunAsUser:    uid,
-		RunAsGroup:   g,
 		FSGroup:      g,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -372,7 +372,7 @@ func (client *K8sClient) getPodsForPVC(pvcName, ns string) ([]corev1.Pod, error)
 	return pods, nil
 }
 
-func setGroupLibguestfs() (*int64, error) {
+func setFSGroupLibguestfs() (*int64, error) {
 	if root && fsGroup != "" {
 		return nil, fmt.Errorf("cannot set fsGroup id with root")
 	}
@@ -384,8 +384,8 @@ func setGroupLibguestfs() (*int64, error) {
 		return &n, nil
 	}
 	if root {
-		var rootGID int64 = 0
-		return &rootGID, nil
+		var rootFsID int64 = 0
+		return &rootFsID, nil
 	}
 	return nil, nil
 }
@@ -424,7 +424,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 	if err != nil {
 		return nil, err
 	}
-	g, err := setGroupLibguestfs()
+	f, err := setFSGroupLibguestfs()
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 	securityContext := &corev1.PodSecurityContext{
 		RunAsNonRoot: pointer.Bool(!root),
 		RunAsUser:    u,
-		FSGroup:      g,
+		FSGroup:      f,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -148,6 +148,14 @@ var _ = Describe("Guestfs shell", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal(fmt.Sprintf("The PVC %s doesn't exist", pvcName)))
 		})
+
+		It("UID cannot be used with root", func() {
+			guestfs.SetClient(fakeCreateClientPVC)
+			cmd := virtctlcmd.NewRepeatableVirtctlCommand(commandName, pvcName, "--root=true", "--uid=1001")
+			err := cmd()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(Equal(fmt.Sprintf("cannot set uid if root is true")))
+		})
 	})
 
 	Context("URL authenticity", func() {

--- a/pkg/virtctl/guestfs/guestfs_test.go
+++ b/pkg/virtctl/guestfs/guestfs_test.go
@@ -156,6 +156,13 @@ var _ = Describe("Guestfs shell", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal(fmt.Sprintf("cannot set uid if root is true")))
 		})
+		It("GID can be use only together with the uid flag", func() {
+			guestfs.SetClient(fakeCreateClientPVC)
+			cmd := virtctlcmd.NewRepeatableVirtctlCommand(commandName, pvcName, "--gid=1001")
+			err := cmd()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(Equal(fmt.Sprintf("gid requires the uid to be set")))
+		})
 	})
 
 	Context("URL authenticity", func() {

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		podName := libguestsTools + pvcClaim
 		o := append([]string{"guestfs", pvcClaim, "--namespace", util.NamespaceTestDefault}, options...)
 		if setGroup {
-			o = append(o, "--group", testGroup)
+			o = append(o, "--fsGroup", testGroup)
 		}
 		guestfsCmd := clientcmd.NewVirtctlCommand(o...)
 		go func() {


### PR DESCRIPTION
Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add flag to specify uid for guestfs pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Flag for setting the guestfs uid and gid
```
