### PR TITLE
instancetype: Drop PreferredMachineType test assertions

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -254,10 +254,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			preference.Spec.Firmware = &instancetypev1alpha1.FirmwarePreferences{
 				PreferredUseBios: pointer.Bool(true),
 			}
-			// We don't want to break tests randomly so just use the q35 alias for now
-			preference.Spec.Machine = &instancetypev1alpha1.MachinePreferences{
-				PreferredMachineType: "q35",
-			}
 
 			preference, err = virtClient.VirtualMachinePreference(util.NamespaceTestDefault).
 				Create(context.Background(), preference, metav1.CreateOptions{})
@@ -302,9 +298,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			// Assert that the correct firmware preferences are enabled
 			Expect(vmi.Spec.Domain.Firmware.Bootloader.BIOS).ToNot(BeNil())
-
-			// Assert that the correct machine type preference is applied to the VMI
-			Expect(vmi.Spec.Domain.Machine.Type).To(Equal(preference.Spec.Machine.PreferredMachineType))
 
 			// Assert the correct annotations have been set
 			Expect(vmi.Annotations[v1.InstancetypeAnnotation]).To(Equal(instancetype.Name))


### PR DESCRIPTION
**What this PR does / why we need it**:

Unfortunately these assertions and their use of the default MachineType
of `q35` hid bug #8338 upstream where a MachineType is always provided
by the VirtualMachine mutation webhook [1] thus causing
PreferredMachineType to never be applied later by the VirtualMachine
controller [2].

This change removes these assertions while we look into a complete
bugfix, likely requiring looking up preferences within the
VirtualMachine mutation webhook to ensure they supersede any
configuration defaults.

[1] https://github.com/kubevirt/kubevirt/blob/bcfbd78d803e9868e0665b51878a2a093e9b74c2/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go#L98-L112
[2] https://github.com/kubevirt/kubevirt/blob/bcfbd78d803e9868e0665b51878a2a093e9b74c2/pkg/instancetype/instancetype.go#L950-L952

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

These assertions cause failures in any test env where the configured default is different to `q35`, such as downstream where a versioned machine type is used.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
