### PR TITLE
Update kubevirt_vmi_memory_used_bytes type

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -73,7 +73,7 @@ Amount of `unused` memory as seen by the domain. Type: Gauge.
 The amount of memory which can be reclaimed by balloon without causing host swapping in bytes. Type: Gauge.
 
 ### kubevirt_vmi_memory_used_bytes
-Amount of `used` memory as seen by the domain. Type: Counter.
+Amount of `used` memory as seen by the domain. Type: Gauge.
 
 ### kubevirt_vmi_network_receive_bytes_total
 Network traffic receive in bytes. Type: Counter.

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -55,7 +55,7 @@ const (
 
 	vmiMemoryUsedBytes     = "kubevirt_vmi_memory_used_bytes"
 	vmiMemoryUsedBytesDesc = "Amount of `used` memory as seen by the domain."
-	vmiMemoryUsedBytesType = "Counter"
+	vmiMemoryUsedBytesType = "Gauge"
 )
 
 func main() {


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update kubevirt_vmi_memory_used_bytes recording rule type to gauge.
It was set to counter by mistake. The recording rule is calculated based on gauge metrics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
