### PR TITLE
Fix VMClone OpenShift owner reference requirement

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -692,17 +692,8 @@ spec:
           - clone.kubevirt.io
           resources:
           - virtualmachineclones
-          verbs:
-          - get
-          - list
-          - watch
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - clone.kubevirt.io
-          resources:
           - virtualmachineclones/status
+          - virtualmachineclones/finalizers
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -611,17 +611,8 @@ rules:
   - clone.kubevirt.io
   resources:
   - virtualmachineclones
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - clone.kubevirt.io
-  resources:
   - virtualmachineclones/status
+  - virtualmachineclones/finalizers
   verbs:
   - get
   - list

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -469,17 +469,8 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					clone.ResourceVMClonePlural,
-				},
-				Verbs: []string{
-					"get", "list", "watch", "update", "patch", "delete",
-				},
-			},
-			{
-				APIGroups: []string{
-					clone.GroupName,
-				},
-				Resources: []string{
 					clone.ResourceVMClonePlural + "/status",
+					clone.ResourceVMClonePlural + "/finalizers",
 				},
 				Verbs: []string{
 					"get", "list", "watch", "update", "patch", "delete",


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Was seen before with https://github.com/kubevirt/kubevirt/pull/6957/commits/6ac5d6223f70b9bc876f5d5caa2d062ab4bc92a3;
Basically, OpenShift deploys enforcement that says we `cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on`.
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
