### PR TITLE
Fix vm-cirros-cluster-csmall VirtualMachineClusterInstancetype name value.

### DIFF
--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   instancetype:
     kind: VirtualMachineClusterInstancetype
-    name: csmall
+    name: cluster-csmall
   running: false
   template:
     metadata:

--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -3,8 +3,8 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:
-    kubevirt.io/vm: vm-cirros-csmall
-  name: vm-cirros-csmall
+    kubevirt.io/vm: vm-cirros-cluster-csmall
+  name: vm-cirros-cluster-csmall
 spec:
   instancetype:
     kind: VirtualMachineClusterInstancetype
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        kubevirt.io/vm: vm-cirros-csmall
+        kubevirt.io/vm: vm-cirros-cluster-csmall
     spec:
       domain:
         devices:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -1254,8 +1254,8 @@ func GetVmCirrosInstancetypeComputeSmall() *v1.VirtualMachine {
 }
 
 func GetVmCirrosClusterInstancetypeComputeSmall() *v1.VirtualMachine {
-	vm := getBaseVM(VmCirrosInstancetypeComputeSmall, map[string]string{
-		kubevirtIoVM: VmCirrosInstancetypeComputeSmall,
+	vm := getBaseVM(VmCirrosClusterInstancetypeComputeSmall, map[string]string{
+		kubevirtIoVM: VmCirrosClusterInstancetypeComputeSmall,
 	})
 
 	vm.Spec.Instancetype = &v1.InstancetypeMatcher{

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -1259,7 +1259,7 @@ func GetVmCirrosClusterInstancetypeComputeSmall() *v1.VirtualMachine {
 	})
 
 	vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-		Name: VirtualMachineInstancetypeComputeSmall,
+		Name: VirtualMachineClusterInstancetypeComputeSmall,
 		Kind: "VirtualMachineClusterInstancetype",
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change VirtualMachineClusterInstancetype name value from "csmall" to "cluster-csmall" for making it work with the ClusterInstanceType defined at cluster-csmall.yaml.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
