### PR TITLE
instancetype: Create ControllerRevisions earlier within VM reconcile loop

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -491,8 +491,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			vm, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(vm)
 			Expect(err).ToNot(HaveOccurred())
 
-			vm = tests.StartVirtualMachine(vm)
-
 			expectedInstancetypeRevisionName := instancetypepkg.GetRevisionName(vm.Name, instancetype.Name, instancetype.UID, instancetype.Generation)
 			By("Waiting for a VirtualMachineInstancetypeSpec ControllerRevision to be referenced from the VirtualMachine")
 			Eventually(func() string {
@@ -534,6 +532,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(json.Unmarshal(stashedPreferenceSpecRevision.Spec, &stashedPreferenceSpec)).To(Succeed())
 			Expect(stashedPreferenceSpec).To(Equal(preference.Spec))
 
+			vm = tests.StartVirtualMachine(vm)
+
 			By("Checking that a VirtualMachineInstance has been created with the VirtualMachineInstancetype and VirtualMachinePreference applied")
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -569,8 +569,6 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			newVM, err = virtClient.VirtualMachine(util.NamespaceTestDefault).Create(newVM)
 			Expect(err).ToNot(HaveOccurred())
 
-			newVM = tests.StartVirtualMachine(newVM)
-
 			By("Waiting for a VirtualMachineInstancetypeSpec ControllerRevision to be referenced from the new VirtualMachine")
 			Eventually(func() string {
 				newVM, err = virtClient.VirtualMachine(newVM.Namespace).Get(newVM.Name, &metav1.GetOptions{})
@@ -594,6 +592,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(stashedInstancetypeSpecRevision.APIVersion).To(Equal(updatedInstancetype.APIVersion))
 			Expect(json.Unmarshal(stashedInstancetypeSpecRevision.Spec, &stashedInstancetypeSpec)).To(Succeed())
 			Expect(stashedInstancetypeSpec).To(Equal(updatedInstancetype.Spec))
+
+			newVM = tests.StartVirtualMachine(newVM)
 
 			By("Checking that the new VirtualMachineInstance is using the updated VirtualMachineInstancetype")
 			newVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(newVM.Name, &metav1.GetOptions{})


### PR DESCRIPTION
/area instancetype
/cc @akrejcir 
/cc @davidvossel 
/cc @rmohr 

**What this PR does / why we need it**:

Until now ControllerRevisions for instancetypes and preferences had only
been created by the VirtualMachine controller when starting the
VirtualMachine and initially creating the VirtualMachineInstance. This
delay allowed users to potentially update or delete any referenced
instancetype or preference before a copy was made in a
ControllerRevision.

This change moves the creation of the ControllerRevisions to earlier
within the reconcile loop, ensuring they are created as soon as the
VirtualMachine is seen by the controller. This should help avoid
races with user modifications or removals that could then cause
the VirtualMachine to fail to launch at a later time.

A single VirtualMachine controller unit test is updated as we now expect
the VirtualMachine to be patched with ControllerRevision details ahead
of any conflict check occurring at runtime.

The main ControllerRevision functional test is also updated to assert
that the ControllerRevisions are captured, their details are patched
into the VirtualMachine and with any modifications made after this not
being reflected in the VirtualMachineInstance created at runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8142

**Special notes for your reviewer**:

Marked as a draft until https://github.com/kubevirt/kubevirt/pull/8282 lands.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
