### PR TITLE
tests/libvmi: Panic when trying to add existing Disks or Volumes

### DIFF
--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -20,6 +20,8 @@
 package libvmi
 
 import (
+	"fmt"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -60,15 +62,19 @@ func WithEmptyDisk(diskName string, bus v1.DiskBus, capacity resource.Quantity) 
 }
 
 func addDisk(vmi *v1.VirtualMachineInstance, disk v1.Disk) {
-	if !diskExists(vmi, disk) {
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
+	if diskExists(vmi, disk) {
+		panic(fmt.Errorf("disk %s already exists", disk.Name))
 	}
+
+	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, disk)
 }
 
 func addVolume(vmi *v1.VirtualMachineInstance, volume v1.Volume) {
-	if !volumeExists(vmi, volume) {
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
+	if volumeExists(vmi, volume) {
+		panic(fmt.Errorf("volume %s already exists", volume.Name))
 	}
+
+	vmi.Spec.Volumes = append(vmi.Spec.Volumes, volume)
 }
 
 func getVolume(vmi *v1.VirtualMachineInstance, name string) *v1.Volume {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Panic when trying to add existing Disks or Volumes to a VMI instead of
silently failing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
