### PR TITLE
probe: Add test for guest agent ping liveliness probe

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/matcher:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/service:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
The guest agent liveliness probe was not tested before.

**Release note**:
```release-note
None
```
