### PR TITLE
errcheck, instancetype: Remove pkg/instancetype from exclude_files

### DIFF
--- a/nogo_config.json
+++ b/nogo_config.json
@@ -163,7 +163,6 @@
       "pkg/hotplug-disk/": "KubeVirt hotplug-disk pkg does not pass errcheck yet",
       "pkg/ignition/": "KubeVirt ignition pkg does not pass errcheck yet",
       "pkg/inotify-informer/": "KubeVirt inotify-informer pkg does not pass errcheck yet",
-      "pkg/instancetype/": "KubeVirt instancetype pkg does not pass errcheck yet",
       "pkg/monitoring/": "KubeVirt monitoring pkg does not pass errcheck yet",
       "pkg/os/": "KubeVirt os pkg does not pass errcheck yet",
       "pkg/rest/": "KubeVirt rest pkg does not pass errcheck yet",


### PR DESCRIPTION
/area instancetype
/sig code-quality

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

pkg/instancetype currently builds successfully without any errcheck errors and so can be removed from exclude_files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
