### PR TITLE
Fix hotplug with disk mutating sidecar; add integration tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -189,6 +189,7 @@ container_bundle(
     images = {
         # cmd images
         "$(container_prefix)/$(image_prefix)example-hook-sidecar:$(container_tag)": "//cmd/example-hook-sidecar:example-hook-sidecar-image",
+        "$(container_prefix)/$(image_prefix)example-disk-mutation-hook-sidecar:$(container_tag)": "//cmd/example-disk-mutation-hook-sidecar:example-disk-mutation-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)example-cloudinit-hook-sidecar:$(container_tag)": "//cmd/example-cloudinit-hook-sidecar:example-cloudinit-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)subresource-access-test:$(container_tag)": "//cmd/subresource-access-test:subresource-access-test-image",
         # container-disk images

--- a/cmd/example-disk-mutation-hook-sidecar/BUILD.bazel
+++ b/cmd/example-disk-mutation-hook-sidecar/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["diskimage.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/example-disk-mutation-hook-sidecar",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/hooks:go_default_library",
+        "//pkg/hooks/info:go_default_library",
+        "//pkg/hooks/v1alpha2:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "example-disk-mutation-hook-sidecar",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "example-disk-mutation-hook-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
+    base = select({
+        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora_aarch64//image",
+        "//conditions:default": "@fedora//image",
+    }),
+    directory = "/",
+    entrypoint = ["/example-disk-mutation-hook-sidecar"],
+    files = [":example-disk-mutation-hook-sidecar"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/example-disk-mutation-hook-sidecar/README.md
+++ b/cmd/example-disk-mutation-hook-sidecar/README.md
@@ -1,0 +1,11 @@
+# KubeVirt Root disk mutation hook sidecar
+
+To use this hook, use following annotations:
+
+```yaml
+annotations:
+  # Request the hook sidecar
+  hooks.kubevirt.io/hookSidecars: '[{"image": "registry:5000/kubevirt/example-disk-mutation-hook-sidecar:devel"}]'
+  # Overwrite the disk image name
+  diskimage.vm.kubevirt.io/bootImageName: "virt-disk.img"
+```

--- a/cmd/example-disk-mutation-hook-sidecar/diskimage.go
+++ b/cmd/example-disk-mutation-hook-sidecar/diskimage.go
@@ -1,0 +1,149 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Nvidia
+ *
+ */
+
+// Inspired by cmd/example-hook-sidecar
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+
+	vmSchema "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/hooks"
+	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
+	hooksV1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
+	domainSchema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const bootDiskImageNameAnnotation = "diskimage.vm.kubevirt.io/bootImageName"
+
+type infoServer struct {
+	Version string
+}
+
+func (s infoServer) Info(ctx context.Context, params *hooksInfo.InfoParams) (*hooksInfo.InfoResult, error) {
+	log.Log.Info("Hook's Info method has been called")
+
+	return &hooksInfo.InfoResult{
+		Name: "bootdiskimage",
+		Versions: []string{
+			hooksV1alpha2.Version,
+		},
+		HookPoints: []*hooksInfo.HookPoint{
+			{
+				Name:     hooksInfo.OnDefineDomainHookPointName,
+				Priority: 0,
+			},
+		},
+	}, nil
+}
+
+type v1alpha2Server struct{}
+
+func (s v1alpha2Server) OnDefineDomain(ctx context.Context, params *hooksV1alpha2.OnDefineDomainParams) (*hooksV1alpha2.OnDefineDomainResult, error) {
+	log.Log.Info("Disk mutation hook's OnDefineDomain callback method has been called")
+
+	domainXML := params.GetDomainXML()
+	vmiJSON := params.GetVmi()
+	vmiSpec := vmSchema.VirtualMachineInstance{}
+	err := json.Unmarshal(vmiJSON, &vmiSpec)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Failed to unmarshal given VMI spec: %s", vmiJSON)
+		panic(err)
+	}
+
+	annotations := vmiSpec.GetAnnotations()
+	if _, found := annotations[bootDiskImageNameAnnotation]; !found {
+		log.Log.Info("Boot disk hook sidecar was requested, but no attributes provided. Returning original domain spec")
+		return &hooksV1alpha2.OnDefineDomainResult{
+			DomainXML: domainXML,
+		}, nil
+	}
+
+	domainSpec := domainSchema.DomainSpec{}
+	err = xml.Unmarshal(domainXML, &domainSpec)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Failed to unmarshal given domain spec: %s", domainXML)
+		panic(err)
+	}
+
+	// Get Boot disk
+	bootDiskLocation := domainSpec.Devices.Disks[0].Source.File
+	dir, diskName := filepath.Split(bootDiskLocation)
+	newDiskName := annotations[bootDiskImageNameAnnotation]
+	if newDiskName == diskName {
+		log.Log.Infof("Boot disk image name is already %q. Returning original domain spec", newDiskName)
+		return &hooksV1alpha2.OnDefineDomainResult{
+			DomainXML: domainXML,
+		}, nil
+	}
+
+	bootDiskLocation = filepath.Join(dir, newDiskName)
+	domainSpec.Devices.Disks[0].Source.File = bootDiskLocation
+
+	newDomainXML, err := xml.Marshal(domainSpec)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Failed to marshal updated domain spec: %+v", domainSpec)
+		panic(err)
+	}
+
+	log.Log.Info("Successfully updated original domain spec with requested boot disk attribute")
+	return &hooksV1alpha2.OnDefineDomainResult{
+		DomainXML: newDomainXML,
+	}, nil
+}
+
+func (s v1alpha2Server) PreCloudInitIso(_ context.Context, params *hooksV1alpha2.PreCloudInitIsoParams) (*hooksV1alpha2.PreCloudInitIsoResult, error) {
+	return &hooksV1alpha2.PreCloudInitIsoResult{
+		CloudInitData: params.GetCloudInitData(),
+	}, nil
+}
+
+func main() {
+	log.InitializeLogging("bootdisk-hook-sidecar")
+
+	var version string
+	pflag.StringVar(&version, "version", "", "hook version to use")
+	pflag.Parse()
+
+	socketPath := filepath.Join(hooks.HookSocketsSharedDirectory, "bootdisk.sock")
+	socket, err := net.Listen("unix", socketPath)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Failed to initialized socket on path: %s", socket)
+		log.Log.Error("Check whether given directory exists and socket name is not already taken by other file")
+		panic(err)
+	}
+	defer os.Remove(socketPath)
+
+	server := grpc.NewServer([]grpc.ServerOption{}...)
+	hooksInfo.RegisterInfoServer(server, infoServer{Version: version})
+	hooksV1alpha2.RegisterCallbacksServer(server, v1alpha2Server{})
+	log.Log.Infof("Starting hook server exposing 'info' and 'v1alpha2' services on socket %s", socketPath)
+	server.Serve(socket)
+}

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -328,7 +328,7 @@ func main() {
 	virtShareDir := pflag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	ephemeralDiskDir := pflag.String("ephemeral-disk-dir", "/var/run/kubevirt-ephemeral-disks", "Base directory for ephemeral disk data")
 	containerDiskDir := pflag.String("container-disk-dir", "/var/run/kubevirt/container-disks", "Base directory for container disk data")
-	hotplugDiskDir := pflag.String("hotplug-disk-dir", "/var/run/kubevirt/hotplug-disks", "Base directory for hotplug disk data")
+	hotplugDiskDir := pflag.String("hotplug-disk-dir", v1.HotplugDiskDir, "Base directory for hotplug disk data")
 	name := pflag.String("name", "", "Name of the VirtualMachineInstance")
 	uid := pflag.String("uid", "", "UID of the VirtualMachineInstance")
 	namespace := pflag.String("namespace", "", "Namespace of the VirtualMachineInstance")

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Template", func() {
 				"/var/lib/kubevirt",
 				"/var/run/kubevirt-ephemeral-disks",
 				"/var/run/kubevirt/container-disks",
-				"/var/run/kubevirt/hotplug-disks",
+				v1.HotplugDiskDir,
 				"pull-secret-1",
 				pvcCache,
 				virtClient,

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2784,7 +2784,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Device: "disk",
 					Type:   "file",
 					Source: api.DiskSource{
-						File: "/var/run/kubevirt/hotplug-disks/hpvolume1/disk.img",
+						File: filepath.Join(v1.HotplugDiskDir, "hpvolume1/disk.img"),
 					},
 					Target: api.DiskTarget{
 						Bus:    v1.DiskBusSCSI,

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3125,10 +3125,10 @@ var _ = Describe("Converter", func() {
 				expectedDisk.Driver.ErrorPolicy = "stop"
 				if isBlockMode {
 					expectedDisk.Type = "block"
-					expectedDisk.Source.Dev = fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s", volumeName)
+					expectedDisk.Source.Dev = filepath.Join(v1.HotplugDiskDir, volumeName)
 				} else {
 					expectedDisk.Type = "file"
-					expectedDisk.Source.File = fmt.Sprintf("/var/run/kubevirt/hotplug-disks/%s.img", volumeName)
+					expectedDisk.Source.File = fmt.Sprintf("%s.img", filepath.Join(v1.HotplugDiskDir, volumeName))
 				}
 				if !ignoreDiscard {
 					expectedDisk.Driver.Discard = "unmap"

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1018,6 +1018,10 @@ func checkIfDiskReadyToUseFunc(filename string) (bool, error) {
 	return true, nil
 }
 
+func isHotplugDisk(disk api.Disk) bool {
+	return strings.HasPrefix(getSourceFile(disk), v1.HotplugDiskDir)
+}
+
 func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
 	newDiskMap := make(map[string]api.Disk)
 	for _, disk := range newDisks {
@@ -1028,6 +1032,9 @@ func getDetachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
 	}
 	res := make([]api.Disk, 0)
 	for _, oldDisk := range oldDisks {
+		if !isHotplugDisk(oldDisk) {
+			continue
+		}
 		if _, ok := newDiskMap[getSourceFile(oldDisk)]; !ok {
 			// This disk got detached, add it to the list
 			res = append(res, oldDisk)
@@ -1046,6 +1053,9 @@ func getAttachedDisks(oldDisks, newDisks []api.Disk) []api.Disk {
 	}
 	res := make([]api.Disk, 0)
 	for _, newDisk := range newDisks {
+		if !isHotplugDisk(newDisk) {
+			continue
+		}
 		if _, ok := oldDiskMap[getSourceFile(newDisk)]; !ok {
 			// This disk got attached, add it to the list
 			res = append(res, newDisk)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -677,7 +677,7 @@ var _ = Describe("Manager", func() {
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
-				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
+				Expect(filename).To(Equal(filepath.Join(v1.HotplugDiskDir, "/hpvolume1.img")))
 				return true, nil
 			}
 			domainSpec.Devices.Disks = []api.Disk{
@@ -704,7 +704,7 @@ var _ = Describe("Manager", func() {
 				Device: "disk",
 				Type:   "file",
 				Source: api.DiskSource{
-					File: "/var/run/kubevirt/hotplug-disks/hpvolume1.img",
+					File: filepath.Join(v1.HotplugDiskDir, "hpvolume1.img"),
 				},
 				Target: api.DiskTarget{
 					Bus:    "scsi",
@@ -809,7 +809,7 @@ var _ = Describe("Manager", func() {
 				Device: "disk",
 				Type:   "file",
 				Source: api.DiskSource{
-					File: "/var/run/kubevirt/hotplug-disks/hpvolume1.img",
+					File: filepath.Join(v1.HotplugDiskDir, "hpvolume1.img"),
 				},
 				Target: api.DiskTarget{
 					Bus:    "scsi",
@@ -916,7 +916,7 @@ var _ = Describe("Manager", func() {
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
-				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
+				Expect(filename).To(Equal(filepath.Join(v1.HotplugDiskDir, "hpvolume1.img")))
 				return true, nil
 			}
 			mockConn.EXPECT().DomainDefineXML(string(xmlDomain)).Return(mockDomain, nil)
@@ -995,7 +995,7 @@ var _ = Describe("Manager", func() {
 			xmlDomain, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
 			checkIfDiskReadyToUse = func(filename string) (bool, error) {
-				Expect(filename).To(Equal("/var/run/kubevirt/hotplug-disks/hpvolume1.img"))
+				Expect(filename).To(Equal(filepath.Join(v1.HotplugDiskDir, "hpvolume1.img")))
 				return false, nil
 			}
 			domainSpec.Devices.Disks = []api.Disk{
@@ -2212,7 +2212,7 @@ var _ = Describe("getAttachedDisks", func() {
 				{
 					Source: api.DiskSource{
 						Name: "test2",
-						File: "file2",
+						File: filepath.Join(v1.HotplugDiskDir, "file2"),
 					},
 				},
 			},
@@ -2220,10 +2220,34 @@ var _ = Describe("getAttachedDisks", func() {
 				{
 					Source: api.DiskSource{
 						Name: "test2",
-						File: "file2",
+						File: filepath.Join(v1.HotplugDiskDir, "file2"),
 					},
 				},
 			}),
+		Entry("be empty if non-hotplug disk is added",
+			[]api.Disk{
+				{
+					Source: api.DiskSource{
+						Name: "test",
+						File: "file",
+					},
+				},
+			},
+			[]api.Disk{
+				{
+					Source: api.DiskSource{
+						Name: "test",
+						File: "file",
+					},
+				},
+				{
+					Source: api.DiskSource{
+						Name: "test2",
+						File: "file2",
+					},
+				},
+			},
+			[]api.Disk{}),
 	)
 })
 
@@ -2265,7 +2289,7 @@ var _ = Describe("getDetachedDisks", func() {
 				{
 					Source: api.DiskSource{
 						Name: "test2",
-						File: "file2",
+						File: filepath.Join(v1.HotplugDiskDir, "file2"),
 					},
 				},
 			},
@@ -2281,10 +2305,28 @@ var _ = Describe("getDetachedDisks", func() {
 				{
 					Source: api.DiskSource{
 						Name: "test2",
-						File: "file2",
+						File: filepath.Join(v1.HotplugDiskDir, "file2"),
 					},
 				},
 			}),
+		Entry("be empty if non-hotplug disk changed",
+			[]api.Disk{
+				{
+					Source: api.DiskSource{
+						Name: "test",
+						File: "file",
+					},
+				},
+			},
+			[]api.Disk{
+				{
+					Source: api.DiskSource{
+						Name: "test",
+						File: "file-changed",
+					},
+				},
+			},
+			[]api.Disk{}),
 	)
 })
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -37,6 +37,8 @@ const (
 	DefaultCPUModel                        = CPUModeHostModel
 )
 
+const HotplugDiskDir = "/var/run/kubevirt/hotplug-disks/"
+
 /*
  ATTENTION: Rerun code generators when comments on structs or fields are modified.
 */

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1376,12 +1376,12 @@ func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, 
 		Eventually(func() error {
 			return virtClient.VirtualMachine(vm.Namespace).AddVolume(vm.Name, addVolumeOptions)
 		}, 3*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-		VerifyVolumeAndDiskVMAdded(virtClient, vm, addVolumeName)
+		verifyVolumeAndDiskVMAdded(virtClient, vm, addVolumeName)
 	}
 
 	vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	VerifyVolumeAndDiskVMIAdded(virtClient, vmi, addVolumeName)
+	verifyVolumeAndDiskVMIAdded(virtClient, vmi, addVolumeName)
 
 	return addVolumeName
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1293,6 +1293,14 @@ func ChangeImgFilePermissionsToNonQEMU(pvc *k8sv1.PersistentVolumeClaim) {
 	RunPodAndExpectCompletion(pod)
 }
 
+func RenameImgFile(pvc *k8sv1.PersistentVolumeClaim, newName string) {
+	args := []string{fmt.Sprintf("mv %s %s && ls -al %s", filepath.Join(libstorage.DefaultPvcMountPath, "disk.img"), filepath.Join(libstorage.DefaultPvcMountPath, newName), libstorage.DefaultPvcMountPath)}
+
+	By("renaming disk.img")
+	pod := libstorage.RenderPodWithPVC("rename-disk-img-pod", []string{"/bin/bash", "-c"}, args, pvc)
+	RunPodAndExpectCompletion(pod)
+}
+
 func CopyAlpineWithNonQEMUPermissions() (dstPath, nodeName string) {
 	dstPath = testsuite.HostPathAlpine + "-nopriv"
 	args := []string{fmt.Sprintf(`mkdir -p %[1]s-nopriv && cp %[1]s/disk.img %[1]s-nopriv/ && chmod 640 %[1]s-nopriv/disk.img  && chown root:root %[1]s-nopriv/disk.img`, testsuite.HostPathAlpine)}
@@ -1677,9 +1685,10 @@ func NewRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.V
 			Running: &running,
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:    vmLabels,
-					Name:      name + "makeitinteresting", // this name should have no effect
-					Namespace: namespace,
+					Labels:      vmLabels,
+					Name:        name + "makeitinteresting", // this name should have no effect
+					Namespace:   namespace,
+					Annotations: vmi.ObjectMeta.Annotations,
 				},
 				Spec: vmi.Spec,
 			},


### PR DESCRIPTION
Signed-off-by: Prashanth Dintyala <vdintyala@nvidia.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
#8237 fixed the scenario where `SyncVMI` is being called for the first time and new domain was being created. However, when `SyncVMI` is called subsequently, the `vmi *v1.VirtualMachineInstance` passed as input doesn't contain the disk mutation made by the hook as `hookManager.OnDefineDomain` is only called only when  `LookupDomainByName` returns `NotFound` error. The `getAttachedDisk`/`getDetachedDisk` compare the disks obtained from `dom.GetXMLDesc(0)`, containing disk mutation changes and `domain.Spec.Devices.Disks`, obtained from `vmi` passed as parameter which doesn't contain mutations by hook. This will result in incorrect detach/attach operation  and the VMI will fail to boot.

This PR:
1.  Implements the @awels suggestion from https://github.com/kubevirt/kubevirt/issues/7690#issuecomment-1199848712
2. Adds an example sidecar hook that mutates the root disk image source file, and an integration test that tests hotplug and disk mutation hooks. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7690

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
