### PR TITLE
[release-0.49] Alter scsi test code to work without the lsscsi binary

### DIFF
--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -21,7 +21,9 @@ package tests
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -85,24 +87,34 @@ func CreateSCSIDisk(nodeName string, opts []string) (address string, device stri
 	_, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create faulty disk")
 
-	args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/bin/lsscsi"}
-	stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to find out address of  SCSI disk")
-
-	// Example output
-	// [2:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.5+  /dev/sr0
-	// [6:0:0:0]    disk    Linux    scsi_debug       0190  /dev/sda
-	lines := strings.Split(stdout, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "scsi_debug") {
-			line = strings.TrimSpace(line)
-			disk := strings.Split(line, " ")
-			address = disk[0]
-			address = address[1 : len(address)-1]
-			device = disk[len(disk)-1]
-			break
+	EventuallyWithOffset(1, func() error {
+		args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/bin/lsscsi"}
+		stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
+		if err != nil {
+			return err
 		}
-	}
+
+		// Example output
+		// [2:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.5+  /dev/sr0
+		// [6:0:0:0]    disk    Linux    scsi_debug       0190  /dev/sda
+		lines := strings.Split(stdout, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "scsi_debug") {
+				line = strings.TrimSpace(line)
+				disk := strings.Split(line, " ")
+				address = disk[0]
+				address = address[1 : len(address)-1]
+				device = disk[len(disk)-1]
+				break
+			}
+		}
+
+		if !filepath.IsAbs(device) {
+			return fmt.Errorf("Device path extracted from lsscsi is not populated: %s", device)
+		}
+
+		return nil
+	}, 20*time.Second, 5*time.Second).ShouldNot(HaveOccurred())
 
 	return address, device
 }

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -88,30 +88,27 @@ func CreateSCSIDisk(nodeName string, opts []string) (address string, device stri
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create faulty disk")
 
 	EventuallyWithOffset(1, func() error {
-		args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/usr/bin/lsscsi"}
+		args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/bin/sh", "-c", "/bin/grep -l scsi_debug /sys/bus/scsi/devices/*/model"}
 		stdout, err := ExecuteCommandInVirtHandlerPod(nodeName, args)
 		if err != nil {
 			return err
 		}
 
 		// Example output
-		// [2:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.5+  /dev/sr0
-		// [6:0:0:0]    disk    Linux    scsi_debug       0190  /dev/sda
-		lines := strings.Split(stdout, "\n")
-		for _, line := range lines {
-			if strings.Contains(line, "scsi_debug") {
-				line = strings.TrimSpace(line)
-				disk := strings.Split(line, " ")
-				address = disk[0]
-				address = address[1 : len(address)-1]
-				device = disk[len(disk)-1]
-				break
-			}
+		// /sys/bus/scsi/devices/0:0:0:0/model
+		if !filepath.IsAbs(stdout) {
+			return fmt.Errorf("Device path extracted from sysfs is not populated: %s", stdout)
 		}
 
-		if !filepath.IsAbs(device) {
-			return fmt.Errorf("Device path extracted from lsscsi is not populated: %s", device)
+		pathname := strings.Split(stdout, "/")
+		address = pathname[5]
+
+		args = []string{UsrBinVirtChroot, Mount, Proc1NsMnt, "exec", "--", "/bin/ls", "/sys/bus/scsi/devices/" + address + "/block"}
+		stdout, err = ExecuteCommandInVirtHandlerPod(nodeName, args)
+		if err != nil {
+			return err
 		}
+		device = "/dev/" + strings.TrimSpace(stdout)
 
 		return nil
 	}, 20*time.Second, 5*time.Second).ShouldNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
cherry-pick of https://github.com/kubevirt/kubevirt/pull/8204

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
