### PR TITLE
[Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed

### DIFF
--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -35,6 +35,7 @@ const (
 	PatchReplaceOp = "replace"
 	PatchTestOp    = "test"
 	PatchAddOp     = "add"
+	PatchRemoveOp  = "remove"
 )
 
 func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -86,6 +86,17 @@ func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil
 }
 
+func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	domainFeatures := vmi.Spec.Domain.Features
+
+	return domainFeatures != nil && domainFeatures.Hyperv != nil && domainFeatures.Hyperv.Reenlightenment != nil &&
+		domainFeatures.Hyperv.Reenlightenment.Enabled != nil && *domainFeatures.Hyperv.Reenlightenment.Enabled
+}
+
 // WantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/topology",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//pkg/util/nodes:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/topology/generated_mock_hinter.go
+++ b/pkg/virt-controller/watch/topology/generated_mock_hinter.go
@@ -29,25 +29,26 @@ func (_m *MockHinter) EXPECT() *_MockHinterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockHinter) TopologyHintsForVMI(vmi *v1.VirtualMachineInstance) (*v1.TopologyHints, error) {
+func (_m *MockHinter) TopologyHintsForVMI(vmi *v1.VirtualMachineInstance) (*v1.TopologyHints, TscFrequencyRequirementType, error) {
 	ret := _m.ctrl.Call(_m, "TopologyHintsForVMI", vmi)
 	ret0, _ := ret[0].(*v1.TopologyHints)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(TscFrequencyRequirementType)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockHinterRecorder) TopologyHintsForVMI(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyHintsForVMI", arg0)
 }
 
-func (_m *MockHinter) TopologyHintsRequiredForVMI(vmi *v1.VirtualMachineInstance) bool {
-	ret := _m.ctrl.Call(_m, "TopologyHintsRequiredForVMI", vmi)
+func (_m *MockHinter) IsTscFrequencyRequiredForBoot(vmi *v1.VirtualMachineInstance) bool {
+	ret := _m.ctrl.Call(_m, "IsTscFrequencyRequiredForBoot", vmi)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockHinterRecorder) TopologyHintsRequiredForVMI(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyHintsRequiredForVMI", arg0)
+func (_mr *_MockHinterRecorder) IsTscFrequencyRequiredForBoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTscFrequencyRequiredForBoot", arg0)
 }
 
 func (_m *MockHinter) TSCFrequenciesInUse() []int64 {

--- a/pkg/virt-controller/watch/topology/hinter_test.go
+++ b/pkg/virt-controller/watch/topology/hinter_test.go
@@ -52,9 +52,7 @@ var _ = Describe("Hinter", func() {
 			NodeWithTSC("node4", 12, false),
 		)
 		vmi := vmiWithTSCFrequencyOnNode("myvmi", 12, "oldnode")
-		g.Expect(hinter.TopologyHintsRequiredForVMI(
-			vmi),
-		).To(g.BeTrue())
+		g.Expect(GetTscFrequencyRequirement(vmi).Type).ToNot(g.Equal(NotRequired))
 		g.Expect(hinter.TopologyHintsForVMI(vmi)).To(g.Equal(
 			&virtv1.TopologyHints{
 				TSCFrequency: pointer.Int64Ptr(12),
@@ -80,10 +78,11 @@ var _ = Describe("Hinter", func() {
 		)
 		hinter.arch = arch
 		vmi := vmiWithoutTSCFrequency("myvmi")
-		g.Expect(hinter.TopologyHintsRequiredForVMI(
-			vmi),
-		).To(g.BeFalse())
-		g.Expect(hinter.TopologyHintsForVMI(vmi)).To(g.BeNil())
+		g.Expect(hinter.IsTscFrequencyRequiredForBoot(vmi)).To(g.BeFalse())
+
+		hints, _, err := hinter.TopologyHintsForVMI(vmi)
+		g.Expect(hints).To(g.BeNil())
+		g.Expect(err).To(g.Not(g.HaveOccurred()))
 	},
 		Entry("arm64", "arm64"),
 		Entry("ppc64le", "ppc64le"),

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -435,7 +435,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
 			if vmi.Status.TopologyHints == nil {
-				if topologyHints, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil {
+				if topologyHints, tscRequirement, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil && tscRequirement == topology.RequiredForBoot {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedGatherhingClusterTopologyHints, err.Error())
 					return &syncErrorImpl{err, FailedGatherhingClusterTopologyHints}
 				} else if topologyHints != nil {
@@ -1015,7 +1015,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 			return nil
 		}
 		// let's check if we already have topology hints or if we are still waiting for them
-		if vmi.Status.TopologyHints == nil && c.topologyHinter.TopologyHintsRequiredForVMI(vmi) {
+		if vmi.Status.TopologyHints == nil && c.topologyHinter.IsTscFrequencyRequiredForBoot(vmi) {
 			log.Log.V(3).Object(vmi).Infof("Delaying pod creation until topology hints are set")
 			return nil
 		}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2765,7 +2765,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				var vmi *virtv1.VirtualMachineInstance
 				vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
 					vmi = arg.(*virtv1.VirtualMachineInstance)
-					Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+					Expect(topology.AreTSCFrequencyTopologyHintsDefined(vmi)).To(BeTrue())
 				}).Return(vmi, nil)
 			}
 
@@ -2790,16 +2790,44 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				runController(vmi)
 			})
 
-			It("HyperV reenlightenment is enabled", func() {
-				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Spec.Domain.Features = &v1.Features{
-					Hyperv: &v1.FeatureHyperv{
-						Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
-					},
-				}
+			Context("HyperV reenlightenment is enabled", func() {
+				var vmi *v1.VirtualMachineInstance
 
-				expectTopologyHintsUpdate()
-				runController(vmi)
+				BeforeEach(func() {
+					vmi = NewPendingVirtualMachine("testvmi")
+					vmi.Spec.Domain.Features = &v1.Features{
+						Hyperv: &v1.FeatureHyperv{
+							Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+						},
+					}
+				})
+
+				When("TSC frequency is exposed", func() {
+					It("topology hints need to be set", func() {
+						expectTopologyHintsUpdate()
+						runController(vmi)
+
+						testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+					})
+				})
+
+				When("TSC frequency is not exposed", func() {
+					unexposeTscFrequency := func(requirement topology.TscFrequencyRequirementType) {
+						mockHinter := topology.NewMockHinter(ctrl)
+						mockHinter.EXPECT().TopologyHintsForVMI(gomock.Any()).Return(nil, requirement, fmt.Errorf("tsc frequency is not exposed on the cluster")).AnyTimes()
+						mockHinter.EXPECT().IsTscFrequencyRequiredForBoot(gomock.Any()).Return(requirement == topology.RequiredForBoot)
+						controller.topologyHinter = mockHinter
+					}
+
+					It("topology hints don't need to be set and VMI needs to be non-migratable", func() {
+						unexposeTscFrequency(topology.RequiredForMigration)
+						// Make sure no update occurs
+						runController(vmi)
+
+						testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+					})
+				})
+
 			})
 
 		})

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -33,6 +33,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
@@ -1363,6 +1365,10 @@ func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 
 	if util.IsSEVVMI(vmi) {
 		return newNonMigratableCondition("VMI uses SEV", v1.VirtualMachineInstanceReasonSEVNotMigratable), isBlockMigration
+	}
+
+	if tscRequirement := topology.GetTscFrequencyRequirement(vmi); !topology.AreTSCFrequencyTopologyHintsDefined(vmi) && tscRequirement.Type == topology.RequiredForMigration {
+		return newNonMigratableCondition(tscRequirement.Reason, v1.VirtualMachineInstanceReasonNoTSCFrequencyMigratable), isBlockMigration
 	}
 
 	return &v1.VirtualMachineInstanceCondition{

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2598,6 +2598,17 @@ var _ = Describe("VirtualMachineInstance", func() {
 			)
 		})
 
+		It("HyperV reenlightenment shouldn't be migratable when tsc frequency is missing", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Features = &v1.Features{Hyperv: &v1.FeatureHyperv{Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)}}}
+			vmi.Status.TopologyHints = nil
+
+			cond, _ := controller.calculateLiveMigrationCondition(vmi)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+			Expect(cond.Status).To(Equal(k8sv1.ConditionFalse))
+		})
+
 	})
 
 	Context("VirtualMachineInstance network status", func() {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1708,17 +1708,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			}
 		}
 
-		// Make use of the tsc frequency topology hint
-		if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
-			freq := *vmi.Status.TopologyHints.TSCFrequency
-			clock := domain.Spec.Clock
-			if clock == nil {
-				clock = &api.Clock{}
-			}
-			clock.Timer = append(clock.Timer, api.Timer{Name: "tsc", Frequency: strconv.FormatInt(freq, 10)})
-			domain.Spec.Clock = clock
-		}
-
 		// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning
 		if vmi.IsCPUDedicated() {
 			err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, c.Topology, c.CPUSet, useIOThreads)
@@ -1726,6 +1715,17 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 				return err
 			}
 		}
+	}
+
+	// Make use of the tsc frequency topology hint
+	if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
+		freq := *vmi.Status.TopologyHints.TSCFrequency
+		clock := domain.Spec.Clock
+		if clock == nil {
+			clock = &api.Clock{}
+		}
+		clock.Timer = append(clock.Timer, api.Timer{Name: "tsc", Frequency: strconv.FormatInt(freq, 10)})
+		domain.Spec.Clock = clock
 	}
 
 	domain.Spec.Devices.HostDevices = append(domain.Spec.Devices.HostDevices, c.GenericHostDevices...)

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -35,11 +35,11 @@ import (
 	"strings"
 	"syscall"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	"golang.org/x/sys/unix"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
-
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -473,6 +473,8 @@ const (
 	VirtualMachineInstanceReasonHostDeviceNotMigratable = "HostDeviceNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it uses Secure Encrypted Virtualization (SEV)
 	VirtualMachineInstanceReasonSEVNotMigratable = "SEVNotLiveMigratable"
+	// Reason means that VMI is not live migratable because it uses HyperV Reenlightenment while TSC Frequency is not available
+	VirtualMachineInstanceReasonNoTSCFrequencyMigratable = "NoTSCFrequencyNotLiveMigratable"
 )
 
 const (

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -25,9 +25,15 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-
 	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libstorage"
+
+	"k8s.io/utils/pointer"
+
+	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/tests/libnode"
+
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,7 +49,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet"
-	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -78,6 +83,10 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	})
 
 	Context("VMI with HyperV reenlightenment enabled", func() {
+		BeforeEach(func() {
+			windowsVMI.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+		})
+
 		When("TSC frequency is exposed on the cluster", func() {
 			It("should be able to migrate", func() {
 				if !isTSCFrequencyExposed(virtClient) {
@@ -96,6 +105,75 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 
 				By("Checking VMI, confirm migration state")
 				tests.ConfirmVMIPostMigration(virtClient, windowsVMI, migrationUID)
+			})
+		})
+
+		When("TSC frequency is not exposed on the cluster", func() {
+
+			BeforeEach(func() {
+				if isTSCFrequencyExposed(virtClient) {
+					nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					for _, node := range nodeList.Items {
+						stopNodeLabeller(node.Name, virtClient)
+						removeTSCFrequencyFromNode(node)
+					}
+				}
+			})
+
+			AfterEach(func() {
+				nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, node := range nodeList.Items {
+					_, isNodeLabellerStopped := node.Annotations[v1.LabellerSkipNodeAnnotation]
+					Expect(isNodeLabellerStopped).To(BeTrue())
+
+					updatedNode := resumeNodeLabeller(node.Name, virtClient)
+					_, isNodeLabellerStopped = updatedNode.Annotations[v1.LabellerSkipNodeAnnotation]
+					Expect(isNodeLabellerStopped).To(BeFalse(), "after node labeller is resumed, %s annotation is expected to disappear from node", v1.LabellerSkipNodeAnnotation)
+				}
+			})
+
+			It("should be able to start successfully", func() {
+				var err error
+				By("Creating a windows VM")
+				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+				winrnLoginCommand(virtClient, windowsVMI)
+			})
+
+			It("should be marked as non-migratable", func() {
+				var err error
+				By("Creating a windows VM")
+				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+
+				conditionManager := controller.NewVirtualMachineInstanceConditionManager()
+				isNonMigratable := func() error {
+					windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(windowsVMI.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					cond := conditionManager.GetCondition(windowsVMI, v1.VirtualMachineInstanceIsMigratable)
+					const errFmt = "condition " + string(v1.VirtualMachineInstanceIsMigratable) + " is expected to be %s %s"
+
+					if statusFalse := k8sv1.ConditionFalse; cond.Status != statusFalse {
+						return fmt.Errorf(errFmt, "of status", string(statusFalse))
+					}
+					if notMigratableNoTscReason := v1.VirtualMachineInstanceReasonNoTSCFrequencyMigratable; cond.Reason != notMigratableNoTscReason {
+						return fmt.Errorf(errFmt, "of reason", notMigratableNoTscReason)
+					}
+					if !strings.Contains(cond.Message, "HyperV Reenlightenment") {
+						return fmt.Errorf(errFmt, "with message that contains", "HyperV Reenlightenment")
+					}
+					return nil
+				}
+
+				Eventually(isNonMigratable, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+				Consistently(isNonMigratable, 15*time.Second, 3*time.Second).ShouldNot(HaveOccurred())
 			})
 		})
 	})
@@ -401,4 +479,14 @@ func isTSCFrequencyExposed(virtClient kubecli.KubevirtClient) bool {
 	}
 
 	return false
+}
+
+func removeTSCFrequencyFromNode(node k8sv1.Node) {
+	for _, baseLabelToRemove := range []string{topology.TSCFrequencyLabel, topology.TSCFrequencySchedulingLabel} {
+		for key, _ := range node.Labels {
+			if strings.HasPrefix(key, baseLabelToRemove) {
+				libnode.RemoveLabelFromNode(node.Name, key)
+			}
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to this PR: https://github.com/kubevirt/kubevirt/pull/7986. In this PR, I've explicitly provided QEMU with the lowest TSC frequency on the cluster since that's the only way such VMIs can be migratable.

However, sometimes (e.g. on some virtual nodes) TSC frequency is not exposed. In such cases, VMIs with Reenlightenment shouldn't be migratable - but they should be able to run.

In the above PR, an error occurs when trying to create a Reenlightenment VMIs when TSC frequency is not exposed on the cluster nodes. In this PR it would be started successfully, but wouldn't be able to migrate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2119069

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed
```
