### PR TITLE
use variable to select packages to test for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ bazel-push-images:
 push: bazel-push-images
 
 bazel-test:
-	hack/dockerized "hack/bazel-fmt.sh && CI=${CI} ARTIFACTS=${ARTIFACTS} hack/bazel-test.sh"
+	hack/dockerized "hack/bazel-fmt.sh && CI=${CI} ARTIFACTS=${ARTIFACTS} WHAT=${WHAT}  hack/bazel-test.sh"
 
 gen-proto:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/gen-proto.sh"

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -4,6 +4,8 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
+WHAT=${WHAT:=-"//staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... //tests/framework/..."}
+
 rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 if [ "${CI}" == "true" ]; then
@@ -28,4 +30,4 @@ fi
 bazel test \
     --config=${ARCHITECTURE} \
     --features race \
-    --test_output=errors -- //staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... //tests/framework/...
+    --test_output=errors -- ${WHAT}


### PR DESCRIPTION
During unit test development, it is very helpful being able to only test
a single package. This can be achieved by setting the variable WHAT.
Example:
  export WHAT="//pkg/virt-handler/..."
  make test

Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This speed up the execution of unit tests focused on a single package and it can be very useful for developers during the unit test development.
Even if you set a focus on a single test, this is effective only under a single path

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
