### PR TITLE
tests, libvmi: Introduce the `oper` sub-package with the sync-delete command

### DIFF
--- a/tests/libvmi/oper/BUILD.bazel
+++ b/tests/libvmi/oper/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "command.go",
+        "wait.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tests/libvmi/oper",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+    ],
+)

--- a/tests/libvmi/oper/command.go
+++ b/tests/libvmi/oper/command.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package oper
+
+import (
+	"fmt"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+// SyncDelete deletes the specified VMI and waits for its absence.
+func SyncDelete(vmi *v1.VirtualMachineInstance) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		panic(err)
+	}
+
+	if err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &k8smetav1.DeleteOptions{}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete VMI: %v", err)
+	}
+
+	const timeout = 30 * time.Second
+	return waitRemoval(vmi.Namespace, vmi.Name, timeout)
+}

--- a/tests/libvmi/oper/wait.go
+++ b/tests/libvmi/oper/wait.go
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package oper
+
+import (
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+// waitRemoval deletes the specified VMI and waits for its absence.
+func waitRemoval(namespace, name string, timeout time.Duration) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		panic(err)
+	}
+
+	return wait.PollImmediate(1*time.Second, timeout, func() (done bool, err error) {
+		_, err = virtClient.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+}

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//tests/libnet/service:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libvmi:go_default_library",
+        "//tests/libvmi/oper:go_default_library",
         "//tests/testsuite:go_default_library",
         "//tests/util:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

The operation of deleting a VMI in a synchronic manner is extracted out
to a dedicated libvmi/oper package.

The new `SyncDelete` attempts to delete a VMI and wait for it to
disappear from the API server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~Depends on #8307 (please examine the last commit).~

~It was introduced as a separate PR because I prefer not to block on this part the original change.~

**Release note**:
```release-note
NONE
```
