### PR TITLE
Change KubeVirt to follow the Kubernetes release guidance

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -39,33 +39,83 @@ These artifacts are provided in their respective channels and their natural way
 of distribution.
 
 # Cadence and Timeline
-Both a new release branch and initial release candidate are cut on the **first
-business day of each month.**
+New release branches are cut 3 times a year, or about every 15 weeks beginning
+on the first Monday in January.  This is the same [release cycle](https://kubernetes.io/releases/release/) as Kubernetes, but KubeVirt will trail Kubernetes releases
+by 1 to 4 weeks.
 
-If no blocker issues are discovered the release candidate is **promoted to a full
-release after 5 business days.**
+Here's an example release cycle using the 2022 calendar:
+| Week Number in Year | K8s Release Number | K8s Release Week | KubeVirt Release Number | KubeVirt Release Week |                     Note                    |
+|:-------------------:|:------------------:|:----------------:|-------------------------|-----------------------|:-------------------------------------------:|
+| 1                   | 1.24               | 1 (January 03)   | 0.55                    | 2 (January 10)        |                                             |
+| 15                  | 1.24               | 15 (April 12)    | 0.55                    | 16 (April 19)         |                                             |
+| 17                  | 1.25               | 1 (May 23)       | 0.56                    | 2 (May 30)            | KubeCon + CloudNativeCon EU likely to occur |
+| 32                  | 1.25               | 15 (August 22)   | 0.56                    | 16 (August 29) - 19 (September 26)        |                                             |
+| 34                  | 1.26               | 1 (September 5)  | 0.57                    | 2 (September 12)      | KubeCon + CloudNativeCon NA likely to occur |
+| 49                  | 1.26               | 14 (December 05) | 0.57                    | 15 (December 12) - 18 (January 9)    |                                             |
+
+Initial release candidates are cut **every 4 weeks.**
+With a 15 week cadence, there will be at least 3 release candidates:
+- v*-rc.0
+- v*-rc.1
+- v*-rc.2
+
+The stable branch will be created when the -rc.2 is tagged, 12 weeks into
+the release cycle.  Once the branch is created, only backports will be
+allowed into the stable branch, following KubeVirt's backport policy.
+
+| Week | Tag | Branch |
+|:----:|-----|--------|
+| 0 | - |  - |
+| 4 | v0.56.0-rc.0 | - |
+| 8 | v0.56.0-rc.1 | - |
+| 12 | v0.56.0-rc.2 | release-v0.56 |
+| 15 | v0.56 | - |
+
+After a new Kubernetes version is released, the KubeVirt community needs to create a Kubernetes
+provider and CI lanes.  This can take **between 1 to 4 weeks**.  If no blocker issues are discovered
+in KubeVirt's release candidate, then it's **promoted to a full release after 5 business days.**
 
 If blockers are detected, a new release candidate is generated and will be
 promoted after giving the impacted parties enough time to validate the blocker is
 addressed.
 
-**Timeline Example: No blockers detected, release is cut from the first rc**
-```
-July 1st  - release-v0.31 branch and v0.31.0-rc.0 tag are cut
-July 8th  - promotion of v0.31.0-rc.0 to be the official v0.31.0 release
-```
+Just like in Kubernetes, there will be slowdowns during common holidays which will
+cause delays.  So releases that overlap with holidays may be delayed.
 
-**Example: blocker is detected for release branch**
-```
-July 1st  - release-v0.31 branch and v0.31.0-rc.0 tag are cut
-July 2nd  - blocker is detected and marked using ‘/release-block release-31` in a comment on an issue.
-July 6th  - blocker issue is closed, new rc v0.31.0-rc.1 is allowed to be created
-July 13th - promotion of v0.31.0-rc.1 to be the official v0.31.0 release
-```
+**Timeline Example: Final release of the year (14 weeks), no blockers detected, release is cut from the third rc on the 14th week of the release cycle**
+|           Event          | Date           | Week |
+|:------------------------:|----------------|------|
+| Start Release Cycle      | September 12th |    1 |
+| v0.57.0-rc.0 Released    |  October 10th  |    5 |
+| Enhancement Freeze       |  October 24th  |    8 |
+| v0.57.0-rc.1 Released    |  October 31st  |    9 |
+| Exceptions Accepted      |  November 7th  |   10 |
+| v0.57.0-rc.2 Released    |  November 21st |   13 |
+| v0.57.0 Branch Created   |  November 21st |   13 |
+| Kubernetes 1.26 Released |  December 5th  |   14 |
+| K8s 1.26 Provider Available |  December 12th  |   15 |
+| v0.57.0 Released         |  December 17th |   16 |
+
+**Example: blocker is detected for release branch on the second release of the year (15 week cycle)**
+|            Event            | Date          | Week |
+|:---------------------------:|---------------|------|
+| Start Release Cycle         |    May 30th   |    1 |
+| v0.56.0-rc.0 Released       |   June 27th   |    5 |
+| Enhancement Freeze          |    July 4th   |    8 |
+| v0.56.0-rc.1 Released       |   July 11th   |    9 |
+| Exceptions Accepted         |   July 18th   |   10 |
+| v0.56.0-rc.2 Released       |   August 8th  |   13 |
+| v0.56.0 Branch Created      |   August 8th  |   13 |
+| Kubernetes 1.25 Released    |  August 23rd  |   15 |
+| K8s 1.25 Provider Available |  August 29th  |   16 |
+| v0.56.0-rc.2 Bug Found      |  August 29th  |   16 |
+| v0.56.0-rc.2 Bug Fixed      |  August 30th  |   16 |
+| v0.56.0-rc.3 Released       |  August 31th  |   16 |
+| v0.56.0 Released            | September 5th |   17 |
 
 # Versioning
 **Branches are created for every minor release and take the form of** `release-<major>.<minor>`
-For example, the release branch for an upcoming v0.30.0 release will be 
+For example, the release branch for an upcoming v0.30.0 release will be
 `release-0.30`
 
 **Releases are cut from release branches must adhere to** [semantic versioning conventions](http://semver.org).


### PR DESCRIPTION
KubeVirt has been released monthly since its early days, but it might be time to settle into a slower release cycle.  The high velocity of KubeVirt made sense to keep a monthly release cadence since the project's beginning.  There were key features KubeVirt needed in order to be production ready those features needed to get into customer hands as soon as possible.  However, KubeVirt has now reached production readiness, which is backed-up by the [many companies that use it in production](https://github.com/kubevirt/kubevirt/blob/main/ADOPTERS.md), so it might be time for the community to pivot.

For vendors and end-users, a monthly release cadence puts pressure on teams to upgrade constantly.  There's sometimes a security update, often new features, or some bug fixes that need to be rolled out by upgrading, but the question is always when.  At a monthly cadence, it's too difficult to stay up to date.   So vendors end up staying multiple releases behind latest and backport changes until it becomes too costly.  The same issue is observed in the community, where desirable changes need to be backported 4, 5, or ever 6 releases back, but aren't because it's too much of a burden.

My proposal is to change KubeVirt's release cycle to match the Kubernetes release cadence - 15 week releases or 3 releases a year.  With fewer releases, the community will have additional time to pack more content into a release, which would relive vendors from feeling pressure to backport changes and incentivize waiting for the next release to upgrade.

```release-note
Move KubeVirt to a 15 week release cadence
```