### PR TITLE
fix guest memory setting

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1400,7 +1400,7 @@ var _ = Describe("Converter", func() {
 		})
 
 		It("should handle float memory", func() {
-			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("2222222200m")
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("2222222200m")
 			xml := vmiToDomainXML(vmi, c)
 			Expect(strings.Contains(xml, `<memory unit="b">2222222</memory>`)).To(BeTrue(), xml)
 		})

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -517,14 +517,16 @@ func GetVirtualMemory(vmi *v12.VirtualMachineInstance) *resource.Quantity {
 		return vmi.Spec.Domain.Memory.Guest
 	}
 
-	// Otherwise, take memory from the memory-limit, if set
-	if v, ok := vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory]; ok {
+	// Get the requested memory
+	reqMemory, isReqMemSet := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
+
+	// Otherwise, take memory from the memory-limit, if set and requested Memory not set
+	if v, ok := vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory]; ok && !isReqMemSet {
 		return &v
 	}
 
 	// Otherwise, take memory from the requested memory
-	v, _ := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]
-	return &v
+	return &reqMemory
 }
 
 // numaMapping maps numa nodes based on already applied VCPU pinning. The sort result is stable compared to the order


### PR DESCRIPTION
**What this PR does / why we need it**:

It appears that we are incorrectly setting the guest memory to equal `resources.limits.memory`.
VMI specs that don't explicitly provide a value for `domain.memory.guest`
and provide different values for resources requests and limits will be converted to a domain definition where guest memory equals `resources.limits.memory`.

**Special notes for your reviewer**:
From my recollection, we used to have a vmi mutator webhook that set the correct value, but I don't see it right now.


**Release note**:
```release-note
fix the guest memory conversion by setting it to resources.requests.memory when guest memory is not explicitly provided 
```
