### PR TITLE
builder: Don't set up multiarch support multiple times

### DIFF
--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -13,7 +13,14 @@ SCRIPT_DIR="$(
 # shellcheck source=hack/builder/version.sh
 . "${SCRIPT_DIR}/version.sh"
 
-${KUBEVIRT_CRI} run --rm --privileged multiarch/qemu-user-static --reset -p yes
+# If qemu-static has already been registered as a runner for foreign
+# binaries, for example by installing qemu-user and qemu-user-binfmt
+# packages on Fedora or by having already run this script earlier,
+# then we shouldn't alter the existing configuration to avoid the
+# risk of possibly breaking it
+if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
+    ${KUBEVIRT_CRI} run --rm --privileged multiarch/qemu-user-static --reset -p yes
+fi
 
 for ARCH in ${ARCHITECTURES}; do
     case ${ARCH} in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

On Fedora 36, setting up support for building multiarch containers in Docker using the multiarch/qemu-user-static container image doesn't work as intended. Specifically, running

```
$ docker run --platform=linux/aarch64 --rm alpine uname -m
```

doesn't produce any output and results in the SELinux error

```
avc: denied { read } for comm="uname" path="/usr/bin/qemu-aarch64-static"
```

Installing the qemu-user and qemu-user-binfmt packages results in being able to successfully run container images for foreign
architectures, but since we currently run the container-based qemu-user setup unconditionally, that will get blown away as soon as `make builder-build` is executed and the build will not be able to complete successfully.

Fix this by only running the setup step if things have not already been configured earlier.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```