### PR TITLE
Fix export restore PVC owner reference

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -561,9 +561,9 @@ func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.Virtual
 			Namespace: vmExport.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(vmExport, schema.GroupVersionKind{
-					Group:   exportv1.SchemeGroupVersion.Group,
-					Version: exportv1.SchemeGroupVersion.Version,
-					Kind:    "VirtualMachineExport",
+					Group:   exportGVK.Group,
+					Version: exportGVK.Version,
+					Kind:    exportGVK.Kind,
 				}),
 			},
 			Labels: map[string]string{

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -166,8 +166,8 @@ func (ctrl *VMExportController) getOrCreatePVCFromSnapshot(vmExport *exportv1.Vi
 	}
 	pvc.SetOwnerReferences([]metav1.OwnerReference{
 		{
-			APIVersion:         apiVersion,
-			Kind:               "VirtualMachineExport",
+			APIVersion:         exportGVK.GroupVersion().String(),
+			Kind:               exportGVK.Kind,
 			Name:               vmExport.Name,
 			UID:                vmExport.UID,
 			Controller:         pointer.BoolPtr(true),

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -426,7 +426,7 @@ var _ = Describe("VMSnapshot source", func() {
 			By("Ensuring the PVC is owned by the vmExport")
 			Expect(pvc.OwnerReferences).To(HaveLen(1))
 			Expect(pvc.OwnerReferences[0]).To(Equal(metav1.OwnerReference{
-				APIVersion:         apiVersion,
+				APIVersion:         exportGVK.GroupVersion().String(),
 				Kind:               "VirtualMachineExport",
 				Name:               testVMExport.Name,
 				UID:                testVMExport.UID,
@@ -518,7 +518,7 @@ var _ = Describe("VMSnapshot source", func() {
 			By("Ensuring the PVC is owned by the vmExport")
 			Expect(pvc.OwnerReferences).To(HaveLen(1))
 			Expect(pvc.OwnerReferences[0]).To(Equal(metav1.OwnerReference{
-				APIVersion:         apiVersion,
+				APIVersion:         exportGVK.GroupVersion().String(),
 				Kind:               "VirtualMachineExport",
 				Name:               testVMExport.Name,
 				UID:                testVMExport.UID,
@@ -569,7 +569,7 @@ var _ = Describe("VMSnapshot source", func() {
 			By("Ensuring the PVC is owned by the vmExport")
 			Expect(pvc.OwnerReferences).To(HaveLen(1))
 			Expect(pvc.OwnerReferences[0]).To(Equal(metav1.OwnerReference{
-				APIVersion:         apiVersion,
+				APIVersion:         exportGVK.GroupVersion().String(),
 				Kind:               "VirtualMachineExport",
 				Name:               testVMExport.Name,
 				UID:                testVMExport.UID,


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently this is
```yaml
ownerReferences:
  - apiVersion: v1alpha1
```
But we want
```yaml
ownerReferences:
  - apiVersion: export.kubevirt.io/v1alpha1
```
This gets validated with https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
which is enabled in OpenShift, but disabled in our kubevirtci clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
