### PR TITLE
Add support for HostDisk local qcow2 format image file

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16315,6 +16315,10 @@
       "description": "Capacity of the sparse disk",
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      },
+     "format": {
+      "description": "The format of HostDisk image file",
+      "type": "string"
+     },
      "path": {
       "description": "The path to HostDisk image located on the cluster",
       "type": "string"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2130,6 +2130,15 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 				})
 			}
 
+			if hostDisk.Type == v1.HostDiskExistsOrCreate && hostDisk.Format == v1.Qcow2Format {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("%s only support '%s' when use qcow2 file format", field.Index(idx).Child("hostDisk", "type").String(), v1.HostDiskExists),
+					Field:   field.Index(idx).Child("hostDisk", "type").String(),
+				})
+
+			}
+
 			// if disk.img already exists and user knows that by specifying type 'Disk' it is pointless to set capacity
 			if hostDisk.Type == v1.HostDiskExists && !hostDisk.Capacity.IsZero() {
 				causes = append(causes, metav1.StatusCause{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3359,6 +3359,44 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
+		It("should reject hostDisk volumes if the hostDisk.Type is DiskOrCreate when image is qcow2 format", func() {
+			enableFeatureGate(virtconfig.HostDiskGate)
+			vmi := api.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "testHostDisk",
+				VolumeSource: v1.VolumeSource{
+					HostDisk: &v1.HostDisk{
+						Type:   v1.HostDiskExistsOrCreate,
+						Path:   "/hostdisktest.qcow2",
+						Format: "qcow2",
+					},
+				},
+			})
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes, config)
+			Expect(causes).To(BeEmpty())
+		})
+
+		It("should accept hostDisk volumes if the hostDisk.Type is Disk when image is qcow2 format", func() {
+			enableFeatureGate(virtconfig.HostDiskGate)
+			vmi := api.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "testHostDisk",
+				VolumeSource: v1.VolumeSource{
+					HostDisk: &v1.HostDisk{
+						Type:   v1.HostDiskExists,
+						Path:   "/hostdisktest.qcow2",
+						Format: "qcow2",
+					},
+				},
+			})
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes, config)
+			Expect(causes).To(BeEmpty())
+		})
+
 		It("should accept sysprep volumes", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -584,7 +584,7 @@ func Convert_v1_Volume_To_api_Disk(source *v1.Volume, disk *api.Disk, c *Convert
 	}
 
 	if source.HostDisk != nil {
-		return Convert_v1_HostDisk_To_api_Disk(source.Name, source.HostDisk.Path, disk)
+		return Convert_v1_HostDisk_To_api_Disk(source.Name, source.HostDisk.Path, disk, source.HostDisk.Format)
 	}
 
 	if source.PersistentVolumeClaim != nil {
@@ -758,9 +758,13 @@ func Convert_v1_Hotplug_BlockVolumeSource_To_api_Disk(volumeName string, disk *a
 	return nil
 }
 
-func Convert_v1_HostDisk_To_api_Disk(volumeName string, path string, disk *api.Disk) error {
+func Convert_v1_HostDisk_To_api_Disk(volumeName string, path string, disk *api.Disk, format v1.ImageFileFormat) error {
 	disk.Type = "file"
-	disk.Driver.Type = "raw"
+	if format == v1.Qcow2Format {
+		disk.Driver.Type = "qcow2"
+	} else {
+		disk.Driver.Type = "raw"
+	}
 	disk.Driver.ErrorPolicy = "stop"
 	disk.Source.File = hostdisk.GetMountedHostDiskPath(volumeName, path)
 	return nil

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6413,6 +6413,9 @@ var CRDsValidation map[string]string = map[string]string{
                             description: Capacity of the sparse disk
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          format:
+                            description: The format of HostDisk image file
+                            type: string
                           path:
                             description: The path to HostDisk image located on the
                               cluster
@@ -10483,6 +10486,9 @@ var CRDsValidation map[string]string = map[string]string{
                     description: Capacity of the sparse disk
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  format:
+                    description: The format of HostDisk image file
+                    type: string
                   path:
                     description: The path to HostDisk image located on the cluster
                     type: string
@@ -14947,6 +14953,9 @@ var CRDsValidation map[string]string = map[string]string{
                             description: Capacity of the sparse disk
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          format:
+                            description: The format of HostDisk image file
+                            type: string
                           path:
                             description: The path to HostDisk image located on the
                               cluster
@@ -18980,6 +18989,9 @@ var CRDsValidation map[string]string = map[string]string{
                                     description: Capacity of the sparse disk
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  format:
+                                    description: The format of HostDisk image file
+                                    type: string
                                   path:
                                     description: The path to HostDisk image located
                                       on the cluster
@@ -23683,6 +23695,10 @@ var CRDsValidation map[string]string = map[string]string{
                                         description: Capacity of the sparse disk
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      format:
+                                        description: The format of HostDisk image
+                                          file
+                                        type: string
                                       path:
                                         description: The path to HostDisk image located
                                           on the cluster

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -53,6 +53,8 @@ type HostDisk struct {
 	Capacity resource.Quantity `json:"capacity,omitempty"`
 	// Shared indicate whether the path is shared between nodes
 	Shared *bool `json:"shared,omitempty"`
+	// The format of HostDisk image file
+	Format ImageFileFormat `json:"format,omitempty"`
 }
 
 // ConfigMapVolumeSource adapts a ConfigMap into a volume.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -9,6 +9,7 @@ func (HostDisk) SwaggerDoc() map[string]string {
 		"type":     "Contains information if disk.img exists or should be created\nallowed options are 'Disk' and 'DiskOrCreate'",
 		"capacity": "Capacity of the sparse disk\n+optional",
 		"shared":   "Shared indicate whether the path is shared between nodes",
+		"format":   "The format of HostDisk image file",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1495,6 +1495,15 @@ const (
 	HostDiskExists HostDiskType = "Disk"
 )
 
+type ImageFileFormat string
+
+const (
+	// a raw format disk image file
+	RawFormat ImageFileFormat = "raw"
+	// a qcow2 format disk image file
+	Qcow2Format ImageFileFormat = "qcow2"
+)
+
 type NetworkInterfaceType string
 
 const (
@@ -1650,7 +1659,6 @@ const (
 	WorkloadUpdateMethodEvict WorkloadUpdateMethod = "Evict"
 )
 
-//
 // KubeVirtWorkloadUpdateStrategy defines options related to updating a KubeVirt install
 type KubeVirtWorkloadUpdateStrategy struct {
 	// WorkloadUpdateMethods defines the methods that can be used to disrupt workloads

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -16905,6 +16905,13 @@ func schema_kubevirtio_api_core_v1_HostDisk(ref common.ReferenceCallback) common
 							Format:      "",
 						},
 					},
+					"format": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The format of HostDisk image file",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"path", "type"},
 			},


### PR DESCRIPTION
Signed-off-by: Zhou, Lei <lei.zhou@intel.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, HostDisk only support **raw** format image file. 
This patch is to add support for existing local **qcow2** format image file, not for PVC.
When no Format is set, it will still use raw as the default format, this patch just gives the user one more option.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for HostDisk local qcow2 format image file
```
