### PR TITLE
[e2e tests]: fix flaky migration test 1862

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2523,7 +2523,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			It("[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi", func() {
 				// Start the VirtualMachineInstance with the PVC attached
 
-				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpineTestTooling), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi.Spec.Hostname = string(cd.ContainerDiskAlpine)
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
`test_id:1862` tends to fail due to the following error during VM boot:
```
Cloud-init v. 22.2 running 'init' at Sun, 07 Aug 2022 15:03:53 +0000. Up 46.66 seconds.
ci-info: ++++++++++++++++++++++++Net device info++++++++++++++++++++++++
ci-info: +--------+-------+---------+------+-------+-------------------+
ci-info: | Device |   Up  | Address | Mask | Scope |     Hw-Address    |
ci-info: +--------+-------+---------+------+-------+-------------------+
ci-info: |  eth0  | False |    .    |  .   |   .   | 52:54:00:a8:54:b5 |
ci-info: |   lo   | False |    .    |  .   |   .   |         .         |
ci-info: +--------+-------+---------+------+-------+-------------------+
ci-info: 
2022-08-07 15:03:53,983 - __init__.py[ERROR]: Could not import DataSourceVMware. Does the DataSource exist and is it importable?
2022-08-07 15:04:14,041 - url_helper.py[WARNING]: Calling 'None' failed [0/120s]: request error [HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /2009-04-04/meta-data/instance-id (Caused by NewConnectionError('\u003curllib3.connection.HTTPConnection object at 0x7fb6fc5a6830\u003e: Failed to establish a new connection: [Errno 101] Network unreachable'))]
2022-08-07 15:04:14,060 - url_helper.py[WARNING]: Calling 'None' failed [0/120s]: request error [HTTPConnectionPool(host='fd00:ec2::254', port=80): Max retries exceeded with url: /2009-04-04/meta-data/instance-id (Caused by NewConnectionError('\u003curllib3.connection.HTTPConnection object at 0x7fb6fc5a7220\u003e: Failed to establish a new connection: [Errno -2] Name does not resolve'))]
2022-08-07 15:04:15,082 - url_helper.py[WARNING]: Calling 'None' failed [1/120s]: request error [HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /2009-04-04/meta-data/instance-id (Caused by NewConnectionError('\u003curllib3.connection.HTTPConnection object at 0x7fb6fc5a5ba0\u003e: Failed to establish a new connection: [Errno 101] Network unreachable'))]
2022-08-07 15:04:15,104 - url_helper.py[WARNING]: Calling 'None' failed [1/120s]: request error [HTTPConnectionPool(host='fd00:ec2::254', port=80): Max retries exceeded with url: /2009-04-04/meta-data/instance-id (Caused by NewCon
```

This error can occur when using the could-init based Alpine image called `alpineWithTestTooling`. When using this image
some minimal cloud-init configuration needs to be provided as part of the VMI spec. `test_id:1862` was using the simple Alpine image in the first place, and since there is not need to use  the new Alpine image with the cloud-int, this PR reverts the image type.

Fixes #
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-08-28-168h.html#row22\

**Special notes for your reviewer**:
In this case I've decided not to refactor the test to use `libvmi` because we don't have
enough VM builders for storage configurtaion, and adding them in this PR will cause a drift
in the scope.

**Release note**:
```release-note
NONE
```
