### PR TITLE
Stop enabling deprecated live migration feature gate as part of functional tests initialization

### DIFF
--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -82,7 +82,6 @@ func AdjustKubeVirtResource() {
 	}
 	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
 		virtconfig.CPUManager,
-		virtconfig.LiveMigrationGate,
 		virtconfig.IgnitionGate,
 		virtconfig.SidecarGate,
 		virtconfig.SnapshotGate,


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently live migration feature gate [was deprecated](https://github.com/kubevirt/kubevirt/pull/8047) according to the new feature gate [deprecation policy](https://github.com/kubevirt/kubevirt/pull/7791).

This policy dictates that whenever a feature get is being deprecated, a warning should pop up when explicitly enabling the feature gate. In our functional test suite, we enable live migration feature gate, therefore whenever functests are being run the following warning pops up:

`W0830 09:39:42.797978  103627 warnings.go:70] feature gate LiveMigration is deprecated, therefore it can be safely removed and is redundant. For more info, please look at: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md`

After this PR functests won't enable the feature gate, therefore the warning would stop appearing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
