### PR TITLE
[e2e tests]: adapt tests to the master node-role label deprecation

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -426,18 +426,20 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 
 				By("selecting one compute only node that runs kubevirt components")
-				// master nodes should never have the CriticalAddonsOnly taint because core components might not
+				// control-plane nodes should never have the CriticalAddonsOnly taint because core components might not
 				// tolerate this taint because it is meant to be used on compute nodes only. If we set this taint
-				// on a master node, we risk in breaking the test cluster.
+				// on a control-plane node, we risk in breaking the test cluster.
 				for _, pod := range pods.Items {
 					node, ok := schedulableNodes[pod.Spec.NodeName]
 					if !ok {
 						// Pod is running on a non-schedulable node?
 						continue
 					}
-					if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
+
+					if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
 						continue
 					}
+
 					selectedNodeName = node.Name
 					break
 				}


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

As stated in k8s 1.24 [changelog](https://github.com/kubernetes/kubernetes/blob/58c10aa6eb5adfb1f3aa4d6cb898b8c347ba9e72/CHANGELOG/CHANGELOG-1.24.md), kueadm would be migrated away from using the word `master`.
`node-role.kubernetes.io/control-plane` would be used instead.

Therefore some places in the e2e code were updated. Also refactored var names
where master word was used.

Fixes #
https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.24-sig-compute/1554882304050991104

**Release note**:
```release-note
NONE
```
