### PR TITLE
[e2e]: add toleration to the disk-images-provider manifest

### DIFF
--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -16,6 +16,9 @@ spec:
         kubevirt.io: disks-images-provider
       name: disks-images-provider
     spec:
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
       serviceAccountName: kubevirt-testing
       containers:
         - name: target


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
In some cases like in `test_id:4134` the toleration is being tested against
the cluster, and since the disk-images-provider is not part of the control-plane
components, it would be evicted.

Therefore I've added the toleration to improve stability during test runs.

Fixes #
https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.23-sig-compute/1555106282447310848

**Release note**:
```release-note
NONE
```
