### PR TITLE
Add restart policy to rsync container used in cluster-sync

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -46,7 +46,7 @@ $KUBEVIRT_CRI run ${CONTAINER_ENV} -v "${BUILDER}:/root:rw,z" --security-opt "la
 mkdir -p ${OUT_DIR}
 
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID=$($KUBEVIRT_CRI run ${CONTAINER_ENV} -d -v "${BUILDER}:/root:rw,z" --security-opt "label=disable" --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID=$($KUBEVIRT_CRI run ${CONTAINER_ENV} -d -v "${BUILDER}:/root:rw,z" --restart always --security-opt "label=disable" --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
     $KUBEVIRT_CRI stop ${RSYNC_CID} >/dev/null 2>&1 &


### PR DESCRIPTION
Signed-off-by: Brian Carey <bcarey@redhat.com>

**What this PR does / why we need it**:
An intermittent issue appears when testing kind based e2e jobs with
podman in CI[1]. The rsync container hits an error as the rsync daemon
fails to attach to the specified port. Adding a restart policy to
restart unless the container is stopped allows the vgpu lanes to run
successfully using podman.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-kind-1.23-vgpu/1564606226711449600

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
