### PR TITLE
Wait for daemonsets to be ready before starting the testsuite

### DIFF
--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -217,6 +217,7 @@ func deployOrWipeTestingInfrastrucure(actionOnObject func(unstructured.Unstructu
 		}
 	}
 
+	waitForAllDaemonSetsReady(3 * time.Minute)
 	waitForAllPodsReady(3*time.Minute, metav1.ListOptions{})
 }
 
@@ -226,6 +227,25 @@ func DeployTestingInfrastructure() {
 
 func WipeTestingInfrastructure() {
 	deployOrWipeTestingInfrastrucure(DeleteRawManifest)
+}
+
+func waitForAllDaemonSetsReady(timeout time.Duration) {
+	checkForDaemonSetsReady := func() []string {
+		dsNotReady := make([]string, 0)
+		virtClient, err := kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+
+		dsList, err := virtClient.AppsV1().DaemonSets(k8sv1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+		util.PanicOnError(err)
+		for _, ds := range dsList.Items {
+			if ds.Status.DesiredNumberScheduled != ds.Status.NumberReady {
+				dsNotReady = append(dsNotReady, ds.Name)
+			}
+		}
+		return dsNotReady
+
+	}
+	Eventually(checkForDaemonSetsReady, timeout, 2*time.Second).Should(BeEmpty(), "There are daemonsets in system which are not ready.")
 }
 
 func waitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) {


### PR DESCRIPTION
There might not be pods for the daemonset yet at the time we check.
Resolves a flake where disks-images-provider is not yet ready in time
for running the tests.

This failure doesn't show up in our regular CI as the daemonset is also
deployed by `make cluster-sync` and has plenty of time to come up, but
will show up if we attempt to run the testsuite on a cluster deployed in
other means.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
