### PR TITLE
Add auth clients to test suite

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -272,6 +272,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -39,6 +39,8 @@ import (
 
 	vmsgeneratorutils "kubevirt.io/kubevirt/tools/vms-generator/utils"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	_ "kubevirt.io/kubevirt/tests/launchsecurity"
 	_ "kubevirt.io/kubevirt/tests/monitoring"
 	_ "kubevirt.io/kubevirt/tests/network"


### PR DESCRIPTION
Include the auth provider client library in the test_suite so users can leverage external auth processes to access kubernetes clusters.

fixes: #8392 
```release-note
NONE
```
