### PR TITLE
Update probes

### DIFF
--- a/examples/vm-cirros-cluster-csmall.yaml
+++ b/examples/vm-cirros-cluster-csmall.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   instancetype:
     kind: VirtualMachineClusterInstancetype
-    name: csmall
+    name: cluster-csmall
   running: false
   template:
     metadata:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -1254,8 +1254,8 @@ func GetVmCirrosInstancetypeComputeSmall() *v1.VirtualMachine {
 }
 
 func GetVmCirrosClusterInstancetypeComputeSmall() *v1.VirtualMachine {
-	vm := getBaseVM(VmCirrosInstancetypeComputeSmall, map[string]string{
-		kubevirtIoVM: VmCirrosInstancetypeComputeSmall,
+	vm := getBaseVM(VmCirrosClusterInstancetypeComputeSmall, map[string]string{
+		kubevirtIoVM: VmCirrosClusterInstancetypeComputeSmall,
 	})
 
 	vm.Spec.Instancetype = &v1.InstancetypeMatcher{

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -1259,7 +1259,7 @@ func GetVmCirrosClusterInstancetypeComputeSmall() *v1.VirtualMachine {
 	})
 
 	vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-		Name: VirtualMachineInstancetypeComputeSmall,
+		Name: VirtualMachineClusterInstancetypeComputeSmall,
 		Kind: "VirtualMachineClusterInstancetype",
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow to perform the readiness probes. As it was, the SELinux system denied attempts to open the /tmp/healthy.txt file causing the probe to fail. The documentation is modified to explain why the context assignation is required. Finally, the disk image is updated to use a more modern one intended for end users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
