### PR TITLE
Rename metrics to follow the naming convention

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -36,7 +36,7 @@ Indication for a virt-controller that is ready to take the lead. Type: Gauge.
 ### kubevirt_vmi_cpu_affinity
 The vcpu affinity details. Type: Counter.
 
-### kubevirt_vmi_filesystem_total_bytes
+### kubevirt_vmi_filesystem_capacity_bytes_total
 Total VM filesystem capacity in bytes. Type: Gauge.
 
 ### kubevirt_vmi_filesystem_used_bytes
@@ -48,7 +48,7 @@ Current balloon bytes. Type: Gauge.
 ### kubevirt_vmi_memory_available_bytes
 Amount of `usable` memory as seen by the domain. Type: Gauge.
 
-### kubevirt_vmi_memory_domain_total_bytes
+### kubevirt_vmi_memory_domain_bytes_total
 The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file. Type: Gauge.
 
 ### kubevirt_vmi_memory_pgmajfault

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -206,7 +206,7 @@ func (metrics *vmiMetrics) updateMemory(mem *stats.DomainStatsMemory) {
 
 	if mem.TotalSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_memory_domain_total_bytes",
+			"kubevirt_vmi_memory_domain_bytes_total",
 			"The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file.",
 			prometheus.GaugeValue,
 			float64(mem.Total)*1024,
@@ -491,7 +491,7 @@ func (metrics *vmiMetrics) updateFilesystem(vmFSStats k6tv1.VirtualMachineInstan
 		fsLabelValues := []string{fsStat.DiskName, fsStat.MountPoint, fsStat.FileSystemType}
 
 		metrics.pushCustomMetric(
-			"kubevirt_vmi_filesystem_total_bytes",
+			"kubevirt_vmi_filesystem_capacity_bytes_total",
 			"Total VM filesystem capacity in bytes.",
 			prometheus.GaugeValue,
 			float64(fsStat.TotalBytes),

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -320,7 +320,7 @@ var _ = Describe("Prometheus", func() {
 			result.Write(dto)
 
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_domain_total_bytes"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_domain_bytes_total"))
 			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(float64(1024)))
 		})
 
@@ -1181,7 +1181,7 @@ var _ = Describe("Prometheus", func() {
 			ps.Report("test", &vmi, newVmStats(domainStats, fsStats))
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_total_bytes"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_capacity_bytes_total"))
 			result = <-ch
 			Expect(result).ToNot(BeNil())
 			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_used_bytes"))


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`kubevirt_vmi_memory_domain_total_bytes` and `kubevirt_vmi_filesystem_total_bytes` were not following the metrics naming convention that we are following in the other metrics. This PR renames them.

`kubevirt_vmi_memory_domain_total_bytes` -> `kubevirt_vmi_filesystem_capacity_bytes_total` 
`kubevirt_vmi_filesystem_total_bytes` -> `kubevirt_vmi_memory_domain_bytes_total`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename metrics to follow the naming convention
```
