### PR TITLE
[Clean code] Equal(true/false) => BeTrue/BeFalse

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Validating VM Admitter", func() {
 		virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(mockVMIClient)
 		mockVMIClient.EXPECT().Get(gomock.Any(), gomock.Any()).Return(vmi, nil)
 		resp := vmsAdmitter.Admit(ar)
-		Expect(resp.Allowed).To(Equal(false))
+		Expect(resp.Allowed).To(BeFalse())
 	},
 		Entry("with valid request to add volume", []v1.VirtualMachineVolumeRequest{
 			{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1069,7 +1069,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should mount default serviceAccountToken", func() {
-				Expect(*pod.Spec.AutomountServiceAccountToken).To(Equal(true))
+				Expect(*pod.Spec.AutomountServiceAccountToken).To(BeTrue())
 			})
 		})
 		Context("with node selectors", func() {
@@ -3005,7 +3005,7 @@ var _ = Describe("Template", func() {
 
 				resources := pod.Spec.Containers[0].Resources
 				val, ok := resources.Requests["vendor.com/gpu_name"]
-				Expect(ok).To(Equal(true))
+				Expect(ok).To(BeTrue())
 				Expect(val).To(Equal(*resource.NewQuantity(1, resource.DecimalSI)))
 			})
 		})
@@ -3082,7 +3082,7 @@ var _ = Describe("Template", func() {
 
 				resources := pod.Spec.Containers[0].Resources
 				val, ok := resources.Requests["vendor.com/dev_name"]
-				Expect(ok).To(Equal(true))
+				Expect(ok).To(BeTrue())
 				Expect(val).To(Equal(*resource.NewQuantity(1, resource.DecimalSI)))
 			})
 		})

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Node-labeller config", func() {
 		Expect(err).ToNot(HaveOccurred())
 		for _, val := range features {
 			if _, ok := f[val]; !ok {
-				Expect(ok).To(Equal(false), "expect feature")
+				Expect(ok).To(BeFalse(), "expect feature")
 			}
 		}
 

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -290,7 +290,7 @@ var _ = Describe("AccessCredentials", func() {
 		}()
 
 		manager.watchSecrets(vmi)
-		Expect(matched).To(Equal(true))
+		Expect(matched).To(BeTrue())
 
 		// And wait again after modifying file
 		// Another execute command should occur with the updated password

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1268,9 +1268,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				for key := range node.Labels {
 					if strings.Contains(key, v1.CPUModelLabel) {
 						model := strings.TrimPrefix(key, v1.CPUModelLabel)
-						for obsoleteModel := range nodelabellerutil.DefaultObsoleteCPUModels {
-							Expect(model == obsoleteModel).To(Equal(false), "Node can't contain label with cpu model, which is in default obsolete filter")
-						}
+						Expect(nodelabellerutil.DefaultObsoleteCPUModels).ToNot(HaveKey(model),
+							"Node can't contain label with cpu model, which is in default obsolete filter")
 					}
 				}
 			})

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1040,7 +1040,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 					containK8sLabel = true
 				}
 			}
-			Expect(containK8sLabel).To(Equal(true))
+			Expect(containK8sLabel).To(BeTrue())
 		},
 			Entry("[test_id:4147] by IPv4", k8sv1.IPv4Protocol),
 			Entry("[test_id:6244] by IPv6", k8sv1.IPv6Protocol),
@@ -1219,7 +1219,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 						}
 					}
 					return true
-				}, 15*time.Second, 1*time.Second).Should(Equal(true))
+				}, 15*time.Second, 1*time.Second).Should(BeTrue())
 			})
 
 			It("[test_id:6246] label nodes with cpu model, cpu features and host cpu model", func() {

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -136,7 +136,7 @@ var _ = SIGDescribe("Infosource", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				return dummyInterfaceExists(vmi)
-			}, 120*time.Second, 2*time.Second).Should(Equal(true))
+			}, 120*time.Second, 2*time.Second).Should(BeTrue())
 
 			networkInterface := netvmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, primaryInterfaceMac)
 			Expect(networkInterface).NotTo(BeNil(), "interface not found")

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2826,7 +2826,7 @@ spec:
 				}
 				Expect(err).ToNot(HaveOccurred())
 				return d.Status.AvailableReplicas > 0
-			}, time.Minute*5, 2*time.Second).Should(Equal(true))
+			}, time.Minute*5, 2*time.Second).Should(BeTrue())
 		}
 
 		AfterEach(func() {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -115,7 +115,7 @@ var _ = SIGDescribe("Export", func() {
 			}
 			Expect(err).ToNot(HaveOccurred())
 			return d.Status.AvailableReplicas > 0
-		}, 90*time.Second, 1*time.Second).Should(Equal(true))
+		}, 90*time.Second, 1*time.Second).Should(BeTrue())
 	}
 
 	BeforeEach(func() {

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -384,7 +384,7 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(expandedVm.Spec.Preference).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
-					Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(Equal(true), "VM should have preference expanded")
+					Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeTrue(), "VM should have preference expanded")
 				})
 
 				It("[test_id:TODO] should fail, if referenced preference does not exist", func() {

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -81,7 +81,7 @@ var _ = Describe("[Serial][sig-compute]GPU", func() {
 			pod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 			Expect(pod.Status.Phase).To(Equal(k8sv1.PodPending))
 			Expect(pod.Status.Conditions[0].Type).To(Equal(k8sv1.PodScheduled))
-			Expect(strings.Contains(pod.Status.Conditions[0].Message, "Insufficient "+gpuName)).To(Equal(true))
+			Expect(strings.Contains(pod.Status.Conditions[0].Message, "Insufficient "+gpuName)).To(BeTrue())
 			Expect(pod.Status.Conditions[0].Reason).To(Equal("Unschedulable"))
 		})
 


### PR DESCRIPTION
Fix all cases with gomaga's Equal assertion to a boolean values.

`Equal(true)` ahould be `BeTrue()`
`Equal(false)` ahould be `BeFalse()`

/sig code-quality

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```
