### PR TITLE
tests: Ignore deprecation warnings when cleaning up namespaces

### DIFF
--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -40,5 +40,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With the deprecation of VirtualMachineInstancePresets by 16ca54f
warnings were previously printed during functional test runs cluttering
the output:

```
FUNC_TEST_ARGS='-focus=Instancetype -regexScansFilePath' make functest
[..]
W0830 12:16:53.681522 2907587 warnings.go:70] kubevirt.io/v1alpha3 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
[..]
```

This change introduces a simple warning handler that ignores this
deprecation warning when cleaning up namespaces. Warnings will still be
printed for tests that interact directly with the deprecated CRD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8381

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
