### PR TITLE
[e2e tests]: Use default scp protocol instead of explicitly using legacy

### DIFF
--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -50,7 +50,6 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 			"--identity-file", keyFile,
 			"-t", "-o StrictHostKeyChecking=no",
 			"-t", "-o UserKnownHostsFile=/dev/null",
-			"-t", "-O",
 		}
 		if recursive {
 			args = append(args, "--recursive")
@@ -61,7 +60,7 @@ var _ = Describe("[sig-compute][virtctl]SCP", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		out, err := cmd.CombinedOutput()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "out[%s]", string(out))
 		Expect(out).ToNot(BeEmpty())
 	}
 

--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -69,7 +69,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", func() {
 	DescribeTable("should succeed to execute a command on the VM", func(cmdFn func(string)) {
 		By("injecting a SSH public key into a VMI")
 		vmi := libvmi.NewCirros(
-			libvmi.WithCloudInitNoCloudUserData(renderUserDataWithKey(pub), false))
+			libvmi.WithCloudInitNoCloudUserData(renderUserDataWithKey("cirros", pub), false))
 		vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some testing environment may have an older SCP, and thus not have the -O option.
I don't think there is a particular reason to opt for the legacy method:
https://wiki.archlinux.org/title/SCP_and_SFTP
```
Note: Since OpenSSH 8.8 the scp utility uses the SFTP protocol by default. The -O option must be used to use the legacy SCP protocol.
```
```
Warning: The scp protocol is outdated, inflexible and not readily fixed. Its authors recommend the use of more modern protocols like sftp and rsync for file transfer instead:
https://lists.mindrot.org/pipermail/openssh-unix-dev/2019-March/037672.html
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
