### PR TITLE
safepath: improving error messages

### DIFF
--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -20,6 +20,7 @@
 package hotplugdisk
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -82,7 +83,7 @@ func (h *hotplugDiskManager) GetFileSystemDirectoryTargetPathFromHostView(virtla
 		return nil, err
 	}
 	_, err = safepath.JoinNoFollow(targetPath, volumeName)
-	if os.IsNotExist(err) && create {
+	if errors.Is(err, os.ErrNotExist) && create {
 		if err := safepath.MkdirAtNoFollow(targetPath, volumeName, 0750); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Giving more details which path caused the error can improve the
debugging of the root cause.

Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This could help in debugging safepath related issue like for example: https://github.com/kubevirt/kubevirt/issues/8387

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
