### PR TITLE
Enable automatic token generation for VirtualMachineExport objects

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20131,8 +20131,7 @@
     "description": "VirtualMachineExportSpec is the spec for a VirtualMachineExport resource",
     "type": "object",
     "required": [
-     "source",
-     "tokenSecretRef"
+     "source"
     ],
     "properties": {
      "source": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20138,7 +20138,7 @@
       "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
      },
      "tokenSecretRef": {
-      "description": "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
+      "description": "TokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod",
       "type": "string"
      }
     }
@@ -20163,6 +20163,10 @@
      },
      "serviceName": {
       "description": "ServiceName is the name of the service created associated with the Virtual Machine export. It will be used to create the internal URLs for downloading the images",
+      "type": "string"
+     },
+     "tokenSecretRef": {
+      "description": "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
       "type": "string"
      }
     }

--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/storage/types:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/util:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7738,8 +7738,8 @@ var CRDsValidation map[string]string = map[string]string{
           - name
           type: object
         tokenSecretRef:
-          description: TokenSecretRef is the name of the secret that contains the
-            token used by the export server pod
+          description: TokenSecretRef is the name of the custom-defined secret that
+            contains the token used by the export server pod
           type: string
       required:
       - source
@@ -7881,6 +7881,10 @@ var CRDsValidation map[string]string = map[string]string{
           description: ServiceName is the name of the service created associated with
             the Virtual Machine export. It will be used to create the internal URLs
             for downloading the images
+          type: string
+        tokenSecretRef:
+          description: TokenSecretRef is the name of the secret that contains the
+            token used by the export server pod
           type: string
       type: object
   required:

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7743,7 +7743,6 @@ var CRDsValidation map[string]string = map[string]string{
           type: string
       required:
       - source
-      - tokenSecretRef
       type: object
     status:
       description: VirtualMachineExportStatus is the status for a VirtualMachineExport

--- a/staging/src/kubevirt.io/api/export/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/deepcopy_generated.go
@@ -161,6 +161,11 @@ func (in *VirtualMachineExportList) DeepCopyObject() runtime.Object {
 func (in *VirtualMachineExportSpec) DeepCopyInto(out *VirtualMachineExportSpec) {
 	*out = *in
 	in.Source.DeepCopyInto(&out.Source)
+	if in.TokenSecretRef != nil {
+		in, out := &in.TokenSecretRef, &out.TokenSecretRef
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -181,6 +186,11 @@ func (in *VirtualMachineExportStatus) DeepCopyInto(out *VirtualMachineExportStat
 		in, out := &in.Links, &out.Links
 		*out = new(VirtualMachineExportLinks)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.TokenSecretRef != nil {
+		in, out := &in.TokenSecretRef, &out.TokenSecretRef
+		*out = new(string)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types.go
@@ -56,7 +56,7 @@ type VirtualMachineExportSpec struct {
 
 	// +optional
 	// TokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod
-	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
+	TokenSecretRef *string `json:"tokenSecretRef,omitempty"`
 }
 
 // VirtualMachineExportPhase is the current phase of the VirtualMachineExport
@@ -83,7 +83,7 @@ type VirtualMachineExportStatus struct {
 
 	// +optional
 	// TokenSecretRef is the name of the secret that contains the token used by the export server pod
-	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
+	TokenSecretRef *string `json:"tokenSecretRef,omitempty"`
 
 	// +optional
 	// ServiceName is the name of the service created associated with the Virtual Machine export. It will be used to

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types.go
@@ -54,7 +54,8 @@ type VirtualMachineExportList struct {
 type VirtualMachineExportSpec struct {
 	Source corev1.TypedLocalObjectReference `json:"source"`
 
-	// TokenSecretRef is the name of the secret that contains the token used by the export server pod
+	// +optional
+	// TokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod
 	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
 }
 
@@ -79,6 +80,10 @@ type VirtualMachineExportStatus struct {
 
 	// +optional
 	Links *VirtualMachineExportLinks `json:"links,omitempty"`
+
+	// +optional
+	// TokenSecretRef is the name of the secret that contains the token used by the export server pod
+	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
 
 	// +optional
 	// ServiceName is the name of the service created associated with the Virtual Machine export. It will be used to

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types.go
@@ -55,7 +55,7 @@ type VirtualMachineExportSpec struct {
 	Source corev1.TypedLocalObjectReference `json:"source"`
 
 	// TokenSecretRef is the name of the secret that contains the token used by the export server pod
-	TokenSecretRef string `json:"tokenSecretRef"`
+	TokenSecretRef string `json:"tokenSecretRef,omitempty"`
 }
 
 // VirtualMachineExportPhase is the current phase of the VirtualMachineExport

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types_swagger_generated.go
@@ -19,17 +19,18 @@ func (VirtualMachineExportList) SwaggerDoc() map[string]string {
 func (VirtualMachineExportSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":               "VirtualMachineExportSpec is the spec for a VirtualMachineExport resource",
-		"tokenSecretRef": "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
+		"tokenSecretRef": "+optional\nTokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod",
 	}
 }
 
 func (VirtualMachineExportStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":            "VirtualMachineExportStatus is the status for a VirtualMachineExport resource",
-		"phase":       "+optional",
-		"links":       "+optional",
-		"serviceName": "+optional\nServiceName is the name of the service created associated with the Virtual Machine export. It will be used to\ncreate the internal URLs for downloading the images",
-		"conditions":  "+optional\n+listType=atomic",
+		"":               "VirtualMachineExportStatus is the status for a VirtualMachineExport resource",
+		"phase":          "+optional",
+		"links":          "+optional",
+		"tokenSecretRef": "+optional\nTokenSecretRef is the name of the secret that contains the token used by the export server pod",
+		"serviceName":    "+optional\nServiceName is the name of the service created associated with the Virtual Machine export. It will be used to\ncreate the internal URLs for downloading the images",
+		"conditions":     "+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23040,7 +23040,7 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportSpec(ref common.R
 						},
 					},
 				},
-				Required: []string{"source", "tokenSecretRef"},
+				Required: []string{"source"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23034,7 +23034,7 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportSpec(ref common.R
 					},
 					"tokenSecretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
+							Description: "TokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -23064,6 +23064,13 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportStatus(ref common
 					"links": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubevirt.io/api/export/v1alpha1.VirtualMachineExportLinks"),
+						},
+					},
+					"tokenSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"serviceName": {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -532,6 +532,7 @@ var _ = SIGDescribe("Export", func() {
 		export, err := virtClient.VirtualMachineExport(pvc.Namespace).Create(context.Background(), vmExport, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		export = waitForReadyExport(export)
+		Expect(export.Status.TokenSecretRef).To(Equal(token.Name))
 
 		By("Creating download pod, so we can download image")
 		targetPvc := &k8sv1.PersistentVolumeClaim{
@@ -599,6 +600,26 @@ var _ = SIGDescribe("Export", func() {
 			},
 			Spec: exportv1.VirtualMachineExportSpec{
 				TokenSecretRef: token.Name,
+				Source: k8sv1.TypedLocalObjectReference{
+					APIGroup: &k8sv1.SchemeGroupVersion.Group,
+					Kind:     "PersistentVolumeClaim",
+					Name:     name,
+				},
+			},
+		}
+		By("Creating VMExport we can start exporting the volume")
+		export, err := virtClient.VirtualMachineExport(namespace).Create(context.Background(), vmExport, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return export
+	}
+
+	createPVCExportObjectWithoutSecret := func(name, namespace string) *exportv1.VirtualMachineExport {
+		vmExport := &exportv1.VirtualMachineExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-export-%s", rand.String(12)),
+				Namespace: namespace,
+			},
+			Spec: exportv1.VirtualMachineExportSpec{
 				Source: k8sv1.TypedLocalObjectReference{
 					APIGroup: &k8sv1.SchemeGroupVersion.Group,
 					Kind:     "PersistentVolumeClaim",
@@ -696,6 +717,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+		Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 		By("looking up the exporter pod and secret name")
 		exporterPod := getExporterPod(vmExport)
 		Expect(exporterPod).ToNot(BeNil())
@@ -740,6 +762,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+		Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 		By("looking up the exporter pod and secret name")
 		exporterPod := getExporterPod(vmExport)
 		Expect(exporterPod).ToNot(BeNil())
@@ -758,6 +781,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+		Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 		By("looking up the exporter pod and secret name")
 		exporterService := getExportService(vmExport)
 		Expect(exporterService).ToNot(BeNil())
@@ -809,6 +833,7 @@ var _ = SIGDescribe("Export", func() {
 
 		By("Making sure the export becomes ready")
 		waitForReadyExport(export)
+		Expect(export.Status.TokenSecretRef).To(Equal(token.Name))
 	})
 
 	It("should be possibe to observe exportserver pod exiting", func() {
@@ -817,6 +842,7 @@ var _ = SIGDescribe("Export", func() {
 			Skip("Skip test when Filesystem storage is not present")
 		}
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+		Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 		By("looking up the exporter pod")
 		exporterPod := getExporterPod(vmExport)
 		Expect(exporterPod).ToNot(BeNil())
@@ -845,6 +871,25 @@ var _ = SIGDescribe("Export", func() {
 			Expect(err).ToNot(HaveOccurred())
 			return p.Status.Phase == k8sv1.PodSucceeded
 		}, 90*time.Second, 1*time.Second).Should(BeTrue())
+	})
+
+	It("Should handle populating an export without a previously defined tokenSecretRef", func() {
+		sc, exists := libstorage.GetRWOFileSystemStorageClass()
+		if !exists {
+			Skip("Skip test when Filesystem storage is not present")
+		}
+
+		pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
+		export := createPVCExportObjectWithoutSecret(pvc.Name, pvc.Namespace)
+		By("Making sure the export becomes ready")
+		waitForReadyExport(export)
+
+		By("Making sure the default secret is created")
+		export, err = virtClient.VirtualMachineExport(export.Namespace).Get(context.Background(), export.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		token, err = virtClient.CoreV1().Secrets(export.Namespace).Get(context.Background(), export.Status.TokenSecretRef, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token.Name).To(Equal(export.Status.TokenSecretRef))
 	})
 
 	Context("Ingress", func() {
@@ -971,6 +1016,7 @@ var _ = SIGDescribe("Export", func() {
 			Expect(err).NotTo(HaveOccurred())
 			ingress := createIngress(tlsSecretName)
 			vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+			Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 			Expect(vmExport.Status.Links.External.Cert).To(Equal(testCert))
 			certs, err := certutil.ParseCertsPEM([]byte(vmExport.Status.Links.External.Cert))
 			Expect(err).ToNot(HaveOccurred())
@@ -998,6 +1044,7 @@ var _ = SIGDescribe("Export", func() {
 				Skip("Not on openshift")
 			}
 			vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+			Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 			certs, err := certutil.ParseCertsPEM([]byte(vmExport.Status.Links.External.Cert))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(certs).To(HaveLen(1))
@@ -1193,6 +1240,7 @@ var _ = SIGDescribe("Export", func() {
 		defer deleteSnapshot(snapshot)
 		export := createRunningVMSnapshotExport(snapshot)
 		Expect(export).ToNot(BeNil())
+		Expect(export.Spec.TokenSecretRef).To(Equal(export.Status.TokenSecretRef))
 		restoreName := fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
 		verifyKubevirtInternal(export, export.Name, export.Namespace, restoreName)
 	})
@@ -1261,6 +1309,7 @@ var _ = SIGDescribe("Export", func() {
 		defer deleteSnapshot(snapshot)
 		export := createRunningVMSnapshotExport(snapshot)
 		Expect(export).ToNot(BeNil())
+		Expect(export.Spec.TokenSecretRef).To(Equal(export.Status.TokenSecretRef))
 		restoreName := fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
 		// [1] is the cloud init
 		restoreName2 := fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[2].DataVolume.Name)
@@ -1338,6 +1387,7 @@ var _ = SIGDescribe("Export", func() {
 		By("Stopping VM, we should get the export ready eventually")
 		vm = stopVM(vm)
 		export = waitForReadyExport(export)
+		Expect(export.Status.TokenSecretRef).To(Equal(token.Name))
 		verifyKubevirtInternal(export, export.Name, export.Namespace, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
 		By("Starting VM, the export should return to pending")
 		vm = startVM(vm)
@@ -1379,6 +1429,7 @@ var _ = SIGDescribe("Export", func() {
 		By("Deleting VMI, we should get the export ready eventually")
 		deleteVMI(vmi)
 		export = waitForReadyExport(export)
+		Expect(export.Status.TokenSecretRef).To(Equal(token.Name))
 		verifyKubevirtInternal(export, export.Name, export.Namespace, vmi.Spec.Volumes[0].DataVolume.Name)
 		By("Starting VMI, the export should return to pending")
 		vmi = tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -1463,6 +1514,7 @@ var _ = SIGDescribe("Export", func() {
 				Skip("Skip test when Filesystem storage is not present")
 			}
 			vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
+			Expect(vmExport.Spec.TokenSecretRef).To(Equal(vmExport.Status.TokenSecretRef))
 			By("looking up the exporter pod")
 			exporterPod := getExporterPod(vmExport)
 			Expect(exporterPod).ToNot(BeNil())


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

## **What this PR does / why we need it**

This PR introduces a new mechanism in the export controller so that when a VMExport with no `tokenSecretRef` is created, a corresponding secret is made using a name specific to the current object.

**Which issue(s) this PR fixes**: https://issues.redhat.com/browse/CNV-20651

**Special notes for your reviewer**: Work in progress

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable automatic token generation for VirtualMachineExport objects
```
