### PR TITLE
SECURITY: Vulnerability reporting and vendor update

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,4 +30,9 @@ mailing list and published to the
 page.
 
 ## Security Team
-The security team currently consists of the Maintainers of Kubevirt.
+
+The security team currently consists of the Maintainers of KubeVirt and is
+supported by security teams of involved vendors.
+
+List of involved vendor security teams:
+- Red Hat <secalert@redhat.com>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
 # Security Policy
 
 ## Reporting a Vulnerability
+
 The KubeVirt project treats security vulnerabilities seriously, so we
 strive to take action quickly when required.
 
@@ -9,7 +10,7 @@ manner to allow adequate time to respond.  If a security issue or
 vulnerability has been found, please disclose the details to our
 dedicated email address:
 
-cncf-kubevirt-security@lists.cncf.io [PGP](#PGP Encryption)
+cncf-kubevirt-security@lists.cncf.io
 
 Please include as much information as possible with the report. The
 following details assist with analysis efforts:
@@ -21,19 +22,8 @@ following details assist with analysis efforts:
 Any confidential information disclosed to the security team will be
 handled appropriately to prevent misuse or accidental disclosure.
 
-## PGP Encryption
-Security issues can often be sensitive in nature, so information can be
-disclosed with PGP encryption. Our public key can be found on 
-[public keyservers](https://pgp.mit.edu/pks/lookup?search=0x26A3D09E&op=vindex&exact=on)
-and our fingerprint is as follows:
-
-```CEF1 66F8 B929 4CDE 3233  5FCF B3D9 0475 26A3 D09E```
-
-Please note that the above key will not be used for signing releases.
-Please refer to your vendors instructions for verifying packages, images
-or source code.
-
 ## Security Notices
+
 Security notices will be sent to the kubevirt-dev@googlegroups.com
 mailing list and published to the
 [Security Advisories](https://github.com/kubevirt/kubevirt/security/advisories)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,3 +36,4 @@ supported by security teams of involved vendors.
 
 List of involved vendor security teams:
 - Red Hat <secalert@redhat.com>
+- SUSE <security@suse.de>


### PR DESCRIPTION
**What this PR does / why we need it**:

Clarifying how KubeVirt is supported by vendor security teams, removes the requirement for PGP encrypted vulnerability reporting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Removal of PGP encryption got discussed offlist.
While it is less confidential, it is removing friction on the reporter side, as well as on the maintainer side - this benefit is considered to be more beneficial (aka faster and lower burden for reporters) besides the increased security of an encrypted email.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
