### PR TITLE
Quarantine flaky test with external alpine-based kernel boot

### DIFF
--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -134,7 +134,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 			return vmi
 		}
 
-		It("ensure successful boot", func() {
+		It("[QUARANTINE] ensure successful boot", func() {
 			vmi := getVMIKernelBoot()
 
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

This test is causing impact to the sig-compute CI lanes due to flaky failures[1].

[1] https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-09-07-024h.html

The intermittent failure has been raised in the following issue:
https://github.com/kubevirt/kubevirt/issues/8423

Signed-off-by: Brian Carey <bcarey@redhat.com>


**Special notes for your reviewer**:
/cc @enp0s3  @xpivarc 

**Release note**:
```release-note
NONE
```
