### PR TITLE
Stop updating volume snapshot status on every reconcile

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -706,6 +706,9 @@ func (ctrl *VMSnapshotController) updateVolumeSnapshotStatuses(vm *kubevirtv1.Vi
 	}
 
 	vmCopy.Status.VolumeSnapshotStatuses = statuses
+	if equality.Semantic.DeepEqual(vmCopy.Status.VolumeSnapshotStatuses, vm.Status.VolumeSnapshotStatuses) {
+		return nil
+	}
 	return ctrl.vmStatusUpdater.UpdateStatus(vmCopy)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that the snapshot controller only updates the VM status when something changed.

Without this comparision, the snapshot controller is performing a REST operation after every trigger. This leads to the following behaviour:

 * Every VM modification leads to a rest call by the snapshot controller.
 * On ther periodic 5-minute reconcile by this controller a REST call is performed too.

This can easily be observed by watching this metric:

```
rest_client_request_latency_seconds_count{url="https://10.96.0.1:443/apis/kubevirt.io/v1alpha3/namespaces/%7Bnamespace%7D/virtualmachines/%7Bname%7D/status",verb="PUT"} 26
```

Even if the cluster is idle, the number of REST calls goes up by the number of existing VMs every 5 minutes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix shadow status updates and periodic status updates on VMs, performed by the snapshot controller
```
