### PR TITLE
instancetype: Add one final check for conflicts before creating CRs 

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -72,6 +72,11 @@ var _ = Describe("Instancetype and Preferences", func() {
 		instancetypeMethods = instancetype.NewMethods(virtClient)
 
 		vm = kubecli.NewMinimalVM("testvm")
+		vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{
+			Spec: v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{},
+			},
+		}
 		vm.Namespace = k8sv1.NamespaceDefault
 
 	})
@@ -230,6 +235,14 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("found existing ControllerRevision with unexpected data")))
 			})
 
+			It("store ControllerRevision fails if instancetype conflicts with vm", func() {
+				vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
+					Cores: 1,
+				}
+
+				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("VM field conflicts with selected Instancetype")))
+			})
+
 		})
 
 		Context("Using namespaced Instancetype", func() {
@@ -351,6 +364,14 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("found existing ControllerRevision with unexpected data")))
+			})
+
+			It("store ControllerRevision fails if instancetype conflicts with vm", func() {
+				vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{
+					Cores: 1,
+				}
+
+				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("VM field conflicts with selected Instancetype")))
 			})
 		})
 	})


### PR DESCRIPTION
/area instancetype
/cc @akrejcir
/cc @davidvossel

**What this PR does / why we need it**:

Even after moving the creation of the instancetype CRs earlier in the
reconcile loop of the virt-controller there remained a small window
where updates to an instancetype after the VM had been accepted by the
API could result in undetected conflicts with the VM later at runtime.

This change seeks to remove this window entirely by preforming one final
check for conflicts using the copy of the instancetype that will be
stored in the CR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is a follow up from https://github.com/kubevirt/kubevirt/pull/8346.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
