### PR TITLE
Create /usr/lib64/qemu-kvm with proper permissions

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -154,6 +154,18 @@ pkg_tar(
     package_dir = "/etc",
 )
 
+# Workaround for https://github.com/moby/moby/issues/44106
+# Need to create the directory upfront, otherwise it gets assigned wrong
+# permissions when unpacked.
+pkg_tar(
+    name = "qemu-kvm-modules-dir-tar",
+    empty_dirs = [
+        "usr/lib64/qemu-kvm",
+    ],
+    mode = "0755",
+    owner = "0.0",
+)
+
 container_image(
     name = "version-container",
     directory = "/",
@@ -163,12 +175,14 @@ container_image(
             ":libvirt-config",
             ":passwd-tar",
             ":nsswitch-tar",
+            ":qemu-kvm-modules-dir-tar",
             "//rpm:launcherbase_aarch64",
         ],
         "//conditions:default": [
             ":libvirt-config",
             ":passwd-tar",
             ":nsswitch-tar",
+            ":qemu-kvm-modules-dir-tar",
             "//rpm:launcherbase_x86_64",
         ],
     }),


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Workaround for https://github.com/moby/moby/issues/44106

Need to create the directory upfront, otherwise it gets assigned wrong permissions when unpacked.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8195, fixes #8362

**Special notes for your reviewer**:

The same directory with qemu modules is present in the aarch64 image. Applied the workaround there as well.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
