### PR TITLE
unit tests: disable string truncation in failed test output

### DIFF
--- a/staging/src/kubevirt.io/client-go/testutils/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/testutils/BUILD.bazel
@@ -11,5 +11,6 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2/reporters:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/format:go_default_library",
     ],
 )

--- a/staging/src/kubevirt.io/client-go/testutils/setup.go
+++ b/staging/src/kubevirt.io/client-go/testutils/setup.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/onsi/gomega/format"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/gomega"
@@ -38,6 +40,8 @@ func KubeVirtTestSuiteSetup(t *testing.T) {
 	outputFile := os.Getenv("XML_OUTPUT_FILE")
 
 	suiteConfig, _ := GinkgoConfiguration()
+	format.TruncatedDiff = false
+	format.MaxLength = 8192
 
 	// if run on bazel (XML_OUTPUT_FILE is not empty)
 	// and rules_go is configured to not produce the junit xml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR intends to make unit test results more explicit, and avoid nonsense like:
```
Expected
    <string>: "...r": 0,
        ..."
to equal               |
    <string>: "...r": 0
      }
    }..."
```
(see https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8344/pull-kubevirt-unit-test/1567932631205548032)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I'm open to suggestions for the maximum string length. 8192 seems like a good compromise to me.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
