### PR TITLE
Extend bazel sandbox to run commands

### DIFF
--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -64,6 +64,16 @@ build --sandbox_add_mount_pair=${sandbox_root}/lib64:/lib64
 build --sandbox_add_mount_pair=${sandbox_root}/lib:/lib
 build --sandbox_add_mount_pair=${sandbox_root}/bin:/bin
 
+run --sandbox_add_mount_pair=${sandbox_root}/usr/:/usr/
+run --sandbox_add_mount_pair=${sandbox_root}/lib64:/lib64
+run --sandbox_add_mount_pair=${sandbox_root}/lib:/lib
+run --sandbox_add_mount_pair=${sandbox_root}/bin:/bin
+
+coverage --sandbox_add_mount_pair=${sandbox_root}/usr/:/usr/
+coverage --sandbox_add_mount_pair=${sandbox_root}/lib64:/lib64
+coverage --sandbox_add_mount_pair=${sandbox_root}/lib:/lib
+coverage --sandbox_add_mount_pair=${sandbox_root}/bin:/bin
+
 build --incompatible_enable_cc_toolchain_resolution --platforms=//bazel/platforms:x86_64-none-linux-gnu
 EOT
 }


### PR DESCRIPTION
Previously container-runtime and build time shared library consistency was given in `.bazeldnf/sandbox.bazelrc` for `bazel build` and `bazel test` (since `test` in herits from `build`) commands

This can still lead to situations where `run` commands were building their tools inside the sandbox but then try to execute these binaries with the libc.so files from the node.

With the extension of the sandbox mounts to `run` this is not longer the case. Bazel will always see the same set of shared libraries.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
