### PR TITLE
Add break in validateEmulatedMachine

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -21,6 +21,7 @@ package admitters
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -1985,7 +1986,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				{Option: 240, Value: "sameextra.options.kubevirt.io"},
 			}
 			err := ValidateDuplicateDHCPPrivateOptions(testDHCPPrivateOptions)
-			Expect(err).To(Equal(fmt.Errorf("You have provided duplicate DHCPPrivateOptions")))
+			Expect(err).To(Equal(errors.New("you have provided duplicate DHCPPrivateOptions")))
 		})
 
 		It("should not return error if unique DHCPPrivateOptions", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -305,7 +305,7 @@ func filterKubevirtLabels(labels map[string]string) map[string]string {
 		return m
 	}
 	for label, value := range labels {
-		if _, ok := restriectedVmiLabels[label]; ok {
+		if _, ok := restrictedVmiLabels[label]; ok {
 			m[label] = value
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Xiaodong Ye <yeahdongcn@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add the missing `break` in `validateEmulatedMachine`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
1. Correct several typos
2. Remove unnecessary use of `fmt.Sprintf`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
