### PR TITLE
instancetype: Apply instancetype to copy of VM during admission

### DIFF
--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -101,8 +101,6 @@ func (s *vmSnapshotSource) Lock() (bool, error) {
 		return false, nil
 	}
 
-	log.Log.Infof("Adding VM snapshot finalizer to %s", s.vm.Name)
-
 	vmCopy := s.vm.DeepCopy()
 
 	if vmCopy.Status.SnapshotInProgress == nil {
@@ -114,6 +112,7 @@ func (s *vmSnapshotSource) Lock() (bool, error) {
 	}
 
 	if !controller.HasFinalizer(vmCopy, sourceFinalizer) {
+		log.Log.Infof("Adding VM snapshot finalizer to %s", s.vm.Name)
 		controller.AddFinalizer(vmCopy, sourceFinalizer)
 		_, err = s.controller.Client.VirtualMachine(vmCopy.Namespace).Update(vmCopy)
 		if err != nil {

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",


### PR DESCRIPTION
/area instancetype
/cc @akrejcir

**What this PR does / why we need it**:

Previously the VirtualMachine validation webhook would attempt to apply
any referenced instancetype and preferences to the provided
VirtualMachineInstanceSpec within the VirtualMachine before validating
the contents. Doing so however would cause calls to
validateSnapshotStatus to fail when a snapshot was in progress as the
now updated VirtualMachineInstanceSpec differed from the original. In
issue https://github.com/kubevirt/kubevirt/issues/8435 this left the Snapshot controller unable to update the
VirtualMachine with a required finalizer, blocking the progress of the
overall snapshot.

This PR corrects this by applying any referenced instancetype and
preferences to a copy of the VirtualMachine and using this updated copy
to validate the fully rendered VirtualMachineInstanceSpec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8435

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
