### PR TITLE
Start serving the device plugin API prior to registering with kubelet

### DIFF
--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -135,10 +135,6 @@ func (dpi *GenericDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	defer dpi.stopDevicePlugin()
 
 	pluginapi.RegisterDevicePluginServer(dpi.server, dpi)
-	err = dpi.register()
-	if err != nil {
-		return fmt.Errorf("error registering with device plugin manager: %v", err)
-	}
 
 	errChan := make(chan error, 2)
 
@@ -149,6 +145,11 @@ func (dpi *GenericDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	err = waitForGRPCServer(dpi.socketPath, connectionTimeout)
 	if err != nil {
 		return fmt.Errorf("error starting the GRPC server: %v", err)
+	}
+
+	err = dpi.register()
+	if err != nil {
+		return fmt.Errorf("error registering with device plugin manager: %v", err)
 	}
 
 	go func() {

--- a/pkg/virt-handler/device-manager/mediated_device.go
+++ b/pkg/virt-handler/device-manager/mediated_device.go
@@ -132,10 +132,6 @@ func (dpi *MediatedDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	defer dpi.stopDevicePlugin()
 
 	pluginapi.RegisterDevicePluginServer(dpi.server, dpi)
-	err = dpi.register()
-	if err != nil {
-		return fmt.Errorf("error registering with device plugin manager: %v", err)
-	}
 
 	errChan := make(chan error, 2)
 
@@ -146,6 +142,11 @@ func (dpi *MediatedDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	err = waitForGRPCServer(dpi.socketPath, connectionTimeout)
 	if err != nil {
 		return fmt.Errorf("error starting the GRPC server: %v", err)
+	}
+
+	err = dpi.register()
+	if err != nil {
+		return fmt.Errorf("error registering with device plugin manager: %v", err)
 	}
 
 	go func() {

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -132,10 +132,6 @@ func (dpi *PCIDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	defer dpi.stopDevicePlugin()
 
 	pluginapi.RegisterDevicePluginServer(dpi.server, dpi)
-	err = dpi.register()
-	if err != nil {
-		return fmt.Errorf("error registering with device plugin manager: %v", err)
-	}
 
 	errChan := make(chan error, 2)
 
@@ -146,6 +142,11 @@ func (dpi *PCIDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	err = waitForGRPCServer(dpi.socketPath, connectionTimeout)
 	if err != nil {
 		return fmt.Errorf("error starting the GRPC server: %v", err)
+	}
+
+	err = dpi.register()
+	if err != nil {
+		return fmt.Errorf("error registering with device plugin manager: %v", err)
 	}
 
 	go func() {


### PR DESCRIPTION
Signed-off-by: Christopher Desiniotis <cdesiniotis@nvidia.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is the recommended order when starting a device plugin. Additionally, this addresses issues seen on K8s 1.25. Without this change, all device plugins fail to start on K8s 1.25 and we see the following kubelet logs:

```
"Got registration request from device plugin with resource" resourceName="***" 
"Unable to connect to device plugin client with socket path" err="failed to dial device plugin: context deadline exceeded" path="/var/lib/kubelet/device-plugins/***.sock"
```

For an explanation on what changed in 1.25 concerning the device-plugin registration process, see the following: https://github.com/kubernetes/kubernetes/issues/112395.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @vladikr 