### PR TITLE
[release-0.53] [Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed

### DIFF
--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -19,8 +19,61 @@
 
 package types
 
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
 type PatchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
+	Value interface{} `json:"value"`
+}
+
+const (
+	PatchReplaceOp = "replace"
+	PatchTestOp    = "test"
+	PatchAddOp     = "add"
+	PatchRemoveOp  = "remove"
+)
+
+func GeneratePatchPayload(patches ...PatchOperation) ([]byte, error) {
+	if len(patches) == 0 {
+		return nil, fmt.Errorf("list of patches is empty")
+	}
+
+	payloadBytes, err := json.Marshal(patches)
+	if err != nil {
+		return nil, err
+	}
+
+	return payloadBytes, nil
+}
+
+func GenerateTestReplacePatch(path string, oldValue, newValue interface{}) ([]byte, error) {
+	return GeneratePatchPayload(
+		PatchOperation{
+			Op:    PatchTestOp,
+			Path:  path,
+			Value: oldValue,
+		},
+		PatchOperation{
+			Op:    PatchReplaceOp,
+			Path:  path,
+			Value: newValue,
+		},
+	)
+}
+
+func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
+	var p []PatchOperation
+	err := json.Unmarshal(patch, &p)
+
+	return p, err
+}
+
+func EscapeJSONPointer(ptr string) string {
+	s := strings.ReplaceAll(ptr, "~", "~0")
+	return strings.ReplaceAll(s, "/", "~1")
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -83,6 +83,17 @@ func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil
 }
 
+func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	domainFeatures := vmi.Spec.Domain.Features
+
+	return domainFeatures != nil && domainFeatures.Hyperv != nil && domainFeatures.Hyperv.Reenlightenment != nil &&
+		domainFeatures.Hyperv.Reenlightenment.Enabled != nil && *domainFeatures.Hyperv.Reenlightenment.Enabled
+}
+
 // WantVirtioNetDevice checks whether a VMI references at least one "virtio" network interface.
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/topology",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-controller/watch/topology/generated_mock_hinter.go
+++ b/pkg/virt-controller/watch/topology/generated_mock_hinter.go
@@ -30,25 +30,26 @@ func (_m *MockHinter) EXPECT() *_MockHinterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockHinter) TopologyHintsForVMI(vmi *v1.VirtualMachineInstance) (*v1.TopologyHints, error) {
+func (_m *MockHinter) TopologyHintsForVMI(vmi *v1.VirtualMachineInstance) (*v1.TopologyHints, TscFrequencyRequirementType, error) {
 	ret := _m.ctrl.Call(_m, "TopologyHintsForVMI", vmi)
 	ret0, _ := ret[0].(*v1.TopologyHints)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(TscFrequencyRequirementType)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockHinterRecorder) TopologyHintsForVMI(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyHintsForVMI", arg0)
 }
 
-func (_m *MockHinter) TopologyHintsRequiredForVMI(vmi *v1.VirtualMachineInstance) bool {
-	ret := _m.ctrl.Call(_m, "TopologyHintsRequiredForVMI", vmi)
+func (_m *MockHinter) IsTscFrequencyRequiredForBoot(vmi *v1.VirtualMachineInstance) bool {
+	ret := _m.ctrl.Call(_m, "IsTscFrequencyRequiredForBoot", vmi)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockHinterRecorder) TopologyHintsRequiredForVMI(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyHintsRequiredForVMI", arg0)
+func (_mr *_MockHinterRecorder) IsTscFrequencyRequiredForBoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTscFrequencyRequiredForBoot", arg0)
 }
 
 func (_m *MockHinter) TSCFrequenciesInUse() []int64 {

--- a/pkg/virt-controller/watch/topology/hinter_test.go
+++ b/pkg/virt-controller/watch/topology/hinter_test.go
@@ -52,9 +52,7 @@ var _ = Describe("Hinter", func() {
 			NodeWithTSC("node4", 12, false),
 		)
 		vmi := vmiWithTSCFrequencyOnNode("myvmi", 12, "oldnode")
-		g.Expect(hinter.TopologyHintsRequiredForVMI(
-			vmi),
-		).To(g.BeTrue())
+		g.Expect(GetTscFrequencyRequirement(vmi).Type).ToNot(g.Equal(NotRequired))
 		g.Expect(hinter.TopologyHintsForVMI(vmi)).To(g.Equal(
 			&virtv1.TopologyHints{
 				TSCFrequency: pointer.Int64Ptr(12),
@@ -80,10 +78,11 @@ var _ = Describe("Hinter", func() {
 		)
 		hinter.arch = arch
 		vmi := vmiWithoutTSCFrequency("myvmi")
-		g.Expect(hinter.TopologyHintsRequiredForVMI(
-			vmi),
-		).To(g.BeFalse())
-		g.Expect(hinter.TopologyHintsForVMI(vmi)).To(g.BeNil())
+		g.Expect(hinter.IsTscFrequencyRequiredForBoot(vmi)).To(g.BeFalse())
+
+		hints, _, err := hinter.TopologyHintsForVMI(vmi)
+		g.Expect(hints).To(g.BeNil())
+		g.Expect(err).To(g.Not(g.HaveOccurred()))
 	},
 		Entry("arm64", "arm64"),
 		Entry("ppc64le", "ppc64le"),

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -436,7 +436,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
 			if vmi.Status.TopologyHints == nil {
-				if topologyHints, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil {
+				if topologyHints, tscRequirement, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil && tscRequirement == topology.RequiredForBoot {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedGatherhingClusterTopologyHints, err.Error())
 					return &syncErrorImpl{err, FailedGatherhingClusterTopologyHints}
 				} else if topologyHints != nil {
@@ -1007,7 +1007,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 			return nil
 		}
 		// let's check if we already have topology hints or if we are still waiting for them
-		if vmi.Status.TopologyHints == nil && c.topologyHinter.TopologyHintsRequiredForVMI(vmi) {
+		if vmi.Status.TopologyHints == nil && c.topologyHinter.IsTscFrequencyRequiredForBoot(vmi) {
 			log.Log.V(3).Object(vmi).Infof("Delaying pod creation until topology hints are set")
 			return nil
 		}

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 
@@ -1303,6 +1305,10 @@ func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 
 	if util.IsSEVVMI(vmi) {
 		return newNonMigratableCondition("VMI uses SEV", v1.VirtualMachineInstanceReasonSEVNotMigratable), isBlockMigration
+	}
+
+	if tscRequirement := topology.GetTscFrequencyRequirement(vmi); !topology.AreTSCFrequencyTopologyHintsDefined(vmi) && tscRequirement.Type == topology.RequiredForMigration {
+		return newNonMigratableCondition(tscRequirement.Reason, v1.VirtualMachineInstanceReasonNoTSCFrequencyMigratable), isBlockMigration
 	}
 
 	return &v1.VirtualMachineInstanceCondition{

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2523,6 +2523,17 @@ var _ = Describe("VirtualMachineInstance", func() {
 			)
 		})
 
+		It("HyperV reenlightenment shouldn't be migratable when tsc frequency is missing", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Features = &v1.Features{Hyperv: &v1.FeatureHyperv{Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)}}}
+			vmi.Status.TopologyHints = nil
+
+			cond, _ := controller.calculateLiveMigrationCondition(vmi)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+			Expect(cond.Status).To(Equal(k8sv1.ConditionFalse))
+		})
+
 	})
 
 	Context("VirtualMachineInstance network status", func() {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -35,11 +35,11 @@ import (
 	"strings"
 	"syscall"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	"golang.org/x/sys/unix"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
-
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1696,17 +1696,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			}
 		}
 
-		// Make use of the tsc frequency topology hint
-		if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
-			freq := *vmi.Status.TopologyHints.TSCFrequency
-			clock := domain.Spec.Clock
-			if clock == nil {
-				clock = &api.Clock{}
-			}
-			clock.Timer = append(clock.Timer, api.Timer{Name: "tsc", Frequency: strconv.FormatInt(freq, 10)})
-			domain.Spec.Clock = clock
-		}
-
 		// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning
 		if vmi.IsCPUDedicated() {
 			err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, c.Topology, c.CPUSet, useIOThreads)
@@ -1714,6 +1703,17 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 				return err
 			}
 		}
+	}
+
+	// Make use of the tsc frequency topology hint
+	if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
+		freq := *vmi.Status.TopologyHints.TSCFrequency
+		clock := domain.Spec.Clock
+		if clock == nil {
+			clock = &api.Clock{}
+		}
+		clock.Timer = append(clock.Timer, api.Timer{Name: "tsc", Frequency: strconv.FormatInt(freq, 10)})
+		domain.Spec.Clock = clock
 	}
 
 	domain.Spec.Devices.HostDevices = append(domain.Spec.Devices.HostDevices, c.GenericHostDevices...)

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3242,6 +3242,80 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[1].Rom.Enabled).To(Equal("no"))
 		})
 	})
+
+	Context("when TSC Frequency", func() {
+		var (
+			vmi *v1.VirtualMachineInstance
+			c   *ConverterContext
+		)
+
+		const fakeFrequency = 12345
+
+		BeforeEach(func() {
+			vmi = kvapi.NewMinimalVMI("testvmi")
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: pointer.Int64(fakeFrequency)}
+			c = &ConverterContext{
+				AllowEmulation: true,
+			}
+		})
+
+		expectTsc := func(domain *api.Domain, expectExists bool) {
+			Expect(domain).ToNot(BeNil())
+			if !expectExists && domain.Spec.Clock == nil {
+				return
+			}
+
+			Expect(domain.Spec.Clock).ToNot(BeNil())
+
+			found := false
+			for _, timer := range domain.Spec.Clock.Timer {
+				if timer.Name == "tsc" {
+					actualFrequency, err := strconv.Atoi(timer.Frequency)
+					Expect(err).ToNot(HaveOccurred(), "frequency cannot be converted into a number")
+					Expect(actualFrequency).To(Equal(fakeFrequency), "set frequency is incorrect")
+
+					found = true
+					break
+				}
+			}
+
+			expectationStr := "exist"
+			if !expectExists {
+				expectationStr = "not " + expectationStr
+			}
+			Expect(found).To(Equal(expectExists), fmt.Sprintf("domain TSC frequency is expected to %s", expectationStr))
+		}
+
+		Context("is required because VMI is using", func() {
+			It("hyperV reenlightenment", func() {
+				vmi.Spec.Domain.Features = &v1.Features{
+					Hyperv: &v1.FeatureHyperv{
+						Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+					},
+				}
+
+				domain := vmiToDomain(vmi, c)
+				expectTsc(domain, true)
+			})
+
+			It("invtsc CPU feature", func() {
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Features: []v1.CPUFeature{
+						{Name: "invtsc", Policy: "require"},
+					},
+				}
+
+				domain := vmiToDomain(vmi, c)
+				expectTsc(domain, true)
+			})
+		})
+
+		It("is not required", func() {
+			domain := vmiToDomain(vmi, c)
+			expectTsc(domain, false)
+		})
+	})
 })
 
 var _ = Describe("disk device naming", func() {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -445,6 +445,8 @@ const (
 	VirtualMachineInstanceReasonHostDeviceNotMigratable = "HostDeviceNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it uses Secure Encrypted Virtualization (SEV)
 	VirtualMachineInstanceReasonSEVNotMigratable = "SEVNotLiveMigratable"
+	// Reason means that VMI is not live migratable because it uses HyperV Reenlightenment while TSC Frequency is not available
+	VirtualMachineInstanceReasonNoTSCFrequencyMigratable = "NoTSCFrequencyNotLiveMigratable"
 )
 
 const (

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -182,6 +182,7 @@ go_test(
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/dns:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -30,11 +30,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 
 	utiltype "kubevirt.io/kubevirt/pkg/util/types"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/libstorage"
+
+	"k8s.io/utils/pointer"
+
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/tests/libnode"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-
-	"kubevirt.io/kubevirt/tests/framework/checks"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -51,7 +55,6 @@ import (
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet"
-	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/util"
 )
@@ -372,6 +375,10 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 			return node
 		}
 
+		BeforeEach(func() {
+			windowsVMI.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+		})
+
 		When("TSC frequency is exposed on the cluster", func() {
 			It("should be able to migrate", func() {
 				if !isTSCFrequencyExposed(virtClient) {
@@ -390,6 +397,75 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 
 				By("Checking VMI, confirm migration state")
 				tests.ConfirmVMIPostMigration(virtClient, windowsVMI, migrationUID)
+			})
+		})
+
+		When("TSC frequency is not exposed on the cluster", func() {
+
+			BeforeEach(func() {
+				if isTSCFrequencyExposed(virtClient) {
+					nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					for _, node := range nodeList.Items {
+						stopNodeLabeller(node.Name, virtClient)
+						removeTSCFrequencyFromNode(node)
+					}
+				}
+			})
+
+			AfterEach(func() {
+				nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, node := range nodeList.Items {
+					_, isNodeLabellerStopped := node.Annotations[v1.LabellerSkipNodeAnnotation]
+					Expect(isNodeLabellerStopped).To(BeTrue())
+
+					updatedNode := resumeNodeLabeller(node.Name, virtClient)
+					_, isNodeLabellerStopped = updatedNode.Annotations[v1.LabellerSkipNodeAnnotation]
+					Expect(isNodeLabellerStopped).To(BeFalse(), "after node labeller is resumed, %s annotation is expected to disappear from node", v1.LabellerSkipNodeAnnotation)
+				}
+			})
+
+			It("should be able to start successfully", func() {
+				var err error
+				By("Creating a windows VM")
+				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+				winrnLoginCommand(virtClient, windowsVMI)
+			})
+
+			It("should be marked as non-migratable", func() {
+				var err error
+				By("Creating a windows VM")
+				windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(windowsVMI)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 360)
+
+				conditionManager := controller.NewVirtualMachineInstanceConditionManager()
+				isNonMigratable := func() error {
+					windowsVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(windowsVMI.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					cond := conditionManager.GetCondition(windowsVMI, v1.VirtualMachineInstanceIsMigratable)
+					const errFmt = "condition " + string(v1.VirtualMachineInstanceIsMigratable) + " is expected to be %s %s"
+
+					if statusFalse := k8sv1.ConditionFalse; cond.Status != statusFalse {
+						return fmt.Errorf(errFmt, "of status", string(statusFalse))
+					}
+					if notMigratableNoTscReason := v1.VirtualMachineInstanceReasonNoTSCFrequencyMigratable; cond.Reason != notMigratableNoTscReason {
+						return fmt.Errorf(errFmt, "of reason", notMigratableNoTscReason)
+					}
+					if !strings.Contains(cond.Message, "HyperV Reenlightenment") {
+						return fmt.Errorf(errFmt, "with message that contains", "HyperV Reenlightenment")
+					}
+					return nil
+				}
+
+				Eventually(isNonMigratable, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+				Consistently(isNonMigratable, 15*time.Second, 3*time.Second).ShouldNot(HaveOccurred())
 			})
 		})
 	})
@@ -665,4 +741,14 @@ func isTSCFrequencyExposed(virtClient kubecli.KubevirtClient) bool {
 	}
 
 	return false
+}
+
+func removeTSCFrequencyFromNode(node k8sv1.Node) {
+	for _, baseLabelToRemove := range []string{topology.TSCFrequencyLabel, topology.TSCFrequencySchedulingLabel} {
+		for key, _ := range node.Labels {
+			if strings.HasPrefix(key, baseLabelToRemove) {
+				libnode.RemoveLabelFromNode(node.Name, key)
+			}
+		}
+	}
 }

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -21,10 +21,16 @@ package tests_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	utiltype "kubevirt.io/kubevirt/pkg/util/types"
+	"kubevirt.io/kubevirt/tests/libnode"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
@@ -161,6 +167,211 @@ var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
 	})
 
 	Context("VMI with HyperV reenlightenment enabled", func() {
+
+		type mapType string
+
+		const (
+			label      mapType = "label"
+			annotation mapType = "annotation"
+		)
+
+		type mapAction string
+
+		const (
+			add    mapAction = "add"
+			remove mapAction = "remove"
+		)
+
+		patchLabelAnnotationHelper := func(virtCli kubecli.KubevirtClient, nodeName string, newMap, oldMap map[string]string, mapType mapType) (*k8sv1.Node, error) {
+			p := []utiltype.PatchOperation{
+				{
+					Op:    "test",
+					Path:  "/metadata/" + string(mapType) + "s",
+					Value: oldMap,
+				},
+				{
+					Op:    "replace",
+					Path:  "/metadata/" + string(mapType) + "s",
+					Value: newMap,
+				},
+			}
+
+			patchBytes, err := json.Marshal(p)
+			Expect(err).ToNot(HaveOccurred())
+
+			patchedNode, err := virtCli.CoreV1().Nodes().Patch(context.Background(), nodeName, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+			return patchedNode, err
+		}
+
+		// Adds or removes a label or annotation from a node. When removing a label/annotation, the "value" parameter
+		// is ignored.
+		addRemoveLabelAnnotationHelper := func(nodeName, key, value string, mapType mapType, mapAction mapAction) *k8sv1.Node {
+			var fetchMap func(node *k8sv1.Node) map[string]string
+			var mutateMap func(key, val string, m map[string]string) map[string]string
+
+			switch mapType {
+			case label:
+				fetchMap = func(node *k8sv1.Node) map[string]string { return node.Labels }
+			case annotation:
+				fetchMap = func(node *k8sv1.Node) map[string]string { return node.Annotations }
+			}
+
+			switch mapAction {
+			case add:
+				mutateMap = func(key, val string, m map[string]string) map[string]string {
+					m[key] = val
+					return m
+				}
+			case remove:
+				mutateMap = func(key, val string, m map[string]string) map[string]string {
+					delete(m, key)
+					return m
+				}
+			}
+
+			Expect(fetchMap).ToNot(BeNil())
+			Expect(mutateMap).ToNot(BeNil())
+
+			virtCli, err := kubecli.GetKubevirtClient()
+			Expect(err).ToNot(HaveOccurred())
+
+			var nodeToReturn *k8sv1.Node
+			EventuallyWithOffset(2, func() error {
+				origNode, err := virtCli.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				originalMap := fetchMap(origNode)
+				expectedMap := make(map[string]string, len(originalMap))
+				for k, v := range originalMap {
+					expectedMap[k] = v
+				}
+
+				expectedMap = mutateMap(key, value, expectedMap)
+
+				if equality.Semantic.DeepEqual(originalMap, expectedMap) {
+					// key and value already exist in node
+					nodeToReturn = origNode
+					return nil
+				}
+
+				patchedNode, err := patchLabelAnnotationHelper(virtCli, nodeName, expectedMap, originalMap, mapType)
+				if err != nil {
+					return err
+				}
+
+				resultMap := fetchMap(patchedNode)
+
+				const errPattern = "adding %s (key: %s. value: %s) to node %s failed. Expected %ss: %v, actual: %v"
+				if !equality.Semantic.DeepEqual(resultMap, expectedMap) {
+					return fmt.Errorf(errPattern, string(mapType), key, value, nodeName, string(mapType), expectedMap, resultMap)
+				}
+
+				nodeToReturn = patchedNode
+				return nil
+			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+			return nodeToReturn
+		}
+
+		addAnnotationToNode := func(nodeName, key, value string) *k8sv1.Node {
+			return addRemoveLabelAnnotationHelper(nodeName, key, value, annotation, add)
+		}
+
+		removeAnnotationFromNode := func(nodeName string, key string) *k8sv1.Node {
+			return addRemoveLabelAnnotationHelper(nodeName, key, "", annotation, remove)
+		}
+
+		wakeNodeLabellerUp := func(virtClient kubecli.KubevirtClient) {
+			const fakeModel = "fake-model-1423"
+
+			By("Updating Kubevirt CR to wake node-labeller up")
+			kvConfig := util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
+			if kvConfig.ObsoleteCPUModels == nil {
+				kvConfig.ObsoleteCPUModels = make(map[string]bool)
+			}
+			kvConfig.ObsoleteCPUModels[fakeModel] = true
+			tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+			delete(kvConfig.ObsoleteCPUModels, fakeModel)
+			tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
+		}
+
+		stopNodeLabeller := func(nodeName string, virtClient kubecli.KubevirtClient) *k8sv1.Node {
+			var err error
+			var node *k8sv1.Node
+
+			suiteConfig, _ := GinkgoConfiguration()
+			Expect(suiteConfig.ParallelTotal).To(Equal(1), "stopping / resuming node-labeller is supported for serial tests only")
+
+			By(fmt.Sprintf("Patching node to %s include %s label", nodeName, v1.LabellerSkipNodeAnnotation))
+			key, value := v1.LabellerSkipNodeAnnotation, "true"
+			addAnnotationToNode(nodeName, key, value)
+
+			By(fmt.Sprintf("Expecting node %s to include %s label", nodeName, v1.LabellerSkipNodeAnnotation))
+			Eventually(func() bool {
+				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				value, exists := node.Annotations[v1.LabellerSkipNodeAnnotation]
+				return exists && value == "true"
+			}, 30*time.Second, time.Second).Should(BeTrue(), fmt.Sprintf("node %s is expected to have annotation %s", nodeName, v1.LabellerSkipNodeAnnotation))
+
+			return node
+		}
+
+		resumeNodeLabeller := func(nodeName string, virtClient kubecli.KubevirtClient) *k8sv1.Node {
+			var err error
+			var node *k8sv1.Node
+
+			node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			if _, isNodeLabellerStopped := node.Annotations[v1.LabellerSkipNodeAnnotation]; !isNodeLabellerStopped {
+				// Nothing left to do
+				return node
+			}
+
+			By(fmt.Sprintf("Patching node to %s not include %s annotation", nodeName, v1.LabellerSkipNodeAnnotation))
+			removeAnnotationFromNode(nodeName, v1.LabellerSkipNodeAnnotation)
+
+			// In order to make sure node-labeller has updated the node, the host-model label (which node-labeller
+			// makes sure always resides on any node) will be removed. After node-labeller is enabled again, the
+			// host model label would be expected to show up again on the node.
+			By(fmt.Sprintf("Removing host model label %s from node %s (so we can later expect it to return)", v1.HostModelCPULabel, nodeName))
+			for _, label := range node.Labels {
+				if strings.HasPrefix(label, v1.HostModelCPULabel) {
+					libnode.RemoveLabelFromNode(nodeName, label)
+				}
+			}
+
+			wakeNodeLabellerUp(virtClient)
+
+			By(fmt.Sprintf("Expecting node %s to not include %s annotation", nodeName, v1.LabellerSkipNodeAnnotation))
+			Eventually(func() error {
+				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				_, exists := node.Annotations[v1.LabellerSkipNodeAnnotation]
+				if exists {
+					return fmt.Errorf("node %s is expected to not have annotation %s", node.Name, v1.LabellerSkipNodeAnnotation)
+				}
+
+				foundHostModelLabel := false
+				for labelKey := range node.Labels {
+					if strings.HasPrefix(labelKey, v1.HostModelCPULabel) {
+						foundHostModelLabel = true
+						break
+					}
+				}
+				if !foundHostModelLabel {
+					return fmt.Errorf("node %s is expected to have a label with %s prefix. this means node-labeller is not enabled for the node", nodeName, v1.HostModelCPULabel)
+				}
+
+				return nil
+			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+
+			return node
+		}
+
 		When("TSC frequency is exposed on the cluster", func() {
 			It("should be able to migrate", func() {
 				if !isTSCFrequencyExposed(virtClient) {


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/8359

**Reason for manual cherry-pick**
The main conflict was with node labeller test helper functions that did not exist in this release. Therefore, in commit https://github.com/kubevirt/kubevirt/pull/8452/commits/76bb414f43a4f3f6d2de13fa73e1780a3b4f3884 I've added them into the test's local scope. Aside from that, nothing significant is changed.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2125985

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bugfix]: HyperV Reenlightenment VMIs should be able to start when TSC Frequency is not exposed
```
