### PR TITLE
Quarantine test 7748 due to large number of flaky failures

### DIFF
--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -55,7 +55,7 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 	})
 
 	Context("with external alpine-based kernel & initrd images", func() {
-		It("[test_id:7748]ensure successful boot", func() {
+		It("[test_id:7748][QUARANTINE]ensure successful boot", func() {
 			vmi := utils.GetVMIKernelBoot()
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Brian Carey <bcarey@redhat.com>

**What this PR does / why we need it**:

A large number of failures[1] have been seen in the following test: 
```
[sig-compute]VMI with external kernel boot with external alpine-based kernel & initrd images [test_id:7748]ensure successful boot
```
These flaky failures are causing impact to CI and the number of retests that are required.

A similar test was quarantined in https://github.com/kubevirt/kubevirt/pull/8428

[1] https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-09-12-168h.html#row0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @iholder-redhat @xpivarc 
**Release note**:
```release-note
NONE
```
