### PR TITLE
Use the containerdisk image name from the VMI spec

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -384,11 +384,11 @@ func ExtractImageIDsFromSourcePod(vmi *v1.VirtualMachineInstance, sourcePod *kub
 		if volume.ContainerDisk == nil {
 			continue
 		}
-		imageIDs[volume.Name] = ""
+		imageIDs[volume.Name] = volume.ContainerDisk.Image
 	}
 
 	if util.HasKernelBootContainerImage(vmi) {
-		imageIDs[KernelBootVolumeName] = ""
+		imageIDs[KernelBootVolumeName] = vmi.Spec.Domain.Firmware.KernelBoot.Container.Image
 	}
 
 	for _, status := range sourcePod.Status.ContainerStatuses {
@@ -396,10 +396,11 @@ func ExtractImageIDsFromSourcePod(vmi *v1.VirtualMachineInstance, sourcePod *kub
 			continue
 		}
 		key := toVolumeName(status.Name)
-		if _, exists := imageIDs[key]; !exists {
+		image, exists := imageIDs[key]
+		if !exists {
 			continue
 		}
-		imageID, err := toImageWithDigest(status.Image, status.ImageID)
+		imageID, err := toImageWithDigest(image, status.ImageID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

It appears that `ContainerStatuses[].Image` from the Pod spec cannot be used to reliably identify the name of the containerdisk image. E.g. while testing the bellow containerdisk:
```
    quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.57.0
```
it was observed with `containerd` that `ContainerStatuses[].Image` may contain either an internal image ID in the form of:
```
    sha256:e3559e53b6b1df866598887793f94b9908d3a7e343f4a6394670d69fbe511cb2
```
or the image can be resolved to an alias:
```
    192.168.122.1:5000/fedora-with-test-tooling-container-disk@sha256:30750fe1f8936e21890a4e45289ec3afdbcae3d9072ec7d7629ec20f4afbd00e
```
This eventually breaks live migration, as such references cannot be resolved on the target node.

To solve the issue, the final pullable reference is now composed using the base image name from the VMI spec and the unique SHA digest is taken from `ContainerStatuses[].ImageID` of the Pod spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8471

**Special notes for your reviewer**:

More context here: https://github.com/kubevirt/kubevirt/issues/8471#issuecomment-1247938485

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed migration failure of VMs with containerdisks on systems with containerd
```
