### PR TITLE
Allow setting virt-operator log verbosity through Kubevirt CR

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -301,6 +301,15 @@ func (c *ClusterConfig) GetVirtControllerVerbosity(nodeName string) uint {
 	return logConf.VirtController
 }
 
+func (c *ClusterConfig) GetVirtOperatorVerbosity(nodeName string) uint {
+	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
+	if level := logConf.NodeVerbosity[nodeName]; level != 0 {
+		return level
+	}
+	return logConf.VirtOperator
+}
+
+
 func (c *ClusterConfig) GetVirtLauncherVerbosity() uint {
 	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
 	return logConf.VirtLauncher

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -26,6 +26,8 @@ package virtconfig
 import (
 	"fmt"
 
+	"kubevirt.io/client-go/log"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -277,42 +279,61 @@ func (c *ClusterConfig) GetDesiredMDEVTypes(node *k8sv1.Node) []string {
 	return mdevTypesConf.MediatedDevicesTypes
 }
 
-func (c *ClusterConfig) GetVirtHandlerVerbosity(nodeName string) uint {
+type virtComponent int
+
+const (
+	virtHandler virtComponent = iota
+	virtApi
+	virtController
+	virtOperator
+	virtLauncher
+)
+
+// Gets the component verbosity. nodeName can be empty, then it's ignored.
+func (c *ClusterConfig) getComponentVerbosity(component virtComponent, nodeName string) uint {
 	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
-	if level := logConf.NodeVerbosity[nodeName]; level != 0 {
-		return level
+
+	if nodeName != "" {
+		if level := logConf.NodeVerbosity[nodeName]; level != 0 {
+			return level
+		}
 	}
-	return logConf.VirtHandler
+
+	switch component {
+	case virtHandler:
+		return logConf.VirtHandler
+	case virtApi:
+		return logConf.VirtAPI
+	case virtController:
+		return logConf.VirtController
+	case virtOperator:
+		return logConf.VirtOperator
+	case virtLauncher:
+		return logConf.VirtLauncher
+	default:
+		log.Log.Errorf("getComponentVerbosity called with an unknown virtComponent: %v", component)
+		return 0
+	}
+}
+
+func (c *ClusterConfig) GetVirtHandlerVerbosity(nodeName string) uint {
+	return c.getComponentVerbosity(virtHandler, nodeName)
 }
 
 func (c *ClusterConfig) GetVirtAPIVerbosity(nodeName string) uint {
-	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
-	if level := logConf.NodeVerbosity[nodeName]; level != 0 {
-		return level
-	}
-	return logConf.VirtAPI
+	return c.getComponentVerbosity(virtApi, nodeName)
 }
 
 func (c *ClusterConfig) GetVirtControllerVerbosity(nodeName string) uint {
-	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
-	if level := logConf.NodeVerbosity[nodeName]; level != 0 {
-		return level
-	}
-	return logConf.VirtController
+	return c.getComponentVerbosity(virtController, nodeName)
 }
 
 func (c *ClusterConfig) GetVirtOperatorVerbosity(nodeName string) uint {
-	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
-	if level := logConf.NodeVerbosity[nodeName]; level != 0 {
-		return level
-	}
-	return logConf.VirtOperator
+	return c.getComponentVerbosity(virtOperator, nodeName)
 }
 
-
 func (c *ClusterConfig) GetVirtLauncherVerbosity() uint {
-	logConf := c.GetConfig().DeveloperConfiguration.LogVerbosity
-	return logConf.VirtLauncher
+	return c.getComponentVerbosity(virtLauncher, "")
 }
 
 //GetMinCPUModel return minimal cpu which is used in node-labeller


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now it wasn't possible to set virt-operator's verbosity. In fact, for all other components it's possible to set verbosity level through [log verbosity](https://kubevirt.io/api-reference/master/definitions.html#_v1_logverbosity) configurations in Kubevirt CR, but for some reason virt-operator did not support this, although a `virtOperator` configuration spec field existed, but as a no-op.

I also made a small refactoring in virt-api so that the logic of getting a component's verbosity level isn't duplicated for each and every component.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2105257

**Special notes for your reviewer**:
I didn't include any functional tests, since I saw those didn't exist for any log verbosity logic (perhaps since they're a bit tricky to test, although it's possible).

I did, of course, check manually that the behavior works as expected. I've changed virtOperator's direct verbosity to 3:
```bash
$> k -n kubevirt logs virt-operator-56fcc789bb-7726v | grep "set log verbosity"
{"component":"virt-operator","level":"info","msg":"set log verbosity to 3"}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow setting virt-operator log verbosity through Kubevirt CR
```
