### PR TITLE
Allow using custom hostname via cloud-init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	google.golang.org/grpc v1.40.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.5
 	k8s.io/apiextensions-apiserver v0.23.5
 	k8s.io/apimachinery v0.23.5
@@ -153,7 +154,6 @@ require (
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157 // indirect
 	sigs.k8s.io/controller-runtime v0.8.3 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -27,10 +27,13 @@ go_test(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
     ],
 )

--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
+        "//vendor/gopkg.in/yaml.v3:go_default_library",
     ],
 )
 

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -31,6 +31,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
+
 	"github.com/pborman/uuid"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -39,7 +41,6 @@ import (
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
 )
 
 const isoStagingFmt = "%s.staging"
@@ -106,6 +107,12 @@ type DeviceData struct {
 	NumaNode    uint32             `json:"numaNode,omitempty"`
 	AlignedCPUs []uint32           `json:"alignedCPUs,omitempty"`
 	Tags        []string           `json:"tags"`
+}
+
+type UserData struct {
+	// UserData contains more fields that aren't needed for unmarshalling. If more are needed
+	// in the future, they can be added here.
+	Hostname string `json:"hostname"`
 }
 
 // IsValidCloudInitData checks if the given CloudInitData object is valid in the sense that GenerateLocalData can be called with it.

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -89,6 +89,8 @@ var _ = Describe("Manager", func() {
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
 	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
 
+	const fakeUserData = "#fake user data"
+
 	BeforeEach(func() {
 		testVirtShareDir = fmt.Sprintf("fake-virt-share-%d", GinkgoRandomSeed())
 		testEphemeralDiskDir = fmt.Sprintf("fake-ephemeral-disk-%d", GinkgoRandomSeed())
@@ -175,9 +177,8 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 
-			userData := "fake\nuser\ndata\n"
 			networkData := ""
-			addCloudInitDisk(vmi, userData, networkData)
+			addCloudInitDisk(vmi, fakeUserData, networkData)
 			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
@@ -195,9 +196,8 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			userData := "fake\nuser\ndata\n"
 			networkData := "FakeNetwork"
-			addCloudInitDisk(vmi, userData, networkData)
+			addCloudInitDisk(vmi, fakeUserData, networkData)
 			domainSpec := expectedDomainFor(vmi)
 			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
@@ -1612,9 +1612,8 @@ var _ = Describe("Manager", func() {
 				MigrationUID: "111222333",
 			}
 
-			userData := "fake\nuser\ndata\n"
 			networkData := "FakeNetwork"
-			addCloudInitDisk(vmi, userData, networkData)
+			addCloudInitDisk(vmi, fakeUserData, networkData)
 			domainSpec := expectedDomainFor(vmi)
 			domainSpec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{}
 
@@ -1765,9 +1764,8 @@ var _ = Describe("Manager", func() {
 					},
 				},
 			}
-			userData := "fake\nuser\ndata\n"
 			networkData := "FakeNetwork"
-			addCloudInitDisk(vmi, userData, networkData)
+			addCloudInitDisk(vmi, fakeUserData, networkData)
 
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(convertedDomain), nil)
 
@@ -2115,9 +2113,8 @@ var _ = Describe("Manager", func() {
 			Size: 42,
 		}
 
-		userData := "fake\nuser\ndata\n"
 		networkData := "FakeNetwork"
-		addCloudInitDisk(vmi, userData, networkData)
+		addCloudInitDisk(vmi, fakeUserData, networkData)
 		libvirtmanager.cloudInitDataStore = &cloudinit.CloudInitData{
 			DataSource: cloudinit.DataSourceNoCloud,
 			VolumeName: "test1",
@@ -2151,9 +2148,8 @@ var _ = Describe("Manager", func() {
 		vmi := newVMI(testNamespace, testVmName)
 		vmi.Status.VolumeStatus = make([]v1.VolumeStatus, 1)
 
-		userData := "fake\nuser\ndata\n"
 		networkData := "FakeNetwork"
-		addCloudInitDisk(vmi, userData, networkData)
+		addCloudInitDisk(vmi, fakeUserData, networkData)
 		libvirtmanager.cloudInitDataStore = &cloudinit.CloudInitData{
 			DataSource: cloudinit.DataSourceNoCloud,
 			VolumeName: "test1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, defining a custom hostname via cloud-init is a no-op.
This PR aims to fix that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2092198

**Special notes for your reviewer**:
In order to being able to test this, I needed to make a small refactoring to our login functions.
For more info please look at the commit (https://github.com/kubevirt/kubevirt/pull/8483/commits/768bd05f847bb83301b4b016520726403c8696ac) message.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow using custom hostname via cloud-init
```
