### PR TITLE
Clean redundant condition in virtwrap converter

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -863,9 +863,6 @@ func Convert_v1_EphemeralVolumeSource_To_api_Disk(volumeName string, disk *api.D
 		Format: &api.BackingStoreFormat{},
 		Source: &api.DiskSource{},
 	}
-	if !contains(c.VolumesDiscardIgnore, volumeName) {
-		disk.Driver.Discard = "unmap"
-	}
 
 	backingDisk := &api.Disk{Driver: &api.DiskDriver{}}
 	if c.IsBlockPVC[volumeName] {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

## **What this PR does / why we need it**
Some volumes allow enabling the `discard=unmap` option to free space when the underlying storage supports the trim operation. This option is enabled by default in volumes that meet certain requirements.

This Pull Request updates the converter code, so we remove an unnecessary condition after `discard=unmap` has already been set in ephemeral volumes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
