### PR TITLE
virtctl: Be less verbose when forwarding in stdio mode

### DIFF
--- a/pkg/virtctl/portforward/portforward.go
+++ b/pkg/virtctl/portforward/portforward.go
@@ -158,7 +158,7 @@ func (o *PortForward) startStdoutStream(namespace, name string, port forwardedPo
 		return err
 	}
 
-	glog.Infof("forwarding to %s/%s:%d", namespace, name, port.remote)
+	glog.V(3).Infof("forwarding to %s/%s:%d", namespace, name, port.remote)
 	if err := streamer.Stream(kubecli.StreamOptions{
 		In:  os.Stdin,
 		Out: os.Stdout,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This changes the verbosity of the port-forwarding destination in stdio mode to 3 so it is no logged by default.

**Special notes for your reviewer**:

In combination with https://github.com/kubevirt/kubevirt/pull/8326 the log output of `virtctl ssh` is now the same for the native and the wrapped ssh client.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: Be less verbose when using the local ssh client
```
