### PR TITLE
[e2e tests]: Use FIPS compliant cipher in crypto cfg tests

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -379,7 +379,11 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				Skip(fmt.Sprintf("Cluster has the %s featuregate disabled, skipping  the tests", virtconfig.VMExportGate))
 			}
 
-			cipher = tls.CipherSuites()[0]
+			// FIPS-compliant so we can test on different platforms (otherwise won't revert properly)
+			cipher = &tls.CipherSuite{
+				ID:   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				Name: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			}
 			kvConfig := util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
 			kvConfig.TLSConfiguration = &v1.TLSConfiguration{
 				MinTLSVersion: v1.VersionTLS12,


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Testing on FIPS-compliant clusters might fail miserably because the cipher we pick for testing purposes is not FIPS-friendly.
https://wiki.openssl.org/index.php/FIPS_mode_and_TLS

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
It seems the failure would occur on the top level afterEach so can't even clean up the cipher field,
potentially messing up an entire test suite

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
