### PR TITLE
Simplify handling of cluster URIs from kubeconfig

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
@@ -21,7 +21,6 @@ package kubecli
 
 import (
 	"context"
-	"path"
 
 	"encoding/json"
 	"fmt"
@@ -41,27 +40,20 @@ type GuestfsInfo struct {
 func (k *kubevirt) GuestfsVersion() *GuestfsVersion {
 	return &GuestfsVersion{
 		restClient: k.restClient,
-		config:     k.config,
 		resource:   "guestfs",
 	}
 }
 
 type GuestfsVersion struct {
 	restClient *rest.RESTClient
-	config     *rest.Config
 	resource   string
 }
 
 func (v *GuestfsVersion) Get() (*GuestfsInfo, error) {
 	var group metav1.APIGroup
 	// First, find out which version to query
-	u, err := url.Parse(v.config.Host)
-	if err != nil {
-		return nil, err
-	}
-	uri := path.Join(u.Path, ApiGroupName)
-
-	result := v.restClient.Get().RequestURI(uri).Do(context.Background())
+	uri := ApiGroupName
+	result := v.restClient.Get().AbsPath(uri).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
 
@@ -75,11 +67,10 @@ func (v *GuestfsVersion) Get() (*GuestfsInfo, error) {
 	}
 
 	// Now, query the preferred version
-	uri = fmt.Sprintf("%s/apis/%s/guestfs", u.Path, group.PreferredVersion.GroupVersion)
-
+	uri = fmt.Sprintf("/apis/%s/guestfs", group.PreferredVersion.GroupVersion)
 	var info GuestfsInfo
 
-	result = v.restClient.Get().RequestURI(uri).Do(context.Background())
+	result = v.restClient.Get().AbsPath(uri).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
 

--- a/staging/src/kubevirt.io/client-go/kubecli/instancetype.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/instancetype.go
@@ -23,7 +23,7 @@ func (e *ExpandSpec) ForVirtualMachine(vm *v1.VirtualMachine) (*v1.VirtualMachin
 	uri := fmt.Sprintf("/apis/"+v1.SubresourceGroupName+"/%s/expand-spec", v1.ApiStorageVersion)
 	expandedVm := &v1.VirtualMachine{}
 	err := e.restClient.Put().
-		RequestURI(uri).
+		AbsPath(uri).
 		Body(vm).
 		Do(context.Background()).
 		Into(expandedVm)

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -34,23 +34,22 @@ import (
 )
 
 var _ = Describe("Kubevirt Client", func() {
-
 	var server *ghttp.Server
-	var client KubevirtClient
 	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/kubevirts"
 	kubevirtPath := path.Join(basePath, "testkubevirt")
+	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
-		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
-		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should fetch a KubeVirt", func() {
+	DescribeTable("should fetch a KubeVirt", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		kubevirt := NewMinimalKubeVirt("testkubevirt")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", kubevirtPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
 		fetchedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
@@ -58,24 +57,36 @@ var _ = Describe("Kubevirt Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedKubeVirt).To(Equal(kubevirt))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should detect non existent KubeVirts", func() {
+	DescribeTable("should detect non existent KubeVirts", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", kubevirtPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testkubevirt")),
 		))
-		_, err := client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
+		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Get("testkubevirt", &k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch a KubeVirt list", func() {
+	DescribeTable("should fetch a KubeVirt list", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		kubevirt := NewMinimalKubeVirt("testkubevirt")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", basePath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewKubeVirtList(*kubevirt)),
 		))
 		fetchedKubeVirtList, err := client.KubeVirt(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
@@ -84,12 +95,18 @@ var _ = Describe("Kubevirt Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedKubeVirtList.Items).To(HaveLen(1))
 		Expect(fetchedKubeVirtList.Items[0]).To(Equal(*kubevirt))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should create a KubeVirt", func() {
+	DescribeTable("should create a KubeVirt", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		kubevirt := NewMinimalKubeVirt("testkubevirt")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("POST", basePath),
+			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, kubevirt),
 		))
 		createdKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Create(kubevirt)
@@ -97,12 +114,18 @@ var _ = Describe("Kubevirt Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdKubeVirt).To(Equal(kubevirt))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should update a KubeVirt", func() {
+	DescribeTable("should update a KubeVirt", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		kubevirt := NewMinimalKubeVirt("testkubevirt")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", kubevirtPath),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
 		updatedKubeVirt, err := client.KubeVirt(k8sv1.NamespaceDefault).Update(kubevirt)
@@ -110,35 +133,50 @@ var _ = Describe("Kubevirt Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedKubeVirt).To(Equal(kubevirt))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should patch a KubeVirt", func() {
+	DescribeTable("should patch a KubeVirt", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		kubevirt := NewMinimalKubeVirt("testkubevirt")
 		kubevirt.Spec.ImagePullPolicy = "somethingelse"
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PATCH", kubevirtPath),
+			ghttp.VerifyRequest("PATCH", path.Join(proxyPath, kubevirtPath)),
 			ghttp.VerifyBody([]byte("{\"spec\":{\"imagePullPolicy\":something}}")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, kubevirt),
 		))
 
-		_, err := client.KubeVirt(k8sv1.NamespaceDefault).Patch(kubevirt.Name, types.MergePatchType,
+		_, err = client.KubeVirt(k8sv1.NamespaceDefault).Patch(kubevirt.Name, types.MergePatchType,
 			[]byte("{\"spec\":{\"imagePullPolicy\":something}}"), &k8smetav1.PatchOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should delete a KubeVirt", func() {
+	DescribeTable("should delete a KubeVirt", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("DELETE", kubevirtPath),
+			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, kubevirtPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.KubeVirt(k8sv1.NamespaceDefault).Delete("testkubevirt", &k8smetav1.DeleteOptions{})
+		err = client.KubeVirt(k8sv1.NamespaceDefault).Delete("testkubevirt", &k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
 	AfterEach(func() {
 		server.Close()

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -34,23 +34,22 @@ import (
 )
 
 var _ = Describe("Kubevirt Migration Client", func() {
-
 	var server *ghttp.Server
-	var client KubevirtClient
 	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstancemigrations"
 	migrationPath := path.Join(basePath, "testmigration")
+	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
-		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
-		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should fetch a MigrationMigration", func() {
+	DescribeTable("should fetch a MigrationMigration", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		migration := NewMinimalMigration("testmigration")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", migrationPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
 		fetchedMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get("testmigration", &k8smetav1.GetOptions{})
@@ -58,24 +57,36 @@ var _ = Describe("Kubevirt Migration Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedMigration).To(Equal(migration))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should detect non existent Migrations", func() {
+	DescribeTable("should detect non existent Migrations", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", migrationPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testmigration")),
 		))
-		_, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get("testmigration", &k8smetav1.GetOptions{})
+		_, err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Get("testmigration", &k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch a Migration list", func() {
+	DescribeTable("should fetch a Migration list", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		migration := NewMinimalMigration("testmigration")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", basePath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewMigrationList(*migration)),
 		))
 		fetchedMigrationList, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
@@ -84,12 +95,18 @@ var _ = Describe("Kubevirt Migration Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedMigrationList.Items).To(HaveLen(1))
 		Expect(fetchedMigrationList.Items[0]).To(Equal(*migration))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should create a Migration", func() {
+	DescribeTable("should create a Migration", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		migration := NewMinimalMigration("testmigration")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("POST", basePath),
+			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, migration),
 		))
 		createdMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Create(migration, &k8smetav1.CreateOptions{})
@@ -97,12 +114,18 @@ var _ = Describe("Kubevirt Migration Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdMigration).To(Equal(migration))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should update a Migration", func() {
+	DescribeTable("should update a Migration", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		migration := NewMinimalMigration("testmigration")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", migrationPath),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
 		updatedMigration, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Update(migration)
@@ -110,35 +133,50 @@ var _ = Describe("Kubevirt Migration Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedMigration).To(Equal(migration))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should patch a Migration", func() {
+	DescribeTable("should patch a Migration", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		migration := NewMinimalMigration("testmigration")
 		migration.Spec.VMIName = "somethingelse"
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PATCH", migrationPath),
+			ghttp.VerifyRequest("PATCH", path.Join(proxyPath, migrationPath)),
 			ghttp.VerifyBody([]byte("{\"spec\":{\"vmiName\":something}}")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
 
-		_, err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Patch(migration.Name, types.MergePatchType,
+		_, err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Patch(migration.Name, types.MergePatchType,
 			[]byte("{\"spec\":{\"vmiName\":something}}"))
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should delete a Migration", func() {
+	DescribeTable("should delete a Migration", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("DELETE", migrationPath),
+			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, migrationPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Delete("testmigration", &k8smetav1.DeleteOptions{})
+		err = client.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Delete("testmigration", &k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
 	AfterEach(func() {
 		server.Close()

--- a/staging/src/kubevirt.io/client-go/kubecli/profiler.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/profiler.go
@@ -47,7 +47,7 @@ func (v *ClusterProfiler) preferredVersion() (string, error) {
 	var group metav1.APIGroup
 	// First, find out which version to query
 	uri := ApiGroupName
-	result := v.restClient.Get().RequestURI(uri).Do(context.Background())
+	result := v.restClient.Get().AbsPath(uri).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
 
@@ -73,7 +73,7 @@ func (v *ClusterProfiler) Start() error {
 	// Now, query the preferred version
 	uri := fmt.Sprintf("/apis/%s/start-cluster-profiler", preferredVersion)
 
-	return v.restClient.Get().RequestURI(uri).Do(context.Background()).Error()
+	return v.restClient.Get().AbsPath(uri).Do(context.Background()).Error()
 }
 
 func (v *ClusterProfiler) Stop() error {
@@ -86,7 +86,7 @@ func (v *ClusterProfiler) Stop() error {
 	// Now, query the preferred version
 	uri := fmt.Sprintf("/apis/%s/stop-cluster-profiler", preferredVersion)
 
-	return v.restClient.Get().RequestURI(uri).Do(context.Background()).Error()
+	return v.restClient.Get().AbsPath(uri).Do(context.Background()).Error()
 }
 
 // Dump returns at most cpRequest.PageSize profiler results. To fetch results from all kubevirt pods
@@ -112,7 +112,7 @@ func (v *ClusterProfiler) Dump(cpRequest *v1.ClusterProfilerRequest) (*v1.Cluste
 
 	var profileResults v1.ClusterProfilerResults
 
-	result := v.restClient.Get().RequestURI(uri).Body(bytes).Do(context.Background())
+	result := v.restClient.Get().AbsPath(uri).Body(bytes).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
 

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -34,23 +34,22 @@ import (
 )
 
 var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
-
 	var server *ghttp.Server
-	var client KubevirtClient
 	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstancereplicasets"
 	rsPath := path.Join(basePath, "testrs")
+	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
-		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
-		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should fetch a VirtualMachineInstanceReplicaSet", func() {
+	DescribeTable("should fetch a VirtualMachineInstanceReplicaSet", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		rs := NewMinimalVirtualMachineInstanceReplicaSet("testrs")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", rsPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
 		))
 		fetchedVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
@@ -58,24 +57,36 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMIReplicaSet).To(Equal(rs))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should detect non existent VMIReplicaSets", func() {
+	DescribeTable("should detect non existent VMIReplicaSets", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", rsPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testrs")),
 		))
-		_, err := client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
+		_, err = client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch a VirtualMachineInstanceReplicaSet list", func() {
+	DescribeTable("should fetch a VirtualMachineInstanceReplicaSet list", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		rs := NewMinimalVirtualMachineInstanceReplicaSet("testrs")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", basePath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVirtualMachineInstanceReplicaSetList(*rs)),
 		))
 		fetchedVMIReplicaSetList, err := client.ReplicaSet(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
@@ -84,12 +95,18 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(fetchedVMIReplicaSetList.Items).To(HaveLen(1))
 		Expect(fetchedVMIReplicaSetList.Items[0]).To(Equal(*rs))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should create a VirtualMachineInstanceReplicaSet", func() {
+	DescribeTable("should create a VirtualMachineInstanceReplicaSet", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		rs := NewMinimalVirtualMachineInstanceReplicaSet("testrs")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("POST", basePath),
+			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, rs),
 		))
 		createdVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Create(rs)
@@ -97,12 +114,18 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdVMIReplicaSet).To(Equal(rs))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should update a VirtualMachineInstanceReplicaSet", func() {
+	DescribeTable("should update a VirtualMachineInstanceReplicaSet", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		rs := NewMinimalVirtualMachineInstanceReplicaSet("testrs")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", rsPath),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
 		))
 		updatedVMIReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Update(rs)
@@ -110,13 +133,19 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedVMIReplicaSet).To(Equal(rs))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should update a VirtualMachineInstanceReplicaSet scale subresource", func() {
+	DescribeTable("should update a VirtualMachineInstanceReplicaSet scale subresource", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		rs := NewMinimalVirtualMachineInstanceReplicaSet("testrs")
 		scale := &v1.Scale{Spec: v1.ScaleSpec{Replicas: 3}}
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(rsPath, "scale")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, rsPath, "scale")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, scale),
 		))
 		scaleResponse, err := client.ReplicaSet(k8sv1.NamespaceDefault).UpdateScale(rs.Name, scale)
@@ -124,13 +153,19 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(scaleResponse).To(Equal(scale))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should get a VirtualMachineInstanceReplicaSet scale subresource", func() {
+	DescribeTable("should get a VirtualMachineInstanceReplicaSet scale subresource", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		rs := NewMinimalVirtualMachineInstanceReplicaSet("testrs")
 		scale := &v1.Scale{Spec: v1.ScaleSpec{Replicas: 3}}
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", path.Join(rsPath, "scale")),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, rsPath, "scale")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, scale),
 		))
 		scaleResponse, err := client.ReplicaSet(k8sv1.NamespaceDefault).GetScale(rs.Name, k8smetav1.GetOptions{})
@@ -138,18 +173,27 @@ var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(scaleResponse).To(Equal(scale))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should delete a VirtualMachineInstanceReplicaSet", func() {
+	DescribeTable("should delete a VirtualMachineInstanceReplicaSet", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("DELETE", rsPath),
+			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, rsPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.ReplicaSet(k8sv1.NamespaceDefault).Delete("testrs", &k8smetav1.DeleteOptions{})
+		err = client.ReplicaSet(k8sv1.NamespaceDefault).Delete("testrs", &k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
 	AfterEach(func() {
 		server.Close()

--- a/staging/src/kubevirt.io/client-go/kubecli/version.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/version.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"path"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -42,14 +41,12 @@ const (
 func (k *kubevirt) ServerVersion() ServerVersionInterface {
 	return &ServerVersion{
 		restClient: k.restClient,
-		config:     k.config,
 		resource:   "version",
 	}
 }
 
 type ServerVersion struct {
 	restClient *rest.RESTClient
-	config     *rest.Config
 	resource   string
 }
 
@@ -57,13 +54,8 @@ func (v *ServerVersion) Get() (*version.Info, error) {
 
 	var group metav1.APIGroup
 	// First, find out which version to query
-	u, err := url.Parse(v.config.Host)
-	if err != nil {
-		return nil, err
-	}
-	uri := path.Join(u.Path, ApiGroupName)
-
-	result := v.restClient.Get().RequestURI(uri).Do(context.Background())
+	uri := ApiGroupName
+	result := v.restClient.Get().AbsPath(uri).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
 
@@ -77,10 +69,10 @@ func (v *ServerVersion) Get() (*version.Info, error) {
 	}
 
 	// Now, query the preferred version
-	uri = fmt.Sprintf("%s/apis/%s/version", u.Path, group.PreferredVersion.GroupVersion)
+	uri = fmt.Sprintf("/apis/%s/version", group.PreferredVersion.GroupVersion)
 	var serverInfo version.Info
 
-	result = v.restClient.Get().RequestURI(uri).Do(context.Background())
+	result = v.restClient.Get().AbsPath(uri).Do(context.Background())
 	if data, err := result.Raw(); err != nil {
 		connErr, isConnectionErr := err.(*url.Error)
 

--- a/staging/src/kubevirt.io/client-go/kubecli/version_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/version_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Kubevirt Version Client", func() {
 				ghttp.RespondWithJSONEncoded(http.StatusOK, groupInfo),
 			),
 			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("GET", "/apis/"+groupInfo.PreferredVersion.GroupVersion+"/version"),
+				ghttp.VerifyRequest("GET", "/apis"+groupInfo.PreferredVersion.GroupVersion+"/version"),
 				ghttp.RespondWithJSONEncoded(http.StatusOK, info),
 			),
 		)

--- a/staging/src/kubevirt.io/client-go/kubecli/version_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/version_test.go
@@ -22,6 +22,7 @@ package kubecli
 import (
 	"fmt"
 	"net/http"
+	"path"
 	"runtime"
 	"time"
 
@@ -35,16 +36,19 @@ import (
 
 var _ = Describe("Kubevirt Version Client", func() {
 	var server *ghttp.Server
-	var client KubevirtClient
+	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
-		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
-		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should fetch version", func() {
+	AfterEach(func() {
+		server.Close()
+	})
+
+	DescribeTable("should fetch version", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
 
 		groupInfo := metav1.APIGroup{
 			Name:             ApiGroupName,
@@ -61,11 +65,11 @@ var _ = Describe("Kubevirt Version Client", func() {
 
 		server.AppendHandlers(
 			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("GET", ApiGroupName),
+				ghttp.VerifyRequest("GET", path.Join(proxyPath, ApiGroupName)),
 				ghttp.RespondWithJSONEncoded(http.StatusOK, groupInfo),
 			),
 			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("GET", "/apis"+groupInfo.PreferredVersion.GroupVersion+"/version"),
+				ghttp.VerifyRequest("GET", path.Join(proxyPath, "/apis"+groupInfo.PreferredVersion.GroupVersion+"/version")),
 				ghttp.RespondWithJSONEncoded(http.StatusOK, info),
 			),
 		)
@@ -77,5 +81,8 @@ var _ = Describe("Kubevirt Version Client", func() {
 		Expect(fetchedVersion.BuildDate).To(Equal(info.BuildDate))
 		Expect(fetchedVersion.GoVersion).To(Equal(info.GoVersion))
 		Expect(fetchedVersion.Platform).To(Equal(info.Platform))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 })

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -24,8 +24,6 @@ import (
 
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"path"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -71,15 +69,6 @@ func (v *vm) Create(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
 	return newVm, err
 }
 
-// Compute URI based on host path
-func (v *vm) adaptUriForHostPath(uri string) string {
-	u, err := url.Parse(v.config.Host)
-	if err != nil {
-		return uri
-	}
-	return path.Join(u.Path, uri)
-}
-
 // Get the Virtual machine from the cluster by its name and namespace
 func (v *vm) Get(name string, options *k8smetav1.GetOptions) (*v1.VirtualMachine, error) {
 	newVm := &v1.VirtualMachine{}
@@ -100,7 +89,7 @@ func (v *vm) GetWithExpandedSpec(name string) (*v1.VirtualMachine, error) {
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "expand-spec")
 	newVm := &v1.VirtualMachine{}
 	err := v.restClient.Get().
-		RequestURI(uri).
+		AbsPath(uri).
 		Do(context.Background()).
 		Into(newVm)
 
@@ -203,7 +192,7 @@ func (v *vm) Restart(name string, restartOptions *v1.RestartOptions) error {
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
 	}
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "restart")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vm) ForceRestart(name string, restartOptions *v1.RestartOptions) error {
@@ -212,7 +201,7 @@ func (v *vm) ForceRestart(name string, restartOptions *v1.RestartOptions) error 
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
 	}
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "restart")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vm) Start(name string, startOptions *v1.StartOptions) error {
@@ -222,7 +211,7 @@ func (v *vm) Start(name string, startOptions *v1.StartOptions) error {
 	if err != nil {
 		return err
 	}
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(optsJson).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(optsJson).Do(context.Background()).Error()
 }
 
 func (v *vm) Stop(name string, stopOptions *v1.StopOptions) error {
@@ -231,7 +220,7 @@ func (v *vm) Stop(name string, stopOptions *v1.StopOptions) error {
 	if err != nil {
 		return err
 	}
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(optsJson).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(optsJson).Do(context.Background()).Error()
 }
 
 func (v *vm) ForceStop(name string, stopOptions *v1.StopOptions) error {
@@ -240,7 +229,7 @@ func (v *vm) ForceStop(name string, stopOptions *v1.StopOptions) error {
 		return fmt.Errorf(cannotMarshalJSONErrFmt, err)
 	}
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "stop")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vm) Migrate(name string, migrateOptions *v1.MigrateOptions) error {
@@ -249,7 +238,7 @@ func (v *vm) Migrate(name string, migrateOptions *v1.MigrateOptions) error {
 	if err != nil {
 		return err
 	}
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(optsJson).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(optsJson).Do(context.Background()).Error()
 }
 
 func (v *vm) MemoryDump(name string, memoryDumpRequest *v1.VirtualMachineMemoryDumpRequest) error {
@@ -260,13 +249,13 @@ func (v *vm) MemoryDump(name string, memoryDumpRequest *v1.VirtualMachineMemoryD
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vm) RemoveMemoryDump(name string) error {
 	uri := fmt.Sprintf(vmSubresourceURLFmt, v1.ApiStorageVersion, v.namespace, name, "removememorydump")
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Do(context.Background()).Error()
 }
 
 func (v *vm) AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) error {
@@ -278,7 +267,7 @@ func (v *vm) AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) error
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vm) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
@@ -290,7 +279,7 @@ func (v *vm) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptio
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vm) PortForward(name string, port int, protocol string) (StreamInterface, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -40,91 +40,121 @@ import (
 var _ = Describe("Kubevirt VirtualMachine Client", func() {
 
 	var server *ghttp.Server
-	var client KubevirtClient
 	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"
-	vmiPath := path.Join(basePath, "testvm")
+	vmPath := path.Join(basePath, "testvm")
 	subBasePath := fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/default/virtualmachines", v1.SubresourceStorageGroupVersion.Version)
-	subVMIPath := path.Join(subBasePath, "testvm")
+	subVMPath := path.Join(subBasePath, "testvm")
+	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
-		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
-		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should fetch a VirtualMachineInstance", func() {
+	DescribeTable("should fetch a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vm := NewMinimalVM("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vmiPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vmPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
 		))
-		fetchedVMI, err := client.VirtualMachine(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
+		fetchedVM, err := client.VirtualMachine(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(fetchedVMI).To(Equal(vm))
-	})
+		Expect(fetchedVM).To(Equal(vm))
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should detect non existent VirtualMachines", func() {
+	DescribeTable("should detect non existent VirtualMachines", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vmiPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vmPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testvm")),
 		))
-		_, err := client.VirtualMachine(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
+		_, err = client.VirtualMachine(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch a VirtualMachine list", func() {
+	DescribeTable("should fetch a VirtualMachine list", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vm := NewMinimalVM("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", basePath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMList(*vm)),
 		))
-		fetchedVMIList, err := client.VirtualMachine(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
+		fetchedVMList, err := client.VirtualMachine(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(fetchedVMIList.Items).To(HaveLen(1))
-		Expect(fetchedVMIList.Items[0]).To(Equal(*vm))
-	})
+		Expect(fetchedVMList.Items).To(HaveLen(1))
+		Expect(fetchedVMList.Items[0]).To(Equal(*vm))
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should create a VirtualMachine", func() {
+	DescribeTable("should create a VirtualMachine", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vm := NewMinimalVM("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("POST", basePath),
+			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, vm),
 		))
-		createdVMI, err := client.VirtualMachine(k8sv1.NamespaceDefault).Create(vm)
+		createdVM, err := client.VirtualMachine(k8sv1.NamespaceDefault).Create(vm)
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(createdVMI).To(Equal(vm))
-	})
+		Expect(createdVM).To(Equal(vm))
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should update a VirtualMachine", func() {
+	DescribeTable("should update a VirtualMachine", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vm := NewMinimalVM("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", vmiPath),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, vmPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
 		))
-		updatedVMI, err := client.VirtualMachine(k8sv1.NamespaceDefault).Update(vm)
+		updatedVM, err := client.VirtualMachine(k8sv1.NamespaceDefault).Update(vm)
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(updatedVMI).To(Equal(vm))
-	})
+		Expect(updatedVM).To(Equal(vm))
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should patch a VirtualMachine", func() {
+	DescribeTable("should patch a VirtualMachine", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vm := NewMinimalVM("testvm")
 		running := true
 		vm.Spec.Running = &running
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PATCH", vmiPath),
+			ghttp.VerifyRequest("PATCH", path.Join(proxyPath, vmPath)),
 			ghttp.VerifyBody([]byte("{\"spec\":{\"running\":true}}")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
 		))
@@ -135,14 +165,19 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vm.Spec.Running).To(Equal(patchedVM.Spec.Running))
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	})
+	DescribeTable("should fail on patch a VirtualMachine", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
 
-	It("should fail on patch a VirtualMachine", func() {
 		vm := NewMinimalVM("testvm")
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PATCH", vmiPath),
+			ghttp.VerifyRequest("PATCH", path.Join(proxyPath, vmPath)),
 			ghttp.VerifyBody([]byte("{\"spec\":{\"running\":true}}")),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, vm),
 		))
@@ -153,41 +188,61 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
 		Expect(vm.Spec.Running).To(Equal(patchedVM.Spec.Running))
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	})
+	DescribeTable("should delete a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
 
-	It("should delete a VirtualMachineInstance", func() {
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("DELETE", vmiPath),
+			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, vmPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachine(k8sv1.NamespaceDefault).Delete("testvm", &k8smetav1.DeleteOptions{})
+		err = client.VirtualMachine(k8sv1.NamespaceDefault).Delete("testvm", &k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should restart a VirtualMachine", func() {
+	DescribeTable("should restart a VirtualMachine", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMIPath, "restart")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMPath, "restart")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachine(k8sv1.NamespaceDefault).Restart("testvm", &v1.RestartOptions{})
+		err = client.VirtualMachine(k8sv1.NamespaceDefault).Restart("testvm", &v1.RestartOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should migrate a VirtualMachine", func() {
+	DescribeTable("should migrate a VirtualMachine", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMIPath, "migrate")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMPath, "migrate")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachine(k8sv1.NamespaceDefault).Migrate("testvm", &virtv1.MigrateOptions{})
+		err = client.VirtualMachine(k8sv1.NamespaceDefault).Migrate("testvm", &virtv1.MigrateOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
 	AfterEach(func() {
 		server.Close()

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -173,15 +173,6 @@ func (v *vmis) PortForward(name string, port int, protocol string) (StreamInterf
 	return asyncSubresourceHelper(v.config, v.resource, v.namespace, name, buildPortForwardResourcePath(port, protocol))
 }
 
-// Compute URI based on host path
-func (v *vmis) adaptUriForHostPath(uri string) string {
-	u, err := url.Parse(v.config.Host)
-	if err != nil {
-		return uri
-	}
-	return path.Join(u.Path, uri)
-}
-
 func buildPortForwardResourcePath(port int, protocol string) string {
 	resource := strings.Builder{}
 	resource.WriteString("portforward/")
@@ -262,19 +253,19 @@ func (v *vmis) Freeze(name string, unfreezeTimeout time.Duration) error {
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vmis) Unfreeze(name string) error {
 	log.Log.Infof("Unfreeze VMI %s", name)
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "unfreeze")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Do(context.Background()).Error()
 }
 
 func (v *vmis) SoftReboot(name string) error {
 	log.Log.Infof("SoftReboot VMI")
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "softreboot")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Do(context.Background()).Error()
 }
 
 func (v *vmis) Pause(name string, pauseOptions *v1.PauseOptions) error {
@@ -283,7 +274,7 @@ func (v *vmis) Pause(name string, pauseOptions *v1.PauseOptions) error {
 		return fmt.Errorf("Cannot Marshal to json: %s", err)
 	}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "pause")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vmis) Unpause(name string, unpauseOptions *v1.UnpauseOptions) error {
@@ -292,7 +283,7 @@ func (v *vmis) Unpause(name string, unpauseOptions *v1.UnpauseOptions) error {
 		return fmt.Errorf("Cannot Marshal to json: %s", err)
 	}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "unpause")
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body(body).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body(body).Do(context.Background()).Error()
 }
 
 func (v *vmis) Get(name string, options *k8smetav1.GetOptions) (vmi *v1.VirtualMachineInstance, err error) {
@@ -432,7 +423,7 @@ func (v *vmis) GuestOsInfo(name string) (v1.VirtualMachineInstanceGuestAgentInfo
 	// this issue should be solved.
 	// This workaround can go away once the least supported k8s version is the working one.
 	// The issue has been described in: https://github.com/kubevirt/kubevirt/issues/3059
-	res := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background())
+	res := v.restClient.Get().AbsPath(uri).Do(context.Background())
 	rawInfo, err := res.Raw()
 	if err != nil {
 		log.Log.Errorf("Cannot retrieve GuestOSInfo: %s", err.Error())
@@ -450,14 +441,14 @@ func (v *vmis) GuestOsInfo(name string) (v1.VirtualMachineInstanceGuestAgentInfo
 func (v *vmis) UserList(name string) (v1.VirtualMachineInstanceGuestOSUserList, error) {
 	userList := v1.VirtualMachineInstanceGuestOSUserList{}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "userlist")
-	err := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Into(&userList)
+	err := v.restClient.Get().AbsPath(uri).Do(context.Background()).Into(&userList)
 	return userList, err
 }
 
 func (v *vmis) FilesystemList(name string) (v1.VirtualMachineInstanceFileSystemList, error) {
 	fsList := v1.VirtualMachineInstanceFileSystemList{}
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "filesystemlist")
-	err := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Do(context.Background()).Into(&fsList)
+	err := v.restClient.Get().AbsPath(uri).Do(context.Background()).Into(&fsList)
 	return fsList, err
 }
 
@@ -468,7 +459,7 @@ func (v *vmis) Screenshot(name string, screenshotOptions *v1.ScreenshotOptions) 
 	}
 
 	uri := fmt.Sprintf(vmiSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "vnc/screenshot")
-	res := v.restClient.Get().RequestURI(v.adaptUriForHostPath(uri)).Param("moveCursor", moveCursor).Do(context.Background())
+	res := v.restClient.Get().AbsPath(uri).Param("moveCursor", moveCursor).Do(context.Background())
 	raw, err := res.Raw()
 	if err != nil {
 		return nil, res.Error()
@@ -485,7 +476,7 @@ func (v *vmis) AddVolume(name string, addVolumeOptions *v1.AddVolumeOptions) err
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(context.Background()).Error()
 }
 
 func (v *vmis) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOptions) error {
@@ -497,5 +488,5 @@ func (v *vmis) RemoveVolume(name string, removeVolumeOptions *v1.RemoveVolumeOpt
 		return err
 	}
 
-	return v.restClient.Put().RequestURI(v.adaptUriForHostPath(uri)).Body([]byte(JSON)).Do(context.Background()).Error()
+	return v.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(context.Background()).Error()
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -43,22 +43,22 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 
 	var upgrader websocket.Upgrader
 	var server *ghttp.Server
-	var client KubevirtClient
 	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances"
 	vmiPath := path.Join(basePath, "testvm")
-	subVMPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"
+	subVMIPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"
+	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
-		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
-		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should fetch a VirtualMachineInstance", func() {
+	DescribeTable("should fetch a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vmi := api.NewMinimalVMI("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vmiPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vmiPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 		))
 		fetchedVMI, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
@@ -66,24 +66,36 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMI).To(Equal(vmi))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should detect non existent VMIs", func() {
+	DescribeTable("should detect non existent VMIs", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vmiPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vmiPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testvm")),
 		))
-		_, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).Get("testvm", &k8smetav1.GetOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch a VirtualMachineInstance list", func() {
+	DescribeTable("should fetch a VirtualMachineInstance list", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vmi := api.NewMinimalVMI("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", basePath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMIList(*vmi)),
 		))
 		fetchedVMIList, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).List(&k8smetav1.ListOptions{})
@@ -92,12 +104,18 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(fetchedVMIList.Items).To(HaveLen(1))
 		Expect(fetchedVMIList.Items[0]).To(Equal(*vmi))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should create a VirtualMachineInstance", func() {
+	DescribeTable("should create a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vmi := api.NewMinimalVMI("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("POST", basePath),
+			ghttp.VerifyRequest("POST", path.Join(proxyPath, basePath)),
 			ghttp.RespondWithJSONEncoded(http.StatusCreated, vmi),
 		))
 		createdVMI, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Create(vmi)
@@ -105,12 +123,18 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(createdVMI).To(Equal(vmi))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should update a VirtualMachineInstance", func() {
+	DescribeTable("should update a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vmi := api.NewMinimalVMI("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", vmiPath),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, vmiPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 		))
 		updatedVMI, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Update(vmi)
@@ -118,24 +142,36 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updatedVMI).To(Equal(vmi))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should delete a VirtualMachineInstance", func() {
+	DescribeTable("should delete a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("DELETE", vmiPath),
+			ghttp.VerifyRequest("DELETE", path.Join(proxyPath, vmiPath)),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Delete("testvm", &k8smetav1.DeleteOptions{})
+		err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).Delete("testvm", &k8smetav1.DeleteOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should allow to connect a stream to a VM", func() {
+	DescribeTable("should allow to connect a stream to a VM", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vncPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm/vnc"
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vncPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vncPath)),
 			func(w http.ResponseWriter, r *http.Request) {
 				_, err := upgrader.Upgrade(w, r, nil)
 				if err != nil {
@@ -143,28 +179,40 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 				}
 			},
 		))
-		_, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should handle a failure connecting to the VM", func() {
+	DescribeTable("should handle a failure connecting to the VM", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		vncPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm/vnc"
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vncPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vncPath)),
 			func(w http.ResponseWriter, r *http.Request) {
 				return
 			},
 		))
-		_, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
+		_, err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).VNC("testvm")
 		Expect(err).To(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should exchange data with the VM", func() {
-		vncPath := path.Join(subVMPath, "vnc")
+	DescribeTable("should exchange data with the VM", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
+		vncPath := path.Join(subVMIPath, "vnc")
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", vncPath),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, vncPath)),
 			func(w http.ResponseWriter, r *http.Request) {
 				c, err := upgrader.Upgrade(w, r, nil)
 				if err != nil {
@@ -220,95 +268,143 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 
 		By("checking the result")
 		Expect(bufOut).To(Equal(bufIn))
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should pause a VirtualMachineInstance", func() {
+	DescribeTable("should pause a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMPath, "pause")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMIPath, "pause")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Pause("testvm", &v1.PauseOptions{})
+		err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).Pause("testvm", &v1.PauseOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should unpause a VirtualMachineInstance", func() {
+	DescribeTable("should unpause a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMPath, "unpause")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMIPath, "unpause")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Unpause("testvm", &v1.UnpauseOptions{})
+		err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).Unpause("testvm", &v1.UnpauseOptions{})
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should freeze a VirtualMachineInstance", func() {
+	DescribeTable("should freeze a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMPath, "freeze")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMIPath, "freeze")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Freeze("testvm", 0*time.Second)
+		err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).Freeze("testvm", 0*time.Second)
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should unfreeze a VirtualMachineInstance", func() {
+	DescribeTable("should unfreeze a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMPath, "unfreeze")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMIPath, "unfreeze")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).Unfreeze("testvm")
+		err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).Unfreeze("testvm")
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should soft reboot a VirtualMachineInstance", func() {
+	DescribeTable("should soft reboot a VirtualMachineInstance", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", path.Join(subVMPath, "softreboot")),
+			ghttp.VerifyRequest("PUT", path.Join(proxyPath, subVMIPath, "softreboot")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
-		err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).SoftReboot("testvm")
+		err = client.VirtualMachineInstance(k8sv1.NamespaceDefault).SoftReboot("testvm")
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch GuestOSInfo from VirtualMachineInstance via subresource", func() {
+	DescribeTable("should fetch GuestOSInfo from VirtualMachineInstance via subresource", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		osInfo := v1.VirtualMachineInstanceGuestAgentInfo{
 			GAVersion: "4.1.1",
 		}
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", path.Join(subVMPath, "guestosinfo")),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, subVMIPath, "guestosinfo")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, osInfo),
 		))
 		fetchedInfo, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).GuestOsInfo("testvm")
 
 		Expect(err).ToNot(HaveOccurred(), "should fetch info normally")
 		Expect(fetchedInfo).To(Equal(osInfo), "fetched info should be the same as passed in")
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch UserList from VirtualMachineInstance via subresource", func() {
+	DescribeTable("should fetch UserList from VirtualMachineInstance via subresource", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		userList := v1.VirtualMachineInstanceGuestOSUserList{
 			Items: []v1.VirtualMachineInstanceGuestOSUser{
 				{UserName: "testUser"},
 			},
 		}
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", path.Join(subVMPath, "userlist")),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, subVMIPath, "userlist")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, userList),
 		))
 		fetchedInfo, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).UserList("testvm")
 
 		Expect(err).ToNot(HaveOccurred(), "should fetch info normally")
 		Expect(fetchedInfo).To(Equal(userList), "fetched info should be the same as passed in")
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
-	It("should fetch FilesystemList from VirtualMachineInstance via subresource", func() {
+	DescribeTable("should fetch FilesystemList from VirtualMachineInstance via subresource", func(proxyPath string) {
+		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
+		Expect(err).ToNot(HaveOccurred())
+
 		fileSystemList := v1.VirtualMachineInstanceFileSystemList{
 			Items: []v1.VirtualMachineInstanceFileSystem{
 				{
@@ -319,14 +415,17 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		}
 
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", path.Join(subVMPath, "filesystemlist")),
+			ghttp.VerifyRequest("GET", path.Join(proxyPath, subVMIPath, "filesystemlist")),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, fileSystemList),
 		))
 		fetchedInfo, err := client.VirtualMachineInstance(k8sv1.NamespaceDefault).FilesystemList("testvm")
 
 		Expect(err).ToNot(HaveOccurred(), "should fetch info normally")
 		Expect(fetchedInfo).To(Equal(fileSystemList), "fetched info should be the same as passed in")
-	})
+	},
+		Entry("with regular server URL", ""),
+		Entry("with proxied server URL", proxyPath),
+	)
 
 	AfterEach(func() {
 		server.Close()


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Handling of cluster URIs with additional path elements added in the commit fba65ed2ce can be simplified with the use of `Request.AbsPath`

https://github.com/kubevirt/kubevirt/blob/0f2c6714ae95371f14b34361f747c2311df18a4d/vendor/k8s.io/client-go/rest/request.go#L305-L317

which literally does the same as the introduced `adaptUriForHostPath` function:

https://github.com/kubevirt/kubevirt/blob/0f2c6714ae95371f14b34361f747c2311df18a4d/staging/src/kubevirt.io/client-go/kubecli/vmi.go#L177-L183



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is a follow-up of the discussion https://github.com/kubevirt/kubevirt/pull/8129#discussion_r929231101

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
