### PR TITLE
tests/migration_test.go: Fix migration test with usb disk

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1016,7 +1016,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			It("should migrate vmi with a usb disk", func() {
 
 				vmi := libvmi.NewAlpineWithTestTooling(
-					libvmi.WithEmptyDisk("disk0", v1.DiskBusUSB, resource.MustParse("128Mi")),
+					libvmi.WithEmptyDisk("uniqueusbdisk", v1.DiskBusUSB, resource.MustParse("128Mi")),
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)


### PR DESCRIPTION
**What this PR does / why we need it**:

By reusing the identifier 'disk0' the empty disk with 'DiskBusUSB' was never attached to the VM because of libvmi silently doing nothing when trying to re-add an existing disk with another bus type.

See https://github.com/kubevirt/kubevirt/pull/8348 for more information.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
