### PR TITLE
[release-0.53] Snapshot tests: Partial backport of snapshot tests skip condition change

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1140,14 +1140,14 @@ func getSnapshotStorageClass(client kubecli.KubevirtClient) (string, error) {
 		return "", err
 	}
 
-	hasV1beta1 := false
+	hasV1 := false
 	for _, v := range crd.Spec.Versions {
-		if v.Name == "v1beta1" && v.Served {
-			hasV1beta1 = true
+		if v.Name == "v1" && v.Served {
+			hasV1 = true
 		}
 	}
 
-	if !hasV1beta1 {
+	if !hasV1 {
 		return "", nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On 1.24 and thus OpenShift 4.11 v1beta1 is not going to be served anymore (deprecated), which means we will skip these tests.
On newer branches we had this fixed by https://github.com/kubevirt/kubevirt/pull/8173 (Can't cherry pick because its part of a bigger commit)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
