### PR TITLE
Improve error handling in virtctl image-upload

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -76,6 +76,11 @@ const (
 	UploadProxyURI = "/v1alpha1/upload"
 
 	configName = "config"
+
+	// ProvisioningFailed stores the 'ProvisioningFailed' event condition used for PVC error handling
+	ProvisioningFailed = "ProvisioningFailed"
+	// ErrClaimNotValid stores the 'ErrClaimNotValid' event condition used for DV error handling
+	ErrClaimNotValid = "ErrClaimNotValid"
 )
 
 var (
@@ -469,12 +474,17 @@ func waitDvUploadScheduled(client kubecli.KubevirtClient, namespace, name string
 		if dv.Status.Phase == cdiv1.WaitForFirstConsumer && !forceBind {
 			return false, fmt.Errorf("cannot upload to DataVolume in WaitForFirstConsumer state, make sure the PVC is Bound")
 		}
-		// TODO: can check Condition/Event here to provide user with some error messages
 
 		done := dv.Status.Phase == cdiv1.UploadReady
-		if !done && !loggedStatus {
-			fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
-			loggedStatus = true
+		if !done {
+			// We check events to provide user with pertinent error messages
+			if err := handleEventErrors(client, dv.Status.ClaimName, name, namespace); err != nil {
+				return false, err
+			}
+			if !loggedStatus {
+				fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
+				loggedStatus = true
+			}
 		}
 
 		if done && loggedStatus {
@@ -497,7 +507,6 @@ func waitUploadServerReady(client kubernetes.Interface, namespace, name string, 
 			if k8serrors.IsNotFound(err) {
 				return false, nil
 			}
-
 			return false, err
 		}
 
@@ -505,9 +514,15 @@ func waitUploadServerReady(client kubernetes.Interface, namespace, name string, 
 		podReady := pvc.Annotations[PodReadyAnnotation]
 		done, _ := strconv.ParseBool(podReady)
 
-		if !done && !loggedStatus {
-			fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
-			loggedStatus = true
+		if !done {
+			// We check events to provide user with pertinent error messages
+			if err := handleEventErrors(client, name, name, namespace); err != nil {
+				return false, err
+			}
+			if !loggedStatus {
+				fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
+				loggedStatus = true
+			}
 		}
 
 		if done && loggedStatus {
@@ -544,6 +559,14 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 	pvcSpec, err := createStorageSpec(client, size, storageClass, accessMode, blockVolume)
 	if err != nil {
 		return nil, err
+	}
+
+	// We check if the storageClass exists before attempting to create the dataVolume
+	if storageClass != "" {
+		_, err = client.StorageV1().StorageClasses().Get(context.Background(), storageClass, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	annotations := map[string]string{}
@@ -615,6 +638,14 @@ func createStorageSpec(client kubecli.KubevirtClient, size, storageClass, access
 func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string, blockVolume, archiveUpload bool) (*v1.PersistentVolumeClaim, error) {
 	if accessMode == string(v1.ReadOnlyMany) {
 		return nil, fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
+	}
+
+	// We check if the storageClass exists before attempting to create the PVC
+	if storageClass != "" {
+		_, err := client.StorageV1().StorageClasses().Get(context.Background(), storageClass, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	quantity, err := resource.ParseQuantity(size)
@@ -722,4 +753,33 @@ func getUploadProxyURL(client cdiClientset.Interface) (string, error) {
 		return *cdiConfig.Status.UploadProxyURL, nil
 	}
 	return "", nil
+}
+
+// handleEventErrors checks PVC and DV-related events and, when encountered, returns appropiate errors
+func handleEventErrors(client kubernetes.Interface, pvcName, dvName, namespace string) error {
+	var err error
+
+	eventList, err := client.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// TODO: Currently, we only check 'ProvisioningFailed' and 'ErrClaimNotValid' events.
+	// If necessary, support more relevant errors
+	for _, event := range eventList.Items {
+		if event.InvolvedObject.Kind == "PersistentVolumeClaim" && event.InvolvedObject.Name == pvcName {
+			if event.Reason == ProvisioningFailed {
+				err = fmt.Errorf("Provisioning failed: %s", event.Message)
+				break
+			}
+		}
+		if event.InvolvedObject.Kind == "DataVolume" && event.InvolvedObject.Name == dvName {
+			if event.Reason == ErrClaimNotValid {
+				err = fmt.Errorf("Claim not valid: %s", event.Message)
+				break
+			}
+		}
+	}
+
+	return err
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When running the `virtctl image-upload` command, some storageclass-related errors leave the command waiting for pod creation without providing any relevant error message.

This pull request improves the error handling in those cases, so an appropriate message is returned instead.

**Which issue(s) this PR fixes:** 

https://bugzilla.redhat.com/show_bug.cgi?id=2126104

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bug-fix] Fix error handling in virtctl image-upload 
```
