### PR TITLE
Increase DefaultDiskVerificationMemoryLimitMBytes

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -68,7 +68,7 @@ const (
 	DefaultAARCH64OVMFPath                          = "/usr/share/AAVMF"
 	DefaultMemBalloonStatsPeriod             uint32 = 10
 	DefaultCPUAllocationRatio                       = 10
-	DefaultDiskVerificationMemoryLimitMBytes        = 1500
+	DefaultDiskVerificationMemoryLimitMBytes        = 1700
 	DefaultVirtAPILogVerbosity                      = 2
 	DefaultVirtControllerLogVerbosity               = 2
 	DefaultVirtHandlerLogVerbosity                  = 2


### PR DESCRIPTION
**What this PR does / why we need it**:
It was observed that recently memory limit applied to virt-chroot is too low. This is an attempt to fix
this issue. Further profiling and optimization are needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
