### PR TITLE
Remove mediated devices tests from quarantine

### DIFF
--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -167,7 +167,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			cleanupConfiguredMdevs()
 		})
 
-		It("[QUARANTINE]Should successfully passthrough a mediated device", func() {
+		It("Should successfully passthrough a mediated device", func() {
 
 			By("Creating a Fedora VMI")
 			vmi = tests.NewRandomFedoraVMIWithGuestAgent()
@@ -227,7 +227,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*display=.?on.?`), "Display should not be enabled")
 			Expect(domXml).ToNot(MatchRegexp(`<hostdev .*ramfb=.?on.?`), "RamFB should not be enabled")
 		})
-		It("[QUARANTINE]Should override default mdev configuration on a specific node", func() {
+		It("Should override default mdev configuration on a specific node", func() {
 			newDesiredMdevTypeName := "nvidia-223"
 			newExpectedInstancesNum := 8
 			By("Creating a configuration for mediated devices")


### PR DESCRIPTION
**What this PR does / why we need it**:
These mediated devices tests have passed successfully in the last 12 runs of the periodic vgpu test lane[1] so they should be removed from quarantine.

[1]https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-kind-1.23-vgpu


**Special notes for your reviewer**:
/cc @xpivarc @dhiller 

**Release note**:

```release-note
NONE
```
Signed-off-by: Brian Carey <bcarey@redhat.com>