### PR TITLE
Use exponential backoff for failing migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -22,6 +22,7 @@ package watch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -34,7 +35,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -86,6 +87,8 @@ const defaultFinalizedMigrationGarbageCollectionBuffer = 5
 // period of time, so we want to make this timeout long enough that it doesn't
 // cause the migration to fail when it could have reasonably succeeded.
 const defaultCatchAllPendingTimeoutSeconds = int64(60 * 15)
+
+var migrationBackoffError = errors.New(MigrationBackoffReason)
 
 type MigrationController struct {
 	templateService         services.TemplateService
@@ -687,6 +690,66 @@ func (c *MigrationController) expandPDB(pdb *policyv1.PodDisruptionBudget, vmi *
 	return nil
 }
 
+func (c *MigrationController) handleMigrationBackoff(key string, vmi *virtv1.VirtualMachineInstance, migration *virtv1.VirtualMachineInstanceMigration) error {
+	if _, exists := migration.Annotations[virtv1.FuncTestForceIgnoreMigrationBackoffAnnotation]; exists {
+		return nil
+	}
+
+	migrations, err := c.listMigrationsMatchingVMI(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return err
+	}
+	if len(migrations) < 2 {
+		return nil
+	}
+
+	// Newest first
+	sort.Sort(sort.Reverse(vmimCollection(migrations)))
+	if migrations[0].UID != migration.UID {
+		return nil
+	}
+
+	backoff := time.Second * 0
+	for _, m := range migrations[1:] {
+		if m.Status.Phase == virtv1.MigrationSucceeded {
+			break
+		}
+		if m.DeletionTimestamp != nil {
+			continue
+		}
+
+		if m.Status.Phase == virtv1.MigrationFailed {
+			if backoff == 0 {
+				backoff = time.Second * 20
+			} else {
+				backoff = backoff * 2
+			}
+		}
+	}
+	if backoff == 0 {
+		return nil
+	}
+
+	getFailedTS := func(migration *virtv1.VirtualMachineInstanceMigration) metav1.Time {
+		for _, ts := range migration.Status.PhaseTransitionTimestamps {
+			if ts.Phase == virtv1.MigrationFailed {
+				return ts.PhaseTransitionTimestamp
+			}
+		}
+		return metav1.Time{}
+	}
+
+	outOffBackoffTS := getFailedTS(migrations[1]).Add(backoff)
+	backoff = outOffBackoffTS.Sub(time.Now())
+
+	if backoff > 0 {
+		log.Log.Object(vmi).V(2).Errorf("vmi in migration backoff, re-enqueueing after %v", backoff)
+		c.Queue.AddAfter(key, backoff)
+		return migrationBackoffError
+	}
+	return nil
+}
+
 func (c *MigrationController) handleMarkMigrationFailedOnVMI(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
 
 	// Mark Migration Done on VMI if virt handler never started it.
@@ -1112,6 +1175,11 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 		if migration.DeletionTimestamp != nil {
 			return c.handlePreHandoffMigrationCancel(migration, vmi, pod)
 		}
+		if err = c.handleMigrationBackoff(key, vmi, migration); errors.Is(err, migrationBackoffError) {
+			warningMsg := fmt.Sprintf("backoff migrating vmi %s/%s", vmi.Namespace, vmi.Name)
+			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, err.Error(), warningMsg)
+			return nil
+		}
 
 		if !targetPodExists {
 			sourcePod, err := controller.CurrentVMIPod(vmi, c.podInformer)
@@ -1476,7 +1544,7 @@ func (c *MigrationController) garbageCollectFinalizedMigrations(vmi *virtv1.Virt
 
 	for i := 0; i < garbageCollectionCount; i++ {
 		err = c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Delete(finalizedMigrations[i], &v1.DeleteOptions{})
-		if err != nil && errors.IsNotFound(err) {
+		if err != nil && k8serrors.IsNotFound(err) {
 			// This is safe to ignore. It's possible in some
 			// scenarios that the migration we're trying to garbage
 			// collect has already disappeared. Let's log it as debug

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1838,6 +1838,56 @@ var _ = Describe("Migration watcher", func() {
 			shouldExpectMigrationFailedState(migration)
 		})
 	})
+
+	Context("Migration backoff", func() {
+		var vmi *virtv1.VirtualMachineInstance
+
+		It("should be applied after a migration fails", func() {
+			vmi = newVirtualMachine("testvmi", virtv1.Running)
+			failedMigration := newMigration("testmigration", vmi.Name, virtv1.MigrationFailed)
+			pendingMigration := newMigration("testmigration2", vmi.Name, virtv1.MigrationPending)
+
+			failedMigration.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+				{
+					Phase:                    virtv1.MigrationFailed,
+					PhaseTransitionTimestamp: failedMigration.CreationTimestamp,
+				},
+			}
+			pendingMigration.CreationTimestamp = metav1.NewTime(failedMigration.CreationTimestamp.Add(time.Second * 1))
+
+			_ = migrationInformer.GetStore().Add(failedMigration)
+			_ = vmiInformer.GetStore().Add(vmi)
+			addMigration(pendingMigration)
+
+			controller.Execute()
+			Expect(pendingMigration.Status.Phase).To(Equal(virtv1.MigrationPending))
+			testutils.ExpectEvent(recorder, "MigrationBackoff")
+		})
+
+		It("should be cleared when a migration succeeds", func() {
+			vmi = newVirtualMachine("testvmi", virtv1.Running)
+			failedMigration := newMigration("testmigration", vmi.Name, virtv1.MigrationFailed)
+			successfulMigration := newMigration("testmigration2", vmi.Name, virtv1.MigrationSucceeded)
+			pendingMigration := newMigration("testmigration3", vmi.Name, virtv1.MigrationPending)
+
+			failedMigration.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+				{
+					Phase:                    virtv1.MigrationFailed,
+					PhaseTransitionTimestamp: failedMigration.CreationTimestamp,
+				},
+			}
+			successfulMigration.CreationTimestamp = metav1.NewTime(failedMigration.CreationTimestamp.Add(time.Second * 1))
+			pendingMigration.CreationTimestamp = metav1.NewTime(successfulMigration.CreationTimestamp.Add(time.Second * 1))
+
+			_ = migrationInformer.GetStore().Add(failedMigration)
+			_ = migrationInformer.GetStore().Add(successfulMigration)
+			_ = vmiInformer.GetStore().Add(vmi)
+			addMigration(pendingMigration)
+
+			controller.Execute()
+			shouldExpectPodCreation(vmi.UID, pendingMigration.UID, 1, 0, 0)
+		})
+	})
 })
 
 func newPDB(name string, vmi *virtv1.VirtualMachineInstance, pods int) *policyv1.PodDisruptionBudget {
@@ -1872,6 +1922,7 @@ func newMigration(name string, vmiName string, phase virtv1.VirtualMachineInstan
 				virtv1.ControllerAPILatestVersionObservedAnnotation:  virtv1.ApiLatestVersion,
 				virtv1.ControllerAPIStorageVersionObservedAnnotation: virtv1.ApiStorageVersion,
 			},
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: virtv1.VirtualMachineInstanceMigrationSpec{
 			VMIName: vmiName,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -118,6 +118,9 @@ const (
 	NoSuitableNodesForHostModelMigration = "NoSuitableNodesForHostModelMigration"
 	// FailedPodPatchReason is set when a pod patch error occurs during sync
 	FailedPodPatchReason = "FailedPodPatch"
+	// MigrationBackoffReason is set when an error has occured while migrating
+	// and virt-controller is backing off before retrying.
+	MigrationBackoffReason = "MigrationBackoff"
 )
 
 const failedToRenderLaunchManifestErrFormat = "failed to render launch manifest: %v"

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -727,6 +727,10 @@ const (
 
 	// Used by functional tests to simulate virt-launcher crash looping
 	FuncTestLauncherFailFastAnnotation string = "kubevirt.io/func-test-virt-launcher-fail-fast"
+
+	// Used by functional tests to ignore backoff applied to migrations
+	FuncTestForceIgnoreMigrationBackoffAnnotation string = "kubevirt.io/func-test-ignore-migration-backoff"
+
 	// This label is used to match virtual machine instance IDs with pods.
 	// Similar to kubevirt.io/domain. Used on Pod.
 	// Internal use only.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When migrating a VM fails an increasingly exponential backoff will be applied before retrying.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2124528

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use exponential backoff for failing migrations
```
