### PR TITLE
virt-api: Set default machinetype after preference kind

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -62,9 +62,9 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 
 	// Set VM defaults
 	log.Log.Object(&vm).V(4).Info("Apply defaults")
-	mutator.setDefaultMachineType(&vm)
 	mutator.setDefaultInstancetypeKind(&vm)
 	mutator.setDefaultPreferenceKind(&vm)
+	mutator.setDefaultMachineType(&vm)
 
 	patchBytes, err := utiltypes.GeneratePatchPayload(
 		utiltypes.PatchOperation{


### PR DESCRIPTION
/area instancetype
/cc @akrejcir 
/cc @davidvossel 

**What this PR does / why we need it**:

b91332fd2b1b8b2967b1cac92da0522908e95763 recently added a preference lookup within the mutation webhook but this was done before setDefaultPreferenceKind was able to run. As a result the call could fail if a user had not provided a kind within the preferenceMatcher.

This changes corrects this by moving the setDefaultMachineType to after setDefaultPreferenceKind ensuring a kind is always set by the mutation webhook before any lookups are attempted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I've not written up a bug for this as b91332fd2b1b8b2967b1cac92da0522908e95763 has just landed but happy to do so if people think it would be useful.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
