### PR TITLE
Fix tests CDI DV GC default reference

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -58,7 +58,9 @@ function _ensure_cdi_deployment() {
     _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"uploadProxyURLOverride": "'"$override"'"}}}'
 
     # Enable succeeded DataVolume garbage collection
-    _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"dataVolumeTTLSeconds": '"$CDI_DV_GC"'}}}'
+    if [[ $CDI_DV_GC != "0" ]]; then
+        _kubectl patch cdi ${cdi_namespace} --type merge -p '{"spec": {"config": {"dataVolumeTTLSeconds": '"$CDI_DV_GC"'}}}'
+    fi
 }
 
 function configure_prometheus() {

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -171,7 +171,7 @@ func SetDataVolumeGC(virtCli kubecli.KubevirtClient, ttlSec *int32) {
 func IsDataVolumeGC(virtCli kubecli.KubevirtClient) bool {
 	config, err := virtCli.CdiClient().CdiV1beta1().CDIConfigs().Get(context.TODO(), "config", v12.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	return config.Spec.DataVolumeTTLSeconds != nil
+	return config.Spec.DataVolumeTTLSeconds == nil || *config.Spec.DataVolumeTTLSeconds >= 0
 }
 
 func GetCDI(virtCli kubecli.KubevirtClient) *v1beta1.CDI {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -893,7 +893,6 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 	Describe("[Serial][rfe_id:8400][crit:high][vendor:cnv-qe@redhat.com][level:system] Garbage collection of succeeded DV", func() {
 		var originalTTL *int32
-		ttl0 := int32(0)
 
 		BeforeEach(func() {
 			cdi := libstorage.GetCDI(virtClient)
@@ -937,8 +936,8 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			vm = tests.StopVirtualMachine(vm)
 		},
-			Entry("[test_id:8567]GC is enabled", &ttl0, &ttl0, ""),
-			Entry("[test_id:8571]GC is disabled, and after VM creation, GC is enabled and DV is annotated", nil, &ttl0, "true"),
+			Entry("[test_id:8567]GC is enabled", pointer.Int32(0), pointer.Int32(0), ""),
+			Entry("[test_id:8571]GC is disabled, and after VM creation, GC is enabled and DV is annotated", pointer.Int32(-1), pointer.Int32(0), "true"),
 		)
 	})
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/pointer"
 
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 
@@ -1171,7 +1172,6 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 		Context("[Serial]With more complicated VM with/out GC of succeeded DV", func() {
 			var originalTTL *int32
-			ttl0 := int32(0)
 
 			BeforeEach(func() {
 				cdi := libstorage.GetCDI(virtClient)
@@ -1247,8 +1247,8 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					Expect(found).To(BeTrue())
 				}
 			},
-				Entry("[test_id:4611] without DV garbage collection", nil),
-				Entry("[test_id:8668] with DV garbage collection", &ttl0),
+				Entry("[test_id:4611] without DV garbage collection", pointer.Int32(-1)),
+				Entry("[test_id:8668] with DV garbage collection", pointer.Int32(0)),
 			)
 		})
 


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
CDI is enabling DataVolume garbage collection by default since: https://github.com/kubevirt/containerized-data-importer/pull/2421

To prevent DV-related CI failures due to the old GC disabled default reference, we enabled GC by default for all lanes in cluster-deploy: https://github.com/kubevirt/kubevirt/pull/8479

With the current fix, we no more need to explicitly enable it by default in cluster-deploy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
