### PR TITLE
cloud-init: Skip networkData lookup if not needed

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -175,15 +175,13 @@ func resolveNoCloudSecrets(vmi *v1.VirtualMachineInstance, secretSourceDir strin
 	}
 
 	baseDir := filepath.Join(secretSourceDir, volume.Name)
-	userData, userDataError := readFileFromDir(baseDir, "userdata")
-	// If "userdata" was not found, try "userData"
-	if userDataError != nil {
-		userData, userDataError = readFileFromDir(baseDir, "userData")
+	var userDataError, networkDataError error
+	var userData, networkData string
+	if volume.CloudInitNoCloud.UserDataSecretRef != nil {
+		userData, userDataError = readFirstFoundFileFromDir(baseDir, []string{"userdata", "userData"})
 	}
-	networkData, networkDataError := readFileFromDir(baseDir, "networkdata")
-	// If "networkdata" was not found, try "networkData"
-	if networkDataError != nil {
-		networkData, networkDataError = readFileFromDir(baseDir, "networkData")
+	if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
+		networkData, networkDataError = readFirstFoundFileFromDir(baseDir, []string{"networkdata", "networkData"})
 	}
 	if userDataError != nil && networkDataError != nil {
 		return fmt.Errorf("no cloud-init data-source found at volume: %s", volume.Name)
@@ -253,20 +251,17 @@ func resolveConfigDriveSecrets(vmi *v1.VirtualMachineInstance, secretSourceDir s
 	}
 
 	baseDir := filepath.Join(secretSourceDir, volume.Name)
-	userData, userDataError := readFileFromDir(baseDir, "userdata")
-	// If "userdata" was not found, try "userData"
-	if userDataError != nil {
-		userData, userDataError = readFileFromDir(baseDir, "userData")
+	var userDataError, networkDataError error
+	var userData, networkData string
+	if volume.CloudInitConfigDrive.UserDataSecretRef != nil {
+		userData, userDataError = readFirstFoundFileFromDir(baseDir, []string{"userdata", "userData"})
 	}
-	networkData, networkDataError := readFileFromDir(baseDir, "networkdata")
-	// If "networkdata" was not found, try "networkData"
-	if networkDataError != nil {
-		networkData, networkDataError = readFileFromDir(baseDir, "networkData")
+	if volume.CloudInitConfigDrive.NetworkDataSecretRef != nil {
+		networkData, networkDataError = readFirstFoundFileFromDir(baseDir, []string{"networkdata", "networkData"})
 	}
 	if userDataError != nil && networkDataError != nil {
 		return keys, fmt.Errorf("no cloud-init data-source found at volume: %s", volume.Name)
 	}
-
 	if userData != "" {
 		volume.CloudInitConfigDrive.UserData = userData
 	}
@@ -293,16 +288,27 @@ func findCloudInitConfigDriveSecretVolume(volumes []v1.Volume) *v1.Volume {
 	return nil
 }
 
-func readFileFromDir(basedir, secretFile string) (string, error) {
-	userDataSecretFile := filepath.Join(basedir, secretFile)
+func readFirstFoundFileFromDir(basedir string, files []string) (string, error) {
+	var err error
+	var data string
+	for _, file := range files {
+		data, err = readFileFromDir(basedir, file)
+		if err == nil {
+			break
+		}
+	}
+	return data, err
+}
+func readFileFromDir(basedir, file string) (string, error) {
+	filePath := filepath.Join(basedir, file)
 	// #nosec No risk for path injection: basedir & secretFile are static strings
-	userDataSecret, err := os.ReadFile(userDataSecretFile)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Log.V(2).Reason(err).
-			Errorf("could not read secret data from source: %s", userDataSecretFile)
+			Errorf("could not read data from source: %s", filePath)
 		return "", err
 	}
-	return string(userDataSecret), nil
+	return string(data), nil
 }
 
 // findCloudInitNoCloudSecretVolume loops over a given list of volumes and return a pointer

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -397,6 +397,9 @@ var _ = Describe("CloudInit", func() {
 									UserDataSecretRef: &k8sv1.LocalObjectReference{
 										Name: secret,
 									},
+									NetworkDataSecretRef: &k8sv1.LocalObjectReference{
+										Name: secret,
+									},
 								},
 							},
 						}
@@ -510,6 +513,9 @@ var _ = Describe("CloudInit", func() {
 							VolumeSource: v1.VolumeSource{
 								CloudInitConfigDrive: &v1.CloudInitConfigDriveSource{
 									UserDataSecretRef: &k8sv1.LocalObjectReference{
+										Name: secret,
+									},
+									NetworkDataSecretRef: &k8sv1.LocalObjectReference{
 										Name: secret,
 									},
 								},


### PR DESCRIPTION
**What this PR does / why we need it**:
When a ConfigDrive cloud-init is configured the networkData from the mounted secret has to be only checked if NetworkDataSecretRef is set.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't show a failure if ConfigDrive cloud init has UserDataSecretRef and not NetworkDataSecretRef
```
