### PR TITLE
Fix flakiness in vmsnapshot tests due to racy indexer

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -613,19 +613,6 @@ func GetVirtualMachineSnapshotInformerIndexers() cache.Indexers {
 
 			return nil, nil
 		},
-		"vmSnapshotContent": func(obj interface{}) ([]string, error) {
-			vms, ok := obj.(*snapshotv1.VirtualMachineSnapshot)
-			if !ok {
-				return nil, unexpectedObjectError
-			}
-
-			if vms.Status != nil &&
-				vms.Status.VirtualMachineSnapshotContentName != nil {
-				return []string{fmt.Sprintf("%s/%s", vms.Namespace, *vms.Status.VirtualMachineSnapshotContentName)}, nil
-			}
-
-			return nil, nil
-		},
 	}
 }
 

--- a/pkg/storage/snapshot/snapshot_base.go
+++ b/pkg/storage/snapshot/snapshot_base.go
@@ -398,13 +398,9 @@ func (ctrl *VMSnapshotController) handleVMSnapshotContent(obj interface{}) {
 			log.Log.Errorf(failedKeyFromObjectFmt, err, content)
 			return
 		}
-		keys, err := ctrl.VMSnapshotInformer.GetIndexer().IndexKeys("vmSnapshotContent", objName)
-		if err != nil {
-			utilruntime.HandleError(err)
-			return
-		}
 
-		for _, k := range keys {
+		if content.Spec.VirtualMachineSnapshotName != nil {
+			k := cacheKeyFunc(content.Namespace, *content.Spec.VirtualMachineSnapshotName)
 			log.Log.V(5).Infof("enqueued vmsnapshot %q for sync", k)
 			ctrl.vmSnapshotQueue.Add(k)
 		}


### PR DESCRIPTION
Revert "Add vm snapshot obj to queue in case of content deletion" With the exception of callback to handleVMSnapshotContent in case of delete.
This change wasn't required and also introduced a flakiness due to race of updating the content and updating the vmsnapshot status with the content name, hence the indexer didnt work all the time as expected.

This reverts commit e7621e58921c8615dbd91747b0b55f63798c1672.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This should fix the flakiness in snapshot tests espacially in the last quarantined test: 
[test_id:6952][QUARANTINE]snapshot change phase to in progress and succeeded and then should not fail

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
