### PR TITLE
[sig-scale] add deletion percentiles to audit report after sig-scale tests

### DIFF
--- a/tools/perfscale-audit/api/api.go
+++ b/tools/perfscale-audit/api/api.go
@@ -96,9 +96,15 @@ const (
 	ResultTypeCreatePodsCount ResultType = "CREATE-pods-count"
 
 	// kubevirt_vmi_phase_transition_time_from_creation_seconds_bucket
-	ResultTypeVMICreationToRunningP99 ResultType = "vmiCreationToRunningSecondsP99"
-	ResultTypeVMICreationToRunningP95 ResultType = "vmiCreationToRunningSecondsP95"
-	ResultTypeVMICreationToRunningP50 ResultType = "vmiCreationToRunningSecondsP50"
+	ResultTypeVMICreationToRunningP99   ResultType = "vmiCreationToRunningSecondsP99"
+	ResultTypeVMICreationToRunningP95   ResultType = "vmiCreationToRunningSecondsP95"
+	ResultTypeVMICreationToRunningP50   ResultType = "vmiCreationToRunningSecondsP50"
+	ResultTypeVMIDeletionToSucceededP99 ResultType = "vmiDeletionToSucceededSecondsP99"
+	ResultTypeVMIDeletionToSucceededP95 ResultType = "vmiDeletionToSucceededSecondsP95"
+	ResultTypeVMIDeletionToSucceededP50 ResultType = "vmiDeletionToSucceededSecondsP50"
+	ResultTypeVMIDeletionToFailedP99    ResultType = "vmiDeletionToFailedSecondsP99"
+	ResultTypeVMIDeletionToFailedP95    ResultType = "vmiDeletionToFailedSecondsP95"
+	ResultTypeVMIDeletionToFailedP50    ResultType = "vmiDeletionToFailedSecondsP50"
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds deletion time percentiles to the audit report
```
$ cat _out/artifacts/perfscale/perfscale-audit-results.json | grep -C 3 vmi.*To.*
    "UPDATE-virtualmachineinstances-count": {
      "value": 131.11111111111111
    },
    "vmiCreationToRunningSecondsP50": {
      "value": 15
    },
    "vmiCreationToRunningSecondsP95": {
      "value": 19.5
    },
    "vmiCreationToRunningSecondsP99": {
      "value": 19.9
    },
    "vmiDeletionToFailedSecondsP50": {
      "value": 0
    },
    "vmiDeletionToFailedSecondsP95": {
      "value": 0
    },
    "vmiDeletionToFailedSecondsP99": {
      "value": 0
    },
    "vmiDeletionToSucceededSecondsP50": {
      "value": 0.625
    },
    "vmiDeletionToSucceededSecondsP95": {
      "value": 0.9624999999999999
    },
    "vmiDeletionToSucceededSecondsP99": {
      "value": 0.9925
    }
  }
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8540 

**Special notes for your reviewer**:
This is for sig-scale tests, not release-facing (if that is even a valid phrase :D ).


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
