### PR TITLE
Change the libdv.WithPVC to work with default values and options

### DIFF
--- a/tests/libdv/BUILD.bazel
+++ b/tests/libdv/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libdv",
     visibility = ["//visibility:public"],
     deps = [
+        "//tests/containerdisk:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tests/libdv/dv.go
+++ b/tests/libdv/dv.go
@@ -25,6 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
 const (
@@ -60,17 +62,28 @@ func WithNamespace(namespace string) dvOption {
 	}
 }
 
+type pvcOption func(*corev1.PersistentVolumeClaimSpec)
+
 // WithPVC is a dvOption to add a PVCOption spec to the DataVolume
-func WithPVC(storageClass string, size string, accessMode corev1.PersistentVolumeAccessMode, volumeMode corev1.PersistentVolumeMode) dvOption {
+// The function receives an optional list of pvcOption, to override the defaults
+//
+// The default values are:
+// * no storage class
+// * access mode of ReadWriteOnce
+// * volume size of cd.CirrosVolumeSize
+// * no volume mode. kubernetes default is PersistentVolumeFilesystem
+func WithPVC(options ...pvcOption) dvOption {
 	pvc := &corev1.PersistentVolumeClaimSpec{
-		AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
-		VolumeMode:  &volumeMode,
+		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				"storage": resource.MustParse(size),
+				"storage": resource.MustParse(cd.CirrosVolumeSize),
 			},
 		},
-		StorageClassName: &storageClass,
+	}
+
+	for _, opt := range options {
+		opt(pvc)
 	}
 
 	return func(dv *v1beta1.DataVolume) {
@@ -121,6 +134,8 @@ func WithPVCSource(namespace, name string) dvOption {
 	})
 }
 
+// WithForceBindAnnotation adds the "cdi.kubevirt.io/storage.bind.immediate.requested" annotation to the DV,
+// with the value of "true"
 func WithForceBindAnnotation() dvOption {
 	return func(dv *v1beta1.DataVolume) {
 		if dv.Annotations == nil {
@@ -132,4 +147,61 @@ func WithForceBindAnnotation() dvOption {
 
 func randName() string {
 	return "test-datavolume-" + rand.String(dvRandomNameLength)
+}
+
+// PVC Options
+
+// PVCWithStorageClass add the sc storage class name to the DV
+func PVCWithStorageClass(sc string) pvcOption {
+	return func(pvc *corev1.PersistentVolumeClaimSpec) {
+		if pvc == nil {
+			return
+		}
+
+		pvc.StorageClassName = &sc
+	}
+}
+
+// PVCWithVolumeSize overrides the default volume size (cd.CirrosVolumeSize), with the size parameter
+// The size parameter must be in parsable valid quantity string.
+func PVCWithVolumeSize(size string) pvcOption {
+	return func(pvc *corev1.PersistentVolumeClaimSpec) {
+		if pvc == nil {
+			return
+		}
+
+		pvc.Resources.Requests = corev1.ResourceList{"storage": resource.MustParse(size)}
+	}
+}
+
+// PVCWithVolumeMode adds the volume mode to the DV
+func PVCWithVolumeMode(volumeMode corev1.PersistentVolumeMode) pvcOption {
+	return func(pvc *corev1.PersistentVolumeClaimSpec) {
+		if pvc == nil {
+			return
+		}
+
+		pvc.VolumeMode = &volumeMode
+	}
+}
+
+// PVCWithBlockVolumeMode adds the PersistentVolumeBlock volume mode to the DV
+func PVCWithBlockVolumeMode() pvcOption {
+	return PVCWithVolumeMode(corev1.PersistentVolumeBlock)
+}
+
+// PVCWithAccessMode overrides the DV default access mode (ReadWriteOnce) with the accessMode parameter
+func PVCWithAccessMode(accessMode corev1.PersistentVolumeAccessMode) pvcOption {
+	return func(pvc *corev1.PersistentVolumeClaimSpec) {
+		if pvc == nil {
+			return
+		}
+
+		pvc.AccessModes = []corev1.PersistentVolumeAccessMode{accessMode}
+	}
+}
+
+// PVCWithReadWriteManyAccessMode set the DV access mode to ReadWriteMany
+func PVCWithReadWriteManyAccessMode() pvcOption {
+	return PVCWithAccessMode(corev1.ReadWriteMany)
 }

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1456,7 +1456,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -1665,7 +1665,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 				dv = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(url),
-					libdv.WithPVC(sc, cd.FedoraVolumeSize, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(
+						libdv.PVCWithStorageClass(sc),
+						libdv.PVCWithVolumeSize(cd.FedoraVolumeSize),
+						libdv.PVCWithReadWriteManyAccessMode(),
+					),
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dv, metav1.CreateOptions{})
@@ -1720,7 +1724,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			dv := libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
-				libdv.WithPVC(sc, size, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeFilesystem),
+				libdv.WithPVC(
+					libdv.PVCWithStorageClass(sc),
+					libdv.PVCWithVolumeSize(size),
+					libdv.PVCWithReadWriteManyAccessMode(),
+				),
 				libdv.WithForceBindAnnotation(),
 			)
 
@@ -2119,7 +2127,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				dv = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)),
-					libdv.WithPVC(sc, cd.FedoraVolumeSize, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(
+						libdv.PVCWithStorageClass(sc),
+						libdv.PVCWithVolumeSize(cd.FedoraVolumeSize),
+						libdv.PVCWithReadWriteManyAccessMode(),
+					),
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dv, metav1.CreateOptions{})
@@ -2617,7 +2629,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				dv := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)),
-					libdv.WithPVC(sc, cd.FedoraVolumeSize, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeBlock),
+					libdv.WithPVC(
+						libdv.PVCWithStorageClass(sc),
+						libdv.PVCWithVolumeSize(cd.FedoraVolumeSize),
+						libdv.PVCWithReadWriteManyAccessMode(),
+						libdv.PVCWithBlockVolumeMode(),
+					),
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dv, metav1.CreateOptions{})

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -172,7 +172,11 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dv := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
-					libdv.WithPVC(sc, size, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(
+						libdv.PVCWithStorageClass(sc),
+						libdv.PVCWithVolumeSize(size),
+						libdv.PVCWithReadWriteManyAccessMode(),
+					),
 					libdv.WithForceBindAnnotation(),
 				)
 
@@ -225,7 +229,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -271,7 +275,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				for idx := 0; idx < numVmis; idx++ {
 					dataVolume := libdv.NewDataVolume(
 						libdv.WithRegistryURLSource(imageUrl),
-						libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+						libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 					)
 
 					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -304,7 +308,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				vmi := tests.NewRandomVMIWithPVC(dataVolume.Name)
@@ -336,7 +340,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -390,7 +394,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				dv = libdv.NewDataVolume(
 					libdv.WithNamespace(util.NamespaceTestDefault), // need it for deletion. Reading it from Create() does not work here
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-					libdv.WithPVC(storageClass.Name, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(storageClass.Name)),
 				)
 				vmi = libvmi.New(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -437,7 +441,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(InvalidDataVolumeUrl, cdiv1.RegistryPullPod),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMIWithDataVolume(dataVolume.Name), true)
@@ -463,7 +467,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				// Don't actually create the DataVolume since it's invalid.
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(InvalidDataVolumeUrl),
-					libdv.WithPVC("fakeStorageClass", cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass("fakeStorageClass")),
 				)
 
 				//  Add the invalid DataVolume to a VMI
@@ -504,7 +508,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullPod),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				defer libstorage.DeleteDataVolume(&dataVolume)
@@ -751,7 +755,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 				dataVolume = libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-					libdv.WithPVC(storageClass, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(storageClass)),
 					libdv.WithForceBindAnnotation(),
 				)
 
@@ -1000,7 +1004,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			dataVolume := libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)),
-				libdv.WithPVC(sc, cd.FedoraVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.FedoraVolumeSize)),
 			)
 
 			dataVolume = dvChange(dataVolume)
@@ -1184,7 +1188,7 @@ func volumeExpansionAllowed(sc string) bool {
 func newRandomVMWithCloneDataVolume(sourceNamespace, sourceName, targetNamespace, sc string) *v1.VirtualMachine {
 	dataVolume := libdv.NewDataVolume(
 		libdv.WithPVCSource(sourceNamespace, sourceName),
-		libdv.WithPVC(sc, "1Gi", k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+		libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize("1Gi")),
 	)
 
 	vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -326,7 +326,7 @@ var _ = SIGDescribe("Export", func() {
 		By("Creating source volume")
 		dv := libdv.NewDataVolume(
 			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
-			libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, volumeMode),
+			libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeMode(volumeMode)),
 		)
 
 		dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dv, metav1.CreateOptions{})
@@ -815,7 +815,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 		dv := libdv.NewDataVolume(
 			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
-			libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+			libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 		)
 
 		name := dv.Name
@@ -1319,7 +1319,7 @@ var _ = SIGDescribe("Export", func() {
 
 		blankDv := libdv.NewDataVolume(
 			libdv.WithBlankImageSource(),
-			libdv.WithPVC(sc, cd.BlankVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+			libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 		)
 
 		vm := tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
@@ -1430,7 +1430,7 @@ var _ = SIGDescribe("Export", func() {
 		dataVolume := libdv.NewDataVolume(
 			libdv.WithNamespace(util.NamespaceTestDefault),
 			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-			libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+			libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 		)
 		dataVolume = createDataVolume(dataVolume)
 		vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -1486,7 +1486,7 @@ var _ = SIGDescribe("Export", func() {
 		dv := libdv.NewDataVolume(
 			libdv.WithNamespace(vm.Namespace),
 			libdv.WithBlankImageSource(),
-			libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+			libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 		)
 		dv = createDataVolume(dv)
 		Eventually(ThisPVCWith(vm.Namespace, dv.Name), 160).Should(Exist())
@@ -1631,7 +1631,7 @@ var _ = SIGDescribe("Export", func() {
 			// Create a populated Snapshot
 			blankDv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(sc, cd.BlankVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 			)
 
 			vm := tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
@@ -1764,7 +1764,7 @@ var _ = SIGDescribe("Export", func() {
 				// Create a populated Snapshot
 				blankDv := libdv.NewDataVolume(
 					libdv.WithBlankImageSource(),
-					libdv.WithPVC(sc, cd.BlankVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 				)
 				vm := tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros),

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -474,7 +474,12 @@ var _ = SIGDescribe("Hotplug", func() {
 		By("Creating DataVolume")
 		dvBlock := libdv.NewDataVolume(
 			libdv.WithBlankImageSource(),
-			libdv.WithPVC(sc, cd.BlankVolumeSize, accessMode, volumeMode),
+			libdv.WithPVC(
+				libdv.PVCWithStorageClass(sc),
+				libdv.PVCWithVolumeSize(cd.BlankVolumeSize),
+				libdv.PVCWithAccessMode(accessMode),
+				libdv.PVCWithVolumeMode(volumeMode),
+			),
 			libdv.WithForceBindAnnotation(),
 		)
 
@@ -575,7 +580,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			for i := 0; i < numPVs; i++ {
 				dv := libdv.NewDataVolume(
 					libdv.WithBlankImageSource(),
-					libdv.WithPVC(sc, cd.BlankVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.TODO(), dv, metav1.CreateOptions{})
@@ -1081,7 +1086,11 @@ var _ = SIGDescribe("Hotplug", func() {
 				dv = libdv.NewDataVolume(
 					libdv.WithNamespace(util.NamespaceTestDefault),
 					libdv.WithRegistryURLSource(url),
-					libdv.WithPVC(storageClass, "256Mi", corev1.ReadWriteMany, corev1.PersistentVolumeFilesystem),
+					libdv.WithPVC(
+						libdv.PVCWithStorageClass(storageClass),
+						libdv.PVCWithVolumeSize("256Mi"),
+						libdv.PVCWithReadWriteManyAccessMode(),
+					),
 					libdv.WithForceBindAnnotation(),
 				)
 
@@ -1208,7 +1217,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			dv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(sc, cd.BlankVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 			)
 
 			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.TODO(), dv, metav1.CreateOptions{})
@@ -1260,7 +1269,10 @@ var _ = SIGDescribe("Hotplug", func() {
 		It("should attach a hostpath based volume to running VM", func() {
 			dv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(libstorage.StorageClassHostPathSeparateDevice, cd.BlankVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+				libdv.WithPVC(
+					libdv.PVCWithStorageClass(libstorage.StorageClassHostPathSeparateDevice),
+					libdv.PVCWithVolumeSize(cd.BlankVolumeSize),
+				),
 			)
 
 			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.TODO(), dv, metav1.CreateOptions{})
@@ -1311,7 +1323,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			dv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(sc, cd.BlankVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 			)
 
 			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.TODO(), dv, metav1.CreateOptions{})
@@ -1344,7 +1356,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
 			dv := libdv.NewDataVolume(
 				libdv.WithBlankImageSource(),
-				libdv.WithPVC(sc, cd.BlankVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+				libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 			)
 
 			dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.TODO(), dv, metav1.CreateOptions{})

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1553,7 +1553,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 
 					source := libdv.NewDataVolume(
 						libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
-						libdv.WithPVC(sourceSC, cd.CirrosVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+						libdv.WithPVC(libdv.PVCWithStorageClass(sourceSC)),
 						libdv.WithForceBindAnnotation(),
 					)
 
@@ -1606,7 +1606,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 				createVMFromSource := func() *v1.VirtualMachine {
 					dataVolume := libdv.NewDataVolume(
 						libdv.WithPVCSource(sourceDV.Namespace, sourceDV.Name),
-						libdv.WithPVC(snapshotStorageClass, "1Gi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+						libdv.WithPVC(libdv.PVCWithStorageClass(snapshotStorageClass), libdv.PVCWithVolumeSize("1Gi")),
 					)
 
 					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1252,7 +1252,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			DescribeTable("should accurately report DataVolume provisioning", func(vmif func(string) *v1.VirtualMachineInstance) {
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-					libdv.WithPVC(snapshotStorageClass, cd.CirrosVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(snapshotStorageClass)),
 				)
 
 				vmi := vmif(dataVolume.Name)
@@ -1395,7 +1395,7 @@ func getSnapshotStorageClass(client kubecli.KubevirtClient) (string, error) {
 func AddVolumeAndVerify(virtClient kubecli.KubevirtClient, storageClass string, vm *v1.VirtualMachine, addVMIOnly bool) string {
 	dv := libdv.NewDataVolume(
 		libdv.WithBlankImageSource(),
-		libdv.WithPVC(storageClass, cd.BlankVolumeSize, corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem),
+		libdv.WithPVC(libdv.PVCWithStorageClass(storageClass), libdv.PVCWithVolumeSize(cd.BlankVolumeSize)),
 	)
 
 	var err error

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -540,7 +540,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				dataVolume = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 			})
 
@@ -1304,7 +1304,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				dv = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
-					libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 				)
 
 				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dv, metav1.CreateOptions{})
@@ -1497,7 +1497,7 @@ func createBlockDataVolume(virtClient kubecli.KubevirtClient) (*cdiv1.DataVolume
 
 	dataVolume := libdv.NewDataVolume(
 		libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
-		libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeBlock),
+		libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithBlockVolumeMode()),
 	)
 
 	return virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dataVolume, metav1.CreateOptions{})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -456,7 +456,12 @@ func NewRandomVirtualMachineInstanceWithDisk(imageUrl, namespace, sc string, acc
 
 	dv := libdv.NewDataVolume(
 		libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
-		libdv.WithPVC(sc, dvSizeBySourceURL(imageUrl), accessMode, volMode),
+		libdv.WithPVC(
+			libdv.PVCWithStorageClass(sc),
+			libdv.PVCWithVolumeSize(dvSizeBySourceURL(imageUrl)),
+			libdv.PVCWithAccessMode(accessMode),
+			libdv.PVCWithVolumeMode(volMode),
+		),
 	)
 
 	dv, err = virtCli.CdiClient().CdiV1beta1().DataVolumes(namespace).Create(context.Background(), dv, metav1.CreateOptions{})
@@ -537,7 +542,11 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 func NewRandomVMWithDataVolumeWithRegistryImport(imageUrl, namespace, storageClass string, accessMode k8sv1.PersistentVolumeAccessMode) *v1.VirtualMachine {
 	dataVolume := libdv.NewDataVolume(
 		libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
-		libdv.WithPVC(storageClass, dvSizeBySourceURL(imageUrl), accessMode, k8sv1.PersistentVolumeFilesystem),
+		libdv.WithPVC(
+			libdv.PVCWithStorageClass(storageClass),
+			libdv.PVCWithVolumeSize(dvSizeBySourceURL(imageUrl)),
+			libdv.PVCWithAccessMode(accessMode),
+		),
 	)
 
 	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -555,7 +564,7 @@ func NewRandomVMWithDataVolume(imageUrl string, namespace string) (*v1.VirtualMa
 
 	dataVolume := libdv.NewDataVolume(
 		libdv.WithRegistryURLSource(imageUrl),
-		libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+		libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
 	)
 
 	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -577,7 +586,7 @@ func NewRandomVMWithDataVolumeAndUserData(dataVolume *cdiv1.DataVolume, userData
 func NewRandomVMWithDataVolumeAndUserDataInStorageClass(imageUrl, namespace, userData, storageClass string) *v1.VirtualMachine {
 	dataVolume := libdv.NewDataVolume(
 		libdv.WithRegistryURLSourceAndPullMethod(imageUrl, cdiv1.RegistryPullNode),
-		libdv.WithPVC(storageClass, dvSizeBySourceURL(imageUrl), k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem),
+		libdv.WithPVC(libdv.PVCWithStorageClass(storageClass), libdv.PVCWithVolumeSize(dvSizeBySourceURL(imageUrl))),
 	)
 
 	return NewRandomVMWithDataVolumeAndUserData(dataVolume, userData)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -3155,7 +3155,7 @@ func createBlockDataVolume(virtClient kubecli.KubevirtClient) (*cdiv1.DataVolume
 
 	dataVolume := libdv.NewDataVolume(
 		libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
-		libdv.WithPVC(sc, cd.CirrosVolumeSize, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeBlock),
+		libdv.WithPVC(libdv.PVCWithStorageClass(sc), libdv.PVCWithBlockVolumeMode()),
 	)
 
 	return virtClient.CdiClient().CdiV1beta1().DataVolumes(util.NamespaceTestDefault).Create(context.Background(), dataVolume, metav1.CreateOptions{})


### PR DESCRIPTION
This commit modifies the `libdv.WithPVC` dvOption to be more readable, by removing all its mandatory parameters, and replace them with optional list of `pvcOption`s.

The default values of the `WithPVC` dvOption are:
* no storage class
* access mode of `ReadWriteOnce`
* volume size of `cd.CirrosVolumeSize`
* no volume mode. kubernetes default is `PersistentVolumeFilesystem`

The new pvcOptions are:
* `PVCWithStorageClass` adds the storage class name to the DV
* `PVCWithVolumeSize` overrides the default volume size (`cd.CirrosVolumeSize`), with the size parameter. The size parameter must be a parsable valid quantity string.
* `PVCWithVolumeMode` adds the volume mode to the DV
* `PVCWithBlockVolumeMode` adds the PersistentVolumeBlock volume mode to the DV
* `PVCWithAccessMode` overrides the DV default access mode (ReadWriteOnce) with the accessMode parameter
* `PVCWithReadWriteManyAccessMode` set the DV access mode to ReadWriteMany

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

/sig code-quality

**Release note**:
```release-note
None
```
