### PR TITLE
[release-0.49] WORKSPACE: Freeze repository that deprecated go 1.16

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -270,6 +270,14 @@ go_repository(
     importpath = "golang.org/x/crypto",
 )
 
+# Force v1.15.9 on github.com/klauspost/compress
+# v1.15.11 deprecates go 1.16, and v1.15.10 fails to compile
+go_repository(
+    name = "com_github_klauspost_compress",
+    commit = "4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed",
+    importpath = "github.com/klauspost/compress",
+)
+
 # override rules_docker issue with this dependency
 # rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to
 go_repository(


### PR DESCRIPTION
**What this PR does / why we need it**:
We use bazeldnf, which uses sassoftware/go-rpmutils, which uses klauspost/compress, which just deprecated go 1.16.

This shouldn't have been a problem, because bazeldnf actually replaces sassoftware/go-rpmutils with a safe fork:
https://github.com/rmohr/bazeldnf/blob/eeba90f99f2088abf6ffdf0b9d0b57de62eece4b/deps.bzl#L501
However, that replace doesn't seem to work, probably because of this bug:
https://issuehint.com/issue/bazelbuild/bazel-gazelle/1045

Forcing klauspost/compress to a release prior to go 1.16 deprecation fixes the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
