### PR TITLE
Mark hosts with no virtualization capabilities as unschedulable when emulation isn't allowed

### DIFF
--- a/pkg/virt-handler/heartbeat/BUILD.bazel
+++ b/pkg/virt-handler/heartbeat/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubevirt uses `"kubevirt.io/schedulable"` label to indicate whether a node is schedulable / unschedulable in Kubevirt's context.

Today, we set `"kubevirt.io/schedulable"` to `true` even if virtualization features (i.e. `vmx` for Intel or `svm` for AMD) are missing from the host and emulation is not allowed. If these features are missing, CPU virtualization is not supported and therefore KVM is unusable - and if emulation isn't allowed that means that we can't run any VMs on that node.

This PR aims to set `"kubevirt.io/schedulable"` to `false` in such cases. In addition, node-labeller will skip labeling this node as it's node usable in Kubevirt's scope.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2081133

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mark hosts with no virtualization capabilities as unschedulable
```
