### PR TITLE
[release-0.49] Bump virtlogd memory requirement to 18Mi

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -121,7 +121,7 @@ const ephemeralStorageOverheadSize = "50M"
 
 const (
 	VirtLauncherOverhead = "200Mi" // The sum of the `ps` RSS for the 2 virt-launcher processes
-	VirtlogdOverhead     = "17Mi"  // The RSS for virtlogd
+	VirtlogdOverhead     = "18Mi"  // The RSS for virtlogd
 	LibvirtdOverhead     = "33Mi"  // The RSS for libvirtd
 	QemuOverhead         = "30Mi"  // The RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 )

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1638,8 +1638,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				table.Entry("on amd64", "amd64", "1329108837", "2329108837"),
-				table.Entry("on arm64", "arm64", "1463326565", "2463326565"),
+				table.Entry("on amd64", "amd64", "1330157413", "2330157413"),
+				table.Entry("on arm64", "arm64", "1464375141", "2464375141"),
 			)
 			table.DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1674,8 +1674,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				table.Entry("on amd64", "amd64", "2329108837"),
-				table.Entry("on arm64", "arm64", "2463326565"),
+				table.Entry("on amd64", "amd64", "2330157413"),
+				table.Entry("on arm64", "arm64", "2464375141"),
 			)
 			table.DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1712,8 +1712,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				table.Entry("on amd64", "amd64", 409),
-				table.Entry("on arm64", "arm64", 543),
+				table.Entry("on amd64", "amd64", 410),
+				table.Entry("on arm64", "arm64", 544),
 			)
 
 			table.DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1748,12 +1748,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				table.Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 409),
-				table.Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 409),
-				table.Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 392),
-				table.Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 543),
-				table.Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 543),
-				table.Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 526),
+				table.Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 410),
+				table.Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 410),
+				table.Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 393),
+				table.Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 544),
+				table.Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 544),
+				table.Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 527),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1941,10 +1941,10 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
 			},
-				table.Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 328),
-				table.Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 328),
-				table.Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 462),
-				table.Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 462),
+				table.Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 329),
+				table.Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 329),
+				table.Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 463),
+				table.Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 463),
 			)
 			table.DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1999,8 +1999,8 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(7))
 				Expect(pod.Spec.Containers[0].VolumeMounts[6].MountPath).To(Equal("/dev/hugepages"))
 			},
-				table.Entry("on amd64", "amd64", 328),
-				table.Entry("on arm64", "arm64", 462),
+				table.Entry("on amd64", "amd64", 329),
+				table.Entry("on arm64", "arm64", 463),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -277,7 +277,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(409)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(410)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
Signed-off-by: fossedihelm <ffossemo@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a partial manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/8247

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @acardace 