### PR TITLE
Fix LimitRange namespace bug

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
@@ -44,10 +44,10 @@ func isResourceRequirementMissing(resourceRequirements kubev1.ResourceRequiremen
 	return memoryOrCpuIsMissing(resourceRequirements.Limits) || memoryOrCpuIsMissing(resourceRequirements.Requests)
 }
 
-func applyNamespaceLimitRangeValues(vmi *kubev1.VirtualMachineInstance, limitrangeInformer cache.SharedIndexInformer) {
+func applyNamespaceLimitRangeValues(vmi *kubev1.VirtualMachineInstance, limitrangeInformer cache.SharedIndexInformer, namespace string) {
 	// Copy namespace limits (if exist) to the VM spec
 	if isResourceRequirementMissing(vmi.Spec.Domain.Resources) {
-		limits, err := limitrangeInformer.GetIndexer().ByIndex(cache.NamespaceIndex, vmi.Namespace)
+		limits, err := limitrangeInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
 		if err != nil {
 			return
 		}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 			}
 
 			By("Applying namespace range values on the VMI")
-			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer, vmi.Namespace)
 
 			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("64M"))
 			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("2"))
@@ -89,7 +89,7 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 	When("VMI does not have limits under spec", func() {
 		It("should apply all namespace limits", func() {
 			By("Applying namespace range values on the VMI")
-			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer, vmi.Namespace)
 
 			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("256M"))
 			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("4"))
@@ -109,7 +109,7 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 			}
 
 			By("Applying namespace range values on the VMI")
-			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer, vmi.Namespace)
 
 			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("256M"))
 			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("2"))
@@ -127,7 +127,7 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 			}
 
 			By("Applying namespace range values on the VMI")
-			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer, vmi.Namespace)
 
 			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("64M"))
 			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("2"))

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -81,8 +81,10 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 			}
 		}
 
+		namespace := ar.Request.Namespace
+
 		// Apply namespace limits
-		applyNamespaceLimitRangeValues(newVMI, mutator.NamespaceLimitsInformer)
+		applyNamespaceLimitRangeValues(newVMI, mutator.NamespaceLimitsInformer, namespace)
 
 		// Set VMI defaults
 		log.Log.Object(newVMI).V(4).Info("Apply defaults")


### PR DESCRIPTION
**What this PR does / why we need it**:
LimitRange integration had long standing bug
that caused every VMI to require namespace to
be set.

This also fixes situations where we don't apply
limits to VMI if the VMI is missing the label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7681

**Special notes for your reviewer**:

**Release note**:

```release-note
Bug-fix: LimitRange integration now works when VMI is missing namespace
```
