### PR TITLE
Bump virtlogd memory requirement to 20Mi

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -119,7 +119,7 @@ const ephemeralStorageOverheadSize = "50M"
 const (
 	VirtLauncherMonitorOverhead = "25Mi"  // The `ps` RSS for virt-launcher-monitor
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
-	VirtlogdOverhead            = "18Mi"  // The `ps` RSS for virtlogd
+	VirtlogdOverhead            = "20Mi"  // The `ps` RSS for virtlogd
 	LibvirtdOverhead            = "35Mi"  // The `ps` RSS for libvirtd
 	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 )

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1726,8 +1726,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1253611365", "2253611365"),
-				Entry("on arm64", "arm64", "1387829093", "2387829093"),
+				Entry("on amd64", "amd64", "1255708517", "2255708517"),
+				Entry("on arm64", "arm64", "1389926245", "2389926245"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1762,8 +1762,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2253611365"),
-				Entry("on arm64", "arm64", "2387829093"),
+				Entry("on amd64", "amd64", "2255708517"),
+				Entry("on arm64", "arm64", "2389926245"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -1800,8 +1800,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 333),
-				Entry("on arm64", "arm64", 467),
+				Entry("on amd64", "amd64", 335),
+				Entry("on arm64", "arm64", 469),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -1836,12 +1836,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 333),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 333),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 316),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 467),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 467),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 451),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 335),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 335),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 318),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 469),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 469),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 453),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -2040,10 +2040,10 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 252),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 252),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 387),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 387),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 254),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 254),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 389),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 389),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvInformer, svc = configFactory(arch)
@@ -2109,8 +2109,8 @@ var _ = Describe("Template", func() {
 							MountPath: "/dev/hugepages"},
 					))
 			},
-				Entry("on amd64", "amd64", 252),
-				Entry("on arm64", "arm64", 387),
+				Entry("on amd64", "amd64", 254),
+				Entry("on arm64", "arm64", 389),
 			)
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -329,7 +329,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				if computeContainer == nil {
 					util.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(369)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(371)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The 18Mi virtlogd limit still seems to be a little tight.
Increase it to 20Mi.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
