### PR TITLE
Specify Seccomp on all pods

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -337,8 +337,9 @@ func generateContainerFromVolume(vmi *v1.VirtualMachineInstance, imageIDs map[st
 		},
 		Resources: resources,
 		SecurityContext: &kubev1.SecurityContext{
-			RunAsUser:    &userId,
-			RunAsNonRoot: &nonRoot,
+			RunAsUser:      &userId,
+			RunAsNonRoot:   &nonRoot,
+			SeccompProfile: &kubev1.SeccompProfile{Type: kubev1.SeccompProfileTypeRuntimeDefault},
 		},
 	}
 

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -160,10 +160,11 @@ func xdgEnvironmentVariables() []k8sv1.EnvVar {
 func securityContext(userId int64, privileged bool, requiredCapabilities *k8sv1.Capabilities) *k8sv1.SecurityContext {
 	isNonRoot := userId != 0
 	context := &k8sv1.SecurityContext{
-		RunAsUser:    &userId,
-		RunAsNonRoot: &isNonRoot,
-		Privileged:   &privileged,
-		Capabilities: requiredCapabilities,
+		RunAsUser:      &userId,
+		RunAsNonRoot:   &isNonRoot,
+		Privileged:     &privileged,
+		Capabilities:   requiredCapabilities,
+		SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault},
 	}
 
 	if isNonRoot {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -746,6 +746,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 							Level: "s0",
 							Type:  t.clusterConfig.GetSELinuxLauncherType(),
 						},
+						SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault},
 					},
 					VolumeMounts: []k8sv1.VolumeMount{
 						{
@@ -775,6 +776,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			},
 			Volumes:                       []k8sv1.Volume{emptyDirVolume(hotplugDisks)},
 			TerminationGracePeriodSeconds: &zero,
+			SecurityContext:               &k8sv1.PodSecurityContext{SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault}},
 		},
 	}
 
@@ -879,6 +881,7 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 							Type:  t.clusterConfig.GetSELinuxLauncherType(),
 							Level: "s0",
 						},
+						SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault},
 					},
 					VolumeMounts: []k8sv1.VolumeMount{
 						{
@@ -914,6 +917,7 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				emptyDirVolume(hotplugDisks),
 			},
 			TerminationGracePeriodSeconds: &zero,
+			SecurityContext:               &k8sv1.PodSecurityContext{SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault}},
 		},
 	}
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -416,7 +416,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			newSidecarContainerRenderer(
 				sidecarContainerName(i), vmi, sidecarResources(vmi), requestedHookSidecar, userId).Render(requestedHookSidecar.Command))
 	}
-
 	podAnnotations, err := generatePodAnnotations(vmi)
 	if err != nil {
 		return nil, err
@@ -465,7 +464,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			Hostname:  hostName,
 			Subdomain: vmi.Spec.Subdomain,
 			SecurityContext: &k8sv1.PodSecurityContext{
-				RunAsUser: &userId,
+				RunAsUser:      &userId,
+				SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault},
 			},
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,
 			RestartPolicy:                 k8sv1.RestartPolicyNever,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -973,8 +973,10 @@ func (t *templateService) RenderExporterManifest(vmExport *exportv1.VirtualMachi
 							},
 						},
 					},
+					SecurityContext: &k8sv1.SecurityContext{SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault}},
 				},
 			},
+			SecurityContext: &k8sv1.PodSecurityContext{SeccompProfile: &k8sv1.SeccompProfile{Type: k8sv1.SeccompProfileTypeRuntimeDefault}},
 		},
 	}
 	return exporterPod


### PR DESCRIPTION
**What this PR does / why we need it**:
Specifying Seccomp for pods is required to comply with Restricted Pod Security. Only virtiofsd is left out of this PR as I did not check the required syscalls there yet.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
