### PR TITLE
Refactor virt controller template container command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-github/v32 v32.0.0
 	github.com/google/goexpect v0.0.0-20190425035906-112704a48083
 	github.com/google/gofuzz v1.1.0
@@ -120,7 +121,6 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/google/renameio v0.1.0 // indirect

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "launchercommandrenderer.go",
         "multus_annotations.go",
         "nodeselectorrenderer.go",
         "rendercontainer.go",
@@ -50,6 +51,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "launchercommandrenderer_test.go",
         "multus_annotations_test.go",
         "nodeselectorrenderer_test.go",
         "rendercontainer_test.go",

--- a/pkg/virt-controller/services/launchercommandrenderer.go
+++ b/pkg/virt-controller/services/launchercommandrenderer.go
@@ -2,6 +2,9 @@ package services
 
 import (
 	"strconv"
+
+	"github.com/google/go-cmp/cmp"
+	"kubevirt.io/client-go/log"
 )
 
 type VirtLauncherCommandRenderer struct {
@@ -71,6 +74,9 @@ func NewDoppelgangerPodRender(opts ...VirtLauncherCommandRendererOption) *VirtLa
 
 func (vlcr *VirtLauncherCommandRenderer) Render() []string {
 	if vlcr.isDoppelgangerPod {
+		if vlcr.doesDoppelgangerPodHaveOptions() {
+			log.Log.Warning("doppelganger pod does not allow options")
+		}
 		return []string{"/bin/bash",
 			"-c",
 			"echo", "bound PVCs"}
@@ -108,6 +114,14 @@ func (vlcr *VirtLauncherCommandRenderer) Render() []string {
 		command = append(command, "--simulate-crash")
 	}
 	return command
+}
+
+func (vlcr *VirtLauncherCommandRenderer) doesDoppelgangerPodHaveOptions() bool {
+	return cmp.Equal(
+		vlcr,
+		&VirtLauncherCommandRenderer{isDoppelgangerPod: true},
+		cmp.AllowUnexported(VirtLauncherCommandRenderer{}, VirtLauncherStaticConfig{}),
+	)
 }
 
 func WithNonRootUser() VirtLauncherCommandRendererOption {

--- a/pkg/virt-controller/services/launchercommandrenderer.go
+++ b/pkg/virt-controller/services/launchercommandrenderer.go
@@ -1,0 +1,141 @@
+package services
+
+import (
+	"strconv"
+)
+
+type VirtLauncherCommandRenderer struct {
+	allowEmulation           bool
+	customDebugFilters       string
+	domainName               string
+	isDoppelgangerPod        bool
+	isNonRoot                bool
+	gracePeriodSeconds       int
+	numberOfHookSidecars     int
+	keepAfterFailure         bool
+	namespace                string
+	shouldSimulateCrash      bool
+	virtLauncherStaticConfig VirtLauncherStaticConfig
+	vmUID                    string
+}
+
+type VirtLauncherStaticConfig struct {
+	containerDiskDir string
+	ephemeralDiskDir string
+	launcherTimeout  int
+	ovmfPath         string
+	virtShareDir     string
+}
+
+type VirtLauncherCommandRendererOption func(renderer *VirtLauncherCommandRenderer)
+
+func NewVirtLauncherCommandRenderer(
+	vmUID string,
+	domainName string,
+	gracePeriodSeconds int,
+	hookSidecarListLen int,
+	vmNamespace string,
+	virtLauncherStaticConfig VirtLauncherStaticConfig,
+	opts ...VirtLauncherCommandRendererOption,
+) *VirtLauncherCommandRenderer {
+
+	return applyOptionsToRenderer(
+		&VirtLauncherCommandRenderer{
+			domainName:               domainName,
+			gracePeriodSeconds:       gracePeriodSeconds,
+			numberOfHookSidecars:     hookSidecarListLen,
+			namespace:                vmNamespace,
+			virtLauncherStaticConfig: virtLauncherStaticConfig,
+			vmUID:                    vmUID,
+		},
+		opts,
+	)
+}
+
+func applyOptionsToRenderer(virtLauncherCmdRenderer *VirtLauncherCommandRenderer, opts []VirtLauncherCommandRendererOption) *VirtLauncherCommandRenderer {
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(virtLauncherCmdRenderer)
+	}
+	return virtLauncherCmdRenderer
+}
+
+func NewDoppelgangerPodRender(opts ...VirtLauncherCommandRendererOption) *VirtLauncherCommandRenderer {
+	return applyOptionsToRenderer(
+		&VirtLauncherCommandRenderer{isDoppelgangerPod: true},
+		opts,
+	)
+}
+
+func (vlcr *VirtLauncherCommandRenderer) Render() []string {
+	if vlcr.isDoppelgangerPod {
+		return []string{"/bin/bash",
+			"-c",
+			"echo", "bound PVCs"}
+	}
+
+	const launcherExecBinary = "/usr/bin/virt-launcher-monitor"
+	command := []string{
+		launcherExecBinary,
+		"--qemu-timeout", generateQemuTimeoutWithJitter(vlcr.virtLauncherStaticConfig.launcherTimeout),
+		"--name", vlcr.domainName,
+		"--uid", vlcr.vmUID,
+		"--namespace", vlcr.namespace,
+		"--kubevirt-share-dir", vlcr.virtLauncherStaticConfig.virtShareDir,
+		"--ephemeral-disk-dir", vlcr.virtLauncherStaticConfig.ephemeralDiskDir,
+		"--container-disk-dir", vlcr.virtLauncherStaticConfig.containerDiskDir,
+		"--grace-period-seconds", strconv.Itoa(vlcr.gracePeriodSeconds),
+		"--hook-sidecars", strconv.Itoa(vlcr.numberOfHookSidecars),
+		"--ovmf-path", vlcr.virtLauncherStaticConfig.ovmfPath,
+	}
+	if vlcr.isNonRoot {
+		command = append(command, "--run-as-nonroot")
+	}
+
+	if vlcr.customDebugFilters != "" {
+		command = append(command, "--libvirt-log-filters", vlcr.customDebugFilters)
+	}
+
+	if vlcr.allowEmulation {
+		command = append(command, "--allow-emulation")
+	}
+	if vlcr.keepAfterFailure {
+		command = append(command, "--keep-after-failure")
+	}
+	if vlcr.shouldSimulateCrash {
+		command = append(command, "--simulate-crash")
+	}
+	return command
+}
+
+func WithNonRootUser() VirtLauncherCommandRendererOption {
+	return func(renderer *VirtLauncherCommandRenderer) {
+		renderer.isNonRoot = true
+	}
+}
+
+func WithLibvirtCustomDebugFilters(debugFilters string) VirtLauncherCommandRendererOption {
+	return func(renderer *VirtLauncherCommandRenderer) {
+		renderer.customDebugFilters = debugFilters
+	}
+}
+
+func WithEmulation() VirtLauncherCommandRendererOption {
+	return func(renderer *VirtLauncherCommandRenderer) {
+		renderer.allowEmulation = true
+	}
+}
+
+func WithKeepAfterFailure() VirtLauncherCommandRendererOption {
+	return func(renderer *VirtLauncherCommandRenderer) {
+		renderer.keepAfterFailure = true
+	}
+}
+
+func WithSimulatedCrash() VirtLauncherCommandRendererOption {
+	return func(renderer *VirtLauncherCommandRenderer) {
+		renderer.shouldSimulateCrash = true
+	}
+}

--- a/pkg/virt-controller/services/launchercommandrenderer_test.go
+++ b/pkg/virt-controller/services/launchercommandrenderer_test.go
@@ -1,0 +1,118 @@
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Launcher pod command Renderer", func() {
+	Context("Doppelganger pod command", func() {
+		DescribeTable("should look like", func(expectedCommand []string, options ...VirtLauncherCommandRendererOption) {
+			launcherCommandRenderer := NewDoppelgangerPodRender(options...)
+			Expect(launcherCommandRenderer.Render()).To(
+				ConsistOf(expectedCommand))
+		},
+			Entry(
+				"without options",
+				doppelgangerPodCommand(),
+			),
+			Entry(
+				"the non-root option is ignored for doppelgangers",
+				doppelgangerPodCommand(),
+				WithNonRootUser(),
+			),
+			Entry(
+				"the custom libvirt log filters option is ignored for doppelgangers",
+				doppelgangerPodCommand(),
+				WithLibvirtCustomDebugFilters("debug-this!"),
+			),
+			Entry(
+				"the simulate-crash option is ignored for doppelgangers",
+				doppelgangerPodCommand(),
+				WithSimulatedCrash(),
+			),
+			Entry(
+				"the allowEmulation option is ignored for doppelgangers",
+				doppelgangerPodCommand(),
+				WithEmulation(),
+			),
+			Entry(
+				"the keepAfterFailure option is ignored for doppelgangers",
+				doppelgangerPodCommand(),
+				WithKeepAfterFailure(),
+			))
+	})
+
+	Context("Real launcher pod command", func() {
+		DescribeTable("a real launcher pod command should look like", func(option VirtLauncherCommandRendererOption, expectedCommand ...interface{}) {
+			const (
+				domainName         = "d1"
+				gracePeriodSeconds = 22
+				namespace          = "ns1"
+				vmUID              = "1234"
+			)
+			launcherCommandRenderer := NewVirtLauncherCommandRenderer(vmUID, domainName, gracePeriodSeconds, 0, namespace, dummyStaticConfig(), option)
+			Expect(launcherCommandRenderer.Render()).To(
+				ConsistOf(expectedCommand...))
+		},
+			Entry("simple pod", nil, basicRealVirtLauncherCommand()),
+			Entry("WithNonRootUser option",
+				WithNonRootUser(),
+				append(basicRealVirtLauncherCommand(), "--run-as-nonroot")),
+			Entry("WithLibvirtCustomDebugFilters option",
+				WithLibvirtCustomDebugFilters("debug-this!"),
+				append(
+					basicRealVirtLauncherCommand(),
+					"--libvirt-log-filters",
+					"debug-this!")),
+			Entry("WithEmulation option",
+				WithEmulation(),
+				append(basicRealVirtLauncherCommand(), "--allow-emulation")),
+			Entry("WithKeepAfterFailure option",
+				WithKeepAfterFailure(),
+				append(basicRealVirtLauncherCommand(), "--keep-after-failure")),
+			Entry("WithSimulatedCrash option",
+				WithSimulatedCrash(),
+				append(basicRealVirtLauncherCommand(), "--simulate-crash")),
+		)
+	})
+})
+
+func doppelgangerPodCommand() []string {
+	return []string{"/bin/bash", "-c", "echo", "bound PVCs"}
+}
+
+func dummyStaticConfig() VirtLauncherStaticConfig {
+	return VirtLauncherStaticConfig{
+		containerDiskDir: "/cont-disk",
+		ephemeralDiskDir: "/ephemeral-disk",
+		launcherTimeout:  1200,
+		ovmfPath:         "/over-there/behind-the-counter",
+		virtShareDir:     "/next/to-the-tomato-sauce",
+	}
+}
+
+func basicRealVirtLauncherCommand() []interface{} {
+	return []interface{}{
+		"/usr/bin/virt-launcher-monitor",
+		"--qemu-timeout",
+		MatchRegexp("[0-9]+s"),
+		"--name",
+		"d1",
+		"--uid",
+		"1234",
+		"--namespace",
+		"ns1",
+		"--kubevirt-share-dir",
+		"/next/to-the-tomato-sauce",
+		"--ephemeral-disk-dir",
+		"/ephemeral-disk",
+		"--container-disk-dir",
+		"/cont-disk",
+		"--grace-period-seconds",
+		"22",
+		"--hook-sidecars",
+		"0",
+		"--ovmf-path",
+		"/over-there/behind-the-counter"}
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -301,7 +301,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	if err != nil {
 		return nil, err
 	}
-	resources := resourceRenderer.ResourceRequirements()
 
 	// Read requested hookSidecars from VMI meta
 	requestedHookSidecarList, err := hooks.UnmarshalHookSidecarList(vmi)
@@ -356,7 +355,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		return nil, err
 	}
 
-	compute := t.newContainerSpecRenderer(vmi, volumeRenderer, resources, userId).Render(command)
+	compute := t.newContainerSpecRenderer(
+		vmi,
+		volumeRenderer,
+		resourceRenderer.ResourceRequirements(),
+		userId,
+	).Render(command)
 
 	for networkName, resourceName := range networkToResourceMap {
 		varName := fmt.Sprintf("KUBEVIRT_RESOURCE_NAME_%s", networkName)

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -131,7 +131,7 @@ const customSELinuxType = "virt_launcher.process"
 type TemplateService interface {
 	RenderMigrationManifest(vmi *v1.VirtualMachineInstance, sourcePod *k8sv1.Pod) (*k8sv1.Pod, error)
 	RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error)
-	RenderHotplugAttachmentPodTemplate(volume []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim, tempPod bool) (*k8sv1.Pod, error)
+	RenderHotplugAttachmentPodTemplate(volume []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim) (*k8sv1.Pod, error)
 	RenderHotplugAttachmentTriggerPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock bool, tempPod bool) (*k8sv1.Pod, error)
 	RenderLaunchManifestNoVm(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
 	RenderExporterManifest(vmExport *exportv1.VirtualMachineExport, namePrefix string) *k8sv1.Pod
@@ -694,7 +694,7 @@ func sidecarContainerName(i int) string {
 	return fmt.Sprintf("hook-sidecar-%d", i)
 }
 
-func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim, tempPod bool) (*k8sv1.Pod, error) {
+func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim) (*k8sv1.Pod, error) {
 	zero := int64(0)
 	sharedMount := k8sv1.MountPropagationHostToContainer
 	command := []string{"/bin/sh", "-c", "/usr/bin/container-disk --copy-path /path/hp"}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -891,7 +891,7 @@ func (c *MigrationController) createAttachmentPod(migration *virtv1.VirtualMachi
 	// Reset the hotplug volume statuses to enforce mount
 	vmiCopy := vmi.DeepCopy()
 	vmiCopy.Status.VolumeStatus = []virtv1.VolumeStatus{}
-	attachmentPodTemplate, err := c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtLauncherPod, vmiCopy, volumeNamesPVCMap, false)
+	attachmentPodTemplate, err := c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtLauncherPod, vmiCopy, volumeNamesPVCMap)
 	if err != nil {
 		return fmt.Errorf("failed to render attachment pod template: %v", err)
 	}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1880,7 +1880,7 @@ func (c *VMIController) createAttachmentPodTemplate(vmi *virtv1.VirtualMachineIn
 	}
 
 	if len(volumeNamesPVCMap) > 0 {
-		pod, err = c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtlauncherPod, vmi, volumeNamesPVCMap, false)
+		pod, err = c.templateService.RenderHotplugAttachmentPodTemplate(volumes, virtlauncherPod, vmi, volumeNamesPVCMap)
 	}
 	return pod, err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR refactors the existing virt-controller launcher pod templating service to use the builder pattern to generate the launcher pod command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
