### PR TITLE
fsfreeze on Paused VM fails

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -792,6 +792,35 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
 			})
 
+			It("Calling Velero hooks should not error if VM Paused", func() {
+				By("Creating VM")
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+				vmi.Namespace = util.NamespaceTestDefault
+				vm = tests.NewRandomVirtualMachine(vmi, false)
+
+				vm, vmi = createAndStartVM(vm)
+				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Logging into Fedora")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Pausing the VirtualMachineInstance")
+				err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+
+				By("Calling Velero pre-backup hook")
+				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr).Should(ContainSubstring("Paused"))
+
+				By("Calling Velero post-backup hook")
+				_, stderr, err = callVeleroHook(vmi, VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr).Should(ContainSubstring("Paused"))
+			})
+
 			Context("with memory dump", func() {
 				var memoryDumpPVC *corev1.PersistentVolumeClaim
 				const memoryDumpPVCName = "fs-pvc"


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Test fsfreeze on Paused VM.

As it shows fsfreeze does not work correctly on paused VM. In fact it does not need to be run there, so in case of Paused VM 
the fsfreeze can be a NOOP, and just return successfully. This needs to be fixed.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Opening a Draft PR with test for Paused VM freeze hook, so we can have a discussion about solutions. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
