### PR TITLE
Fix bug in restore-controller when creating a restore PVC with both dataSource and dataSourceRef

### DIFF
--- a/pkg/storage/snapshot/restore.go
+++ b/pkg/storage/snapshot/restore.go
@@ -878,11 +878,16 @@ func CreateRestorePVCDef(restorePVCName string, volumeSnapshot *vsv1.VolumeSnaps
 	}
 
 	apiGroup := vsv1.GroupName
-	pvc.Spec.DataSource = &corev1.TypedLocalObjectReference{
+	dataSource := corev1.TypedLocalObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     "VolumeSnapshot",
 		Name:     *volumeBackup.VolumeSnapshotName,
 	}
+
+	// We need to overwrite both dataSource and dataSourceRef to avoid incompatibilities between the two
+	pvc.Spec.DataSource = &dataSource
+	pvc.Spec.DataSourceRef = &dataSource
+
 	pvc.Spec.VolumeName = ""
 	return pvc
 }

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -32,7 +32,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/status"
 )
 
-var _ = Describe("Restore controlleer", func() {
+var _ = Describe("Restore controller", func() {
 	const (
 		testNamespace  = "default"
 		uid            = "uid"
@@ -173,6 +173,24 @@ var _ = Describe("Restore controlleer", func() {
 				RestoreSize: &restoreSize,
 			},
 		}
+	}
+
+	createPVCsForVMWithDataSourceRef := func(vm *v1.VirtualMachine) []corev1.PersistentVolumeClaim {
+		var pvcs []corev1.PersistentVolumeClaim
+		for i, dv := range vm.Spec.DataVolumeTemplates {
+			pvc := corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: vm.Namespace,
+					Name:      dv.Name,
+				},
+				Spec: *dv.Spec.PVC,
+			}
+			pvc.Spec.DataSourceRef = dv.Spec.PVC.DataSource
+			pvc.Spec.VolumeName = fmt.Sprintf("volume%d", i+1)
+			pvc.ResourceVersion = "1"
+			pvcs = append(pvcs, pvc)
+		}
+		return pvcs
 	}
 
 	Context("One valid Restore controller given", func() {
@@ -881,6 +899,43 @@ var _ = Describe("Restore controlleer", func() {
 
 			})
 		})
+
+		It("should create restore PVCs with populated dataSourceRef and dataSource", func() {
+			// Mock the restore environment from scratch, so we use source PVCs with dataSourceRef
+			vm := createSnapshotVM()
+			pvcs := createPVCsForVMWithDataSourceRef(vm)
+			s := createSnapshot()
+			sc := createVirtualMachineSnapshotContent(s, vm, pvcs)
+			storageClass := createStorageClass()
+			s.Status.VirtualMachineSnapshotContentName = &sc.Name
+			sc.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+				CreationTime: timeFunc(),
+				ReadyToUse:   &t,
+			}
+			vmSnapshotSource.Add(s)
+			vmSnapshotContentSource.Add(sc)
+			storageClassSource.Add(storageClass)
+
+			// Actual test
+			r := createRestoreWithOwner()
+			vm = createModifiedVM()
+			r.Status = &snapshotv1.VirtualMachineRestoreStatus{
+				Complete: &f,
+				Conditions: []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "Creating new PVCs"),
+					newReadyCondition(corev1.ConditionFalse, "Waiting for new PVCs"),
+				},
+			}
+			vmSource.Add(vm)
+			addVolumeRestores(r)
+			pvcSize := resource.MustParse("2Gi")
+			vs := createVolumeSnapshot(r.Status.Restores[0].VolumeSnapshotName, pvcSize)
+			fakeVolumeSnapshotProvider.Add(vs)
+			expectUpdateVMRestoreInProgress(vm)
+			expectPVCCreateWithDataSourceRef(k8sClient, r, pvcSize)
+			addVirtualMachineRestore(r)
+			controller.processVMRestoreWorkItem()
+		})
 	})
 })
 
@@ -899,6 +954,30 @@ func expectPVCCreates(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMa
 			}
 		}
 		Expect(found).To(BeTrue())
+
+		return true, create.GetObject(), nil
+	})
+}
+
+func expectPVCCreateWithDataSourceRef(client *k8sfake.Clientset, vmRestore *snapshotv1.VirtualMachineRestore, expectedSize resource.Quantity) {
+	client.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		create, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+
+		createObj := create.GetObject().(*corev1.PersistentVolumeClaim)
+		found := false
+		for _, vr := range vmRestore.Status.Restores {
+			if vr.PersistentVolumeClaimName == createObj.Name {
+				Expect(createObj.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(expectedSize))
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
+
+		Expect(createObj.Spec.DataSource).ToNot(BeNil())
+		Expect(createObj.Spec.DataSourceRef).ToNot(BeNil())
+		Expect(createObj.Spec.DataSource).To(Equal(createObj.Spec.DataSourceRef))
 
 		return true, create.GetObject(), nil
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With the [dataSourceRef API inclusion](https://kubernetes.io/blog/2021/08/30/volume-populators-redesigned/) in k8s v1.22, a new validation mechanism was added for PVCs ensuring that, if present, both the dataSource and dataSourceRef fields must be equal.

This behavior conflicts with the restore-controller, which creates the restore PVC using the source spec as a reference, but overwriting the dataSource field. If the source PVC has a populated dataSourceRef field, just overwriting the dataSource triggers the validation error.

This Pull Request aims to modify this behavior, so both dataSource and dataSourceRef are overwritten.

**Which issue(s) this PR fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2128872

**Special notes for your reviewer**:
In order to replicate the bug in older k8s versions (v1.18-v1.23), the `AnyVolumeDataSource` feature gate needs to be enabled in kube-apiserver. This feature gate is enabled by default in newer versions.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
