### PR TITLE
Fix the CPU set migration test case.

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2347,9 +2347,9 @@ var _ = Describe("migratableDomXML", func() {
 </domain>`
 		vmi := newVMI("testns", "kubevirt")
 		mockDomain.EXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
-		domain := &api.Domain{}
-		Expect(xml.Unmarshal([]byte(domXML), domain)).To(Succeed())
-		newXML, err := migratableDomXML(mockDomain, vmi, &domain.Spec)
+		domSpec := &api.DomainSpec{}
+		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
+		newXML, err := migratableDomXML(mockDomain, vmi, domSpec)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	})
@@ -2425,9 +2425,11 @@ var _ = Describe("migratableDomXML", func() {
 
 		By("generated the domain XML for a migration to that target")
 		mockDomain.EXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
-		domain := &api.Domain{}
-		Expect(xml.Unmarshal([]byte(domXML), domain)).To(Succeed())
-		newXML, err := migratableDomXML(mockDomain, vmi, &domain.Spec)
+		domSpec := &api.DomainSpec{}
+		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
+		Expect(domSpec.VCPU).NotTo(BeNil())
+		Expect(domSpec.CPUTune).NotTo(BeNil())
+		newXML, err := migratableDomXML(mockDomain, vmi, domSpec)
 		Expect(err).ToNot(HaveOccurred(), "failed to generate target domain XML")
 
 		By("ensuring the generated XML is accurate")


### PR DESCRIPTION
The spec passed to `migratableDomXML()` should be the current domain spec. If unmarshall the domXML to domain, the `domain.Spec` is actually empty and the 2 new assertions added in this commit will fail.

Signed-off-by: Zhuchen Wang <zcwang@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:  It fixes a unit test logic. Although the test passes originally but the logic is not correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I seems unmarshalling the domain xml to the `Domain` object is not correct. The domain xml can be only unmarshalled to the `DomainSpec` object. Is this by design or a bug?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
