### PR TITLE
virt-api: Cleanup API and improve authentication required checks

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11093,7 +11093,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "v1alpha3GetSubAPIGroup",
+     "operationId": "v1GetSubAPIGroup",
      "responses": {
       "200": {
        "description": "OK",
@@ -11645,35 +11645,6 @@
        "schema": {
         "type": "string"
        }
-      }
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Name of the resource",
-      "name": "name",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Object name and auth scope, such as for teams and projects",
-      "name": "namespace",
-      "in": "path",
-      "required": true
-     }
-    ]
-   },
-   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/test": {
-    "get": {
-     "description": "Test endpoint verifying apiserver connectivity.",
-     "operationId": "v1Test",
-     "responses": {
-      "401": {
-       "description": "Unauthorized"
       }
      }
     },
@@ -13100,35 +13071,6 @@
      }
     ]
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/test": {
-    "get": {
-     "description": "Test endpoint verifying apiserver connectivity.",
-     "operationId": "v1alpha3Test",
-     "responses": {
-      "401": {
-       "description": "Unauthorized"
-      }
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Name of the resource",
-      "name": "name",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "Object name and auth scope, such as for teams and projects",
-      "name": "namespace",
-      "in": "path",
-      "required": true
-     }
-    ]
-   },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unfreeze": {
     "put": {
      "description": "Unfreeze a VirtualMachineInstance object.",
@@ -14009,7 +13951,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "func7",
+     "operationId": "func6",
      "responses": {
       "401": {
        "description": "Unauthorized"

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -162,18 +162,6 @@ var _ = Describe("Virt-api", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		})
 
-		It("should have a test endpoint", func() {
-			app.authorizor = authorizorMock
-			authorizorMock.EXPECT().
-				Authorize(gomock.Not(gomock.Nil())).
-				Return(true, "", nil).
-				AnyTimes()
-			app.Compose()
-			resp, err := http.Get(backend.URL + "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/vm1/test")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		})
-
 		It("should have a version endpoint", func() {
 			app.authorizor = authorizorMock
 			authorizorMock.EXPECT().

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -221,14 +221,29 @@ var _ = Describe("Authorizer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(allowed).To(BeTrue())
 			},
+				// Root resources
 				Entry("root", "/"),
-				Entry("apis", "/apis"),
-				Entry("group", "/apis/subresources.kubevirt.io"),
-				Entry("version", "/apis/subresources.kubevirt.io/version"),
-				Entry("healthz", "/apis/subresources.kubevirt.io/healthz"),
-				Entry("start profiler", "/apis/subresources.kubevirt.io/start-cluster-profiler"),
-				Entry("stop profiler", "/apis/subresources.kubevirt.io/stop-cluster-profiler"),
-				Entry("dump profiler", "/apis/subresources.kubevirt.io/dump-cluster-profiler"),
+				Entry("healthz", "/healthz"),
+				Entry("openapi", "/openapi/v2"),
+				Entry("start profiler", "/start-profiler"),
+				Entry("stop profiler", "/stop-profiler"),
+				Entry("dump profiler", "/dump-profiler"),
+				// Subresources v1
+				Entry("subresource v1 groupversion", "/apis/subresources.kubevirt.io/v1"),
+				Entry("subresource v1 version", "/apis/subresources.kubevirt.io/v1/version"),
+				Entry("subresource v1 guestfs", "/apis/subresources.kubevirt.io/v1/guestfs"),
+				Entry("subresource v1 healthz", "/apis/subresources.kubevirt.io/v1/healthz"),
+				Entry("subresource v1 start profiler", "/apis/subresources.kubevirt.io/v1/start-cluster-profiler"),
+				Entry("subresource v1 stop profiler", "/apis/subresources.kubevirt.io/v1/stop-cluster-profiler"),
+				Entry("subresource v1 dump profiler", "/apis/subresources.kubevirt.io/v1/dump-cluster-profiler"),
+				// Subresource v1alpha3
+				Entry("subresource v1alpha3 groupversion", "/apis/subresources.kubevirt.io/v1alpha3"),
+				Entry("subresource v1alpha3 version", "/apis/subresources.kubevirt.io/v1alpha3/version"),
+				Entry("subresource v1alpha3 guestfs", "/apis/subresources.kubevirt.io/v1alpha3/guestfs"),
+				Entry("subresource v1alpha3 healthz", "/apis/subresources.kubevirt.io/v1alpha3/healthz"),
+				Entry("subresource v1alpha3 start profiler", "/apis/subresources.kubevirt.io/v1alpha3/start-cluster-profiler"),
+				Entry("subresource v1alpha3 stop profiler", "/apis/subresources.kubevirt.io/v1alpha3/stop-cluster-profiler"),
+				Entry("subresource v1alpha3 dump profiler", "/apis/subresources.kubevirt.io/v1alpha3/dump-cluster-profiler"),
 			)
 
 			DescribeTable("should reject all users for unknown endpoint paths", func(path string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This cleans up the API by:
 - by removing the duplicated '/apis' entry in the list of root paths
 - by removing the test endpoint below VMIs doing nothing
 - by avoiding a useless loop when adding the endpoint for
   '/apis/subresources.kubevirt.io'.

The check for endpoints requiring authentication is improved by
explicitly stating every endpoint that requires no authentication.
This avoids running through a loop every time the virt-api is hit.

This also allows for finer granularity when specifying endpoints
which require no authentication.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
