### PR TITLE
Passt unprivilege low ports release 0.57

### DIFF
--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -79,6 +79,7 @@ type NetworkHandler interface {
 	ConfigureRouteLocalNet(string) error
 	ConfigureIpv4ArpIgnore() error
 	ConfigurePingGroupRange() error
+	ConfigureUnprivilegedPortStart(string) error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
 	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
 	NftablesNewChain(proto iptables.Protocol, table, chain string) error
@@ -176,6 +177,11 @@ func (h *NetworkUtilsHandler) ConfigurePingGroupRange() error {
 func (h *NetworkUtilsHandler) ConfigureRouteLocalNet(iface string) error {
 	routeLocalNetForIface := fmt.Sprintf(sysctl.IPv4RouteLocalNet, iface)
 	err := sysctl.New().SetSysctl(routeLocalNetForIface, allowRouteLocalNet)
+	return err
+}
+
+func (h *NetworkUtilsHandler) ConfigureUnprivilegedPortStart(port string) error {
+	err := sysctl.New().SetSysctl(sysctl.UnprivilegedPortStart, port)
 	return err
 }
 

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -284,6 +284,16 @@ func (_mr *_MockNetworkHandlerRecorder) ConfigurePingGroupRange() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigurePingGroupRange")
 }
 
+func (_m *MockNetworkHandler) ConfigureUnprivilegedPortStart(_param0 string) error {
+	ret := _m.ctrl.Call(_m, "ConfigureUnprivilegedPortStart", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) ConfigureUnprivilegedPortStart(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureUnprivilegedPortStart", arg0)
+}
+
 func (_m *MockNetworkHandler) IptablesNewChain(proto iptables.Protocol, table string, chain string) error {
 	ret := _m.ctrl.Call(_m, "IptablesNewChain", proto, table, chain)
 	ret0, _ := ret[0].(error)

--- a/pkg/network/infraconfigurators/passt.go
+++ b/pkg/network/infraconfigurators/passt.go
@@ -33,6 +33,13 @@ func (b *PasstPodNetworkConfigurator) PreparePodNetworkInterface() error {
 		log.Log.Reason(err).Errorf("failed to configure ping group range")
 		return err
 	}
+	// bugs.passt.top/show_bug.cgi?id=15 and bugs.passt.top/show_bug.cgi?id=18 are resolved
+	log.Log.V(4).Info("Configuring unprivilegedPortStart to 0")
+	err = b.handler.ConfigureUnprivilegedPortStart("0")
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to configure unprivilegedPortStart")
+		return err
+	}
 	return nil
 }
 

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	sysctlBase        = "/proc/sys"
-	NetIPv6Forwarding = "net/ipv6/conf/all/forwarding"
-	NetIPv4Forwarding = "net/ipv4/ip_forward"
-	Ipv4ArpIgnoreAll  = "net/ipv4/conf/all/arp_ignore"
-	PingGroupRange    = "net/ipv4/ping_group_range"
-	IPv4RouteLocalNet = "net/ipv4/conf/%s/route_localnet"
+	sysctlBase            = "/proc/sys"
+	NetIPv6Forwarding     = "net/ipv6/conf/all/forwarding"
+	NetIPv4Forwarding     = "net/ipv4/ip_forward"
+	Ipv4ArpIgnoreAll      = "net/ipv4/conf/all/arp_ignore"
+	PingGroupRange        = "net/ipv4/ping_group_range"
+	IPv4RouteLocalNet     = "net/ipv4/conf/%s/route_localnet"
+	UnprivilegedPortStart = "net/ipv4/ip_unprivileged_port_start"
 )
 
 // Interface is an injectable interface for running sysctl commands.

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -161,6 +161,7 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 						}
 					},
 						Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080, Protocol: "TCP"}}, 8080, k8sv1.IPv4Protocol),
+						Entry("with a specific lower port number [IPv4]", []v1.Port{{Name: "http", Port: 80, Protocol: "TCP"}}, 80, k8sv1.IPv4Protocol),
 						Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, k8sv1.IPv4Protocol),
 						Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080, Protocol: "TCP"}}, 8080, k8sv1.IPv6Protocol),
 						Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, k8sv1.IPv6Protocol),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubevirt/kubevirt/pull/8516

When using Passt network binding mechanism, and not specifying any ports explicitly, traffic to the low ports (<1024) is not passed through to the VM.

This PR sets all virt-launcher ports to be unprivileged, so that all ports may be used by Passt.
This allows using for example SSH to access VM with Passt binding.

The capability for binding to lower ports is moved to a bazel file, instead of defining it in the handler
code, however, due to the following bugs:

https://bugs.passt.top/show_bug.cgi?id=15
https://bugs.passt.top/show_bug.cgi?id=18
Passt is still unable to bind to lower ports.
When the abovementioned bugs are resolved, we can remove the code introduced in the first commit of this PR.

The final commit in this PR adde an e2e test that verifies connectivity to a lower port.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When using Passt binding, virl-launcher has unprivileged_port_start set to 0, so that passt may bind to all ports.
```
