### PR TITLE
docs: add minimum container-selinux version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,12 @@ login`. Your `$HOME/.docker/config.json` should look like:
 }
 ```
 
+## Requirements
+
+### SELinux support
+
+SELinux-enabled nodes need to have [Container-selinux](https://github.com/containers/container-selinux) version 2.170.0 or newer installed.
+
 ## Building
 
 The KubeVirt build system runs completely inside Docker. 


### PR DESCRIPTION
**What this PR does / why we need it**:
Document the fact that, for SELinux support, KubeVirt requires a recent-enough version of container-selinux to be installed on the nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
