### PR TITLE
[Functest stabilization]: Properly limit bandwidth with migration policies

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "io_utils.go",
         "job.go",
         "migration.go",
+        "migration_policy.go",
         "pod_servers.go",
         "utils.go",
         "vmi_servers.go",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -203,7 +203,6 @@ go_test(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
-        "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/pool:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot:go_default_library",

--- a/tests/migration_policy.go
+++ b/tests/migration_policy.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	v1 "kubevirt.io/api/core/v1"
+	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
+	util2 "kubevirt.io/kubevirt/tests/util"
+
+	. "github.com/onsi/gomega"
+)
+
+// If matchingNSLabels is zero, namespace parameter is being ignored and can be nil
+func PreparePolicyAndVMIWithNsAndVmiLabels(vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int) *migrationsv1.MigrationPolicy {
+	Expect(vmi).ToNot(BeNil())
+	if matchingNSLabels > 0 {
+		Expect(namespace).ToNot(BeNil())
+	}
+
+	policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
+	policy := kubecli.NewMinimalMigrationPolicy(policyName)
+	if policy.Labels == nil {
+		policy.Labels = map[string]string{}
+	}
+	policy.Labels[cleanup.TestLabelForNamespace(util2.NamespaceTestDefault)] = ""
+
+	if vmi.Labels == nil {
+		vmi.Labels = make(map[string]string)
+	}
+
+	var namespaceLabels map[string]string
+	if namespace != nil {
+		if namespace.Labels == nil {
+			namespace.Labels = make(map[string]string)
+		}
+
+		namespaceLabels = namespace.Labels
+	}
+
+	if policy.Spec.Selectors == nil {
+		policy.Spec.Selectors = &migrationsv1.Selectors{
+			VirtualMachineInstanceSelector: migrationsv1.LabelSelector{},
+			NamespaceSelector:              migrationsv1.LabelSelector{},
+		}
+	} else if policy.Spec.Selectors.VirtualMachineInstanceSelector == nil {
+		policy.Spec.Selectors.VirtualMachineInstanceSelector = migrationsv1.LabelSelector{}
+	} else if policy.Spec.Selectors.NamespaceSelector == nil {
+		policy.Spec.Selectors.NamespaceSelector = migrationsv1.LabelSelector{}
+	}
+
+	labelKeyPattern := policyName + "-key-%d"
+	labelValuePattern := policyName + "-value-%d"
+
+	applyLabels := func(policyLabels, vmiOrNSLabels map[string]string, labelCount int) {
+		for i := 0; i < labelCount; i++ {
+			labelKey := fmt.Sprintf(labelKeyPattern, i)
+			labelValue := fmt.Sprintf(labelValuePattern, i)
+
+			vmiOrNSLabels[labelKey] = labelValue
+			policyLabels[labelKey] = labelValue
+		}
+	}
+
+	applyLabels(policy.Spec.Selectors.VirtualMachineInstanceSelector, vmi.Labels, matchingVmiLabels)
+	applyLabels(policy.Spec.Selectors.NamespaceSelector, namespaceLabels, matchingNSLabels)
+
+	if namespace != nil {
+		namespace.Labels = namespaceLabels
+	}
+
+	return policy
+}
+
+// PreparePolicyAndVMI mutates the given vmi parameter by adding labels to it. Therefore, it's recommended
+// to use this function before creating the vmi. Otherwise, its labels need to be updated.
+func PreparePolicyAndVMI(vmi *v1.VirtualMachineInstance) *migrationsv1.MigrationPolicy {
+	return PreparePolicyAndVMIWithNsAndVmiLabels(vmi, nil, 1, 0)
+}
+
+func PreparePolicyAndVMIWithBandwidthLimitation(vmi *v1.VirtualMachineInstance, bandwidth resource.Quantity) *migrationsv1.MigrationPolicy {
+	policy := PreparePolicyAndVMI(vmi)
+	policy.Spec.BandwidthPerMigration = &bandwidth
+
+	return policy
+}
+
+func CreateMigrationPolicy(virtClient kubecli.KubevirtClient, policy *migrationsv1.MigrationPolicy) *migrationsv1.MigrationPolicy {
+	var err error
+
+	policy, err = virtClient.MigrationPolicy().Create(context.Background(), policy, metav1.CreateOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "migration policy creation failed")
+
+	return policy
+}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3104,13 +3104,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			}
 
-			getVmisNamespace := func(vmi *v1.VirtualMachineInstance) *k8sv1.Namespace {
-				namespace, err := virtClient.CoreV1().Namespaces().Get(context.Background(), vmi.Namespace, metav1.GetOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(namespace).ShouldNot(BeNil())
-				return namespace
-			}
-
 			DescribeTable("migration policy", func(defineMigrationPolicy bool) {
 				By("Updating config to allow auto converge")
 				config := getCurrentKv()
@@ -3122,7 +3115,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				var expectedPolicyName *string
 				if defineMigrationPolicy {
 					By("Creating a migration policy that overrides cluster policy")
-					policy := tests.GetPolicyMatchedToVmi("testpolicy", vmi, getVmisNamespace(vmi), 1, 0)
+					policy := tests.PreparePolicyAndVMI(vmi)
 					policy.Spec.AllowPostCopy = pointer.BoolPtr(false)
 
 					_, err := virtClient.MigrationPolicy().Create(context.Background(), policy, metav1.CreateOptions{})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2448,6 +2448,22 @@ func PreparePolicyAndVMI(vmi *v1.VirtualMachineInstance) *migrationsv1.Migration
 	return PreparePolicyAndVMIWithNsAndVmiLabels(vmi, nil, 1, 0)
 }
 
+func PreparePolicyAndVMIWithBandwidthLimitation(vmi *v1.VirtualMachineInstance, bandwidth resource.Quantity) *migrationsv1.MigrationPolicy {
+	policy := PreparePolicyAndVMI(vmi)
+	policy.Spec.BandwidthPerMigration = &bandwidth
+
+	return policy
+}
+
+func CreateMigrationPolicy(virtClient kubecli.KubevirtClient, policy *migrationsv1.MigrationPolicy) *migrationsv1.MigrationPolicy {
+	var err error
+
+	policy, err = virtClient.MigrationPolicy().Create(context.Background(), policy, metav1.CreateOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "migration policy creation failed")
+
+	return policy
+}
+
 func GetIdOfLauncher(vmi *v1.VirtualMachineInstance) string {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -45,8 +45,6 @@ import (
 
 	v12 "k8s.io/api/apps/v1"
 
-	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,8 +70,6 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 
 	util2 "kubevirt.io/kubevirt/tests/util"
-
-	"kubevirt.io/kubevirt/tests/framework/cleanup"
 
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -2379,89 +2375,6 @@ func ArchiveToFile(tgtFile *os.File, sourceFilesNames ...string) {
 		_, err = io.Copy(w, srcFile)
 		Expect(err).ToNot(HaveOccurred())
 	}
-}
-
-// If matchingNSLabels is zero, namespace parameter is being ignored and can be nil
-func PreparePolicyAndVMIWithNsAndVmiLabels(vmi *v1.VirtualMachineInstance, namespace *k8sv1.Namespace, matchingVmiLabels, matchingNSLabels int) *migrationsv1.MigrationPolicy {
-	Expect(vmi).ToNot(BeNil())
-	if matchingNSLabels > 0 {
-		Expect(namespace).ToNot(BeNil())
-	}
-
-	policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
-	policy := kubecli.NewMinimalMigrationPolicy(policyName)
-	if policy.Labels == nil {
-		policy.Labels = map[string]string{}
-	}
-	policy.Labels[cleanup.TestLabelForNamespace(util2.NamespaceTestDefault)] = ""
-
-	if vmi.Labels == nil {
-		vmi.Labels = make(map[string]string)
-	}
-
-	var namespaceLabels map[string]string
-	if namespace != nil {
-		if namespace.Labels == nil {
-			namespace.Labels = make(map[string]string)
-		}
-
-		namespaceLabels = namespace.Labels
-	}
-
-	if policy.Spec.Selectors == nil {
-		policy.Spec.Selectors = &migrationsv1.Selectors{
-			VirtualMachineInstanceSelector: migrationsv1.LabelSelector{},
-			NamespaceSelector:              migrationsv1.LabelSelector{},
-		}
-	} else if policy.Spec.Selectors.VirtualMachineInstanceSelector == nil {
-		policy.Spec.Selectors.VirtualMachineInstanceSelector = migrationsv1.LabelSelector{}
-	} else if policy.Spec.Selectors.NamespaceSelector == nil {
-		policy.Spec.Selectors.NamespaceSelector = migrationsv1.LabelSelector{}
-	}
-
-	labelKeyPattern := policyName + "-key-%d"
-	labelValuePattern := policyName + "-value-%d"
-
-	applyLabels := func(policyLabels, vmiOrNSLabels map[string]string, labelCount int) {
-		for i := 0; i < labelCount; i++ {
-			labelKey := fmt.Sprintf(labelKeyPattern, i)
-			labelValue := fmt.Sprintf(labelValuePattern, i)
-
-			vmiOrNSLabels[labelKey] = labelValue
-			policyLabels[labelKey] = labelValue
-		}
-	}
-
-	applyLabels(policy.Spec.Selectors.VirtualMachineInstanceSelector, vmi.Labels, matchingVmiLabels)
-	applyLabels(policy.Spec.Selectors.NamespaceSelector, namespaceLabels, matchingNSLabels)
-
-	if namespace != nil {
-		namespace.Labels = namespaceLabels
-	}
-
-	return policy
-}
-
-// PreparePolicyAndVMI mutates the given vmi parameter by adding labels to it. Therefore, it's recommended
-// to use this function before creating the vmi. Otherwise, its labels need to be updated.
-func PreparePolicyAndVMI(vmi *v1.VirtualMachineInstance) *migrationsv1.MigrationPolicy {
-	return PreparePolicyAndVMIWithNsAndVmiLabels(vmi, nil, 1, 0)
-}
-
-func PreparePolicyAndVMIWithBandwidthLimitation(vmi *v1.VirtualMachineInstance, bandwidth resource.Quantity) *migrationsv1.MigrationPolicy {
-	policy := PreparePolicyAndVMI(vmi)
-	policy.Spec.BandwidthPerMigration = &bandwidth
-
-	return policy
-}
-
-func CreateMigrationPolicy(virtClient kubecli.KubevirtClient, policy *migrationsv1.MigrationPolicy) *migrationsv1.MigrationPolicy {
-	var err error
-
-	policy, err = virtClient.MigrationPolicy().Create(context.Background(), policy, metav1.CreateOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "migration policy creation failed")
-
-	return policy
 }
 
 func GetIdOfLauncher(vmi *v1.VirtualMachineInstance) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses migration policies to limit bandwidth instead of using Kubevirt CR. This enhances tests isolation as they're not dependent on a global resource. In addition, it allows more tests to run in parallel.

One of the tests that now uses this method is test 8482 which is currently quarantined.

The logs (see example [1]) show that the migration already is finished when the test failed on not finding any Prometheus metrics. This sounds familiar - many tests used stress in the past to delay migration progress and prevent it from finishing immediately, and this issue was fixed for other tests by limiting migration bandwidth. The same approach is used here.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.24-sig-compute-migrations/1579489650844635136

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
