### PR TITLE
Fix the pre stop hook for disks-images-provider

### DIFF
--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -27,7 +27,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","source /etc/bashrc && chroot /host losetup -d ${LOOP_DEVICE} && chroot /host umount ${LOOP_DEVICE_HP} && chroot /host losetup -d ${LOOP_DEVICE_HP}"]
+                command: ["/bin/sh","-c","source /etc/bashrc && chroot /host umount ${LOOP_DEVICE_HP} && chroot /host losetup -d ${LOOP_DEVICE_HP}"]
           volumeMounts:
           - name: images
             mountPath: /hostImages


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The manual creation of local block storage has been removed from images/disks-images-provider/entrypoint.sh along with the LOOP_DEVICE env var in 23fae807d7. So drop the leftover cleanup code of the loop device as it causes failures of the pre stop hook.

This fixes the error when trying to remove the daemonset `kubectl -n kubevirt delete daemonset disks-images-provider --cascade=foreground`:
```
Exec lifecycle hook ([/bin/sh -c source /etc/bashrc && chroot /host losetup -d ${LOOP_DEVICE} && chroot /host umount ${LOOP_DEVICE_HP} && chroot /host losetup -d ${LOOP_DEVICE_HP}]) for Container "target" in Pod "disks-images-provider-p2xtr_kubevirt(205e6ca9-0fa7-4bd5-8726-db5914e42ce5)" failed - error: command '/bin/sh -c source /etc/bashrc && chroot /host losetup -d ${LOOP_DEVICE} && chroot /host umount ${LOOP_DEVICE_HP} && chroot /host losetup -d ${LOOP_DEVICE_HP}' exited with 1: losetup: option requires an argument -- 'd'
Try 'losetup --help' for more information.
, message: "losetup: option requires an argument -- 'd'\nTry 'losetup --help' for more information.\n"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
