### PR TITLE
Use fgetxattr to get selinux labels

### DIFF
--- a/cmd/virt-chroot/BUILD.bazel
+++ b/cmd/virt-chroot/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
-        "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of using lgetxattr on a fd path (/proc/self/fd/<num>), directly use `fgetxattr`.

It turns out that `lgetxattr` does not return a consistent result on all kernel version when used on a filedescriptor path.

This is often not an issue. It would just mean that virt-handler would label a few devices in its namespces on every start, even if it would not have to. But on some operating systems (e.g. Centos8, but not Centos8 stream) we then fail on the not needed relabeling attempt.

Before:

lgetxattr sometimes returns weird resources on a file descroptor path:

```
Error: error relabeling file /proc/self/fd/7 from label system_u:system_r:spc_t:s0 to label system_u:object_r:container_file_t:s0. Reason: operation not supported
[...]
error relabeling file /proc/self/fd/7 from label system_u:system_r:spc_t:s0 to label system_u:object_r:container_file_t:s0. Reason: operation not supported
```

After:

Successful detection of matching labels results in no action:

```
root@virt-handler-gk5vb:~# ./virt-chroot selinux relabel system_u:object_r:container_file_t:s0 /dev/net/tun
```

Mismatches are still detected as expected:

```
root@virt-handler-gk5vb:~# ./virt-chroot selinux relabel system_u:object_r:container_file_t:s1 /dev/net/tun
Error: error relabeling file /proc/self/fd/7 from label system_u:object_r:container_file_t:s0 to label system_u:object_r:container_file_t:s1. Reason: operation not supported

[...]
error relabeling file /proc/self/fd/7 from label system_u:object_r:container_file_t:s0 to label system_u:object_r:container_file_t:s1. Reason: operation not supported
```

Signed-off-by: Roman Mohr <rmohr@google.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8544 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix permission denied on on selinux relabeling on some kernel versions
```

