### PR TITLE
[flaky] test 6838 should wait for VM to be updated

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1161,10 +1161,15 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 						errors.IsNotFound(contentErr)
 				}, time.Minute, 2*time.Second).Should(BeTrue())
 
-				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(updatedVM.Status.SnapshotInProgress).To(BeNil())
-				Expect(updatedVM.Finalizers).To(BeEmpty())
+				Eventually(ThisVM(vm), 30*time.Second, 2*time.Second).Should(
+					And(
+						WithTransform(func(vm *v1.VirtualMachine) *string {
+							return vm.Status.SnapshotInProgress
+						}, BeNil()),
+						WithTransform(func(vm *v1.VirtualMachine) []string {
+							return vm.Finalizers
+						}, BeEmpty())),
+					"SnapshotInProgress should be empty")
 
 				Expect(snapshot.Status.CreationTime).To(BeNil())
 			})


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Test verifies that snapshot is failed, and expects VM to not have SnapshotInProgress. VM will be eventually updated. Test waits for VM to be updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
