### PR TITLE
e2e expose: Use EndpointSlices instead of Endpoints and remove XFail blocks

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tests:go_default_library",
-        "//tests/assert:go_default_library",
         "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -28,7 +28,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
@@ -83,8 +82,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 	var err error
 
 	const testPort = 1500
-
-	const xfailError = "Secondary ip on dual stack service is not working. Tracking issue - https://github.com/kubevirt/kubevirt/issues/5477"
 
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
@@ -156,10 +153,8 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		serviceIPs := svc.Spec.ClusterIPs
 		for _, jobFactory := range jobFactories {
 			for ipOrderNum, ip := range serviceIPs {
-				assert.XFail(xfailError, func() {
-					servicePort := fmt.Sprint(svc.Spec.Ports[0].Port)
-					Expect(createAndWaitForJobToSucceed(jobFactory, namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
-				}, ipOrderNum > 0)
+				servicePort := fmt.Sprint(svc.Spec.Ports[0].Port)
+				Expect(createAndWaitForJobToSucceed(jobFactory, namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 			}
 		}
 	}
@@ -410,9 +405,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 					if includesIpv4(ipFamily) {
 						By("Connecting to IPv4 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
-						}, ipFamily == dualIPv6Primary)
+						Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
 					}
 					if inlcudesIpv6(ipFamily) {
 						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
@@ -424,9 +417,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						Expect(ipv6NodeIP).NotTo(BeEmpty(), "must have been able to resolve the IPv6 address of the node")
 
 						By("Connecting to IPv6 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
-						}, ipFamily == dualIPv4Primary)
+						Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobTCP, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
 					}
 				}
 			},
@@ -542,15 +533,11 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 					if includesIpv4(ipFamily) {
 						By("Connecting to IPv4 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
-						}, ipFamily == dualIPv6Primary)
+						Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
 					}
 					if inlcudesIpv6(ipFamily) {
 						By("Connecting to IPv6 node IP")
-						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
-						}, ipFamily == dualIPv4Primary)
+						Expect(createAndWaitForJobToSucceed(tests.NewHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
 					}
 				}
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
e2e,expose: Correct expectation for service endpoints

Endpoint only exposes IP addresses of one family. If dual-stack
cluster is used, then Endpoints expose addresses of whatever family is
the first in the list (for ipv4,ipv6 it's ipv4 and for ipv6,ipv4 it's ipv6).

Since Kubernetes 1.21, there is a new resource EndpointSlices.
The EndpointSlices controller creates a new EndpointSlice for each
address family for Pods selected by a service.

For example, having a Pod with IPv4 and IPv6 address, with a service
selecting it, the following EndpointSlices are created:
```
$ kubectl get EndpointSlices -n kubevirt-test-default1
NAME                               ADDRESSTYPE   PORTS   ENDPOINTS        AGE
cluster-ip-target-vmivnmz7-l892x   IPv6          80      fd10:244::c494   56m
cluster-ip-target-vmivnmz7-wb6b4   IPv4          80      10.244.196.149   56m
```

This commit updates e2e test checking the addresses in endpoints so that
the number of addresses in the created EndpointSlices matches the
expected number of IPs (2), instead of asserting the Endpoint to contain
two addresses of two different families.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
