### PR TITLE
Switch VMs with hugepages to use the container_t SELinux type

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -48,11 +48,6 @@
     ; This is therefore not blocking the switch to container_t
     (allow process self (tun_socket (relabelfrom relabelto attach_queue)))
     ;
-    ; Allowing libvirtd to access the hugetlbfs to setup huge tables.
-    ; Huge tables won't work without it, unless the memory backend is memfd.
-    ; The following rule could be removed if memfd was the only supported memoty backend.
-    (allow process hugetlbfs_t (dir (create rmdir setattr)))
-    ;
     ; This is needed to allow virtiofs to mount filesystem and access NFS
     (allow process nfs_t (dir (mounton)))
     (allow process proc_t (dir (mounton)))
@@ -60,7 +55,7 @@
     ;
     ; This is needed for passt when running with this policy.
     ; container_t is compatible with passt without needing any additional rule.
-    ; This rule is therefore only needed for VMs that use both virtiofs/hugetables and passt.
+    ; This rule is therefore only needed for VMs that use both virtiofs and passt.
     ; The policy will be removed from here once it will be installed via the passt package.
     (allow process tmpfs_t (filesystem (mount)))
 )

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -324,6 +324,8 @@ func withVirioFS() VolumeRendererOption {
 
 func withHugepages() VolumeRendererOption {
 	return func(renderer *VolumeRenderer) error {
+		hugepagesBasePath := "/dev/hugepages"
+
 		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 			Name: "hugepages",
 			VolumeSource: k8sv1.VolumeSource{
@@ -334,7 +336,18 @@ func withHugepages() VolumeRendererOption {
 		})
 		renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
 			Name:      "hugepages",
-			MountPath: filepath.Join("/dev/hugepages"),
+			MountPath: hugepagesBasePath,
+		})
+
+		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
+			Name: "hugetblfs-dir",
+			VolumeSource: k8sv1.VolumeSource{
+				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+			},
+		})
+		renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{
+			Name:      "hugetblfs-dir",
+			MountPath: filepath.Join(hugepagesBasePath, "libvirt/qemu"),
 		})
 		return nil
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -487,9 +487,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	if nonRoot {
-		if util.HasHugePages(vmi) {
-			pod.Spec.SecurityContext.FSGroup = &userId
-		}
 		pod.Spec.SecurityContext.RunAsGroup = &userId
 		pod.Spec.SecurityContext.RunAsNonRoot = &nonRoot
 	}
@@ -1113,7 +1110,7 @@ func wrapGuestAgentPingWithVirtProbe(vmi *v1.VirtualMachineInstance, probe *k8sv
 
 func alignPodMultiCategorySecurity(pod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, selinuxType string, dockerSELinuxMCSWorkaround bool) {
 	if selinuxType == "" {
-		if util.HasHugePages(vmi) || util.IsVMIVirtiofsEnabled(vmi) || util.IsPasstVMI(vmi) {
+		if util.IsVMIVirtiofsEnabled(vmi) || util.IsPasstVMI(vmi) {
 			// If no SELinux type was specified, use our custom type for VMIs that need it
 			selinuxType = customSELinuxType
 		} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMs configured with hugepages can now run using the default container_t SELinux type
```
