### PR TITLE
Change KubevirtVmHighMemoryUsage threshold from 20MB to 50MB

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -538,13 +538,13 @@ tests:
         alertname: LowKVMNodesCount
         exp_alerts: []
 
-  # Memory utilization less than 20MB close to requested memory - based on memory working set
+  # Memory utilization less than 50MB close to requested memory - based on memory working set
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
 
@@ -564,7 +564,7 @@ tests:
               container: "compute"
               namespace: "ns-test"
 
-  # Memory utilization less than 20MB close to requested memory - based on memory RSS
+  # Memory utilization less than 50MB close to requested memory - based on memory RSS
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
@@ -572,7 +572,7 @@ tests:
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
 
     alert_rule_test:
       - eval_time: 1m
@@ -590,15 +590,15 @@ tests:
               container: "compute"
               namespace: "ns-test"
 
-  # Memory utilization less than 20MB close to requested memory - based on memory RSS and memory working set
+  # Memory utilization less than 50MB close to requested memory - based on memory RSS and memory working set
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
 
     alert_rule_test:
       - eval_time: 1m
@@ -616,15 +616,15 @@ tests:
               container: "compute"
               namespace: "ns-test"
 
-  # Memory utilization more than 20MB close to requested memory
+  # Memory utilization more than 50MB close to requested memory
   - interval: 30s
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "19922944 18874368 18874368 17825792"
+        values: "9922944 8874368 8874368 7825792"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "19922944 18874368 18874368 17825792"
+        values: "9922944 8874368 8874368 7825792"
 
     alert_rule_test:
       - eval_time: 1m

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -433,7 +433,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "KubevirtVmHighMemoryUsage",
-						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 20971520 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 20971520"),
+						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 52428800 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 52428800"),
 						For:   "1m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than 20 MB and it is close to requested memory",


### PR DESCRIPTION
Alerting on 20MB free space margin is too close, and late alert for the consumers. This PR increases the threshold to 50MB.

jira-ticket: CNV-21883

Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change KubevirtVmHighMemoryUsage threshold from 20MB to 50MB
```
