### PR TITLE
tests: ignore transient PSA warning events

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1065,6 +1065,11 @@ func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhas
 
 	objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(seconds+2) * time.Second)
 	if wp.FailOnWarnings == true {
+		// let's ignore PSA events as kubernetes internally uses a namespace informer
+		// that might not be up to date after virt-controller relabeled the namespace
+		// to use a 'privileged' policy
+		// TODO: remove this when KubeVirt will be able to run VMs under the 'restricted' level
+		wp.WarningsIgnoreList = append(wp.WarningsIgnoreList, "violates PodSecurity")
 		objectEventWatcher.SetWarningsPolicy(wp)
 	}
 


### PR DESCRIPTION
Kubernetes internally uses a namespace informer
that might not be up to date after virt-controller relabeled the namespace to use a 'privileged' policy, let's ignore those events in tests as with enough time k8s will catch up and the pod will be created.

This patch has to be removed when KubeVirt will be able to run VMs using the 'restricted' PSA level.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
