### PR TITLE
Drop RunAsGroup from the libguestfs pod manifest

### DIFF
--- a/cmd/libguestfs/BUILD.bazel
+++ b/cmd/libguestfs/BUILD.bazel
@@ -27,6 +27,7 @@ container_image(
         "//:get-version",
     ],
     tars = [
+        "//:passwd-tar",
         "//rpm:libguestfs-tools",
         ":appliance_layer",
         ":entrypoint",

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -53,7 +53,7 @@ var (
 	kvm           bool
 	podName       string
 	root          bool
-	group         string
+	fsGroup       string
 )
 
 type guestfsCommand struct {
@@ -78,7 +78,7 @@ func NewGuestfsShellCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 	cmd.PersistentFlags().BoolVar(&kvm, "kvm", true, "Use kvm for the libguestfs-tools container")
 	cmd.PersistentFlags().BoolVar(&root, "root", false, "Set uid 0 for the libguestfs-tool container")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
-	cmd.PersistentFlags().StringVar(&group, "group", "", "Set the gid and fsgroup for the libguestfs-tool container")
+	cmd.PersistentFlags().StringVar(&fsGroup, "fsGroup", "", "Set the fsgroup for the libguestfs-tool container")
 
 	return cmd
 }
@@ -369,11 +369,11 @@ func (client *K8sClient) getPodsForPVC(pvcName, ns string) ([]corev1.Pod, error)
 }
 
 func setGroupLibguestfs() (*int64, error) {
-	if root && group != "" {
-		return nil, fmt.Errorf("cannot set group id with root")
+	if root && fsGroup != "" {
+		return nil, fmt.Errorf("cannot set fsGroup id with root")
 	}
-	if group != "" {
-		n, err := strconv.ParseInt(group, 10, 64)
+	if fsGroup != "" {
+		n, err := strconv.ParseInt(fsGroup, 10, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -418,7 +418,6 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 	securityContext := &corev1.PodSecurityContext{
 		RunAsNonRoot: &nonRoot,
 		RunAsUser:    uid,
-		RunAsGroup:   g,
 		FSGroup:      g,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		podName := libguestsTools + pvcClaim
 		o := append([]string{"guestfs", pvcClaim, "--namespace", util.NamespaceTestDefault}, options...)
 		if setGroup {
-			o = append(o, "--group", testGroup)
+			o = append(o, "--fsGroup", testGroup)
 		}
 		guestfsCmd := clientcmd.NewVirtctlCommand(o...)
 		go func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Same as 0821a5c900. Specifying `RunAsGroup` without `RunAsUser` violates the specification:

https://github.com/kubernetes/cri-api/blob/2b5244cefaeace624cb160d6b3d85dd3fd14baea/pkg/apis/runtime/v1/api.proto#L307-L309

>  run_as_group should only be specified when run_as_user is specified; otherwise, the runtime MUST error.

For some reason, this works fine with `cri-o` but `containerd` returns an error:

>  Failed to create pod sandbox: rpc error: code = Unknown desc = failed to generate sanbdox container spec options: failed to generate user string: user group "2000" is specified without user

Additional context: https://github.com/kubevirt/kubevirt/pull/8167#issuecomment-1201074836

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
