### PR TITLE
Bump memory requests according to values seen in testing

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1201,7 +1201,7 @@ spec:
                 resources:
                   requests:
                     cpu: 10m
-                    memory: 250Mi
+                    memory: 400Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -266,7 +266,7 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("230Mi"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
 		},
 	}
 

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -16,6 +16,7 @@
  * Copyright 2018 Red Hat, Inc.
  *
  */
+
 package components
 
 import (
@@ -367,7 +368,7 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("250Mi"),
+			corev1.ResourceMemory: resource.MustParse("300Mi"),
 		},
 	}
 
@@ -580,7 +581,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("250Mi"),
+									corev1.ResourceMemory: resource.MustParse("400Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps up the memory requests for various components (namely virt-operator, virt-api and virt-handler).
I took the highest values seen in recent testing and rounded them up. These are the values:
virt-operator: 380MB
virt-api: 300MB
virt-controller: 250MB
virt-handler: 270MB

Having values that are too low not only triggers many `KubeVirtComponentExceedsRequestedMemory` alerts, but also risks getting killed on busy nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
These values are high, but they just represent our current consumption.
As a separate effort, we need to investigate the high memory needs of our components, and hopefully find ways to lower them.
virt-operator is especially concerning.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
