### PR TITLE
Improve error handling when using fsfreeze with paused VMs

### DIFF
--- a/cmd/virt-freezer/BUILD.bazel
+++ b/cmd/virt-freezer/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -792,7 +792,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
 			})
 
-			It("Calling Velero hooks should not error if VM Paused", func() {
+			It("Calling Velero hooks should error if VM is Paused", func() {
 				By("Creating VM")
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Namespace = util.NamespaceTestDefault
@@ -812,13 +812,8 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 
 				By("Calling Velero pre-backup hook")
 				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr).Should(ContainSubstring("Paused"))
-
-				By("Calling Velero post-backup hook")
-				_, stderr, err = callVeleroHook(vmi, VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(stderr).Should(ContainSubstring("Paused"))
+				Expect(err).To(HaveOccurred())
+				Expect(stderr).Should(ContainSubstring("not running"))
 			})
 
 			Context("with memory dump", func() {

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -792,6 +792,35 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(stderr).Should(ContainSubstring(noGuestAgentString))
 			})
 
+			It("Calling Velero hooks should not error if VM Paused", func() {
+				By("Creating VM")
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+				vmi.Namespace = util.NamespaceTestDefault
+				vm = tests.NewRandomVirtualMachine(vmi, false)
+
+				vm, vmi = createAndStartVM(vm)
+				tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 300)
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Logging into Fedora")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Pausing the VirtualMachineInstance")
+				err := virtClient.VirtualMachineInstance(vmi.Namespace).Pause(vmi.Name, &v1.PauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
+
+				By("Calling Velero pre-backup hook")
+				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr).Should(ContainSubstring("Paused"))
+
+				By("Calling Velero post-backup hook")
+				_, stderr, err = callVeleroHook(vmi, VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stderr).Should(ContainSubstring("Paused"))
+			})
+
 			Context("with memory dump", func() {
 				var memoryDumpPVC *corev1.PersistentVolumeClaim
 				const memoryDumpPVCName = "fs-pvc"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This Pull Request aims to modify `fsfreeze` behavior so, in case of using it with a paused VM, it exits triggering an appropriate error message.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
