### PR TITLE
fix regex for kind/api-change labels

### DIFF
--- a/staging/src/kubevirt.io/api/OWNERS
+++ b/staging/src/kubevirt.io/api/OWNERS
@@ -4,6 +4,6 @@ filters:
   # examples:
   #   pkg/api/types.go
   #   pkg/api/*/register.go
-  "*.go$":
+  "\\.go$":
     labels:
       - kind/api-change


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes the labels for **kind/api-change**

**Special notes for your reviewer**:
Following the examples from upstream kubernetes documentation: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#filters

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @rthallisey @rmohr 
