### PR TITLE
Return directly when key function executes failed

### DIFF
--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -286,6 +286,7 @@ func (c *DisruptionBudgetController) enqueueVirtualMachine(obj interface{}) {
 	key, err := controller.KeyFunc(vmi)
 	if err != nil {
 		logger.Object(vmi).Reason(err).Error("Failed to extract key from virtualmachineinstance.")
+		return
 	}
 	c.Queue.Add(key)
 }

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -110,6 +110,7 @@ func (c *EvacuationController) enqueueNode(obj interface{}) {
 	key, err := controller.KeyFunc(node)
 	if err != nil {
 		logger.Object(node).Reason(err).Error("Failed to extract key from node.")
+		return
 	}
 	c.Queue.Add(key)
 }
@@ -240,6 +241,7 @@ func (c *EvacuationController) enqueueVirtualMachine(obj interface{}) {
 	key, err := controller.KeyFunc(vmi)
 	if err != nil {
 		logger.Object(vmi).Reason(err).Error("Failed to extract key from virtualmachineinstance.")
+		return
 	}
 	c.Queue.Add(key)
 }

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -1264,6 +1264,7 @@ func (c *MigrationController) enqueueMigration(obj interface{}) {
 	key, err := controller.KeyFunc(migration)
 	if err != nil {
 		logger.Object(migration).Reason(err).Error("Failed to extract key from migration.")
+		return
 	}
 	c.Queue.Add(key)
 }

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -87,6 +87,7 @@ func (c *NodeController) enqueueNode(obj interface{}) {
 	key, err := controller.KeyFunc(node)
 	if err != nil {
 		logger.Object(node).Reason(err).Error("Failed to extract key from node.")
+		return
 	}
 	c.Queue.Add(key)
 }

--- a/pkg/virt-controller/watch/pool.go
+++ b/pkg/virt-controller/watch/pool.go
@@ -341,6 +341,7 @@ func (c *PoolController) enqueuePool(obj interface{}) {
 	key, err := controller.KeyFunc(pool)
 	if err != nil {
 		logger.Object(pool).Reason(err).Error("Failed to extract key from pool.")
+		return
 	}
 
 	// Delay prevents pool from being reconciled too often

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -578,6 +578,7 @@ func (c *VMIReplicaSet) enqueueReplicaSet(obj interface{}) {
 	key, err := controller.KeyFunc(rs)
 	if err != nil {
 		logger.Object(rs).Reason(err).Error(failedRsKeyExtraction)
+		return
 	}
 	c.Queue.Add(key)
 }
@@ -603,7 +604,7 @@ func max(x int, y int) int {
 	return y
 }
 
-//limit
+// limit
 func limit(x int, burstReplicas uint) int {
 	replicas := int(burstReplicas)
 	if x <= 0 {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1643,6 +1643,7 @@ func (c *VMController) enqueueVm(obj interface{}) {
 	key, err := controller.KeyFunc(vm)
 	if err != nil {
 		logger.Object(vm).Reason(err).Error(failedExtractVmkeyFromVmErrMsg)
+		return
 	}
 	c.Queue.Add(key)
 }

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1397,6 +1397,7 @@ func (c *VMIController) enqueueVirtualMachine(obj interface{}) {
 	key, err := controller.KeyFunc(vmi)
 	if err != nil {
 		logger.Object(vmi).Reason(err).Error("Failed to extract key from virtualmachine.")
+		return
 	}
 	c.Queue.Add(key)
 }

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -210,6 +210,7 @@ func (c *WorkloadUpdateController) enqueueKubeVirt(obj interface{}) {
 	key, err := controller.KeyFunc(kv)
 	if err != nil {
 		logger.Object(kv).Reason(err).Error("Failed to extract key from KubeVirt.")
+		return
 	}
 	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
 }

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -549,6 +549,7 @@ func (c *KubeVirtController) enqueueKubeVirt(obj interface{}) {
 	key, err := controller.KeyFunc(kv)
 	if err != nil {
 		logger.Object(kv).Reason(err).Error("Failed to extract key from KubeVirt.")
+		return
 	}
 	c.delayedQueueAdder(key, c.queue)
 }


### PR DESCRIPTION
workqueue

Signed-off-by: HF <crazytaxii666@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixed code error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Return directly when key function executes failed, the unexpected key should not be added into workqueue.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
