### PR TITLE
[Functest] several fixes to default runtime class configuration tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -251,7 +251,7 @@ go_test(
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/api/node/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/node/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -301,9 +301,13 @@ func RunVMIAndExpectLaunchIgnoreWarnings(vmi *v1.VirtualMachineInstance, timeout
 }
 
 func RunVMIAndExpectScheduling(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
+	wp := watcher.WarningsPolicy{FailOnWarnings: true}
+	return RunVMIAndExpectSchedulingWithWarningPolicy(vmi, timeout, wp)
+}
+
+func RunVMIAndExpectSchedulingWithWarningPolicy(vmi *v1.VirtualMachineInstance, timeout int, wp watcher.WarningsPolicy) *v1.VirtualMachineInstance {
 	obj := RunVMI(vmi, timeout)
 	By("Waiting until the VirtualMachineInstance will be scheduled")
-	wp := watcher.WarningsPolicy{FailOnWarnings: true}
 	return waitForVMIScheduling(obj, timeout, wp)
 }
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1692,8 +1692,9 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 				By("Creating a new VMI")
 				var vmi = tests.NewRandomVMI()
-				vmi = tests.RunVMIAndExpectScheduling(vmi, 30)
-				Expect(err).NotTo(HaveOccurred())
+				// Runtime class related warnings are expected since we created a fake runtime class that isn't supported
+				wp := watcher.WarningsPolicy{FailOnWarnings: true, WarningsIgnoreList: []string{"RuntimeClass"}}
+				vmi = tests.RunVMIAndExpectSchedulingWithWarningPolicy(vmi, 30, wp)
 
 				By("Checking for presence of runtimeClassName")
 				pod := tests.GetPodByVirtualMachineInstance(vmi)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/pborman/uuid"
 	k8sv1 "k8s.io/api/core/v1"
 	kubev1 "k8s.io/api/core/v1"
-	nodev1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -3096,7 +3096,7 @@ func createRuntimeClass(name, handler string) (*nodev1.RuntimeClass, error) {
 		return nil, err
 	}
 
-	return virtCli.NodeV1beta1().RuntimeClasses().Create(
+	return virtCli.NodeV1().RuntimeClasses().Create(
 		context.Background(),
 		&nodev1.RuntimeClass{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -3112,7 +3112,7 @@ func deleteRuntimeClass(name string) error {
 		return err
 	}
 
-	return virtCli.NodeV1beta1().RuntimeClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
+	return virtCli.NodeV1().RuntimeClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
 }
 
 func withNoRng() libvmi.Option {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1674,13 +1674,14 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			BeforeEach(func() {
 				By("Creating a runtime class")
-				createRuntimeClass(runtimeClassName, "custom-handler")
+				_, err := createRuntimeClass(runtimeClassName, "custom-handler")
+				Expect(err).NotTo(HaveOccurred(), "cannot create runtime-class "+runtimeClassName)
 			})
 
 			AfterEach(func() {
 				By("Cleaning up runtime class")
-				err = deleteRuntimeClass(runtimeClassName)
-				Expect(err).NotTo(HaveOccurred())
+				err := deleteRuntimeClass(runtimeClassName)
+				Expect(err).NotTo(HaveOccurred(), "cannot delete runtime-class "+runtimeClassName)
 			})
 
 			It("should apply runtimeClassName to pod when set", func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1670,11 +1670,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		Context("[Serial]using defaultRuntimeClass configuration", func() {
-			runtimeClassName := "custom-runtime-class"
+			const runtimeClassName = "fake-runtime-class"
 
 			BeforeEach(func() {
 				By("Creating a runtime class")
-				_, err := createRuntimeClass(runtimeClassName, "custom-handler")
+				_, err := createRuntimeClass(runtimeClassName, "fake-handler")
 				Expect(err).NotTo(HaveOccurred(), "cannot create runtime-class "+runtimeClassName)
 			})
 
@@ -1691,24 +1691,20 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
 
 				By("Creating a new VMI")
-				var vmi = tests.NewRandomVMI()
+				vmi := tests.NewRandomVMI()
 				// Runtime class related warnings are expected since we created a fake runtime class that isn't supported
 				wp := watcher.WarningsPolicy{FailOnWarnings: true, WarningsIgnoreList: []string{"RuntimeClass"}}
 				vmi = tests.RunVMIAndExpectSchedulingWithWarningPolicy(vmi, 30, wp)
 
 				By("Checking for presence of runtimeClassName")
 				pod := tests.GetPodByVirtualMachineInstance(vmi)
+				Expect(pod.Spec.RuntimeClassName).ToNot(BeNil())
 				Expect(*pod.Spec.RuntimeClassName).To(BeEquivalentTo(runtimeClassName))
 			})
 
 			It("should not apply runtimeClassName to pod when not set", func() {
 				By("Creating a VMI")
-				var vmi = tests.NewRandomVMI()
-				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
-				Expect(err).NotTo(HaveOccurred())
-
-				By("Waiting for successful start of VMI")
-				tests.WaitForSuccessfulVMIStart(vmi)
+				vmi := tests.RunVMIAndExpectLaunch(tests.NewRandomVMI(), 60)
 
 				By("Checking for absence of runtimeClassName")
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings a few fixes and improvements to default runtime class configuration tests.

In short, the main changes are:
- Expect error from createRuntimeClass() to not have occurred
- Ignore warning about fake runtime class not being found
- Use NodeV1 client instead of NodeV1beta1 to eliminate deprecation warning
- Refactoring and a few small fixes

Please see commit description for more info

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
