### PR TITLE
[release-0.53] Rename metrics to follow naming convention

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -36,7 +36,7 @@ Current balloon bytes. Type: Gauge.
 ### kubevirt_vmi_memory_available_bytes
 Amount of `usable` memory as seen by the domain. Type: Gauge.
 
-### kubevirt_vmi_memory_domain_total_bytes
+### kubevirt_vmi_memory_domain_bytes_total
 The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file. Type: Gauge.
 
 ### kubevirt_vmi_memory_pgmajfault

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -186,7 +186,7 @@ func (metrics *vmiMetrics) updateMemory(mem *stats.DomainStatsMemory) {
 
 	if mem.TotalSet {
 		metrics.pushCommonMetric(
-			"kubevirt_vmi_memory_domain_total_bytes",
+			"kubevirt_vmi_memory_domain_bytes_total",
 			"The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file.",
 			prometheus.GaugeValue,
 			float64(mem.Total)*1024,

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -306,7 +306,7 @@ var _ = Describe("Prometheus", func() {
 			result.Write(dto)
 
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_domain_total_bytes"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_domain_bytes_total"))
 			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(float64(1024)))
 		})
 


### PR DESCRIPTION
This is a manual cherry-pick of #8401 

Signed-off-by: João Vilaça <jvilaca@redhat.com>

```release-note
Rename metrics to follow naming convention
```
