### PR TITLE
tests: fix nil point error for kubeClient

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -667,6 +667,7 @@ var _ = Describe("ImageUpload", func() {
 		})
 
 		It("Upload fails when using a nonexistent storageClass", func() {
+			testInit(http.StatusInternalServerError)
 			invalidStorageClass := "no-sc"
 			kubeClient.Fake.PrependReactor("get", "storageclasses", func(action testing.Action) (bool, runtime.Object, error) {
 				_, ok := action.(testing.GetAction)
@@ -674,7 +675,6 @@ var _ = Describe("ImageUpload", func() {
 				return false, nil, nil
 			})
 
-			testInit(http.StatusInternalServerError)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath, "--storage-class", invalidStorageClass)
 			Expect(cmd()).NotTo(Succeed())


### PR DESCRIPTION
testInit is later than usage of kubeClient, this
would lead to nil pointer error when do go_parallel_test

Signed-off-by: Howard Zhang <howard.zhang@arm.com>

**Release note**:

```release-note
None
```
