### PR TITLE
Handle errors in pkg/downwardmetrics

### DIFF
--- a/nogo_config.json
+++ b/nogo_config.json
@@ -153,7 +153,6 @@
       "pkg/config/": "KubeVirt config pkg does not pass errcheck yet",
       "pkg/container-disk/": "KubeVirt container-disk pkg does not pass errcheck yet",
       "pkg/controller/": "KubeVirt controller pkg does not pass errcheck yet",
-      "pkg/downwardmetrics/": "KubeVirt downwardmetrics pkg does not pass errcheck yet",
       "pkg/emptydisk/": "KubeVirt emptydisk pkg does not pass errcheck yet",
       "pkg/ephemeral-disk/": "KubeVirt ephemeral-disk pkg does not pass errcheck yet",
       "pkg/ephemeral-disk-utils/": "KubeVirt ephemeral-disk-utils pkg does not pass errcheck yet",

--- a/pkg/downwardmetrics/vhostmd/BUILD.bazel
+++ b/pkg/downwardmetrics/vhostmd/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
     ],
     importpath = "kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/downwardmetrics/vhostmd/api:go_default_library"],
+    deps = [
+        "//pkg/downwardmetrics/vhostmd/api:go_default_library",
+        "//pkg/util:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/downwardmetrics/vhostmd/disk.go
+++ b/pkg/downwardmetrics/vhostmd/disk.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"kubevirt.io/kubevirt/pkg/downwardmetrics/vhostmd/api"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const fileSize = 262144
@@ -102,7 +103,10 @@ func readDisk(filePath string) (*Disk, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	// If the read operation succeeds, but close fails, we have already read the data,
+	// so it is ok to not return the error.
+	defer util.CloseIOAndCheckErr(f, nil)
+
 	d := &Disk{
 		Header: &Header{},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore error when closing a read-only file.

**Release note**:
```release-note
None
```
