### PR TITLE
Wait for podman to stop rsync container successfully

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -46,11 +46,11 @@ $KUBEVIRT_CRI run ${CONTAINER_ENV} -v "${BUILDER}:/root:rw,z" --security-opt "la
 mkdir -p ${OUT_DIR}
 
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID=$($KUBEVIRT_CRI run ${CONTAINER_ENV} -d -v "${BUILDER}:/root:rw,z" --restart always --security-opt "label=disable" --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID=$($KUBEVIRT_CRI run ${CONTAINER_ENV} -d -v "${BUILDER}:/root:rw,z" --security-opt "label=disable" --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
-    $KUBEVIRT_CRI stop ${RSYNC_CID} >/dev/null 2>&1 &
-    $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1 &
+    $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1
+    $KUBEVIRT_CRI rm -f ${RSYNC_CID} >/dev/null 2>&1
 }
 trap finish EXIT
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The dockerized script is run numerous times during the large e2e jobs. Each time the script is run a temporary rsync container is started. If one of these rsync containers is not cleaned up correctly it can lead to rsync daemon failures[1] when e2e jobs are run with podman.

`podman stop`[2] attempts to stop a container using `SIGTERM` if this fails within the default 10 seconds a `SIGKILL` is used to forceably stop the container. Previously the script was not waiting for the container to be successfully stopped.

Also updating the wait before the `SIGKILL` to 1 second.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-kubevirt-main/1582303864453861376#1:build-log.txt%3A1017 
[2] https://docs.podman.io/en/latest/markdown/podman-stop.1.html#description

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @xpivarc 
**Release note**:
```release-note
NONE
```
