### PR TITLE
Unfreeze VM when all VolumeSnapshots "created" instead of "ready"

### DIFF
--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -68,6 +68,10 @@ func VmSnapshotReady(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
 	return vmSnapshot.Status != nil && vmSnapshot.Status.ReadyToUse != nil && *vmSnapshot.Status.ReadyToUse
 }
 
+func vmSnapshotContentCreated(vmSnapshotContent *snapshotv1.VirtualMachineSnapshotContent) bool {
+	return vmSnapshotContent.Status != nil && vmSnapshotContent.Status.CreationTime != nil
+}
+
 func vmSnapshotContentReady(vmSnapshotContent *snapshotv1.VirtualMachineSnapshotContent) bool {
 	return vmSnapshotContent.Status != nil && vmSnapshotContent.Status.ReadyToUse != nil && *vmSnapshotContent.Status.ReadyToUse
 }
@@ -288,7 +292,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 
 	}
 
-	currentlyCreated := content.Status != nil && content.Status.CreationTime != nil
+	currentlyCreated := vmSnapshotContentCreated(content)
 	currentlyError := (content.Status != nil && content.Status.Error != nil) || vmSnapshotError(vmSnapshot) != nil
 
 	for _, volumeBackup := range content.Spec.VolumeBackups {

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -1338,7 +1338,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				testutils.ExpectEvent(recorder, "VolumeSnapshotMissing")
 			})
 
-			It("should unfreeze vm with online snapshot and guest agent", func() {
+			DescribeTable("should unfreeze vm with online snapshot and guest agent", func(ct *metav1.Time, r bool) {
 				storageClass := createStorageClass()
 				storageClassSource.Add(storageClass)
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
@@ -1366,8 +1366,8 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
 				for i := range volumeSnapshots {
-					volumeSnapshots[i].Status.ReadyToUse = &t
-					volumeSnapshots[i].Status.CreationTime = timeFunc()
+					volumeSnapshots[i].Status.ReadyToUse = &r
+					volumeSnapshots[i].Status.CreationTime = ct
 					volumeSnapshotSource.Add(&volumeSnapshots[i])
 					vss := snapshotv1.VolumeSnapshotStatus{
 						VolumeSnapshotName: volumeSnapshots[i].Name,
@@ -1387,8 +1387,8 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent.UID = contentUID
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					CreationTime: timeFunc(),
-					ReadyToUse:   &t,
+					CreationTime: ct,
+					ReadyToUse:   &r,
 				}
 				for i := range volumeSnapshots {
 					vss := snapshotv1.VolumeSnapshotStatus{
@@ -1400,13 +1400,19 @@ var _ = Describe("Snapshot controlleer", func() {
 					updatedContent.Status.VolumeSnapshotStatus = append(updatedContent.Status.VolumeSnapshotStatus, vss)
 				}
 
-				vmiInterface.EXPECT().Unfreeze(vm.Name).Return(nil)
+				if ct != nil {
+					vmiInterface.EXPECT().Unfreeze(vm.Name).Return(nil)
+				}
 				expectVMSnapshotUpdate(vmSnapshotClient, updatedVMSnapshot)
 				expectVMSnapshotContentUpdate(vmSnapshotClient, updatedContent)
 				vmSnapshotSource.Add(vmSnapshot)
 				addVolumeSnapshotClass(volumeSnapshotClass)
 				controller.processVMSnapshotContentWorkItem()
-			})
+			},
+				Entry("not created and not ready", nil, false),
+				Entry("created and not ready", timeFunc(), false),
+				Entry("created and ready", timeFunc(), true),
+			)
 
 			It("should unfreeze vm with and remove content finalizer if vmsnapshot deleting", func() {
 				vm := createLockedVM()

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -1209,13 +1209,13 @@ var _ = Describe("Snapshot controlleer", func() {
 				testutils.ExpectEvent(recorder, "SuccessfulVolumeSnapshotCreate")
 			})
 
-			It("should update VirtualMachineSnapshotContent", func() {
+			DescribeTable("should update VirtualMachineSnapshotContent", func(readyToUse bool) {
 				vmSnapshot := createVMSnapshotInProgress()
 				vmSnapshotContent := createVMSnapshotContent()
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
-					ReadyToUse:   &t,
+					ReadyToUse:   &readyToUse,
 					CreationTime: timeFunc(),
 				}
 
@@ -1225,7 +1225,7 @@ var _ = Describe("Snapshot controlleer", func() {
 
 				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
 				for i := range volumeSnapshots {
-					volumeSnapshots[i].Status.ReadyToUse = &t
+					volumeSnapshots[i].Status.ReadyToUse = &readyToUse
 					volumeSnapshots[i].Status.CreationTime = timeFunc()
 					addVolumeSnapshot(&volumeSnapshots[i])
 
@@ -1239,7 +1239,10 @@ var _ = Describe("Snapshot controlleer", func() {
 				}
 
 				controller.processVMSnapshotContentWorkItem()
-			})
+			},
+				Entry("not ready", false),
+				Entry("ready", true),
+			)
 
 			It("should update VirtualMachineSnapshotContent no snapshots", func() {
 				vmSnapshot := createVMSnapshotInProgress()


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Turns out that it may take a long time for a VolumeSnapshot to be "ready to use."  For example with EBS backed PVCs that store snapshots in S3.  So instead of unfreezing a VM when all snapshots are ready, just unfreeze when `status.creationTime` is set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
