### PR TITLE
[release-0.58] Backport 8521 'TTL field for VMExport objects' 

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19893,6 +19893,10 @@
      "tokenSecretRef": {
       "description": "TokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod",
       "type": "string"
+     },
+     "ttlDuration": {
+      "description": "ttlDuration limits the lifetime of an export If this field is set, after this duration has passed from counting from CreationTimestamp, the export is eligible to be automatically deleted. If this field is omitted, a reasonable default is applied.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Duration"
      }
     }
    },
@@ -19921,6 +19925,10 @@
      "tokenSecretRef": {
       "description": "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
       "type": "string"
+     },
+     "ttlExpirationTime": {
+      "description": "The time at which the VM Export will be completely removed according to specified TTL Formula is CreationTimestamp + TTL",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      }
     }
    },

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -595,19 +595,7 @@ var _ = Describe("Export controller", func() {
 
 	It("Should create a service based on the name of the VMExport", func() {
 		var service *k8sv1.Service
-		testVMExport := &exportv1.VirtualMachineExport{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testNamespace,
-			},
-			Spec: exportv1.VirtualMachineExportSpec{
-				Source: k8sv1.TypedLocalObjectReference{
-					APIGroup: &k8sv1.SchemeGroupVersion.Group,
-					Kind:     "PersistentVolumeClaim",
-					Name:     testPVCName,
-				},
-			},
-		}
+		testVMExport := createPVCVMExport()
 		k8sClient.Fake.PrependReactor("create", "services", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			create, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
@@ -655,7 +643,7 @@ var _ = Describe("Export controller", func() {
 			},
 		}
 		testVMExport := createPVCVMExport()
-		// We call handleVMExportToken to populate the Status field appropiately
+		populateInitialVMExportStatus(testVMExport)
 		err := controller.handleVMExportToken(testVMExport)
 		Expect(testVMExport.Status.TokenSecretRef).ToNot(BeNil())
 		Expect(err).ToNot(HaveOccurred())
@@ -726,7 +714,7 @@ var _ = Describe("Export controller", func() {
 		scp, err := serializeCertParams(cp)
 		Expect(err).ToNot(HaveOccurred())
 		testVMExport := createPVCVMExport()
-		// We call handleVMExportToken to populate the Status field appropiately
+		populateInitialVMExportStatus(testVMExport)
 		err = controller.handleVMExportToken(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		testExportPod := &k8sv1.Pod{
@@ -798,6 +786,7 @@ var _ = Describe("Export controller", func() {
 			Expect(secret.GetNamespace()).To(Equal(testNamespace))
 			return true, secret, nil
 		})
+		populateInitialVMExportStatus(testVMExport)
 		err := controller.handleVMExportToken(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testVMExport.Status.TokenSecretRef).ToNot(BeNil())
@@ -833,10 +822,44 @@ var _ = Describe("Export controller", func() {
 		testVMExport := createPVCVMExport()
 		Expect(testVMExport.Spec.TokenSecretRef).ToNot(BeNil())
 		expectedName := *testVMExport.Spec.TokenSecretRef
+		populateInitialVMExportStatus(testVMExport)
 		err := controller.handleVMExportToken(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testVMExport.Status.TokenSecretRef).ToNot(BeNil())
 		Expect(*testVMExport.Status.TokenSecretRef).To(Equal(expectedName))
+	})
+
+	It("Should completely clean up VM export, when TTL is reached", func() {
+		var deleted bool
+		testVMExport := createPVCVMExport()
+		ttl := &metav1.Duration{Duration: time.Minute}
+		testVMExport.Spec.TTLDuration = ttl
+		// Artificially reach TTL expiration time
+		testVMExport.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-1 * ttl.Duration)))
+		pvc := &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testPVCName,
+				Namespace: testNamespace,
+			},
+			Status: k8sv1.PersistentVolumeClaimStatus{
+				Phase: k8sv1.ClaimBound,
+			},
+		}
+		Expect(controller.PVCInformer.GetStore().Add(pvc)).To(Succeed())
+
+		vmExportClient.Fake.PrependReactor("delete", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			delete, ok := action.(testing.DeleteAction)
+			Expect(ok).To(BeTrue())
+			Expect(delete.GetName()).To(Equal(testVMExport.GetName()))
+			deleted = true
+			return true, nil, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(deleted).To(BeTrue())
+		// Status update fails (call UPDATE on deleted VMExport), but its fine in real world
+		// since requeue will back out of the reconcile loop if a deletion timestamp is set
+		Expect(err).To(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
 	})
 
 	DescribeTable("Should ignore invalid VMExports kind/api combinations", func(kind, apigroup string) {
@@ -1004,8 +1027,9 @@ func writeCertsToDir(dir string) {
 func createPVCVMExport() *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: testNamespace,
+			Name:              "test",
+			Namespace:         testNamespace,
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{
@@ -1037,9 +1061,10 @@ func createPVCVMExportWithoutSecret() *exportv1.VirtualMachineExport {
 func createSnapshotVMExport() *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: testNamespace,
-			UID:       "11111-22222-33333",
+			Name:              "test",
+			Namespace:         testNamespace,
+			UID:               "11111-22222-33333",
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{
@@ -1055,9 +1080,10 @@ func createSnapshotVMExport() *exportv1.VirtualMachineExport {
 func createVMVMExport() *exportv1.VirtualMachineExport {
 	return &exportv1.VirtualMachineExport{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: testNamespace,
-			UID:       "44444-555555-666666",
+			Name:              "test",
+			Namespace:         testNamespace,
+			UID:               "44444-555555-666666",
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: exportv1.VirtualMachineExportSpec{
 			Source: k8sv1.TypedLocalObjectReference{

--- a/pkg/storage/export/export/pvc-source_test.go
+++ b/pkg/storage/export/export/pvc-source_test.go
@@ -184,6 +184,20 @@ var _ = Describe("PVC source", func() {
 					Namespace: controller.KubevirtNamespace,
 					Name:      "kv",
 				},
+				Spec: virtv1.KubeVirtSpec{
+					CertificateRotationStrategy: virtv1.KubeVirtCertificateRotateStrategy{
+						SelfSigned: &virtv1.KubeVirtSelfSignConfiguration{
+							CA: &virtv1.CertConfig{
+								Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+								RenewBefore: &metav1.Duration{Duration: 3 * time.Hour},
+							},
+							Server: &virtv1.CertConfig{
+								Duration:    &metav1.Duration{Duration: 2 * time.Hour},
+								RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
+							},
+						},
+					},
+				},
 				Status: virtv1.KubeVirtStatus{
 					Phase: virtv1.KubeVirtPhaseDeployed,
 				},

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -182,6 +182,20 @@ var _ = Describe("PVC source", func() {
 					Namespace: controller.KubevirtNamespace,
 					Name:      "kv",
 				},
+				Spec: virtv1.KubeVirtSpec{
+					CertificateRotationStrategy: virtv1.KubeVirtCertificateRotateStrategy{
+						SelfSigned: &virtv1.KubeVirtSelfSignConfiguration{
+							CA: &virtv1.CertConfig{
+								Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+								RenewBefore: &metav1.Duration{Duration: 3 * time.Hour},
+							},
+							Server: &virtv1.CertConfig{
+								Duration:    &metav1.Duration{Duration: 2 * time.Hour},
+								RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
+							},
+						},
+					},
+				},
 				Status: virtv1.KubeVirtStatus{
 					Phase: virtv1.KubeVirtPhaseDeployed,
 				},

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -186,6 +186,20 @@ var _ = Describe("VMSnapshot source", func() {
 					Namespace: controller.KubevirtNamespace,
 					Name:      "kv",
 				},
+				Spec: virtv1.KubeVirtSpec{
+					CertificateRotationStrategy: virtv1.KubeVirtCertificateRotateStrategy{
+						SelfSigned: &virtv1.KubeVirtSelfSignConfiguration{
+							CA: &virtv1.CertConfig{
+								Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+								RenewBefore: &metav1.Duration{Duration: 3 * time.Hour},
+							},
+							Server: &virtv1.CertConfig{
+								Duration:    &metav1.Duration{Duration: 2 * time.Hour},
+								RenewBefore: &metav1.Duration{Duration: 1 * time.Hour},
+							},
+						},
+					},
+				},
 				Status: virtv1.KubeVirtStatus{
 					Phase: virtv1.KubeVirtPhaseDeployed,
 				},

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7805,6 +7805,12 @@ var CRDsValidation map[string]string = map[string]string{
           description: TokenSecretRef is the name of the custom-defined secret that
             contains the token used by the export server pod
           type: string
+        ttlDuration:
+          description: ttlDuration limits the lifetime of an export If this field
+            is set, after this duration has passed from counting from CreationTimestamp,
+            the export is eligible to be automatically deleted. If this field is omitted,
+            a reasonable default is applied.
+          type: string
       required:
       - source
       type: object
@@ -7949,6 +7955,11 @@ var CRDsValidation map[string]string = map[string]string{
         tokenSecretRef:
           description: TokenSecretRef is the name of the secret that contains the
             token used by the export server pod
+          type: string
+        ttlExpirationTime:
+          description: The time at which the VM Export will be completely removed
+            according to specified TTL Formula is CreationTimestamp + TTL
+          format: date-time
           type: string
       type: object
   required:

--- a/staging/src/kubevirt.io/api/export/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/deepcopy_generated.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -166,6 +167,11 @@ func (in *VirtualMachineExportSpec) DeepCopyInto(out *VirtualMachineExportSpec) 
 		*out = new(string)
 		**out = **in
 	}
+	if in.TTLDuration != nil {
+		in, out := &in.TTLDuration, &out.TTLDuration
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 
@@ -191,6 +197,10 @@ func (in *VirtualMachineExportStatus) DeepCopyInto(out *VirtualMachineExportStat
 		in, out := &in.TokenSecretRef, &out.TokenSecretRef
 		*out = new(string)
 		**out = **in
+	}
+	if in.TTLExpirationTime != nil {
+		in, out := &in.TTLExpirationTime, &out.TTLExpirationTime
+		*out = (*in).DeepCopy()
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types.go
@@ -20,12 +20,15 @@
 package v1alpha1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	App = "virt-exporter"
+	App                = "virt-exporter"
+	DefaultDurationTTL = 2 * time.Hour
 )
 
 // VirtualMachineExport defines the operation of exporting a VM source
@@ -57,6 +60,13 @@ type VirtualMachineExportSpec struct {
 	// +optional
 	// TokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod
 	TokenSecretRef *string `json:"tokenSecretRef,omitempty"`
+
+	// ttlDuration limits the lifetime of an export
+	// If this field is set, after this duration has passed from counting from CreationTimestamp,
+	// the export is eligible to be automatically deleted.
+	// If this field is omitted, a reasonable default is applied.
+	// +optional
+	TTLDuration *metav1.Duration `json:"ttlDuration,omitempty"`
 }
 
 // VirtualMachineExportPhase is the current phase of the VirtualMachineExport
@@ -84,6 +94,10 @@ type VirtualMachineExportStatus struct {
 	// +optional
 	// TokenSecretRef is the name of the secret that contains the token used by the export server pod
 	TokenSecretRef *string `json:"tokenSecretRef,omitempty"`
+
+	// The time at which the VM Export will be completely removed according to specified TTL
+	// Formula is CreationTimestamp + TTL
+	TTLExpirationTime *metav1.Time `json:"ttlExpirationTime,omitempty"`
 
 	// +optional
 	// ServiceName is the name of the service created associated with the Virtual Machine export. It will be used to

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types_swagger_generated.go
@@ -20,17 +20,19 @@ func (VirtualMachineExportSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":               "VirtualMachineExportSpec is the spec for a VirtualMachineExport resource",
 		"tokenSecretRef": "+optional\nTokenSecretRef is the name of the custom-defined secret that contains the token used by the export server pod",
+		"ttlDuration":    "ttlDuration limits the lifetime of an export\nIf this field is set, after this duration has passed from counting from CreationTimestamp,\nthe export is eligible to be automatically deleted.\nIf this field is omitted, a reasonable default is applied.\n+optional",
 	}
 }
 
 func (VirtualMachineExportStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":               "VirtualMachineExportStatus is the status for a VirtualMachineExport resource",
-		"phase":          "+optional",
-		"links":          "+optional",
-		"tokenSecretRef": "+optional\nTokenSecretRef is the name of the secret that contains the token used by the export server pod",
-		"serviceName":    "+optional\nServiceName is the name of the service created associated with the Virtual Machine export. It will be used to\ncreate the internal URLs for downloading the images",
-		"conditions":     "+optional\n+listType=atomic",
+		"":                  "VirtualMachineExportStatus is the status for a VirtualMachineExport resource",
+		"phase":             "+optional",
+		"links":             "+optional",
+		"tokenSecretRef":    "+optional\nTokenSecretRef is the name of the secret that contains the token used by the export server pod",
+		"ttlExpirationTime": "The time at which the VM Export will be completely removed according to specified TTL\nFormula is CreationTimestamp + TTL",
+		"serviceName":       "+optional\nServiceName is the name of the service created associated with the Virtual Machine export. It will be used to\ncreate the internal URLs for downloading the images",
+		"conditions":        "+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23094,12 +23094,18 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportSpec(ref common.R
 							Format:      "",
 						},
 					},
+					"ttlDuration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ttlDuration limits the lifetime of an export If this field is set, after this duration has passed from counting from CreationTimestamp, the export is eligible to be automatically deleted. If this field is omitted, a reasonable default is applied.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 				Required: []string{"source"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.TypedLocalObjectReference"},
+			"k8s.io/api/core/v1.TypedLocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
@@ -23126,6 +23132,12 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportStatus(ref common
 							Description: "TokenSecretRef is the name of the secret that contains the token used by the export server pod",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"ttlExpirationTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The time at which the VM Export will be completely removed according to specified TTL Formula is CreationTimestamp + TTL",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"serviceName": {
@@ -23156,7 +23168,7 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportStatus(ref common
 			},
 		},
 		Dependencies: []string{
-			"kubevirt.io/api/export/v1alpha1.Condition", "kubevirt.io/api/export/v1alpha1.VirtualMachineExportLinks"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Time", "kubevirt.io/api/export/v1alpha1.Condition", "kubevirt.io/api/export/v1alpha1.VirtualMachineExportLinks"},
 	}
 }
 

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1763,6 +1763,19 @@ var _ = SIGDescribe("Export", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("Create with TTL", func() {
+			ttl := &metav1.Duration{Duration: 2 * time.Minute}
+			pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
+			// Run vmexport
+			By("Running vmexport command")
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(commandName, "create", vmeName, "--pvc", pvc.Name, "--namespace", util.NamespaceTestDefault, "--ttl", ttl.Duration.String())
+			err = virtctlCmd()
+			Expect(err).ToNot(HaveOccurred())
+			export, err := virtClient.VirtualMachineExport(util.NamespaceTestDefault).Get(context.Background(), vmeName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(export.Spec.TTLDuration).To(Equal(ttl))
+		})
+
 		Context("Download a volume with vmexport", func() {
 			BeforeEach(func() {
 				if !checks.IsOpenShift() {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -913,6 +913,48 @@ var _ = SIGDescribe("Export", func() {
 		Expect(*export.Status.TokenSecretRef).ToNot(BeEmpty())
 	})
 
+	It("Should honor TTL by cleaning up the the VMExport altogether", func() {
+		sc, exists := libstorage.GetRWOFileSystemStorageClass()
+		if !exists {
+			Skip("Skip test when Filesystem storage is not present")
+		}
+
+		pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
+		ttl := &metav1.Duration{Duration: 2 * time.Minute}
+		export := &exportv1.VirtualMachineExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-export-%s", rand.String(12)),
+				Namespace: pvc.Namespace,
+			},
+			Spec: exportv1.VirtualMachineExportSpec{
+				Source: k8sv1.TypedLocalObjectReference{
+					APIGroup: &k8sv1.SchemeGroupVersion.Group,
+					Kind:     "PersistentVolumeClaim",
+					Name:     pvc.Name,
+				},
+				TTLDuration: ttl,
+			},
+		}
+		export, err := virtClient.VirtualMachineExport(export.Namespace).Create(context.Background(), export, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// VMExport sticks around exactly until TTL expiration time is reached
+		// Take a couple of seconds off so we don't start flaking because of races
+		safeTimeout := ttl.Duration - 2*time.Second
+		Consistently(func() error {
+			_, err := virtClient.VirtualMachineExport(export.Namespace).Get(context.Background(), export.Name, metav1.GetOptions{})
+			return err
+		}, safeTimeout, time.Second).Should(Succeed())
+		// Now gets cleaned up
+		Eventually(func() error {
+			_, err := virtClient.VirtualMachineExport(export.Namespace).Get(context.Background(), export.Name, metav1.GetOptions{})
+			return err
+		}, 10*time.Second, 1*time.Second).Should(
+			SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())),
+			"The VM export should have been cleaned up according to TTL by now",
+		)
+	})
+
 	Context("Ingress", func() {
 		const (
 			tlsSecretName = "test-tls"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The release was cut on Oct 3rd, but we would consider it an issue if a user wouldn't be able to limit the lifetime of an export:
- No reason to keep serving after import on the other end took place
- Security concerns

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Backport #8521 
https://bugzilla.redhat.com/show_bug.cgi?id=2136534

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Add an option to specify a TTL for VMExport objects
```
