### PR TITLE
Make exporter pod PSA ready

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -798,8 +798,9 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 	podManifest.Labels = map[string]string{exportServiceLabel: vmExport.Name}
 	podManifest.Annotations = map[string]string{annCertParams: scp}
 	podManifest.Spec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.Bool(true),
-		FSGroup:      pointer.Int64Ptr(kvm),
+		RunAsNonRoot:   pointer.Bool(true),
+		FSGroup:        pointer.Int64Ptr(kvm),
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 	for i, pvc := range pvcs {
 		var mountPoint string

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
+	"k8s.io/utils/pointer"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -962,6 +963,10 @@ func (t *templateService) RenderExporterManifest(vmExport *exportv1.VirtualMachi
 								},
 							},
 						},
+					},
+					SecurityContext: &k8sv1.SecurityContext{
+						AllowPrivilegeEscalation: pointer.Bool(false),
+						Capabilities:             &k8sv1.Capabilities{Drop: []k8sv1.Capability{"ALL"}},
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
AFAIK there is no reason to not make this pod fully PSA ready, most things were already there.

```bash
E1023 15:51:16.640185       1 util.go:72] pods "virt-export-vme-test-whttslbd8wvd" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "vme-test-whttslbd8wvd" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "vme-test-whttslbd8wvd" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "vme-test-whttslbd8wvd" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
BZ Will be added here

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Exporter pod does not comply with restricted PSA
```
