### PR TITLE
Fix remoteAddress field being truncated when it is an ipv6 address

### DIFF
--- a/pkg/rest/filter/filter.go
+++ b/pkg/rest/filter/filter.go
@@ -20,9 +20,8 @@
 package filter
 
 import (
-	"strings"
-
 	restful "github.com/emicklei/go-restful"
+	"net"
 
 	"kubevirt.io/client-go/log"
 )
@@ -36,8 +35,9 @@ func RequestLoggingFilter() restful.FilterFunction {
 			}
 		}
 		chain.ProcessFilter(req, resp)
+		remoteAddr, _, _ := net.SplitHostPort(req.Request.RemoteAddr)
 		log.Log.Level(log.INFO).
-			With("remoteAddress", strings.Split(req.Request.RemoteAddr, ":")[0]).
+			With("remoteAddress", remoteAddr).
 			With("username", username).
 			With("method", req.Request.Method).
 			With("url", req.Request.URL.RequestURI()).

--- a/pkg/rest/filter/filter.go
+++ b/pkg/rest/filter/filter.go
@@ -20,8 +20,9 @@
 package filter
 
 import (
-	restful "github.com/emicklei/go-restful"
 	"net"
+
+	restful "github.com/emicklei/go-restful"
 
 	"kubevirt.io/client-go/log"
 )


### PR DESCRIPTION
when deploy the kubevirt in an ipv6-only cluster, the remoteAddress field in virt-api rest log is truncated, which looks like `{"component":"virt-api","contentLength":2677,..."remoteAddress":"[fd00",` 
so we use the `net.SplitHostPort` to split the host and port, then log the real host in remoteAddress field.

Signed-off-by: huyinhou <huyinhou@bytedance.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix remoteAddress field in virt-api log being truncated when it is an ipv6 address
```
