### PR TITLE
[tests] Use random custom runtime classes to avoid cleanup collisions

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -30,6 +30,8 @@ import (
 	"time"
 	"unicode"
 
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	expect "github.com/google/goexpect"
@@ -1671,18 +1673,20 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		Context("[Serial]using defaultRuntimeClass configuration", func() {
-			const runtimeClassName = "fake-runtime-class"
+			var runtimeClassName string
 
 			BeforeEach(func() {
+				// use random runtime class to avoid collisions with cleanup where a
+				// runtime class is still in the process of being deleted because pod
+				// cleanup is still in progress
+				runtimeClassName = "fake-runtime-class" + "-" + rand.String(5)
 				By("Creating a runtime class")
-				_, err := createRuntimeClass(runtimeClassName, "fake-handler")
-				Expect(err).NotTo(HaveOccurred(), "cannot create runtime-class "+runtimeClassName)
+				Expect(createRuntimeClass(runtimeClassName, "fake-handler")).To(Succeed())
 			})
 
 			AfterEach(func() {
 				By("Cleaning up runtime class")
-				err := deleteRuntimeClass(runtimeClassName)
-				Expect(err).NotTo(HaveOccurred(), "cannot delete runtime-class "+runtimeClassName)
+				Expect(deleteRuntimeClass(runtimeClassName)).To(Succeed())
 			})
 
 			It("should apply runtimeClassName to pod when set", func() {
@@ -1702,15 +1706,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(pod.Spec.RuntimeClassName).ToNot(BeNil())
 				Expect(*pod.Spec.RuntimeClassName).To(BeEquivalentTo(runtimeClassName))
 			})
+		})
+		It("should not apply runtimeClassName to pod when not set", func() {
+			By("verifying no default runtime class name is set")
+			config := util.GetCurrentKv(virtClient).Spec.Configuration
+			Expect(config.DefaultRuntimeClass).To(BeEmpty())
+			By("Creating a VMI")
+			vmi := tests.RunVMIAndExpectLaunch(tests.NewRandomVMI(), 60)
 
-			It("should not apply runtimeClassName to pod when not set", func() {
-				By("Creating a VMI")
-				vmi := tests.RunVMIAndExpectLaunch(tests.NewRandomVMI(), 60)
-
-				By("Checking for absence of runtimeClassName")
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
-				Expect(pod.Spec.RuntimeClassName).To(BeNil())
-			})
+			By("Checking for absence of runtimeClassName")
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+			Expect(pod.Spec.RuntimeClassName).To(BeNil())
 		})
 	})
 
@@ -3087,13 +3093,13 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	})
 })
 
-func createRuntimeClass(name, handler string) (*nodev1.RuntimeClass, error) {
+func createRuntimeClass(name, handler string) error {
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return virtCli.NodeV1().RuntimeClasses().Create(
+	_, err = virtCli.NodeV1().RuntimeClasses().Create(
 		context.Background(),
 		&nodev1.RuntimeClass{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -3101,6 +3107,7 @@ func createRuntimeClass(name, handler string) (*nodev1.RuntimeClass, error) {
 		},
 		metav1.CreateOptions{},
 	)
+	return err
 }
 
 func deleteRuntimeClass(name string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that vm configuration tests use random runtime classes, to avoid colliding with delayed deletions of the custom runtime class from previous tests.

The failing runtime test in https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-10-24-168h.html#row0 shows that the test does not have the runtime class present.

Digging into the artifacts logs shows that the runtime class is indeed not present. It turns out that when we crate the runtime class, we don't check for an error. This allows that we will still start the test if the runtime class exists, but is already makred for deletion.

Switch to random runtime classes, to give runtime classes all the time they need to be finally removed (when all pods using it are teared down).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
