### PR TITLE
Slighlty randomize CI startup to distribute disk usage a little bit

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -26,6 +26,13 @@ readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
 
+
+if [ ${CI} == "true" ]; then
+  _delay="$(( ( RANDOM % 180 )))"
+  echo "INFO: Sleeping for ${_delay}s to randomize job startup slighty"
+  sleep ${_delay}
+fi
+
 if [ -z $TARGET ]; then
   echo "FATAL: TARGET must be non empty"
   exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

A possible solution to slighly de-synchronize mass-job-starts.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
