### PR TITLE
Introduce InterfaceModel constants

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1154,8 +1154,8 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 					v1.Input{
-						Bus:  "usb",
-						Type: "tablet",
+						Bus:  v1.InputBusUSB,
+						Type: v1.InputTypeTablet,
 					},
 					v1.Input{},
 				}

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1161,7 +1161,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
 					v1.Interface{
-						Model: "e1000",
+						Model: v1.InterfaceModelE1000,
 					},
 					v1.Interface{},
 				}
@@ -1192,7 +1192,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						PreferredLunBus:         v1.DiskBusSATA,
 						PreferredInputBus:       v1.InputBusVirtio,
 						PreferredInputType:      v1.InputTypeTablet,
-						PreferredInterfaceModel: "virtio",
+						PreferredInterfaceModel: v1.InterfaceModelVirtio,
 						PreferredSoundModel:     "ac97",
 						PreferredRng:            &v1.Rng{},
 						PreferredTPM:            &v1.TPMDevice{},
@@ -1218,7 +1218,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(vmi.Spec.Domain.Devices.Disks[4].DiskDevice.LUN.Bus).To(Equal(v1.DiskBusSATA))
 				Expect(vmi.Spec.Domain.Devices.Inputs[0].Bus).To(Equal(v1.InputBusUSB))
 				Expect(vmi.Spec.Domain.Devices.Inputs[0].Type).To(Equal(v1.InputTypeTablet))
-				Expect(vmi.Spec.Domain.Devices.Interfaces[0].Model).To(Equal("e1000"))
+				Expect(vmi.Spec.Domain.Devices.Interfaces[0].Model).To(Equal(v1.InterfaceModelE1000))
 
 				// Assert that everything that isn't defined in the VM/VMI should use Preferences
 				Expect(*vmi.Spec.Domain.Devices.AutoattachPodInterface).To(Equal(*preferenceSpec.Devices.PreferredAutoattachPodInterface))

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1192,7 +1192,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 						PreferredLunBus:         v1.DiskBusSATA,
 						PreferredInputBus:       v1.InputBusVirtio,
 						PreferredInputType:      v1.InputTypeTablet,
-						PreferredInterfaceModel: v1.VirtIO,
+						PreferredInterfaceModel: "virtio",
 						PreferredSoundModel:     "ac97",
 						PreferredRng:            &v1.Rng{},
 						PreferredTPM:            &v1.TPMDevice{},

--- a/pkg/network/domainspec/domainspec_suite_test.go
+++ b/pkg/network/domainspec/domainspec_suite_test.go
@@ -62,7 +62,7 @@ func NewDomainWithMacvtapInterface(macvtapName string) *api.Domain {
 	domain.Spec.Devices.Interfaces = []api.Interface{{
 		Alias: api.NewUserDefinedAlias(macvtapName),
 		Model: &api.Model{
-			Type: v1.VirtIO,
+			Type: "virtio",
 		},
 		Type: "ethernet",
 	}}

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Pod Network", func() {
 			It("Should create an interface in the qemu command line, remove it from the interfaces and leave the other interfaces inplace", func() {
 				domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, api.Interface{
 					Model: &api.Model{
-						Type: v1.VirtIO,
+						Type: "virtio",
 					},
 					Type: "bridge",
 					Source: api.InterfaceSource{

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -136,7 +136,7 @@ func (b *BridgePodNetworkConfigurator) PreparePodNetworkInterface() error {
 		tapOwner = strconv.Itoa(util.NonRootUID)
 	}
 
-	queues := converter.CalculateNetworkQueues(b.vmi, converter.GetInterfaceType(b.vmiSpecIface))
+	queues := converter.CalculateNetworkQueues(b.vmi, string(converter.GetInterfaceType(b.vmiSpecIface)))
 	err := createAndBindTapToBridge(b.handler, b.tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, tapOwner, queues)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", b.tapDeviceName)

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -123,7 +123,7 @@ func (b *MasqueradePodNetworkConfigurator) PreparePodNetworkInterface() error {
 	}
 	tapDeviceName := virtnetlink.GenerateTapDeviceName(b.podNicLink.Attrs().Name)
 
-	queues := converter.CalculateNetworkQueues(b.vmi, converter.GetInterfaceType(b.vmiSpecIface))
+	queues := converter.CalculateNetworkQueues(b.vmi, string(converter.GetInterfaceType(b.vmiSpecIface)))
 	err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, tapOwner, queues)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -42,7 +42,7 @@ func NewDomainWithBridgeInterface() *api.Domain {
 	domain := &api.Domain{}
 	domain.Spec.Devices.Interfaces = []api.Interface{{
 		Model: &api.Model{
-			Type: v1.VirtIO,
+			Type: "virtio",
 		},
 		Type: "bridge",
 		Source: api.InterfaceSource{

--- a/pkg/testutils/domain.go
+++ b/pkg/testutils/domain.go
@@ -24,7 +24,7 @@ func ExpectVirtioTransitionalOnly(dom *api.DomainSpec) {
 
 	hit = false
 	for _, ifc := range dom.Devices.Interfaces {
-		if strings.HasPrefix(ifc.Model.Type, v1.VirtIO) {
+		if strings.HasPrefix(ifc.Model.Type, "virtio") {
 			ExpectWithOffset(1, ifc.Model.Type).To(Equal(virtioTrans))
 			hit = true
 		}
@@ -33,9 +33,9 @@ func ExpectVirtioTransitionalOnly(dom *api.DomainSpec) {
 
 	hit = false
 	for _, input := range dom.Devices.Inputs {
-		if strings.HasPrefix(input.Model, v1.VirtIO) {
+		if strings.HasPrefix(input.Model, "virtio") {
 			// All our input types only exist only as virtio 1.0 and only accept virtio
-			ExpectWithOffset(1, input.Model).To(Equal(v1.VirtIO))
+			ExpectWithOffset(1, input.Model).To(Equal("virtio"))
 			hit = true
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -117,7 +117,7 @@ func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Model == "" || iface.Model == v1.VirtIO {
+		if iface.Model == "" || iface.Model == "virtio" {
 			return true
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -117,7 +117,7 @@ func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
 // Note that the reference can be explicit or implicit (unspecified nic models defaults to "virtio").
 func WantVirtioNetDevice(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Model == "" || iface.Model == "virtio" {
+		if iface.Model == "" || iface.Model == v1.InterfaceModelVirtio {
 			return true
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -64,7 +64,7 @@ const (
 	maxDNSSearchListChars = 256
 )
 
-var validInterfaceModels = map[string]*struct{}{"e1000": nil, "e1000e": nil, "ne2k_pci": nil, "pcnet": nil, "rtl8139": nil, v1.VirtIO: nil}
+var validInterfaceModels = map[string]*struct{}{"e1000": nil, "e1000e": nil, "ne2k_pci": nil, "pcnet": nil, "rtl8139": nil, "virtio": nil}
 var validIOThreadsPolicies = []v1.IOThreadsPolicy{v1.IOThreadsPolicyShared, v1.IOThreadsPolicyAuto}
 var validCPUFeaturePolicies = map[string]*struct{}{"": nil, "force": nil, "require": nil, "optional": nil, "disable": nil, "forbid": nil}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -64,7 +64,14 @@ const (
 	maxDNSSearchListChars = 256
 )
 
-var validInterfaceModels = map[string]*struct{}{"e1000": nil, "e1000e": nil, "ne2k_pci": nil, "pcnet": nil, "rtl8139": nil, "virtio": nil}
+var validInterfaceModels = map[v1.InterfaceModel]*struct{}{
+	v1.InterfaceModelE1000:    nil,
+	v1.InterfaceModelE1000e:   nil,
+	v1.InterfaceModelNe2k_pci: nil,
+	v1.InterfaceModelpcnet:    nil,
+	v1.InterfaceModelrtl8139:  nil,
+	v1.InterfaceModelVirtio:   nil,
+}
 var validIOThreadsPolicies = []v1.IOThreadsPolicy{v1.IOThreadsPolicyShared, v1.IOThreadsPolicyAuto}
 var validCPUFeaturePolicies = map[string]*struct{}{"": nil, "force": nil, "require": nil, "optional": nil, "disable": nil, "forbid": nil}
 

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -33,7 +33,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -26,6 +26,7 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var exampleXMLwithNoneMemballoon string
@@ -332,8 +333,8 @@ var _ = ginkgo.Describe("Schema", func() {
 
 		exampleDomain.Spec.Devices.Inputs = []Input{
 			{
-				Type:  "tablet",
-				Bus:   "virtio",
+				Type:  v1.InputTypeTablet,
+				Bus:   v1.InputBusVirtio,
 				Alias: NewUserDefinedAlias("tablet0"),
 			},
 		}

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -26,8 +26,6 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	v1 "kubevirt.io/api/core/v1"
 )
 
 var exampleXMLwithNoneMemballoon string
@@ -335,7 +333,7 @@ var _ = ginkgo.Describe("Schema", func() {
 		exampleDomain.Spec.Devices.Inputs = []Input{
 			{
 				Type:  "tablet",
-				Bus:   v1.VirtIO,
+				Bus:   "virtio",
 				Alias: NewUserDefinedAlias("tablet0"),
 			},
 		}
@@ -354,7 +352,7 @@ var _ = ginkgo.Describe("Schema", func() {
 			Alias:  NewUserDefinedAlias("mywatchdog"),
 		}
 		exampleDomain.Spec.Devices.Rng = &Rng{
-			Model:   v1.VirtIO,
+			Model:   "virtio",
 			Backend: &RngBackend{Source: "/dev/urandom", Model: "random"},
 		}
 		exampleDomain.Spec.Devices.Controllers = []Controller{
@@ -405,7 +403,7 @@ var _ = ginkgo.Describe("Schema", func() {
 		exampleDomain.Spec.Metadata.KubeVirt.GracePeriod = &GracePeriodMetadata{}
 		exampleDomain.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds = 5
 		exampleDomain.Spec.IOThreads = &IOThreads{IOThreads: 2}
-		exampleDomain.Spec.Devices.Ballooning = &MemBalloon{Model: v1.VirtIO, Stats: &Stats{Period: 10}}
+		exampleDomain.Spec.Devices.Ballooning = &MemBalloon{Model: "virtio", Stats: &Stats{Period: 10}}
 		exampleDomainWithMemballonDevice = exampleDomain.DeepCopy()
 		exampleDomainWithMemballonDevice.Spec.Devices.Ballooning = &MemBalloon{Model: "none"}
 	})

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -169,7 +169,7 @@ func Convert_v1_Disk_To_api_Disk(c *ConverterContext, diskDevice *v1.Disk, disk 
 			disk.Address = addr
 		}
 		if diskDevice.Disk.Bus == v1.DiskBusVirtio {
-			disk.Model = translateModel(c, v1.VirtIO)
+			disk.Model = translateModel(c, "virtio")
 		}
 		disk.ReadOnly = toApiReadOnly(diskDevice.Disk.ReadOnly)
 		disk.Serial = diskDevice.Serial
@@ -564,7 +564,7 @@ func Add_Agent_To_api_Channel() (channel api.Channel) {
 	channel.Source = nil
 	channel.Target = &api.ChannelTarget{
 		Name: "org.qemu.guest_agent.0",
-		Type: v1.VirtIO,
+		Type: "virtio",
 	}
 
 	return
@@ -807,7 +807,7 @@ func Convert_v1_DownwardMetricSource_To_api_Disk(disk *api.Disk, c *ConverterCon
 		Name: "qemu",
 	}
 	// This disk always needs `virtio`. Validation ensures that bus is unset or is already virtio
-	disk.Model = translateModel(c, v1.VirtIO)
+	disk.Model = translateModel(c, "virtio")
 	disk.Source = api.DiskSource{
 		File: config.DownwardMetricDisk,
 	}
@@ -895,7 +895,7 @@ func Convert_v1_Watchdog_To_api_Watchdog(source *v1.Watchdog, watchdog *api.Watc
 func Convert_v1_Rng_To_api_Rng(_ *v1.Rng, rng *api.Rng, c *ConverterContext) error {
 
 	// default rng model for KVM/QEMU virtualization
-	rng.Model = translateModel(c, v1.VirtIO)
+	rng.Model = translateModel(c, "virtio")
 
 	// default backend model, random
 	rng.Backend = &api.RngBackend{
@@ -982,7 +982,7 @@ func Convert_v1_Input_To_api_InputDevice(input *v1.Input, inputDevice *api.Input
 	inputDevice.Alias = api.NewUserDefinedAlias(input.Name)
 
 	if input.Bus == v1.InputBusVirtio {
-		inputDevice.Model = v1.VirtIO
+		inputDevice.Model = "virtio"
 	}
 	return nil
 }
@@ -1131,7 +1131,7 @@ func ConvertV1ToAPIBalloning(source *v1.Devices, ballooning *api.MemBalloon, c *
 		ballooning.Model = "none"
 		ballooning.Stats = nil
 	} else {
-		ballooning.Model = translateModel(c, v1.VirtIO)
+		ballooning.Model = translateModel(c, "virtio")
 		if c.MemBalloonStatsPeriod != 0 {
 			ballooning.Stats = &api.Stats{Period: c.MemBalloonStatsPeriod}
 		}
@@ -1616,7 +1616,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		scsiController := api.Controller{
 			Type:   "scsi",
 			Index:  "0",
-			Model:  translateModel(c, v1.VirtIO),
+			Model:  translateModel(c, "virtio"),
 			Driver: controllerDriver,
 		}
 		if useIOThreads {
@@ -1704,7 +1704,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
 			Type:   "virtio-serial",
 			Index:  "0",
-			Model:  translateModel(c, v1.VirtIO),
+			Model:  translateModel(c, "virtio"),
 			Driver: controllerDriver,
 		})
 
@@ -1743,7 +1743,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			domain.Spec.Devices.Video = []api.Video{
 				{
 					Model: api.VideoModel{
-						Type:  v1.VirtIO,
+						Type:  "virtio",
 						Heads: &heads,
 					},
 				},
@@ -1942,7 +1942,7 @@ func newDeviceNamer(volumeStatuses []v1.VolumeStatus, disks []v1.Disk) map[strin
 
 func translateModel(ctx *ConverterContext, bus string) string {
 	switch bus {
-	case v1.VirtIO:
+	case "virtio":
 		if ctx.UseVirtioTransitional {
 			return "virtio-transitional"
 		} else {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Converter", func() {
 			v1Disk := v1.Disk{
 				Name: "myvolume",
 				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{Bus: v1.VirtIO},
+					Disk: &v1.DiskTarget{Bus: "virtio"},
 				},
 			}
 			apiDisk := api.Disk{}
@@ -144,7 +144,7 @@ var _ = Describe("Converter", func() {
 				BootOrder: &order,
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: v1.VirtIO,
+						Bus: "virtio",
 					},
 				},
 			}
@@ -190,7 +190,7 @@ var _ = Describe("Converter", func() {
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: v1.VirtIO,
+						Bus: "virtio",
 					},
 				},
 			}
@@ -230,7 +230,7 @@ var _ = Describe("Converter", func() {
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: v1.VirtIO,
+						Bus: "virtio",
 					},
 				},
 				Shareable: True(),
@@ -325,7 +325,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.DisableHotplug = true
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 				{
-					Bus:  v1.VirtIO,
+					Bus:  "virtio",
 					Type: "tablet",
 					Name: "tablet0",
 				},
@@ -335,7 +335,7 @@ var _ = Describe("Converter", func() {
 					Name: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: v1.VirtIO,
+							Bus: "virtio",
 						},
 					},
 					DedicatedIOThread: True(),
@@ -344,7 +344,7 @@ var _ = Describe("Converter", func() {
 					Name: "nocloud",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: v1.VirtIO,
+							Bus: "virtio",
 						},
 					},
 					DedicatedIOThread: True(),
@@ -2361,7 +2361,7 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Graphics).To(HaveLen(devices))
 
 			if isARM64(arch) && (autoAttach == nil || *autoAttach) {
-				Expect(domain.Spec.Devices.Video[0].Model.Type).To(Equal(v1.VirtIO))
+				Expect(domain.Spec.Devices.Video[0].Model.Type).To(Equal("virtio"))
 				Expect(domain.Spec.Devices.Inputs[0].Type).To(Equal(v1.InputTypeTablet))
 				Expect(domain.Spec.Devices.Inputs[1].Type).To(Equal(v1.InputTypeKeyboard))
 			}
@@ -2491,7 +2491,7 @@ var _ = Describe("Converter", func() {
 									Name: "dedicated",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 									DedicatedIOThread: True(),
@@ -2500,7 +2500,7 @@ var _ = Describe("Converter", func() {
 									Name: "shared",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 									DedicatedIOThread: False(),
@@ -2509,7 +2509,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted1",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 								},
@@ -2517,7 +2517,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted2",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 								},
@@ -2525,7 +2525,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted3",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 								},
@@ -2533,7 +2533,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted4",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 								},
@@ -2541,7 +2541,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted5",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: v1.VirtIO,
+											Bus: "virtio",
 										},
 									},
 								},
@@ -2661,7 +2661,7 @@ var _ = Describe("Converter", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: v1.VirtIO,
+							Bus: "virtio",
 						},
 					},
 				},
@@ -2691,7 +2691,7 @@ var _ = Describe("Converter", func() {
 
 			v1Disk := v1.Disk{
 				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{Bus: v1.VirtIO},
+					Disk: &v1.DiskTarget{Bus: "virtio"},
 				},
 			}
 			apiDisk := api.Disk{}
@@ -3345,23 +3345,23 @@ var _ = Describe("disk device naming", func() {
 
 	It("makeDeviceName should generate proper name", func() {
 		prefixMap := make(map[string]deviceNamer)
-		res, index := makeDeviceName("test1", v1.VirtIO, prefixMap)
+		res, index := makeDeviceName("test1", "virtio", prefixMap)
 		Expect(res).To(Equal("vda"))
 		Expect(index).To(Equal(0))
 		for i := 2; i < 10; i++ {
-			makeDeviceName(fmt.Sprintf("test%d", i), v1.VirtIO, prefixMap)
+			makeDeviceName(fmt.Sprintf("test%d", i), "virtio", prefixMap)
 		}
-		prefix := getPrefixFromBus(v1.VirtIO)
+		prefix := getPrefixFromBus("virtio")
 		delete(prefixMap[prefix].usedDeviceMap, "vdd")
 		By("Verifying next value is vdd")
-		res, index = makeDeviceName("something", v1.VirtIO, prefixMap)
+		res, index = makeDeviceName("something", "virtio", prefixMap)
 		Expect(index).To(Equal(3))
 		Expect(res).To(Equal("vdd"))
-		res, index = makeDeviceName("something_else", v1.VirtIO, prefixMap)
+		res, index = makeDeviceName("something_else", "virtio", prefixMap)
 		Expect(res).To(Equal("vdj"))
 		Expect(index).To(Equal(9))
 		By("verifying existing returns correct value")
-		res, index = makeDeviceName("something", v1.VirtIO, prefixMap)
+		res, index = makeDeviceName("something", "virtio", prefixMap)
 		Expect(res).To(Equal("vdd"))
 		Expect(index).To(Equal(3))
 		By("Verifying a new bus returns from start")

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Converter", func() {
 			v1Disk := v1.Disk{
 				Name: "myvolume",
 				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{Bus: "virtio"},
+					Disk: &v1.DiskTarget{Bus: v1.DiskBusVirtio},
 				},
 			}
 			apiDisk := api.Disk{}
@@ -144,7 +144,7 @@ var _ = Describe("Converter", func() {
 				BootOrder: &order,
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 			}
@@ -190,7 +190,7 @@ var _ = Describe("Converter", func() {
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 			}
@@ -230,7 +230,7 @@ var _ = Describe("Converter", func() {
 				Name: "mydisk",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{
-						Bus: "virtio",
+						Bus: v1.DiskBusVirtio,
 					},
 				},
 				Shareable: True(),
@@ -325,8 +325,8 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.DisableHotplug = true
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 				{
-					Bus:  "virtio",
-					Type: "tablet",
+					Bus:  v1.InputBusVirtio,
+					Type: v1.InputTypeTablet,
 					Name: "tablet0",
 				},
 			}
@@ -335,7 +335,7 @@ var _ = Describe("Converter", func() {
 					Name: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					DedicatedIOThread: True(),
@@ -344,7 +344,7 @@ var _ = Describe("Converter", func() {
 					Name: "nocloud",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 					DedicatedIOThread: True(),
@@ -2491,7 +2491,7 @@ var _ = Describe("Converter", func() {
 									Name: "dedicated",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 									DedicatedIOThread: True(),
@@ -2500,7 +2500,7 @@ var _ = Describe("Converter", func() {
 									Name: "shared",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 									DedicatedIOThread: False(),
@@ -2509,7 +2509,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted1",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 								},
@@ -2517,7 +2517,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted2",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 								},
@@ -2525,7 +2525,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted3",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 								},
@@ -2533,7 +2533,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted4",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 								},
@@ -2541,7 +2541,7 @@ var _ = Describe("Converter", func() {
 									Name: "omitted5",
 									DiskDevice: v1.DiskDevice{
 										Disk: &v1.DiskTarget{
-											Bus: "virtio",
+											Bus: v1.DiskBusVirtio,
 										},
 									},
 								},
@@ -2661,7 +2661,7 @@ var _ = Describe("Converter", func() {
 					Name: "mydisk",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus: "virtio",
+							Bus: v1.DiskBusVirtio,
 						},
 					},
 				},
@@ -2691,7 +2691,7 @@ var _ = Describe("Converter", func() {
 
 			v1Disk := v1.Disk{
 				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{Bus: "virtio"},
+					Disk: &v1.DiskTarget{Bus: v1.DiskBusVirtio},
 				},
 			}
 			apiDisk := api.Disk{}
@@ -2873,7 +2873,7 @@ var _ = Describe("Converter", func() {
 		})
 
 		It("should not assign queues to a non-virtio devices", func() {
-			vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
+			vmi.Spec.Domain.Devices.Interfaces[0].Model = v1.InterfaceModelE1000
 			domain := vmiToDomain(vmi, &ConverterContext{AllowEmulation: true})
 			Expect(domain.Spec.Devices.Interfaces[0].Driver).To(BeNil(),
 				"queues should not be set for models other than virtio")

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -65,7 +65,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 
 		// if AllowEmulation unset and at least one NIC model is virtio,
 		// /dev/vhost-net must be present as we should have asked for it.
-		if ifaceType == v1.VirtIO && virtioNetProhibited {
+		if ifaceType == "virtio" && virtioNetProhibited {
 			return nil, fmt.Errorf("In-kernel virtio-net device emulation '/dev/vhost-net' not present")
 		}
 
@@ -124,7 +124,7 @@ func createDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 		if c.UseLaunchSecurity {
 			// It's necessary to disable the iPXE option ROM as iPXE is not aware of SEV
 			domainIface.Rom = &api.Rom{Enabled: "no"}
-			if ifaceType == v1.VirtIO {
+			if ifaceType == "virtio" {
 				if domainIface.Driver != nil {
 					domainIface.Driver.IOMMU = "on"
 				} else {
@@ -150,7 +150,7 @@ func GetInterfaceType(iface *v1.Interface) string {
 	if iface.Model != "" {
 		return iface.Model
 	}
-	return v1.VirtIO
+	return "virtio"
 }
 
 func validateNetworksTypes(networks []v1.Network) error {
@@ -198,7 +198,7 @@ func createSlirpNetwork(iface v1.Interface, network v1.Network, domain *api.Doma
 }
 
 func CalculateNetworkQueues(vmi *v1.VirtualMachineInstance, ifaceType string) uint32 {
-	if !isTrue(vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue) || ifaceType != v1.VirtIO {
+	if !isTrue(vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue) || ifaceType != "virtio" {
 		return 0
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -45,7 +45,7 @@ func PlacePCIDevicesOnRootComplex(spec *api.DomainSpec) (err error) {
 		}
 	}
 	for i, input := range spec.Devices.Inputs {
-		if input.Bus != v1.VirtIO {
+		if input.Bus != "virtio" {
 			continue
 		}
 		spec.Devices.Inputs[i].Address, err = assigner.PlacePCIDeviceAtNextSlot(input.Address)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5245,9 +5245,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: object
                               model:
                                 description: 'Interface model. One of: e1000, e1000e,
-                                  ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.
-                                  TODO:(ihar) switch to enums once opengen-api supports
-                                  them. See: https://github.com/kubernetes/kube-openapi/issues/51'
+                                  ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.'
                                 type: string
                               name:
                                 description: Logical name of the interface as well
@@ -9412,8 +9410,7 @@ var CRDsValidation map[string]string = map[string]string{
                         type: object
                       model:
                         description: 'Interface model. One of: e1000, e1000e, ne2k_pci,
-                          pcnet, rtl8139, virtio. Defaults to virtio. TODO:(ihar)
-                          switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51'
+                          pcnet, rtl8139, virtio. Defaults to virtio.'
                         type: string
                       name:
                         description: Logical name of the interface as well as a reference
@@ -11758,8 +11755,7 @@ var CRDsValidation map[string]string = map[string]string{
                         type: object
                       model:
                         description: 'Interface model. One of: e1000, e1000e, ne2k_pci,
-                          pcnet, rtl8139, virtio. Defaults to virtio. TODO:(ihar)
-                          switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51'
+                          pcnet, rtl8139, virtio. Defaults to virtio.'
                         type: string
                       name:
                         description: Logical name of the interface as well as a reference
@@ -13851,9 +13847,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 type: object
                               model:
                                 description: 'Interface model. One of: e1000, e1000e,
-                                  ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.
-                                  TODO:(ihar) switch to enums once opengen-api supports
-                                  them. See: https://github.com/kubernetes/kube-openapi/issues/51'
+                                  ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.'
                                 type: string
                               name:
                                 description: Logical name of the interface as well
@@ -17813,9 +17807,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       model:
                                         description: 'Interface model. One of: e1000,
                                           e1000e, ne2k_pci, pcnet, rtl8139, virtio.
-                                          Defaults to virtio. TODO:(ihar) switch to
-                                          enums once opengen-api supports them. See:
-                                          https://github.com/kubernetes/kube-openapi/issues/51'
+                                          Defaults to virtio.'
                                         type: string
                                       name:
                                         description: Logical name of the interface
@@ -22474,9 +22466,7 @@ var CRDsValidation map[string]string = map[string]string{
                                           model:
                                             description: 'Interface model. One of:
                                               e1000, e1000e, ne2k_pci, pcnet, rtl8139,
-                                              virtio. Defaults to virtio. TODO:(ihar)
-                                              switch to enums once opengen-api supports
-                                              them. See: https://github.com/kubernetes/kube-openapi/issues/51'
+                                              virtio. Defaults to virtio.'
                                             type: string
                                           name:
                                             description: Logical name of the interface

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -1145,6 +1145,17 @@ type I6300ESBWatchdog struct {
 	Action WatchdogAction `json:"action,omitempty"`
 }
 
+type InterfaceModel string
+
+const (
+	InterfaceModelVirtio   InterfaceModel = "virtio"
+	InterfaceModelE1000    InterfaceModel = "e1000"
+	InterfaceModelE1000e   InterfaceModel = "e1000e"
+	InterfaceModelNe2k_pci InterfaceModel = "ne2k_pci"
+	InterfaceModelpcnet    InterfaceModel = "pcnet"
+	InterfaceModelrtl8139  InterfaceModel = "rtl8139"
+)
+
 type Interface struct {
 	// Logical name of the interface as well as a reference to the associated networks.
 	// Must match the Name of a Network.
@@ -1152,8 +1163,7 @@ type Interface struct {
 	// Interface model.
 	// One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
 	// Defaults to virtio.
-	// TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
-	Model string `json:"model,omitempty"`
+	Model InterfaceModel `json:"model,omitempty"`
 	// BindingMethod specifies the method which will be used to connect the interface to the guest.
 	// Defaults to Bridge.
 	InterfaceBindingMethod `json:",inline"`

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -631,7 +631,7 @@ type DiskBus string
 const (
 	DiskBusSCSI   DiskBus = "scsi"
 	DiskBusSATA   DiskBus = "sata"
-	DiskBusVirtio DiskBus = VirtIO
+	DiskBusVirtio DiskBus = "virtio"
 	DiskBusUSB    DiskBus = "usb"
 )
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -829,8 +829,6 @@ const (
 	// This label represents vendor of cpu model on the node
 	CPUModelVendorLabel = "cpu-vendor.node.kubevirt.io/"
 
-	VirtIO = "virtio"
-
 	// This label represents the host model CPU name
 	HostModelCPULabel = "host-model-cpu.node.kubevirt.io/"
 	// This label represents the host model required features

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha2/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha2/types.go
@@ -354,7 +354,7 @@ type DevicePreferences struct {
 	// PreferredInterfaceModel optionally defines the preferred model to be used by Interface devices.
 	//
 	// +optional
-	PreferredInterfaceModel string `json:"preferredInterfaceModel,omitempty"`
+	PreferredInterfaceModel v1.InterfaceModel `json:"preferredInterfaceModel,omitempty"`
 
 	// PreferredRng optionally defines the preferred rng device to be used.
 	//

--- a/staging/src/kubevirt.io/client-go/api/schema_test.go
+++ b/staging/src/kubevirt.io/client-go/api/schema_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Schema", func() {
 				Name: "disk0",
 				DiskDevice: v12.DiskDevice{
 					Disk: &v12.DiskTarget{
-						Bus:      v12.VirtIO,
+						Bus:      "virtio",
 						ReadOnly: false,
 					},
 				},
@@ -261,7 +261,7 @@ var _ = Describe("Schema", func() {
 				Name: "cdrom0",
 				DiskDevice: v12.DiskDevice{
 					CDRom: &v12.CDRomTarget{
-						Bus:      v12.VirtIO,
+						Bus:      "virtio",
 						ReadOnly: pointer.BoolPtr(true),
 						Tray:     "open",
 					},
@@ -271,7 +271,7 @@ var _ = Describe("Schema", func() {
 				Name: "lun0",
 				DiskDevice: v12.DiskDevice{
 					LUN: &v12.LunTarget{
-						Bus:      v12.VirtIO,
+						Bus:      "virtio",
 						ReadOnly: true,
 					},
 				},
@@ -281,7 +281,7 @@ var _ = Describe("Schema", func() {
 				Serial: "sn-11223344",
 				DiskDevice: v12.DiskDevice{
 					Disk: &v12.DiskTarget{
-						Bus:      v12.VirtIO,
+						Bus:      "virtio",
 						ReadOnly: false,
 					},
 				},
@@ -291,7 +291,7 @@ var _ = Describe("Schema", func() {
 		exampleVMI.Spec.Domain.Devices.Rng = &v12.Rng{}
 		exampleVMI.Spec.Domain.Devices.Inputs = []v12.Input{
 			{
-				Bus:  v12.VirtIO,
+				Bus:  "virtio",
 				Type: "tablet",
 				Name: "tablet0",
 			},

--- a/staging/src/kubevirt.io/client-go/api/schema_test.go
+++ b/staging/src/kubevirt.io/client-go/api/schema_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Schema", func() {
 				Name: "disk0",
 				DiskDevice: v12.DiskDevice{
 					Disk: &v12.DiskTarget{
-						Bus:      "virtio",
+						Bus:      v12.DiskBusVirtio,
 						ReadOnly: false,
 					},
 				},
@@ -261,7 +261,7 @@ var _ = Describe("Schema", func() {
 				Name: "cdrom0",
 				DiskDevice: v12.DiskDevice{
 					CDRom: &v12.CDRomTarget{
-						Bus:      "virtio",
+						Bus:      v12.DiskBusVirtio,
 						ReadOnly: pointer.BoolPtr(true),
 						Tray:     "open",
 					},
@@ -271,7 +271,7 @@ var _ = Describe("Schema", func() {
 				Name: "lun0",
 				DiskDevice: v12.DiskDevice{
 					LUN: &v12.LunTarget{
-						Bus:      "virtio",
+						Bus:      v12.DiskBusVirtio,
 						ReadOnly: true,
 					},
 				},
@@ -281,7 +281,7 @@ var _ = Describe("Schema", func() {
 				Serial: "sn-11223344",
 				DiskDevice: v12.DiskDevice{
 					Disk: &v12.DiskTarget{
-						Bus:      "virtio",
+						Bus:      v12.DiskBusVirtio,
 						ReadOnly: false,
 					},
 				},
@@ -291,8 +291,8 @@ var _ = Describe("Schema", func() {
 		exampleVMI.Spec.Domain.Devices.Rng = &v12.Rng{}
 		exampleVMI.Spec.Domain.Devices.Inputs = []v12.Input{
 			{
-				Bus:  "virtio",
-				Type: "tablet",
+				Bus:  v12.InputBusVirtio,
+				Type: v12.InputTypeTablet,
 				Name: "tablet0",
 			},
 		}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -731,7 +731,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			// TODO: introspect the VMI and get the device name of this
 			// block device?
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			tests.AppendEmptyDisk(vmi, "testdisk", "virtio", "1Gi")
+			tests.AppendEmptyDisk(vmi, "testdisk", v1.DiskBusVirtio, "1Gi")
 
 			if preferredNodeName != "" {
 				pinVMIOnNode(vmi, preferredNodeName)

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -731,7 +731,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			// TODO: introspect the VMI and get the device name of this
 			// block device?
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			tests.AppendEmptyDisk(vmi, "testdisk", v1.VirtIO, "1Gi")
+			tests.AppendEmptyDisk(vmi, "testdisk", "virtio", "1Gi")
 
 			if preferredNodeName != "" {
 				pinVMIOnNode(vmi, preferredNodeName)

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -386,7 +386,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			clusterPreference := newVirtualMachineClusterPreference()
 			clusterPreference.Spec.Devices = &instancetypev1alpha2.DevicePreferences{
-				PreferredInterfaceModel: v1.VirtIO,
+				PreferredInterfaceModel: "virtio",
 			}
 
 			clusterPreference, err := virtClient.VirtualMachineClusterPreference().

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -386,7 +386,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 			clusterPreference := newVirtualMachineClusterPreference()
 			clusterPreference.Spec.Devices = &instancetypev1alpha2.DevicePreferences{
-				PreferredInterfaceModel: "virtio",
+				PreferredInterfaceModel: v1.InterfaceModelVirtio,
 			}
 
 			clusterPreference, err := virtClient.VirtualMachineClusterPreference().

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1594,7 +1594,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// Start the VirtualMachineInstance with PVC and Ephemeral Disks
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				image := cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-				tests.AddEphemeralDisk(vmi, "myephemeral", v1.VirtIO, image)
+				tests.AddEphemeralDisk(vmi, "myephemeral", "virtio", image)
 
 				By("Starting the VirtualMachineInstance")
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1594,7 +1594,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				// Start the VirtualMachineInstance with PVC and Ephemeral Disks
 				vmi, _ := tests.NewRandomVirtualMachineInstanceWithBlockDisk(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				image := cd.ContainerDiskFor(cd.ContainerDiskAlpine)
-				tests.AddEphemeralDisk(vmi, "myephemeral", "virtio", image)
+				tests.AddEphemeralDisk(vmi, "myephemeral", v1.DiskBusVirtio, image)
 
 				By("Starting the VirtualMachineInstance")
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 180)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -119,7 +119,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
 				libvmi.WithRng(),
 			)
-			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.InputBusVirtio, Type: v1.InputTypeTablet}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -138,7 +138,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	Context("when requesting virtio-transitional models", func() {
 		It("[test_id:6957]should start and run the guest", func() {
 			vmi := libvmi.NewCirros(libvmi.WithRng())
-			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.InputBusVirtio, Type: v1.InputTypeTablet}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.BoolPtr(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -119,7 +119,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				libvmi.WithAnnotation(v1.PlacePCIDevicesOnRootComplex, "true"),
 				libvmi.WithRng(),
 			)
-			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(console.LoginToCirros(vmi)).To(Succeed())
@@ -138,7 +138,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	Context("when requesting virtio-transitional models", func() {
 		It("[test_id:6957]should start and run the guest", func() {
 			vmi := libvmi.NewCirros(libvmi.WithRng())
-			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: v1.VirtIO, Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
+			vmi.Spec.Domain.Devices.Inputs = []v1.Input{{Name: "tablet", Bus: "virtio", Type: "tablet"}, {Name: "tablet1", Bus: "usb", Type: "tablet"}}
 			vmi.Spec.Domain.Devices.Watchdog = &v1.Watchdog{Name: "watchdog", WatchdogDevice: v1.WatchdogDevice{I6300ESB: &v1.I6300ESBWatchdog{Action: v1.WatchdogActionPoweroff}}}
 			vmi.Spec.Domain.Devices.UseVirtioTransitional = pointer.BoolPtr(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
@@ -860,7 +860,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					{
 						Name: "tablet0",
 						Type: "keyboard",
-						Bus:  v1.VirtIO,
+						Bus:  "virtio",
 					},
 				}
 				By("Starting a VirtualMachineInstance")
@@ -888,7 +888,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					{
 						Name: "tablet0",
 						Type: "tablet",
-						Bus:  v1.VirtIO,
+						Bus:  "virtio",
 					},
 				}
 				By("Starting a VirtualMachineInstance")

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -61,7 +61,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			availableCPUs = libnode.GetHighestCPUNumberAmongNodes(virtClient)
 		})
 
-		DescribeTable("should be able to successfully boot fedora to the login prompt with multi-queue without being blocked by selinux", func(interfaceModel string, expectedQueueCount int32) {
+		DescribeTable("should be able to successfully boot fedora to the login prompt with multi-queue without being blocked by selinux", func(interfaceModel v1.InterfaceModel, expectedQueueCount int32) {
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
@@ -83,8 +83,8 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			By("Checking QueueCount has the expected value")
 			Expect(vmi.Status.Interfaces[0].QueueCount).To(Equal(expectedQueueCount))
 		},
-			Entry("[test_id:4599] with default virtio interface", "virtio", numCpus),
-			Entry("with e1000 interface", "e1000", int32(1)),
+			Entry("[test_id:4599] with default virtio interface", v1.InterfaceModelVirtio, numCpus),
+			Entry("with e1000 interface", v1.InterfaceModelE1000, int32(1)),
 		)
 
 		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -83,7 +83,7 @@ var _ = Describe("[sig-compute]MultiQueue", func() {
 			By("Checking QueueCount has the expected value")
 			Expect(vmi.Status.Interfaces[0].QueueCount).To(Equal(expectedQueueCount))
 		},
-			Entry("[test_id:4599] with default virtio interface", v1.VirtIO, numCpus),
+			Entry("[test_id:4599] with default virtio interface", "virtio", numCpus),
 			Entry("with e1000 interface", "e1000", int32(1)),
 		)
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -1324,7 +1324,7 @@ func GetVirtualMachinePreferenceVirtio() *instancetypev1alpha2.VirtualMachinePre
 		},
 		Spec: instancetypev1alpha2.VirtualMachinePreferenceSpec{
 			Devices: &instancetypev1alpha2.DevicePreferences{
-				PreferredDiskBus:        "virtio",
+				PreferredDiskBus:        v1.DiskBusVirtio,
 				PreferredInterfaceModel: v1.InterfaceModelVirtio,
 			},
 		},

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -1325,7 +1325,7 @@ func GetVirtualMachinePreferenceVirtio() *instancetypev1alpha2.VirtualMachinePre
 		Spec: instancetypev1alpha2.VirtualMachinePreferenceSpec{
 			Devices: &instancetypev1alpha2.DevicePreferences{
 				PreferredDiskBus:        "virtio",
-				PreferredInterfaceModel: "virtio",
+				PreferredInterfaceModel: v1.InterfaceModelVirtio,
 			},
 		},
 	}

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -87,7 +87,7 @@ const (
 	VirtualMachineInstancetypeComputeSmall              = "csmall"
 	VirtualMachineClusterInstancetypeComputeSmall       = "cluster-csmall"
 	VirtualMachineInstancetypeComputeLarge              = "clarge"
-	VirtualMachinePreferenceVirtio                      = v1.VirtIO
+	VirtualMachinePreferenceVirtio                      = "virtio"
 	VirtualMachinePreferenceWindows                     = "windows"
 	VmCirrosInstancetypeComputeSmall                    = "vm-cirros-csmall"
 	VmCirrosClusterInstancetypeComputeSmall             = "vm-cirros-cluster-csmall"
@@ -122,7 +122,7 @@ const (
 const windowsFirmware = "5d307ca9-b3ef-428c-8861-06e72d69f223"
 const defaultInterfaceName = "default"
 const enableNetworkInterfaceMultiqueueForTemplate = true
-const EthernetAdaptorModelToEnableMultiqueue = v1.VirtIO
+const EthernetAdaptorModelToEnableMultiqueue = "virtio"
 
 const (
 	cloudConfigHeader = "#cloud-config"
@@ -1324,8 +1324,8 @@ func GetVirtualMachinePreferenceVirtio() *instancetypev1alpha2.VirtualMachinePre
 		},
 		Spec: instancetypev1alpha2.VirtualMachinePreferenceSpec{
 			Devices: &instancetypev1alpha2.DevicePreferences{
-				PreferredDiskBus:        v1.VirtIO,
-				PreferredInterfaceModel: v1.VirtIO,
+				PreferredDiskBus:        "virtio",
+				PreferredInterfaceModel: "virtio",
 			},
 		},
 	}


### PR DESCRIPTION
/cc @ohadlevy 

**What this PR does / why we need it**:

As introduced by https://github.com/kubevirt/kubevirt/pull/7597 and later as part of https://github.com/kubevirt/kubevirt/pull/8006 we currently have a number of typed device specific constants for supported buses, models etc. This PR reverts commit 83aa78efd9b9777fed3a337498f03bd5bafaa407 that did a mass string replacement of `virtio` with a single constant and replaces it with a new set of typed interface model constants. The previously added constants are used in a few areas of the code previously missed but highlighted by 83aa78efd9b9777fed3a337498f03bd5bafaa407.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
