### PR TITLE
[e2e tests]: Avoid deleting default labels when cleaning up namespace

### DIFF
--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/flags:go_default_library",
-        "//tests/framework/cleanup:go_default_library",
         "//tests/libnet/cluster:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/libnet/namespace.go
+++ b/tests/libnet/namespace.go
@@ -3,6 +3,7 @@ package libnet
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,12 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	"kubevirt.io/client-go/kubecli"
-
-	"kubevirt.io/kubevirt/tests/framework/cleanup"
 )
 
 func AddLabelToNamespace(client kubecli.KubevirtClient, namespace, key, value string) error {
-	return patchNamespace(client, namespace, func(ns *v1.Namespace) {
+	return PatchNamespace(client, namespace, func(ns *v1.Namespace) {
 		if ns.Labels == nil {
 			ns.Labels = map[string]string{}
 		}
@@ -24,7 +23,7 @@ func AddLabelToNamespace(client kubecli.KubevirtClient, namespace, key, value st
 }
 
 func RemoveLabelFromNamespace(client kubecli.KubevirtClient, namespace, key string) error {
-	return patchNamespace(client, namespace, func(ns *v1.Namespace) {
+	return PatchNamespace(client, namespace, func(ns *v1.Namespace) {
 		if ns.Labels == nil {
 			return
 		}
@@ -32,37 +31,29 @@ func RemoveLabelFromNamespace(client kubecli.KubevirtClient, namespace, key stri
 	})
 }
 
-func RemoveAllLabelsFromNamespace(client kubecli.KubevirtClient, namespace string) error {
-	return patchNamespace(client, namespace, func(ns *v1.Namespace) {
-		if ns.Labels == nil {
-			return
-		}
-		ns.Labels = map[string]string{
-			cleanup.TestLabelForNamespace(namespace): "",
-		}
-	})
-}
-
-func patchNamespace(client kubecli.KubevirtClient, namespace string, patchFunc func(*v1.Namespace)) error {
+func PatchNamespace(client kubecli.KubevirtClient, namespace string, patchFunc func(*v1.Namespace)) error {
 	ns, err := client.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	old, err := json.Marshal(ns)
 	if err != nil {
 		return err
 	}
 
 	newNS := ns.DeepCopy()
 	patchFunc(newNS)
+	if reflect.DeepEqual(ns, newNS) {
+		return nil
+	}
+
+	oldJSON, err := json.Marshal(ns)
+	if err != nil {
+		return err
+	}
 
 	newJSON, err := json.Marshal(newNS)
 	if err != nil {
 		return err
 	}
 
-	patch, err := strategicpatch.CreateTwoWayMergePatch(old, newJSON, ns)
+	patch, err := strategicpatch.CreateTwoWayMergePatch(oldJSON, newJSON, ns)
 	if err != nil {
 		return err
 	}

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -87,7 +87,7 @@ func CleanNamespaces() {
 		}
 
 		// Clean namespace labels
-		err = libnet.RemoveAllLabelsFromNamespace(virtCli, namespace)
+		err = resetNamespaceLabelsToDefault(virtCli, namespace)
 		util.PanicOnError(err)
 
 		//Remove all Jobs
@@ -300,6 +300,27 @@ func detectInstallNamespace() {
 	flags.KubeVirtInstallNamespace = kvs.Items[0].Namespace
 }
 
+func GetLabelsForNamespace(namespace string) map[string]string {
+	labels := map[string]string{
+		cleanup.TestLabelForNamespace(namespace):         "",
+		"security.openshift.io/scc.podSecurityLabelSync": "false",
+	}
+	if namespace == NamespacePrivileged {
+		labels["pod-security.kubernetes.io/enforce"] = "privileged"
+	}
+
+	return labels
+}
+
+func resetNamespaceLabelsToDefault(client kubecli.KubevirtClient, namespace string) error {
+	return libnet.PatchNamespace(client, namespace, func(ns *k8sv1.Namespace) {
+		if ns.Labels == nil {
+			return
+		}
+		ns.Labels = GetLabelsForNamespace(namespace)
+	})
+}
+
 func createNamespaces() {
 	virtCli, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
@@ -308,15 +329,9 @@ func createNamespaces() {
 	for _, namespace := range TestNamespaces {
 		ns := &k8sv1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: namespace,
-				Labels: map[string]string{
-					cleanup.TestLabelForNamespace(namespace):         "",
-					"security.openshift.io/scc.podSecurityLabelSync": "false",
-				},
+				Name:   namespace,
+				Labels: GetLabelsForNamespace(namespace),
 			},
-		}
-		if namespace == NamespacePrivileged {
-			ns.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
 		}
 
 		_, err = virtCli.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We noticed the label sync and PSA labels are missing in test runs;
This happens because today, we just reset the labels completely before each test.
Let's keep some labels at all times and only delete ephemeral ones that get in the way.
```bash
         "metadata": {
                "name": "kubevirt-test-privileged3",
                "uid": "96dd63f7-5210-4d74-b484-7e80f0564c28",
                "resourceVersion": "7736",
                "creationTimestamp": "2022-10-25T10:47:45Z",
                "labels": {
                    "kubernetes.io/metadata.name": "kubevirt-test-privileged3",
                    "test.kubevirt.io/kubevirt-test-privileged3": ""
                },
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
