### PR TITLE
fix stat virt-vnc and virt-serial0 return error

### DIFF
--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -200,7 +200,7 @@ func (t *ConsoleHandler) getUnixSocketPath(vmi *v1.VirtualMachineInstance, socke
 	if err != nil {
 		return "", err
 	}
-	socketDir := path.Join("proc", strconv.Itoa(result.Pid()), "root", "var", "run", "kubevirt-private", string(vmi.GetUID()))
+	socketDir := path.Join("/proc", strconv.Itoa(result.Pid()), "root", "var", "run", "kubevirt-private", string(vmi.GetUID()))
 	socketPath := path.Join(socketDir, socketName)
 	if _, err = os.Stat(socketPath); errors.Is(err, os.ErrNotExist) {
 		return "", err


### PR DESCRIPTION
the default base image for virt-handler is centos, which workdir is /. but we use a custom debian:buster as the base image, which workdir is /root.

when we run `virtctl -n test vnc vm1`, it reports an error:  
Can't access VMI vm1: Internal error occurred: dialing virt-handler: websocket: bad handshake 
I digged into this problem, and found that the virt-vnc sock path in `getUnixSocketPath` is `proc/3484989/root/var/run/kubevirt-private/a44829ef-d44c-4a64-bf8a-2bcf274bad12/virt-vnc` without leading '/'.
when it runs `os.Stat` with this path, it will return an error "no such file or directory".

so, I think maybe we can add a leading '/' to make an absolute path, it will work no matter what the workdir of the virt-handler image is.

Signed-off-by: huyinhou <huyinhou@bytedance.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
connect VM vnc failed when virt-launcher work directory is not /
```
