### PR TITLE
Fix test_id:7182

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -138,10 +138,8 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			It("[test_id:7182]disk verification should fail when the memory limit is too low", func() {
 				By("Reducing the diskVerificaton memory usage limit")
 				kv := util.GetCurrentKv(virtClient)
-				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
-					DiskVerification: &v1.DiskVerification{
-						MemoryLimit: resource.NewScaledQuantity(42, resource.Kilo),
-					},
+				kv.Spec.Configuration.DeveloperConfiguration.DiskVerification = &v1.DiskVerification{
+					MemoryLimit: resource.NewScaledQuantity(42, resource.Kilo),
 				}
 				tests.UpdateKubeVirtConfigValueAndWait(kv.Spec.Configuration)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
We override DeveloperConfiguration in test_id:7182
Instead we should just set DeveloperConfiguration.DiskVerification

This issue cause failure when PSA is enabled
in the cluster becuase we disable PSA featureGate
when overriding DeveloperConfiguration

Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
