### PR TITLE
fix junit-merger build error on Arm64

### DIFF
--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -14,7 +14,7 @@ EOF
     function collect_results() {
         cd ${KUBEVIRT_DIR}
         mkdir -p ${ARTIFACTS}/junit/
-        bazel run //tools/junit-merger:junit-merger -- -o ${ARTIFACTS}/junit/junit.unittests.xml $(find bazel-testlogs/ -name 'test.xml' -printf "%p ")
+        bazel run --config=${ARCHITECTURE} //tools/junit-merger:junit-merger -- -o ${ARTIFACTS}/junit/junit.unittests.xml $(find bazel-testlogs/ -name 'test.xml' -printf "%p ")
 
         for f in $(find bazel-out/ -name 'test.log'); do
             dir=${ARTIFACTS}/testlogs/$(dirname $f)


### PR DESCRIPTION
Fix following error when running ` make test`
```
INFO: Build options --action_env, --cache_test_results, --features, and 2 more have changed, discarding analysis cache.
Analyzing: target //tools/junit-merger:junit-merger (0 packages loaded, 0 targets configured)
Analyzing: target //tools/junit-merger:junit-merger (0 packages loaded, 0 targets configured)
ERROR: While resolving toolchains for target @io_bazel_rules_go//:cgo_context_data: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type. Maybe --incompatible_use_cc_configure_from_rules_cc has been flipped and there is no default C++ toolchain added in the WORKSPACE file? See https://github.com/bazelbuild/bazel/issues/10134 for details and migration instructions.
ERROR: Analysis of target '//tools/junit-merger:junit-merger' failed; build aborted: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type. Maybe --incompatible_use_cc_configure_from_rules_cc has been flipped and there is no default C++ toolchain added in the WORKSPACE file? See https://github.com/bazelbuild/bazel/issues/10134 for details and migration instructions.
INFO: Elapsed time: 2.365s
```

Signed-off-by: howard zhang <howard.zhang@arm.com>


**Release note**:
```release-note
none
```
