### PR TITLE
Allow specifying custom images for core components

### DIFF
--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
+        "//tests:go_default_library",
         "//vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -287,7 +287,7 @@ func Execute() {
 	app.kubeVirtRecorder = app.getNewRecorder(k8sv1.NamespaceAll, VirtOperator)
 	app.kubeVirtController = *NewKubeVirtController(app.clientSet, app.aggregatorClient.ApiregistrationV1().APIServices(), app.kubeVirtInformer, app.kubeVirtRecorder, app.stores, app.informers, app.operatorNamespace)
 
-	image := os.Getenv(util.OperatorImageEnvName)
+	image := util.GetOperatorImage()
 	if image == "" {
 		golog.Fatalf("Error getting operator's image: %v", err)
 	}

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -756,7 +756,7 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
 							Env: []k8sv1.EnvVar{
 								{
 									// Deprecated, keep it for backwards compatibility
-									Name:  util.OperatorImageEnvName,
+									Name:  util.OldOperatorImageEnvName,
 									Value: operatorImage,
 								},
 								{

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -148,12 +147,20 @@ type KubeVirtTestData struct {
 	deleteFromCache bool
 	addToCache      bool
 
-	defaultConfig *util.KubeVirtDeploymentConfig
+	defaultConfig     *util.KubeVirtDeploymentConfig
+	mockEnvVarManager util.EnvVarManager
 }
+
+var mockEnvVarManager = &util.EnvVarManagerMock{}
 
 func (k *KubeVirtTestData) BeforeTest() {
 
-	k.defaultConfig = getConfig("", "")
+	k.mockEnvVarManager = mockEnvVarManager
+
+	err := k.mockEnvVarManager.Setenv(util.OldOperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "someregistry", "v9.9.9"))
+	Expect(err).NotTo(HaveOccurred())
+
+	k.defaultConfig = k.getConfig("", "")
 
 	k.totalAdds = 0
 	k.totalUpdates = 0
@@ -1072,7 +1079,7 @@ func (k *KubeVirtTestData) addPrometheusRule(prometheusRule *promv1.PrometheusRu
 func (k *KubeVirtTestData) generateRandomResources() int {
 	version := fmt.Sprintf("rand-%s", rand.String(10))
 	registry := fmt.Sprintf("rand-%s", rand.String(10))
-	config := getConfig(registry, version)
+	config := k.getConfig(registry, version)
 
 	all := make([]runtime.Object, 0)
 	all = append(all, &k8sv1.ServiceAccount{
@@ -1487,7 +1494,7 @@ func (k *KubeVirtTestData) makeHandlerReady() {
 func (k *KubeVirtTestData) addDummyValidationWebhook() {
 	version := fmt.Sprintf("rand-%s", rand.String(10))
 	registry := fmt.Sprintf("rand-%s", rand.String(10))
-	config := getConfig(registry, version)
+	config := k.getConfig(registry, version)
 
 	validationWebhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1648,11 +1655,23 @@ func (k *KubeVirtTestData) addPodsAndPodDisruptionBudgets(config *util.KubeVirtD
 	k.addPodsWithOptionalPodDisruptionBudgets(config, true, kv)
 }
 
+func (k *KubeVirtTestData) getConfig(registry, version string) *util.KubeVirtDeploymentConfig {
+	return util.GetTargetConfigFromKVWithEnvVarManager(&v1.KubeVirt{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: NAMESPACE,
+		},
+		Spec: v1.KubeVirtSpec{
+			ImageRegistry: registry,
+			ImageTag:      version,
+		},
+	},
+		k.mockEnvVarManager)
+}
+
 var _ = Describe("KubeVirt Operator", func() {
 
 	BeforeEach(func() {
-		err := os.Setenv(util.OldOperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "someregistry", "v9.9.9"))
-		Expect(err).NotTo(HaveOccurred())
+		util.DefaultEnvVarManager = mockEnvVarManager
 	})
 
 	Context("On valid KubeVirt object", func() {
@@ -1761,7 +1780,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
-			customConfig := getConfig(kvTestData.defaultConfig.GetImageRegistry(), "custom.tag")
+			customConfig := kvTestData.getConfig(kvTestData.defaultConfig.GetImageRegistry(), "custom.tag")
 
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()
@@ -2131,7 +2150,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
 
-			config := getConfig("registry", "v1.1.1")
+			config := kvTestData.getConfig("registry", "v1.1.1")
 			envKey := rand.String(10)
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
@@ -2142,7 +2161,11 @@ var _ = Describe("KubeVirt Operator", func() {
 		})
 
 		It("should create an api server deployment with passthrough env vars, if provided in config", func() {
-			config := getConfig("registry", "v1.1.1")
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			config := kvTestData.getConfig("registry", "v1.1.1")
 			envKey := rand.String(10)
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
@@ -2154,7 +2177,11 @@ var _ = Describe("KubeVirt Operator", func() {
 		})
 
 		It("should create a controller deployment with passthrough env vars, if provided in config", func() {
-			config := getConfig("registry", "v1.1.1")
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			config := kvTestData.getConfig("registry", "v1.1.1")
 			envKey := rand.String(10)
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
@@ -2166,7 +2193,11 @@ var _ = Describe("KubeVirt Operator", func() {
 		})
 
 		It("should create a handler daemonset with passthrough env vars, if provided in config", func() {
-			config := getConfig("registry", "v1.1.1")
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			config := kvTestData.getConfig("registry", "v1.1.1")
 			envKey := rand.String(10)
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
@@ -2361,7 +2392,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
 
-			rollbackConfig := getConfig("otherregistry", "9.9.7")
+			rollbackConfig := kvTestData.getConfig("otherregistry", "9.9.7")
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2427,7 +2458,9 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
 
-			updatedConfig := getConfig("otherregistry", "9.9.10")
+			err := kvTestData.mockEnvVarManager.Unsetenv(util.OldOperatorImageEnvName)
+			Expect(err).NotTo(HaveOccurred())
+			updatedConfig := kvTestData.getConfig("otherregistry", "9.9.10")
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2494,7 +2527,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
 
-			updatedConfig := getConfig("otherregistry", "9.9.10")
+			updatedConfig := kvTestData.getConfig("otherregistry", "9.9.10")
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2562,12 +2595,12 @@ var _ = Describe("KubeVirt Operator", func() {
 		})
 
 		DescribeTable("should update kubevirt resources when Operator version changes if no imageTag and imageRegistry is explicitly set.", func(withExport bool, patchCount, resourceCount, numPDBs int) {
-			os.Setenv(util.OldOperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "otherregistry", "1.1.1"))
-			updatedConfig := getConfig("", "")
-
 			kvTestData := KubeVirtTestData{}
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
+
+			kvTestData.mockEnvVarManager.Setenv(util.OldOperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "otherregistry", "1.1.1"))
+			updatedConfig := kvTestData.getConfig("", "")
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2639,11 +2672,11 @@ var _ = Describe("KubeVirt Operator", func() {
 		)
 
 		DescribeTable("should update resources when changing KubeVirt version.", func(withExport bool, patchCount, resourceCount int) {
-			updatedConfig := getConfig("otherregistry", "1.1.1")
-
 			kvTestData := KubeVirtTestData{}
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
+
+			updatedConfig := kvTestData.getConfig("otherregistry", "1.1.1")
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2713,11 +2746,11 @@ var _ = Describe("KubeVirt Operator", func() {
 		)
 
 		DescribeTable("should patch poddisruptionbudgets when changing KubeVirt version.", func(withExport bool, numPDBs int) {
-			updatedConfig := getConfig("otherregistry", "1.1.1")
-
 			kvTestData := KubeVirtTestData{}
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
+
+			updatedConfig := kvTestData.getConfig("otherregistry", "1.1.1")
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3031,18 +3064,6 @@ func getSCC() secv1.SecurityContextConstraints {
 			"someUser",
 		},
 	}
-}
-
-func getConfig(registry, version string) *util.KubeVirtDeploymentConfig {
-	return util.GetTargetConfigFromKV(&v1.KubeVirt{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: NAMESPACE,
-		},
-		Spec: v1.KubeVirtSpec{
-			ImageRegistry: registry,
-			ImageTag:      version,
-		},
-	})
 }
 
 func syncCaches(stop chan struct{}, kvInformer cache.SharedIndexInformer, informers util.Informers) {

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -100,6 +100,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests:go_default_library",
         "//tools/util:go_default_library",
         "//vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"strings"
 
+	"kubevirt.io/kubevirt/tests"
+
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
 
@@ -117,7 +119,11 @@ var _ = Describe("Apply Apps", func() {
 			clientset.EXPECT().PolicyV1().Return(pdbClient.PolicyV1()).AnyTimes()
 			kv = &v1.KubeVirt{}
 
-			deployment, err = components.NewApiServerDeployment(Namespace, Registry, "", Version, "", "", "", corev1.PullIfNotPresent, "verbosity", map[string]string{})
+			virtApiConfig := &util.KubeVirtDeploymentConfig{
+				Registry:        Registry,
+				KubeVirtVersion: Version,
+			}
+			deployment, err = tests.GetDefaultVirtApiDeployment(Namespace, virtApiConfig)
 			Expect(err).ToNot(HaveOccurred())
 
 			cachedPodDisruptionBudget = components.NewPodDisruptionBudgetForDeployment(deployment)
@@ -307,7 +313,11 @@ var _ = Describe("Apply Apps", func() {
 				},
 			}
 
-			daemonSet, err = components.NewHandlerDaemonSet(Namespace, Registry, "", Version, "", "", "", "", corev1.PullIfNotPresent, nil, "verbosity", map[string]string{})
+			virtHandlerConfig := &util.KubeVirtDeploymentConfig{
+				Registry:        Registry,
+				KubeVirtVersion: Version,
+			}
+			daemonSet, err = tests.GetDefaultVirtHandlerDaemonSet(Namespace, virtHandlerConfig)
 			Expect(err).ToNot(HaveOccurred())
 			markHandlerReady(daemonSet)
 			daemonSet.UID = "random-id"

--- a/pkg/virt-operator/resource/apply/pdb_test.go
+++ b/pkg/virt-operator/resource/apply/pdb_test.go
@@ -3,12 +3,13 @@ package apply
 import (
 	"encoding/json"
 
+	"kubevirt.io/kubevirt/tests"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v12 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	_ "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,7 +74,11 @@ var _ = Describe("Apply PDBs", func() {
 			expectations:   expectations,
 		}
 
-		deployment, err = components.NewApiServerDeployment(Namespace, Registry, "", Version, "", "", "", corev1.PullIfNotPresent, "verbosity", map[string]string{})
+		virtApiConfig := &util.KubeVirtDeploymentConfig{
+			Registry:        Registry,
+			KubeVirtVersion: Version,
+		}
+		deployment, err = tests.GetDefaultVirtApiDeployment(Namespace, virtApiConfig)
 		Expect(err).ToNot(HaveOccurred())
 
 		kv.Status.TargetKubeVirtRegistry = Registry

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -393,13 +393,12 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 	if err != nil {
 		return nil, err
 	}
-	exportServerVersion = AddVersionSeparatorPrefix(exportServerVersion)
-	launcherVersion = AddVersionSeparatorPrefix(launcherVersion)
+
 	if launcherImage == "" {
-		launcherImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", launcherVersion)
+		launcherImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", AddVersionSeparatorPrefix(launcherVersion))
 	}
 	if exporterImage == "" {
-		exporterImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-exportserver", exportServerVersion)
+		exporterImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-exportserver", AddVersionSeparatorPrefix(exportServerVersion))
 	}
 
 	pod := &deployment.Spec.Template.Spec
@@ -482,15 +481,15 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 }
 
 // Used for manifest generation only
-func NewOperatorDeployment(namespace string, repository string, imagePrefix string, version string,
-	pullPolicy corev1.PullPolicy, verbosity string,
-	kubeVirtVersionEnv string, virtApiShaEnv string, virtControllerShaEnv string,
-	virtHandlerShaEnv string, virtLauncherShaEnv string, virtExportProxyShaEnv string, virtExportServerShaEnv string, gsShaEnv string) (*appsv1.Deployment, error) {
+func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosity, kubeVirtVersionEnv, virtApiShaEnv, virtControllerShaEnv, virtHandlerShaEnv, virtLauncherShaEnv, virtExportProxyShaEnv,
+	virtExportServerShaEnv, gsShaEnv, image string, pullPolicy corev1.PullPolicy) (*appsv1.Deployment, error) {
 
 	const kubernetesOSLinux = "linux"
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, kubernetesHostnameTopologyKey, metav1.LabelSelectorOpIn, []string{VirtOperatorName})
 	version = AddVersionSeparatorPrefix(version)
-	image := fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, VirtOperatorName, version)
+	if image == "" {
+		image = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, VirtOperatorName, version)
+	}
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -573,7 +572,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 							},
 							Env: []corev1.EnvVar{
 								{
-									Name:  operatorutil.OperatorImageEnvName,
+									Name:  operatorutil.OldOperatorImageEnvName,
 									Value: image,
 								},
 								{

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -151,9 +151,11 @@ func NewExportProxyService(namespace string) *corev1.Service {
 	}
 }
 
-func newPodTemplateSpec(podName string, imageName string, repository string, version string, productName string, productVersion string, productComponent string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*corev1.PodTemplateSpec, error) {
+func newPodTemplateSpec(podName, imageName, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*corev1.PodTemplateSpec, error) {
 
-	version = AddVersionSeparatorPrefix(version)
+	if image == "" {
+		image = fmt.Sprintf("%s/%s%s", repository, imageName, AddVersionSeparatorPrefix(version))
+	}
 
 	podTemplateSpec := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -170,7 +172,7 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 			Containers: []corev1.Container{
 				{
 					Name:            podName,
-					Image:           fmt.Sprintf("%s/%s%s", repository, imageName, version),
+					Image:           image,
 					ImagePullPolicy: pullPolicy,
 				},
 			},
@@ -234,9 +236,9 @@ func attachCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath 
 	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, secretVolumeMount)
 }
 
-func newBaseDeployment(deploymentName string, imageName string, namespace string, repository string, version string, productName string, productVersion string, productComponent string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*appsv1.Deployment, error) {
+func newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*appsv1.Deployment, error) {
 
-	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, productComponent, pullPolicy, podAffinity, envVars)
+	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, productComponent, image, pullPolicy, podAffinity, envVars)
 	if err != nil {
 		return nil, err
 	}
@@ -304,12 +306,12 @@ func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOp
 	}
 }
 
-func NewApiServerDeployment(namespace string, repository string, imagePrefix string, version string, productName string, productVersion string, productComponent string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewApiServerDeployment(namespace, repository, imagePrefix, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, kubernetesHostnameTopologyKey, metav1.LabelSelectorOpIn, []string{VirtAPIName})
 	deploymentName := VirtAPIName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, pullPolicy, podAntiAffinity, env)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image, pullPolicy, podAntiAffinity, env)
 	if err != nil {
 		return nil, err
 	}
@@ -382,14 +384,22 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	return deployment, nil
 }
 
-func NewControllerDeployment(namespace string, repository string, imagePrefix string, controllerVersion string, launcherVersion string, exportServerVersion string, productName string, productVersion string, productComponent string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersion, launcherVersion, exportServerVersion, productName, productVersion, productComponent, image, launcherImage, exporterImage string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, kubernetesHostnameTopologyKey, metav1.LabelSelectorOpIn, []string{VirtControllerName})
 	deploymentName := VirtControllerName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, productName, productVersion, productComponent, pullPolicy, podAntiAffinity, env)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, productName, productVersion, productComponent, image, pullPolicy, podAntiAffinity, env)
 	if err != nil {
 		return nil, err
+	}
+	exportServerVersion = AddVersionSeparatorPrefix(exportServerVersion)
+	launcherVersion = AddVersionSeparatorPrefix(launcherVersion)
+	if launcherImage == "" {
+		launcherImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", launcherVersion)
+	}
+	if exporterImage == "" {
+		exporterImage = fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-exportserver", exportServerVersion)
 	}
 
 	pod := &deployment.Spec.Template.Spec
@@ -399,18 +409,15 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
 
-	launcherVersion = AddVersionSeparatorPrefix(launcherVersion)
-	exportServerVersion = AddVersionSeparatorPrefix(exportServerVersion)
-
 	container := &deployment.Spec.Template.Spec.Containers[0]
 	container.Command = []string{
 		VirtControllerName,
 	}
 	container.Args = []string{
 		"--launcher-image",
-		fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-launcher", launcherVersion),
+		launcherImage,
 		"--exporter-image",
-		fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, "virt-exportserver", exportServerVersion),
+		exporterImage,
 		portName,
 		"8443",
 		"-v",
@@ -650,12 +657,12 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 	return deployment, nil
 }
 
-func NewExportProxyDeployment(namespace string, repository string, imagePrefix string, version string, productName string, productVersion string, productComponent string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewExportProxyDeployment(namespace, repository, imagePrefix, version, productName, productVersion, productComponent, image string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, kubernetesHostnameTopologyKey, metav1.LabelSelectorOpIn, []string{VirtAPIName})
 	deploymentName := VirtExportProxyName
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, pullPolicy, podAntiAffinity, env)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, productComponent, image, pullPolicy, podAntiAffinity, env)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-operator/resource/generate/csv/csv.go
+++ b/pkg/virt-operator/resource/generate/csv/csv.go
@@ -59,6 +59,7 @@ type NewClusterServiceVersionData struct {
 	IconBase64           string
 	ReplacesCsvVersion   string
 	CreatedAtTimestamp   string
+	VirtOperatorImage    string
 }
 
 type csvClusterPermissions struct {
@@ -152,7 +153,6 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		data.DockerPrefix,
 		data.ImagePrefix,
 		data.OperatorImageVersion,
-		v1.PullPolicy(data.ImagePullPolicy),
 		data.Verbosity,
 		data.KubeVirtVersion,
 		data.VirtApiSha,
@@ -161,7 +161,9 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		data.VirtLauncherSha,
 		data.VirtExportProxySha,
 		data.VirtExportServerSha,
-		data.GsSha)
+		data.GsSha,
+		data.VirtOperatorImage,
+		v1.PullPolicy(data.ImagePullPolicy))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -493,13 +493,13 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	strategy.services = append(strategy.services, components.NewApiServerService(config.GetNamespace()))
 	strategy.services = append(strategy.services, components.NewOperatorWebhookService(operatorNamespace))
 	strategy.services = append(strategy.services, components.NewExportProxyService(config.GetNamespace()))
-	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), productName, productVersion, productComponent, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), productName, productVersion, productComponent, config.VirtApiImage, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-apiserver deployment %v", err)
 	}
 	strategy.deployments = append(strategy.deployments, apiDeployment)
 
-	controller, err := components.NewControllerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetExportServerVersion(), productName, productVersion, productComponent, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+	controller, err := components.NewControllerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetExportServerVersion(), productName, productVersion, productComponent, config.VirtControllerImage, config.VirtLauncherImage, config.VirtExportServerImage, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-controller deployment %v", err)
 	}
@@ -507,13 +507,13 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 
 	strategy.configMaps = append(strategy.configMaps, components.NewCAConfigMaps(operatorNamespace)...)
 
-	exportProxyDeployment, err := components.NewExportProxyDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetExportProxyVersion(), productName, productVersion, productComponent, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+	exportProxyDeployment, err := components.NewExportProxyDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetExportProxyVersion(), productName, productVersion, productComponent, config.VirtExportProxyImage, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 	if err != nil {
 		return nil, fmt.Errorf("error generating export proxy deployment %v", err)
 	}
 	strategy.deployments = append(strategy.deployments, exportProxyDeployment)
 
-	handler, err := components.NewHandlerDaemonSet(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetLauncherVersion(), productName, productVersion, productComponent, config.GetImagePullPolicy(), config.GetMigrationNetwork(), config.GetVerbosity(), config.GetExtraEnv())
+	handler, err := components.NewHandlerDaemonSet(config.GetNamespace(), config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetLauncherVersion(), productName, productVersion, productComponent, config.VirtHandlerImage, config.VirtLauncherImage, config.GetImagePullPolicy(), config.GetMigrationNetwork(), config.GetVerbosity(), config.GetExtraEnv())
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-handler deployment %v", err)
 	}

--- a/pkg/virt-operator/util/BUILD.bazel
+++ b/pkg/virt-operator/util/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "client.go",
         "config.go",
+        "env_var_manager.go",
         "readycheck.go",
         "types.go",
     ],

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -39,7 +39,14 @@ import (
 
 const (
 	// Name of env var containing the operator's image name
-	OperatorImageEnvName          = "OPERATOR_IMAGE"
+	OperatorImageEnvName         = "OPERATOR_IMAGE"
+	VirtApiImageEnvName          = "VIRT_API_IMAGE"
+	VirtControllerImageEnvName   = "VIRT_CONTROLLER_IMAGE"
+	VirtHandlerImageEnvName      = "VIRT_HANDLER_IMAGE"
+	VirtLauncherImageEnvName     = "VIRT_LAUNCHER_IMAGE"
+	VirtExportProxyImageEnvName  = "VIRT_EXPORTPROXY_IMAGE"
+	VirtExportServerImageEnvName = "VIRT_EXPORTSERVER_IMAGE"
+
 	VirtApiShasumEnvName          = "VIRT_API_SHASUM"
 	VirtControllerShasumEnvName   = "VIRT_CONTROLLER_SHASUM"
 	VirtHandlerShasumEnvName      = "VIRT_HANDLER_SHASUM"
@@ -107,6 +114,15 @@ type KubeVirtDeploymentConfig struct {
 	// matches the image tag, if tags are used, either by the manifest, or by the KubeVirt CR
 	// used on the KubeVirt CR status and on annotations, and for determining up-/downgrade path, even when using shasums for the images
 	KubeVirtVersion string `json:"kubeVirtVersion,omitempty" optional:"true"`
+
+	// the images names of every image we use
+	VirtOperatorImage     string `json:"virtOperatorImage,omitempty" optional:"true"`
+	VirtApiImage          string `json:"virtApiImage,omitempty" optional:"true"`
+	VirtControllerImage   string `json:"virtControllerImage,omitempty" optional:"true"`
+	VirtHandlerImage      string `json:"virtHandlerImage,omitempty" optional:"true"`
+	VirtLauncherImage     string `json:"virtLauncherImage,omitempty" optional:"true"`
+	VirtExportProxyImage  string `json:"virtExportProxyImage,omitempty" optional:"true"`
+	VirtExportServerImage string `json:"virtExportServerImage,omitempty" optional:"true"`
 
 	// the shasums of every image we use
 	VirtOperatorSha     string `json:"virtOperatorSha,omitempty" optional:"true"`
@@ -246,7 +262,15 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 
 	passthroughEnv := GetPassthroughEnv()
 
-	config := newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, additionalProperties, passthroughEnv)
+	operatorImage := os.Getenv(OperatorImageEnvName)
+	apiImage := os.Getenv(VirtApiImageEnvName)
+	controllerImage := os.Getenv(VirtControllerImageEnvName)
+	handlerImage := os.Getenv(VirtHandlerImageEnvName)
+	launcherImage := os.Getenv(VirtLauncherImageEnvName)
+	exportProxyImage := os.Getenv(VirtExportProxyImageEnvName)
+	exportServerImage := os.Getenv(VirtExportServerImageEnvName)
+
+	config := newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, additionalProperties, passthroughEnv)
 	if skipShasums {
 		return config
 	}
@@ -309,14 +333,21 @@ func GetPassthroughEnv() map[string]string {
 	return passthroughEnv
 }
 
-func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
+func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
 	c := &KubeVirtDeploymentConfig{
-		Registry:             registry,
-		ImagePrefix:          imagePrefix,
-		KubeVirtVersion:      tag,
-		Namespace:            namespace,
-		AdditionalProperties: kvSpec,
-		PassthroughEnvVars:   passthroughEnv,
+		Registry:              registry,
+		ImagePrefix:           imagePrefix,
+		KubeVirtVersion:       tag,
+		VirtOperatorImage:     operatorImage,
+		VirtApiImage:          apiImage,
+		VirtControllerImage:   controllerImage,
+		VirtHandlerImage:      handlerImage,
+		VirtLauncherImage:     launcherImage,
+		VirtExportProxyImage:  exportProxyImage,
+		VirtExportServerImage: exportServerImage,
+		Namespace:             namespace,
+		AdditionalProperties:  kvSpec,
+		PassthroughEnvVars:    passthroughEnv,
 	}
 	c.generateInstallStrategyID()
 	return c

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -47,11 +47,18 @@ const (
 	VirtExportProxyImageEnvName  = "VIRT_EXPORTPROXY_IMAGE"
 	VirtExportServerImageEnvName = "VIRT_EXPORTSERVER_IMAGE"
 
-	VirtApiShasumEnvName          = "VIRT_API_SHASUM"
-	VirtControllerShasumEnvName   = "VIRT_CONTROLLER_SHASUM"
-	VirtHandlerShasumEnvName      = "VIRT_HANDLER_SHASUM"
-	VirtLauncherShasumEnvName     = "VIRT_LAUNCHER_SHASUM"
-	VirtExportProxyShasumEnvName  = "VIRT_EXPORTPROXY_SHASUM"
+	// The below Shasum variables would be ignored if Image env vars are being used.
+	// Deprecated, use VirtApiImageEnvName instead
+	VirtApiShasumEnvName = "VIRT_API_SHASUM"
+	// Deprecated, use VirtControllerImageEnvName instead
+	VirtControllerShasumEnvName = "VIRT_CONTROLLER_SHASUM"
+	// Deprecated, use VirtHandlerImageEnvName instead
+	VirtHandlerShasumEnvName = "VIRT_HANDLER_SHASUM"
+	// Deprecated, use VirtLauncherImageEnvName instead
+	VirtLauncherShasumEnvName = "VIRT_LAUNCHER_SHASUM"
+	// Deprecated, use VirtExportProxyImageEnvName instead
+	VirtExportProxyShasumEnvName = "VIRT_EXPORTPROXY_SHASUM"
+	// Deprecated, use VirtExportServerImageEnvName instead
 	VirtExportServerShasumEnvName = "VIRT_EXPORTSERVER_SHASUM"
 	GsEnvShasumName               = "GS_SHASUM"
 	KubeVirtVersionEnvName        = "KUBEVIRT_VERSION"

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -39,7 +39,9 @@ import (
 
 const (
 	// Name of env var containing the operator's image name
-	OperatorImageEnvName         = "OPERATOR_IMAGE"
+	// Deprecated. Use VirtOperatorImageEnvName instead
+	OldOperatorImageEnvName      = "OPERATOR_IMAGE"
+	VirtOperatorImageEnvName     = "VIRT_OPERATOR_IMAGE"
 	VirtApiImageEnvName          = "VIRT_API_IMAGE"
 	VirtControllerImageEnvName   = "VIRT_CONTROLLER_IMAGE"
 	VirtHandlerImageEnvName      = "VIRT_HANDLER_IMAGE"
@@ -225,10 +227,19 @@ func getKVMapFromSpec(spec v1.KubeVirtSpec) map[string]string {
 	return kvMap
 }
 
+func GetOperatorImage() string {
+	image := os.Getenv(VirtOperatorImageEnvName)
+	if image != "" {
+		return image
+	}
+
+	return os.Getenv(OldOperatorImageEnvName)
+}
+
 func getConfig(registry, tag, namespace string, additionalProperties map[string]string) *KubeVirtDeploymentConfig {
 
 	// get registry and tag/shasum from operator image
-	imageString := os.Getenv(OperatorImageEnvName)
+	imageString := GetOperatorImage()
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
 	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)
 
@@ -269,7 +280,7 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 
 	passthroughEnv := GetPassthroughEnv()
 
-	operatorImage := os.Getenv(OperatorImageEnvName)
+	operatorImage := GetOperatorImage()
 	apiImage := os.Getenv(VirtApiImageEnvName)
 	controllerImage := os.Getenv(VirtControllerImageEnvName)
 	handlerImage := os.Getenv(VirtHandlerImageEnvName)
@@ -300,9 +311,9 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 
 func VerifyEnv() error {
 	// ensure the operator image is valid
-	imageString := os.Getenv(OperatorImageEnvName)
+	imageString := GetOperatorImage()
 	if imageString == "" {
-		return fmt.Errorf("empty env var %s for operator image", OperatorImageEnvName)
+		return fmt.Errorf("empty env var %s for operator image", OldOperatorImageEnvName)
 	}
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
 	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Operator Config", func() {
 	}
 
 	DescribeTable("Parse image", func(image string, config *KubeVirtDeploymentConfig, valid bool) {
-		os.Setenv(OperatorImageEnvName, image)
+		os.Setenv(OldOperatorImageEnvName, image)
 
 		err := VerifyEnv()
 		if valid {
@@ -86,7 +86,7 @@ var _ = Describe("Operator Config", func() {
 	}
 
 	DescribeTable("Read shasums", func(image string, envVersions *KubeVirtDeploymentConfig, expectedConfig *KubeVirtDeploymentConfig, useShasums, valid bool) {
-		os.Setenv(OperatorImageEnvName, image)
+		os.Setenv(OldOperatorImageEnvName, image)
 
 		os.Setenv(VirtApiShasumEnvName, envVersions.VirtApiSha)
 		os.Setenv(VirtControllerShasumEnvName, envVersions.VirtControllerSha)

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -32,6 +32,13 @@ import (
 
 var _ = Describe("Operator Config", func() {
 
+	var envVarManager EnvVarManager
+
+	BeforeEach(func() {
+		envVarManager = &EnvVarManagerMock{}
+		DefaultEnvVarManager = envVarManager
+	})
+
 	getConfig := func(registry, version string) *KubeVirtDeploymentConfig {
 		return &KubeVirtDeploymentConfig{
 			Registry:        registry,
@@ -40,7 +47,7 @@ var _ = Describe("Operator Config", func() {
 	}
 
 	DescribeTable("Parse image", func(image string, config *KubeVirtDeploymentConfig, valid bool) {
-		os.Setenv(OldOperatorImageEnvName, image)
+		envVarManager.Setenv(OldOperatorImageEnvName, image)
 
 		err := VerifyEnv()
 		if valid {
@@ -86,13 +93,13 @@ var _ = Describe("Operator Config", func() {
 	}
 
 	DescribeTable("Read shasums", func(image string, envVersions *KubeVirtDeploymentConfig, expectedConfig *KubeVirtDeploymentConfig, useShasums, valid bool) {
-		os.Setenv(OldOperatorImageEnvName, image)
+		envVarManager.Setenv(OldOperatorImageEnvName, image)
 
-		os.Setenv(VirtApiShasumEnvName, envVersions.VirtApiSha)
-		os.Setenv(VirtControllerShasumEnvName, envVersions.VirtControllerSha)
-		os.Setenv(VirtHandlerShasumEnvName, envVersions.VirtHandlerSha)
-		os.Setenv(VirtLauncherShasumEnvName, envVersions.VirtLauncherSha)
-		os.Setenv(KubeVirtVersionEnvName, envVersions.KubeVirtVersion)
+		envVarManager.Setenv(VirtApiShasumEnvName, envVersions.VirtApiSha)
+		envVarManager.Setenv(VirtControllerShasumEnvName, envVersions.VirtControllerSha)
+		envVarManager.Setenv(VirtHandlerShasumEnvName, envVersions.VirtHandlerSha)
+		envVarManager.Setenv(VirtLauncherShasumEnvName, envVersions.VirtLauncherSha)
+		envVarManager.Setenv(KubeVirtVersionEnvName, envVersions.KubeVirtVersion)
 
 		err := VerifyEnv()
 		if valid {
@@ -141,10 +148,10 @@ var _ = Describe("Operator Config", func() {
 			otherKey := rand.String(10)
 			val := rand.String(10)
 
-			err := os.Setenv(passthroughKey, val)
+			err := envVarManager.Setenv(passthroughKey, val)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = os.Setenv(otherKey, val)
+			err = envVarManager.Setenv(otherKey, val)
 			Expect(err).ToNot(HaveOccurred())
 
 			envMap := GetPassthroughEnv()
@@ -182,7 +189,7 @@ var _ = Describe("Operator Config", func() {
 	Describe("Config json from env var", func() {
 		It("should be parsed", func() {
 			json := `{"id":"9ca7273e4d5f1bee842f64a8baabc15cbbf1ce59","namespace":"kubevirt","registry":"registry:5000/kubevirt","imagePrefix":"somePrefix","kubeVirtVersion":"devel","additionalProperties":{"ImagePullPolicy":"IfNotPresent", "MonitorNamespace":"non-default-monitor-namespace", "MonitorAccount":"non-default-prometheus-k8s"}}`
-			os.Setenv(TargetDeploymentConfig, json)
+			envVarManager.Setenv(TargetDeploymentConfig, json)
 			parsedConfig, err := GetConfigFromEnv()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(parsedConfig.GetDeploymentID()).To(Equal("9ca7273e4d5f1bee842f64a8baabc15cbbf1ce59"))
@@ -199,7 +206,7 @@ var _ = Describe("Operator Config", func() {
 	Describe("Config json with default value", func() {
 		It("should be parsed", func() {
 			json := `{"id":"9ca7273e4d5f1bee842f64a8baabc15cbbf1ce59","additionalProperties":{"ImagePullPolicy":"IfNotPresent"}}`
-			os.Setenv(TargetDeploymentConfig, json)
+			envVarManager.Setenv(TargetDeploymentConfig, json)
 			parsedConfig, err := GetConfigFromEnv()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(parsedConfig.GetPotentialMonitorNamespaces()).To(ConsistOf("openshift-monitoring", "monitoring"))
@@ -304,10 +311,10 @@ var _ = Describe("Operator Config", func() {
 			imageEnvVarName := envVarNameBase + "IMAGE"
 			shaEnvVarName := envVarNameBase + "SHASUM"
 
-			ExpectWithOffset(1, os.Setenv(imageEnvVarName, customImage)).To(Succeed())
+			ExpectWithOffset(1, envVarManager.Setenv(imageEnvVarName, customImage)).To(Succeed())
 			definedEnvVars = append(definedEnvVars, imageEnvVarName)
 
-			ExpectWithOffset(1, os.Setenv(shaEnvVarName, customSha)).To(Succeed())
+			ExpectWithOffset(1, envVarManager.Setenv(shaEnvVarName, customSha)).To(Succeed())
 			definedEnvVars = append(definedEnvVars, shaEnvVarName)
 
 			return customImage
@@ -318,7 +325,7 @@ var _ = Describe("Operator Config", func() {
 
 			config := getConfig("kubevirt", "v123")
 
-			ExpectWithOffset(1, os.Setenv(KubeVirtVersionEnvName, config.KubeVirtVersion)).To(Succeed())
+			ExpectWithOffset(1, envVarManager.Setenv(KubeVirtVersionEnvName, config.KubeVirtVersion)).To(Succeed())
 		})
 
 		AfterEach(func() {

--- a/pkg/virt-operator/util/env_var_manager.go
+++ b/pkg/virt-operator/util/env_var_manager.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"fmt"
+	"os"
+)
+
+type EnvVarManager interface {
+	Getenv(key string) string
+	Setenv(key, value string) error
+	Unsetenv(key string) error
+	Environ() []string
+}
+
+type EnvVarManagerImpl struct{}
+
+func (e EnvVarManagerImpl) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+func (e EnvVarManagerImpl) Setenv(key, value string) error {
+	return os.Setenv(key, value)
+}
+
+func (e EnvVarManagerImpl) Unsetenv(key string) error {
+	return os.Unsetenv(key)
+}
+
+func (e EnvVarManagerImpl) Environ() []string {
+	return os.Environ()
+}
+
+type EnvVarManagerMock struct {
+	envVars map[string]string
+}
+
+func (e *EnvVarManagerMock) Getenv(key string) string {
+	return e.envVars[key]
+}
+
+func (e *EnvVarManagerMock) Setenv(key, value string) error {
+	if e.envVars == nil {
+		e.envVars = make(map[string]string)
+	}
+
+	e.envVars[key] = value
+	return nil
+}
+
+func (e *EnvVarManagerMock) Unsetenv(key string) error {
+	delete(e.envVars, key)
+	return nil
+}
+
+func (e *EnvVarManagerMock) Environ() (ret []string) {
+	for key, value := range e.envVars {
+		ret = append(ret, fmt.Sprintf("%s=%s", key, value))
+	}
+	return ret
+}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -588,7 +588,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 
 				operator.Spec.Template.Spec.Containers[0].Image = newImage
 				for idx, env := range operator.Spec.Template.Spec.Containers[0].Env {
-					if env.Name == util.OperatorImageEnvName {
+					if env.Name == util.OldOperatorImageEnvName {
 						env.Value = newImage
 						operator.Spec.Template.Spec.Containers[0].Env[idx] = env
 						break

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -43,6 +43,8 @@ import (
 	"sync"
 	"time"
 
+	v12 "k8s.io/api/apps/v1"
+
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 
 	expect "github.com/google/goexpect"
@@ -2648,4 +2650,20 @@ func dvSizeBySourceURL(url string) string {
 	}
 
 	return cd.CirrosVolumeSize
+}
+
+func GetDefaultVirtApiDeployment(namespace string, config *util.KubeVirtDeploymentConfig) (*v12.Deployment, error) {
+	return components.NewApiServerDeployment(namespace, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", "", config.VirtApiImage, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+}
+
+func GetDefaultVirtControllerDeployment(namespace string, config *util.KubeVirtDeploymentConfig) (*v12.Deployment, error) {
+	return components.NewControllerDeployment(namespace, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetExportServerVersion(), "", "", "", config.VirtControllerImage, config.VirtLauncherImage, config.VirtExportServerImage, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+}
+
+func GetDefaultVirtHandlerDaemonSet(namespace string, config *util.KubeVirtDeploymentConfig) (*v12.DaemonSet, error) {
+	return components.NewHandlerDaemonSet(namespace, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), "", "", "", config.GetLauncherVersion(), config.VirtHandlerImage, config.VirtLauncherImage, config.GetImagePullPolicy(), nil, config.GetVerbosity(), config.GetExtraEnv())
+}
+
+func GetDefaultExportProxyDeployment(namespace string, config *util.KubeVirtDeploymentConfig) (*v12.Deployment, error) {
+	return components.NewExportProxyDeployment(namespace, config.GetImageRegistry(), config.GetImagePrefix(), config.GetExportProxyVersion(), "", "", "", config.VirtExportProxyImage, config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 }

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -48,6 +48,7 @@ func main() {
 	replacesCsvVersion := flag.String("replacesCsvVersion", "", "the CSV version being replaced by this generated CSV")
 	csvCreatedAtTimestamp := flag.String("csvCreatedAtTimestamp", "", "creation timestamp set in the 'createdAt' annotation on the CSV")
 	dumpCRDs := flag.Bool("dumpCRDs", false, "dump CRDs along with CSV manifests to stdout")
+	virtOperatorImage := flag.String("virt-operator-image", "", "custom image for virt-operator")
 
 	flag.Parse()
 
@@ -71,6 +72,7 @@ func main() {
 		IconBase64:           *kubeVirtLogo,
 		Replicas:             2,
 		CreatedAtTimestamp:   *csvCreatedAtTimestamp,
+		VirtOperatorImage:    *virtOperatorImage,
 	}
 
 	operatorCsv, err := csv.NewClusterServiceVersion(&csvData)

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -71,6 +71,7 @@ type templateData struct {
 	FeatureGates           []string
 	InfraReplicas          uint8
 	GeneratedManifests     map[string]string
+	VirtOperatorImage      string
 }
 
 func main() {
@@ -101,6 +102,7 @@ func main() {
 	gsSha := flag.String("gs-sha", "", "")
 	featureGates := flag.String("feature-gates", "", "")
 	infraReplicas := flag.Uint("infra-replicas", 0, "")
+	virtOperatorImage := flag.String("virt-operator-image", "", "custom image for virt-operator")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
@@ -151,6 +153,7 @@ func main() {
 		data.ReplacesCsvVersion = ""
 		data.OperatorDeploymentSpec = getOperatorDeploymentSpec(data, 2)
 		data.PriorityClassSpec = getPriorityClassSpec(2)
+		data.VirtOperatorImage = *virtOperatorImage
 		if *featureGates != "" {
 			data.FeatureGates = strings.Split(*featureGates, ",")
 		}
@@ -264,7 +267,6 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		data.DockerPrefix,
 		data.ImagePrefix,
 		version,
-		v1.PullPolicy(data.ImagePullPolicy),
 		data.Verbosity,
 		data.DockerTag,
 		data.VirtApiSha,
@@ -273,7 +275,9 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		data.VirtLauncherSha,
 		data.VirtExportProxySha,
 		data.VirtExportServerSha,
-		data.GsSha)
+		data.GsSha,
+		data.VirtOperatorImage,
+		v1.PullPolicy(data.ImagePullPolicy))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to provide custom images for core components, e.g. `virt-handler`, `virt-launcher`, etc.

Custom images can be provided via environment variables:
```yaml
env:
- name: VIRT_OPERATOR_IMAGE
  value: some.registry.com:tag1
- name: VIRT_API_IMAGE
  value: some.registry.com:tag2
- name: VIRT_CONTROLLER_IMAGE
  value: some.registry.com@sha256:abcdefghijklmnop
- name: VIRT_HANDLER_IMAGE
  value: some.registry.com:tag4
- name: VIRT_LAUNCHER_IMAGE
  value: some.registry.com:tag5
- name: VIRT_EXPORTPROXY_IMAGE
  value: some.registry.com:tag6
- name: VIRT_EXPORTSERVER_IMAGE
  value: some.registry.com:tag7
```

In addition, I've made some refactoring, mainly to use mocked environment variables to perform better isolation between unit tests.

This work is based on the following PR: https://github.com/kubevirt/kubevirt/pull/8390

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8302

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow specifying custom images for core components
```
