### PR TITLE
Instancetype: Refactor ControllerRevision comparison code and use to check existing CR content during restore

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -271,7 +271,7 @@ func (m *methods) StoreControllerRevisions(vm *virtv1.VirtualMachine) error {
 	return nil
 }
 
-func compareRevisions(revisionA *appsv1.ControllerRevision, revisionB *appsv1.ControllerRevision, isPreference bool) (bool, error) {
+func CompareRevisions(revisionA *appsv1.ControllerRevision, revisionB *appsv1.ControllerRevision, isPreference bool) (bool, error) {
 	if err := decodeRevisionObject(revisionA, isPreference); err != nil {
 		return false, err
 	}
@@ -306,7 +306,7 @@ func storeRevision(revision *appsv1.ControllerRevision, clientset kubecli.Kubevi
 			return nil, fmt.Errorf("failed to get ControllerRevision: %w", err)
 		}
 
-		equal, err := compareRevisions(revision, existingRevision, isPreference)
+		equal, err := CompareRevisions(revision, existingRevision, isPreference)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/instancetype:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/status:go_default_library",

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -2539,3 +2539,15 @@ func expectControllerRevisionUpdate(client *k8sfake.Clientset, expectedCR *appsv
 		return true, update.GetObject(), nil
 	})
 }
+
+func expectControllerRevisionDelete(client *k8sfake.Clientset, expectedCRName string) {
+	client.Fake.PrependReactor("delete", "controllerrevisions", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		delete, ok := action.(testing.DeleteAction)
+		Expect(ok).To(BeTrue())
+
+		name := delete.GetName()
+		Expect(name).To(Equal(expectedCRName))
+
+		return true, nil, nil
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up to #8466 that I've broken out of that PR given the need to refactor some existing code before using it during the restore of a `VirtualMachine`. This PR should ensure that the contents of any existing instance type or preference `ControllerRevisions` found during a restore to an existing `VirtualMachine` match those of the `VirtualMachineSnapshot`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
