### PR TITLE
Improve error in "using the local ssh method" test

### DIFF
--- a/tests/virtctl/ssh.go
+++ b/tests/virtctl/ssh.go
@@ -49,7 +49,7 @@ var _ = Describe("[sig-compute][virtctl]SSH", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		out, err := cmd.CombinedOutput()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "out[%s]", string(out))
 		Expect(out).ToNot(BeEmpty())
 	}
 


### PR DESCRIPTION
Improve error in "using the local ssh method" test
For easier debugging.

Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
