### PR TITLE
tests: Run mkfs.ext4 with force flag -F

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -306,7 +306,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 	verifyCreateData := func(vmi *v1.VirtualMachineInstance, device string) {
 		batch := []expect.Batcher{
-			&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 %s\n", device)},
+			&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", device)},
 			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: tests.EchoLastReturnValue},
 			&expect.BExp{R: console.RetValue("0")},

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -607,7 +607,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 					var batch []expect.Batcher
 					if device != "" {
 						batch = append(batch, []expect.Batcher{
-							&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 %s\n", device)},
+							&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 -F %s\n", device)},
 							&expect.BExp{R: console.PromptExpression},
 							&expect.BSnd{S: tests.EchoLastReturnValue},
 							&expect.BExp{R: console.RetValue("0")},

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -357,7 +357,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				By("Checking if we can write to /dev/vdc")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
+					&expect.BSnd{S: "sudo mkfs.ext4 -F /dev/vdc\n"},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: tests.EchoLastReturnValue},
 					&expect.BExp{R: console.RetValue("0")},


### PR DESCRIPTION
If the underlying volume has already been formatted to ext4, the tool will prompt for a user confirmation to proceed:
```
    $ mkfs.ext4 img
    mke2fs 1.46.5 (30-Dec-2021)
    img contains a ext4 file system
            created on Thu Oct 27 09:12:53 2022
    Proceed anyway? (y,N)
```
This is probably not desirable during a test run.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I hit this issue while running the tests with Longhorn storage provisioner.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
