### PR TITLE
e2e: restore cluster condition

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -272,6 +272,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			"There are no control-plane nodes in the cluster")
 
 		for _, node := range controlPlaneNodes.Items {
+			if node.Spec.Unschedulable == mode {
+				continue
+			}
+
 			nodeCopy := node.DeepCopy()
 			nodeCopy.Spec.Unschedulable = mode
 
@@ -3391,6 +3395,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						tests.UpdateKubeVirtConfigValueAndWait(cfg)
 					}
 					setControlPlaneUnschedulable(true)
+				})
+
+				AfterEach(func() {
+					setControlPlaneUnschedulable(false)
 				})
 
 				It("[test_id:6982]should migrate a VMI only one time", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some tests change the nodes spec and restore them during the test itself. This could cause that if the test fails before resetting the spec, all the subsequent tests will have a non-cleaned cluster, generating fails on cascade. Resetting the cluster conditions on `AfterEach` will improve test stability.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
