### PR TITLE
node-labeller.sh: Consider AppArmor restrictions

### DIFF
--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -21,6 +21,13 @@ fi
 
 libvirtd -d
 
+# If the below command fails, then probably we run under AppArmor restrictions
+# and the active profile denies exec of /usr/libexec/qemu-kvm for libvirtd. In
+# such case, move the binary to a more common location and try again.
+if ! virsh domcapabilities --machine q35 --arch x86_64 --virttype $VIRTTYPE > /dev/null; then
+    [ -f /usr/libexec/qemu-kvm ] && mv /usr/libexec/qemu-kvm /usr/bin/qemu-system-x86_64
+fi
+
 virsh domcapabilities --machine q35 --arch x86_64 --virttype $VIRTTYPE > /var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml
 
 cp -r /usr/share/libvirt/cpu_map /var/lib/kubevirt-node-labeller

--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 KVM_MINOR=$(grep -w 'kvm' /proc/misc | cut -f 1 -d' ')
 VIRTTYPE=qemu


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Even though the virt-handler pod is privileged, on the systems with AppArmor there might be a host profile which will be automatically picked for the `/usr/sbin/libvirtd` binary. That may block the execution of `/usr/libexec/qemu-kvm`. In such a case, try moving the qemu executable to a location, which is more common for AppArmor-enabled Linux distros.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7771, fixes #7638

**Special notes for your reviewer**:

The fix is needed only when the script is executed in a **privileged** container. In that case, the container runtime will not apply any profile (i.e. the container will run `unconfined`). However, if an AppArmor profile for libvirt is installed on the host, it will be automatically picked for the binary /usr/bin/libvirtd.

For the VM workloads the problem is not relevant since `virt-launcher` pod is not privileged, hence the runtime will apply the default profile (e.g. `cri-containerd.apparmor.d` in the output belllow):

```
 # aa-status 
apparmor module is loaded.
58 profiles are loaded.
58 profiles are in enforce mode.
   ...
   cri-containerd.apparmor.d
   ...
   libvirtd
   libvirtd//qemu_bridge_helper
   ...
0 profiles are in complain mode.
0 profiles are in kill mode.
0 profiles are in unconfined mode.
11 processes have profiles defined.
11 processes are in enforce mode.
   /bin/busybox (1778) cri-containerd.apparmor.d
   /bin/busybox (1921) cri-containerd.apparmor.d
   /usr/bin/virt-controller (2111) cri-containerd.apparmor.d
   /usr/bin/virt-operator (2354) cri-containerd.apparmor.d
   /usr/bin/virt-api (2515) cri-containerd.apparmor.d
   /usr/bin/virt-launcher-monitor (3889) cri-containerd.apparmor.d
   /usr/bin/virt-launcher (3906) cri-containerd.apparmor.d
   /usr/sbin/libvirtd (3916) cri-containerd.apparmor.d
   /usr/sbin/virtlogd (3917) cri-containerd.apparmor.d
   /usr/bin/container-disk (3955) cri-containerd.apparmor.d
   /usr/libexec/qemu-kvm (4068) cri-containerd.apparmor.d
0 processes are in complain mode.
0 processes are unconfined but have a profile defined.
0 processes are in mixed mode.
0 processes are in kill mode.

# k exec -ti virt-launcher-vmi-fedora-p5xq5 -- bash
bash-4.4# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.5 1238196 23476 ?       Ssl  07:46   0:00 /usr/bin/virt-launcher-monitor --qemu-timeout 297s --name vmi-fedora --uid 05979244-f909-45f2-875f-c8455b9b9
root        12  0.1  1.4 2148452 59176 ?       Sl   07:46   0:01 /usr/bin/virt-launcher --qemu-timeout 297s --name vmi-fedora --uid 05979244-f909-45f2-875f-c8455b9b9dad --na
root        22  0.1  0.6 1473748 27236 ?       Sl   07:46   0:00 /usr/sbin/libvirtd -f /var/run/libvirt/libvirtd.conf
root        23  0.0  0.3 137876 14092 ?        S    07:46   0:00 /usr/sbin/virtlogd -f /etc/libvirt/virtlogd.conf
qemu        77  4.7 11.6 3412228 467488 ?      Sl   07:47   0:29 /usr/libexec/qemu-kvm -name guest=default_vmi-fedora,debug-threads=on -S -object {"qom-type":"secret","id":"
root       169  0.0  0.0  12060  3180 pts/0    Ss   07:57   0:00 bash
root       175  0.0  0.0  44704  3268 pts/0    R+   07:57   0:00 ps aux
bash-4.4# cat /proc/22/attr/current 
cri-containerd.apparmor.d (enforce)
bash-4.4# cat /proc/77/attr/current 
cri-containerd.apparmor.d (enforce)
```

Also **note**: after moving the binary, we will have the new path reflected in the `/var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml`: 

```xml
<domainCapabilities>
  <path>/usr/bin/qemu-system-x86_64</path>
  ...
```

But I do not think it will cause issues, as AFAIK this path element is not used by the node-labeller.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix virt-handler Init:CrashLoopBackOff on systems with AppArmor
```
