### PR TITLE
Fix the flaky VSOCK unit test

### DIFF
--- a/pkg/virt-controller/watch/vsock_test.go
+++ b/pkg/virt-controller/watch/vsock_test.go
@@ -19,6 +19,8 @@ var _ = Describe("VSOCK", func() {
 		var vmis []*virtv1.VirtualMachineInstance
 		for i := 0; i < totalVMINum; i++ {
 			vmi := tests.NewRandomVMI()
+			// NewRandomVMI isn't guaranteed to have a unique name.
+			vmi.Name = fmt.Sprintf("%s-%d", vmi.Name, i)
 			if i < vsockVMINum {
 				cid := uint32(i + 3)
 				vmi.Status.VSOCKCID = &cid
@@ -35,9 +37,6 @@ var _ = Describe("VSOCK", func() {
 	DescribeTable("Syncing CIDs from exsisting VMIs",
 		func(totalVMINum, vsockVMINum int) {
 			vmis := newRandomVMIsWithORWithoutVSOCK(totalVMINum, vsockVMINum)
-			for _, vmi := range vmis {
-				fmt.Println(vmi.Status.VSOCKCID)
-			}
 			m.Sync(vmis)
 			Expect(m.cids).To(HaveLen(vsockVMINum))
 			Expect(m.reverse).To(HaveLen(vsockVMINum))


### PR DESCRIPTION
Signed-off-by: Zhuchen Wang <zcwang@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: It fixes the flaky VSOCK unit test.

The [`randName()`](https://github.com/kubevirt/kubevirt/blob/main/tests/libvmi/vmi.go#L49) doesn't guarantee to generate unique name all the time.

Before the fix `ginkgo --repeat=100 --focus-file=vsock_test.go ./pkg/virt-controller/watch` fails every time I run.

After the fix `ginkgo --repeat=1000 --focus-file=vsock_test.go ./pkg/virt-controller/watch` passes 3 times in a rolls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
