### PR TITLE
Remove the virtiofs SELinux rules from our custom policy

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -48,11 +48,6 @@
     ; This is therefore not blocking the switch to container_t
     (allow process self (tun_socket (relabelfrom relabelto attach_queue)))
     ;
-    ; This is needed to allow virtiofs to mount filesystem and access NFS
-    (allow process nfs_t (dir (mounton)))
-    (allow process proc_t (dir (mounton)))
-    (allow process proc_t (filesystem (mount unmount)))
-    ;
     ; This is needed for passt when running with this policy.
     ; container_t is compatible with passt without needing any additional rule.
     ; This rule is therefore only needed for VMs that use both virtiofs and passt.

--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -48,9 +48,7 @@
     ; This is therefore not blocking the switch to container_t
     (allow process self (tun_socket (relabelfrom relabelto attach_queue)))
     ;
-    ; This is needed for passt when running with this policy.
-    ; container_t is compatible with passt without needing any additional rule.
-    ; This rule is therefore only needed for VMs that use both virtiofs and passt.
+    ; This is needed for passt. This is the only thing for which this policy is actually needed.
     ; The policy will be removed from here once it will be installed via the passt package.
     (allow process tmpfs_t (filesystem (mount)))
 )

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -97,7 +97,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.VMExportGate,
 		virtconfig.VSOCKGate,
 	)
-	kv.Spec.Configuration.SELinuxLauncherType = "virt_launcher.process"
 
 	if kv.Spec.Configuration.NetworkConfiguration == nil {
 		testDefaultPermitSlirpInterface := true


### PR DESCRIPTION
**What this PR does / why we need it**:
With the Centos 9 update, we got a much more recent version of virtiofsd.
Let's see if the functional tests pass with the new version and without our custom SELinux rules.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
