### PR TITLE
[virt-controller]: consider the ParallelOutboundMigrationsPerNode when evicting VMs

### DIFF
--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -210,26 +210,29 @@ var _ = Describe("Evacuation", func() {
 			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
 			addNode(node)
 
-			vmi := newVirtualMachine("testvm", node.Name)
-			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
-			vmi1 := newVirtualMachine("testvm1", node.Name)
-			vmi1.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
-			vmiFeeder.Add(vmi)
+			vmi1 := newVirtualMachineMarkedForEviction("testvmi1", node.Name)
+			migration1 := newMigration("mig1", vmi1.Name, v1.MigrationRunning)
 			vmiFeeder.Add(vmi1)
-			migration := newMigration("mig1", vmi.Name, v1.MigrationRunning)
+			migrationFeeder.Add(migration1)
 
-			migrationFeeder.Add(migration)
-			migrationFeeder.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
-			migrationFeeder.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
-			migrationFeeder.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
-			migrationFeeder.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
+			vmi2 := newVirtualMachineMarkedForEviction("testvmi2", node.Name)
+			migration2 := newMigration("mig2", vmi1.Name, v1.MigrationRunning)
+			vmiFeeder.Add(vmi2)
+			migrationFeeder.Add(migration2)
+
+			vmi3 := newVirtualMachineMarkedForEviction("testvmi3", node.Name)
+			vmiFeeder.Add(vmi3)
 
 			controller.Execute()
 
-			migration.Status.Phase = v1.MigrationSucceeded
-			migrationFeeder.Modify(migration)
+			migration2.Status.Phase = v1.MigrationSucceeded
+			migrationFeeder.Modify(migration2)
 
-			migrationInterface.EXPECT().Create(gomock.Any(), &v13.CreateOptions{}).Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+			migrationInterface.
+				EXPECT().
+				Create(gomock.Any(), &v13.CreateOptions{}).
+				Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
+
 			controller.Execute()
 			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
 		})
@@ -291,49 +294,6 @@ var _ = Describe("Evacuation", func() {
 			migrationFeeder.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
 			migrationFeeder.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
 			controller.Execute()
-		})
-
-		It("Should start a migration when we have a free spot", func() {
-			node := newNode("foo")
-			addNode(node)
-			vmi := newVirtualMachine("testvm", node.Name)
-			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-				{
-					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: v12.ConditionTrue,
-				},
-			}
-			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
-			vmi.Status.EvacuationNodeName = node.Name
-			vmiFeeder.Add(vmi)
-
-			vmi1 := newVirtualMachine("testvm1", node.Name)
-			vmi1.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
-			vmi1.Status.Conditions = []v1.VirtualMachineInstanceCondition{
-				{
-					Type:   v1.VirtualMachineInstanceIsMigratable,
-					Status: v12.ConditionTrue,
-				},
-			}
-			vmi1.Status.EvacuationNodeName = node.Name
-			vmiFeeder.Add(vmi1)
-
-			migration := newMigration("mig1", vmi.Name, v1.MigrationRunning)
-			migrationFeeder.Add(migration)
-			migrationFeeder.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
-			migrationFeeder.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
-			migrationFeeder.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
-			migrationFeeder.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
-
-			controller.Execute()
-
-			migration.Status.Phase = v1.MigrationSucceeded
-			migrationFeeder.Modify(migration)
-
-			migrationInterface.EXPECT().Create(gomock.Any(), &v13.CreateOptions{}).
-				Return(&v1.VirtualMachineInstanceMigration{ObjectMeta: v13.ObjectMeta{Name: "something"}}, nil)
-			controller.Execute()
-			testutils.ExpectEvent(recorder, evacuation.SuccessfulCreateVirtualMachineInstanceMigrationReason)
 		})
 
 		It("Should not create a migration if one is already in progress", func() {


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
If not considering the maximum per-source-node active migrations we can have a scenario where we reach the maximum capacity of concurrent migrations in a cluster, where most of the migrations are pending because all the migrations are from the same source node.

This can be problematic in a case where multiple drains occur at the same time, therefore evictions from different source nodes can start simultaneously, but it won't happen because the migraiton queue was occupied with VMs from the same source node.

The solution is to observe migration queue with active migrations from same source node and limit the creation of new migrations up to the ParallelOutboundMigrationsPerNode.

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=2069098

**Special notes for your reviewer**:
In this PR I'm not aiming to re-factor or improve the current eviction flow, but only concentrate on the fix.

**Release note**:
```release-note
Consider the ParallelOutboundMigrationsPerNode when evicting VMs
```
