### PR TITLE
Run quarantined io error test with alpine

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -229,11 +229,7 @@ var _ = SIGDescribe("Storage", func() {
 
 			It("[QUARANTINE] should pause VMI on IO error", func() {
 				By("Creating VMI with faulty disk")
-				vmi := libvmi.New(
-					libvmi.WithPersistentVolumeClaim("disk0", pvc.Name),
-					libvmi.WithResourceMemory("256Mi"),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
+				vmi := libvmi.NewAlpine(libvmi.WithPersistentVolumeClaim("faulty-disk", pvc.Name))
 
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), failedCreateVMI)


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Not sure if this test should have ever worked without an OS;
```yaml
  volumes:
  - name: disk0
    persistentVolumeClaim:
      claimName: ioerrorpvcg5gnq
```
(Just a VM with the error block device)
Seems that its also the reason we don't get manifests in the periodic, @maya-r spotted this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
