### PR TITLE
Stabilize slirp outside connectivity test

### DIFF
--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -163,8 +163,8 @@ var _ = SIGDescribe("Slirp Networking", func() {
 			vmi := *vmiRef
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
-			tests.GenerateHelloWorldServer(vmi, 80, "tcp", console.LoginToCirros, true)
+			vmi = tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+			vmi = tests.LoginToVM(vmi, console.LoginToCirros)
 
 			dns := "google.com"
 			if flags.ConnectivityCheckDNS != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Retry curl command verifying Slirp connectivity: The orignal code using curl was problematic due to its lack of retry - temporary connection drop would fail the test. With this patch, the curl command is retried. 

This PR also removes unused HTTP server from a Slirp test.

**Special notes for your reviewer**:

This should resolve flakes like https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sig-network/1587200279651028992#1:build-log.txt%3A3067.

Due to its lack of ICMP support, the test cannot employ the same ping technique as adopted by otherwise similar [vmi_networking.go](https://github.com/kubevirt/kubevirt/blob/main/tests/network/vmi_networking.go#L729).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
