### PR TITLE
[release-0.53] Manual backport of fix bug in restore-controller when creating a restore PVC with both dataSource and dataSourceRef

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -793,11 +793,16 @@ func (ctrl *VMRestoreController) createRestorePVC(
 	pvc.Annotations[pvcRestoreAnnotation] = vmRestore.Name
 
 	apiGroup := vsv1.GroupName
-	pvc.Spec.DataSource = &corev1.TypedLocalObjectReference{
+	dataSource := corev1.TypedLocalObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     "VolumeSnapshot",
 		Name:     *volumeBackup.VolumeSnapshotName,
 	}
+
+	// We need to overwrite both dataSource and dataSourceRef to avoid incompatibilities between the two
+	pvc.Spec.DataSource = &dataSource
+	pvc.Spec.DataSourceRef = &dataSource
+
 	pvc.Spec.VolumeName = ""
 
 	target.Own(pvc)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1288,6 +1288,35 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(vmi.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(initialMemory))
 			})
 
+			It("should restore a virtual machine using a restore PVC with populated dataSourceRef", func() {
+				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
+					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),
+					util.NamespaceTestDefault,
+					snapshotStorageClass,
+					corev1.ReadWriteOnce))
+
+				By(creatingSnapshot)
+				snapshot = createSnapshot(vm)
+				newVM = tests.StopVirtualMachine(vm)
+
+				// We add an invalid dataSourceRef into the virtualMachineSnapshotContent so it's inherited by the restore PVC
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *snapshot.Status.VirtualMachineSnapshotContentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				content.Spec.VolumeBackups[0].PersistentVolumeClaim.Spec.DataSourceRef = &corev1.TypedLocalObjectReference{
+					Kind: "test",
+					Name: "test",
+				}
+				_, err = virtClient.VirtualMachineSnapshotContent(vm.Namespace).Update(context.Background(), content, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Restoring VM")
+				restore = createRestoreDef(newVM.Name, snapshot.Name)
+				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				restore = waitRestoreComplete(restore, newVM.Name, &newVM.UID)
+				Expect(restore.Status.Restores).To(HaveLen(1))
+			})
+
 			DescribeTable("should restore vm with hot plug disks", func(restoreToNewVM bool) {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeWithRegistryImport(
 					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/kubevirt/pull/8568.

**Which issue(s) this PR fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2128872



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
