### PR TITLE
Re-enable virtio-gpu for aarch64 VMs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4049,6 +4049,12 @@ rpm(
 )
 
 rpm(
+    name = "qemu-kvm-device-display-virtio-gpu-pci-17__7.1.0-3.el9.aarch64",
+    sha256 = "9406a23af79a2f43fd8facb2e74af8f4802eb9052f7651c29fd75392bbfd64c7",
+    urls = ["http://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/qemu-kvm-device-display-virtio-gpu-pci-7.1.0-3.el9.aarch64.rpm"],
+)
+
+rpm(
     name = "qemu-kvm-device-usb-redirect-17__7.1.0-3.el9.x86_64",
     sha256 = "3daebfa32f5e15a5b36b3fc8886a34346a9b487a4971aaa6180394026c403198",
     urls = [

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -26,7 +26,7 @@ KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL:-false}
 HOST_ARCHITECTURE="$(uname -m)"
 
 sandbox_root=${SANDBOX_DIR}/default/root
-sandbox_hash="f959c1cc69e676a4217842451fdfe3d0148942e3"
+sandbox_hash="aad86666e78b16c12d80d25ac0ad405dff58cc67"
 
 function kubevirt::bootstrap::regenerate() {
     (

--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -95,6 +95,7 @@ launcherbase_x86_64="
 "
 launcherbase_aarch64="
   edk2-aarch64-${EDK2_VERSION}
+  qemu-kvm-device-display-virtio-gpu-pci-${QEMU_VERSION}
 "
 launcherbase_extra="
   ethtool

--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -577,6 +577,7 @@ rpmtree(
         "@qemu-img-17__7.1.0-3.el9.aarch64//rpm",
         "@qemu-kvm-common-17__7.1.0-3.el9.aarch64//rpm",
         "@qemu-kvm-core-17__7.1.0-3.el9.aarch64//rpm",
+        "@qemu-kvm-device-display-virtio-gpu-pci-17__7.1.0-3.el9.aarch64//rpm",
         "@readline-0__8.1-4.el9.aarch64//rpm",
         "@rpm-0__4.16.1.3-17.el9.aarch64//rpm",
         "@rpm-libs-0__4.16.1.3-17.el9.aarch64//rpm",


### PR DESCRIPTION
**What this PR does / why we need it**:

The ability to use virtio-gpu, which is the default video device for aarch64 VMs, was lost during the switch to CentOS Stream 9.

This PR restores it.

**Which issue(s) this PR fixes**:

Fixes #8708

**Release note**:

```release-note
NONE
```