### PR TITLE
network,passt: consider overhead when binding all ports

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -357,6 +357,14 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource
 		overhead.Add(resource.MustParse("53Mi"))
 	}
 
+	// Additional overhead for each interface with Passt binding, that forwards all ports.
+	// More information can be found here: https://bugs.passt.top/show_bug.cgi?id=20
+	for _, net := range vmi.Spec.Domain.Devices.Interfaces {
+		if net.Passt != nil && len(net.Ports) == 0 {
+			overhead.Add(resource.MustParse("800Mi"))
+		}
+	}
+
 	return overhead
 }
 

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -511,7 +511,6 @@ func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(ports...)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.ISTIO_INJECT_ANNOTATION, "true"),
-		withPasstExtendedResourceMemory(ports...),
 	)
 	return vmi
 }

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -80,7 +80,6 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 					serverVMI = libvmi.NewAlpineWithTestTooling(
 						libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(ports...)),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
-						withPasstExtendedResourceMemory(ports...),
 					)
 
 					serverVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(serverVMI)
@@ -214,7 +213,6 @@ EOL`, inetSuffix, serverIP, serverPort)
 						clientVMI = libvmi.NewAlpineWithTestTooling(
 							libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding()),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-							withPasstExtendedResourceMemory(),
 						)
 						clientVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(clientVMI)
 						Expect(err).ToNot(HaveOccurred())
@@ -288,11 +286,3 @@ EOL`, inetSuffix, serverIP, serverPort)
 		})
 	})
 })
-
-func withPasstExtendedResourceMemory(ports ...v1.Port) libvmi.Option {
-	if len(ports) == 0 {
-		return libvmi.WithResourceMemory("2048M")
-	}
-	return func(vmi *v1.VirtualMachineInstance) {
-	}
-}


### PR DESCRIPTION
When VMI uses Passt interface and doesn't specify ports, all the ports are forwarded by Passt process.
Opening all the sockets for forwarding causes kernel to consume considerable amount of memory.

At the moment, Passt binding can only be used on primary interface, but since we need to loop over the VMI interfaces anyway, there's no reason not to be generic and account for each Passt binding with no specified Ports.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add overhead of interface with Passt binding when no ports are specified
```
