### PR TITLE
guest-agent, tests: Increase timeout fetching pod IPs

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -98,12 +98,12 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 
 				It("should report PodIP/s IPv4 as its own on interface status", func() {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-					Eventually(vmiIP).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
-					Eventually(vmiIPs).Should(ContainElement(vmiPod.Status.PodIP), "should contain IPv4 reported by guest agent")
+					Eventually(vmiIP, 2*time.Minute, 5*time.Second).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
+					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(ContainElement(vmiPod.Status.PodIP), "should contain IPv4 reported by guest agent")
 				})
 
 				It("should report VMIs static IPv6 at interface status", func() {
-					Eventually(vmiIPs).Should(ContainElement(libnet.DefaultIPv6Address), "should contain IPv6 address set by cloud-init and reported by guest agent")
+					Eventually(vmiIPs, 2*time.Minute, 5*time.Second).Should(ContainElement(libnet.DefaultIPv6Address), "should contain IPv6 address set by cloud-init and reported by guest agent")
 				})
 			})
 			When("no Guest Agent exists", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
When testing pod IPs reported by the guest-agent on the VMI
the tests wait for a default timeout to get the updated IPs.
Since the status update depends on guest agent polling and propagation
between virt-launcher and virt-handler which can take more time
the Expect timeout should allow more time in order to make sure 
that the IPs are picked up by the test.
Timeout is set to 2 minutes which is the guest agent steady state polling time

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
