### PR TITLE
hostdev: Avoid creating SR-IOV pool when not configured

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -40,6 +40,9 @@ import (
 
 func CreateHostDevices(vmi *v1.VirtualMachineInstance) ([]api.HostDevice, error) {
 	SRIOVInterfaces := vmispec.FilterSRIOVInterfaces(vmi.Spec.Domain.Devices.Interfaces)
+	if len(SRIOVInterfaces) == 0 {
+		return []api.HostDevice{}, nil
+	}
 	netStatusPath := path.Join(sriov.MountPath, sriov.VolumePath)
 	pciAddressPoolWithNetworkStatus, err := newPCIAddressPoolWithNetworkStatusFromFile(netStatusPath)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When no SR-IOV interfaces are set on the vmi, there is no need to try and create a SRIOV pool. Return an empty HostDevice list.

Not doing so results with the `found no SR-IOV networks to PCI-Address mapping. fall back to resource address pool` warning to pop up even if there are no SRIOV interfaces on the vmi.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
