### PR TITLE
Use libguestfs appliance with qcow2 root

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -386,11 +386,11 @@ http_archive(
     ],
 )
 
-http_file(
+http_archive(
     name = "libguestfs-appliance",
-    sha256 = "59fe17973fdaf4d969203b66b1446d855d406aea0736d06ee1cd624100942c8f",
+    sha256 = "124d6325a799e958843be4818ef2c32661755be1c56e519665779948861b04f6",
     urls = [
-        "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/appliance-1.48.4-linux-5.14.0-176-centos9.tar.xz",
+        "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/libguestfs-appliance-1.48.4-qcow2-linux-5.14.0-183-centos9.tar.xz",
     ],
 )
 

--- a/cmd/libguestfs/BUILD.bazel
+++ b/cmd/libguestfs/BUILD.bazel
@@ -5,18 +5,31 @@ load(
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
-    name = "appliance_layer",
-    srcs = ["@libguestfs-appliance//file"],
-    mode = "0444",
-    package_dir = "/usr/local/lib/guestfs",
-    visibility = ["//visibility:public"],
-)
-
-pkg_tar(
     name = "entrypoint",
     srcs = [":entrypoint.sh"],
     mode = "0775",
     package_dir = "/",
+)
+
+# Create done file. This was used in the previous version of the image to understand when the appliance was extracted.
+genrule(
+    name = "done-file",
+    outs = ["done"],
+    cmd = "touch $@",
+)
+
+pkg_tar(
+    name = "appliance_layer",
+    srcs = [
+        ":done-file",
+        "@libguestfs-appliance//appliance:README.fixed",
+        "@libguestfs-appliance//appliance:initrd",
+        "@libguestfs-appliance//appliance:kernel",
+        "@libguestfs-appliance//appliance:root",
+    ],
+    mode = "0444",
+    package_dir = "/usr/local/lib/guestfs/appliance",
+    visibility = ["//visibility:public"],
 )
 
 container_image(

--- a/cmd/libguestfs/entrypoint.sh
+++ b/cmd/libguestfs/entrypoint.sh
@@ -1,10 +1,3 @@
 #!/bin/bash -xe
 
-LIBGUESTFS_PATH=${LIBGUESTFS_PATH:=/tmp/guestfs}
-LIBGUEST_APPLIANCE=/usr/local/lib/guestfs/downloaded
-mkdir -p ${LIBGUESTFS_PATH}
-tar -Jxf ${LIBGUEST_APPLIANCE} -C ${LIBGUESTFS_PATH} --strip-components=1
-
-touch ${LIBGUESTFS_PATH}/done
-
 /bin/bash

--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -132,7 +132,6 @@ libguestfstools_main="
   libvirt-daemon-driver-qemu-${LIBVIRT_VERSION}
   qemu-kvm-core-${QEMU_VERSION}
   seabios-${SEABIOS_VERSION}
-  tar
 "
 libguestfstools_x86_64="
   edk2-ovmf-${EDK2_VERSION}

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -41,6 +41,7 @@ const (
 	applianceDir      = "/usr/local/lib/guestfs"
 	guestfsVolume     = "guestfs"
 	appliancePath     = applianceDir + "/appliance"
+	guestfsHome       = "/home/guestfs"
 	tmpDirVolumeName  = "libguestfs-tmp-dir"
 	tmpDirPath        = "/tmp/guestfs"
 	pullPolicyDefault = corev1.PullIfNotPresent
@@ -528,7 +529,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 						},
 						{
 							Name:  "HOME",
-							Value: appliancePath,
+							Value: guestfsHome,
 						},
 					},
 					SecurityContext: containerSecurityContext,
@@ -541,7 +542,7 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 						{
 							Name:      guestfsVolume,
 							ReadOnly:  false,
-							MountPath: appliancePath,
+							MountPath: guestfsHome,
 						},
 					},
 					ImagePullPolicy: corev1.PullPolicy(pullPolicy),


### PR DESCRIPTION
Libguestfs package available in centos stream 9 supports using the root in qcow2 format. This allows to keep the libguestfs-tools image with a reasonable size (~550MB), and at the same time it avoids to extract the appliance at runtime.

Signed-off-by: Alice Frosi <afrosi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change libguestfs-tools image using root appliance in qcow2 format
```
