### PR TITLE
Add more precise rest_client_request_latency_seconds histogram buckets

### DIFF
--- a/pkg/monitoring/client/prometheus/prometheus.go
+++ b/pkg/monitoring/client/prometheus/prometheus.go
@@ -40,9 +40,12 @@ var (
 	// "verb" and "url" labels. It is used for the rest client latency metrics.
 	requestLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "rest_client_request_latency_seconds",
-			Help:    "Request latency in seconds. Broken down by verb and URL.",
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+			Name: "rest_client_request_latency_seconds",
+			Help: "Request latency in seconds. Broken down by verb and URL.",
+			// Buckets based on Kubernetes apiserver_request_duration_seconds.
+			// See https://github.com/kubernetes/kubernetes/pull/73638 for the discussion.
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 		},
 		[]string{"verb", "url"},
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Current `rest_client_request_latency_seconds` histogram `Buckets` values are arbitrary, do not correspond to real-life requests latency distribution and are not giving the best observability possible. 
Assuming that in a production deployment, majority of requests has a latency from range `[150ms, 1s]`, current histogram definition will segregate the requests into only 3 buckets (`(0.128, 0.256], (0.256,0.512], (0.512, + Inf)`). This behavior causes KPIs like P95 or P99 to be less precise.

This PR follows the example of Kubernetes (https://github.com/kubernetes/kubernetes/pull/73638) and introduces custom buckets values for requests latency histogram. Especially, for mentioned before range of latencies `[150ms, 1s]`, it will segregate the requests into at least 5 buckets (much more when considered +Inf or 1m instead of 1s).


**Special notes for your reviewer**:
It would be great to to discuss if the proposed buckets (taken from Kubernetes) are actually meaningful in KubeVirt context. Especially, it the largest buckets are relevant for KubeVirt requests profile.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added more precise rest_client_request_latency_seconds histogram buckets
```
