### PR TITLE
Use a readiness probe for guestfs

### DIFF
--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -548,6 +548,13 @@ func createLibguestfsPod(pvc, image, cmd string, args []string, kvm, isBlock boo
 					Stdin:           true,
 					TTY:             true,
 					Resources:       resources,
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"/bin/cat", appliancePath + "/done"},
+							},
+						},
+					},
 				},
 			},
 			RestartPolicy: corev1.RestartPolicyNever,

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -106,10 +106,10 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		guestfsCmd := clientcmd.NewVirtctlCommand(o...)
 		go guestfsWithSync(f, guestfsCmd)
 		// Waiting until the libguestfs pod is ready
-		Eventually(func() bool {
+		Eventually(func() corev1.ConditionStatus {
 			pod, _ := virtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), podName, metav1.GetOptions{})
-			return tests.PodReady(pod) == corev1.ConditionTrue
-		}, 90*time.Second, 2*time.Second).Should(BeTrue())
+			return tests.PodReady(pod)
+		}, 90*time.Second, 2*time.Second).Should(BeEquivalentTo(corev1.ConditionTrue))
 
 	}
 


### PR DESCRIPTION
Our tests have to check for the existence of a file before running commands, and this is a bit of a hack.
Use the kubernetes native way of expressing that the pod is ready for use.

**Special notes for your reviewer**:
Thought of this change while looking at a flaky test, but I'm not sure if it will make a difference.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a readiness probe to communicate when the setup for a guestfs pod is complete
```
