### PR TITLE
Fix: Align Reenlightenment flows between converter.go and template.go

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/network-attachment-definition-client/clientset/versioned/fake:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/utils/pointer"
 
@@ -543,7 +545,7 @@ func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		)
 	}
 
-	if vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil {
+	if topology.IsManualTSCFrequencyRequired(vmi) {
 		opts = append(opts, WithTSCTimer(vmi.Status.TopologyHints.TSCFrequency))
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1412,31 +1412,13 @@ var _ = Describe("Template", func() {
 				DescribeTable("should", func(topologyHints *v1.TopologyHints, tscRequirementType topology.TscFrequencyRequirementType, isLabelExpected bool) {
 					config, kvInformer, svc = configFactory(defaultArch)
 
-					var someHertzios int64 = 123123
-					vmi := v1.VirtualMachineInstance{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "testvmi",
-							Namespace: "default",
-							UID:       "1234",
-						},
-						Spec: v1.VirtualMachineInstanceSpec{
-							Domain: v1.DomainSpec{
-								Devices: v1.Devices{
-									DisableHotplug: true,
-								},
-							},
-						},
-						Status: v1.VirtualMachineInstanceStatus{
-							TopologyHints: &v1.TopologyHints{
-								TSCFrequency: &someHertzios,
-							},
-						},
-					}
-
+					By("Setting up the vm")
+					vmi := api.NewMinimalVMIWithNS("testvmi", "default")
 					vmi.Status.TopologyHints = topologyHints
-					setVmWithTscRequirementType(&vmi, tscRequirementType)
+					setVmWithTscRequirementType(vmi, tscRequirementType)
 
-					pod, err := svc.RenderLaunchManifest(&vmi)
+					By("Rendering the vm into a pod")
+					pod, err := svc.RenderLaunchManifest(vmi)
 					Expect(err).ToNot(HaveOccurred())
 
 					if isLabelExpected {
@@ -1883,11 +1865,11 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
 				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 335),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", True(), 335),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", False(), 318),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.Bool(true), 335),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.Bool(false), 318),
 				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 469),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", True(), 469),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", False(), 453),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.Bool(true), 469),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.Bool(false), 453),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -3672,16 +3654,6 @@ func newVMIWithSriovInterface(name, uid string) *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{sriovInterface}
 
 	return vmi
-}
-
-func True() *bool {
-	b := true
-	return &b
-}
-
-func False() *bool {
-	b := false
-	return &b
 }
 
 func validateAndExtractQemuTimeoutArg(args []string) string {

--- a/pkg/virt-controller/watch/topology/generated_mock_hinter.go
+++ b/pkg/virt-controller/watch/topology/generated_mock_hinter.go
@@ -41,14 +41,14 @@ func (_mr *_MockHinterRecorder) TopologyHintsForVMI(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TopologyHintsForVMI", arg0)
 }
 
-func (_m *MockHinter) IsTscFrequencyRequiredForBoot(vmi *v1.VirtualMachineInstance) bool {
-	ret := _m.ctrl.Call(_m, "IsTscFrequencyRequiredForBoot", vmi)
+func (_m *MockHinter) IsTscFrequencyRequired(vmi *v1.VirtualMachineInstance) bool {
+	ret := _m.ctrl.Call(_m, "IsTscFrequencyRequired", vmi)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockHinterRecorder) IsTscFrequencyRequiredForBoot(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTscFrequencyRequiredForBoot", arg0)
+func (_mr *_MockHinterRecorder) IsTscFrequencyRequired(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTscFrequencyRequired", arg0)
 }
 
 func (_m *MockHinter) TSCFrequenciesInUse() []int64 {

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -59,9 +59,6 @@ func (t *topologyHinter) LowestTSCFrequencyOnCluster() (int64, error) {
 		HasInvTSCFrequency,
 	)
 	freq := LowestTSCFrequency(nodes)
-	if freq == 0 {
-		return 0, fmt.Errorf("no schedulable node exposes a tsc-frequency")
-	}
 	return freq, nil
 }
 
@@ -69,7 +66,7 @@ func (t *topologyHinter) TSCFrequenciesInUse() []int64 {
 	frequencyMap := map[int64]struct{}{}
 	for _, obj := range t.vmiStore.List() {
 		vmi := obj.(*k6tv1.VirtualMachineInstance)
-		if vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil {
+		if AreTSCFrequencyTopologyHintsDefined(vmi) {
 			frequencyMap[*vmi.Status.TopologyHints.TSCFrequency] = struct{}{}
 		}
 	}

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -15,7 +15,7 @@ import (
 
 type Hinter interface {
 	TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) (hints *k6tv1.TopologyHints, requirement TscFrequencyRequirementType, err error)
-	IsTscFrequencyRequiredForBoot(vmi *k6tv1.VirtualMachineInstance) bool
+	IsTscFrequencyRequired(vmi *k6tv1.VirtualMachineInstance) bool
 	TSCFrequenciesInUse() []int64
 	LowestTSCFrequencyOnCluster() (int64, error)
 }
@@ -27,8 +27,8 @@ type topologyHinter struct {
 	arch          string
 }
 
-func (t *topologyHinter) IsTscFrequencyRequiredForBoot(vmi *k6tv1.VirtualMachineInstance) bool {
-	return t.arch == "amd64" && GetTscFrequencyRequirement(vmi).Type == RequiredForBoot
+func (t *topologyHinter) IsTscFrequencyRequired(vmi *k6tv1.VirtualMachineInstance) bool {
+	return t.arch == "amd64" && GetTscFrequencyRequirement(vmi).Type != NotRequired
 }
 
 func (t *topologyHinter) TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) (hints *k6tv1.TopologyHints, requirement TscFrequencyRequirementType, err error) {

--- a/pkg/virt-controller/watch/topology/hinter_test.go
+++ b/pkg/virt-controller/watch/topology/hinter_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Hinter", func() {
 		)
 		hinter.arch = arch
 		vmi := vmiWithoutTSCFrequency("myvmi")
-		g.Expect(hinter.IsTscFrequencyRequiredForBoot(vmi)).To(g.BeFalse())
+		g.Expect(hinter.IsTscFrequencyRequired(vmi)).To(g.BeFalse())
 
 		hints, _, err := hinter.TopologyHintsForVMI(vmi)
 		g.Expect(hints).To(g.BeNil())

--- a/pkg/virt-controller/watch/topology/tsc.go
+++ b/pkg/virt-controller/watch/topology/tsc.go
@@ -127,7 +127,9 @@ func AreTSCFrequencyTopologyHintsDefined(vmi *k6tv1.VirtualMachineInstance) bool
 }
 
 func IsManualTSCFrequencyRequired(vmi *k6tv1.VirtualMachineInstance) bool {
-	return GetTscFrequencyRequirement(vmi).Type != NotRequired
+	return vmi != nil &&
+		GetTscFrequencyRequirement(vmi).Type != NotRequired &&
+		AreTSCFrequencyTopologyHintsDefined(vmi)
 }
 
 func GetTscFrequencyRequirement(vmi *k6tv1.VirtualMachineInstance) TscFrequencyRequirement {

--- a/pkg/virt-controller/watch/topology/tsc.go
+++ b/pkg/virt-controller/watch/topology/tsc.go
@@ -123,7 +123,12 @@ func ToTSCSchedulableLabel(frequency int64) string {
 }
 
 func AreTSCFrequencyTopologyHintsDefined(vmi *k6tv1.VirtualMachineInstance) bool {
-	return vmi != nil && vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil
+	if vmi == nil {
+		return false
+	}
+
+	topologyHints := vmi.Status.TopologyHints
+	return topologyHints != nil && topologyHints.TSCFrequency != nil && *topologyHints.TSCFrequency > 0
 }
 
 func IsManualTSCFrequencyRequired(vmi *k6tv1.VirtualMachineInstance) bool {

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -76,8 +76,15 @@ var _ = Describe("TSC", func() {
 
 	Context("needs to be set when", func() {
 
+		newVmi := func(options ...libvmi.Option) *v1.VirtualMachineInstance {
+			vmi := libvmi.New(options...)
+			vmi.Status.TopologyHints = &v1.TopologyHints{TSCFrequency: pointer.Int64(12345)}
+
+			return vmi
+		}
+
 		It("invtsc feature exists", func() {
-			vmi := libvmi.New(
+			vmi := newVmi(
 				libvmi.WithCPUFeature("invtsc", "require"),
 			)
 
@@ -85,7 +92,7 @@ var _ = Describe("TSC", func() {
 		})
 
 		It("HyperV reenlightenment is enabled", func() {
-			vmi := libvmi.New()
+			vmi := newVmi()
 			vmi.Spec.Domain.Features = &v1.Features{
 				Hyperv: &v1.FeatureHyperv{
 					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1050,7 +1050,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 			return nil
 		}
 		// let's check if we already have topology hints or if we are still waiting for them
-		if vmi.Status.TopologyHints == nil && c.topologyHinter.IsTscFrequencyRequiredForBoot(vmi) {
+		if vmi.Status.TopologyHints == nil && c.topologyHinter.IsTscFrequencyRequired(vmi) {
 			log.Log.V(3).Object(vmi).Infof("Delaying pod creation until topology hints are set")
 			return nil
 		}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2923,7 +2923,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					unexposeTscFrequency := func(requirement topology.TscFrequencyRequirementType) {
 						mockHinter := topology.NewMockHinter(ctrl)
 						mockHinter.EXPECT().TopologyHintsForVMI(gomock.Any()).Return(nil, requirement, fmt.Errorf("tsc frequency is not exposed on the cluster")).AnyTimes()
-						mockHinter.EXPECT().IsTscFrequencyRequiredForBoot(gomock.Any()).Return(requirement == topology.RequiredForBoot)
+						mockHinter.EXPECT().IsTscFrequencyRequired(gomock.Any()).Return(requirement == topology.RequiredForBoot)
 						controller.topologyHinter = mockHinter
 					}
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2867,15 +2867,40 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 	Context("topology hints", func() {
 
-		Context("needs to be set when", func() {
-
-			expectTopologyHintsUpdate := func() {
-				var vmi *virtv1.VirtualMachineInstance
-				vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-					vmi = arg.(*virtv1.VirtualMachineInstance)
-					Expect(topology.AreTSCFrequencyTopologyHintsDefined(vmi)).To(BeTrue())
-				}).Return(vmi, nil)
+		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
+			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Features: []virtv1.CPUFeature{
+					{
+						Name:   "invtsc",
+						Policy: "require",
+					},
+				},
 			}
+
+			return vmi
+		}
+
+		getVmiWithReenlightenment := func() *virtv1.VirtualMachineInstance {
+			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Spec.Domain.Features = &v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+				},
+			}
+
+			return vmi
+		}
+
+		expectTopologyHintsUpdate := func() {
+			var vmi *virtv1.VirtualMachineInstance
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				vmi = arg.(*virtv1.VirtualMachineInstance)
+				Expect(topology.AreTSCFrequencyTopologyHintsDefined(vmi)).To(BeTrue())
+			}).Return(vmi, nil)
+		}
+
+		Context("needs to be set when", func() {
 
 			runController := func(vmi *virtv1.VirtualMachineInstance) {
 				addVirtualMachine(vmi)
@@ -2884,15 +2909,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 
 			It("invtsc feature exists", func() {
-				vmi := NewPendingVirtualMachine("testvmi")
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Features: []virtv1.CPUFeature{
-						{
-							Name:   "invtsc",
-							Policy: "require",
-						},
-					},
-				}
+				vmi := getVmiWithInvTsc()
 
 				expectTopologyHintsUpdate()
 				runController(vmi)
@@ -2902,20 +2919,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				var vmi *v1.VirtualMachineInstance
 
 				BeforeEach(func() {
-					vmi = NewPendingVirtualMachine("testvmi")
-					vmi.Spec.Domain.Features = &v1.Features{
-						Hyperv: &v1.FeatureHyperv{
-							Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
-						},
-					}
+					vmi = getVmiWithReenlightenment()
 				})
 
 				When("TSC frequency is exposed", func() {
 					It("topology hints need to be set", func() {
 						expectTopologyHintsUpdate()
 						runController(vmi)
-
-						testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 					})
 				})
 
@@ -2938,6 +2948,39 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			})
 
+		})
+
+		Context("pod creation", func() {
+
+			runController := func(vmi *virtv1.VirtualMachineInstance) {
+				addVirtualMachine(vmi)
+				controller.Execute()
+			}
+
+			It("does not need to happen if tsc requiredment is of type RequiredForBoot", func() {
+				vmi := getVmiWithInvTsc()
+				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.RequiredForBoot))
+
+				expectTopologyHintsUpdate()
+				runController(vmi)
+			})
+
+			It("does not need to happen if tsc requiredment is of type RequiredForMigration", func() {
+				vmi := getVmiWithReenlightenment()
+				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.RequiredForMigration))
+
+				expectTopologyHintsUpdate()
+				runController(vmi)
+			})
+
+			It("does not need to happen if tsc requiredment is of type NotRequired", func() {
+				vmi := NewPendingVirtualMachine("testvmi")
+				Expect(topology.GetTscFrequencyRequirement(vmi).Type).To(Equal(topology.NotRequired))
+
+				shouldExpectPodCreation(vmi.UID)
+				runController(vmi)
+				testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+			})
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1682,7 +1682,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	}
 
 	// Make use of the tsc frequency topology hint
-	if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
+	if topology.IsManualTSCFrequencyRequired(vmi) {
 		freq := *vmi.Status.TopologyHints.TSCFrequency
 		clock := domain.Spec.Clock
 		if clock == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to fix an inconsistency regarding re-enlightenment VMs and TSC frequency.

While the converter.go's logic checked whether we have topology hints defined and that tsc frequency is [required](https://github.com/kubevirt/kubevirt/blob/v0.58.0/pkg/virt-controller/watch/topology/tsc.go#L19) (which is the right thing to do), template.go logic did not check the later. The both flows are now aligned, with `IsManualTSCFrequencyRequired()` being the sole source of truth.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Align Reenlightenment flows between converter.go and template.go
```
