### PR TITLE
Use a unique pvc/pod name for guestfs test

### DIFF
--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -208,7 +208,7 @@ var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
 		It("Should successfully run guestfs command on a filesystem-based PVC with root", func() {
 			f := createFakeAttacher()
 			defer f.closeChannel()
-			pvcClaim = "pvc-fs-with-different-uid"
+			pvcClaim = "pvc-fs-with-root"
 			podName := libguestsTools + pvcClaim
 			createPVCFilesystem(pvcClaim)
 			runGuestfsOnPVC(pvcClaim, "--root")


### PR DESCRIPTION
We have a flake where the pod is terminating -- this is likely due to the name conflict with another test. This name is more appropriate, too.

**What this PR does / why we need it**:
This test has [flakes](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8724/pull-kubevirt-e2e-k8s-1.23-sig-storage/1589919931783188480)

**Special notes for your reviewer**:
Not 100% sure this is the cause, as I don't see the previous test running just before it, but it's likely.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
