### PR TITLE
[export tests]: Specify fsGroup so we can write the exported PVC

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -112,6 +112,7 @@ var _ = SIGDescribe("Export", func() {
 	var err error
 	var token *k8sv1.Secret
 	var virtClient kubecli.KubevirtClient
+	var qemuGid = int64(107)
 
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
@@ -174,6 +175,10 @@ var _ = SIGDescribe("Export", func() {
 				},
 			},
 		})
+		if pod.Spec.SecurityContext == nil {
+			pod.Spec.SecurityContext = &k8sv1.PodSecurityContext{}
+		}
+		pod.Spec.SecurityContext.FSGroup = &qemuGid
 
 		volumeMode := pvc.Spec.VolumeMode
 		if volumeMode != nil && *volumeMode == k8sv1.PersistentVolumeBlock {
@@ -186,7 +191,6 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	createSourcePodChecker := func(pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
-		nonRootUser := int64(107)
 		volumeName := pvc.GetName()
 		podName := "download-pod"
 		pod := tests.RenderPod(podName, []string{"/bin/sh", "-c", "sleep 360"}, []string{})
@@ -201,7 +205,7 @@ var _ = SIGDescribe("Export", func() {
 		if pod.Spec.SecurityContext == nil {
 			pod.Spec.SecurityContext = &k8sv1.PodSecurityContext{}
 		}
-		pod.Spec.SecurityContext.FSGroup = &nonRootUser
+		pod.Spec.SecurityContext.FSGroup = &qemuGid
 
 		volumeMode := pvc.Spec.VolumeMode
 		if volumeMode != nil && *volumeMode == k8sv1.PersistentVolumeBlock {


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As non-root out of the box, most storage's won't give us a PVC that is world writeable. Noticed this on OpenShift testing lanes where cephcsi is used instead of the "local" SC that is used in kubevirtci.

Ceph stopping chmod 777 reference:
https://github.com/ceph/ceph-csi/pull/2697

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
