### PR TITLE
WIP: fix junit-merger wrt/ AfterSuite being a legit failure

### DIFF
--- a/tools/junit-merger/junit-merger_test.go
+++ b/tools/junit-merger/junit-merger_test.go
@@ -1,0 +1,256 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestJunitMerger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "junit-merger_test.go")
+}
+
+var _ = Describe("junit-merger", func() {
+
+	When("merging", func() {
+
+		It("fails on same test names", func() {
+			suites := []reporters.JUnitTestSuite{
+				{
+					Name:       "SomeRidiculousSuite1",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestName",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped:   nil,
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				},
+				{
+					Name:       "SomeRidiculousSuite2",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestName",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped:   nil,
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				},
+			}
+			_, err := mergeJUnitFiles(suites)
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("doesn't fail on different test names", func() {
+			suites := []reporters.JUnitTestSuite{
+				{
+					Name:       "SomeRidiculousSuite1",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestName1",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped:   nil,
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				},
+				{
+					Name:       "SomeRidiculousSuite2",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestName2",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped:   nil,
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				},
+			}
+			_, err := mergeJUnitFiles(suites)
+			Expect(err).To(BeNil())
+		})
+
+		It("does keep different skipped tests if they are only seen once", func() {
+			suites := []reporters.JUnitTestSuite{
+				{
+					Name:       "SomeRidiculousSuite1",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestNameSkipped1",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped: &reporters.JUnitSkipped{
+								Message: "Skipped",
+							},
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				},
+				{
+					Name:       "SomeRidiculousSuite2",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestNameSkipped2",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped: &reporters.JUnitSkipped{
+								Message: "Skipped",
+							},
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				},
+			}
+			result, err := mergeJUnitFiles(suites)
+			Expect(err).To(BeNil())
+			Expect(result).To(BeEquivalentTo(
+				reporters.JUnitTestSuite{
+					Name:       "Merged Test Suite",
+					Package:    "",
+					Tests:      0,
+					Disabled:   0,
+					Skipped:    0,
+					Errors:     0,
+					Failures:   0,
+					Time:       0,
+					Timestamp:  "",
+					Properties: reporters.JUnitProperties{},
+					TestCases: []reporters.JUnitTestCase{
+						{
+							Name:      "SomeRidiculousTestNameSkipped1",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped: &reporters.JUnitSkipped{
+								Message: "Skipped",
+							},
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+						{
+							Name:      "SomeRidiculousTestNameSkipped2",
+							Classname: "",
+							Status:    "",
+							Time:      0,
+							Skipped: &reporters.JUnitSkipped{
+								Message: "Skipped",
+							},
+							Error:     nil,
+							Failure:   nil,
+							SystemOut: "",
+							SystemErr: "",
+						},
+					},
+				}))
+		})
+
+	})
+
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix junit-merger wrt/ AfterSuite failures being legit.
```
