### PR TITLE
tests: avoid opting out from OCP/OKD podSecurityLabelSync

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -306,11 +306,11 @@ func detectInstallNamespace() {
 
 func GetLabelsForNamespace(namespace string) map[string]string {
 	labels := map[string]string{
-		cleanup.TestLabelForNamespace(namespace):         "",
-		"security.openshift.io/scc.podSecurityLabelSync": "false",
+		cleanup.TestLabelForNamespace(namespace): "",
 	}
 	if namespace == NamespacePrivileged {
 		labels["pod-security.kubernetes.io/enforce"] = "privileged"
+		labels["pod-security.kubernetes.io/warn"] = "privileged"
 	}
 
 	return labels


### PR DESCRIPTION
**What this PR does / why we need it**:

This was done there because the virt-controller auto labelling
mechanism is overlapping and fighting with the
Openshift Pod Security Admission Autolabeling.
So we were setting that at test suite level
assuming that the Kubevirt PSA FG was always
on when deploying on Openshift.

Now we revisited that decision and so HCO
is not going to enable the PSA FG on Kubevirt, see:
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2136
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2135
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2134
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2133

but at this point, if PSA is enabled on the cluster,
on Openshift we should rely on its default
Pod Security Admission Autolabeling,
and so always blindly setting
"security.openshift.io/scc.podSecurityLabelSync": "false"
at testsuite level appears as a bad idea.

Set also
pod-security.kubernetes.io/warn=privileged
on the namespaces where we set
pod-security.kubernetes.io/enforce=privileged
to get rid of warnings from those namespaces.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2136

**Special notes for your reviewer**:
we need to identify a configuration for the test suite that works at the same time with vanilla k8s and OCP/OKD without special assumptions

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
