### PR TITLE
Add restricted seccomp profile to controller SCC

### DIFF
--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -74,6 +74,9 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyRunAsAny,
 	}
+	scc.SeccompProfiles = []string{
+		"runtime/default",
+	}
 	scc.AllowedCapabilities = []corev1.Capability{
 		// add CAP_SYS_NICE capability to allow setting cpu affinity
 		"SYS_NICE",


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With PSA, one of the things we will try to comply with is the seccomp profile:
https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
Thus, we need our SCC to allow setting this.
Note this is also included in the restricted-v2 SCC:
```bash
$ oc get scc restricted-v2 -o json | jq .seccompProfiles
[
  "runtime/default"
]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
