### PR TITLE
passt,selinux: remove tmpfs mount rule

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -52,10 +52,4 @@
     (allow process nfs_t (dir (mounton)))
     (allow process proc_t (dir (mounton)))
     (allow process proc_t (filesystem (mount unmount)))
-    ;
-    ; This is needed for passt when running with this policy.
-    ; container_t is compatible with passt without needing any additional rule.
-    ; This rule is therefore only needed for VMs that use both virtiofs and passt.
-    ; The policy will be removed from here once it will be installed via the passt package.
-    (allow process tmpfs_t (filesystem (mount)))
 )


### PR DESCRIPTION
The policy should be installed along with passt
package installation.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
