### PR TITLE
Add an option to specify memory_mode attribute for NUMATune when using dedicated CPUs.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18142,6 +18142,10 @@
      "guestMappingPassthrough": {
       "description": "GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod. The created topology ensures that memory and CPUs on the virtual numa nodes never cross boundaries of host numa nodes.",
       "$ref": "#/definitions/v1.NUMAGuestMappingPassthrough"
+     },
+     "memoryMode": {
+      "description": "MemoryMode defines how memory is allocated from the nodes in a system. Only works with DedicatedCPUPlacement. The nodeset attribute will be set to NUMA nodes where CPU is pinned. Possible modes: strict - means that the allocation will fail if the memory cannot be allocated on the target node. interleave - memory pages are allocated across nodes specified by a nodeset, but are allocated in a round-robin fashion.",
+      "type": "string"
      }
     }
    },

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/numa_placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/numa_placement_test.go
@@ -24,167 +24,169 @@ var _ = Describe("NumaPlacement", func() {
 	var MiBInBytes_20 uint64 = 20 * 1024 * 1024
 	var MiBInBytes_32 uint64 = 32 * 1024 * 1024
 
-	BeforeEach(func() {
-		var err error
-		givenSpec = &api.DomainSpec{
-			CPUTune: &api.CPUTune{
-				VCPUPin: []api.CPUTuneVCPUPin{
+	Context("numaMapping", func() {
+		BeforeEach(func() {
+			var err error
+			givenSpec = &api.DomainSpec{
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "10"},
+						{VCPU: 1, CPUSet: "20"},
+						{VCPU: 3, CPUSet: "30"},
+					},
+					IOThreadPin: nil,
+					EmulatorPin: nil,
+				},
+			}
+			givenSpec.Memory, err = QuantityToByte(resource.MustParse("64Mi"))
+			Expect(err).ToNot(HaveOccurred())
+			givenTopology = &cmdv1.Topology{
+				NumaCells: []*cmdv1.Cell{
+					{
+						Id: 0,
+						Cpus: []*cmdv1.CPU{
+							{Id: 10},
+							{Id: 20},
+						},
+					},
+					{
+						Id: 4,
+						Cpus: []*cmdv1.CPU{
+							{Id: 30},
+							{Id: 50},
+						},
+					},
+				},
+			}
+			expectedSpec = &api.DomainSpec{
+				CPU: api.CPU{NUMA: &api.NUMA{Cells: []api.NUMACell{
+					{ID: "0", CPUs: "0,1", Memory: MiBInBytes_32, Unit: "b"},
+					{ID: "1", CPUs: "3", Memory: MiBInBytes_32, Unit: "b"},
+				}}},
+				CPUTune: &api.CPUTune{VCPUPin: []api.CPUTuneVCPUPin{
 					{VCPU: 0, CPUSet: "10"},
 					{VCPU: 1, CPUSet: "20"},
 					{VCPU: 3, CPUSet: "30"},
-				},
-				IOThreadPin: nil,
-				EmulatorPin: nil,
-			},
-		}
-		givenSpec.Memory, err = QuantityToByte(resource.MustParse("64Mi"))
-		Expect(err).ToNot(HaveOccurred())
-		givenTopology = &cmdv1.Topology{
-			NumaCells: []*cmdv1.Cell{
-				{
-					Id: 0,
-					Cpus: []*cmdv1.CPU{
-						{Id: 10},
-						{Id: 20},
-					},
-				},
-				{
-					Id: 4,
-					Cpus: []*cmdv1.CPU{
-						{Id: 30},
-						{Id: 50},
-					},
-				},
-			},
-		}
-		expectedSpec = &api.DomainSpec{
-			CPU: api.CPU{NUMA: &api.NUMA{Cells: []api.NUMACell{
-				{ID: "0", CPUs: "0,1", Memory: MiBInBytes_32, Unit: "b"},
-				{ID: "1", CPUs: "3", Memory: MiBInBytes_32, Unit: "b"},
-			}}},
-			CPUTune: &api.CPUTune{VCPUPin: []api.CPUTuneVCPUPin{
-				{VCPU: 0, CPUSet: "10"},
-				{VCPU: 1, CPUSet: "20"},
-				{VCPU: 3, CPUSet: "30"},
-			}},
-			NUMATune: &api.NUMATune{
-				Memory: api.NumaTuneMemory{Mode: "strict", NodeSet: "0,4"},
-				MemNodes: []api.MemNode{
-					{CellID: 0, Mode: "strict", NodeSet: "0"},
-					{CellID: 1, Mode: "strict", NodeSet: "4"},
 				}},
-		}
-		givenVMI = &v1.VirtualMachineInstance{}
-		memory := resource.MustParse("64Mi")
-		givenVMI.Spec.Domain.Memory = &v1.Memory{Guest: &memory}
-	})
-
-	It("should not map the numa topology without hugepages requested", func() {
-		Expect(numaMapping(givenVMI, givenSpec, givenTopology)).ToNot(Succeed())
-	})
-
-	DescribeTable("it should do nothing", func(givenTopology *cmdv1.Topology) {
-		expectedSpec := givenSpec.DeepCopy()
-		Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
-		Expect(givenSpec.CPUTune).To(Equal(expectedSpec.CPUTune))
-		Expect(givenSpec.NUMATune).To(Equal(expectedSpec.NUMATune))
-		Expect(givenSpec.CPU).To(Equal(expectedSpec.CPU))
-	},
-		Entry("if no topology is provided", nil),
-		Entry("if no numa cells are reported", &cmdv1.Topology{NumaCells: nil}),
-	)
-
-	It("should detect invalid cpu pinning", func() {
-		givenSpec.CPUTune.VCPUPin = append(givenSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
-			VCPU:   4,
-			CPUSet: "40",
-		})
-		Expect(numaMapping(givenVMI, givenSpec, givenTopology)).ToNot(Succeed())
-	})
-
-	Context("with hugepages", func() {
-		var expectedMemoryBacking *api.MemoryBacking
-		BeforeEach(func() {
-			givenVMI.Spec.Domain.Memory.Hugepages = &v1.Hugepages{
-				PageSize: "2Mi",
+				NUMATune: &api.NUMATune{
+					Memory: api.NumaTuneMemory{Mode: "strict", NodeSet: "0,4"},
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "0"},
+						{CellID: 1, Mode: "strict", NodeSet: "4"},
+					}},
 			}
-
-			givenSpec.MemoryBacking = &api.MemoryBacking{
-				HugePages: &api.HugePages{},
-			}
-			expectedMemoryBacking = &api.MemoryBacking{
-				HugePages: &api.HugePages{HugePage: []api.HugePage{
-					{Size: MiBInBytes_2, Unit: "b", NodeSet: "0"},
-					{Size: MiBInBytes_2, Unit: "b", NodeSet: "1"},
-				}},
-				Allocation: &api.MemoryAllocation{Mode: api.MemoryAllocationModeImmediate},
-			}
-		})
-		It("should detect hugepages and map them equally to nodes", func() {
-			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
-			Expect(givenSpec.CPUTune).To(Equal(expectedSpec.CPUTune))
-			Expect(givenSpec.NUMATune).To(Equal(expectedSpec.NUMATune))
-			Expect(givenSpec.CPU).To(Equal(expectedSpec.CPU))
-			Expect(givenSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
+			givenVMI = &v1.VirtualMachineInstance{}
+			memory := resource.MustParse("64Mi")
+			givenVMI.Spec.Domain.Memory = &v1.Memory{Guest: &memory}
 		})
 
-		It("should detect if not enough memory is requested", func() {
-			var err error
-			memory := resource.MustParse("2Mi")
-			givenSpec.Memory, err = QuantityToByte(memory)
-			Expect(err).ToNot(HaveOccurred())
-			givenVMI.Spec.Domain.Memory.Guest = &memory
+		It("should not map the numa topology without hugepages requested", func() {
 			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).ToNot(Succeed())
 		})
 
-		It("should detect not divisable hugepages and shuffle the memory", func() {
-			var err error
-			givenSpec.Memory, err = QuantityToByte(resource.MustParse("66Mi"))
-			Expect(err).ToNot(HaveOccurred())
-			givenSpec.CPUTune.VCPUPin = append(givenSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
-				VCPU: 4, CPUSet: "40",
-			})
-			givenTopology.NumaCells = append(givenTopology.NumaCells, &cmdv1.Cell{
-				Id: 5,
-				Cpus: []*cmdv1.CPU{
-					{Id: 40},
-				},
-			})
-
-			expectedSpec.CPUTune.VCPUPin = append(expectedSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
-				VCPU: 4, CPUSet: "40",
-			})
-			expectedSpec.NUMATune.Memory = api.NumaTuneMemory{
-				Mode: "strict", NodeSet: "0,4,5",
-			}
-			expectedSpec.NUMATune.MemNodes = append(expectedSpec.NUMATune.MemNodes, api.MemNode{
-				CellID: 2, Mode: "strict", NodeSet: "5",
-			})
-			expectedMemoryBacking := &api.MemoryBacking{
-				HugePages: &api.HugePages{HugePage: []api.HugePage{
-					{Size: MiBInBytes_2, Unit: "b", NodeSet: "0"},
-					{Size: MiBInBytes_2, Unit: "b", NodeSet: "1"},
-					{Size: MiBInBytes_2, Unit: "b", NodeSet: "2"},
-				}},
-				Allocation: &api.MemoryAllocation{Mode: api.MemoryAllocationModeImmediate},
-			}
-			expectedSpec.CPU.NUMA.Cells = []api.NUMACell{
-				{ID: "0", CPUs: "0,1", Memory: MiBInBytes_22, Unit: "b"},
-				{ID: "1", CPUs: "3", Memory: MiBInBytes_22, Unit: "b"},
-				{ID: "2", CPUs: "4", Memory: MiBInBytes_20, Unit: "b"},
-			}
-
+		DescribeTable("it should do nothing", func(givenTopology *cmdv1.Topology) {
+			expectedSpec := givenSpec.DeepCopy()
 			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
 			Expect(givenSpec.CPUTune).To(Equal(expectedSpec.CPUTune))
 			Expect(givenSpec.NUMATune).To(Equal(expectedSpec.NUMATune))
 			Expect(givenSpec.CPU).To(Equal(expectedSpec.CPU))
-			Expect(givenSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
-		})
-		It("should process no shared pages when tuned for real time", func() {
-			givenVMI.Spec.Domain.CPU = &v1.CPU{Realtime: &v1.Realtime{}}
-			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
+		},
+			Entry("if no topology is provided", nil),
+			Entry("if no numa cells are reported", &cmdv1.Topology{NumaCells: nil}),
+		)
 
-			Expect(givenSpec.MemoryBacking.NoSharePages).To(Equal(&api.NoSharePages{}))
+		It("should detect invalid cpu pinning", func() {
+			givenSpec.CPUTune.VCPUPin = append(givenSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
+				VCPU:   4,
+				CPUSet: "40",
+			})
+			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).ToNot(Succeed())
+		})
+
+		Context("with hugepages", func() {
+			var expectedMemoryBacking *api.MemoryBacking
+			BeforeEach(func() {
+				givenVMI.Spec.Domain.Memory.Hugepages = &v1.Hugepages{
+					PageSize: "2Mi",
+				}
+
+				givenSpec.MemoryBacking = &api.MemoryBacking{
+					HugePages: &api.HugePages{},
+				}
+				expectedMemoryBacking = &api.MemoryBacking{
+					HugePages: &api.HugePages{HugePage: []api.HugePage{
+						{Size: MiBInBytes_2, Unit: "b", NodeSet: "0"},
+						{Size: MiBInBytes_2, Unit: "b", NodeSet: "1"},
+					}},
+					Allocation: &api.MemoryAllocation{Mode: api.MemoryAllocationModeImmediate},
+				}
+			})
+			It("should detect hugepages and map them equally to nodes", func() {
+				Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
+				Expect(givenSpec.CPUTune).To(Equal(expectedSpec.CPUTune))
+				Expect(givenSpec.NUMATune).To(Equal(expectedSpec.NUMATune))
+				Expect(givenSpec.CPU).To(Equal(expectedSpec.CPU))
+				Expect(givenSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
+			})
+
+			It("should detect if not enough memory is requested", func() {
+				var err error
+				memory := resource.MustParse("2Mi")
+				givenSpec.Memory, err = QuantityToByte(memory)
+				Expect(err).ToNot(HaveOccurred())
+				givenVMI.Spec.Domain.Memory.Guest = &memory
+				Expect(numaMapping(givenVMI, givenSpec, givenTopology)).ToNot(Succeed())
+			})
+
+			It("should detect not divisable hugepages and shuffle the memory", func() {
+				var err error
+				givenSpec.Memory, err = QuantityToByte(resource.MustParse("66Mi"))
+				Expect(err).ToNot(HaveOccurred())
+				givenSpec.CPUTune.VCPUPin = append(givenSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
+					VCPU: 4, CPUSet: "40",
+				})
+				givenTopology.NumaCells = append(givenTopology.NumaCells, &cmdv1.Cell{
+					Id: 5,
+					Cpus: []*cmdv1.CPU{
+						{Id: 40},
+					},
+				})
+
+				expectedSpec.CPUTune.VCPUPin = append(expectedSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
+					VCPU: 4, CPUSet: "40",
+				})
+				expectedSpec.NUMATune.Memory = api.NumaTuneMemory{
+					Mode: "strict", NodeSet: "0,4,5",
+				}
+				expectedSpec.NUMATune.MemNodes = append(expectedSpec.NUMATune.MemNodes, api.MemNode{
+					CellID: 2, Mode: "strict", NodeSet: "5",
+				})
+				expectedMemoryBacking := &api.MemoryBacking{
+					HugePages: &api.HugePages{HugePage: []api.HugePage{
+						{Size: MiBInBytes_2, Unit: "b", NodeSet: "0"},
+						{Size: MiBInBytes_2, Unit: "b", NodeSet: "1"},
+						{Size: MiBInBytes_2, Unit: "b", NodeSet: "2"},
+					}},
+					Allocation: &api.MemoryAllocation{Mode: api.MemoryAllocationModeImmediate},
+				}
+				expectedSpec.CPU.NUMA.Cells = []api.NUMACell{
+					{ID: "0", CPUs: "0,1", Memory: MiBInBytes_22, Unit: "b"},
+					{ID: "1", CPUs: "3", Memory: MiBInBytes_22, Unit: "b"},
+					{ID: "2", CPUs: "4", Memory: MiBInBytes_20, Unit: "b"},
+				}
+
+				Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
+				Expect(givenSpec.CPUTune).To(Equal(expectedSpec.CPUTune))
+				Expect(givenSpec.NUMATune).To(Equal(expectedSpec.NUMATune))
+				Expect(givenSpec.CPU).To(Equal(expectedSpec.CPU))
+				Expect(givenSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
+			})
+			It("should process no shared pages when tuned for real time", func() {
+				givenVMI.Spec.Domain.CPU = &v1.CPU{Realtime: &v1.Realtime{}}
+				Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
+
+				Expect(givenSpec.MemoryBacking.NoSharePages).To(Equal(&api.NoSharePages{}))
+			})
 		})
 	})
 })

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5471,6 +5471,16 @@ var CRDsValidation map[string]string = map[string]string{
                                 memory and CPUs on the virtual numa nodes never cross
                                 boundaries of host numa nodes.
                               type: object
+                            memoryMode:
+                              description: 'MemoryMode defines how memory is allocated
+                                from the nodes in a system. Only works with DedicatedCPUPlacement.
+                                The nodeset attribute will be set to NUMA nodes where
+                                CPU is pinned. Possible modes: strict - means that
+                                the allocation will fail if the memory cannot be allocated
+                                on the target node. interleave - memory pages are
+                                allocated across nodes specified by a nodeset, but
+                                are allocated in a round-robin fashion.'
+                              type: string
                           type: object
                         realtime:
                           description: Realtime instructs the virt-launcher to tune
@@ -7893,6 +7903,15 @@ var CRDsValidation map[string]string = map[string]string{
                     created topology ensures that memory and CPUs on the virtual numa
                     nodes never cross boundaries of host numa nodes.
                   type: object
+                memoryMode:
+                  description: 'MemoryMode defines how memory is allocated from the
+                    nodes in a system. Only works with DedicatedCPUPlacement. The
+                    nodeset attribute will be set to NUMA nodes where CPU is pinned.
+                    Possible modes: strict - means that the allocation will fail if
+                    the memory cannot be allocated on the target node. interleave
+                    - memory pages are allocated across nodes specified by a nodeset,
+                    but are allocated in a round-robin fashion.'
+                  type: string
               type: object
             realtime:
               description: Realtime instructs the virt-launcher to tune the VMI for
@@ -9967,6 +9986,16 @@ var CRDsValidation map[string]string = map[string]string{
                         the virtual numa nodes never cross boundaries of host numa
                         nodes.
                       type: object
+                    memoryMode:
+                      description: 'MemoryMode defines how memory is allocated from
+                        the nodes in a system. Only works with DedicatedCPUPlacement.
+                        The nodeset attribute will be set to NUMA nodes where CPU
+                        is pinned. Possible modes: strict - means that the allocation
+                        will fail if the memory cannot be allocated on the target
+                        node. interleave - memory pages are allocated across nodes
+                        specified by a nodeset, but are allocated in a round-robin
+                        fashion.'
+                      type: string
                   type: object
                 realtime:
                   description: Realtime instructs the virt-launcher to tune the VMI
@@ -12632,6 +12661,16 @@ var CRDsValidation map[string]string = map[string]string{
                         the virtual numa nodes never cross boundaries of host numa
                         nodes.
                       type: object
+                    memoryMode:
+                      description: 'MemoryMode defines how memory is allocated from
+                        the nodes in a system. Only works with DedicatedCPUPlacement.
+                        The nodeset attribute will be set to NUMA nodes where CPU
+                        is pinned. Possible modes: strict - means that the allocation
+                        will fail if the memory cannot be allocated on the target
+                        node. interleave - memory pages are allocated across nodes
+                        specified by a nodeset, but are allocated in a round-robin
+                        fashion.'
+                      type: string
                   type: object
                 realtime:
                   description: Realtime instructs the virt-launcher to tune the VMI
@@ -14755,6 +14794,16 @@ var CRDsValidation map[string]string = map[string]string{
                                 memory and CPUs on the virtual numa nodes never cross
                                 boundaries of host numa nodes.
                               type: object
+                            memoryMode:
+                              description: 'MemoryMode defines how memory is allocated
+                                from the nodes in a system. Only works with DedicatedCPUPlacement.
+                                The nodeset attribute will be set to NUMA nodes where
+                                CPU is pinned. Possible modes: strict - means that
+                                the allocation will fail if the memory cannot be allocated
+                                on the target node. interleave - memory pages are
+                                allocated across nodes specified by a nodeset, but
+                                are allocated in a round-robin fashion.'
+                              type: string
                           type: object
                         realtime:
                           description: Realtime instructs the virt-launcher to tune
@@ -16720,6 +16769,15 @@ var CRDsValidation map[string]string = map[string]string{
                     created topology ensures that memory and CPUs on the virtual numa
                     nodes never cross boundaries of host numa nodes.
                   type: object
+                memoryMode:
+                  description: 'MemoryMode defines how memory is allocated from the
+                    nodes in a system. Only works with DedicatedCPUPlacement. The
+                    nodeset attribute will be set to NUMA nodes where CPU is pinned.
+                    Possible modes: strict - means that the allocation will fail if
+                    the memory cannot be allocated on the target node. interleave
+                    - memory pages are allocated across nodes specified by a nodeset,
+                    but are allocated in a round-robin fashion.'
+                  type: string
               type: object
             realtime:
               description: Realtime instructs the virt-launcher to tune the VMI for
@@ -19032,6 +19090,18 @@ var CRDsValidation map[string]string = map[string]string{
                                         virtual numa nodes never cross boundaries
                                         of host numa nodes.
                                       type: object
+                                    memoryMode:
+                                      description: 'MemoryMode defines how memory
+                                        is allocated from the nodes in a system. Only
+                                        works with DedicatedCPUPlacement. The nodeset
+                                        attribute will be set to NUMA nodes where
+                                        CPU is pinned. Possible modes: strict - means
+                                        that the allocation will fail if the memory
+                                        cannot be allocated on the target node. interleave
+                                        - memory pages are allocated across nodes
+                                        specified by a nodeset, but are allocated
+                                        in a round-robin fashion.'
+                                      type: string
                                   type: object
                                 realtime:
                                   description: Realtime instructs the virt-launcher
@@ -24098,6 +24168,19 @@ var CRDsValidation map[string]string = map[string]string{
                                             memory and CPUs on the virtual numa nodes
                                             never cross boundaries of host numa nodes.
                                           type: object
+                                        memoryMode:
+                                          description: 'MemoryMode defines how memory
+                                            is allocated from the nodes in a system.
+                                            Only works with DedicatedCPUPlacement.
+                                            The nodeset attribute will be set to NUMA
+                                            nodes where CPU is pinned. Possible modes:
+                                            strict - means that the allocation will
+                                            fail if the memory cannot be allocated
+                                            on the target node. interleave - memory
+                                            pages are allocated across nodes specified
+                                            by a nodeset, but are allocated in a round-robin
+                                            fashion.'
+                                          type: string
                                       type: object
                                     realtime:
                                       description: Realtime instructs the virt-launcher

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2926,6 +2926,11 @@ func (in *NUMA) DeepCopyInto(out *NUMA) {
 		*out = new(NUMAGuestMappingPassthrough)
 		**out = **in
 	}
+	if in.MemoryMode != nil {
+		in, out := &in.MemoryMode, &out.MemoryMode
+		*out = new(MemoryMode)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -344,17 +344,30 @@ type Realtime struct {
 	Mask string `json:"mask,omitempty"`
 }
 
+type MemoryMode string
+
+const (
+	MemoryModeStrict     MemoryMode = "strict"
+	MemoryModeInterleave MemoryMode = "interleave"
+)
+
 // NUMAGuestMappingPassthrough instructs kubevirt to model numa topology which is compatible with the CPU pinning on the guest.
 // This will result in a subset of the node numa topology being passed through, ensuring that virtual numa nodes and their memory
 // never cross boundaries coming from the node numa mapping.
-type NUMAGuestMappingPassthrough struct {
-}
+type NUMAGuestMappingPassthrough struct{}
 
 type NUMA struct {
 	// GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod.
 	// The created topology ensures that memory and CPUs on the virtual numa nodes never cross boundaries of host numa nodes.
 	// +opitonal
 	GuestMappingPassthrough *NUMAGuestMappingPassthrough `json:"guestMappingPassthrough,omitempty"`
+	// MemoryMode defines how memory is allocated from the nodes in a system. Only works with DedicatedCPUPlacement.
+	// The nodeset attribute will be set to NUMA nodes where CPU is pinned.
+	// Possible modes:
+	// strict - means that the allocation will fail if the memory cannot be allocated on the target node.
+	// interleave - memory pages are allocated across nodes specified by a nodeset, but are allocated in a round-robin fashion.
+	// +optional
+	MemoryMode *MemoryMode `json:"memoryMode,omitempty"`
 }
 
 // CPUFeature allows specifying a CPU feature.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -185,6 +185,7 @@ func (NUMAGuestMappingPassthrough) SwaggerDoc() map[string]string {
 func (NUMA) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"guestMappingPassthrough": "GuestMappingPassthrough will create an efficient guest topology based on host CPUs exclusively assigned to a pod.\nThe created topology ensures that memory and CPUs on the virtual numa nodes never cross boundaries of host numa nodes.\n+opitonal",
+		"memoryMode":              "MemoryMode defines how memory is allocated from the nodes in a system. Only works with DedicatedCPUPlacement.\nThe nodeset attribute will be set to NUMA nodes where CPU is pinned.\nPossible modes:\nstrict - means that the allocation will fail if the memory cannot be allocated on the target node.\ninterleave - memory pages are allocated across nodes specified by a nodeset, but are allocated in a round-robin fashion.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19995,6 +19995,13 @@ func schema_kubevirtio_api_core_v1_NUMA(ref common.ReferenceCallback) common.Ope
 							Ref:         ref("kubevirt.io/api/core/v1.NUMAGuestMappingPassthrough"),
 						},
 					},
+					"memoryMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MemoryMode defines how memory is allocated from the nodes in a system. Only works with DedicatedCPUPlacement. The nodeset attribute will be set to NUMA nodes where CPU is pinned. Possible modes: strict - means that the allocation will fail if the memory cannot be allocated on the target node. interleave - memory pages are allocated across nodes specified by a nodeset, but are allocated in a round-robin fashion.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allow specifying `memory_mode` attribute for [NUMATune](https://libvirt.org/formatdomain.html#numa-node-tuning), when `DedicatedCPUPlacement` is enabled. It can help with tuning VMs running on multiple NUMA nodes.
The `nodeset` attributes is set to NUMA nodes where vCPUs are pinned.

The aim of this PR is to influence how memory is allocated for VMs when vNUMA is not exposed. 

Even if no NUMA topology is defined for a VM, qemu by default will expose single NUMA node to the VM, running `numactl` from within a VM without `numa` section specifed, gives us:

```sh
$ numactl -H
available: 1 nodes (0)
node 0 cpus: 0 1 2 3 4 5 6 7
node 0 size: 1978 MB
node 0 free: 1301 MB
node distances:
node   0
  0:  10
```

To demonstrate how manipulating `memory_mode` can change memory allocating, I will show how the output of `numastats` utility changes based on 4 different VM specs:

1. no vNUMA exposed(single NUMA node inside VM), cpus coming from single NUMA node on the host, no `memory_mode` specified
2. no vNUMA exposed(single NUMA node inside VM), cpus coming from single NUMA node on the host, `memory_mode` set to strict, which translates to given xml schema:
```xml
<domain>
  ...
  <numatune>
    <memory mode='strict' nodeset='0'/>
  </numatune>
</domain>
```
3. no vNUMA exposed(single NUMA node inside VM), cpus coming from 2 NUMA nodes, no `memory_mode` specified
4. no vNUMA exposed(single NUMA node inside VM), cpus coming from 2 NUMA nodes, `memory_mode` set to interleave, which translates to given xml schema:
```xml
<domain>
  ...
  <numatune>
    <memory mode='interleave' nodeset='0,1'/>
  </numatune>
</domain>
```

The numastats output after creating 4 consecutive 98MB file in memory:

For scenario 1:
```sh

$ numastat -p 906269

Per-node process memory usage (in MBs) for PID 906269 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.29            0.00           18.29
Stack                        0.04            0.00            0.04
Private                    532.80           13.34          546.14
----------------  --------------- --------------- ---------------
Total                      551.12           13.34          564.46
$ numastat -p 906269

Per-node process memory usage (in MBs) for PID 906269 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.34            0.00           18.34
Stack                        0.04            0.00            0.04
Private                    593.20           13.46          606.66
----------------  --------------- --------------- ---------------
Total                      611.58           13.46          625.04
$ numastat -p 906269

Per-node process memory usage (in MBs) for PID 906269 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.34            0.00           18.34
Stack                        0.04            0.00            0.04
Private                    690.83           13.46          704.30
----------------  --------------- --------------- ---------------
Total                      709.21           13.46          722.68
$ numastat -p 906269

Per-node process memory usage (in MBs) for PID 906269 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.34            0.00           18.34
Stack                        0.04            0.00            0.04
Private                    751.98           50.03          802.01
----------------  --------------- --------------- ---------------
Total                      770.36           50.03          820.39
$ numastat -p 906269

Per-node process memory usage (in MBs) for PID 906269 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.34            0.00           18.34
Stack                        0.04            0.00            0.04
Private                    755.98          143.81          899.80
----------------  --------------- --------------- ---------------
Total                      774.36          143.81          918.18

```

For scenario 2:
```sh

$ numastat -p 910228

Per-node process memory usage (in MBs) for PID 910228 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.36            0.00           18.36
Stack                        0.04            0.00            0.04
Private                    529.27           13.96          543.23
----------------  --------------- --------------- ---------------
Total                      547.66           13.96          561.62
$ numastat -p 910228

Per-node process memory usage (in MBs) for PID 910228 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.36            0.00           18.36
Stack                        0.04            0.00            0.04
Private                    582.96           14.02          596.98
----------------  --------------- --------------- ---------------
Total                      601.35           14.02          615.38
$ numastat -p 910228

Per-node process memory usage (in MBs) for PID 910228 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.36            0.00           18.36
Stack                        0.04            0.00            0.04
Private                    679.80           14.02          693.82
----------------  --------------- --------------- ---------------
Total                      698.19           14.02          712.21
$ numastat -p 910228

Per-node process memory usage (in MBs) for PID 910228 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.36            0.00           18.36
Stack                        0.04            0.00            0.04
Private                    777.59           14.02          791.61
----------------  --------------- --------------- ---------------
Total                      795.98           14.02          810.00
$ numastat -p 910228

Per-node process memory usage (in MBs) for PID 910228 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        18.36            0.00           18.36
Stack                        0.04            0.00            0.04
Private                    875.36           14.02          889.39
----------------  --------------- --------------- ---------------
Total                      893.76           14.02          907.78
```

Scenario 3:
```sh

$ numastat -p 914487

Per-node process memory usage (in MBs) for PID 914487 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        17.43            1.67           19.10
Stack                        0.04            0.00            0.04
Private                    546.91          139.96          686.86
----------------  --------------- --------------- ---------------
Total                      564.37          141.63          706.00
$ numastat -p 914487

Per-node process memory usage (in MBs) for PID 914487 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        17.43            1.67           19.10
Stack                        0.04            0.00            0.04
Private                    609.54          139.96          749.50
----------------  --------------- --------------- ---------------
Total                      627.00          141.63          768.63
$ numastat -p 914487

Per-node process memory usage (in MBs) for PID 914487 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        17.43            1.67           19.10
Stack                        0.04            0.00            0.04
Private                    706.11          140.07          846.18
----------------  --------------- --------------- ---------------
Total                      723.57          141.74          865.31
$ numastat -p 914487

Per-node process memory usage (in MBs) for PID 914487 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        17.43            1.67           19.10
Stack                        0.04            0.00            0.04
Private                    803.79          140.04          943.82
----------------  --------------- --------------- ---------------
Total                      821.25          141.71          962.95
$ numastat -p 914487

Per-node process memory usage (in MBs) for PID 914487 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                        17.43            1.67           19.10
Stack                        0.04            0.00            0.04
Private                    874.59          167.19         1041.78
----------------  --------------- --------------- ---------------
Total                      892.05          168.86         1060.91
```

Scenario 4:
```sh

$ numastat -p 918159

Per-node process memory usage (in MBs) for PID 918159 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                         9.50            9.51           19.02
Stack                        0.02            0.02            0.04
Private                    341.32          351.03          692.35
----------------  --------------- --------------- ---------------
Total                      350.84          360.56          711.40
$ numastat -p 918159

Per-node process memory usage (in MBs) for PID 918159 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                         9.50            9.51           19.02
Stack                        0.02            0.02            0.04
Private                    373.29          383.05          756.34
----------------  --------------- --------------- ---------------
Total                      382.81          392.58          775.39
$ numastat -p 918159

Per-node process memory usage (in MBs) for PID 918159 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                         9.50            9.51           19.02
Stack                        0.02            0.02            0.04
Private                    421.97          431.73          853.70
----------------  --------------- --------------- ---------------
Total                      431.49          441.26          872.75
$ numastat -p 918159

Per-node process memory usage (in MBs) for PID 918159 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                         9.50            9.51           19.02
Stack                        0.02            0.02            0.04
Private                    470.86          480.62          951.49
----------------  --------------- --------------- ---------------
Total                      480.39          490.15          970.54
$ numastat -p 918159

Per-node process memory usage (in MBs) for PID 918159 (qemu-kvm)
                           Node 0          Node 1           Total
                  --------------- --------------- ---------------
Huge                         0.00            0.00            0.00
Heap                         9.50            9.51           19.02
Stack                        0.02            0.02            0.04
Private                    519.76          529.52         1049.28
----------------  --------------- --------------- ---------------
Total                      529.29          539.05         1068.33

```

As we can see from scenario 2, setting `memory_mode` to strict can restrict memory allocation to the NUMA node from where cpus are allocated(when not using memory manager).

In scenario 4 using `interleave` policy can help reduce memory fragmentation when resources assigned to Virtual Machine comes from 2 NUMA nodes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow specifying memory_mode attribute for NUMATune when using dedicated CPUs.
```
