### PR TITLE
[WIP] network:dns: Support IPv6 DNS parsing

### DIFF
--- a/pkg/network/dns/resolveconf_test.go
+++ b/pkg/network/dns/resolveconf_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,6 +17,23 @@ var _ = Describe("Resolveconf", func() {
 			nameservers, err := ParseNameservers(resolvConf)
 			Expect(nameservers).To(Equal([][]uint8{ns1, ns2}))
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should support ipv6 nameservers", func() {
+			ipCases := []string{
+				"2001:4860:4860::8888",
+				"240C::6666",
+				"2001:da8:ff:305:20c:29ff:fe1f:a92a",
+			}
+			resolvConf := ""
+			for _, ip := range ipCases {
+				resolvConf = fmt.Sprintf("%snameserver %s\n", resolvConf, ip)
+			}
+			nameservers, err := ParseNameservers(resolvConf)
+			Expect(err).To(BeNil())
+			for i, ns := range nameservers {
+				Expect(net.IP(ns).String()).To(Equal(strings.ToLower(ipCases[i])))
+			}
 		})
 
 		It("should ignore non-nameserver lines and malformed nameserver lines", func() {


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`ParseNameservers` only supports ipv4 nameservers now.
This PR adds ipv6 support for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
network:dns: Support IPv6 DNS parsing
```
