### PR TITLE
Update tests wrt ginkgo 2: Add Serial decorators and change checks for serial run

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,13 +3,13 @@
 ## Writing e2e tests
 
 We aim to run e2e tests in parallel by default. As such the following rules should be followed:
- * Use cirros and alpine VMs for testing wherever possible. If you have to use
+ * Use cirros and alpine VMs for testing wherever possible. If you have to
    use another OS, discuss on the PR why it is needed.
  * Stay within the boundary of the Testnamespaces which we prove. If you have
-   to create resources outside of the test namespaces, discuss potential
+   to create resources outside the test namespaces, discuss potential
    solutions on such a PR.
  * If you really have to run tests serial (destructive tests, infra-tests,
-  ...), mark the test with a `[Serial]` tag.
+  ...), mark the test with a `[Serial]` tag and add the [Serial decorator](https://onsi.github.io/ginkgo/#serial-specs) to the test.
  * If tests are not using the default cleanup code, additional custom
    preparations may be necessary.
 

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -43,7 +43,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", func() {
+var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, func() {
 
 	var err error
 	var originalKV *v1.KubeVirt

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -37,7 +37,7 @@ const (
 
 type loginFunction func(*virtv1.VirtualMachineInstance) error
 
-var _ = Describe("[Serial][sig-compute]VirtualMachineClone Tests", func() {
+var _ = Describe("[Serial][sig-compute]VirtualMachineClone Tests", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -135,7 +135,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(startedVMI.Spec).To(Equal(vmi.Spec))
 			})
 		})
-		Context("[Serial]should obey the disk verification limits in the KubeVirt CR", func() {
+		Context("[Serial]should obey the disk verification limits in the KubeVirt CR", Serial, func() {
 			It("[test_id:7182]disk verification should fail when the memory limit is too low", func() {
 				By("Reducing the diskVerificaton memory usage limit")
 				kv := util.GetCurrentKv(virtClient)

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -491,7 +491,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("[Serial][test_id:7648]delete a KubeVirt CR", func() {
+		It("[Serial][test_id:7648]delete a KubeVirt CR", Serial, func() {
 			By("Make a Dry-Run request to delete a KubeVirt CR")
 			deletePolicy := metav1.DeletePropagationForeground
 			opts := metav1.DeleteOptions{

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -23,7 +23,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
+var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, func() {
 
 	var (
 		virtClient kubecli.KubevirtClient

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -91,7 +91,7 @@ const (
 	remoteCmdErrPattern = "failed running `%s` with stdout:\n %v \n stderr:\n %v \n err: \n %v \n"
 )
 
-var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
+var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -24,7 +24,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", func(
 		checks.SkipTestIfNoFeatureGate(virtconfig.WorkloadEncryptionSEV)
 	})
 
-	Context("[Serial]device management", func() {
+	Context("[Serial]device management", Serial, func() {
 		var (
 			virtClient      kubecli.KubevirtClient
 			nodeName        string

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -29,7 +29,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
+var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -753,7 +753,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
-		Context("[Serial] with bandwidth limitations", func() {
+		Context("[Serial] with bandwidth limitations", Serial, func() {
 
 			var repeatedlyMigrateWithBandwidthLimitation = func(vmi *v1.VirtualMachineInstance, bandwidth string, repeat int) time.Duration {
 				var migrationDurationTotal time.Duration
@@ -1368,7 +1368,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 		})
-		Context("[Serial] with auto converge enabled", func() {
+		Context("[Serial] with auto converge enabled", Serial, func() {
 			BeforeEach(func() {
 
 				// set autoconverge flag
@@ -1768,7 +1768,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			return dv
 		}
 
-		Context("[Serial] migration to nonroot", func() {
+		Context("[Serial] migration to nonroot", Serial, func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
 			var clusterIsRoot bool
@@ -1850,7 +1850,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, console.LoginToAlpine),
 			)
 		})
-		Context("[Serial] migration to root", func() {
+		Context("[Serial] migration to root", Serial, func() {
 			var dv *cdiv1.DataVolume
 			var clusterIsRoot bool
 			size := "256Mi"
@@ -1936,7 +1936,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			)
 		})
 		Context("migration security", func() {
-			Context("[Serial] with TLS disabled", func() {
+			Context("[Serial] with TLS disabled", Serial, func() {
 				It("[test_id:6976] should be successfully migrated", func() {
 					cfg := getCurrentKv()
 					cfg.MigrationConfiguration.DisableTLS = pointer.BoolPtr(true)
@@ -2130,7 +2130,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration postcopy", func() {
+		Context("[Serial] migration postcopy", Serial, func() {
 			var dv *cdiv1.DataVolume
 
 			BeforeEach(func() {
@@ -2205,7 +2205,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 
-		Context("[Serial] migration monitor", func() {
+		Context("[Serial] migration monitor", Serial, func() {
 			var createdPods []string
 			AfterEach(func() {
 				for _, podName := range createdPods {
@@ -2810,7 +2810,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Entry("[sig-compute][test_id:8585]cancel a migration with virtctl", true),
 			)
 
-			Context("[Serial]when target pod cannot be scheduled and is suck in Pending phase", func() {
+			Context("[Serial]when target pod cannot be scheduled and is suck in Pending phase", Serial, func() {
 
 				var nodesSetUnschedulable []string
 
@@ -3019,7 +3019,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectFeatureToBeSupportedOnNode(newNode, requiredFeatures)
 			})
 
-			Context("[Serial]Should trigger event if vmi with host-model start on source node with uniq host-model", func() {
+			Context("[Serial]Should trigger event if vmi with host-model start on source node with uniq host-model", Serial, func() {
 
 				var vmi *v1.VirtualMachineInstance
 				var node *k8sv1.Node
@@ -3080,7 +3080,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			})
 
-			Context("[Serial]Should trigger event if the nodes doesn't contain MigrationSelectorLabel for the vmi host-model type", func() {
+			Context("[Serial]Should trigger event if the nodes doesn't contain MigrationSelectorLabel for the vmi host-model type", Serial, func() {
 
 				var vmi *v1.VirtualMachineInstance
 				var nodes []k8sv1.Node
@@ -3148,7 +3148,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		})
 
-		Context("[Serial] with migration policies", func() {
+		Context("[Serial] with migration policies", Serial, func() {
 
 			confirmMigrationPolicyName := func(vmi *v1.VirtualMachineInstance, expectedName *string) {
 				By("Verifying the VMI's configuration source")
@@ -3399,7 +3399,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 180*time.Second, 500*time.Millisecond).Should(Equal(v1.MigrationSucceeded))
 			})
 
-			Context("[Serial] with node tainted during node drain", func() {
+			Context("[Serial] with node tainted during node drain", Serial, func() {
 				BeforeEach(func() {
 					// Taints defined by k8s are special and can't be applied manually.
 					// Temporarily configure KubeVirt to use something else for the duration of these tests.
@@ -3651,7 +3651,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 			})
 		})
-		Context("[Serial]with multiple VMIs with eviction policies set", func() {
+		Context("[Serial]with multiple VMIs with eviction policies set", Serial, func() {
 
 			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
 				var vmis []*v1.VirtualMachineInstance
@@ -3729,7 +3729,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	})
 
-	Context("[Serial][QUARANTINE][test_id:8482] Migration Metrics", func() {
+	Context("[Serial][QUARANTINE][test_id:8482] Migration Metrics", Serial, func() {
 		It("exposed to prometheus during VM migration", func() {
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
@@ -3762,7 +3762,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", func() {
+	Describe("[Serial] with a cluster-wide live-migrate eviction strategy set", Serial, func() {
 		var originalKV *v1.KubeVirt
 
 		BeforeEach(func() {
@@ -3830,7 +3830,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial] With Huge Pages", func() {
+	Context("[Serial] With Huge Pages", Serial, func() {
 		var hugepagesVmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -3894,7 +3894,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		)
 	})
 
-	Context("[Serial] with CPU pinning and huge pages", func() {
+	Context("[Serial] with CPU pinning and huge pages", Serial, func() {
 		It("should not make migrations fail", func() {
 			checks.SkipTestIfNotEnoughNodesWithCPUManagerWith2MiHugepages(2)
 			var err error
@@ -3994,7 +3994,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			Expect(imageIDs).To(HaveKeyWithValue(container.Name, digest), "expected image:%s for container %s to be the same like on the source pod but got %s", container.Image, container.Name, imageIDs[container.Name])
 		}
 	})
-	Context("[Serial]Testing host-model cpuModel edge cases in the cluster if the cluster is host-model migratable", func() {
+	Context("[Serial]Testing host-model cpuModel edge cases in the cluster if the cluster is host-model migratable", Serial, func() {
 
 		var sourceNode *k8sv1.Node
 		var targetNode *k8sv1.Node
@@ -4322,7 +4322,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("[Serial]with a dedicated migration network", func() {
+	Context("[Serial]with a dedicated migration network", Serial, func() {
 		BeforeEach(func() {
 			virtClient, err = kubecli.GetKubevirtClient()
 			Expect(err).ToNot(HaveOccurred())
@@ -4478,7 +4478,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			)
 		})
 
-		It("[Serial] retrying immediately should be blocked by the migration backoff", func() {
+		It("[Serial] retrying immediately should be blocked by the migration backoff", Serial, func() {
 			By("Starting the VirtualMachineInstance")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
@@ -4498,7 +4498,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			deleteEvents(eventListOpts)
 		})
 
-		It("[Serial] after a successful migration backoff should be cleared", func() {
+		It("[Serial] after a successful migration backoff should be cleared", Serial, func() {
 			By("Starting the VirtualMachineInstance")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -595,8 +595,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	}
 
 	expectSerialRun := func() {
-		suiteConfig, _ := GinkgoConfiguration()
-		Expect(suiteConfig.ParallelTotal).To(Equal(1), "this test is supported for serial tests only")
+		Expect(CurrentSpecReport().IsSerial).To(BeTrue(), "this test is supported for serial tests only")
 	}
 
 	expectEvents := func(eventListOpts metav1.ListOptions, expectedEventsAmount int) {
@@ -4575,8 +4574,7 @@ func stopNodeLabeller(nodeName string, virtClient kubecli.KubevirtClient) *k8sv1
 	var err error
 	var node *k8sv1.Node
 
-	suiteConfig, _ := GinkgoConfiguration()
-	Expect(suiteConfig.ParallelTotal).To(Equal(1), "stopping / resuming node-labeller is supported for serial tests only")
+	Expect(CurrentSpecReport().IsSerial).To(BeTrue(), "stopping / resuming node-labeller is supported for serial tests only")
 
 	By(fmt.Sprintf("Patching node to %s include %s label", nodeName, v1.LabellerSkipNodeAnnotation))
 	key, value := v1.LabellerSkipNodeAnnotation, "true"

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -91,7 +91,7 @@ var (
 	}
 )
 
-var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", func() {
+var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -23,10 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-network] "+text, body)
+func SIGDescribe(text string, args ...interface{}) bool {
+	return Describe("[sig-network] "+text, args)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-network] "+text, body)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	return FDescribe("[sig-network] "+text, args)
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -68,7 +68,7 @@ const (
 	sriovnetLinkEnabled = "sriov-linked"
 )
 
-var _ = Describe("[Serial]SRIOV", func() {
+var _ = Describe("[Serial]SRIOV", Serial, func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -475,9 +475,9 @@ var istioTestsWithPasstBinding = func() {
 	istioTests(Passt)
 }
 
-var _ = SIGDescribe("[Serial] Istio with masquerade binding", istioTestsWithMasqueradeBinding)
+var _ = SIGDescribe("[Serial] Istio with masquerade binding", Serial, istioTestsWithMasqueradeBinding)
 
-var _ = SIGDescribe("[Serial] Istio with passt binding", istioTestsWithPasstBinding)
+var _ = SIGDescribe("[Serial] Istio with passt binding", Serial, istioTestsWithPasstBinding)
 
 func istioServiceMeshDeployed() bool {
 	return strings.ToLower(os.Getenv(istioDeployedEnvVariable)) == "true"

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -56,7 +56,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 
 	Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
 		Context("when virt-handler is responsive", func() {
-			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
+			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", Serial, func() {
 				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
 				bridgeVMI := vmi
 				// Remove the masquerade interface to use the default bridge one

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -89,7 +89,7 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
-var _ = SIGDescribe("[Serial]Multus", func() {
+var _ = SIGDescribe("[Serial]Multus", Serial, func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -1023,7 +1023,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 
-	Context("[Serial]vmi with default bridge interface on pod network", func() {
+	Context("[Serial]vmi with default bridge interface on pod network", Serial, func() {
 		BeforeEach(func() {
 			setBridgeEnabled(false)
 		})

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = SIGDescribe("[Serial] Passt", func() {
+var _ = SIGDescribe("[Serial] Passt", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -186,7 +186,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 		)
 	})
 
-	Context("[Serial]slirp is the default interface", func() {
+	Context("[Serial]slirp is the default interface", Serial, func() {
 		BeforeEach(func() {
 			setSlirpEnabled(false)
 			setDefaultNetworkInterface("slirp")

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -27,7 +27,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = Describe("[sig-compute][Serial]NUMA", func() {
+var _ = Describe("[sig-compute][Serial]NUMA", Serial, func() {
 
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -98,7 +98,7 @@ type vmYamlDefinition struct {
 	vmSnapshots   []vmSnapshotDef
 }
 
-var _ = Describe("[Serial][sig-operator]Operator", func() {
+var _ = Describe("[Serial][sig-operator]Operator", Serial, func() {
 	var originalKv *v1.KubeVirt
 	var originalCDI *cdiv1.CDI
 	var originalOperatorVersion string
@@ -1113,7 +1113,7 @@ spec:
 		waitForKv(kv)
 	})
 
-	Describe("[Serial]should reconcile components", func() {
+	Describe("[Serial]should reconcile components", Serial, func() {
 
 		deploymentName := "virt-controller"
 		daemonSetName := "virt-handler"
@@ -1397,7 +1397,7 @@ spec:
 		})
 	})
 
-	Describe("[test_id:4744][Serial]should apply component customization", func() {
+	Describe("[test_id:4744][Serial]should apply component customization", Serial, func() {
 
 		It("test applying and removing a patch", func() {
 			annotationPatchValue := "new-annotation-value"

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -53,12 +53,12 @@ func init() {
 	}
 }
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-performance][Serial] "+text, body)
+func SIGDescribe(text string, args ...interface{}) bool {
+	return Describe("[sig-performance][Serial] "+text, Serial, args)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-performance][Serial] "+text, body)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	return FDescribe("[sig-performance][Serial] "+text, Serial, args)
 }
 
 func skipIfNoPerformanceTests() {

--- a/tests/pool_test.go
+++ b/tests/pool_test.go
@@ -140,7 +140,7 @@ var _ = Describe("[sig-compute]VirtualMachinePool", func() {
 		return createVirtualMachinePool(newPoolFromVMI(libvmi.NewCirros()))
 	}
 
-	DescribeTable("[Serial]pool should scale", func(startScale int, stopScale int) {
+	DescribeTable("[Serial]pool should scale", Serial, func(startScale int, stopScale int) {
 		newPool := newVirtualMachinePool()
 		doScale(newPool.ObjectMeta.Name, int32(startScale))
 		doScale(newPool.ObjectMeta.Name, int32(stopScale))

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -59,7 +59,7 @@ func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.Kubevir
 	tests.WaitForSuccessfulVMIStart(vmi)
 }
 
-var _ = Describe("[sig-compute-realtime][Serial]Realtime", func() {
+var _ = Describe("[sig-compute-realtime][Serial]Realtime", Serial, func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -49,7 +49,7 @@ const (
 	capNetBindService k8sv1.Capability = "NET_BIND_SERVICE"
 )
 
-var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
+var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -161,7 +161,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachineInstance with a DataVolume as a volume source", func() {
 
-		Context("[Serial]without fsgroup support", func() {
+		Context("[Serial]without fsgroup support", Serial, func() {
 			size := "1Gi"
 
 			It("should succesfully start", func() {
@@ -896,7 +896,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 		})
 	})
 
-	Describe("[Serial][rfe_id:8400][crit:high][vendor:cnv-qe@redhat.com][level:system] Garbage collection of succeeded DV", func() {
+	Describe("[Serial][rfe_id:8400][crit:high][vendor:cnv-qe@redhat.com][level:system] Garbage collection of succeeded DV", Serial, func() {
 		var originalTTL *int32
 
 		BeforeEach(func() {

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -43,7 +43,7 @@ const (
 	diskName   = "disk0"
 )
 
-var _ = SIGDescribe("[Serial]K8s IO events", func() {
+var _ = SIGDescribe("[Serial]K8s IO events", Serial, func() {
 	var (
 		nodeName   string
 		virtClient kubecli.KubevirtClient

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1569,7 +1569,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 	})
 
-	Context("[Serial] with potential KubeVirt CR update", func() {
+	Context("[Serial] with potential KubeVirt CR update", Serial, func() {
 		var beforeCertParams *virtv1.KubeVirtCertificateRotateStrategy
 
 		BeforeEach(func() {

--- a/tests/storage/framework.go
+++ b/tests/storage/framework.go
@@ -23,14 +23,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-func SIGDescribe(text string, body func()) bool {
-	return Describe("[sig-storage] "+text, body)
+func SIGDescribe(text string, args ...interface{}) bool {
+	return Describe("[sig-storage] "+text, args)
 }
 
-func FSIGDescribe(text string, body func()) bool {
-	return FDescribe("[sig-storage] "+text, body)
+func FSIGDescribe(text string, args ...interface{}) bool {
+	return FDescribe("[sig-storage] "+text, args)
 }
 
-func PSIGDescribe(text string, body func()) bool {
-	return PDescribe("[sig-storage] "+text, body)
+func PSIGDescribe(text string, args ...interface{}) bool {
+	return PDescribe("[sig-storage] "+text, args)
 }

--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -36,7 +36,7 @@ func (f *fakeAttacher) closeChannel() {
 	f.done <- true
 }
 
-var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", func() {
+var _ = SIGDescribe("[rfe_id:6364][[Serial]Guestfs", Serial, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		pvcClaim   string

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -796,7 +796,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			},
 				Entry("with VMs", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeFilesystem, false),
 				Entry("with VMIs", addDVVolumeVMI, removeVolumeVMI, corev1.PersistentVolumeFilesystem, true),
-				Entry("[Serial] with VMs and block", addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
+				Entry("[Serial] with VMs and block", Serial, addDVVolumeVM, removeVolumeVM, corev1.PersistentVolumeBlock, false),
 			)
 
 			It("should permanently add hotplug volume when added to VM, but still unpluggable after restart", func() {
@@ -1124,7 +1124,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			},
 				Entry("with DataVolume and running VM", addDVVolumeVM, removeVolumeVM, libstorage.GetRWOBlockStorageClass, corev1.PersistentVolumeFilesystem, false),
 				Entry("with DataVolume and VMI directly", addDVVolumeVMI, removeVolumeVMI, libstorage.GetRWOBlockStorageClass, corev1.PersistentVolumeFilesystem, true),
-				Entry("[Serial] with Block DataVolume immediate attach", addDVVolumeVM, removeVolumeVM, libstorage.GetRWOBlockStorageClass, corev1.PersistentVolumeBlock, false),
+				Entry("[Serial] with Block DataVolume immediate attach", Serial, addDVVolumeVM, removeVolumeVM, libstorage.GetRWOBlockStorageClass, corev1.PersistentVolumeBlock, false),
 			)
 		})
 	})

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -46,7 +46,7 @@ const (
 	insecure             = "--insecure"
 )
 
-var _ = SIGDescribe("[Serial]ImageUpload", func() {
+var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 	var kubectlCmd *exec.Cmd
 
 	pvcSize := "100Mi"

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1199,7 +1199,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 			})
 		})
 
-		Context("[Serial]With more complicated VM with/out GC of succeeded DV", func() {
+		Context("[Serial]With more complicated VM with/out GC of succeeded DV", Serial, func() {
 			var originalTTL *int32
 
 			BeforeEach(func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -306,8 +306,8 @@ var _ = SIGDescribe("Storage", func() {
 					Entry("[test_id:3130]with Disk PVC", newRandomVMIWithPVC, "", nil, true),
 					Entry("[test_id:3131]with CDRom PVC", newRandomVMIWithCDRom, "", nil, true),
 					Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
-					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", newRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
-					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
+					Entry("[Serial]with NFS Disk PVC using ipv6 address of the NFS pod", Serial, newRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
+					Entry("[Serial]with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", Serial, newRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
 				)
 			})
 
@@ -763,7 +763,7 @@ var _ = SIGDescribe("Storage", func() {
 			})
 		})
 
-		Context("[Serial]With feature gates disabled for", func() {
+		Context("[Serial]With feature gates disabled for", Serial, func() {
 			It("[test_id:4620]HostDisk, it should fail to start a VMI", func() {
 				tests.DisableFeatureGate(virtconfig.HostDiskGate)
 				vmi = tests.NewRandomVMIWithHostDisk("somepath", virtv1.HostDiskExistsOrCreate, "")
@@ -1065,7 +1065,7 @@ var _ = SIGDescribe("Storage", func() {
 				}
 
 				// Not a candidate for NFS test due to usage of host disk
-				It("[Serial][test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", func() {
+				It("[Serial][test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", Serial, func() {
 
 					configureToleration(10)
 
@@ -1083,7 +1083,7 @@ var _ = SIGDescribe("Storage", func() {
 				})
 
 				// Not a candidate for NFS test due to usage of host disk
-				It("[Serial][test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration", func() {
+				It("[Serial][test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration", Serial, func() {
 
 					configureToleration(30)
 

--- a/tests/swap_test.go
+++ b/tests/swap_test.go
@@ -62,7 +62,7 @@ const (
 	bytesInKib          = 1024
 )
 
-var _ = Describe("[Serial][sig-compute]SwapTest", func() {
+var _ = Describe("[Serial][sig-compute]SwapTest", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -289,7 +289,7 @@ const (
 	windowsSysprepedVMIPassword = "Gauranga"
 )
 
-var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", func() {
+var _ = Describe("[Serial][Sysprep][sig-compute]Syspreped VirtualMachineInstance", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -55,7 +55,7 @@ const (
 	defaultMemory     = "2Gi"
 )
 
-var _ = Describe("[Serial][sig-compute]Templates", func() {
+var _ = Describe("[Serial][sig-compute]Templates", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -170,10 +170,7 @@ func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 		return kv
 	}
 
-	suiteConfig, _ := GinkgoConfiguration()
-	if suiteConfig.ParallelTotal > 1 {
-		Fail("Tests which alter the global kubevirt configuration must not be executed in parallel")
-	}
+	Expect(CurrentSpecReport().IsSerial).To(BeTrue(), "Tests which alter the global kubevirt configuration must not be executed in parallel, see https://onsi.github.io/ginkgo/#serial-specs")
 
 	updatedKV := kv.DeepCopy()
 	updatedKV.Spec.Configuration = kvConfig

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1981,8 +1981,7 @@ func UpdateKubeVirtConfigValueAndWait(kvConfig v1.KubeVirtConfiguration) *v1.Kub
 // be propagated to all components before it returns. It will only update the configuration and wait for it to be
 // propagated if the current config in use does not match the original one.
 func resetToDefaultConfig() {
-	suiteConfig, _ := GinkgoConfiguration()
-	if suiteConfig.ParallelTotal > 1 {
+	if !CurrentSpecReport().IsSerial {
 		// Tests which alter the global kubevirt config must be run serial, therefor, if we run in parallel
 		// we can just skip the restore step.
 		return

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -56,7 +56,7 @@ const (
 	singleReplica = false
 )
 
-var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience", func() {
+var _ = Describe("[Serial][ref_id:2717][sig-compute]KubeVirt control plane resilience", Serial, func() {
 
 	var err error
 	var virtCli kubecli.KubevirtClient

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -124,7 +124,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 	})
 
-	Context("[Serial]A mutated VirtualMachine given", func() {
+	Context("[Serial]A mutated VirtualMachine given", Serial, func() {
 
 		var testingMachineType string = "pc-q35-2.7"
 
@@ -413,8 +413,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 		},
 			Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-			Entry("[Serial][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithFileDisk),
-			Entry("[Serial][storage-req]with Block Disk", newVirtualMachineInstanceWithBlockDisk),
+			Entry("[Serial][storage-req]with Filesystem Disk", Serial, newVirtualMachineInstanceWithFileDisk),
+			Entry("[Serial][storage-req]with Block Disk", Serial, newVirtualMachineInstanceWithBlockDisk),
 		)
 
 		DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", func(createTemplate vmiBuilder) {
@@ -431,8 +431,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 300*time.Second, 2*time.Second).Should(BeZero(), "The VirtualMachineInstance did not disappear")
 		},
 			Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-			Entry("[Serial][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithFileDisk),
-			Entry("[Serial][storage-req]with Block Disk", newVirtualMachineInstanceWithBlockDisk),
+			Entry("[Serial][storage-req]with Filesystem Disk", Serial, newVirtualMachineInstanceWithFileDisk),
+			Entry("[Serial][storage-req]with Block Disk", Serial, newVirtualMachineInstanceWithBlockDisk),
 		)
 
 		It("[test_id:1522]should remove owner references on the VirtualMachineInstance if it is orphan deleted", func() {
@@ -555,8 +555,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			stopVM(vm)
 		},
 			Entry("with ContainerDisk", newVirtualMachineInstanceWithContainerDisk),
-			Entry("[Serial][storage-req]with Filesystem Disk", newVirtualMachineInstanceWithFileDisk),
-			Entry("[Serial][storage-req]with Block Disk", newVirtualMachineInstanceWithBlockDisk),
+			Entry("[Serial][storage-req]with Filesystem Disk", Serial, newVirtualMachineInstanceWithFileDisk),
+			Entry("[Serial][storage-req]with Block Disk", Serial, newVirtualMachineInstanceWithBlockDisk),
 		)
 
 		It("[test_id:1526]should start and stop VirtualMachineInstance multiple times", func() {
@@ -1404,7 +1404,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			Context("Using RunStrategyOnce", func() {
-				It("[Serial] Should leave a failed VMI", func() {
+				It("[Serial] Should leave a failed VMI", Serial, func() {
 					By("creating a VM with RunStrategyOnce")
 					virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyOnce)
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -281,7 +281,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			),
 		)
 
-		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", func() {
+		Context("[Serial][rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", Serial, func() {
 			var availableNumberOfCPUs int
 			var vmi *v1.VirtualMachineInstance
 
@@ -458,7 +458,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				}, 60)).To(Succeed(), "should report number of threads")
 			})
 
-			It("[Serial][test_id:1664]should map cores to virtio block queues", func() {
+			It("[Serial][test_id:1664]should map cores to virtio block queues", Serial, func() {
 				_true := true
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
@@ -536,7 +536,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", func() {
+		Context("[Serial][rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]with cluster memory overcommit being applied", Serial, func() {
 			BeforeEach(func() {
 				kv := util.GetCurrentKv(virtClient)
 
@@ -639,8 +639,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Expect(domXml).To(MatchRegexp(fileName))
 			}
 		},
-			Entry("[Serial][test_id:1668]should use EFI without secure boot", alpineWithUefiWithoutSecureBoot, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
-			Entry("[Serial][test_id:4437]should enable EFI secure boot", fedoraWithUefiSecuredBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
+			Entry("[Serial][test_id:1668]should use EFI without secure boot", Serial, alpineWithUefiWithoutSecureBoot, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
+			Entry("[Serial][test_id:4437]should enable EFI secure boot", Serial, fedoraWithUefiSecuredBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
 		)
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {
@@ -1213,10 +1213,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				By("Checking that the VM memory equals to a number of consumed hugepages")
 				Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
 			},
-				Entry("[Serial][test_id:1671]hugepages-2Mi", "2Mi", "64Mi", "None", nil, nil),
-				Entry("[Serial][test_id:1672]hugepages-1Gi", "1Gi", "1Gi", "None", nil, nil),
-				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", "2Mi", "70Mi", "64Mi", nil, nil),
-				Entry("[Serial]hugepages-2Mi with passt enabled", "2Mi", "64Mi", "None",
+				Entry("[Serial][test_id:1671]hugepages-2Mi", Serial, "2Mi", "64Mi", "None", nil, nil),
+				Entry("[Serial][test_id:1672]hugepages-1Gi", Serial, "1Gi", "1Gi", "None", nil, nil),
+				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", Serial, "2Mi", "70Mi", "64Mi", nil, nil),
+				Entry("[Serial]hugepages-2Mi with passt enabled", Serial, "2Mi", "64Mi", "None",
 					libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
 			)
 
@@ -1395,7 +1395,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 					"Agent condition should be gone")
 			})
 
-			Context("[Serial]with cluster config changes", func() {
+			Context("[Serial]with cluster config changes", Serial, func() {
 				BeforeEach(func() {
 					kv := util.GetCurrentKv(virtClient)
 
@@ -1709,7 +1709,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		Context("[Serial]using defaultRuntimeClass configuration", func() {
+		Context("[Serial]using defaultRuntimeClass configuration", Serial, func() {
 			var runtimeClassName string
 
 			BeforeEach(func() {
@@ -1886,7 +1886,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", func() {
+	Context("[Serial][rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", Serial, func() {
 		BeforeEach(func() {
 			kv := util.GetCurrentKv(virtClient)
 
@@ -1931,7 +1931,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
 		})
 
-		It("[Serial][test_id:3126]should set machine type from kubevirt-config", func() {
+		It("[Serial][test_id:3126]should set machine type from kubevirt-config", Serial, func() {
 			kv := util.GetCurrentKv(virtClient)
 
 			config := kv.Spec.Configuration
@@ -1985,7 +1985,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			Expect(cpuRequest.String()).To(Equal("100m"))
 		})
 
-		It("[Serial][test_id:3129]should set CPU request from kubevirt-config", func() {
+		It("[Serial][test_id:3129]should set CPU request from kubevirt-config", Serial, func() {
 			kv := util.GetCurrentKv(virtClient)
 
 			config := kv.Spec.Configuration
@@ -2003,7 +2003,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC", func() {
+	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component][storage-req]with driver cache and io settings and PVC", Serial, func() {
 		var dataVolume *cdiv1.DataVolume
 
 		BeforeEach(func() {
@@ -2368,7 +2368,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			}
 		})
 
-		Context("[Serial]with cpu pinning enabled", func() {
+		Context("[Serial]with cpu pinning enabled", Serial, func() {
 
 			It("[test_id:1684]should set the cpumanager label to false when it's not running", func() {
 
@@ -2692,7 +2692,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			})
 		})
 
-		Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", func() {
+		Context("[Serial]cpu pinning with fedora images, dedicated and non dedicated cpu should be possible on same node via spec.domain.cpu.cores", Serial, func() {
 
 			var cpuvmi, vmi *v1.VirtualMachineInstance
 			var node string
@@ -2778,7 +2778,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 	Context("[rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check Chassis value", func() {
 
-		It("[Serial][test_id:2927]Test Chassis value in a newly created VM", func() {
+		It("[Serial][test_id:2927]Test Chassis value in a newly created VM", Serial, func() {
 			vmi := tests.NewRandomFedoraVMIWithDmidecode()
 			vmi.Spec.Domain.Chassis = &v1.Chassis{
 				Asset: "Test-123",
@@ -2806,7 +2806,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", func() {
+	Context("[Serial][rfe_id:2926][crit:medium][vendor:cnv-qe@redhat.com][level:component]Check SMBios with default and custom values", Serial, func() {
 
 		var vmi *v1.VirtualMachineInstance
 

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -56,7 +56,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }
 
-var _ = Describe("[Serial][sig-compute]GPU", func() {
+var _ = Describe("[Serial][sig-compute]GPU", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -147,7 +147,7 @@ var _ = Describe("[sig-compute]HookSidecars", func() {
 			})
 		})
 
-		Context("[Serial]with sidecar feature gate disabled", func() {
+		Context("[Serial]with sidecar feature gate disabled", Serial, func() {
 			BeforeEach(func() {
 				tests.DisableFeatureGate(virtconfig.SidecarGate)
 			})

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -25,7 +25,7 @@ const (
 	failedDeleteVMI = "Failed to delete VMI"
 )
 
-var _ = Describe("[Serial][sig-compute]HostDevices", func() {
+var _ = Describe("[Serial][sig-compute]HostDevices", Serial, func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -107,7 +107,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		testsuite.EnsureKVMPresent()
 	})
 
-	Context("when virt-handler is deleted", func() {
+	Context("when virt-handler is deleted", Serial, func() {
 		It("[Serial][test_id:4716]should label the node with kubevirt.io/schedulable=false", func() {
 			pods, err := virtClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
@@ -549,7 +549,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 
 		Context("when virt-launcher crashes", func() {
-			It("[Serial][test_id:1631]should be stopped and have Failed phase", func() {
+			It("[Serial][test_id:1631]should be stopped and have Failed phase", Serial, func() {
 				vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 
@@ -575,7 +575,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]when virt-handler crashes", func() {
+		Context("[Serial]when virt-handler crashes", Serial, func() {
 			// FIXME: This test has the issues that it tests a lot of different timing scenarios in an intransparent way:
 			// e.g. virt-handler can die before or after virt-launcher. If we wait until virt-handler is dead before we
 			// kill virt-launcher then we don't know if virt-handler already restarted.
@@ -622,7 +622,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]when virt-handler is responsive", func() {
+		Context("[Serial]when virt-handler is responsive", Serial, func() {
 			It("[test_id:1633]should indicate that a node is ready for vmis", func() {
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
@@ -708,7 +708,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]when virt-handler is not responsive", func() {
+		Context("[Serial]when virt-handler is not responsive", Serial, func() {
 
 			var vmi *v1.VirtualMachineInstance
 			var nodeName string
@@ -818,7 +818,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]with node tainted", func() {
+		Context("[Serial]with node tainted", Serial, func() {
 			var nodes *k8sv1.NodeList
 			var err error
 			BeforeEach(func() {
@@ -935,7 +935,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 
 		})
 
-		Context("[Serial]with default cpu model", func() {
+		Context("[Serial]with default cpu model", Serial, func() {
 			var originalConfig v1.KubeVirtConfiguration
 			var supportedCpuModels []string
 			//store old kubevirt-config
@@ -1049,7 +1049,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 			})
 		})
 
-		Context("[Serial]with node feature discovery", func() {
+		Context("[Serial]with node feature discovery", Serial, func() {
 			var node *k8sv1.Node
 			var supportedCPU string
 			var supportedCPUs []string
@@ -1782,7 +1782,7 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 		})
 	})
 
-	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", func() {
+	Describe("[Serial][rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, func() {
 		It("[test_id:1656]should be in Failed phase", func() {
 			By("Starting a VirtualMachineInstance")
 			obj, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[Serial][sig-compute]VSOCK", func() {
+var _ = Describe("[Serial][sig-compute]VSOCK", Serial, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -37,7 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[Serial][sig-compute]VMIDefaults", func() {
+var _ = Describe("[Serial][sig-compute]VMIDefaults", Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -63,7 +63,7 @@ const (
 	winrmCliCmd = "winrm-cli"
 )
 
-var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", func() {
+var _ = Describe("[Serial][sig-compute]Windows VirtualMachineInstance", Serial, func() {
 	var virtClient kubecli.KubevirtClient
 	var windowsVMI *v1.VirtualMachineInstance
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Ginkgo V2 has the decorator [Serial](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#serial-decorator) that is designed for running tests in serial. Further the [docs for parallel test support](https://onsi.github.io/ginkgo/#spec-parallelization) say that test results will all be captured in one output stream in Ginkgo 2.

As a preparation to use the new features this PR:
 * adds the Serial decorator, 
 * updates the checks for serial run and 
 * updates documentation so that people don't forget when they add or update tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

See https://github.com/kubevirt/kubevirt/issues/8776

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Ginkgo V2 Serial decorator to serial tests as preparation to simplify parallel vs. serial test run logic
```
