### PR TITLE
Fix evmcs hyperv feature bug

### DIFF
--- a/pkg/virt-api/webhooks/hyperv.go
+++ b/pkg/virt-api/webhooks/hyperv.go
@@ -178,7 +178,8 @@ func ValidateVirtualMachineInstanceHypervFeatureDependencies(field *k8sfield.Pat
 		}
 	}
 
-	if spec.Domain.Features == nil || spec.Domain.Features.Hyperv == nil || spec.Domain.Features.Hyperv.EVMCS == nil {
+	if spec.Domain.Features == nil || spec.Domain.Features.Hyperv == nil || spec.Domain.Features.Hyperv.EVMCS == nil ||
+		(spec.Domain.Features.Hyperv.EVMCS.Enabled != nil && (*spec.Domain.Features.Hyperv.EVMCS.Enabled) == false) {
 		return causes
 	}
 
@@ -210,7 +211,8 @@ func SetVirtualMachineInstanceHypervFeatureDependencies(vmi *v1.VirtualMachineIn
 	}
 
 	//Check if vmi has EVMCS feature enabled. If yes, we have to add vmx cpu feature
-	if vmi.Spec.Domain.Features != nil && vmi.Spec.Domain.Features.Hyperv != nil && vmi.Spec.Domain.Features.Hyperv.EVMCS != nil {
+	if vmi.Spec.Domain.Features != nil && vmi.Spec.Domain.Features.Hyperv != nil && vmi.Spec.Domain.Features.Hyperv.EVMCS != nil &&
+		(vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled == nil || (*vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled) == true) {
 		setEVMCSDependency(vmi)
 	}
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -945,9 +945,23 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 				},
 			}, nil),
 
+		Entry("if EVMCS is explicitly false ", api.NewMinimalVMI("testvmi"),
+			&v1.FeatureHyperv{
+				EVMCS: &v1.FeatureState{Enabled: pointer.BoolPtr(false)},
+			},
+			nil,
+		),
+
 		Entry("if hyperV does contain EVMCS", api.NewMinimalVMI("testvmi"),
 			&v1.FeatureHyperv{
 				EVMCS: &v1.FeatureState{},
+			}, &v1.CPU{
+				Features: cpuFeatures,
+			}),
+
+		Entry("if EVMCS is explicitly true ", api.NewMinimalVMI("testvmi"),
+			&v1.FeatureHyperv{
+				EVMCS: &v1.FeatureState{Enabled: pointer.BoolPtr(true)},
 			}, &v1.CPU{
 				Features: cpuFeatures,
 			}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix Evmcs Hyperv bug.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Currently whenever EVMCS HyperV feature
Is not nil in the vm spec than all dependencies
features of EVMCS are enabled.
Even if we set vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled
to be false.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
