### PR TITLE
virt-launcher: Remove always nil return values from DomainManager

### DIFF
--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -453,13 +453,7 @@ func (l *Launcher) GetGuestInfo(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv
 		},
 	}
 
-	guestInfo, err := l.domainManager.GetGuestInfo()
-	if err != nil {
-		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
-		return response, nil
-	}
-
+	guestInfo := l.domainManager.GetGuestInfo()
 	if jGuestInfo, err := json.Marshal(guestInfo); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal agent info")
 		response.Response.Success = false
@@ -480,13 +474,7 @@ func (l *Launcher) GetUsers(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.Gu
 		},
 	}
 
-	users, err := l.domainManager.GetUsers()
-	if err != nil {
-		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
-		return response, nil
-	}
-
+	users := l.domainManager.GetUsers()
 	if jUsers, err := json.Marshal(users); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal guest user list")
 		response.Response.Success = false
@@ -507,13 +495,7 @@ func (l *Launcher) GetFilesystems(_ context.Context, _ *cmdv1.EmptyRequest) (*cm
 		},
 	}
 
-	fs, err := l.domainManager.GetFilesystems()
-	if err != nil {
-		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
-		return response, nil
-	}
-
+	fs := l.domainManager.GetFilesystems()
 	if jFS, err := json.Marshal(fs); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal guest user list")
 		response.Response.Success = false

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Virt remote commands", func() {
 				},
 			}
 
-			domainManager.EXPECT().GetUsers().Return(userList, nil)
+			domainManager.EXPECT().GetUsers().Return(userList)
 
 			fetchedList, err := client.GetUsers()
 			Expect(err).ToNot(HaveOccurred(), "should fetch users without any issue")
@@ -252,7 +252,7 @@ var _ = Describe("Virt remote commands", func() {
 				},
 			}
 
-			domainManager.EXPECT().GetFilesystems().Return(fsList, nil)
+			domainManager.EXPECT().GetFilesystems().Return(fsList)
 
 			fetchedList, err := client.GetFilesystems()
 			Expect(err).ToNot(HaveOccurred(), "should fetch filesystems without any issue")

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -187,33 +187,30 @@ func (_mr *_MockDomainManagerRecorder) CancelVMIMigration(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelVMIMigration", arg0)
 }
 
-func (_m *MockDomainManager) GetGuestInfo() (v1.VirtualMachineInstanceGuestAgentInfo, error) {
+func (_m *MockDomainManager) GetGuestInfo() v1.VirtualMachineInstanceGuestAgentInfo {
 	ret := _m.ctrl.Call(_m, "GetGuestInfo")
 	ret0, _ := ret[0].(v1.VirtualMachineInstanceGuestAgentInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 func (_mr *_MockDomainManagerRecorder) GetGuestInfo() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGuestInfo")
 }
 
-func (_m *MockDomainManager) GetUsers() ([]v1.VirtualMachineInstanceGuestOSUser, error) {
+func (_m *MockDomainManager) GetUsers() []v1.VirtualMachineInstanceGuestOSUser {
 	ret := _m.ctrl.Call(_m, "GetUsers")
 	ret0, _ := ret[0].([]v1.VirtualMachineInstanceGuestOSUser)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 func (_mr *_MockDomainManagerRecorder) GetUsers() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUsers")
 }
 
-func (_m *MockDomainManager) GetFilesystems() ([]v1.VirtualMachineInstanceFileSystem, error) {
+func (_m *MockDomainManager) GetFilesystems() []v1.VirtualMachineInstanceFileSystem {
 	ret := _m.ctrl.Call(_m, "GetFilesystems")
 	ret0, _ := ret[0].([]v1.VirtualMachineInstanceFileSystem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 func (_mr *_MockDomainManagerRecorder) GetFilesystems() *gomock.Call {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -115,9 +115,9 @@ type DomainManager interface {
 	PrepareMigrationTarget(*v1.VirtualMachineInstance, bool, *cmdv1.VirtualMachineOptions) error
 	GetDomainStats() ([]*stats.DomainStats, error)
 	CancelVMIMigration(*v1.VirtualMachineInstance) error
-	GetGuestInfo() (v1.VirtualMachineInstanceGuestAgentInfo, error)
-	GetUsers() ([]v1.VirtualMachineInstanceGuestOSUser, error)
-	GetFilesystems() ([]v1.VirtualMachineInstanceFileSystem, error)
+	GetGuestInfo() v1.VirtualMachineInstanceGuestAgentInfo
+	GetUsers() []v1.VirtualMachineInstanceGuestOSUser
+	GetFilesystems() []v1.VirtualMachineInstanceFileSystem
 	FinalizeVirtualMachineMigration(*v1.VirtualMachineInstance) error
 	HotplugHostDevices(vmi *v1.VirtualMachineInstance) error
 	InterfacesStatus() []api.InterfaceStatus
@@ -1831,7 +1831,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 }
 
 // GetGuestInfo queries the agent store and return the aggregated data from Guest agent
-func (l *LibvirtDomainManager) GetGuestInfo() (v1.VirtualMachineInstanceGuestAgentInfo, error) {
+func (l *LibvirtDomainManager) GetGuestInfo() v1.VirtualMachineInstanceGuestAgentInfo {
 	sysInfo := l.agentData.GetSysInfo()
 	fsInfo := l.agentData.GetFS(10)
 	userInfo := l.agentData.GetUsers(10)
@@ -1875,7 +1875,7 @@ func (l *LibvirtDomainManager) GetGuestInfo() (v1.VirtualMachineInstanceGuestAge
 		})
 	}
 
-	return guestInfo, nil
+	return guestInfo
 }
 
 // InterfacesStatus returns the interfaces Guest Agent reported
@@ -1889,7 +1889,7 @@ func (l *LibvirtDomainManager) GetGuestOSInfo() *api.GuestOSInfo {
 }
 
 // GetUsers return the full list of users on the guest machine
-func (l *LibvirtDomainManager) GetUsers() ([]v1.VirtualMachineInstanceGuestOSUser, error) {
+func (l *LibvirtDomainManager) GetUsers() []v1.VirtualMachineInstanceGuestOSUser {
 	userInfo := l.agentData.GetUsers(-1)
 	userList := []v1.VirtualMachineInstanceGuestOSUser{}
 
@@ -1901,11 +1901,11 @@ func (l *LibvirtDomainManager) GetUsers() ([]v1.VirtualMachineInstanceGuestOSUse
 		})
 	}
 
-	return userList, nil
+	return userList
 }
 
 // GetFilesystems return the full list of filesystems on the guest machine
-func (l *LibvirtDomainManager) GetFilesystems() ([]v1.VirtualMachineInstanceFileSystem, error) {
+func (l *LibvirtDomainManager) GetFilesystems() []v1.VirtualMachineInstanceFileSystem {
 	fsInfo := l.agentData.GetFS(-1)
 	fsList := []v1.VirtualMachineInstanceFileSystem{}
 
@@ -1919,7 +1919,7 @@ func (l *LibvirtDomainManager) GetFilesystems() ([]v1.VirtualMachineInstanceFile
 		})
 	}
 
-	return fsList, nil
+	return fsList
 }
 
 // check whether VMI has a certain condition

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2044,8 +2044,19 @@ var _ = Describe("Manager", func() {
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
 
-		_, err := libvirtmanager.GetGuestInfo()
-		Expect(err).ToNot(HaveOccurred())
+		guestInfo := libvirtmanager.GetGuestInfo()
+		Expect(guestInfo.UserList).To(ConsistOf(v1.VirtualMachineInstanceGuestOSUser{
+			UserName:  "test",
+			Domain:    "test",
+			LoginTime: 0,
+		}))
+		Expect(guestInfo.FSInfo.Filesystems).To(ConsistOf(v1.VirtualMachineInstanceFileSystem{
+			DiskName:       "test",
+			MountPoint:     "/mnt/whatever",
+			FileSystemType: "fs",
+			UsedBytes:      0,
+			TotalBytes:     0,
+		}))
 	})
 
 	It("executes GetUsers", func() {
@@ -2063,8 +2074,7 @@ var _ = Describe("Manager", func() {
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
 
-		virtualMachineInstanceGuestAgentInfo, err := libvirtmanager.GetUsers()
-		Expect(err).ToNot(HaveOccurred())
+		virtualMachineInstanceGuestAgentInfo := libvirtmanager.GetUsers()
 		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeEmpty())
 	})
 
@@ -2085,8 +2095,7 @@ var _ = Describe("Manager", func() {
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
 
-		virtualMachineInstanceGuestAgentInfo, err := libvirtmanager.GetFilesystems()
-		Expect(err).ToNot(HaveOccurred())
+		virtualMachineInstanceGuestAgentInfo := libvirtmanager.GetFilesystems()
 		Expect(virtualMachineInstanceGuestAgentInfo).ToNot(BeEmpty())
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some methods in `DomainManager` always return `nil` error. This PR removes the error return value for these methods.

```release-note
None
```
