### PR TITLE
Workaround to prevent libvirt error when using Opteron_G2 cpuModel without `svm` 

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -262,8 +262,18 @@ func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures
 	for key := range cpuFeatures {
 		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
 	}
+	_, svmIsSupported := newLabels[kubevirtv1.CPUFeatureLabel+"svm"]
 
 	for _, value := range cpuModels {
+
+		//This workaround is necessary because currently Opteron_G2 require svm by libvirt (see /usr/share/libvirt/cpu_map/x86_Opteron_G2.xml )
+		//But libvirt still marks it as Usable:yes even without `svm` because it is usable by qemu (/var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml)
+		//For more information : https://wiki.qemu.org/Features/CPUModels in "Getting information about CPU models" section
+		//TODO: Delete this workaround once libvirt resolve the disagreement with qemu
+		if value == "Opteron_G2" && svmIsSupported == false {
+			continue
+		}
+
 		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
 		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
 	}


### PR DESCRIPTION
This workaround is necessary because currently Opteron_G2 require svm by libvirt.
(see /usr/share/libvirt/cpu_map/x86_Opteron_G2.xml)

But libvirt still marks it as Usable:yes even without `svm` because it is usable by qemu.
(/var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml)

For more info:
https://wiki.qemu.org/Features/CPUModels -
"Getting information about CPU models" section

https://bugzilla.redhat.com/show_bug.cgi?id=2122283

Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
