### PR TITLE
[alternative] hotplug-disk container: match SELinux level of virt-launcher

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19167,6 +19167,10 @@
       "type": "integer",
       "format": "int64"
      },
+     "selinuxContext": {
+      "description": "SELinuxContext is the actual SELinux context of the virt-launcher pod",
+      "type": "string"
+     },
      "topologyHints": {
       "$ref": "#/definitions/v1.TopologyHints"
      },

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -731,15 +731,9 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 					},
 					SecurityContext: &k8sv1.SecurityContext{
 						SELinuxOptions: &k8sv1.SELinuxOptions{
-							// FIXME: Forcing an SELinux level without categories is a security risk
-							// This pod will contain a disk image shared with a virt-launcher pod.
-							// If we didn't force a level here, one would be auto-generated with a set of categories
-							// different from the one of its companion virt-launcher. Therefore, SELinux would prevent
-							// virt-launcher('s compute container) from accessing the disk image.
-							// The proper fix here is to force the level of this pod to match the one of virt-launcher.
-							// Unfortunately, pods MCS levels are not exposed by the API. Therefore, we'd have to
-							// enter the mount namespace of virt-launcher and check the level of any file/directory.
-							// We need a way to ask virt-handler to do that.
+							// If SELinux is enabled on the host, this level will be adjusted below to match the level
+							// of its companion virt-launcher pod to allow it to consume our disk images.
+							Type:  t.clusterConfig.GetSELinuxLauncherType(),
 							Level: "s0",
 						},
 					},
@@ -772,6 +766,11 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			Volumes:                       []k8sv1.Volume{emptyDirVolume(hotplugDisks)},
 			TerminationGracePeriodSeconds: &zero,
 		},
+	}
+
+	err := matchSELinuxLevelOfVMI(pod, vmi)
+	if err != nil {
+		return nil, err
 	}
 
 	hotplugVolumeStatusMap := make(map[string]v1.VolumePhase)
@@ -910,6 +909,11 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 			},
 			TerminationGracePeriodSeconds: &zero,
 		},
+	}
+
+	err := matchSELinuxLevelOfVMI(pod, vmi)
+	if err != nil {
+		return nil, err
 	}
 
 	if isBlock {
@@ -1141,6 +1145,20 @@ func alignPodMultiCategorySecurity(pod *k8sv1.Pod, vmi *v1.VirtualMachineInstanc
 			generateContainerSecurityContext(selinuxType, container, dockerSELinuxMCSWorkaround)
 		}
 	}
+}
+
+func matchSELinuxLevelOfVMI(pod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) error {
+	if vmi.Status.SelinuxContext == "" {
+		return fmt.Errorf("VMI is missing SELinux context")
+	} else if vmi.Status.SelinuxContext != "none" {
+		ctx := strings.Split(vmi.Status.SelinuxContext, ":")
+		if len(ctx) < 4 {
+			return fmt.Errorf("VMI has invalid SELinux context: %s", vmi.Status.SelinuxContext)
+		}
+		pod.Spec.Containers[0].SecurityContext.SELinuxOptions.Level = strings.Join(ctx[3:], ":")
+	}
+
+	return nil
 }
 
 func generateContainerSecurityContext(selinuxType string, container *k8sv1.Container, forceLevel bool) {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -411,6 +411,7 @@ var _ = Describe("Migration watcher", func() {
 
 		It("should create target attachment pod", func() {
 			addMigration(migration)
+			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(targetPod)
 			shouldExpectAttachmentPodCreation(vmi.UID, migration.UID)

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -528,16 +528,6 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 					break
 				}
 
-				hotplugPodsReady := false
-				hotplugPodsReady, syncErr = c.hotplugPodsReady(vmi, pod)
-				if syncErr != nil {
-					break
-				}
-				if !hotplugPodsReady {
-					log.Log.V(3).Object(vmi).Infof("Postpone the pod hand-over and await the attachment pod ready")
-					break
-				}
-
 				// Initialize the volume status field with information
 				// about the PVCs that the VMI is consuming. This prevents
 				// virt-handler from needing to make API calls to GET the pvc

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1310,7 +1310,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 		},
 			Entry("should hand over pods if both are ready and running", k8sv1.PodRunning, virtv1.Scheduled),
-			Entry("should not hand over pods if the attachment pod is not ready and running", k8sv1.PodPending, virtv1.Scheduling),
+			Entry("should hand over pods even if the attachment pod is not ready and running", k8sv1.PodPending, virtv1.Scheduled),
 		)
 
 		It("should ignore migration target pods", func() {
@@ -2136,6 +2136,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 		It("CreateAttachmentPodTemplate should create a pod template if DV of owning PVC is ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimBound)
 			Expect(pvcInformer.GetIndexer().Add(pvc)).To(Succeed())
@@ -2729,6 +2730,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Target: "",
 			})
 			vmi.Status.ActivePods["virt-launch-uid"] = ""
+			vmi.Status.SelinuxContext = "system_u:system_r:container_file_t:s0:c1,c2"
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 
 			existingPVC := &k8sv1.PersistentVolumeClaim{

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-handler/node-labeller/api:go_default_library",
+        "//pkg/virt-handler/selinux:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/watchdog:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-handler/selinux/BUILD.bazel
+++ b/pkg/virt-handler/selinux/BUILD.bazel
@@ -13,7 +13,10 @@ go_library(
     deps = [
         "//pkg/safepath:go_default_library",
         "//pkg/unsafepath:go_default_library",
+        "//pkg/util:go_default_library",
+        "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/virt-chroot:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11024,6 +11024,10 @@ var CRDsValidation map[string]string = map[string]string{
             launcher
           format: int64
           type: integer
+        selinuxContext:
+          description: SELinuxContext is the actual SELinux context of the virt-launcher
+            pod
+          type: string
         topologyHints:
           properties:
             tscFrequency:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -265,6 +265,10 @@ type VirtualMachineInstanceStatus struct {
 	// VSOCKCID is used to track the allocated VSOCK CID in the VM.
 	// +optional
 	VSOCKCID *uint32 `json:"VSOCKCID,omitempty"`
+
+	// SELinuxContext is the actual SELinux context of the virt-launcher pod
+	// +optional
+	SelinuxContext string `json:"selinuxContext,omitempty"`
 }
 
 // PersistentVolumeClaimInfo contains the relavant information virt-handler needs cached about a PVC

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -76,6 +76,7 @@ func (VirtualMachineInstanceStatus) SwaggerDoc() map[string]string {
 		"virtualMachineRevisionName":    "VirtualMachineRevisionName is used to get the vm revision of the vmi when doing\nan online vm snapshot\n+optional",
 		"runtimeUser":                   "RuntimeUser is used to determine what user will be used in launcher\n+optional",
 		"VSOCKCID":                      "VSOCKCID is used to track the allocated VSOCK CID in the VM.\n+optional",
+		"selinuxContext":                "SELinuxContext is the actual SELinux context of the virt-launcher pod\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22092,6 +22092,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceStatus(ref common.Refer
 							Format:      "int64",
 						},
 					},
+					"selinuxContext": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SELinuxContext is the actual SELinux context of the virt-launcher pod",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an attempt at matching the SELinux level of virt-launcher in hotplug attachment pods, instead of using s0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR is an alternative to https://github.com/kubevirt/kubevirt/pull/8344 but uses `Fgetxattr` instead of `Getxattr`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
