### PR TITLE
[release-0.58] Rename and authorization for namespaced expand-spec endpoint

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11152,41 +11152,6 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1/expand-spec": {
-    "put": {
-     "description": "Expands instancetype and preference into the passed VirtualMachine object.",
-     "consumes": [
-      "application/json"
-     ],
-     "produces": [
-      "application/json"
-     ],
-     "operationId": "v1ExpandSpec",
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "400": {
-       "description": "Bad Request",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      },
-      "500": {
-       "description": "Internal Server Error",
-       "schema": {
-        "type": "string"
-       }
-      }
-     }
-    }
-   },
    "/apis/subresources.kubevirt.io/v1/guestfs": {
     "get": {
      "produces": [
@@ -11234,6 +11199,41 @@
       },
       "500": {
        "description": "Unhealthy",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/expand-vm-spec": {
+    "put": {
+     "description": "Expands instancetype and preference into the passed VirtualMachine object.",
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1ExpandSpec",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "500": {
+       "description": "Internal Server Error",
        "schema": {
         "type": "string"
        }
@@ -12541,41 +12541,6 @@
      }
     }
    },
-   "/apis/subresources.kubevirt.io/v1alpha3/expand-spec": {
-    "put": {
-     "description": "Expands instancetype and preference into the passed VirtualMachine object.",
-     "consumes": [
-      "application/json"
-     ],
-     "produces": [
-      "application/json"
-     ],
-     "operationId": "v1alpha3ExpandSpec",
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "400": {
-       "description": "Bad Request",
-       "schema": {
-        "type": "string"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      },
-      "500": {
-       "description": "Internal Server Error",
-       "schema": {
-        "type": "string"
-       }
-      }
-     }
-    }
-   },
    "/apis/subresources.kubevirt.io/v1alpha3/guestfs": {
     "get": {
      "produces": [
@@ -12623,6 +12588,41 @@
       },
       "500": {
        "description": "Unhealthy",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/expand-vm-spec": {
+    "put": {
+     "description": "Expands instancetype and preference into the passed VirtualMachine object.",
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1alpha3ExpandSpec",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "500": {
+       "description": "Internal Server Error",
        "schema": {
         "type": "string"
        }

--- a/cmd/subresource-access-test/BUILD.bazel
+++ b/cmd/subresource-access-test/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/cmd/subresource-access-test/subresource-access-test.go
+++ b/cmd/subresource-access-test/subresource-access-test.go
@@ -24,47 +24,82 @@ import (
 	"flag"
 	"fmt"
 
-	"k8s.io/client-go/rest"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 )
 
-func main() {
+func genericRequest(resource string) {
+	client, err := kubecli.GetKubevirtSubresourceClient()
+	if err != nil {
+		panic(err)
+	}
+
+	result := client.RestClient().Get().Resource(resource).Do(context.Background())
+	err = result.Error()
+	if err != nil {
+		panic(err)
+	}
+
 	var statusCode int
+	result.StatusCode(&statusCode)
+	if statusCode != 200 {
+		panic(fmt.Errorf("http status code is %d", statusCode))
+	}
+	fmt.Println("Subresource Test Endpoint returned 200 OK")
+}
+
+func expandSpecRequest(namespace string) {
+	vm := &v1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vm-test",
+			Namespace: namespace,
+		},
+		Spec: v1.VirtualMachineSpec{
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{},
+					},
+				},
+			},
+		},
+	}
+	vm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+
+	client, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		panic(err)
+	}
+	_, err = client.ExpandSpec(namespace).ForVirtualMachine(vm)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func startVM(namespace string, resource string) {
+	client, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		panic(err)
+	}
+	err = client.VirtualMachine(namespace).Start(resource, &v1.StartOptions{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
 	var namespace string
 	var resource string
 	flag.StringVar(&namespace, "n", "", "namespace to use")
 	flag.Parse()
 
 	resource = flag.Arg(0)
-
 	if resource == "version" || resource == "guestfs" {
-		client, err := kubecli.GetKubevirtSubresourceClient()
-		if err != nil {
-			panic(err)
-		}
-		restClient := client.RestClient()
-		var result rest.Result
-		result = restClient.Get().Resource(resource).Do(context.Background())
-		err = result.Error()
-		if err != nil {
-			panic(err)
-		}
-
-		result.StatusCode(&statusCode)
-		if statusCode != 200 {
-			panic(fmt.Errorf("http status code is %d", statusCode))
-		}
-		fmt.Println("Subresource Test Endpoint returned 200 OK")
+		genericRequest(resource)
+	} else if resource == "expand-vm-spec" {
+		expandSpecRequest(namespace)
 	} else {
-		client, err := kubecli.GetKubevirtClient()
-		if err != nil {
-			panic(err)
-		}
-		err = client.VirtualMachine(namespace).Start(resource, &v1.StartOptions{})
-		if err != nil {
-			panic(err)
-		}
+		startVM(namespace, resource)
 	}
 }

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -865,6 +865,12 @@ spec:
         - apiGroups:
           - subresources.kubevirt.io
           resources:
+          - virtualmachines/expand-spec
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
           - virtualmachines/start
           - virtualmachines/stop
           - virtualmachines/restart
@@ -872,6 +878,12 @@ spec:
           - virtualmachines/removevolume
           - virtualmachines/migrate
           - virtualmachines/memorydump
+          verbs:
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - expand-vm-spec
           verbs:
           - update
         - apiGroups:
@@ -970,6 +982,12 @@ spec:
         - apiGroups:
           - subresources.kubevirt.io
           resources:
+          - virtualmachines/expand-spec
+          verbs:
+          - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
           - virtualmachines/start
           - virtualmachines/stop
           - virtualmachines/restart
@@ -977,6 +995,12 @@ spec:
           - virtualmachines/removevolume
           - virtualmachines/migrate
           - virtualmachines/memorydump
+          verbs:
+          - update
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - expand-vm-spec
           verbs:
           - update
         - apiGroups:
@@ -1054,11 +1078,18 @@ spec:
         - apiGroups:
           - subresources.kubevirt.io
           resources:
+          - virtualmachines/expand-spec
           - virtualmachineinstances/guestosinfo
           - virtualmachineinstances/filesystemlist
           - virtualmachineinstances/userlist
           verbs:
           - get
+        - apiGroups:
+          - subresources.kubevirt.io
+          resources:
+          - expand-vm-spec
+          verbs:
+          - update
         - apiGroups:
           - kubevirt.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -784,6 +784,12 @@ rules:
 - apiGroups:
   - subresources.kubevirt.io
   resources:
+  - virtualmachines/expand-spec
+  verbs:
+  - get
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
   - virtualmachines/start
   - virtualmachines/stop
   - virtualmachines/restart
@@ -791,6 +797,12 @@ rules:
   - virtualmachines/removevolume
   - virtualmachines/migrate
   - virtualmachines/memorydump
+  verbs:
+  - update
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - expand-vm-spec
   verbs:
   - update
 - apiGroups:
@@ -889,6 +901,12 @@ rules:
 - apiGroups:
   - subresources.kubevirt.io
   resources:
+  - virtualmachines/expand-spec
+  verbs:
+  - get
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
   - virtualmachines/start
   - virtualmachines/stop
   - virtualmachines/restart
@@ -896,6 +914,12 @@ rules:
   - virtualmachines/removevolume
   - virtualmachines/migrate
   - virtualmachines/memorydump
+  verbs:
+  - update
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - expand-vm-spec
   verbs:
   - update
 - apiGroups:
@@ -973,11 +997,18 @@ rules:
 - apiGroups:
   - subresources.kubevirt.io
   resources:
+  - virtualmachines/expand-spec
   - virtualmachineinstances/guestosinfo
   - virtualmachineinstances/filesystemlist
   - virtualmachineinstances/userlist
   verbs:
   - get
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - expand-vm-spec
+  verbs:
+  - update
 - apiGroups:
   - kubevirt.io
   resources:

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -215,6 +215,7 @@ func (app *virtAPIApp) composeSubresources() {
 	for _, version := range v1.SubresourceGroupVersions {
 		subresourcesvmGVR := schema.GroupVersionResource{Group: version.Group, Version: version.Version, Resource: "virtualmachines"}
 		subresourcesvmiGVR := schema.GroupVersionResource{Group: version.Group, Version: version.Version, Resource: "virtualmachineinstances"}
+		expandvmspecGVR := schema.GroupVersionResource{Group: version.Group, Version: version.Version, Resource: "expand-vm-spec"}
 
 		subws := new(restful.WebService)
 		subws.Doc(fmt.Sprintf("KubeVirt \"%s\" Subresource API.", version.Version))
@@ -374,7 +375,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version + "vm-PortForwardWithProtocol").
 			Doc("Open a websocket connection forwarding traffic of the specified protocol (either tcp or udp) to the specified VirtualMachine and port."))
 
-		subws.Route(subws.PUT(definitions.SubResourcePath("expand-spec")).
+		subws.Route(subws.PUT(definitions.NamespacedResourceBasePath(expandvmspecGVR)).
 			To(subresourceApp.ExpandSpecRequestHandler).
 			Operation(version.Version+"ExpandSpec").
 			Consumes(restful.MIME_JSON).

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -518,6 +518,10 @@ func (app *virtAPIApp) composeSubresources() {
 				list.APIVersion = version.Version
 				list.APIResources = []metav1.APIResource{
 					{
+						Name:       "expand-vm-spec",
+						Namespaced: true,
+					},
+					{
 						Name:       "virtualmachineinstances/vnc",
 						Namespaced: true,
 					},

--- a/pkg/virt-api/rest/expand.go
+++ b/pkg/virt-api/rest/expand.go
@@ -49,6 +49,20 @@ func (app *SubresourceAPIApp) ExpandSpecRequestHandler(request *restful.Request,
 		return
 	}
 
+	requestNamespace := request.PathParameter("namespace")
+	if requestNamespace == "" {
+		writeError(errors.NewBadRequest("The request namespace must not be empty"), response)
+		return
+	}
+	if vm.Namespace != "" && vm.Namespace != requestNamespace {
+		writeError(errors.NewBadRequest(
+			fmt.Sprintf("VM namespace must be empty or %s", requestNamespace)),
+			response,
+		)
+		return
+	}
+	vm.Namespace = request.PathParameter("namespace")
+
 	expandSpecResponse(vm, app.instancetypeMethods, func(err error) *errors.StatusError {
 		return errors.NewBadRequest(err.Error())
 	}, response)

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -102,7 +102,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			}
 
 			recorder := callExpandSpecApi(vm)
-			_ = ExpectStatusErrorWithCode(recorder, expectedStatusError)
+			statusErr := ExpectStatusErrorWithCode(recorder, expectedStatusError)
+			Expect(statusErr.Status().Message).To(ContainSubstring("instancetype does not exist"))
 		})
 
 		It("should fail if VM points to nonexistent preference", func() {
@@ -115,7 +116,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			}
 
 			recorder := callExpandSpecApi(vm)
-			_ = ExpectStatusErrorWithCode(recorder, expectedStatusError)
+			statusErr := ExpectStatusErrorWithCode(recorder, expectedStatusError)
+			Expect(statusErr.Status().Message).To(ContainSubstring("preference does not exist"))
 		})
 
 		It("should apply instancetype to VM", func() {
@@ -180,7 +182,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 
 			recorder := callExpandSpecApi(vm)
 
-			_ = ExpectStatusErrorWithCode(recorder, expectedStatusError)
+			statusErr := ExpectStatusErrorWithCode(recorder, expectedStatusError)
+			Expect(statusErr.Status().Message).To(ContainSubstring("cannot expand instancetype to VM"))
 		})
 	}
 
@@ -210,7 +213,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			)).AnyTimes()
 
 			app.ExpandSpecVMRequestHandler(request, response)
-			_ = ExpectStatusErrorWithCode(recorder, http.StatusNotFound)
+			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusNotFound)
+			Expect(statusErr.Status().Message).To(Equal("virtualmachine.kubevirt.io \"nonexistent-vm\" not found"))
 		})
 	})
 
@@ -235,7 +239,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			request.Request.Body = ioutil.NopCloser(strings.NewReader(invalidJson))
 
 			app.ExpandSpecRequestHandler(request, response)
-			_ = ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
+			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
+			Expect(statusErr.Status().Message).To(ContainSubstring("Can not unmarshal Request body to struct"))
 		})
 
 		It("should fail if received object is not a VirtualMachine", func() {
@@ -254,7 +259,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			request.Request.Body = ioutil.NopCloser(bytes.NewBuffer(jsonBytes))
 
 			app.ExpandSpecRequestHandler(request, response)
-			_ = ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
+			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
+			Expect(statusErr.Status().Message).To(Equal("Object is not a valid VirtualMachine"))
 		})
 	})
 })

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -214,8 +214,10 @@ var _ = Describe("Instancetype expansion subresources", func() {
 		})
 	})
 
-	Context("expand-spec endpoint", func() {
+	Context("expand-vm-spec endpoint", func() {
 		callExpandSpecApi := func(vm *v1.VirtualMachine) *httptest.ResponseRecorder {
+			request.PathParameters()["namespace"] = vmNamespace
+
 			vmJson, err := json.Marshal(vm)
 			Expect(err).ToNot(HaveOccurred())
 			request.Request.Body = ioutil.NopCloser(bytes.NewBuffer(vmJson))
@@ -227,6 +229,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 		testCommonFunctionality(callExpandSpecApi, http.StatusBadRequest)
 
 		It("should fail if received invalid JSON", func() {
+			request.PathParameters()["namespace"] = vmNamespace
+
 			invalidJson := "this is invalid JSON {{{{"
 			request.Request.Body = ioutil.NopCloser(strings.NewReader(invalidJson))
 
@@ -235,6 +239,8 @@ var _ = Describe("Instancetype expansion subresources", func() {
 		})
 
 		It("should fail if received object is not a VirtualMachine", func() {
+			request.PathParameters()["namespace"] = vmNamespace
+
 			notVm := struct {
 				StringField string `json:"stringField"`
 				IntField    int    `json:"intField"`

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -262,5 +262,15 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
 			Expect(statusErr.Status().Message).To(Equal("Object is not a valid VirtualMachine"))
 		})
+
+		It("should fail, if VM and endpoint namespace are different", func() {
+			request.PathParameters()["namespace"] = vmNamespace
+			vm.Namespace = "madethisup"
+
+			recorder = callExpandSpecApi(vm)
+			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
+			errMsg := fmt.Sprintf("VM namespace must be empty or %s", vmNamespace)
+			Expect(statusErr.Status().Message).To(Equal(errMsg))
+		})
 	})
 })

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -172,6 +172,17 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					GroupNameSubresources,
 				},
 				Resources: []string{
+					"virtualmachines/expand-spec",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					GroupNameSubresources,
+				},
+				Resources: []string{
 					"virtualmachines/start",
 					"virtualmachines/stop",
 					"virtualmachines/restart",
@@ -179,6 +190,17 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					"virtualmachines/removevolume",
 					"virtualmachines/migrate",
 					"virtualmachines/memorydump",
+				},
+				Verbs: []string{
+					"update",
+				},
+			},
+			{
+				APIGroups: []string{
+					GroupNameSubresources,
+				},
+				Resources: []string{
+					"expand-vm-spec",
 				},
 				Verbs: []string{
 					"update",
@@ -305,6 +327,17 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					GroupNameSubresources,
 				},
 				Resources: []string{
+					"virtualmachines/expand-spec",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					GroupNameSubresources,
+				},
+				Resources: []string{
 					"virtualmachines/start",
 					"virtualmachines/stop",
 					"virtualmachines/restart",
@@ -312,6 +345,17 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"virtualmachines/removevolume",
 					"virtualmachines/migrate",
 					"virtualmachines/memorydump",
+				},
+				Verbs: []string{
+					"update",
+				},
+			},
+			{
+				APIGroups: []string{
+					GroupNameSubresources,
+				},
+				Resources: []string{
+					"expand-vm-spec",
 				},
 				Verbs: []string{
 					"update",
@@ -415,12 +459,24 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					GroupNameSubresources,
 				},
 				Resources: []string{
+					"virtualmachines/expand-spec",
 					VMInstancesGuestOSInfo,
 					VMInstancesFileSysList,
 					VMInstancesUserList,
 				},
 				Verbs: []string{
 					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					GroupNameSubresources,
+				},
+				Resources: []string{
+					"expand-vm-spec",
+				},
+				Verbs: []string{
+					"update",
 				},
 			},
 			{

--- a/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
@@ -119,6 +119,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "instancetype_test.go",
         "kubecli_suite_test.go",
         "kv_test.go",
         "migration_test.go",

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -259,14 +259,14 @@ func (_mr *_MockKubevirtClientRecorder) MigrationPolicy() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MigrationPolicy")
 }
 
-func (_m *MockKubevirtClient) ExpandSpec() *ExpandSpec {
-	ret := _m.ctrl.Call(_m, "ExpandSpec")
-	ret0, _ := ret[0].(*ExpandSpec)
+func (_m *MockKubevirtClient) ExpandSpec(namespace string) ExpandSpecInterface {
+	ret := _m.ctrl.Call(_m, "ExpandSpec", namespace)
+	ret0, _ := ret[0].(ExpandSpecInterface)
 	return ret0
 }
 
-func (_mr *_MockKubevirtClientRecorder) ExpandSpec() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ExpandSpec")
+func (_mr *_MockKubevirtClientRecorder) ExpandSpec(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ExpandSpec", arg0)
 }
 
 func (_m *MockKubevirtClient) ServerVersion() ServerVersionInterface {
@@ -1917,4 +1917,36 @@ func (_m *MockServerVersionInterface) Get() (*version.Info, error) {
 
 func (_mr *_MockServerVersionInterfaceRecorder) Get() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get")
+}
+
+// Mock of ExpandSpecInterface interface
+type MockExpandSpecInterface struct {
+	ctrl     *gomock.Controller
+	recorder *_MockExpandSpecInterfaceRecorder
+}
+
+// Recorder for MockExpandSpecInterface (not exported)
+type _MockExpandSpecInterfaceRecorder struct {
+	mock *MockExpandSpecInterface
+}
+
+func NewMockExpandSpecInterface(ctrl *gomock.Controller) *MockExpandSpecInterface {
+	mock := &MockExpandSpecInterface{ctrl: ctrl}
+	mock.recorder = &_MockExpandSpecInterfaceRecorder{mock}
+	return mock
+}
+
+func (_m *MockExpandSpecInterface) EXPECT() *_MockExpandSpecInterfaceRecorder {
+	return _m.recorder
+}
+
+func (_m *MockExpandSpecInterface) ForVirtualMachine(vm *v120.VirtualMachine) (*v120.VirtualMachine, error) {
+	ret := _m.ctrl.Call(_m, "ForVirtualMachine", vm)
+	ret0, _ := ret[0].(*v120.VirtualMachine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockExpandSpecInterfaceRecorder) ForVirtualMachine(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ForVirtualMachine", arg0)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/instancetype.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/instancetype.go
@@ -9,18 +9,22 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-func (k *kubevirt) ExpandSpec() *ExpandSpec {
-	return &ExpandSpec{
+func (k *kubevirt) ExpandSpec(namespace string) ExpandSpecInterface {
+	return &expandSpec{
 		restClient: k.restClient,
+		namespace:  namespace,
+		resource:   "expand-vm-spec",
 	}
 }
 
-type ExpandSpec struct {
+type expandSpec struct {
 	restClient *rest.RESTClient
+	namespace  string
+	resource   string
 }
 
-func (e *ExpandSpec) ForVirtualMachine(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
-	uri := fmt.Sprintf("/apis/"+v1.SubresourceGroupName+"/%s/expand-spec", v1.ApiStorageVersion)
+func (e *expandSpec) ForVirtualMachine(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
+	uri := fmt.Sprintf("/apis/"+v1.SubresourceGroupName+"/%s/namespaces/%s/%s", v1.ApiStorageVersion, e.namespace, e.resource)
 	expandedVm := &v1.VirtualMachine{}
 	err := e.restClient.Put().
 		RequestURI(uri).

--- a/staging/src/kubevirt.io/client-go/kubecli/instancetype_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/instancetype_test.go
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package kubecli
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	k8sv1 "k8s.io/api/core/v1"
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("Kubevirt ExpandSpec Client", func() {
+	var server *ghttp.Server
+	var client KubevirtClient
+	expandSpecPath := fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/%s/expand-vm-spec", v1.SubresourceStorageGroupVersion.Version, k8sv1.NamespaceDefault)
+
+	BeforeEach(func() {
+		var err error
+		server = ghttp.NewServer()
+		client, err = GetKubevirtClientFromFlags(server.URL(), "")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should expand a VirtualMachine", func() {
+		vm := NewMinimalVM("testvm")
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("PUT", expandSpecPath),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
+		))
+		expandedVM, err := client.ExpandSpec(k8sv1.NamespaceDefault).ForVirtualMachine(vm)
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(expandedVM).To(Equal(vm))
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+})

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -76,7 +76,7 @@ type KubevirtClient interface {
 	VirtualMachinePreference(namespace string) instancetypev1alpha2.VirtualMachinePreferenceInterface
 	VirtualMachineClusterPreference() instancetypev1alpha2.VirtualMachineClusterPreferenceInterface
 	MigrationPolicy() migrationsv1.MigrationPolicyInterface
-	ExpandSpec() *ExpandSpec
+	ExpandSpec(namespace string) ExpandSpecInterface
 	ServerVersion() ServerVersionInterface
 	VirtualMachineClone(namespace string) clonev1alpha1.VirtualMachineCloneInterface
 	ClusterProfiler() *ClusterProfiler
@@ -323,4 +323,8 @@ type KubeVirtInterface interface {
 
 type ServerVersionInterface interface {
 	Get() (*version.Info, error)
+}
+
+type ExpandSpecInterface interface {
+	ForVirtualMachine(vm *v1.VirtualMachine) (*v1.VirtualMachine, error)
 }

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -309,6 +309,10 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				"virtualmachines", "restart",
 				allowUpdateFor("admin", "edit"),
 				denyAllFor("view", "default")),
+			Entry("on vm expand-spec",
+				"virtualmachines", "expand-spec",
+				allowGetFor("admin", "edit", "view"),
+				denyAllFor("default")),
 			Entry("on vmi guestosinfo",
 				"virtualmachineinstances", "guestosinfo",
 				allowGetFor("admin", "edit", "view"),
@@ -317,7 +321,6 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				"virtualmachineinstances", "userlist",
 				allowGetFor("admin", "edit", "view"),
 				denyAllFor("default")),
-
 			Entry("on vmi filesystemlist",
 				"virtualmachineinstances", "filesystemlist",
 				allowGetFor("admin", "edit", "view"),
@@ -346,6 +349,13 @@ var _ = Describe("[rfe_id:500][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				"virtualmachineinstances", "portforward",
 				allowUpdateFor("admin", "edit"),
 				denyAllFor("view", "default")),
+			Entry("on vmi vsock",
+				"virtualmachineinstances", "vsock",
+				denyAllFor("admin", "edit", "view", "default")),
+			Entry("on expand-vm-spec",
+				"expand-vm-spec", "",
+				allowUpdateFor("admin", "edit", "view"),
+				denyAllFor("default")),
 		)
 	})
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -31,8 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
-	"kubevirt.io/kubevirt/tests/util"
-
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -44,10 +42,10 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/testsuite"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 var _ = Describe("[sig-compute]Subresource Api", func() {
-
 	var err error
 	var virtCli kubecli.KubevirtClient
 
@@ -253,165 +251,6 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
 			})
 		})
-
-		Context("ExpandSpec endpoint", func() {
-			Context("instancetype", func() {
-				var (
-					instancetype *instancetypev1alpha2.VirtualMachineInstancetype
-					expectedCpu  *v1.CPU
-					vmi          *v1.VirtualMachineInstance
-				)
-
-				BeforeEach(func() {
-					instancetype = newVirtualMachineInstancetype(nil)
-					instancetype.Spec.CPU.Guest = 2
-
-					expectedCpu = &v1.CPU{
-						Sockets: 2,
-						Cores:   1,
-						Threads: 1,
-					}
-
-					var err error
-					instancetype, err = virtCli.VirtualMachineInstancetype(util.NamespaceTestDefault).
-						Create(context.Background(), instancetype, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					vmi = libvmi.New()
-				})
-
-				AfterEach(func() {
-					err := virtCli.VirtualMachineInstancetype(util.NamespaceTestDefault).
-						Delete(context.Background(), instancetype.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("[test_id:TODO] should return unchanged VirtualMachine, if instancetype is not used", func() {
-					vm := tests.NewRandomVirtualMachine(vmi, false)
-
-					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{Sockets: 2, Cores: 1, Threads: 1}
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
-						GetWithExpandedSpec(vm.GetName())
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(expandedVm.Spec).To(Equal(vm.Spec))
-				})
-
-				It("[test_id:TODO] should return VirtualMachine with instancetype expanded", func() {
-
-					vm := tests.NewRandomVirtualMachine(vmi, false)
-					vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-						Name: instancetype.Name,
-						Kind: instancetypeapi.SingularResourceName,
-					}
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
-						GetWithExpandedSpec(vm.GetName())
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(expandedVm.Spec.Instancetype).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
-					Expect(expandedVm.Spec.Template.Spec.Domain.CPU).To(Equal(expectedCpu), "VM should have instancetype expanded")
-				})
-
-				It("[test_id:TODO] should fail, if referenced instancetype does not exist", func() {
-					vm := tests.NewRandomVirtualMachine(vmi, false)
-					vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-						Name: "noniexisting-instancetype",
-						Kind: instancetypeapi.SingularResourceName,
-					}
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).To(HaveOccurred())
-				})
-
-				It("[test_id:TODO] should fail, if instancetype expansion hits a conflict", func() {
-					vm := tests.NewRandomVirtualMachine(vmi, false)
-					vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-						Name: instancetype.Name,
-						Kind: instancetypeapi.SingularResourceName,
-					}
-
-					vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{Sockets: 1, Cores: 1, Threads: 1}
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).To(HaveOccurred())
-				})
-			})
-
-			Context("preference", func() {
-				var preference *instancetypev1alpha2.VirtualMachinePreference
-
-				BeforeEach(func() {
-					preference = newVirtualMachinePreference()
-					preference.Spec.Devices = &instancetypev1alpha2.DevicePreferences{
-						PreferredAutoattachGraphicsDevice: pointer.Bool(true),
-					}
-
-					var err error
-					preference, err = virtCli.VirtualMachinePreference(util.NamespaceTestDefault).
-						Create(context.Background(), preference, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				AfterEach(func() {
-					err := virtCli.VirtualMachinePreference(util.NamespaceTestDefault).
-						Delete(context.Background(), preference.Name, metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("[test_id:TODO] should return unchanged VirtualMachine, if preference is not used", func() {
-					// Using NewCirros() here to have some data in spec.
-					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
-						GetWithExpandedSpec(vm.GetName())
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(expandedVm.Spec).To(Equal(vm.Spec))
-				})
-
-				It("[test_id:TODO] should return VirtualMachine with preference expanded", func() {
-					// Using NewCirros() here to have some data in spec.
-					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
-					vm.Spec.Preference = &v1.PreferenceMatcher{
-						Name: preference.Name,
-						Kind: instancetypeapi.SingularPreferenceResourceName,
-					}
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).ToNot(HaveOccurred())
-
-					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
-						GetWithExpandedSpec(vm.GetName())
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(expandedVm.Spec.Preference).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
-					Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeTrue(), "VM should have preference expanded")
-				})
-
-				It("[test_id:TODO] should fail, if referenced preference does not exist", func() {
-					// Using NewCirros() here to have some data in spec.
-					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
-					vm.Spec.Preference = &v1.PreferenceMatcher{
-						Name: "nonexisting-preference",
-						Kind: instancetypeapi.SingularPreferenceResourceName,
-					}
-
-					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
-					Expect(err).To(HaveOccurred())
-				})
-			})
-		})
 	})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources", func() {
@@ -534,6 +373,276 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 
 				By("Wait Unfreeze VMI to be triggered")
 				waitVMIFSFreezeStatus("")
+			})
+		})
+	})
+
+	Describe("ExpandSpec subresource", func() {
+		Context("instancetype", func() {
+			var (
+				instancetype               *instancetypev1alpha2.VirtualMachineInstancetype
+				clusterInstancetype        *instancetypev1alpha2.VirtualMachineClusterInstancetype
+				instancetypeMatcher        *v1.InstancetypeMatcher
+				clusterInstancetypeMatcher *v1.InstancetypeMatcher
+				expectedCpu                *v1.CPU
+
+				instancetypeMatcherFn = func() *v1.InstancetypeMatcher {
+					return instancetypeMatcher
+				}
+				clusterInstancetypeMatcherFn = func() *v1.InstancetypeMatcher {
+					return clusterInstancetypeMatcher
+				}
+			)
+
+			BeforeEach(func() {
+				instancetype = newVirtualMachineInstancetype(nil)
+				instancetype.Spec.CPU.Guest = 2
+				instancetype, err = virtCli.VirtualMachineInstancetype(util.NamespaceTestDefault).
+					Create(context.Background(), instancetype, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				instancetypeMatcher = &v1.InstancetypeMatcher{
+					Name: instancetype.Name,
+					Kind: instancetypeapi.SingularResourceName,
+				}
+
+				clusterInstancetype = newVirtualMachineClusterInstancetype(nil)
+				clusterInstancetype.Spec.CPU.Guest = 2
+				clusterInstancetype, err = virtCli.VirtualMachineClusterInstancetype().
+					Create(context.Background(), clusterInstancetype, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				clusterInstancetypeMatcher = &v1.InstancetypeMatcher{
+					Name: clusterInstancetype.Name,
+					Kind: instancetypeapi.ClusterSingularResourceName,
+				}
+
+				expectedCpu = &v1.CPU{
+					Sockets: 2,
+					Cores:   1,
+					Threads: 1,
+				}
+			})
+
+			AfterEach(func() {
+				err = virtCli.VirtualMachineInstancetype(util.NamespaceTestDefault).
+					Delete(context.Background(), instancetype.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				err = virtCli.VirtualMachineClusterInstancetype().
+					Delete(context.Background(), clusterInstancetype.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("with existing VM", func() {
+				It("[test_id:TODO] should return unchanged VirtualMachine, if instancetype is not used", func() {
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
+						GetWithExpandedSpec(vm.GetName())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec).To(Equal(vm.Spec))
+				})
+
+				DescribeTable("[test_id:TODO] should return VirtualMachine with instancetype expanded", func(matcherFn func() *v1.InstancetypeMatcher) {
+					vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
+					vm.Spec.Instancetype = matcherFn()
+
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
+						GetWithExpandedSpec(vm.GetName())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec.Instancetype).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
+					Expect(expandedVm.Spec.Template.Spec.Domain.CPU).To(Equal(expectedCpu), "VM should have instancetype expanded")
+				},
+					Entry("with VirtualMachineInstancetype", instancetypeMatcherFn),
+					Entry("with VirtualMachineClusterInstancetype", clusterInstancetypeMatcherFn),
+				)
+			})
+
+			Context("with passed VM in request", func() {
+				It("[test_id:TODO] should return unchanged VirtualMachine, if instancetype is not used", func() {
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+
+					expandedVm, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec).To(Equal(vm.Spec))
+				})
+
+				DescribeTable("[test_id:TODO] should return VirtualMachine with instancetype expanded", func(matcherFn func() *v1.InstancetypeMatcher) {
+					vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
+					vm.Spec.Instancetype = matcherFn()
+
+					expandedVm, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec.Instancetype).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
+					Expect(expandedVm.Spec.Template.Spec.Domain.CPU).To(Equal(expectedCpu), "VM should have instancetype expanded")
+				},
+					Entry("with VirtualMachineInstancetype", instancetypeMatcherFn),
+					Entry("with VirtualMachineClusterInstancetype", clusterInstancetypeMatcherFn),
+				)
+
+				DescribeTable("[test_id:TODO] should fail, if referenced instancetype does not exist", func(matcher *v1.InstancetypeMatcher) {
+					vm := tests.NewRandomVirtualMachine(libvmi.New(), false)
+					vm.Spec.Instancetype = matcher
+
+					_, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(matcher.Kind + ".instancetype.kubevirt.io \"" + matcher.Name + "\" not found"))
+				},
+					Entry("with VirtualMachineInstancetype", &v1.InstancetypeMatcher{Name: "nonexisting-instancetype", Kind: instancetypeapi.PluralResourceName}),
+					Entry("with VirtualMachineClusterInstancetype", &v1.InstancetypeMatcher{Name: "nonexisting-clusterinstancetype", Kind: instancetypeapi.ClusterPluralResourceName}),
+				)
+
+				DescribeTable("[test_id:TODO] should fail, if instancetype expansion hits a conflict", func(matcherFn func() *v1.InstancetypeMatcher) {
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+					vm.Spec.Instancetype = matcherFn()
+
+					_, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("cannot expand instancetype to VM"))
+				},
+					Entry("with VirtualMachineInstancetype", instancetypeMatcherFn),
+					Entry("with VirtualMachineClusterInstancetype", clusterInstancetypeMatcherFn),
+				)
+
+				DescribeTable("[test_id:TODO] should fail, if VM and endpoint namespace are different", func(matcherFn func() *v1.InstancetypeMatcher) {
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+					vm.Spec.Instancetype = matcherFn()
+					vm.Namespace = "madethisup"
+
+					_, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).To(HaveOccurred())
+					errMsg := fmt.Sprintf("VM namespace must be empty or %s", util.NamespaceTestDefault)
+					Expect(err).To(MatchError(errMsg))
+				},
+					Entry("with VirtualMachineInstancetype", instancetypeMatcherFn),
+					Entry("with VirtualMachineClusterInstancetype", clusterInstancetypeMatcherFn),
+				)
+			})
+		})
+
+		Context("preference", func() {
+			var (
+				preference        *instancetypev1alpha2.VirtualMachinePreference
+				clusterPreference *instancetypev1alpha2.VirtualMachineClusterPreference
+
+				preferenceMatcher        *v1.PreferenceMatcher
+				clusterPreferenceMatcher *v1.PreferenceMatcher
+
+				preferenceMatcherFn = func() *v1.PreferenceMatcher {
+					return preferenceMatcher
+				}
+				clusterPreferenceMatcherFn = func() *v1.PreferenceMatcher {
+					return clusterPreferenceMatcher
+				}
+			)
+
+			BeforeEach(func() {
+				preference = newVirtualMachinePreference()
+				preference.Spec.Devices = &instancetypev1alpha2.DevicePreferences{
+					PreferredAutoattachGraphicsDevice: pointer.Bool(true),
+				}
+				preference, err = virtCli.VirtualMachinePreference(util.NamespaceTestDefault).
+					Create(context.Background(), preference, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				preferenceMatcher = &v1.PreferenceMatcher{
+					Name: preference.Name,
+					Kind: instancetypeapi.SingularPreferenceResourceName,
+				}
+
+				clusterPreference = newVirtualMachineClusterPreference()
+				clusterPreference.Spec.Devices = &instancetypev1alpha2.DevicePreferences{
+					PreferredAutoattachGraphicsDevice: pointer.Bool(true),
+				}
+				clusterPreference, err = virtCli.VirtualMachineClusterPreference().
+					Create(context.Background(), clusterPreference, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				clusterPreferenceMatcher = &v1.PreferenceMatcher{
+					Name: clusterPreference.Name,
+					Kind: instancetypeapi.ClusterSingularPreferenceResourceName,
+				}
+			})
+
+			AfterEach(func() {
+				err = virtCli.VirtualMachinePreference(util.NamespaceTestDefault).
+					Delete(context.Background(), preference.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				err = virtCli.VirtualMachineClusterPreference().
+					Delete(context.Background(), clusterPreference.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("with existing VM", func() {
+				It("[test_id:TODO] should return unchanged VirtualMachine, if preference is not used", func() {
+					// Using NewCirros() here to have some data in spec.
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
+						GetWithExpandedSpec(vm.GetName())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec).To(Equal(vm.Spec))
+				})
+
+				DescribeTable("[test_id:TODO] should return VirtualMachine with preference expanded", func(matcherFn func() *v1.PreferenceMatcher) {
+					// Using NewCirros() here to have some data in spec.
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+					vm.Spec.Preference = matcherFn()
+
+					vm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).Create(vm)
+					Expect(err).ToNot(HaveOccurred())
+
+					expandedVm, err := virtCli.VirtualMachine(util.NamespaceTestDefault).
+						GetWithExpandedSpec(vm.GetName())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec.Preference).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
+					Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeTrue(), "VM should have preference expanded")
+				},
+					Entry("with VirtualMachinePreference", preferenceMatcherFn),
+					Entry("with VirtualMachineClusterPreference", clusterPreferenceMatcherFn),
+				)
+			})
+
+			Context("with passed VM in request", func() {
+				It("[test_id:TODO] should return unchanged VirtualMachine, if preference is not used", func() {
+					// Using NewCirros() here to have some data in spec.
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+
+					expandedVm, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec).To(Equal(vm.Spec))
+				})
+
+				DescribeTable("[test_id:TODO] should return VirtualMachine with preference expanded", func(matcherFn func() *v1.PreferenceMatcher) {
+					// Using NewCirros() here to have some data in spec.
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+					vm.Spec.Preference = matcherFn()
+
+					expandedVm, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(expandedVm.Spec.Preference).To(BeNil(), "Expanded VM should not have InstancetypeMatcher")
+					Expect(*expandedVm.Spec.Template.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeTrue(), "VM should have preference expanded")
+				},
+					Entry("with VirtualMachinePreference", preferenceMatcherFn),
+					Entry("with VirtualMachineClusterPreference", clusterPreferenceMatcherFn),
+				)
+
+				DescribeTable("[test_id:TODO] should fail, if referenced preference does not exist", func(matcher *v1.PreferenceMatcher) {
+					// Using NewCirros() here to have some data in spec.
+					vm := tests.NewRandomVirtualMachine(libvmi.NewCirros(), false)
+					vm.Spec.Preference = matcher
+
+					_, err := virtCli.ExpandSpec(util.NamespaceTestDefault).ForVirtualMachine(vm)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(matcher.Kind + ".instancetype.kubevirt.io \"" + matcher.Name + "\" not found"))
+				},
+					Entry("with VirtualMachinePreference", &v1.PreferenceMatcher{Name: "nonexisting-preference", Kind: instancetypeapi.PluralPreferenceResourceName}),
+					Entry("with VirtualMachineClusterPreference", &v1.PreferenceMatcher{Name: "nonexisting-clusterpreference", Kind: instancetypeapi.ClusterPluralPreferenceResourceName}),
+				)
 			})
 		})
 	})

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -110,6 +110,18 @@ var _ = Describe("[sig-compute]Subresource Api", func() {
 		})
 	})
 
+	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] Rbac Authorization For Expand-Spec Command", func() {
+		const resource = "expand-vm-spec"
+
+		It("should be allowed to access expand-vm-spec endpoint with authenticated user", func() {
+			testClientJob(virtCli, true, resource)
+		})
+
+		It("should not be able to access expand-vm-spec endpoint without authenticated user", func() {
+			testClientJob(virtCli, false, resource)
+		})
+	})
+
 	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource", func() {
 		Context("with a restart endpoint", func() {
 			It("[test_id:1304] should restart a VM", func() {

--- a/tests/testsuite/serviceaccount.go
+++ b/tests/testsuite/serviceaccount.go
@@ -107,12 +107,14 @@ func createServiceAccount(saName string, clusterRole string) {
 			Name:     clusterRole,
 			APIGroup: "rbac.authorization.k8s.io",
 		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: util.NamespaceTestDefault,
+			},
+		},
 	}
-	roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
-		Kind:      "ServiceAccount",
-		Name:      saName,
-		Namespace: util.NamespaceTestDefault,
-	})
 
 	_, err = virtCli.RbacV1().RoleBindings(util.NamespaceTestDefault).Create(context.Background(), &roleBinding, metav1.CreateOptions{})
 	if !k8serrors.IsAlreadyExists(err) {
@@ -155,7 +157,6 @@ func createSubresourceServiceAccount() {
 	}
 
 	role := rbacv1.Role{
-
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SubresourceServiceAccountName,
 			Namespace: util.NamespaceTestDefault,
@@ -163,12 +164,14 @@ func createSubresourceServiceAccount() {
 				util.KubevirtIoTest: "sa",
 			},
 		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"subresources.kubevirt.io"},
+				Resources: []string{"virtualmachines/start", "expand-vm-spec"},
+				Verbs:     []string{"update"},
+			},
+		},
 	}
-	role.Rules = append(role.Rules, rbacv1.PolicyRule{
-		APIGroups: []string{"subresources.kubevirt.io"},
-		Resources: []string{"virtualmachines/start"},
-		Verbs:     []string{"update"},
-	})
 
 	_, err = virtCli.RbacV1().Roles(util.NamespaceTestDefault).Create(context.Background(), &role, metav1.CreateOptions{})
 	if !k8serrors.IsAlreadyExists(err) {
@@ -188,12 +191,14 @@ func createSubresourceServiceAccount() {
 			Name:     SubresourceServiceAccountName,
 			APIGroup: "rbac.authorization.k8s.io",
 		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      SubresourceServiceAccountName,
+				Namespace: util.NamespaceTestDefault,
+			},
+		},
 	}
-	roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
-		Kind:      "ServiceAccount",
-		Name:      SubresourceServiceAccountName,
-		Namespace: util.NamespaceTestDefault,
-	})
 
 	_, err = virtCli.RbacV1().RoleBindings(util.NamespaceTestDefault).Create(context.Background(), &roleBinding, metav1.CreateOptions{})
 	if !k8serrors.IsAlreadyExists(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual backport of #8720

/area instancetype
/assign @davidvossel 
/assign @lyarwood 

**Which issue(s) this PR fixes**:

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2134825

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The expand-spec subresource endpoint was renamed to expand-vm-spec and made namespaced
```
