### PR TITLE
Update tests wrt ginkgo 2: remove scripting running parallel vs. serial tests 

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -66,45 +66,17 @@ function functest() {
     _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s $@ _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path}
 }
 
-if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
-    trap "_out/tests/junit-merger -o ${ARTIFACTS}/junit.functest.xml '${ARTIFACTS}/partial.*.xml'" EXIT
-    parallel_test_args=""
-    serial_test_args=""
-
-    if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
-        parallel_test_args="${parallel_test_args} --skip=\\[Serial\\]|${KUBEVIRT_E2E_SKIP}"
-        serial_test_args="${serial_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
-    else
-        parallel_test_args="${parallel_test_args} --skip=\\[Serial\\]"
-    fi
-
-    if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
-        parallel_test_args="${parallel_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
-        serial_test_args="${serial_test_args} --focus=\\[Serial\\].*(${KUBEVIRT_E2E_FOCUS})|(${KUBEVIRT_E2E_FOCUS}).*\\[Serial\\]"
-    else
-        serial_test_args="${serial_test_args} --focus=\\[Serial\\]"
-    fi
-
-    return_value=0
-    set +e
-    functest --nodes=${KUBEVIRT_E2E_PARALLEL_NODES} ${parallel_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
-    return_value="$?"
-    set -e
-    if [ "$return_value" -ne 0 ] && ! [ "$KUBEVIRT_E2E_RUN_ALL_SUITES" == "true" ]; then
-        exit "$return_value"
-    fi
-    KUBEVIRT_FUNC_TEST_SUITE_ARGS="-junit-output ${ARTIFACTS}/partial.junit.functest.xml ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
-    functest ${serial_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
-    exit "$return_value"
-else
-    additional_test_args=""
-    if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
-        additional_test_args="${additional_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
-    fi
-
-    if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
-        additional_test_args="${additional_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
-    fi
-
-    functest ${additional_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
+test_args=""
+if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+    test_args="${test_args} --skip=${KUBEVIRT_E2E_SKIP}"
 fi
+
+if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+    test_args="${test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
+fi
+
+if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
+    test_args="--nodes=${KUBEVIRT_E2E_PARALLEL_NODES} ${test_args}"
+fi
+
+functest ${test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -68,7 +68,6 @@ func TestTests(t *testing.T) {
 	suiteConfig, _ := GinkgoConfiguration()
 	if suiteConfig.ParallelTotal > 1 {
 		artifactsPath = filepath.Join(artifactsPath, strconv.Itoa(GinkgoParallelProcess()))
-		junitOutput = filepath.Join(flags.ArtifactsDir, fmt.Sprintf("partial.junit.functest.%d.xml", GinkgoParallelProcess()))
 	}
 
 	outputEnricherReporter := reporter.NewCapturedOutputEnricher(
@@ -77,9 +76,6 @@ func TestTests(t *testing.T) {
 	afterSuiteReporters = append(afterSuiteReporters, outputEnricherReporter)
 
 	if qe_reporters.Polarion.Run {
-		if suiteConfig.ParallelTotal > 1 {
-			qe_reporters.Polarion.Filename = filepath.Join(flags.ArtifactsDir, fmt.Sprintf("partial.polarion.functest.%d.xml", GinkgoParallelProcess()))
-		}
 		afterSuiteReporters = append(afterSuiteReporters, &qe_reporters.Polarion)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Ginkgo V2 has the decorator [Serial](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#serial-decorator) that is designed for running tests in serial. Also the [docs for parallel test support](https://onsi.github.io/ginkgo/#spec-parallelization) say that the test results will be captured in one output stream in Ginkgo 2.

In https://github.com/kubevirt/kubevirt/pull/8770 we have added the Serial decorator and modified the checks for tests running serial.

We are now removing the unnecessary shell code and the output file handling here, since the merge is no longer necessary. Thus also the fuss around output file names was removed from `tests_suite_test.go`.

Note: Removing the junit-merger will be done in a follow up PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

See https://github.com/kubevirt/kubevirt/issues/8776

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Continue changes to Ginkgo V2 Serial runs
```
