### PR TITLE
Expose new custom components env vars to csv-generator and manifest-templator

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1197,8 +1197,6 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: KUBEVIRT_VERSION
-                  value: {{.DockerTag}}
                 - name: VIRT_API_SHASUM
                   value: {{if .VirtApiSha}}{{.VirtApiSha}}{{end}}
                 - name: VIRT_CONTROLLER_SHASUM
@@ -1211,6 +1209,8 @@ spec:
                   value: {{if .VirtExportProxySha}}{{.VirtExportProxySha}}{{end}}
                 - name: VIRT_EXPORTSERVER_SHASUM
                   value: {{if .VirtExportServerSha}}{{.VirtExportServerSha}}{{end}}
+                - name: KUBEVIRT_VERSION
+                  value: {{.DockerTag}}
                 - name: GS_SHASUM
                   value: {{if .GsSha}}{{.GsSha}}{{end}}
                 image: {{.DockerPrefix}}/virt-operator{{if .VirtOperatorSha}}@{{.VirtOperatorSha}}{{else}}:{{.DockerTag}}{{end}}

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -482,7 +482,8 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 
 // Used for manifest generation only
 func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosity, kubeVirtVersionEnv, virtApiShaEnv, virtControllerShaEnv, virtHandlerShaEnv, virtLauncherShaEnv, virtExportProxyShaEnv,
-	virtExportServerShaEnv, gsShaEnv, image string, pullPolicy corev1.PullPolicy) (*appsv1.Deployment, error) {
+	virtExportServerShaEnv, gsShaEnv, virtApiImageEnv, virtControllerImageEnv, virtHandlerImageEnv, virtLauncherImageEnv, virtExportProxyImageEnv, virtExportServerImageEnv,
+	image string, pullPolicy corev1.PullPolicy) (*appsv1.Deployment, error) {
 
 	const kubernetesOSLinux = "linux"
 	podAntiAffinity := newPodAntiAffinity(kubevirtLabelKey, kubernetesHostnameTopologyKey, metav1.LabelSelectorOpIn, []string{VirtOperatorName})

--- a/pkg/virt-operator/resource/generate/csv/csv.go
+++ b/pkg/virt-operator/resource/generate/csv/csv.go
@@ -40,26 +40,32 @@ import (
 const xDescriptorText = "urn:alm:descriptor:text"
 
 type NewClusterServiceVersionData struct {
-	Namespace            string
-	KubeVirtVersion      string
-	OperatorImageVersion string
-	DockerPrefix         string
-	ImagePrefix          string
-	ImagePullPolicy      string
-	Verbosity            string
-	CsvVersion           string
-	VirtApiSha           string
-	VirtControllerSha    string
-	VirtHandlerSha       string
-	VirtLauncherSha      string
-	VirtExportProxySha   string
-	VirtExportServerSha  string
-	GsSha                string
-	Replicas             int
-	IconBase64           string
-	ReplacesCsvVersion   string
-	CreatedAtTimestamp   string
-	VirtOperatorImage    string
+	Namespace             string
+	KubeVirtVersion       string
+	OperatorImageVersion  string
+	DockerPrefix          string
+	ImagePrefix           string
+	ImagePullPolicy       string
+	Verbosity             string
+	CsvVersion            string
+	VirtApiSha            string
+	VirtControllerSha     string
+	VirtHandlerSha        string
+	VirtLauncherSha       string
+	VirtExportProxySha    string
+	VirtExportServerSha   string
+	GsSha                 string
+	Replicas              int
+	IconBase64            string
+	ReplacesCsvVersion    string
+	CreatedAtTimestamp    string
+	VirtOperatorImage     string
+	VirtApiImage          string
+	VirtControllerImage   string
+	VirtHandlerImage      string
+	VirtLauncherImage     string
+	VirtExportProxyImage  string
+	VirtExportServerImage string
 }
 
 type csvClusterPermissions struct {
@@ -163,6 +169,12 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		data.VirtExportServerSha,
 		data.GsSha,
 		data.VirtOperatorImage,
+		data.VirtApiImage,
+		data.VirtControllerImage,
+		data.VirtHandlerImage,
+		data.VirtLauncherImage,
+		data.VirtExportProxyImage,
+		data.VirtExportServerImage,
 		v1.PullPolicy(data.ImagePullPolicy))
 	if err != nil {
 		return nil, err

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -329,26 +329,7 @@ func VerifyEnvWithEnvVarManager(envVarManager EnvVarManager) error {
 	// ensure the operator image is valid
 	imageString := GetOperatorImageWithEnvVarManager(envVarManager)
 	if imageString == "" {
-		return fmt.Errorf("empty env var %s for operator image", OldOperatorImageEnvName)
-	}
-	imageRegEx := regexp.MustCompile(operatorImageRegex)
-	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)
-	if len(matches) != 1 || len(matches[0]) != 4 {
-		return fmt.Errorf("can not parse operator image env var %s", imageString)
-	}
-
-	// ensure that all or no shasums are given
-	missingShas := make([]string, 0)
-	count := 0
-	for _, name := range []string{VirtApiShasumEnvName, VirtControllerShasumEnvName, VirtHandlerShasumEnvName, VirtLauncherShasumEnvName, KubeVirtVersionEnvName} {
-		count++
-		sha := envVarManager.Getenv(name)
-		if sha == "" {
-			missingShas = append(missingShas, name)
-		}
-	}
-	if len(missingShas) > 0 && len(missingShas) < count {
-		return fmt.Errorf("incomplete configuration, missing env vars %v", missingShas)
+		return fmt.Errorf("cannot find virt-operator's image")
 	}
 
 	return nil

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -28,6 +28,10 @@ import (
 	"kubevirt.io/kubevirt/tools/util"
 )
 
+const (
+	customImageExample = "Examples: some.registry.com@sha256:abcdefghijklmnop, other.registry.com:tag1"
+)
+
 func main() {
 	namespace := flag.String("namespace", "placeholder", "Namespace to use.")
 	operatorImageVersion := flag.String("operatorImageVersion", "latest", "Image sha256 hash or image tag used to uniquely identify the operator container image to use in the CSV")
@@ -49,30 +53,42 @@ func main() {
 	csvCreatedAtTimestamp := flag.String("csvCreatedAtTimestamp", "", "creation timestamp set in the 'createdAt' annotation on the CSV")
 	dumpCRDs := flag.Bool("dumpCRDs", false, "dump CRDs along with CSV manifests to stdout")
 	virtOperatorImage := flag.String("virt-operator-image", "", "custom image for virt-operator")
+	virtApiImage := flag.String("virt-api-image", "", "custom image for virt-api. "+customImageExample)
+	virtControllerImage := flag.String("virt-controller-image", "", "custom image for virt-controller. "+customImageExample)
+	virtHandlerImage := flag.String("virt-handler-image", "", "custom image for virt-handler. "+customImageExample)
+	virtLauncherImage := flag.String("virt-launcher-image", "", "custom image for virt-launcher. "+customImageExample)
+	virtExportProxyImage := flag.String("virt-export-proxy-image", "", "custom image for virt-export-proxy. "+customImageExample)
+	virtExportServerImage := flag.String("virt-export-server-image", "", "custom image for virt-export-server. "+customImageExample)
 
 	flag.Parse()
 
 	csvData := csv.NewClusterServiceVersionData{
-		Namespace:            *namespace,
-		KubeVirtVersion:      *kubeVirtVersion,
-		OperatorImageVersion: *operatorImageVersion,
-		DockerPrefix:         *dockerPrefix,
-		ImagePrefix:          *imagePrefix,
-		ImagePullPolicy:      *pullPolicy,
-		Verbosity:            *verbosity,
-		CsvVersion:           *csvVersion,
-		VirtApiSha:           *apiSha,
-		VirtControllerSha:    *controllerSha,
-		VirtHandlerSha:       *handlerSha,
-		VirtLauncherSha:      *launcherSha,
-		VirtExportProxySha:   *exportProxySha,
-		VirtExportServerSha:  *exportServerSha,
-		GsSha:                *gsSha,
-		ReplacesCsvVersion:   *replacesCsvVersion,
-		IconBase64:           *kubeVirtLogo,
-		Replicas:             2,
-		CreatedAtTimestamp:   *csvCreatedAtTimestamp,
-		VirtOperatorImage:    *virtOperatorImage,
+		Namespace:             *namespace,
+		KubeVirtVersion:       *kubeVirtVersion,
+		OperatorImageVersion:  *operatorImageVersion,
+		DockerPrefix:          *dockerPrefix,
+		ImagePrefix:           *imagePrefix,
+		ImagePullPolicy:       *pullPolicy,
+		Verbosity:             *verbosity,
+		CsvVersion:            *csvVersion,
+		VirtApiSha:            *apiSha,
+		VirtControllerSha:     *controllerSha,
+		VirtHandlerSha:        *handlerSha,
+		VirtLauncherSha:       *launcherSha,
+		VirtExportProxySha:    *exportProxySha,
+		VirtExportServerSha:   *exportServerSha,
+		GsSha:                 *gsSha,
+		ReplacesCsvVersion:    *replacesCsvVersion,
+		IconBase64:            *kubeVirtLogo,
+		Replicas:              2,
+		CreatedAtTimestamp:    *csvCreatedAtTimestamp,
+		VirtOperatorImage:     *virtOperatorImage,
+		VirtApiImage:          *virtApiImage,
+		VirtControllerImage:   *virtControllerImage,
+		VirtHandlerImage:      *virtHandlerImage,
+		VirtLauncherImage:     *virtLauncherImage,
+		VirtExportProxyImage:  *virtExportProxyImage,
+		VirtExportServerImage: *virtExportServerImage,
 	}
 
 	operatorCsv, err := csv.NewClusterServiceVersion(&csvData)

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	customImageExample = "Examples: some.registry.com@sha256:abcdefghijklmnop, other.registry.com:tag1"
+	customImageExample   = "Examples: some.registry.com@sha256:abcdefghijklmnop, other.registry.com:tag1"
+	shaEnvDeprecationMsg = "This argument is deprecated. Please use virt-*-image instead"
 )
 
 func main() {
@@ -40,12 +41,12 @@ func main() {
 	kubeVirtVersion := flag.String("kubeVirtVersion", "", "represents the KubeVirt releaseassociated with this CSV. Required when image SHAs are used.")
 	pullPolicy := flag.String("pullPolicy", "IfNotPresent", "ImagePullPolicy to use.")
 	verbosity := flag.String("verbosity", "2", "Verbosity level to use.")
-	apiSha := flag.String("apiSha", "", "virt-api image sha")
-	controllerSha := flag.String("controllerSha", "", "virt-controller image sha")
-	handlerSha := flag.String("handlerSha", "", "virt-handler image sha")
-	launcherSha := flag.String("launcherSha", "", "virt-launcher image sha")
-	exportProxySha := flag.String("exportProxySha", "", "virt-exportproxy image sha")
-	exportServerSha := flag.String("exportServerSha", "", "virt-exportserver image sha")
+	apiSha := flag.String("apiSha", "", "virt-api image sha. "+shaEnvDeprecationMsg)
+	controllerSha := flag.String("controllerSha", "", "virt-controller image sha. "+shaEnvDeprecationMsg)
+	handlerSha := flag.String("handlerSha", "", "virt-handler image sha. "+shaEnvDeprecationMsg)
+	launcherSha := flag.String("launcherSha", "", "virt-launcher image sha. "+shaEnvDeprecationMsg)
+	exportProxySha := flag.String("exportProxySha", "", "virt-exportproxy image sha. "+shaEnvDeprecationMsg)
+	exportServerSha := flag.String("exportServerSha", "", "virt-exportserver image sha. "+shaEnvDeprecationMsg)
 	gsSha := flag.String("gsSha", "", "libguestfs-tools image sha")
 	kubeVirtLogo := flag.String("kubevirtLogo", "", "kubevirt logo data in base64")
 	csvVersion := flag.String("csvVersion", "", "the CSV version being generated")

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -41,6 +41,10 @@ import (
 	"kubevirt.io/kubevirt/tools/util"
 )
 
+const (
+	customImageExample = "Examples: some.registry.com@sha256:abcdefghijklmnop, other.registry.com:tag1"
+)
+
 type templateData struct {
 	Namespace              string
 	CDINamespace           string
@@ -72,6 +76,12 @@ type templateData struct {
 	InfraReplicas          uint8
 	GeneratedManifests     map[string]string
 	VirtOperatorImage      string
+	VirtApiImage           string
+	VirtControllerImage    string
+	VirtHandlerImage       string
+	VirtLauncherImage      string
+	VirtExportProxyImage   string
+	VirtExportServerImage  string
 }
 
 func main() {
@@ -103,6 +113,12 @@ func main() {
 	featureGates := flag.String("feature-gates", "", "")
 	infraReplicas := flag.Uint("infra-replicas", 0, "")
 	virtOperatorImage := flag.String("virt-operator-image", "", "custom image for virt-operator")
+	virtApiImage := flag.String("virt-api-image", "", "custom image for virt-api. "+customImageExample)
+	virtControllerImage := flag.String("virt-controller-image", "", "custom image for virt-controller. "+customImageExample)
+	virtHandlerImage := flag.String("virt-handler-image", "", "custom image for virt-handler. "+customImageExample)
+	virtLauncherImage := flag.String("virt-launcher-image", "", "custom image for virt-launcher. "+customImageExample)
+	virtExportProxyImage := flag.String("virt-export-proxy-image", "", "custom image for virt-export-proxy. "+customImageExample)
+	virtExportServerImage := flag.String("virt-export-server-image", "", "custom image for virt-export-server. "+customImageExample)
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.CommandLine.ParseErrorsWhitelist.UnknownFlags = true
@@ -154,6 +170,12 @@ func main() {
 		data.OperatorDeploymentSpec = getOperatorDeploymentSpec(data, 2)
 		data.PriorityClassSpec = getPriorityClassSpec(2)
 		data.VirtOperatorImage = *virtOperatorImage
+		data.VirtApiImage = *virtApiImage
+		data.VirtControllerImage = *virtControllerImage
+		data.VirtHandlerImage = *virtHandlerImage
+		data.VirtLauncherImage = *virtLauncherImage
+		data.VirtExportProxyImage = *virtExportProxyImage
+		data.VirtExportServerImage = *virtExportServerImage
 		if *featureGates != "" {
 			data.FeatureGates = strings.Split(*featureGates, ",")
 		}
@@ -207,6 +229,12 @@ func main() {
 		data.KubeVirtLogo = "{{.KubeVirtLogo}}"
 		data.PackageName = "{{.PackageName}}"
 		data.CreatedAt = "{{.CreatedAt}}"
+		data.VirtApiImage = "{{.VirtApiImage}}"
+		data.VirtControllerImage = "{{.VirtControllerImage}}"
+		data.VirtHandlerImage = "{{.VirtHandlerImage}}"
+		data.VirtLauncherImage = "{{.VirtLauncherImage}}"
+		data.VirtExportProxyImage = "{{.VirtExportProxyImage}}"
+		data.VirtExportServerImage = "{{.VirtExportServerImage}}"
 	}
 
 	if *processFiles {
@@ -276,6 +304,12 @@ func getOperatorDeploymentSpec(data templateData, indentation int) string {
 		data.VirtExportProxySha,
 		data.VirtExportServerSha,
 		data.GsSha,
+		data.VirtApiImage,
+		data.VirtControllerImage,
+		data.VirtHandlerImage,
+		data.VirtLauncherImage,
+		data.VirtExportProxyImage,
+		data.VirtExportServerImage,
 		data.VirtOperatorImage,
 		v1.PullPolicy(data.ImagePullPolicy))
 	if err != nil {

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -42,7 +42,8 @@ import (
 )
 
 const (
-	customImageExample = "Examples: some.registry.com@sha256:abcdefghijklmnop, other.registry.com:tag1"
+	customImageExample   = "Examples: some.registry.com@sha256:abcdefghijklmnop, other.registry.com:tag1"
+	shaEnvDeprecationMsg = "This argument is deprecated. Please use virt-*-image instead"
 )
 
 type templateData struct {
@@ -102,13 +103,13 @@ func main() {
 	packageName := flag.String("package-name", "", "")
 	bundleOutDir := flag.String("bundle-out-dir", "", "")
 	quayRepository := flag.String("quay-repository", "", "")
-	virtOperatorSha := flag.String("virt-operator-sha", "", "")
-	virtApiSha := flag.String("virt-api-sha", "", "")
-	virtControllerSha := flag.String("virt-controller-sha", "", "")
-	virtHandlerSha := flag.String("virt-handler-sha", "", "")
-	virtLauncherSha := flag.String("virt-launcher-sha", "", "")
-	virtExportProxySha := flag.String("virt-exportproxy-sha", "", "")
-	virtExportServerSha := flag.String("virt-exportserver-sha", "", "")
+	virtOperatorSha := flag.String("virt-operator-sha", "", shaEnvDeprecationMsg)
+	virtApiSha := flag.String("virt-api-sha", "", shaEnvDeprecationMsg)
+	virtControllerSha := flag.String("virt-controller-sha", "", shaEnvDeprecationMsg)
+	virtHandlerSha := flag.String("virt-handler-sha", "", shaEnvDeprecationMsg)
+	virtLauncherSha := flag.String("virt-launcher-sha", "", shaEnvDeprecationMsg)
+	virtExportProxySha := flag.String("virt-exportproxy-sha", "", shaEnvDeprecationMsg)
+	virtExportServerSha := flag.String("virt-exportserver-sha", "", shaEnvDeprecationMsg)
 	gsSha := flag.String("gs-sha", "", "")
 	featureGates := flag.String("feature-gates", "", "")
 	infraReplicas := flag.Uint("infra-replicas", 0, "")


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up for https://github.com/kubevirt/kubevirt/pull/8673. This PR aims to expose the new env vars introduced in the previous PR to csv-generator and manifest-templator.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose new custom components env vars to csv-generator and manifest-templator
```
