### PR TITLE
revert network,passt: configure unprivileged_port_start to 0

### DIFF
--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -78,7 +78,6 @@ type NetworkHandler interface {
 	ConfigureRouteLocalNet(string) error
 	ConfigureIpv4ArpIgnore() error
 	ConfigurePingGroupRange() error
-	ConfigureUnprivilegedPortStart(string) error
 	NftablesNewChain(proto iptables.Protocol, table, chain string) error
 	NftablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
 	NftablesLoad(proto iptables.Protocol) error
@@ -159,11 +158,6 @@ func (h *NetworkUtilsHandler) ConfigurePingGroupRange() error {
 func (h *NetworkUtilsHandler) ConfigureRouteLocalNet(iface string) error {
 	routeLocalNetForIface := fmt.Sprintf(sysctl.IPv4RouteLocalNet, iface)
 	err := sysctl.New().SetSysctl(routeLocalNetForIface, allowRouteLocalNet)
-	return err
-}
-
-func (h *NetworkUtilsHandler) ConfigureUnprivilegedPortStart(port string) error {
-	err := sysctl.New().SetSysctl(sysctl.UnprivilegedPortStart, port)
 	return err
 }
 

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -274,16 +274,6 @@ func (_mr *_MockNetworkHandlerRecorder) ConfigurePingGroupRange() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigurePingGroupRange")
 }
 
-func (_m *MockNetworkHandler) ConfigureUnprivilegedPortStart(_param0 string) error {
-	ret := _m.ctrl.Call(_m, "ConfigureUnprivilegedPortStart", _param0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockNetworkHandlerRecorder) ConfigureUnprivilegedPortStart(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureUnprivilegedPortStart", arg0)
-}
-
 func (_m *MockNetworkHandler) NftablesNewChain(proto iptables.Protocol, table string, chain string) error {
 	ret := _m.ctrl.Call(_m, "NftablesNewChain", proto, table, chain)
 	ret0, _ := ret[0].(error)

--- a/pkg/network/infraconfigurators/passt.go
+++ b/pkg/network/infraconfigurators/passt.go
@@ -33,13 +33,6 @@ func (b *PasstPodNetworkConfigurator) PreparePodNetworkInterface() error {
 		log.Log.Reason(err).Errorf("failed to configure ping group range")
 		return err
 	}
-	// bugs.passt.top/show_bug.cgi?id=15 and bugs.passt.top/show_bug.cgi?id=18 are resolved
-	log.Log.V(4).Info("Configuring unprivilegedPortStart to 0")
-	err = b.handler.ConfigureUnprivilegedPortStart("0")
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to configure unprivilegedPortStart")
-		return err
-	}
 	return nil
 }
 

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -25,13 +25,12 @@ import (
 )
 
 const (
-	sysctlBase            = "/proc/sys"
-	NetIPv6Forwarding     = "net/ipv6/conf/all/forwarding"
-	NetIPv4Forwarding     = "net/ipv4/ip_forward"
-	Ipv4ArpIgnoreAll      = "net/ipv4/conf/all/arp_ignore"
-	PingGroupRange        = "net/ipv4/ping_group_range"
-	IPv4RouteLocalNet     = "net/ipv4/conf/%s/route_localnet"
-	UnprivilegedPortStart = "net/ipv4/ip_unprivileged_port_start"
+	sysctlBase        = "/proc/sys"
+	NetIPv6Forwarding = "net/ipv6/conf/all/forwarding"
+	NetIPv4Forwarding = "net/ipv4/ip_forward"
+	Ipv4ArpIgnoreAll  = "net/ipv4/conf/all/arp_ignore"
+	PingGroupRange    = "net/ipv4/ping_group_range"
+	IPv4RouteLocalNet = "net/ipv4/conf/%s/route_localnet"
 )
 
 // Interface is an injectable interface for running sysctl commands.


### PR DESCRIPTION
The sysctl configuration is no longer needed as the issues in passt are fixed:
- https://bugs.passt.top/show_bug.cgi?id=15
- https://bugs.passt.top/show_bug.cgi?id=18

We continue testing connectivity to low port in e2e tests.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
