### PR TITLE
virt-api: Add test for empty namespace in expand_test.go

### DIFF
--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -263,8 +263,19 @@ var _ = Describe("Instancetype expansion subresources", func() {
 			Expect(statusErr.Status().Message).To(Equal("Object is not a valid VirtualMachine"))
 		})
 
+		It("should fail if endpoint namespace is empty", func() {
+			request.PathParameters()["namespace"] = ""
+
+			vmJson, err := json.Marshal(vm)
+			Expect(err).ToNot(HaveOccurred())
+			request.Request.Body = io.NopCloser(bytes.NewBuffer(vmJson))
+
+			app.ExpandSpecRequestHandler(request, response)
+			statusErr := ExpectStatusErrorWithCode(recorder, http.StatusBadRequest)
+			Expect(statusErr.Status().Message).To(Equal("The request namespace must not be empty"))
+		})
+
 		It("should fail, if VM and endpoint namespace are different", func() {
-			request.PathParameters()["namespace"] = vmNamespace
 			vm.Namespace = "madethisup"
 
 			recorder = callExpandSpecApi(vm)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds a unit test which sets an empty namespace as path parameter for a call to the ExpandSpecRequestHandler. This is a theoretical situation which should not be technically possible at the moment.

Setting of the namespace path parameter in the following test was removed as it was redundant. callExpandSpecApi already does it.

This as a follow up to #8720 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
