### PR TITLE
Improve CleanNodes() function

### DIFF
--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -91,6 +91,7 @@ func CleanNodes() {
 
 		if node.Spec.Unschedulable {
 			new.Spec.Unschedulable = false
+			found = true
 		}
 
 		if !found {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently `CleanNodes()` does not restore the nodes if a test only changes the `spec.unschedulable` field. This can happen for example in a migration test, which set all control-plane nodes unschedulable, in a cluster where all nodes are both control-plane and worker. This results in a test failure, and since the nodes are not properly restored, the subsequent tests fail on cascading.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
