### PR TITLE
[e2e-tests]: Don't run all storage-req tests in sig-storage jobs

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -402,7 +402,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
       add_to_label_filter "(!migration-based-hotplug-NICs)" "&&"
     fi
   elif [[ $TARGET =~ sig-storage ]]; then
-    label_filter='((sig-storage,storage-req) && !sig-compute-migrations)'
+    label_filter='(sig-storage)'
   elif [[ $TARGET =~ vgpu.* ]]; then
     label_filter='(VGPU)'
   elif [[ $TARGET =~ sig-compute-realtime ]]; then


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Basically following up on 2 commits:
https://github.com/kubevirt/kubevirt/pull/7194/commits/5a630968c4a6dcff841074d92688a2cff8015813 https://github.com/kubevirt/kubevirt/pull/8242/commits/fa52935ce06a4c1f8d9daa12e6f4c1f049c7a924

I believe we did not intend for sig-compute tests to be run on sig-storage and vice-versa (this direction was handled in 8242), so let's stop doing that. storage-req tests that are under other sigs will continue running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
