### PR TITLE
Optimization: set termination grace period to zero on VM deletion

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"k8s.io/utils/pointer"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -73,10 +75,9 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 }
 
 func (mutator *VMsMutator) mutateDeletion(vm *v1.VirtualMachine) *admissionv1.AdmissionResponse {
-	// TODO: Implement
-	return &admissionv1.AdmissionResponse{
-		Allowed: true,
-	}
+	vm.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(0)
+
+	return convertVmToAdmissionResponse(vm)
 }
 
 func (mutator *VMsMutator) mutateCreation(vm *v1.VirtualMachine) *admissionv1.AdmissionResponse {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -285,6 +287,13 @@ var _ = Describe("VirtualMachine Mutator", func() {
 
 		vmSpec, _ := getVMSpecMetaFromResponse()
 		Expect(vmSpec.Template.Spec.Domain.Machine.Type).To(Equal(preference.Spec.Machine.PreferredMachineType))
+	})
+
+	It("should set termination grace period to zero on deletion", func() {
+		vm.Spec.Template.Spec.TerminationGracePeriodSeconds = pointer.Int64(123456)
+		vmSpec, _ := getVMSpecMetaFromResponseWithOperation(admissionv1.Delete)
+		Expect(vmSpec.Template.Spec.TerminationGracePeriodSeconds).ToNot(BeNil())
+		Expect(*vmSpec.Template.Spec.TerminationGracePeriodSeconds).To(BeZero())
 	})
 
 	Context("failure tests", func() {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -58,7 +58,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 
 	machineTypeFromConfig := "pc-q35-3.0"
 
-	getVMSpecMetaFromResponse := func() (*v1.VirtualMachineSpec, *k8smetav1.ObjectMeta) {
+	getVMSpecMetaFromResponseWithOperation := func(operation admissionv1.Operation) (*v1.VirtualMachineSpec, *k8smetav1.ObjectMeta) {
 		vmBytes, err := json.Marshal(vm)
 		Expect(err).ToNot(HaveOccurred())
 		By("Creating the test admissions review from the VM")
@@ -68,6 +68,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 				Object: runtime.RawExtension{
 					Raw: vmBytes,
 				},
+				Operation: operation,
 			},
 		}
 		By("Mutating the VM")
@@ -86,6 +87,10 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		Expect(patch).NotTo(BeEmpty())
 
 		return vmSpec, vmMeta
+	}
+
+	getVMSpecMetaFromResponse := func() (*v1.VirtualMachineSpec, *k8smetav1.ObjectMeta) {
+		return getVMSpecMetaFromResponseWithOperation(admissionv1.Create)
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
VMI's `TerminationGracePeriodSeconds` are defined to let the guest have time to gracefully shutdown. This is needed during the VM life-cycle as guest can shutdown and load back up many times.

When the VM is deleted, however, this means we won't ever start the guest again, hence we can forcefully remove it. This optimization is crucial for scaling as it's one of the current bottle-necks when it comes to mass vm deletions.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Optimization: set set termination grace period to zero on VM deletion
```
