### PR TITLE
change user for exportserver to root to make file can be download

### DIFF
--- a/cmd/virt-exportserver/BUILD.bazel
+++ b/cmd/virt-exportserver/BUILD.bazel
@@ -26,32 +26,7 @@ load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
 )
-load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
-passwd_entry(
-    name = "nonroot-user",
-    gid = 1001,
-    home = "/home/nonroot-user",
-    shell = "/bin/bash",
-    uid = 1001,
-    username = "nonroot-user",
-)
-
-passwd_file(
-    name = "passwd",
-    entries = [
-        ":nonroot-user",
-    ],
-)
-
-pkg_tar(
-    name = "passwd-tar",
-    srcs = [":passwd"],
-    mode = "0644",
-    package_dir = "etc",
-    visibility = ["//visibility:public"],
-)
 
 container_image(
     name = "version-container",
@@ -61,11 +36,9 @@ container_image(
     ],
     tars = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": [
-            ":passwd-tar",
             "//rpm:exportserverbase_aarch64",
         ],
         "//conditions:default": [
-            ":passwd-tar",
             "//rpm:exportserverbase_x86_64",
         ],
     }),
@@ -81,6 +54,5 @@ container_image(
     directory = "/usr/bin/",
     entrypoint = ["/usr/bin/virt-exportserver"],
     files = [":virt-exportserver"],
-    user = "1001",
     visibility = ["//visibility:public"],
 )

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -798,7 +798,6 @@ func (ctrl *VMExportController) createExporterPodManifest(vmExport *exportv1.Vir
 	podManifest.Labels = map[string]string{exportServiceLabel: vmExport.Name}
 	podManifest.Annotations = map[string]string{annCertParams: scp}
 	podManifest.Spec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot:   pointer.Bool(true),
 		FSGroup:        pointer.Int64Ptr(kvm),
 		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}


### PR DESCRIPTION
Signed-off-by: zhuanlan <zhuanlan_yewu@cmss.chinamobile.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, Downloading file from Export server failed because user right now(nonroot-user) can't open file /dev/export-volumes/XXX (code at /pkg/storage/export/virt-exportserver/exportserver.go 335 `f, err := os.Open(file) ` return err : permission denied)，because the block file is created by root and user nonroot-user have no permissions in /dev contents.

![image](https://user-images.githubusercontent.com/49519342/202353326-274c8619-9320-4643-873a-1e356078c3a2.png)


I think this is because the `fsgroup` setting in pod securitycontext doesn't work on volumeDevice, one solution is to change to root user in Export-server container. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
