### PR TITLE
migration: apply backoff only for evacuation migrations

### DIFF
--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -1699,10 +1699,23 @@ var _ = Describe("Migration watcher", func() {
 	Context("Migration backoff", func() {
 		var vmi *virtv1.VirtualMachineInstance
 
-		It("should be applied after a migration fails", func() {
+		setEvacuationAnnotation := func(migrations ...*v1.VirtualMachineInstanceMigration) {
+			for _, m := range migrations {
+				if m.Annotations == nil {
+					m.Annotations = map[string]string{
+						v1.EvacuationMigrationAnnotation: m.Name,
+					}
+				} else {
+					m.Annotations[v1.EvacuationMigrationAnnotation] = m.Name
+				}
+			}
+		}
+
+		It("should be applied after an evacuation migration fails", func() {
 			vmi = newVirtualMachine("testvmi", virtv1.Running)
 			failedMigration := newMigration("testmigration", vmi.Name, virtv1.MigrationFailed)
 			pendingMigration := newMigration("testmigration2", vmi.Name, virtv1.MigrationPending)
+			setEvacuationAnnotation(failedMigration, pendingMigration)
 
 			failedMigration.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
 				{
@@ -1721,11 +1734,34 @@ var _ = Describe("Migration watcher", func() {
 			testutils.ExpectEvent(recorder, "MigrationBackoff")
 		})
 
+		It("should not be applied if it is not an evacuation", func() {
+			vmi = newVirtualMachine("testvmi", virtv1.Running)
+			failedMigration := newMigration("testmigration", vmi.Name, virtv1.MigrationFailed)
+			pendingMigration := newMigration("testmigration2", vmi.Name, virtv1.MigrationPending)
+			setEvacuationAnnotation(failedMigration)
+
+			failedMigration.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
+				{
+					Phase:                    virtv1.MigrationFailed,
+					PhaseTransitionTimestamp: failedMigration.CreationTimestamp,
+				},
+			}
+			pendingMigration.CreationTimestamp = metav1.NewTime(failedMigration.CreationTimestamp.Add(time.Second * 1))
+
+			_ = migrationInformer.GetStore().Add(failedMigration)
+			_ = vmiInformer.GetStore().Add(vmi)
+			addMigration(pendingMigration)
+
+			controller.Execute()
+			shouldExpectPodCreation(vmi.UID, pendingMigration.UID, 1, 0, 0)
+		})
+
 		It("should be cleared when a migration succeeds", func() {
 			vmi = newVirtualMachine("testvmi", virtv1.Running)
 			failedMigration := newMigration("testmigration", vmi.Name, virtv1.MigrationFailed)
 			successfulMigration := newMigration("testmigration2", vmi.Name, virtv1.MigrationSucceeded)
 			pendingMigration := newMigration("testmigration3", vmi.Name, virtv1.MigrationPending)
+			setEvacuationAnnotation(failedMigration, pendingMigration, successfulMigration)
 
 			failedMigration.Status.PhaseTransitionTimestamps = []virtv1.VirtualMachineInstanceMigrationPhaseTransitionTimestamp{
 				{


### PR DESCRIPTION
Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Apply migration backoff only for evacuation migrations.
```
