### PR TITLE
[release-0.58] Deprecate mediatedDevicesTypes in favor of mediatedDeviceTypes

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17074,7 +17074,15 @@
     "description": "MediatedDevicesConfiguration holds information about MDEV types to be defined, if available",
     "type": "object",
     "properties": {
+     "mediatedDeviceTypes": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "mediatedDevicesTypes": {
+      "description": "Deprecated. Use mediatedDeviceTypes instead.",
       "type": "array",
       "items": {
        "type": "string"
@@ -17287,11 +17295,18 @@
     "description": "NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specifc node that matches the NodeSelector field.",
     "type": "object",
     "required": [
-     "nodeSelector",
-     "mediatedDevicesTypes"
+     "nodeSelector"
     ],
     "properties": {
+     "mediatedDeviceTypes": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "atomic"
+     },
      "mediatedDevicesTypes": {
+      "description": "Deprecated. Use mediatedDeviceTypes instead.",
       "type": "array",
       "items": {
        "type": "string"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -305,7 +305,13 @@ spec:
                     description: MediatedDevicesConfiguration holds information about
                       MDEV types to be defined, if available
                     properties:
+                      mediatedDeviceTypes:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       mediatedDevicesTypes:
+                        description: Deprecated. Use mediatedDeviceTypes instead.
                         items:
                           type: string
                         type: array
@@ -316,7 +322,13 @@ spec:
                             about MDEV types to be defined in a specifc node that
                             matches the NodeSelector field.
                           properties:
+                            mediatedDeviceTypes:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             mediatedDevicesTypes:
+                              description: Deprecated. Use mediatedDeviceTypes instead.
                               items:
                                 type: string
                               type: array
@@ -330,7 +342,6 @@ spec:
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                           required:
-                          - mediatedDevicesTypes
                           - nodeSelector
                           type: object
                         type: array
@@ -3013,7 +3024,13 @@ spec:
                     description: MediatedDevicesConfiguration holds information about
                       MDEV types to be defined, if available
                     properties:
+                      mediatedDeviceTypes:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       mediatedDevicesTypes:
+                        description: Deprecated. Use mediatedDeviceTypes instead.
                         items:
                           type: string
                         type: array
@@ -3024,7 +3041,13 @@ spec:
                             about MDEV types to be defined in a specifc node that
                             matches the NodeSelector field.
                           properties:
+                            mediatedDeviceTypes:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
                             mediatedDevicesTypes:
+                              description: Deprecated. Use mediatedDeviceTypes instead.
                               items:
                                 type: string
                               type: array
@@ -3038,7 +3061,6 @@ spec:
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                           required:
-                          - mediatedDevicesTypes
                           - nodeSelector
                           type: object
                         type: array

--- a/pkg/virt-config/configuration_test.go
+++ b/pkg/virt-config/configuration_test.go
@@ -487,7 +487,7 @@ var _ = Describe("test configuration", func() {
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
 					MediatedDevicesConfiguration: &v1.MediatedDevicesConfiguration{
-						MediatedDevicesTypes: []string{
+						MediatedDeviceTypes: []string{
 
 							"nvidia-222",
 							"nvidia-228",
@@ -498,7 +498,7 @@ var _ = Describe("test configuration", func() {
 								NodeSelector: map[string]string{
 									"testLabel1": "true",
 								},
-								MediatedDevicesTypes: []string{
+								MediatedDeviceTypes: []string{
 									"nvidia-223",
 								},
 							},
@@ -506,7 +506,7 @@ var _ = Describe("test configuration", func() {
 								NodeSelector: map[string]string{
 									"testLabel2": "true",
 								},
-								MediatedDevicesTypes: []string{
+								MediatedDeviceTypes: []string{
 									"nvidia-229",
 								},
 							},
@@ -515,7 +515,7 @@ var _ = Describe("test configuration", func() {
 									"testLabel3": "true",
 									"testLabel4": "true",
 								},
-								MediatedDevicesTypes: []string{
+								MediatedDeviceTypes: []string{
 									"nvidia-230",
 								},
 							},

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -263,7 +263,12 @@ func (c *ClusterConfig) GetDesiredMDEVTypes(node *k8sv1.Node) []string {
 		mdevTypesMap := make(map[string]struct{})
 		for _, nodeConfig := range nodeMdevConf {
 			if canSelectNode(nodeConfig.NodeSelector, node) {
-				for _, mdevType := range nodeConfig.MediatedDevicesTypes {
+				types := nodeConfig.MediatedDeviceTypes
+				// Handle deprecated spelling
+				if len(types) == 0 {
+					types = nodeConfig.MediatedDevicesTypes
+				}
+				for _, mdevType := range types {
 					mdevTypesMap[mdevType] = struct{}{}
 				}
 			}
@@ -276,7 +281,11 @@ func (c *ClusterConfig) GetDesiredMDEVTypes(node *k8sv1.Node) []string {
 			return mdevTypesList
 		}
 	}
-	return mdevTypesConf.MediatedDevicesTypes
+	// Handle deprecated spelling
+	if len(mdevTypesConf.MediatedDeviceTypes) == 0 {
+		return mdevTypesConf.MediatedDevicesTypes
+	}
+	return mdevTypesConf.MediatedDeviceTypes
 }
 
 type virtComponent int

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -117,7 +117,7 @@ func PermanentHostDevicePlugins(maxDevices int, permissions string) []Device {
 
 type DeviceControllerInterface interface {
 	Initialized() bool
-	RefreshMediatedDevicesTypes()
+	RefreshMediatedDeviceTypes()
 }
 
 type DeviceController struct {
@@ -266,15 +266,15 @@ func (c *DeviceController) splitPermittedDevices(devices []Device) (map[string]D
 	return devicePluginsToRun, devicePluginsToStop
 }
 
-func (c *DeviceController) RefreshMediatedDevicesTypes() {
+func (c *DeviceController) RefreshMediatedDeviceTypes() {
 	go func() {
-		if c.refreshMediatedDevicesTypes() {
+		if c.refreshMediatedDeviceTypes() {
 			c.refreshPermittedDevices()
 		}
 	}()
 }
 
-func (c *DeviceController) refreshMediatedDevicesTypes() bool {
+func (c *DeviceController) refreshMediatedDeviceTypes() bool {
 	requiresDevicePluginsUpdate := false
 	node, err := c.clientset.Nodes().Get(context.Background(), c.host, metav1.GetOptions{})
 	if err != nil {
@@ -352,10 +352,10 @@ func (c *DeviceController) Run(stop chan struct{}) error {
 		}
 	}()
 
-	refreshMediatedDevicesTypesFn := func() {
-		c.refreshMediatedDevicesTypes()
+	refreshMediatedDeviceTypesFn := func() {
+		c.refreshMediatedDeviceTypes()
 	}
-	c.virtConfig.SetConfigModifiedCallback(refreshMediatedDevicesTypesFn)
+	c.virtConfig.SetConfigModifiedCallback(refreshMediatedDeviceTypesFn)
 	c.virtConfig.SetConfigModifiedCallback(c.refreshPermittedDevices)
 	c.refreshPermittedDevices()
 

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -350,7 +350,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			fakeClusterConfig, _, kvInformer := testutils.NewFakeClusterConfigUsingKV(kv)
 			kvConfig := kv.DeepCopy()
 			kvConfig.Spec.Configuration.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{
-				MediatedDevicesTypes: []string{
+				MediatedDeviceTypes: []string{
 
 					"nvidia-222",
 					"nvidia-228",
@@ -361,7 +361,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 						NodeSelector: map[string]string{
 							"testLabel1": "true",
 						},
-						MediatedDevicesTypes: []string{
+						MediatedDeviceTypes: []string{
 							"nvidia-223",
 						},
 					},
@@ -369,7 +369,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 						NodeSelector: map[string]string{
 							"testLabel2": "true",
 						},
-						MediatedDevicesTypes: []string{
+						MediatedDeviceTypes: []string{
 							"nvidia-229",
 						},
 					},
@@ -378,7 +378,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 							"testLabel3": "true",
 							"testLabel4": "true",
 						},
-						MediatedDevicesTypes: []string{
+						MediatedDeviceTypes: []string{
 							"nvidia-224",
 						},
 					},
@@ -401,7 +401,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			By("creating an empty device controller")
 			var noDevices []Device
 			deviceController := NewDeviceController("master", 100, "rw", noDevices, fakeClusterConfig, clientTest.CoreV1())
-			deviceController.refreshMediatedDevicesTypes()
+			deviceController.refreshMediatedDeviceTypes()
 			By("creating the desired mdev types")
 			desiredDevicesToConfigure := make(map[string]struct{})
 			for _, dev := range sc.desiredDevicesList {
@@ -432,7 +432,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			By("removing all created mdevs")
 			kvConfig.Spec.Configuration.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{}
 			testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
-			deviceController.refreshMediatedDevicesTypes()
+			deviceController.refreshMediatedDeviceTypes()
 			files, err := ioutil.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(files).To(BeEmpty())

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -151,7 +151,7 @@ func (h *HeartBeat) do() {
 	// and a MediatedDevicesConfiguration in KubeVirt CR.
 	// When labels change we should initialize a refresh to create/remove mdev types and start/stop
 	// relevant device plugins. This operation should be async.
-	h.deviceManagerController.RefreshMediatedDevicesTypes()
+	h.deviceManagerController.RefreshMediatedDeviceTypes()
 	log.DefaultLogger().V(4).Infof("Heartbeat sent")
 }
 

--- a/pkg/virt-handler/heartbeat/heartbeat_test.go
+++ b/pkg/virt-handler/heartbeat/heartbeat_test.go
@@ -169,7 +169,7 @@ func (f *fakeDeviceController) Initialized() bool {
 	return f.initialized
 }
 
-func (f *fakeDeviceController) RefreshMediatedDevicesTypes() {
+func (f *fakeDeviceController) RefreshMediatedDeviceTypes() {
 	return
 }
 
@@ -200,7 +200,7 @@ func (f *probeCountingDeviceController) Initialized() bool {
 	return f.probes[f.probed-1]
 }
 
-func (f *probeCountingDeviceController) RefreshMediatedDevicesTypes() {
+func (f *probeCountingDeviceController) RefreshMediatedDeviceTypes() {
 	return
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -782,7 +782,13 @@ var CRDsValidation map[string]string = map[string]string{
               description: MediatedDevicesConfiguration holds information about MDEV
                 types to be defined, if available
               properties:
+                mediatedDeviceTypes:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
                 mediatedDevicesTypes:
+                  description: Deprecated. Use mediatedDeviceTypes instead.
                   items:
                     type: string
                   type: array
@@ -793,7 +799,13 @@ var CRDsValidation map[string]string = map[string]string{
                       MDEV types to be defined in a specifc node that matches the
                       NodeSelector field.
                     properties:
+                      mediatedDeviceTypes:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
                       mediatedDevicesTypes:
+                        description: Deprecated. Use mediatedDeviceTypes instead.
                         items:
                           type: string
                         type: array
@@ -807,7 +819,6 @@ var CRDsValidation map[string]string = map[string]string{
                           More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                         type: object
                     required:
-                    - mediatedDevicesTypes
                     - nodeSelector
                     type: object
                   type: array

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2474,6 +2474,11 @@ func (in *MediatedDevicesConfiguration) DeepCopyInto(out *MediatedDevicesConfigu
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MediatedDeviceTypes != nil {
+		in, out := &in.MediatedDeviceTypes, &out.MediatedDeviceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.NodeMediatedDeviceTypes != nil {
 		in, out := &in.NodeMediatedDeviceTypes, &out.NodeMediatedDeviceTypes
 		*out = make([]NodeMediatedDeviceTypesConfig, len(*in))
@@ -2780,6 +2785,11 @@ func (in *NodeMediatedDeviceTypesConfig) DeepCopyInto(out *NodeMediatedDeviceTyp
 	}
 	if in.MediatedDevicesTypes != nil {
 		in, out := &in.MediatedDevicesTypes, &out.MediatedDevicesTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.MediatedDeviceTypes != nil {
+		in, out := &in.MediatedDeviceTypes, &out.MediatedDeviceTypes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2368,8 +2368,13 @@ type MediatedHostDevice struct {
 
 // MediatedDevicesConfiguration holds information about MDEV types to be defined, if available
 type MediatedDevicesConfiguration struct {
+	// Deprecated. Use mediatedDeviceTypes instead.
+	// +optional
 	// +listType=atomic
 	MediatedDevicesTypes []string `json:"mediatedDevicesTypes,omitempty"`
+	// +optional
+	// +listType=atomic
+	MediatedDeviceTypes []string `json:"mediatedDeviceTypes,omitempty"`
 	// +optional
 	// +listType=atomic
 	NodeMediatedDeviceTypes []NodeMediatedDeviceTypesConfig `json:"nodeMediatedDeviceTypes,omitempty"`
@@ -2382,8 +2387,13 @@ type NodeMediatedDeviceTypesConfig struct {
 	// Selector which must match a node's labels for the vmi to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 	NodeSelector map[string]string `json:"nodeSelector"`
+	// Deprecated. Use mediatedDeviceTypes instead.
+	// +optional
 	// +listType=atomic
-	MediatedDevicesTypes []string `json:"mediatedDevicesTypes"`
+	MediatedDevicesTypes []string `json:"mediatedDevicesTypes,omitempty"`
+	// +optional
+	// +listType=atomic
+	MediatedDeviceTypes []string `json:"mediatedDeviceTypes"`
 }
 
 // NetworkConfiguration holds network options

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -763,7 +763,8 @@ func (MediatedHostDevice) SwaggerDoc() map[string]string {
 func (MediatedDevicesConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                        "MediatedDevicesConfiguration holds information about MDEV types to be defined, if available",
-		"mediatedDevicesTypes":    "+listType=atomic",
+		"mediatedDevicesTypes":    "Deprecated. Use mediatedDeviceTypes instead.\n+optional\n+listType=atomic",
+		"mediatedDeviceTypes":     "+optional\n+listType=atomic",
 		"nodeMediatedDeviceTypes": "+optional\n+listType=atomic",
 	}
 }
@@ -772,7 +773,8 @@ func (NodeMediatedDeviceTypesConfig) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                     "NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specifc node that matches the NodeSelector field.\n+k8s:openapi-gen=true",
 		"nodeSelector":         "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
-		"mediatedDevicesTypes": "+listType=atomic",
+		"mediatedDevicesTypes": "Deprecated. Use mediatedDeviceTypes instead.\n+optional\n+listType=atomic",
+		"mediatedDeviceTypes":  "+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18235,6 +18235,25 @@ func schema_kubevirtio_api_core_v1_MediatedDevicesConfiguration(ref common.Refer
 							},
 						},
 						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated. Use mediatedDeviceTypes instead.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"mediatedDeviceTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -18678,6 +18697,25 @@ func schema_kubevirtio_api_core_v1_NodeMediatedDeviceTypesConfig(ref common.Refe
 							},
 						},
 						SchemaProps: spec.SchemaProps{
+							Description: "Deprecated. Use mediatedDeviceTypes instead.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"mediatedDeviceTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -18690,7 +18728,7 @@ func schema_kubevirtio_api_core_v1_NodeMediatedDeviceTypesConfig(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"nodeSelector", "mediatedDevicesTypes"},
+				Required: []string{"nodeSelector"},
 			},
 		},
 	}

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -133,7 +133,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 			config = kv.Spec.Configuration
 			config.DeveloperConfiguration.FeatureGates = append(config.DeveloperConfiguration.FeatureGates, virtconfig.GPUGate)
 			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{
-				MediatedDevicesTypes: []string{desiredMdevTypeName},
+				MediatedDeviceTypes: []string{desiredMdevTypeName},
 			}
 			config.PermittedHostDevices = &v1.PermittedHostDevices{
 				MediatedDevices: []v1.MediatedHostDevice{
@@ -236,7 +236,7 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", func() {
 					NodeSelector: map[string]string{
 						cleanup.TestLabelForNamespace(util.NamespaceTestDefault): mdevTestLabel,
 					},
-					MediatedDevicesTypes: []string{
+					MediatedDeviceTypes: []string{
 						"nvidia-223",
 					},
 				},


### PR DESCRIPTION
This is a manual cherry-pick of #8525 

```release-note
NONE
```
