### PR TITLE
[release-0.58] migration: apply backoff only for evacuation migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -657,12 +657,17 @@ func (c *MigrationController) expandPDB(pdb *policyv1.PodDisruptionBudget, vmi *
 	return nil
 }
 
+// handleMigrationBackoff introduce a backoff (when needed) only for migrations
+// created by the evacuation controller.
 func (c *MigrationController) handleMigrationBackoff(key string, vmi *virtv1.VirtualMachineInstance, migration *virtv1.VirtualMachineInstanceMigration) error {
 	if _, exists := migration.Annotations[virtv1.FuncTestForceIgnoreMigrationBackoffAnnotation]; exists {
 		return nil
 	}
+	if _, exists := migration.Annotations[virtv1.EvacuationMigrationAnnotation]; !exists {
+		return nil
+	}
 
-	migrations, err := c.listMigrationsMatchingVMI(vmi.Namespace, vmi.Name)
+	migrations, err := c.listEvacuationMigrations(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return err
 	}
@@ -1525,21 +1530,35 @@ func (c *MigrationController) garbageCollectFinalizedMigrations(vmi *virtv1.Virt
 	return nil
 }
 
-// takes a namespace and returns all migrations listening for this vmi
-func (c *MigrationController) listMigrationsMatchingVMI(namespace string, name string) ([]*virtv1.VirtualMachineInstanceMigration, error) {
+func (c *MigrationController) filterMigrations(namespace, name string, filter func(*virtv1.VirtualMachineInstanceMigration) bool) ([]*virtv1.VirtualMachineInstanceMigration, error) {
 	objs, err := c.migrationInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}
+
 	migrations := []*virtv1.VirtualMachineInstanceMigration{}
 	for _, obj := range objs {
 		migration := obj.(*virtv1.VirtualMachineInstanceMigration)
 
-		if migration.Spec.VMIName == name {
+		if filter(migration) {
 			migrations = append(migrations, migration)
 		}
 	}
 	return migrations, nil
+}
+
+// takes a namespace and returns all migrations listening for this vmi
+func (c *MigrationController) listMigrationsMatchingVMI(namespace, name string) ([]*virtv1.VirtualMachineInstanceMigration, error) {
+	return c.filterMigrations(namespace, name, func(migration *virtv1.VirtualMachineInstanceMigration) bool {
+		return migration.Spec.VMIName == name
+	})
+}
+
+func (c *MigrationController) listEvacuationMigrations(namespace string, name string) ([]*virtv1.VirtualMachineInstanceMigration, error) {
+	return c.filterMigrations(namespace, name, func(migration *virtv1.VirtualMachineInstanceMigration) bool {
+		_, isEvacuation := migration.Annotations[virtv1.EvacuationMigrationAnnotation]
+		return migration.Spec.VMIName == name && isEvacuation
+	})
 }
 
 func (c *MigrationController) addVMI(obj interface{}) {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2347,7 +2347,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					By("Starting the Migration")
 					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 					migration.Name = fmt.Sprintf("%s-iter-%d", vmi.Name, i)
-					migration.Annotations = map[string]string{v1.FuncTestForceIgnoreMigrationBackoffAnnotation: ""}
 					migrationUID := runMigrationAndExpectFailure(migration, 180)
 
 					// check VMI, confirm migration state
@@ -4436,8 +4435,16 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	})
 
-	Context("when migrating fails", func() {
+	Context("when evacuating fails", func() {
 		var vmi *v1.VirtualMachineInstance
+
+		setEvacuationAnnotation := func(migrations ...*v1.VirtualMachineInstanceMigration) {
+			for _, m := range migrations {
+				m.Annotations = map[string]string{
+					v1.EvacuationMigrationAnnotation: m.Name,
+				}
+			}
+		}
 
 		BeforeEach(func() {
 			vmi = libvmi.NewCirros(
@@ -4453,10 +4460,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			By("Waiting for the migration to fail")
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			setEvacuationAnnotation(migration)
 			_ = runMigrationAndExpectFailure(migration, tests.MigrationWaitTime)
 
 			By("Try again")
 			migration = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			setEvacuationAnnotation(migration)
 			_ = runMigrationAndExpectFailure(migration, tests.MigrationWaitTime)
 
 			By("Expecting for a MigrationBackoff event to be sent")
@@ -4473,6 +4482,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			By("Waiting for the migration to fail")
 			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			setEvacuationAnnotation(migration)
 			_ = runMigrationAndExpectFailure(migration, tests.MigrationWaitTime)
 
 			By("Patch VMI")
@@ -4482,6 +4492,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			By("Try again with backoff")
 			migration = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			setEvacuationAnnotation(migration)
 			_ = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 			eventListOpts := metav1.ListOptions{
@@ -4491,6 +4502,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			By("There should be no backoff now")
 			migration = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			setEvacuationAnnotation(migration)
 			_ = tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
 
 			By("Checking that no backoff event occurred")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/8808.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Apply migration backoff only for evacuation migrations.
```
