### PR TITLE
tests, sriov: Place a delay between tests

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -90,6 +90,16 @@ var _ = Describe("[Serial]SRIOV", Serial, func() {
 		}
 	})
 
+	AfterEach(func() {
+		// Place a delay between tests to assure resources (VF/s) are fully released before reused again on a new VMI.
+		// (results show that waiting for VMI/s to disappear is not enough)
+		// Ref: https://github.com/k8snetworkplumbingwg/sriov-cni/issues/219
+		//
+		// TODO: This workaround should be temporary until the fix [1] can be consumed.
+		// [1] https://github.com/k8snetworkplumbingwg/sriov-cni/pull/220
+		time.Sleep(20 * time.Second)
+	})
+
 	Context("VMI connected to single SRIOV network", func() {
 		BeforeEach(func() {
 			Expect(createSriovNetworkAttachmentDefinition(sriovnet1, util.NamespaceTestDefault, sriovConfNAD)).


### PR DESCRIPTION
**What this PR does / why we need it**:

Place a delay between tests to assure resources (VF/s) are fully released before reused again on a new VMI.
(results show that waiting for VMI/s to disappear is not enough) Ref: https://github.com/k8snetworkplumbingwg/sriov-cni/issues/219

This workaround should be temporary until the fix [1] can be consumed. [1] https://github.com/k8snetworkplumbingwg/sriov-cni/pull/220

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
