### PR TITLE
HyperV functest fix: don't expect node-labeller to always be stopped

### DIFF
--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -138,12 +138,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, func() 
 				Expect(err).ToNot(HaveOccurred())
 
 				for _, node := range nodeList.Items {
-					_, isNodeLabellerStopped := node.Annotations[v1.LabellerSkipNodeAnnotation]
-					Expect(isNodeLabellerStopped).To(BeTrue())
-
-					updatedNode := resumeNodeLabeller(node.Name, virtClient)
-					_, isNodeLabellerStopped = updatedNode.Annotations[v1.LabellerSkipNodeAnnotation]
-					Expect(isNodeLabellerStopped).To(BeFalse(), "after node labeller is resumed, %s annotation is expected to disappear from node", v1.LabellerSkipNodeAnnotation)
+					_ = resumeNodeLabeller(node.Name, virtClient)
 				}
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In HyperV tests in the `"TSC frequency is not exposed on the cluster"` case, at the BeforeEach(), we stop node labeller on a node if TSC is exposed to fake as if it's not exposed.

In the AfterEach(), we then expect node-labeller to be stopped, although it's not always the case (as said above, if TSC is not exposed in the first place, we don't stop node-labeller).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
