### PR TITLE
utils: Remove job's RunAsUser field

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1416,8 +1416,6 @@ func DeleteAlpineWithNonQEMUPermissions() {
 }
 
 func renderContainerSpec(imgPath string, name string, cmd []string, args []string) k8sv1.Container {
-	nonRootUser := int64(1042)
-
 	return k8sv1.Container{
 		Name:    name,
 		Image:   imgPath,
@@ -1427,7 +1425,6 @@ func renderContainerSpec(imgPath string, name string, cmd []string, args []strin
 			Privileged:               NewBool(false),
 			AllowPrivilegeEscalation: NewBool(false),
 			RunAsNonRoot:             NewBool(true),
-			RunAsUser:                &nonRootUser,
 			SeccompProfile: &k8sv1.SeccompProfile{
 				Type: k8sv1.SeccompProfileTypeRuntimeDefault,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes job's RunAsUser field. This job container spec field is mainly used for netcat jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
