### PR TITLE
Quarantine canary upgrade test

### DIFF
--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -173,7 +173,7 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, fu
 		return eventsQueue
 	}
 
-	It("should successfully upgrade virt-handler", func() {
+	It("[QUARANTINE]should successfully upgrade virt-handler", func() {
 		var expectedEventsLock sync.Mutex
 		expectedEvents := []string{
 			"maxUnavailable=1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Put test in quarantine due to high flakiness. According to [ci search](https://search.ci.kubevirt.io/?search=%5C%5BSerial%5D%5C%5Bsig-operator%5Dvirt-handler+canary+upgrade+should+successfully+upgrade+virt-handler&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job )
it has on average beyond 5% impact, max 15%.

See [KubeVirt Quarantine Docs](https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md#putting-tests-in-quarantine)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
