### PR TITLE
Fix evmcs hyperv bug

### DIFF
--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -134,7 +134,7 @@ func hypervNodeSelectors(vmiFeatures *v1.Features) map[string]string {
 		}
 	}
 
-	if vmiFeatures.Hyperv.EVMCS != nil {
+	if vmiFeatures.Hyperv.EVMCS != nil && (vmiFeatures.Hyperv.EVMCS.Enabled == nil || (*vmiFeatures.Hyperv.EVMCS.Enabled) == true) {
 		nodeSelectors[v1.CPUModelVendorLabel+IntelVendorName] = "true"
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1292,11 +1292,9 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(v1.CPUModelVendorLabel))))
 			})
 
-			It("should add node selector for hyperv nodes if VMI requests hyperv features which depend on host kernel", func() {
+			DescribeTable("should add node selector for hyperv nodes if VMI requests hyperv features which depend on host kernel", func(EVMCSEnabled bool) {
 				config, kvInformer, svc = configFactory(defaultArch)
 				enableFeatureGate(virtconfig.HypervStrictCheckGate)
-
-				enabled := true
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -1311,19 +1309,19 @@ var _ = Describe("Template", func() {
 							Features: &v1.Features{
 								Hyperv: &v1.FeatureHyperv{
 									SyNIC: &v1.FeatureState{
-										Enabled: &enabled,
+										Enabled: pointer.BoolPtr(true),
 									},
 									SyNICTimer: &v1.SyNICTimer{
-										Enabled: &enabled,
+										Enabled: pointer.BoolPtr(true),
 									},
 									Frequencies: &v1.FeatureState{
-										Enabled: &enabled,
+										Enabled: pointer.BoolPtr(true),
 									},
 									IPI: &v1.FeatureState{
-										Enabled: &enabled,
+										Enabled: pointer.BoolPtr(true),
 									},
 									EVMCS: &v1.FeatureState{
-										Enabled: &enabled,
+										Enabled: pointer.BoolPtr(EVMCSEnabled),
 									},
 								},
 							},
@@ -1338,8 +1336,16 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"synictimer", "true"))
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"frequencies", "true"))
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"ipi", "true"))
-				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(v1.CPUModelVendorLabel+IntelVendorName, "true"))
-			})
+				if EVMCSEnabled {
+					Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(v1.CPUModelVendorLabel+IntelVendorName, "true"))
+				} else {
+					Expect(pod.Spec.NodeSelector).ShouldNot(HaveKeyWithValue(v1.CPUModelVendorLabel+IntelVendorName, "true"))
+				}
+
+			},
+				Entry("intel vendor and vmx are required when EVMCS is enabled", true),
+				Entry("should not require intel vendor and vmx when EVMCS isn't enabled", false),
+			)
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features which do not depend on host kernel", func() {
 				config, kvInformer, svc = configFactory(defaultArch)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix Evmcs Hyperv bug.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Currently whenever EVMCS HyperV feature
Is not nil in the vm spec than the vm require 
Intel vendor.
Even if we set vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled
to be false.
**Special notes for your reviewer**:
This is a follow up PR to:
https://github.com/kubevirt/kubevirt/pull/8773

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2140808 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
