### PR TITLE
virt-launcher: Drop SYS_PTRACE capability

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -69,7 +69,6 @@ xattrs(
     capabilities = {
         "/usr/bin/virt-launcher": [
             "cap_net_bind_service",
-            "cap_sys_ptrace",
         ],
     },
     selinux_labels = {

--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -236,10 +236,7 @@ func wrapExecProbeWithVirtProbe(vmi *v1.VirtualMachineInstance, probe *k8sv1.Pro
 
 func requiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
 	// These capabilies are always required because we set them on virt-launcher binary
-	// add CAP_SYS_PTRACE capability needed by libvirt + swtpm
-	// TODO: drop SYS_PTRACE after updating libvirt to a release containing:
-	// https://github.com/libvirt/libvirt/commit/a9c500d2b50c5c041a1bb6ae9724402cf1cec8fe
-	capabilities := []k8sv1.Capability{CAP_NET_BIND_SERVICE, CAP_SYS_PTRACE}
+	capabilities := []k8sv1.Capability{CAP_NET_BIND_SERVICE}
 
 	if !util.IsNonRootVMI(vmi) {
 		// add a CAP_SYS_NICE capability to allow setting cpu affinity

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -82,7 +82,6 @@ var _ = Describe("Container spec renderer", func() {
 		allowedCapabilities := []k8sv1.Capability{
 			CAP_NET_BIND_SERVICE,
 			CAP_SYS_NICE,
-			CAP_SYS_PTRACE,
 		}
 		Context("a VMI running as root", func() {
 			BeforeEach(func() {
@@ -94,7 +93,7 @@ var _ = Describe("Container spec renderer", func() {
 					Equal([]k8sv1.Capability{CAP_NET_RAW}))
 			})
 
-			It("must request to add the NET_BIND_SERVICE, SYS_NICE and SYS_PTRACE capabilities", func() {
+			It("must request to add the NET_BIND_SERVICE and SYS_NICE capabilities", func() {
 				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).To(
 					ConsistOf(allowedCapabilities))
 			})
@@ -126,9 +125,9 @@ var _ = Describe("Container spec renderer", func() {
 					WithCapabilities(nonRootVMI(nonRootUser)))
 			})
 
-			It("must request the NET_BIND_SERVICE and SYS_PTRACE capabilities", func() {
+			It("must request the NET_BIND_SERVICE capability", func() {
 				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).Should(
-					ConsistOf(k8sv1.Capability(CAP_NET_BIND_SERVICE), k8sv1.Capability(CAP_SYS_PTRACE)))
+					ConsistOf(k8sv1.Capability(CAP_NET_BIND_SERVICE)))
 			})
 		})
 	})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -84,7 +84,6 @@ const (
 	CAP_NET_RAW          = "NET_RAW"
 	CAP_SYS_ADMIN        = "SYS_ADMIN"
 	CAP_SYS_NICE         = "SYS_NICE"
-	CAP_SYS_PTRACE       = "SYS_PTRACE"
 )
 
 // LibvirtStartupDelay is added to custom liveness and readiness probes initial delay value.

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3391,7 +3391,7 @@ var _ = Describe("Template", func() {
 			for _, container := range pod.Spec.Containers {
 				if container.Name == "compute" {
 					Expect(container.SecurityContext.Capabilities.Add).To(
-						ContainElements(kubev1.Capability("NET_BIND_SERVICE"), kubev1.Capability("SYS_PTRACE")))
+						ContainElements(kubev1.Capability("NET_BIND_SERVICE")))
 					return
 				}
 			}

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -249,7 +249,7 @@ func (l LibvirtWrapper) StartVirtquemud(stopChan chan struct{}) {
 			cmd := exec.Command("/usr/sbin/virtqemud", args...)
 			if l.user != 0 {
 				cmd.SysProcAttr = &syscall.SysProcAttr{
-					AmbientCaps: []uintptr{unix.CAP_NET_BIND_SERVICE, unix.CAP_SYS_PTRACE},
+					AmbientCaps: []uintptr{unix.CAP_NET_BIND_SERVICE},
 				}
 			}
 

--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -82,8 +82,6 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 		"SYS_NICE",
 		// add CAP_NET_BIND_SERVICE capability to allow dhcp and slirp operations
 		"NET_BIND_SERVICE",
-		// add CAP_SYS_PTRACE capability needed for libvirt <8.1.0 to find the pid of swtpm
-		"SYS_PTRACE",
 	}
 	scc.AllowHostDirVolumePlugin = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -45,7 +45,6 @@ import (
 const (
 	capNetRaw         k8sv1.Capability = "NET_RAW"
 	capSysNice        k8sv1.Capability = "SYS_NICE"
-	capSysPTrace      k8sv1.Capability = "SYS_PTRACE"
 	capNetBindService k8sv1.Capability = "NET_BIND_SERVICE"
 )
 
@@ -247,11 +246,11 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, func() {
 			}
 			caps := *container.SecurityContext.Capabilities
 			if !checks.HasFeature(virtconfig.Root) {
-				Expect(caps.Add).To(HaveLen(2), fmt.Sprintf("Found capabilities %s, expected NET_BIND_SERVICE and SYS_PTRACE", caps.Add))
-				Expect(caps.Add).To(ContainElements(k8sv1.Capability("NET_BIND_SERVICE"), k8sv1.Capability("SYS_PTRACE")))
+				Expect(caps.Add).To(HaveLen(1), fmt.Sprintf("Found capabilities %s, expected NET_BIND_SERVICE", caps.Add))
+				Expect(caps.Add).To(ContainElements(k8sv1.Capability("NET_BIND_SERVICE")))
 			} else {
-				Expect(caps.Add).To(HaveLen(3), fmt.Sprintf("Found capabilities %s, expected NET_BIND_SERVICE, SYS_NICE and SYS_PTRACE", caps.Add))
-				Expect(caps.Add).To(ContainElements(k8sv1.Capability("NET_BIND_SERVICE"), k8sv1.Capability("SYS_NICE"), k8sv1.Capability("SYS_PTRACE")))
+				Expect(caps.Add).To(HaveLen(2), fmt.Sprintf("Found capabilities %s, expected NET_BIND_SERVICE and SYS_NICE", caps.Add))
+				Expect(caps.Add).To(ContainElements(k8sv1.Capability("NET_BIND_SERVICE"), k8sv1.Capability("SYS_NICE")))
 			}
 
 			By("Checking virt-launcher Pod's compute container has precisely the documented extra capabilities")
@@ -271,8 +270,7 @@ func isLauncherCapabilityValid(capability k8sv1.Capability) bool {
 	switch capability {
 	case
 		capNetBindService,
-		capSysNice,
-		capSysPTrace:
+		capSysNice:
 		return true
 	}
 	return false


### PR DESCRIPTION
**What this PR does / why we need it**:

Drops the `SYS_PTRACE` capability from the virt-launcher pod.

We're now using libvirt 8.7.0, and the additional capability was only needed for versions of libvirt older than 8.1.0.

**Special notes for your reviewer**:

I keep hitting

```
•! [PANICKED] [0.000 seconds]
Template
pkg/virt-controller/services/template_test.go:62
  Rendering
  pkg/virt-controller/services/template_test.go:163
    [It] should require capabilites which we set on virt-launcher binary
    pkg/virt-controller/services/template_test.go:3384

  Test Panicked
  In [It] at: GOROOT/src/runtime/panic.go:260

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    kubevirt.io/kubevirt/pkg/virt-controller/services.glob..func6.6.39()
    	pkg/virt-controller/services/template_test.go:3388 +0x13a
```

when running `make test` locally, but that happens even against the main branch so I guess it's unrelated?

**Release note**:

```release-note
The virt-launcher pod no longer needs the SYS_PTRACE capability.
```