### PR TITLE
[restore tests]: Use supplied snapshot storage class, don't attempt discover

### DIFF
--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -70,8 +70,16 @@ func DeleteStorageClass(name string) {
 }
 
 func GetSnapshotStorageClass(client kubecli.KubevirtClient) (string, error) {
-	if Config != nil && Config.StorageSnapshot != "" {
-		return Config.StorageSnapshot, nil
+	var snapshotStorageClass string
+
+	if Config == nil || Config.StorageSnapshot == "" {
+		return "", nil
+	}
+	snapshotStorageClass = Config.StorageSnapshot
+
+	sc, err := client.StorageV1().StorageClasses().Get(context.Background(), snapshotStorageClass, metav1.GetOptions{})
+	if err != nil {
+		return "", err
 	}
 
 	crd, err := client.
@@ -87,7 +95,7 @@ func GetSnapshotStorageClass(client kubecli.KubevirtClient) (string, error) {
 		return "", err
 	}
 
-	hasV1 := false
+	var hasV1 bool
 	for _, v := range crd.Spec.Versions {
 		if v.Name == "v1" && v.Served {
 			hasV1 = true
@@ -105,32 +113,20 @@ func GetSnapshotStorageClass(client kubecli.KubevirtClient) (string, error) {
 	if len(volumeSnapshotClasses.Items) == 0 {
 		return "", nil
 	}
-	defaultSnapClass := volumeSnapshotClasses.Items[0]
+
+	var hasMatchingSnapClass bool
 	for _, snapClass := range volumeSnapshotClasses.Items {
-		if snapClass.Annotations["snapshot.storage.kubernetes.io/is-default-class"] == "true" {
-			defaultSnapClass = snapClass
-		}
-	}
-
-	storageClasses, err := client.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	var storageClass string
-
-	for _, sc := range storageClasses.Items {
-		if sc.Provisioner == defaultSnapClass.Driver {
-			storageClass = sc.Name
+		if sc.Provisioner == snapClass.Driver {
+			hasMatchingSnapClass = true
 			break
 		}
 	}
 
-	if Config != nil {
-		Config.StorageSnapshot = storageClass
+	if !hasMatchingSnapClass {
+		return "", nil
 	}
 
-	return storageClass, nil
+	return snapshotStorageClass, nil
 }
 
 func GetSnapshotClass(scName string, client kubecli.KubevirtClient) (string, error) {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -351,8 +351,10 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			It("should accurately report DataVolume provisioning", func() {
 				sc, err := libstorage.GetSnapshotStorageClass(virtClient)
-				if err != nil {
-					Skip("no snapshot storage class configured")
+				Expect(err).ToNot(HaveOccurred())
+
+				if sc == "" {
+					Skip("Skiping test, no VolumeSnapshot support")
 				}
 
 				dataVolume := libdv.NewDataVolume(


### PR DESCRIPTION
We have a mechanism to say which storage class we want to test snapshots with, let's use that, and completely skip those tests if nobody tells us that we can snapshot.
This is useful so we don't run snapshot tests on lanes that are dedicated to storage that doesn't support them.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
