### PR TITLE
api: Ensure Timer is omitted when empty from Clock

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -158,10 +158,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			},
 		}
 		resp := vmiCreateAdmitter.Admit(ar)
-
-		// FIXME - This is bug #8844, the request should be allowed.
-		Expect(resp.Allowed).To(BeFalse())
-		Expect(resp.Result.Message).To(ContainSubstring("spec.domain.clock.timer in body must be of type object"))
+		Expect(resp.Allowed).To(BeTrue())
 	})
 
 	DescribeTable("path validation should fail", func(path string) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -138,6 +138,32 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		Expect(resp.Result.Message).To(ContainSubstring("no memory requested"))
 	})
 
+	It("should allow Clock without Timer", func() {
+		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Clock = &v1.Clock{
+			ClockOffset: v1.ClockOffset{
+				UTC: &v1.ClockOffsetUTC{
+					OffsetSeconds: pointer.Int(5),
+				},
+			},
+		}
+		vmiBytes, _ := json.Marshal(&vmi)
+
+		ar := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Resource: webhooks.VirtualMachineInstanceGroupVersionResource,
+				Object: runtime.RawExtension{
+					Raw: vmiBytes,
+				},
+			},
+		}
+		resp := vmiCreateAdmitter.Admit(ar)
+
+		// FIXME - This is bug #8844, the request should be allowed.
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Message).To(ContainSubstring("spec.domain.clock.timer in body must be of type object"))
+	})
+
 	DescribeTable("path validation should fail", func(path string) {
 		Expect(validatePath(k8sfield.NewPath("fake"), path)).To(HaveLen(1))
 	},

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -861,7 +861,7 @@ type Clock struct {
 	ClockOffset `json:",inline"`
 	// Timer specifies whih timers are attached to the vmi.
 	// +optional
-	Timer *Timer `json:"timer"`
+	Timer *Timer `json:"timer,omitempty"`
 }
 
 // Represents all available timers in a vmi.


### PR DESCRIPTION
/area instancetype
/area api-server

**What this PR does / why we need it**:

As set out in bug #8844 when `Timer` was previously empty it was not omitted from `Clock`  causing validation failures to be raised as an object was expected. This PR now ensures that `Timer` is omitted from `Clock` when empty, avoiding the validation failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8844

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
An empty `Timer` is now correctly omitted from `Clock` fixing bug #8844.
```
