### PR TITLE
[exportServer] Add download file logs when read file error

### DIFF
--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -334,6 +334,7 @@ func fileHandler(file string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f, err := os.Open(file)
 		if err != nil {
+			log.Log.Reason(err).Errorf("error opening %s", file)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When I use export service, I forgot to enable the `device_ownership_from_security_context = true`. service is started, but when I download the `disk.img` file, the pod does not print any logs, just return 500.
The error is the same as  `https://github.com/kubevirt/kubevirt/issues/8618`.
By adding logs, you can quickly help uses and developers locate where the problem is. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #8618 

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
