### PR TITLE
[release-0.53] Rename metrics to follow naming convention

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -30,7 +30,7 @@ Indication for a virt-controller that is ready to take the lead. Type: Gauge.
 ### kubevirt_vmi_cpu_affinity
 The vcpu affinity details. Type: Counter.
 
-### kubevirt_vmi_filesystem_total_bytes
+### kubevirt_vmi_filesystem_capacity_bytes_total
 Total VM filesystem capacity in bytes. Type: Gauge.
 
 ### kubevirt_vmi_filesystem_used_bytes

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -471,7 +471,7 @@ func (metrics *vmiMetrics) updateFilesystem(vmFSStats k6tv1.VirtualMachineInstan
 		fsLabelValues := []string{fsStat.DiskName, fsStat.MountPoint, fsStat.FileSystemType}
 
 		metrics.pushCustomMetric(
-			"kubevirt_vmi_filesystem_total_bytes",
+			"kubevirt_vmi_filesystem_capacity_bytes_total",
 			"Total VM filesystem capacity in bytes.",
 			prometheus.GaugeValue,
 			float64(fsStat.TotalBytes),

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -1168,7 +1168,7 @@ var _ = Describe("Prometheus", func() {
 			ps.Report("test", &vmi, newVmStats(domainStats, fsStats))
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_total_bytes"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_capacity_bytes_total"))
 			result = <-ch
 			Expect(result).ToNot(BeNil())
 			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_filesystem_used_bytes"))


### PR DESCRIPTION
This is a manual cherry-pick of #8401

This was already cherry-picked in #8623, but it failed to update both metrics.

Signed-off-by: João Vilaça <jvilaca@redhat.com>

**Release note**:
-->
```release-note
Rename metrics to follow naming convention
```
