### PR TITLE
Improve testing of events

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -218,6 +218,7 @@ go_test(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/events:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",

--- a/tests/events/BUILD.bazel
+++ b/tests/events/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["events.go"],
+    importpath = "kubevirt.io/kubevirt/tests/events",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+    ],
+)

--- a/tests/events/events.go
+++ b/tests/events/events.go
@@ -1,0 +1,106 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/util"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type k8sObject interface {
+	metav1.Object
+	schema.ObjectKind
+}
+
+// ExpectNoEvent is safe to use in parallel as long as you are asserting namespaced object that is not shared between tests
+func ExpectNoEvent(object k8sObject, eventType, reason string) {
+	By("Expecting for an event to be not triggered")
+	expectEvent(object, eventType, reason, BeEmpty())
+}
+
+// ExpectEvent is safe to use in parallel as long as you are asserting namespaced object that is not shared between tests
+func ExpectEvent(object k8sObject, eventType, reason string) {
+	By("Expecting for an event to be triggered")
+	expectEvent(object, eventType, reason, Not(BeEmpty()))
+}
+
+// DeleteEvents is safe to use in parallel as long as you are asserting namespaced object that is not shared between tests
+func DeleteEvents(object k8sObject, eventType, reason string) {
+	By("Expecting events to be removed")
+	virtClient, err := kubecli.GetKubevirtClient()
+	util.PanicOnError(err)
+
+	fieldSelector, namespace := constructFieldSelectorAndNamespace(object, eventType, reason)
+
+	events, err := virtClient.CoreV1().Events(namespace).List(context.Background(),
+		metav1.ListOptions{
+			FieldSelector: fieldSelector,
+		})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	for _, event := range events.Items {
+		err = virtClient.CoreV1().Events(event.Namespace).Delete(
+			context.TODO(),
+			event.Name,
+			metav1.DeleteOptions{},
+		)
+		ExpectWithOffset(1, err).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete event %s/%s", event.Namespace, event.Name))
+	}
+
+	EventuallyWithOffset(1, func() []k8sv1.Event {
+		events, err := virtClient.CoreV1().Events(namespace).List(context.Background(),
+			metav1.ListOptions{
+				FieldSelector: fieldSelector,
+			})
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		return events.Items
+	}, 30*time.Second, 1*time.Second).Should(BeEmpty(), fmt.Sprintf("Used fieldselector %s", fieldSelector))
+}
+
+func expectEvent(object k8sObject, eventType, reason string, matcher types.GomegaMatcher) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(2, err).ToNot(HaveOccurred())
+
+	fieldSelector, namespace := constructFieldSelectorAndNamespace(object, eventType, reason)
+
+	EventuallyWithOffset(2, func() []k8sv1.Event {
+		events, err := virtClient.CoreV1().Events(namespace).List(
+			context.Background(),
+			metav1.ListOptions{
+				FieldSelector: fieldSelector,
+			},
+		)
+		ExpectWithOffset(3, err).ToNot(HaveOccurred())
+		return events.Items
+	}, 30*time.Second).Should(matcher, fmt.Sprintf("Used fieldselector %s", fieldSelector))
+}
+
+// constructFieldSelectorAndNamespace does best effort to overcome https://github.com/kubernetes/client-go/issues/861
+func constructFieldSelectorAndNamespace(object k8sObject, eventType, reason string) (string, string) {
+	kind := object.GroupVersionKind().Kind
+	if kind == "" {
+		kind = reflect.ValueOf(object).Type().Name()
+	}
+	kindSelector := fmt.Sprintf("involvedObject.kind=%s,", kind)
+	if kind == "" {
+		kindSelector = ""
+	}
+
+	name := object.GetName()
+	namespace := object.GetNamespace()
+
+	fieldSelector := fmt.Sprintf("%sinvolvedObject.name=%s,type=%s,reason=%s", kindSelector, name, eventType, reason)
+	return fieldSelector, namespace
+}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -4521,7 +4521,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			)
 		})
 
-		It("[Serial] retrying immediately should be blocked by the migration backoff", Serial, func() {
+		It("retrying immediately should be blocked by the migration backoff", func() {
 			By("Starting the VirtualMachineInstance")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 
@@ -4538,7 +4538,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			events.ExpectEvent(vmi, k8sv1.EventTypeWarning, watch.MigrationBackoffReason)
 		})
 
-		It("[Serial] after a successful migration backoff should be cleared", Serial, func() {
+		It("after a successful migration backoff should be cleared", func() {
 			By("Starting the VirtualMachineInstance")
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/events:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",
         "//tests/errorhandling:go_default_library",
+        "//tests/events:go_default_library",
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -386,16 +386,6 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(ok).To(BeTrue())
 			Expect(label).To(Equal(overrideFlavor))
 			Expect(newVmi.Spec.Domain.Resources.Requests["memory"]).To(Equal(vmiMemory))
-
-			By("Checking event list")
-			evList, err := virtClient.CoreV1().Events(testsuite.GetTestNamespace(newVmi)).List(context.Background(), k8smetav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			for _, event := range evList.Items {
-				if event.InvolvedObject.GetObjectKind() == newVmi.GetObjectKind() &&
-					event.InvolvedObject.Name == newVmi.GetName() {
-					Expect(event.Message).ToNot(ContainSubstring("Unable to apply VirtualMachineInstancePreset"))
-				}
-			}
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now we have been using events as a global thing. Meaning if we had to check VMI1-caused event we were checking if any VMI caused the particular event. This is not the best solution as it is error-prone. Events from previous tests can cause a match. At the same time, Kubernetes events contain associations with a particular object.

This PR is making use of the above fact, making it easier to test events in the future. It also removes redundant code and makes 2 Serial tests run in parallel.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
