### PR TITLE
tests, console/login: Add fedora root prompt detection

### DIFF
--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -141,9 +141,12 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 	}
 
 	// Do not login, if we already logged in
+	loggedInPromptRegex := fmt.Sprintf(
+		`(\[fedora@(localhost|fedora|%s) ~\]\$ |\[root@(localhost|fedora|%s) fedora\]\# )`, vmi.Name, vmi.Name,
+	)
 	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: fmt.Sprintf(`(\[fedora@(localhost|fedora|%s) ~\]\$ |\[root@(localhost|fedora|%s) fedora\]\# )`, vmi.Name, vmi.Name)},
+		&expect.BExp{R: loggedInPromptRegex},
 	}
 	_, err = expecter.ExpectBatch(b, promptTimeout)
 	if err == nil {
@@ -174,7 +177,7 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
 				Rt: 10,
 			},
 			&expect.Case{
-				R: regexp.MustCompile(fmt.Sprintf(`\[fedora@(localhost|fedora|%s) ~\]\$ `, vmi.Name)),
+				R: regexp.MustCompile(loggedInPromptRegex),
 				T: expect.OK(),
 			},
 		}},


### PR DESCRIPTION
**What this PR does / why we need it**:

The expect "Caser" has only treated the `fedora` user when handling the detecting a logged in prompt.
Add also the `root` user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
