### PR TITLE
tests, storage/restore: Remove a redundant prompt login

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1675,7 +1675,6 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 						snapshotStorageClass,
 						corev1.ReadWriteOnce))
 					Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 					By("Get VM memory dump")
 					getMemoryDump(vm.Name, vm.Namespace, memoryDumpPVCName)


### PR DESCRIPTION
**What this PR does / why we need it**:

A redundant VM console prompt login has been removed. It caused some flakes in the tests, when the second login was attempted.

Although for the Fedora guest, detecting a login should have been supported, it seems that from time to time the detection is not working as expected. Reducing double logins may help reduce the flakes a bit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
