### PR TITLE
[e2e tests]: virt-handler canary upgrade test improvement

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -197,6 +197,7 @@ go_test(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
+        "//pkg/virt-operator/util:go_default_library",
         "//pkg/virtctl/pause:go_default_library",
         "//pkg/virtctl/softreboot:go_default_library",
         "//pkg/virtctl/vm:go_default_library",


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>


**What this PR does / why we need it**:
Recently the test was observerd with high flakiness. The suggested improvement is prone to events that can repeat a few times i.e. update event can happen multiple times with `maxUnavailable:1` or `maxUnavailable:10%` because not only the expected fields are being updated during the rollout. Another improvement is the sequence of events - it may happen that the rollout will finish earlier than the restore of maxUnavailable back to 1, for example if there is some API latency between virt-operator and API server, and there are few worker nodes, it may happen that more than one pod will be updated under the `maxUnavailable:1` configuration.

The following decision tree is suggested:
![Untitled-2022-08-28-1020](https://user-images.githubusercontent.com/59094274/215990380-071290e4-1364-4a64-b793-e9ebbefc67b4.svg)

Fixes #
https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2022-11-16-024h.html#row0

**Release note**:
```release-note
NONE
```
