### PR TITLE
[release-0.58]Fix evmcs hyperv vendor bug

### DIFF
--- a/pkg/virt-controller/services/nodeselectorrenderer.go
+++ b/pkg/virt-controller/services/nodeselectorrenderer.go
@@ -134,7 +134,7 @@ func hypervNodeSelectors(vmiFeatures *v1.Features) map[string]string {
 		}
 	}
 
-	if vmiFeatures.Hyperv.EVMCS != nil {
+	if vmiFeatures.Hyperv.EVMCS != nil && (vmiFeatures.Hyperv.EVMCS.Enabled == nil || (*vmiFeatures.Hyperv.EVMCS.Enabled) == true) {
 		nodeSelectors[v1.CPUModelVendorLabel+IntelVendorName] = "true"
 	}
 

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -250,6 +252,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 		})
 
 		DescribeTable("the vmi with EVMCS HyperV feature should have correct HyperV and cpu features auto filled", func(featureState *v1.FeatureState) {
+			tests.EnableFeatureGate(virtconfig.HypervStrictCheckGate)
 			vmi := libvmi.NewCirros()
 			vmi.Spec.Domain.Features = &v1.Features{
 				Hyperv: &v1.FeatureHyperv{
@@ -264,11 +267,14 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 			Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 			Expect(vmi.Spec.Domain.Features.Hyperv.EVMCS).ToNot(BeNil(), "evmcs should not be nil")
 			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil(), "cpu topology can't be nil")
+			pod := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			if featureState.Enabled == nil || *featureState.Enabled == true {
 				Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).ToNot(BeNil(), "vapic should not be nil")
 				Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(1), "cpu topology has to contain 1 feature")
 				Expect(vmi.Spec.Domain.CPU.Features[0].Name).To(Equal(nodelabellerutil.VmxFeature), "vmx cpu feature should be requested")
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(v1.CPUModelVendorLabel+"Intel", "true"))
 			} else {
+				Expect(pod.Spec.NodeSelector).ShouldNot(HaveKeyWithValue(v1.CPUModelVendorLabel+"Intel", "true"))
 				Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).To(BeNil(), "vapic should be nil")
 				Expect(vmi.Spec.Domain.CPU.Features).To(BeEmpty())
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual backport PR for https://github.com/kubevirt/kubevirt/pull/8840
the cherry-pick conflict was redundant import in hyperv_test.go
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
