### PR TITLE
Add `operator_health_impact` label to each of kubevirt alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -24,6 +24,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-controller-8546c99968-x9jgg"
@@ -50,6 +51,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedMemory"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: ci
@@ -88,6 +90,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 10m
@@ -98,6 +101,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 10m
@@ -108,6 +112,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       # it must trigger when operators are not healthy
@@ -119,6 +124,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtAPIDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 16m
@@ -129,6 +135,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 16m
@@ -139,6 +146,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorDown"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       # it must not trigger when operators are healthy
@@ -189,6 +197,7 @@ tests:
             exp_labels:
               node: "node01"
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -230,6 +239,7 @@ tests:
             exp_labels:
               node: "node01"
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -254,6 +264,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowReadyVirtControllersCount"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -276,6 +287,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
   # All virt controllers are not ready (ImagePullBackOff)
@@ -297,6 +309,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -319,6 +332,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -341,6 +355,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtOperator"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -381,6 +396,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 20m
@@ -391,6 +407,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 20m
@@ -401,6 +418,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 20m
@@ -411,6 +429,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtApiRESTErrorsBurst"
             exp_labels:
               severity: "critical"
+              operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -450,6 +469,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 100m
@@ -460,6 +480,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtOperatorRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 100m
@@ -470,6 +491,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtHandlerRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
       - eval_time: 100m
@@ -480,6 +502,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtApiRESTErrorsHigh"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -501,6 +524,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -522,6 +546,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowKVMNodesCount"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -558,6 +583,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
@@ -584,6 +610,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
@@ -610,6 +637,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-launcher-testvm-123"
@@ -647,6 +675,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/VMCannotBeEvicted"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               name: "vm-evict-nonmigratable"
@@ -719,6 +748,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               vmi: vmi-example-1
@@ -731,6 +761,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMIExcessiveMigrations"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               vmi: vmi-example-1
@@ -769,6 +800,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInStartingState"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               name: "starting-vm-1"
@@ -808,6 +840,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInMigratingState"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               name: "migrating-vm-1"
@@ -847,6 +880,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtVMStuckInErrorState"
             exp_labels:
               severity: "warning"
+              operator_health_impact: "none"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               name: "error-vm-1"

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -16,6 +16,7 @@ const (
 	prometheusLabelValue          = "true"
 	runbookUrlBasePath            = "https://kubevirt.io/monitoring/runbooks/"
 	severityAlertLabelKey         = "severity"
+	operatorHealthImpactLabelKey  = "operator_health_impact"
 	partOfAlertLabelKey           = "kubernetes_operator_part_of"
 	partOfAlertLabelValue         = "kubevirt"
 	componentAlertLabelKey        = "kubernetes_operator_component"
@@ -109,7 +110,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 				"runbook_url": runbookUrlBasePath + alertName,
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey: "warning",
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
 			},
 		}
 	}
@@ -134,7 +136,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtAPIDown",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -150,7 +153,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowVirtAPICount",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -167,7 +171,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowKVMNodesCount",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -191,7 +196,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowReadyVirtControllersCount",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -203,7 +209,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "NoReadyVirtController",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -215,7 +222,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtControllerDown",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -227,7 +235,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowVirtControllersCount",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -238,7 +247,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -250,7 +260,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtControllerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -268,7 +279,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtOperatorDown",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -280,7 +292,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowVirtOperatorCount",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -291,7 +304,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -303,7 +317,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtOperatorRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -327,7 +342,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "LowReadyVirtOperatorsCount",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -339,7 +355,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "NoReadyVirtOperator",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -351,7 +368,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "NoLeadingVirtOperator",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -370,7 +388,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtHandlerDaemonSetRolloutFailing",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -381,7 +400,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -393,7 +413,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtHandlerRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -404,7 +425,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtApiRESTErrorsHigh",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "warning",
 						},
 					},
 					{
@@ -416,7 +438,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VirtApiRESTErrorsBurst",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "critical",
+							severityAlertLabelKey:        "critical",
+							operatorHealthImpactLabelKey: "critical",
 						},
 					},
 					{
@@ -441,7 +464,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubevirtVmHighMemoryUsage",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "none",
 						},
 					},
 					{
@@ -453,7 +477,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "OrphanedVirtualMachineInstances",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "none",
 						},
 					},
 					{
@@ -466,7 +491,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "VMCannotBeEvicted",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "none",
 						},
 					},
 					{
@@ -479,7 +505,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedMemory",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "none",
 						},
 					},
 					{
@@ -494,7 +521,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubeVirtComponentExceedsRequestedCPU",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "none",
 						},
 					},
 					{
@@ -518,7 +546,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 							"runbook_url": runbookUrlBasePath + "KubeVirtVMIExcessiveMigrations",
 						},
 						Labels: map[string]string{
-							severityAlertLabelKey: "warning",
+							severityAlertLabelKey:        "warning",
+							operatorHealthImpactLabelKey: "none",
 						},
 					},
 					vmStuckInStatusRule("starting"),
@@ -540,7 +569,8 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 				"runbook_url": runbookUrlBasePath + "OutdatedVirtualMachineInstanceWorkloads",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey: "warning",
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "none",
 			},
 		})
 	}

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -651,6 +651,8 @@ func checkRequiredAnnotations(rule promv1.Rule) {
 func checkRequiredLabels(rule promv1.Rule) {
 	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("severity", BeElementOf("info", "warning", "critical")),
 		fmt.Sprintf("%s severity label is missing or not valid", rule.Alert))
+	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("operator_health_impact", BeElementOf("none", "warning", "critical")),
+		fmt.Sprintf("%s operator_health_impact label is missing or not valid", rule.Alert))
 	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("kubernetes_operator_part_of", "kubevirt"),
 		fmt.Sprintf("%s kubernetes_operator_part_of label is missing or not valid", rule.Alert))
 	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "kubevirt"),


### PR DESCRIPTION
Signed-off-by: assafad <aadmi@redhat.com>


**What this PR does / why we need it**:

This PR adds to each of kubevirt alerts a label named `operator_health_impact`, which indicates how the alerts impact the operator health. This will enable us filtering alerts based on their impact on the operator health itself, rather than the workload, and to later have an operator health metric, which will tell the user what is the aggregated operator health.

This label gets one of the following values:
- `critical` indicates that the alert fires duo to an issue that impacts the operator health badly, and an action must be taken immediately in order to solve it (e.g. `VirtOperatorDown` alert).
-  `warning` indicates that the alert fires duo to an issue that soon might impact the operator health badly, and the user should be warned in order to solve the issue (e.g. `LowReadyVirtOperatorsCount` alert).
- `none` indicates that the alert fires duo to an issue that doesn't affect the operator health, and in most cases is related to the workload rather than the operator itself (e.g. `KubevirtVmHighMemoryUsage` alert).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Which issue(s) this PR fixes:** 
https://issues.redhat.com/browse/CNV-18923

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
