### PR TITLE
cgroup v2: Drop global rulesPerPid map

### DIFF
--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -53,21 +53,18 @@ type HotplugDiskManagerInterface interface {
 
 func NewHotplugDiskManager(kubeletPodsDir string) *hotplugDiskManager {
 	return &hotplugDiskManager{
-		podsBaseDir:       filepath.Join(util.HostRootMount, kubeletPodsDir),
-		targetPodBasePath: TargetPodBasePath,
+		podsBaseDir: filepath.Join(util.HostRootMount, kubeletPodsDir),
 	}
 }
 
 func NewHotplugDiskWithOptions(podsBaseDir string) *hotplugDiskManager {
 	return &hotplugDiskManager{
-		podsBaseDir:       podsBaseDir,
-		targetPodBasePath: TargetPodBasePath,
+		podsBaseDir: podsBaseDir,
 	}
 }
 
 type hotplugDiskManager struct {
-	podsBaseDir       string
-	targetPodBasePath func(podBaseDir string, podUID types.UID) string
+	podsBaseDir string
 }
 
 // GetHotplugTargetPodPathOnHost retrieves the target pod (virt-launcher) path on the host.

--- a/pkg/hotplug-disk/hotplug-disk_test.go
+++ b/pkg/hotplug-disk/hotplug-disk_test.go
@@ -41,22 +41,14 @@ var _ = Describe("HotplugDisk", func() {
 
 	BeforeEach(func() {
 		// Create some directories and files in temporary location.
-		tempDir, err = os.MkdirTemp("/tmp", "hp-disk-test")
-		Expect(err).ToNot(HaveOccurred())
+		tempDir = GinkgoT().TempDir()
 		podsBaseDir = filepath.Join(tempDir, "podsBaseDir")
 		err = os.MkdirAll(filepath.Join(podsBaseDir), os.FileMode(0755))
 		hotplug = &hotplugDiskManager{
-			podsBaseDir:       podsBaseDir,
-			targetPodBasePath: nil,
+			podsBaseDir: podsBaseDir,
 		}
 
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if tempDir != "" {
-			Expect(os.RemoveAll(tempDir)).To(Succeed())
-		}
 	})
 
 	It("GetHotplugTargetPodPathOnHost should return the correct path", func() {

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
+        "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/container-disk:go_default_library",
         "//pkg/virt-handler/hotplug-disk:go_default_library",

--- a/pkg/virt-handler/cgroup/BUILD.bazel
+++ b/pkg/virt-handler/cgroup/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/cgroup",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -23,6 +24,7 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs2:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/devices:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/cgroup/cgroup_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_test.go
@@ -43,7 +43,7 @@ var _ = Describe("cgroup manager", func() {
 		if version == V1 {
 			return newCustomizedV1Manager(mockRuncCgroupManager, false, execVirtChrootFunc, getCurrentlyDefinedRulesFunc)
 		} else {
-			return newCustomizedV2Manager(mockRuncCgroupManager, false, execVirtChrootFunc)
+			return newCustomizedV2Manager(mockRuncCgroupManager, false, nil, execVirtChrootFunc)
 		}
 	}
 
@@ -85,10 +85,11 @@ var _ = Describe("cgroup manager", func() {
 
 		Expect(rulesDefined).To(ContainElement(fakeRule), "defined rule is expected to exist")
 
-		for _, defaultRule := range GenerateDefaultDeviceRules() {
+		defaultDeviceRules := GenerateDefaultDeviceRules()
+		for _, defaultRule := range defaultDeviceRules {
 			Expect(rulesDefined).To(ContainElement(defaultRule), "default rules are expected to be defined")
 		}
-
+		Expect(rulesDefined).To(HaveLen(len(defaultDeviceRules) + 1))
 	},
 		Entry("for v1", V1),
 		Entry("for v2", V2),

--- a/pkg/virt-handler/cgroup/cgroup_v2_manager.go
+++ b/pkg/virt-handler/cgroup/cgroup_v2_manager.go
@@ -16,8 +16,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 )
 
-var rulesPerPid = make(map[string][]*devices.Rule)
-
 type v2Manager struct {
 	runc_cgroups.Manager
 	dirPath        string
@@ -45,7 +43,7 @@ func newCustomizedV2Manager(
 		runcManager,
 		runcManager.GetPaths()[""],
 		isRootless,
-		deviceRules,
+		append(deviceRules, GenerateDefaultDeviceRules()...),
 		execVirtChroot,
 	}
 
@@ -60,19 +58,14 @@ func (v *v2Manager) Set(r *runc_configs.Resources) error {
 	// We want to keep given resources untouched
 	resourcesToSet := *r
 
-	//Add default rules
-	resourcesToSet.Devices = append(resourcesToSet.Devices, GenerateDefaultDeviceRules()...)
-	resourcesToSet.Devices = append(resourcesToSet.Devices, v.deviceRules...)
-
-	rulesToSet, err := addCurrentRules(rulesPerPid[v.dirPath], resourcesToSet.Devices)
+	rulesToSet, err := addCurrentRules(v.deviceRules, resourcesToSet.Devices)
 	if err != nil {
 		return err
 	}
-	rulesPerPid[v.dirPath] = rulesToSet
+	v.deviceRules = rulesToSet
 	resourcesToSet.Devices = rulesToSet
 
-	err = v.execVirtChroot(&resourcesToSet, map[string]string{"": v.dirPath}, v.isRootless, v.GetCgroupVersion())
-	return err
+	return v.execVirtChroot(&resourcesToSet, map[string]string{"": v.dirPath}, v.isRootless, v.GetCgroupVersion())
 }
 
 func (v *v2Manager) GetCgroupVersion() CgroupVersion {

--- a/pkg/virt-handler/cgroup/util.go
+++ b/pkg/virt-handler/cgroup/util.go
@@ -4,21 +4,28 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/runc/libcontainer/devices"
 
 	runc_cgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 	runc_configs "github.com/opencontainers/runc/libcontainer/configs"
 
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/safepath"
+	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 )
 
 type CgroupVersion string
@@ -82,6 +89,66 @@ func addCurrentRules(currentRules, newRules []*devices.Rule) ([]*devices.Rule, e
 	}
 
 	return newRules, nil
+}
+
+func generateDeviceRulesForVMI(vmi *v1.VirtualMachineInstance, isolationRes isolation.IsolationResult) ([]*devices.Rule, error) {
+	mountRoot, err := isolationRes.MountRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	var vmiDeviceRules []*devices.Rule
+	for _, volume := range vmi.Spec.Volumes {
+		switch {
+		case volume.VolumeSource.PersistentVolumeClaim != nil:
+			if volume.VolumeSource.PersistentVolumeClaim.Hotpluggable {
+				continue
+			}
+		case volume.VolumeSource.DataVolume != nil:
+			if volume.VolumeSource.DataVolume.Hotpluggable {
+				continue
+			}
+		case volume.VolumeSource.Ephemeral != nil:
+		default:
+			continue
+		}
+		path, err := safepath.JoinNoFollow(mountRoot, filepath.Join("dev", volume.Name))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to resolve path for volume %s: %v", volume.Name, err)
+		}
+		if deviceRule, err := newDeviceRule(path, true); err != nil {
+			return nil, fmt.Errorf("failed to create device rule for %s: %v", path, err)
+		} else if deviceRule != nil {
+			log.Log.V(loggingVerbosity).Infof("device rule for volume %s: %v", volume.Name, deviceRule)
+			vmiDeviceRules = append(vmiDeviceRules, deviceRule)
+		}
+	}
+	return vmiDeviceRules, nil
+}
+
+func newDeviceRule(devicePath *safepath.Path, allow bool) (*devices.Rule, error) {
+	fileInfo, err := safepath.StatAtNoFollow(devicePath)
+	if err != nil {
+		return nil, err
+	}
+	if (fileInfo.Mode() & os.ModeDevice) == 0 {
+		return nil, nil //not a device file
+	}
+	deviceType := devices.BlockDevice
+	if (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+		deviceType = devices.CharDevice
+	}
+	stat := fileInfo.Sys().(*syscall.Stat_t)
+	return &devices.Rule{
+		Type:        deviceType,
+		Major:       int64(unix.Major(stat.Rdev)),
+		Minor:       int64(unix.Minor(stat.Rdev)),
+		Permissions: "rwm",
+		Allow:       allow,
+	}, nil
 }
 
 func GenerateDefaultDeviceRules() []*devices.Rule {

--- a/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
@@ -7,6 +7,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 	v1 "kubevirt.io/api/core/v1"
+
+	cgroup "kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 )
 
 // Mock of VolumeMounter interface
@@ -30,44 +32,44 @@ func (_m *MockVolumeMounter) EXPECT() *_MockVolumeMounterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockVolumeMounter) Mount(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "Mount", vmi)
+func (_m *MockVolumeMounter) Mount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "Mount", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) Mount(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0)
+func (_mr *_MockVolumeMounterRecorder) Mount(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0, arg1)
 }
 
-func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error {
-	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID)
+func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1)
+func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1, arg2)
 }
 
-func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "Unmount", vmi)
+func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "Unmount", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) Unmount(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0)
+func (_mr *_MockVolumeMounterRecorder) Unmount(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unmount", arg0, arg1)
 }
 
-func (_m *MockVolumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "UnmountAll", vmi)
+func (_m *MockVolumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	ret := _m.ctrl.Call(_m, "UnmountAll", vmi, cgroupManager)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVolumeMounterRecorder) UnmountAll(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountAll", arg0)
+func (_mr *_MockVolumeMounterRecorder) UnmountAll(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmountAll", arg0, arg1)
 }
 
 func (_m *MockVolumeMounter) IsMounted(vmi *v1.VirtualMachineInstance, volume string, sourceUID types.UID) (bool, error) {

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -46,10 +46,6 @@ var (
 		return safepath.JoinAndResolveWithRelativeRoot("/proc/1/root", fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~empty-dir/hotplug-disks", string(podUID)))
 	}
 
-	sourcePodBasePath = func(podUID types.UID) (*safepath.Path, error) {
-		return safepath.JoinAndResolveWithRelativeRoot("/proc/1/root", fmt.Sprintf("root/var/lib/kubelet/pods/%s/volumes", string(podUID)))
-	}
-
 	socketPath = func(podUID types.UID) string {
 		return fmt.Sprintf("pods/%s/volumes/kubernetes.io~empty-dir/hotplug-disks/hp.sock", string(podUID))
 	}

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -34,8 +34,7 @@ import (
 //go:generate mockgen -source $GOFILE -package=$GOPACKAGE -destination=generated_mock_$GOFILE
 
 const (
-	unableFindHotplugMountedDir            = "unable to find hotplug mounted directories for vmi without uid"
-	failedToCreateCgroupManagerErrTemplate = "could not create cgroup manager. err: %v"
+	unableFindHotplugMountedDir = "unable to find hotplug mounted directories for vmi without uid"
 )
 
 var (
@@ -118,10 +117,6 @@ var (
 		return isolation.NewSocketBasedIsolationDetector(path)
 	}
 
-	getCgroupManager = func(vmi *v1.VirtualMachineInstance) (cgroup.Manager, error) {
-		return cgroup.NewManagerFromVM(vmi)
-	}
-
 	parentPathForMount = func(
 		parent isolation.IsolationResult,
 		child isolation.IsolationResult,
@@ -143,12 +138,12 @@ type volumeMounter struct {
 // VolumeMounter is the interface used to mount and unmount volumes to/from a running virtlauncher pod.
 type VolumeMounter interface {
 	// Mount any new volumes defined in the VMI
-	Mount(vmi *v1.VirtualMachineInstance) error
-	MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error
+	Mount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error
+	MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID, cgroupManager cgroup.Manager) error
 	// Unmount any volumes no longer defined in the VMI
-	Unmount(vmi *v1.VirtualMachineInstance) error
+	Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error
 	//UnmountAll cleans up all hotplug volumes
-	UnmountAll(vmi *v1.VirtualMachineInstance) error
+	UnmountAll(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error
 	//IsMounted returns if the volume is mounted or not.
 	IsMounted(vmi *v1.VirtualMachineInstance, volume string, sourceUID types.UID) (bool, error)
 }
@@ -302,13 +297,20 @@ func (m *volumeMounter) writePathToMountRecord(path string, vmi *v1.VirtualMachi
 	return nil
 }
 
-func (m *volumeMounter) mountHotplugVolume(vmi *v1.VirtualMachineInstance, volumeName string, sourceUID types.UID, record *vmiMountTargetRecord, mountDirectory bool) error {
+func (m *volumeMounter) mountHotplugVolume(
+	vmi *v1.VirtualMachineInstance,
+	volumeName string,
+	sourceUID types.UID,
+	record *vmiMountTargetRecord,
+	mountDirectory bool,
+	cgroupManager cgroup.Manager,
+) error {
 	logger := log.DefaultLogger()
 	logger.V(4).Infof("Hotplug check volume name: %s", volumeName)
 	if sourceUID != types.UID("") {
 		if m.isBlockVolume(&vmi.Status, volumeName) {
 			logger.V(4).Infof("Mounting block volume: %s", volumeName)
-			if err := m.mountBlockHotplugVolume(vmi, volumeName, sourceUID, record); err != nil {
+			if err := m.mountBlockHotplugVolume(vmi, volumeName, sourceUID, record, cgroupManager); err != nil {
 				return fmt.Errorf("failed to mount block hotplug volume %s: %v", volumeName, err)
 			}
 		} else {
@@ -321,15 +323,15 @@ func (m *volumeMounter) mountHotplugVolume(vmi *v1.VirtualMachineInstance, volum
 	return nil
 }
 
-func (m *volumeMounter) Mount(vmi *v1.VirtualMachineInstance) error {
-	return m.mountFromPod(vmi, types.UID(""))
+func (m *volumeMounter) Mount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
+	return m.mountFromPod(vmi, types.UID(""), cgroupManager)
 }
 
-func (m *volumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error {
-	return m.mountFromPod(vmi, sourceUID)
+func (m *volumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID, cgroupManager cgroup.Manager) error {
+	return m.mountFromPod(vmi, sourceUID, cgroupManager)
 }
 
-func (m *volumeMounter) mountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error {
+func (m *volumeMounter) mountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID, cgroupManager cgroup.Manager) error {
 	record, err := m.getMountTargetRecord(vmi)
 	if err != nil {
 		return err
@@ -346,7 +348,7 @@ func (m *volumeMounter) mountFromPod(vmi *v1.VirtualMachineInstance, sourceUID t
 		if sourceUID == types.UID("") {
 			sourceUID = volumeStatus.HotplugVolume.AttachPodUID
 		}
-		if err := m.mountHotplugVolume(vmi, volumeStatus.Name, sourceUID, record, mountDirectory); err != nil {
+		if err := m.mountHotplugVolume(vmi, volumeStatus.Name, sourceUID, record, mountDirectory, cgroupManager); err != nil {
 			return err
 		}
 	}
@@ -374,7 +376,13 @@ func (m *volumeMounter) isBlockVolume(vmiStatus *v1.VirtualMachineInstanceStatus
 	return false
 }
 
-func (m *volumeMounter) mountBlockHotplugVolume(vmi *v1.VirtualMachineInstance, volume string, sourceUID types.UID, record *vmiMountTargetRecord) error {
+func (m *volumeMounter) mountBlockHotplugVolume(
+	vmi *v1.VirtualMachineInstance,
+	volume string,
+	sourceUID types.UID,
+	record *vmiMountTargetRecord,
+	cgroupManager cgroup.Manager,
+) error {
 	virtlauncherUID := m.findVirtlauncherUID(vmi)
 	if virtlauncherUID == "" {
 		// This is not the node the pod is running on.
@@ -383,11 +391,6 @@ func (m *volumeMounter) mountBlockHotplugVolume(vmi *v1.VirtualMachineInstance, 
 	targetPath, err := m.hotplugDiskManager.GetHotplugTargetPodPathOnHost(virtlauncherUID)
 	if err != nil {
 		return err
-	}
-
-	cgroupsManager, err := getCgroupManager(vmi)
-	if err != nil {
-		return fmt.Errorf(failedToCreateCgroupManagerErrTemplate, err)
 	}
 
 	if _, err := safepath.JoinNoFollow(targetPath, volume); errors.Is(err, os.ErrNotExist) {
@@ -418,34 +421,16 @@ func (m *volumeMounter) mountBlockHotplugVolume(vmi *v1.VirtualMachineInstance, 
 		return fmt.Errorf("target device %v exists but it is not a block device", devicePath)
 	}
 
-	isMigrationInProgress := vmi.Status.MigrationState != nil && !vmi.Status.MigrationState.Completed
-	volumeNotReady := !m.volumeStatusReady(volume, vmi)
-
-	if isMigrationInProgress || volumeNotReady {
-		dev, _, err := m.getSourceMajorMinor(sourceUID, volume)
-		if err != nil {
-			return err
-		}
-		// allow block devices
-		if err := m.allowBlockMajorMinor(dev, cgroupsManager); err != nil {
-			return err
-		}
+	dev, _, err := m.getBlockFileMajorMinor(devicePath, statDevice)
+	if err != nil {
+		return err
+	}
+	// allow block devices
+	if err := m.allowBlockMajorMinor(dev, cgroupManager); err != nil {
+		return err
 	}
 
 	return m.ownershipManager.SetFileOwnership(devicePath)
-}
-
-func (m *volumeMounter) volumeStatusReady(volumeName string, vmi *v1.VirtualMachineInstance) bool {
-	for _, volumeStatus := range vmi.Status.VolumeStatus {
-		if volumeStatus.Name == volumeName && volumeStatus.HotplugVolume != nil {
-			if volumeStatus.Phase != v1.VolumeReady {
-				log.DefaultLogger().V(4).Infof("Volume %s is not ready, but the target block device exists", volumeName)
-			}
-			return volumeStatus.Phase == v1.VolumeReady
-		}
-	}
-	// This should never happen, it should always find the volume status in the VMI.
-	return true
 }
 
 func (m *volumeMounter) getSourceMajorMinor(sourceUID types.UID, volumeName string) (uint64, os.FileMode, error) {
@@ -469,17 +454,15 @@ func (m *volumeMounter) getBlockFileMajorMinor(devicePath *safepath.Path, getter
 	return info.Rdev, fileInfo.Mode(), nil
 }
 
-func (m *volumeMounter) removeBlockMajorMinor(dev uint64, manager cgroup.Manager) error {
-	return m.updateBlockMajorMinor(dev, false, manager)
+func (m *volumeMounter) removeBlockMajorMinor(dev uint64, cgroupManager cgroup.Manager) error {
+	return m.updateBlockMajorMinor(dev, false, cgroupManager)
 }
 
-func (m *volumeMounter) allowBlockMajorMinor(dev uint64, manager cgroup.Manager) error {
-	return m.updateBlockMajorMinor(dev, true, manager)
+func (m *volumeMounter) allowBlockMajorMinor(dev uint64, cgroupManager cgroup.Manager) error {
+	return m.updateBlockMajorMinor(dev, true, cgroupManager)
 }
 
-func (m *volumeMounter) updateBlockMajorMinor(dev uint64, allow bool, manager cgroup.Manager) error {
-
-	var err error
+func (m *volumeMounter) updateBlockMajorMinor(dev uint64, allow bool, cgroupManager cgroup.Manager) error {
 	deviceRule := &devices.Rule{
 		Type:        devices.BlockDevice,
 		Major:       int64(unix.Major(dev)),
@@ -488,14 +471,18 @@ func (m *volumeMounter) updateBlockMajorMinor(dev uint64, allow bool, manager cg
 		Allow:       allow,
 	}
 
-	err = manager.Set(&configs.Resources{
+	if cgroupManager == nil {
+		return fmt.Errorf("failed to apply device rule %+v: cgroup manager is nil", *deviceRule)
+	}
+
+	err := cgroupManager.Set(&configs.Resources{
 		Devices: []*devices.Rule{deviceRule},
 	})
 
 	if err != nil {
-		log.Log.Infof("cgroup %s had failed to set device rule. error: %v. rule: %+v", manager.GetCgroupVersion(), err, *deviceRule)
+		log.Log.Errorf("cgroup %s had failed to set device rule. error: %v. rule: %+v", cgroupManager.GetCgroupVersion(), err, *deviceRule)
 	} else {
-		log.Log.Infof("cgroup %s device rule is set successfully. rule: %+v", manager.GetCgroupVersion(), *deviceRule)
+		log.Log.Infof("cgroup %s device rule is set successfully. rule: %+v", cgroupManager.GetCgroupVersion(), *deviceRule)
 	}
 
 	return err
@@ -628,7 +615,7 @@ func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.Virtua
 }
 
 // Unmount unmounts all hotplug disk that are no longer part of the VMI
-func (m *volumeMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
+func (m *volumeMounter) Unmount(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
 	if vmi.UID != "" {
 		record, err := m.getMountTargetRecord(vmi)
 		if err != nil {
@@ -696,7 +683,7 @@ func (m *volumeMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 				if blockDevice, err := isBlockDevice(diskPath); err != nil {
 					return err
 				} else if blockDevice {
-					if err := m.unmountBlockHotplugVolumes(diskPath, vmi); err != nil {
+					if err := m.unmountBlockHotplugVolumes(diskPath, cgroupManager); err != nil {
 						return err
 					}
 				} else if err := m.unmountFileSystemHotplugVolumes(diskPath); err != nil {
@@ -737,12 +724,7 @@ func (m *volumeMounter) unmountFileSystemHotplugVolumes(diskPath *safepath.Path)
 	return nil
 }
 
-func (m *volumeMounter) unmountBlockHotplugVolumes(diskPath *safepath.Path, vmi *v1.VirtualMachineInstance) error {
-	cgroupsManager, err := getCgroupManager(vmi)
-	if err != nil {
-		return fmt.Errorf(failedToCreateCgroupManagerErrTemplate, err)
-	}
-
+func (m *volumeMounter) unmountBlockHotplugVolumes(diskPath *safepath.Path, cgroupManager cgroup.Manager) error {
 	// Get major and minor so we can deny the container.
 	dev, _, err := m.getBlockFileMajorMinor(diskPath, statDevice)
 	if err != nil {
@@ -752,14 +734,11 @@ func (m *volumeMounter) unmountBlockHotplugVolumes(diskPath *safepath.Path, vmi 
 	if err := safepath.UnlinkAtNoFollow(diskPath); err != nil {
 		return err
 	}
-	if err := m.removeBlockMajorMinor(dev, cgroupsManager); err != nil {
-		return err
-	}
-	return nil
+	return m.removeBlockMajorMinor(dev, cgroupManager)
 }
 
 // UnmountAll unmounts all hotplug disks of a given VMI.
-func (m *volumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance) error {
+func (m *volumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance, cgroupManager cgroup.Manager) error {
 	if vmi.UID != "" {
 		logger := log.DefaultLogger().Object(vmi)
 		logger.Info("Cleaning up remaining hotplug volumes")
@@ -779,20 +758,20 @@ func (m *volumeMounter) UnmountAll(vmi *v1.VirtualMachineInstance) error {
 					logger.Infof("Device %v is not mounted anymore, continuing.", entry.TargetFile)
 					continue
 				}
-				logger.Infof("Unable to unmount volume at path %s: %v", entry.TargetFile, err)
+				logger.Warningf("Unable to unmount volume at path %s: %v", entry.TargetFile, err)
 				continue
 			}
 			diskPath.Close()
 			if isBlock, err := isBlockDevice(diskPath.Path()); err != nil {
-				logger.Infof("Unable to remove block device at path %s: %v", diskPath, err)
+				logger.Warningf("Unable to unmount volume at path %s: %v", diskPath, err)
 			} else if isBlock {
-				if err := m.unmountBlockHotplugVolumes(diskPath.Path(), vmi); err != nil {
-					logger.Infof("Unable to remove block device at path %s: %v", diskPath, err)
+				if err := m.unmountBlockHotplugVolumes(diskPath.Path(), cgroupManager); err != nil {
+					logger.Warningf("Unable to remove block device at path %s: %v", diskPath, err)
 					// Don't return error, try next.
 				}
 			} else {
 				if err := m.unmountFileSystemHotplugVolumes(diskPath.Path()); err != nil {
-					logger.Infof("Unable to unmount volume at path %s: %v", diskPath, err)
+					logger.Warningf("Unable to unmount volume at path %s: %v", diskPath, err)
 					// Don't return error, try next.
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

Keep the existing device rules within the manager state.

**What this PR does / why we need it**:

This is an attempt to refactor the cgroup v2 manager, so it keeps the current set of device rules within the internal state rather than in a global map.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7710, fixes https://github.com/kubevirt/kubevirt/issues/8699

**Special notes for your reviewer**:

The PR also includes the changes https://github.com/kubevirt/kubevirt/pull/8828

The idea is to pass the cgroup manager as an argument to hotplug volumes mounter. That way, the manager instance can be created outside the hotplug context and the device rules can be accumulated within the manager. Potentially, the instance can be reused when other hotplug functionality is in place (e.g. for network tap devices).

An alternative solution might be to extend the `generateDeviceRulesForVMI` function, so it also returns the rules for hotplug volumes. However, this will require mixing the cgroup and hotplug code, and it is not very good when it comes to extending the functionality. E.g. if we needed to add other hotplug devices, we would have to extend the function for the new use case.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
