### PR TITLE
Verfiy readiness of virt components in tests

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2501,6 +2501,9 @@ spec:
 			}, 60*time.Second, 1*time.Second).Should(BeTrue())
 
 			patchKvInfra(nil, false, "")
+
+			By("Verifying that all pods are ready to avoid flackiness in the next test")
+			allPodsAreReady(originalKv)
 		})
 
 		It("[test_id:4928]should dynamically update workloads config", func() {
@@ -2523,6 +2526,9 @@ spec:
 			}, 60*time.Second, 1*time.Second).Should(BeTrue())
 
 			patchKvWorkloads(nil, false, "")
+
+			By("Verifying that all pods are ready to avoid flackiness in the next test")
+			allPodsAreReady(originalKv)
 		})
 
 		It("should reject infra placement configuration with incorrect toleration operator", func() {


### PR DESCRIPTION
Sometime virt-componetes aren't ready after
running this tests and that cause flackiness.

Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
