### PR TITLE
Rename migration metrics removing 'total' keyword

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,7 +24,7 @@ The rate of memory being dirty in the Guest OS. Type: Gauge.
 ### kubevirt_migrate_vmi_disk_transfer_rate_bytes
 The rate at which the disk is being transferred. Type: Gauge.
 
-### kubevirt_migrate_vmi_failed_total
+### kubevirt_migrate_vmi_failed
 Number of failed migrations. Type: Gauge.
 
 ### kubevirt_migrate_vmi_memory_transfer_rate_bytes
@@ -39,7 +39,7 @@ Number of current running migrations. Type: Gauge.
 ### kubevirt_migrate_vmi_scheduling_count
 Number of current scheduling migrations. Type: Gauge.
 
-### kubevirt_migrate_vmi_succeeded_total
+### kubevirt_migrate_vmi_succeeded
 Number of migrations successfully executed. Type: Gauge.
 
 ### kubevirt_virt_controller_leading

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -700,7 +700,7 @@ tests:
   # Excessive VMI Migrations in a period of time
   - interval: 1h
     input_series:
-      - series: 'kubevirt_migrate_vmi_succeeded_total{vmi="vmi-example-1"}'
+      - series: 'kubevirt_migrate_vmi_succeeded{vmi="vmi-example-1"}'
         # time:  0 1 2 3 4 5
         values: "_ _ _ 1 7 13"
 

--- a/pkg/monitoring/migrationstats/collector.go
+++ b/pkg/monitoring/migrationstats/collector.go
@@ -31,8 +31,8 @@ const (
 	PendingMigrations    = "kubevirt_migrate_vmi_pending_count"
 	SchedulingMigrations = "kubevirt_migrate_vmi_scheduling_count"
 	RunningMigrations    = "kubevirt_migrate_vmi_running_count"
-	SucceededMigrations  = "kubevirt_migrate_vmi_succeeded_total"
-	FailedMigrations     = "kubevirt_migrate_vmi_failed_total"
+	SucceededMigrations  = "kubevirt_migrate_vmi_succeeded"
+	FailedMigrations     = "kubevirt_migrate_vmi_failed"
 )
 
 var (

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -511,7 +511,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "KubeVirtVMIExcessiveMigrations",
-						Expr:  intstr.FromString("sum by (vmi) (max_over_time(kubevirt_migrate_vmi_succeeded_total[1d])) >= 12"),
+						Expr:  intstr.FromString("sum by (vmi) (max_over_time(kubevirt_migrate_vmi_succeeded[1d])) >= 12"),
 						Annotations: map[string]string{
 							"description": "VirtualMachineInstance {{ $labels.vmi }} has been migrated more than 12 times during the last 24 hours",
 							"summary":     "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours.",

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -325,7 +325,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, func() {
 			labels := map[string]string{
 				"vmi": vmi.Name,
 			}
-			waitForMetricValueWithLabels(virtClient, "kubevirt_migrate_vmi_succeeded_total", 1, labels)
+			waitForMetricValueWithLabels(virtClient, "kubevirt_migrate_vmi_succeeded", 1, labels)
 
 			By("Delete VMIs")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
@@ -354,7 +354,7 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, func() {
 			Eventually(matcher.ThisMigration(migration), 2*time.Minute, 5*time.Second).Should(matcher.BeInPhase(v1.MigrationFailed), "migration creation should fail")
 
 			waitForMetricValue(virtClient, "kubevirt_migrate_vmi_scheduling_count", 0)
-			waitForMetricValueWithLabels(virtClient, "kubevirt_migrate_vmi_failed_total", 1, labels)
+			waitForMetricValueWithLabels(virtClient, "kubevirt_migrate_vmi_failed", 1, labels)
 
 			By("Deleting the VMI")
 			Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`kubevirt_migrate_vmi_succeeded_total` and `kubevirt_migrate_vmi_failed_total` contain the keyword `total`, which is incorrect because they hold the value per vmi, vmim and namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename migration metrics removing 'total' keyword
```
