### PR TITLE
vm-killer-image, Add nonroot user to container image

### DIFF
--- a/images/vm-killer/BUILD.bazel
+++ b/images/vm-killer/BUILD.bazel
@@ -10,5 +10,6 @@ container_image(
         "//conditions:default": "amd64",
     }),
     base = "//images:kubevirt-testing-base",
+    user = "1001",
     visibility = ["//visibility:public"],
 )

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1411,8 +1411,6 @@ func DeleteAlpineWithNonQEMUPermissions() {
 }
 
 func renderContainerSpec(imgPath string, name string, cmd []string, args []string) k8sv1.Container {
-	nonRootUser := int64(1042)
-
 	return k8sv1.Container{
 		Name:    name,
 		Image:   imgPath,
@@ -1422,7 +1420,6 @@ func renderContainerSpec(imgPath string, name string, cmd []string, args []strin
 			Privileged:               NewBool(false),
 			AllowPrivilegeEscalation: NewBool(false),
 			RunAsNonRoot:             NewBool(true),
-			RunAsUser:                &nonRootUser,
 			SeccompProfile: &k8sv1.SeccompProfile{
 				Type: k8sv1.SeccompProfileTypeRuntimeDefault,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, in order to run jobs with specific non-root users, the container spec is set with the userID.
Such a configuration is used on the vm-killer-image image. This however reqires higher SCC priviliges for the jobs running this image.
In order to avoid this, configuring the image to use a non root user on the container dockerfile image level.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
