### PR TITLE
Bugfix: use virt operator image if provided

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1192,7 +1192,7 @@ spec:
                 command:
                 - virt-operator
                 env:
-                - name: OPERATOR_IMAGE
+                - name: VIRT_OPERATOR_IMAGE
                   value: {{.DockerPrefix}}/virt-operator{{if .VirtOperatorSha}}@{{.VirtOperatorSha}}{{else}}:{{.DockerTag}}{{end}}
                 - name: WATCH_NAMESPACE
                   valueFrom:

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -706,7 +706,10 @@ func (c *KubeVirtController) execute(key string) error {
 
 func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.KubeVirtDeploymentConfig) (*batchv1.Job, error) {
 
-	operatorImage := fmt.Sprintf("%s/%s%s%s", config.GetImageRegistry(), config.GetImagePrefix(), VirtOperator, components.AddVersionSeparatorPrefix(config.GetOperatorVersion()))
+	operatorImage := config.VirtOperatorImage
+	if operatorImage == "" {
+		operatorImage = fmt.Sprintf("%s/%s%s%s", config.GetImageRegistry(), config.GetImagePrefix(), VirtOperator, components.AddVersionSeparatorPrefix(config.GetOperatorVersion()))
+	}
 	deploymentConfigJson, err := config.GetJson()
 	if err != nil {
 		return nil, err

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -763,11 +763,6 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
 								},
 								{
 									// Deprecated, keep it for backwards compatibility
-									Name:  util.OldOperatorImageEnvName,
-									Value: operatorImage,
-								},
-								{
-									// Deprecated, keep it for backwards compatibility
 									Name:  util.TargetInstallNamespace,
 									Value: config.GetNamespace(),
 								},

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -758,6 +758,10 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
 							},
 							Env: []k8sv1.EnvVar{
 								{
+									Name:  util.VirtOperatorImageEnvName,
+									Value: operatorImage,
+								},
+								{
 									// Deprecated, keep it for backwards compatibility
 									Name:  util.OldOperatorImageEnvName,
 									Value: operatorImage,

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -573,6 +573,10 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 							},
 							Env: []corev1.EnvVar{
 								{
+									Name:  operatorutil.VirtOperatorImageEnvName,
+									Value: image,
+								},
+								{
 									Name:  operatorutil.OldOperatorImageEnvName,
 									Value: image,
 								},

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -577,10 +577,6 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 									Value: image,
 								},
 								{
-									Name:  operatorutil.OldOperatorImageEnvName,
-									Value: image,
-								},
-								{
 									Name: "WATCH_NAMESPACE", // not used yet
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -576,7 +576,7 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, func() {
 
 				operator.Spec.Template.Spec.Containers[0].Image = newImage
 				for idx, env := range operator.Spec.Template.Spec.Containers[0].Env {
-					if env.Name == util.OldOperatorImageEnvName {
+					if env.Name == util.VirtOperatorImageEnvName {
 						env.Value = newImage
 						operator.Spec.Template.Spec.Containers[0].Env[idx] = env
 						break


### PR DESCRIPTION
**What this PR does / why we need it**:
Small bug fix - use virt-operator custom image if provided.
This is another tiny follow-up to https://github.com/kubevirt/kubevirt/pull/8673, https://github.com/kubevirt/kubevirt/pull/8792 and https://github.com/kubevirt/kubevirt/pull/8811.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: use virt operator image if provided
```
