### PR TITLE
Fix vmexport download snapshot test

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1849,6 +1849,12 @@ var _ = SIGDescribe("Export", func() {
 				Expect(snapshot).ToNot(BeNil())
 				defer deleteSnapshot(snapshot)
 
+				// We create the vmexport object in advance to get the volume name
+				export := createRunningVMSnapshotExport(snapshot)
+				Expect(export).ToNot(BeNil())
+				checkExportSecretRef(export)
+				vmeName = export.Name
+
 				// Run vmexport
 				By("Running vmexport command")
 				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(commandName,
@@ -1856,7 +1862,7 @@ var _ = SIGDescribe("Export", func() {
 					vmeName,
 					"--snapshot", snapshot.Name,
 					"--output", outputFile,
-					"--volume", snapshot.Name,
+					"--volume", export.Status.Links.External.Volumes[0].Name,
 					"--insecure",
 					"--namespace", util.NamespaceTestDefault)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR fixes a minor error in the virtctl vmexport download snapshot test, so we use an appropriate volume name to download.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
