### PR TITLE
Dump VM Exports on tests failure

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -168,6 +168,7 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logVMSnapshot(virtCli)
 	r.logVMRestore(virtCli)
 	r.logDVs(virtCli)
+	r.logVMExports(virtCli)
 	r.logDeployments(virtCli)
 	r.logDaemonsets(virtCli)
 
@@ -756,6 +757,16 @@ func (r *KubernetesReporter) logDVs(virtCli kubecli.KubevirtClient) {
 	}
 
 	r.logObjects(virtCli, dvs, "dvs")
+}
+
+func (r *KubernetesReporter) logVMExports(virtCli kubecli.KubevirtClient) {
+	vmexports, err := virtCli.VirtualMachineExport(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch vm exports: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, vmexports, "vmexports")
 }
 
 func (r *KubernetesReporter) logObjects(virtCli kubecli.KubevirtClient, elements interface{}, name string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make it easier to tell what's happening on a CI failure.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
