### PR TITLE
network, bridge binding: avoid reading link during phase2

### DIFF
--- a/pkg/network/domainspec/BUILD.bazel
+++ b/pkg/network/domainspec/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )

--- a/pkg/network/domainspec/generators.go
+++ b/pkg/network/domainspec/generators.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -134,23 +133,6 @@ func (b *BridgeLibvirtSpecGenerator) Generate() error {
 }
 
 func (b *BridgeLibvirtSpecGenerator) discoverDomainIfaceSpec() (*api.Interface, error) {
-	podNicLink, err := b.handler.LinkByName(b.podInterfaceName)
-	if err != nil {
-		log.Log.Reason(err).Errorf(linkIfaceFailFmt, b.podInterfaceName)
-		return nil, err
-	}
-	_, dummy := podNicLink.(*netlink.Dummy)
-	if dummy {
-		newPodNicName := virtnetlink.GenerateNewBridgedVmiInterfaceName(b.podInterfaceName)
-		podNicLink, err = b.handler.LinkByName(newPodNicName)
-		if err != nil {
-			log.Log.Reason(err).Errorf(linkIfaceFailFmt, newPodNicName)
-			return nil, err
-		}
-	}
-
-	b.cachedDomainInterface.MTU = &api.MTU{Size: strconv.Itoa(podNicLink.Attrs().MTU)}
-
 	b.cachedDomainInterface.Target = &api.InterfaceTarget{
 		Device:  virtnetlink.GenerateTapDeviceName(b.podInterfaceName),
 		Managed: "no"}

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -159,6 +159,7 @@ func (b *BridgePodNetworkConfigurator) PreparePodNetworkInterface() error {
 func (b *BridgePodNetworkConfigurator) GenerateNonRecoverableDomainIfaceSpec() *api.Interface {
 	return &api.Interface{
 		MAC: &api.MAC{MAC: b.vmMac.String()},
+		MTU: &api.MTU{Size: fmt.Sprintf("%d", b.podNicLink.Attrs().MTU)},
 	}
 }
 
@@ -193,7 +194,7 @@ func (b *BridgePodNetworkConfigurator) createBridge() error {
 	}
 	err := b.handler.LinkAdd(bridge)
 	if err != nil {
-		log.Log.Reason(err).Errorf("failed to create a bridge")
+		log.Log.Reason(err).Errorf("failed to create a bridge named: %s", b.bridgeInterfaceName)
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This commit persists all layer2 (MAC & MTU) info in the interface cache, thus freeing the network configuration phase occurring in the launcher pod from having to read the interface state from the kernel.

Since the same is done currently for the MAC, the same should be done for the MTU.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid reading the interface info from the kernel in the unprivileged launcher pod.
```
