### PR TITLE
Add VM snapshot recording rules to documentation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -173,6 +173,12 @@ Total amount of time spent in each state by each vcpu. Where `id` is the vcpu id
 ### kubevirt_vmi_vcpu_wait_seconds
 Amount of time spent by each vcpu while waiting on I/O. Type: Counter.
 
+### kubevirt_vmsnapshot_disks_restored_from_source_bytes
+Returns the amount of space in bytes restored from the source virtual machine. Type: Gauge.
+
+### kubevirt_vmsnapshot_disks_restored_from_source_total
+Returns the total number of virtual machine disks restored from the source virtual machine. Type: Gauge.
+
 ## Developing new metrics
 After developing new metrics or changing old ones, please run `make generate` to regenerate this document.
 

--- a/tools/doc-generator/doc-generator.go
+++ b/tools/doc-generator/doc-generator.go
@@ -56,6 +56,14 @@ const (
 	vmiMemoryUsedBytes     = "kubevirt_vmi_memory_used_bytes"
 	vmiMemoryUsedBytesDesc = "Amount of `used` memory as seen by the domain."
 	vmiMemoryUsedBytesType = "Gauge"
+
+	vmSnapshotDisksRestoredFromSourceTotal     = "kubevirt_vmsnapshot_disks_restored_from_source_total"
+	vmSnapshotDisksRestoredFromSourceTotalDesc = "Returns the total number of virtual machine disks restored from the source virtual machine."
+	vmSnapshotDisksRestoredFromSourceTotalType = "Gauge"
+
+	vmSnapshotDisksRestoredFromSourceBytes     = "kubevirt_vmsnapshot_disks_restored_from_source_bytes"
+	vmSnapshotDisksRestoredFromSourceBytesDesc = "Returns the amount of space in bytes restored from the source virtual machine."
+	vmSnapshotDisksRestoredFromSourceBytesType = "Gauge"
 )
 
 func main() {
@@ -144,6 +152,16 @@ var (
 			name:        vmiMemoryUsedBytes,
 			description: vmiMemoryUsedBytesDesc,
 			mType:       vmiMemoryUsedBytesType,
+		},
+		{
+			name:        vmSnapshotDisksRestoredFromSourceTotal,
+			description: vmSnapshotDisksRestoredFromSourceTotalDesc,
+			mType:       vmSnapshotDisksRestoredFromSourceTotalType,
+		},
+		{
+			name:        vmSnapshotDisksRestoredFromSourceBytes,
+			description: vmSnapshotDisksRestoredFromSourceBytesDesc,
+			mType:       vmSnapshotDisksRestoredFromSourceBytesType,
 		},
 		{
 			name:        domainstats.MigrateVmiDataProcessedMetricName,


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds kubevirt_vmsnapshot_disks_restored_from_source_total and kubevirt_vmsnapshot_disks_restored_from_source_bytes recording rules to the documentation in metrics.md.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7720 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
