### PR TITLE
virt-handler: Replace CGO linking with a Go alternative

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "setsched.go",
         "vm.go",
     ],
-    cgo = True,
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/virt-handler/realtime.go
+++ b/pkg/virt-handler/realtime.go
@@ -30,7 +30,7 @@ var (
 
 	// parse thread comm value expression
 	vcpuRegex = regexp.MustCompile(`^CPU (\d+)/KVM\n$`) // These threads follow this naming pattern as their command value (/proc/{pid}/task/{taskid}/comm)
-// QEMU uses threads to represent vCPUs.
+	// QEMU uses threads to represent vCPUs.
 
 )
 
@@ -55,7 +55,7 @@ func (d *VirtualMachineController) configureVCPUScheduler(vmi *v1.VirtualMachine
 	}
 	for vcpuID, threadID := range vcpus {
 		if mask.isEnabled(vcpuID) {
-			param := schedParam{sched_priority: 1}
+			param := schedParam{priority: 1}
 			tid, err := strconv.Atoi(threadID)
 			if err != nil {
 				return err

--- a/pkg/virt-handler/setsched.go
+++ b/pkg/virt-handler/setsched.go
@@ -6,18 +6,28 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/unix"
-
-	// #include <linux/sched.h>
-	// #include <linux/sched/types.h>
-	// typedef struct sched_param sched_param;
-	"C"
 )
 
-type schedParam C.sched_param
+// schedParam represents the Linux sched_param struct:
+//
+//	struct sched_param {
+//	   int sched_priority;
+//	};
+//
+// Ref: https://github.com/torvalds/linux/blob/c2bf05db6c78f53ca5cd4b48f3b9b71f78d215f1/include/uapi/linux/sched/types.h#L7-L9
+type schedParam struct {
+	priority int
+}
+
 type policy uint32
 
 const (
-	schedFIFO policy = C.SCHED_FIFO
+	// schedFIFO represents the Linux SCHED_FIFO scheduling policy ID:
+	//
+	// #define SCHED_FIFO		1
+	//
+	// Ref: https://github.com/torvalds/linux/blob/c2bf05db6c78f53ca5cd4b48f3b9b71f78d215f1/include/uapi/linux/sched.h#L115
+	schedFIFO policy = 1
 )
 
 func schedSetScheduler(pid int, policy policy, param schedParam) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

It is preferable to avoid CGO linking in virt-handler and limit it as much as possible to the virt-launcher (where it must link with the libvirt lib).

This is sometimes impossible, but in this case, the stable Linux API can be partially duplicated into the native Go code.

The CGO linkage had side effects on packages which imported the `virthandler` package, causing build issues.
(specifically, it collided with the e2e test binary)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

While building the e2e tests, the following error is seen on some platforms:
```
/lib64/libc.so.6: version `GLIBC_2.32'
/lib64/libc.so.6: version `GLIBC_2.34'
```

**Special notes for your reviewer**:
This PR attempts to resolve the e2e test build issues introduced by #8750 

**Release note**:
```release-note
NONE
```
