### PR TITLE
tests, storage, export: Fix VM start helper

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1194,13 +1194,15 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	startVM := func(vm *virtv1.VirtualMachine) *virtv1.VirtualMachine {
+		vmName := vm.Name
+		vmNamespace := vm.Namespace
 		Eventually(func() error {
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			vm, err = virtClient.VirtualMachine(vmNamespace).Get(vmName, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			vm.Spec.Running = pointer.BoolPtr(true)
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
+			vm, err = virtClient.VirtualMachine(vmNamespace).Update(vm)
 			return err
-		}, 15*time.Second, time.Second).Should(BeNil())
+		}, 15*time.Second, time.Second).Should(Succeed())
 		return vm
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The VM start helper is using ginkgo `Eventually` to retry the spec update. In the retry flow, the vm variable is updated even when the update fails, which in practice initializes it.

Update the retry loop by storing the VM namespace and name upfront and using the stored names to fetch a fresh object content.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Test failure has been observed [here](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8903/pull-kubevirt-e2e-k8s-1.24-sig-storage-root/1599488862600564736).

This is the error:
```
20:42:54:   Unexpected error:
20:42:54:       <*errors.errorString | 0xc001699860>: {
20:42:54:           s: "resource name may not be empty",
20:42:54:       }
20:42:54:       resource name may not be empty
20:42:54:   occurred
20:42:54:   In [It] at: tests/storage/export.go:1199 
```

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
