### PR TITLE
Reject VM/VMI creation if a VMI/VM with the same name already exists

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -789,8 +789,11 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig)
 	})
-	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers)
+	http.HandleFunc(components.VMCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
+		validating_webhook.ServeVMCreate(w, r, app.clusterConfig, app.virtCli, informers)
+	})
+	http.HandleFunc(components.VMUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
+		validating_webhook.ServeVMUpdate(w, r, app.clusterConfig, app.virtCli, informers)
 	})
 	http.HandleFunc(components.VMIRSValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -784,7 +784,7 @@ func (app *virtAPIApp) prepareCertManager() {
 func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers) {
 
 	http.HandleFunc(components.VMICreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMICreate(w, r, app.clusterConfig)
+		validating_webhook.ServeVMICreate(w, r, app.clusterConfig, informers)
 	})
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig)
@@ -989,6 +989,7 @@ func (app *virtAPIApp) Run() {
 	namespaceLimitsInformer := kubeInformerFactory.LimitRanges()
 	vmRestoreInformer := kubeInformerFactory.VirtualMachineRestore()
 	vmiInformer := kubeInformerFactory.VMI()
+	vmInformer := kubeInformerFactory.VirtualMachine()
 
 	stopChan := make(chan struct{}, 1)
 	defer close(stopChan)
@@ -1025,6 +1026,7 @@ func (app *virtAPIApp) Run() {
 		VMRestoreInformer:       vmRestoreInformer,
 		DataSourceInformer:      dataSourceInformer,
 		VMIInformer:             vmiInformer,
+		VMInformer:              vmInformer,
 	}
 
 	// Build webhook subresources

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -988,6 +988,7 @@ func (app *virtAPIApp) Run() {
 	vmiPresetInformer := kubeInformerFactory.VirtualMachinePreset()
 	namespaceLimitsInformer := kubeInformerFactory.LimitRanges()
 	vmRestoreInformer := kubeInformerFactory.VirtualMachineRestore()
+	vmiInformer := kubeInformerFactory.VMI()
 
 	stopChan := make(chan struct{}, 1)
 	defer close(stopChan)
@@ -1023,6 +1024,7 @@ func (app *virtAPIApp) Run() {
 		NamespaceLimitsInformer: namespaceLimitsInformer,
 		VMRestoreInformer:       vmRestoreInformer,
 		DataSourceInformer:      dataSourceInformer,
+		VMIInformer:             vmiInformer,
 	}
 
 	// Build webhook subresources

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -78,6 +78,7 @@ type Informers struct {
 	NamespaceLimitsInformer cache.SharedIndexInformer
 	VMRestoreInformer       cache.SharedIndexInformer
 	DataSourceInformer      cache.SharedIndexInformer
+	VMIInformer             cache.SharedIndexInformer
 }
 
 func IsKubeVirtServiceAccount(serviceAccount string) bool {

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -79,6 +79,7 @@ type Informers struct {
 	VMRestoreInformer       cache.SharedIndexInformer
 	DataSourceInformer      cache.SharedIndexInformer
 	VMIInformer             cache.SharedIndexInformer
+	VMInformer              cache.SharedIndexInformer
 }
 
 func IsKubeVirtServiceAccount(serviceAccount string) bool {

--- a/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
@@ -11,5 +11,6 @@ go_library(
         "//pkg/virt-api/webhooks/validating-webhook/admitters:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/api/admissionregistration/v1:go_default_library",
     ],
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
+        "//vendor/k8s.io/api/admissionregistration/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -122,6 +122,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
+        "//vendor/k8s.io/api/admissionregistration/v1:go_default_library",
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -32,8 +32,8 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig})
+func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, informers *webhooks.Informers) {
+	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig, VMInformer: informers.VMInformer})
 }
 
 func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -22,6 +22,8 @@ package validating_webhook
 import (
 	"net/http"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+
 	"kubevirt.io/client-go/kubecli"
 
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
@@ -38,9 +40,13 @@ func ServeVMIUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *
 	validating_webhooks.Serve(resp, req, &admitters.VMIUpdateAdmitter{ClusterConfig: clusterConfig})
 }
 
-func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
+func ServeVMCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, admissionregistrationv1.Create))
+}
 
-	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers))
+func ServeVMUpdate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
+
+	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, admissionregistrationv1.Update))
 }
 
 func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
@@ -97,7 +103,7 @@ func ServeStatusValidation(resp http.ResponseWriter,
 	virtCli kubecli.KubevirtClient,
 	informers *webhooks.Informers) {
 	validating_webhooks.Serve(resp, req, &admitters.StatusAdmitter{
-		VmsAdmitter: admitters.NewVMsAdmitter(clusterConfig, virtCli, informers),
+		VmsAdmitter: admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, admissionregistrationv1.OperationAll),
 	})
 }
 

--- a/pkg/virt-operator/resource/generate/components/webhooks.go
+++ b/pkg/virt-operator/resource/generate/components/webhooks.go
@@ -267,7 +267,8 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissionregistrationv1.ValidatingWebhookConfiguration {
 	vmiPathCreate := VMICreateValidatePath
 	vmiPathUpdate := VMIUpdateValidatePath
-	vmPath := VMValidatePath
+	vmPathCreate := VMCreateValidatePath
+	vmPathUpdate := VMUpdateValidatePath
 	vmirsPath := VMIRSValidatePath
 	vmpoolPath := VMPoolValidatePath
 	vmipresetPath := VMIPresetValidatePath
@@ -378,7 +379,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				},
 			},
 			{
-				Name:                    "virtualmachine-validator.kubevirt.io",
+				Name:                    "virtualmachine-create-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
 				TimeoutSeconds:          &defaultTimeoutSeconds,
@@ -386,6 +387,29 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.Create,
+					},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{core.GroupName},
+						APIVersions: virtv1.ApiSupportedWebhookVersions,
+						Resources:   []string{"virtualmachines"},
+					},
+				}},
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{
+						Namespace: installNamespace,
+						Name:      VirtApiServiceName,
+						Path:      &vmPathCreate,
+					},
+				},
+			},
+			{
+				Name:                    "virtualmachine-update-validator.kubevirt.io",
+				AdmissionReviewVersions: []string{"v1", "v1beta1"},
+				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
+				SideEffects:             &sideEffectNone,
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.Update,
 					},
 					Rule: admissionregistrationv1.Rule{
@@ -398,7 +422,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 					Service: &admissionregistrationv1.ServiceReference{
 						Namespace: installNamespace,
 						Name:      VirtApiServiceName,
-						Path:      &vmPath,
+						Path:      &vmPathUpdate,
 					},
 				},
 			},
@@ -789,7 +813,9 @@ const VMICreateValidatePath = "/virtualmachineinstances-validate-create"
 
 const VMIUpdateValidatePath = "/virtualmachineinstances-validate-update"
 
-const VMValidatePath = "/virtualmachines-validate"
+const VMCreateValidatePath = "/virtualmachines-validate-create"
+
+const VMUpdateValidatePath = "/virtualmachines-validate-update"
 
 const VMIRSValidatePath = "/virtualmachinereplicaset-validate"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
VMI and VM are closely related resources.
The name of the VMI created from a VM is the same of the VM itself.
This might cause some inconsistencies when you create a VM and
there is already a VMI with the same name. This results in the association
between the two resources, but actually they are not.
The same thing happens if you create a VMI with a name which is equal to
an already existing 'stopped' VM. In this case, the created VMI is immediately deleted due to
the 'stopped' VM reconciliation.
This PR "implements" the association of the two, checking the existence
of a VMI with the same name, during the VM creation, and, vice versa.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2132873

**Special notes for your reviewer**:
- In order to correctly handle only the creation of a VM, excluding the `UPDATE` method, the VM webhook has been splitted in two functions. This separation helps us to correctly start a VM.

- there is also a refactoring commit to reduce code duplication in `vmi-create-admitter_test.go` file.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reject VM/VMI creation if a VMI/VM with the same name already exists
```
