### PR TITLE
pod-servers: Move netcat servers to unprivileged pods

### DIFF
--- a/tests/pod_servers.go
+++ b/tests/pod_servers.go
@@ -17,12 +17,12 @@ import (
 
 func NewHTTPServerPod(ipFamily, port int) *corev1.Pod {
 	serverCommand := fmt.Sprintf("nc -%d -klp %d --sh-exec 'echo -e \"HTTP/1.1 200 OK\\nContent-Length: 12\\n\\nHello World!\"'", ipFamily, port)
-	return RenderPrivilegedPod("http-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
+	return RenderPod("http-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
 }
 
 func NewTCPServerPod(ipFamily, port int) *corev1.Pod {
 	serverCommand := fmt.Sprintf("nc -%d -klp %d --sh-exec 'echo \"Hello World!\"'", ipFamily, port)
-	return RenderPrivilegedPod("tcp-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
+	return RenderPod("tcp-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
 }
 
 func CreatePodAndWaitUntil(pod *corev1.Pod, phaseToWait corev1.PodPhase) *corev1.Pod {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes priviliges from TCP/HTTP netcat server pods that are used for network test lane.
Since these pods use a higher level port, there should be no issue with running these pods with a non-privileged pods.
Moving the servers to unprivileged pods

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
