### PR TITLE
Remove quarantine label from passing storage tests

### DIFF
--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1116,7 +1116,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				Expect(*snapshot.Status.ReadyToUse).To(BeTrue())
 			})
 
-			It("[test_id:6952][QUARANTINE]snapshot change phase to in progress and succeeded and then should not fail", func() {
+			It("[test_id:6952]snapshot change phase to in progress and succeeded and then should not fail", func() {
 				createDenyVolumeSnapshotCreateWebhook()
 				snapshot = newSnapshot()
 				snapshot.Spec.FailureDeadline = &metav1.Duration{Duration: time.Minute}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -217,7 +217,7 @@ var _ = SIGDescribe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[QUARANTINE] should pause VMI on IO error", func() {
+			It("should pause VMI on IO error", func() {
 				By("Creating VMI with faulty disk")
 				vmi := libvmi.NewAlpine(libvmi.WithPersistentVolumeClaim("faulty-disk", pvc.Name))
 


### PR DESCRIPTION
These tests haven't failed in 14 days in our periodic test runs, and were probably fixed at some point but forgotten.

**Special notes for your reviewer**:
Caveat: I see two runs with 80 failures where the snapshot test appears, but I'm assuming ceph or the cluster failed here.
We know of a ceph issue that is in external code that still isn't fixed, and we dismiss such failures.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
