### PR TITLE
e2e: Move privileged pods to privileged ns

### DIFF
--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -62,7 +62,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 			probeBackendPod = tests.StartTCPServerPod(family, int(port))
 		}
 		return probeBackendPod, func() error {
-			return virtClient.CoreV1().Pods(util.NamespaceTestDefault).Delete(context.Background(), probeBackendPod.Name, metav1.DeleteOptions{})
+			return virtClient.CoreV1().Pods(probeBackendPod.Namespace).Delete(context.Background(), probeBackendPod.Name, metav1.DeleteOptions{})
 		}
 	}
 

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 				By("restarting kubelet")
 				pod := renderPkillAllPod("kubelet")
 				pod.Spec.NodeName = nodeName
-				_, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+				_, err = virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("starting another VMI on the same node, to verify kubelet is running again")

--- a/tests/pod_servers.go
+++ b/tests/pod_servers.go
@@ -29,11 +29,14 @@ func CreatePodAndWaitUntil(pod *corev1.Pod, phaseToWait corev1.PodPhase) *corev1
 	virtClient, err := kubecli.GetKubevirtClient()
 	util.PanicOnError(err)
 
-	pod, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+	if pod.Namespace == "" {
+		pod.Namespace = util.NamespaceTestDefault
+	}
+	pod, err = virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred(), "should succeed creating pod")
 
 	getStatus := func() corev1.PodPhase {
-		pod, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		pod, err = virtClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		return pod.Status.Phase
 	}

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1009,7 +1009,7 @@ var _ = SIGDescribe("Storage", func() {
 							},
 						},
 					}
-					pod, err = virtClient.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+					pod, err = virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
 
 					By("Waiting for hostPath pod to prepare the mounted directory")
@@ -1032,7 +1032,7 @@ var _ = SIGDescribe("Storage", func() {
 						tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 					}
 					Expect(virtClient.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})).To(Succeed())
-					waitForPodToDisappearWithTimeout(pod.Name, 120)
+					waitForPodToDisappearWithTimeout(pod.Name, pod.Namespace, 120)
 				})
 
 				configureToleration := func(toleration int) {
@@ -1463,11 +1463,11 @@ var _ = SIGDescribe("Storage", func() {
 	})
 })
 
-func waitForPodToDisappearWithTimeout(podName string, seconds int) {
+func waitForPodToDisappearWithTimeout(podName, podNamespace string, seconds int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	EventuallyWithOffset(1, func() bool {
-		_, err := virtClient.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), podName, metav1.GetOptions{})
+		_, err := virtClient.CoreV1().Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
 		return errors.IsNotFound(err)
 	}, seconds, 1*time.Second).Should(BeTrue())
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1354,7 +1354,7 @@ func RunPodAndExpectCompletion(pod *k8sv1.Pod) *k8sv1.Pod {
 	virtClient, err := kubecli.GetKubevirtClient()
 	util2.PanicOnError(err)
 
-	pod, err = virtClient.CoreV1().Pods(util2.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+	pod, err = virtClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(ThisPod(pod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1866,11 +1866,11 @@ func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineI
 func pkillHandler(virtCli kubecli.KubevirtClient, node string) error {
 	pod := renderPkillAllPod("virt-handler")
 	pod.Spec.NodeName = node
-	createdPod, err := virtCli.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+	createdPod, err := virtCli.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred(), "Should create helper pod")
 
 	getStatus := func() k8sv1.PodPhase {
-		podG, err := virtCli.CoreV1().Pods(util.NamespaceTestDefault).Get(context.Background(), createdPod.Name, metav1.GetOptions{})
+		podG, err := virtCli.CoreV1().Pods(createdPod.Namespace).Get(context.Background(), createdPod.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred(), "Should return current status")
 		return podG.Status.Phase
 	}
@@ -1883,13 +1883,13 @@ func pkillHandler(virtCli kubecli.KubevirtClient, node string) error {
 func pkillAllLaunchers(virtCli kubecli.KubevirtClient, node string) (*k8sv1.Pod, error) {
 	pod := renderPkillAllPod("virt-launcher")
 	pod.Spec.NodeName = node
-	return virtCli.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+	return virtCli.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 }
 
 func pkillAllVMIs(virtCli kubecli.KubevirtClient, node string) error {
 	pod := renderPkillAllPod("qemu")
 	pod.Spec.NodeName = node
-	_, err := virtCli.CoreV1().Pods(util.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
+	_, err := virtCli.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently RenderPrivilegedPod() that creates privileges pods in the test suite, is created under the default test namespace. In order to conform with PSA, this PR is moving these pods to dedicated namespace with dedicated PSA privileges.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
