### PR TITLE
Fix dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -179,6 +179,14 @@ load(
     "git_repository",
 )
 
+# Dependency seems to be gone
+# TODO fix on bazeldnf side
+go_repository(
+    name = "com_github_xi2_xz",
+    commit = "48954b6210f8d154cb5f8484d3a3e1f83489309e",
+    importpath = "github.com/xi2/xz",
+)
+
 # Winrmcli dependencies
 go_repository(
     name = "com_github_masterzen_winrmcli",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8878/pull-kubevirt-build/1601145621404717056
```
 Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
compilepkg: missing strict dependencies:
	/tmp/cache/bazel/6f347497f91c9a385dcd9294645b76e0/sandbox/processwrapper-sandbox/289/execroot/kubevirt/external/com_github_sassoftware_go_rpmutils/uncompress.go: import of "github.com/xi2/xz"
No dependencies were provided. 
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
