### PR TITLE
Add parameter verification between cert duration and ca duration 

### DIFF
--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -327,6 +327,10 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ra
 	certRenewBefore := GetCertRenewBefore(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
 	caExportRenewBefore := GetCertRenewBefore(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
 
+	if (caDuration != nil && certDuration != nil) && (caDuration.Milliseconds() < certDuration.Milliseconds()) {
+		return fmt.Errorf("failed to set KubeVirt ca duration and cert duration, Reason: cert duration %s after than ca duration %s", certDuration.String(), caDuration.String())
+	}
+
 	// create/update CA Certificate secret
 	caCert, err := r.createOrUpdateCACertificateSecret(queue, components.KubeVirtCASecretName, caDuration, caRenewBefore)
 	if err != nil {


### PR DESCRIPTION
What this PR does / why we need it:
When create a CR of KubeVirt. If the expiration time of the ca is earlier than the expiration time of the cert, the certificate related secret can be created successfully. However, when updating the KubeVirt CR through kubectl, such as opening a feature gate. The two expiration times were verified, resulting in KubeVirt CR update failure.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

Special notes for your reviewer:

Release note:

update  verification of  KubeVirt parameter
