### PR TITLE
Fix gooveralls tests by unsetting VirtOperatorImageEnvName in AfterEach

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -151,14 +151,14 @@ type KubeVirtTestData struct {
 	mockEnvVarManager util.EnvVarManager
 }
 
-var mockEnvVarManager = &util.EnvVarManagerMock{}
-
 func (k *KubeVirtTestData) BeforeTest() {
 
-	k.mockEnvVarManager = mockEnvVarManager
+	k.mockEnvVarManager = &util.EnvVarManagerMock{}
 
 	err := k.mockEnvVarManager.Setenv(util.OldOperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "someregistry", "v9.9.9"))
 	Expect(err).NotTo(HaveOccurred())
+
+	util.DefaultEnvVarManager = k.mockEnvVarManager
 
 	k.defaultConfig = k.getConfig("", "")
 
@@ -348,6 +348,8 @@ func (k *KubeVirtTestData) BeforeTest() {
 
 func (k *KubeVirtTestData) AfterTest() {
 	close(k.stop)
+
+	util.DefaultEnvVarManager = nil
 
 	// Ensure that we add checks for expected events to every test
 	Expect(k.recorder.Events).To(BeEmpty())
@@ -1669,10 +1671,6 @@ func (k *KubeVirtTestData) getConfig(registry, version string) *util.KubeVirtDep
 }
 
 var _ = Describe("KubeVirt Operator", func() {
-
-	BeforeEach(func() {
-		util.DefaultEnvVarManager = mockEnvVarManager
-	})
 
 	Context("On valid KubeVirt object", func() {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes `pkg/virt-operator` test suite.
A [new test](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-operator/kubevirt_test.go#L2169) introduced unwanted side effect by setting environment variable in `mockEnvVarManager` which is a pointer to the struct shared by all tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8927

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
