### PR TITLE
[e2e tests]: Use storage class from suite config instead of default

### DIFF
--- a/tests/storage/guestfs.go
+++ b/tests/storage/guestfs.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/kubecli"
@@ -59,20 +58,7 @@ var _ = SIGDescribe("[rfe_id:6364]Guestfs", func() {
 	}
 
 	createPVCFilesystem := func(name, namespace string) {
-		quantity, _ := resource.ParseQuantity("500Mi")
-		_, err := virtClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						"storage": quantity,
-					},
-				},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
+		libstorage.CreateFSPVC(name, namespace, "500Mi", nil)
 	}
 
 	createFakeAttacher := func() *fakeAttacher {

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -344,12 +344,18 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 		}
 
 		DescribeTable("Should succeed", func(resource, targetName string, uploadDV bool) {
+			storageClass, exists := libstorage.GetRWOFileSystemStorageClass()
+			if !exists {
+				Skip("Skip test when Filesystem storage is not present")
+			}
+
 			By("Upload archive content")
 			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				resource, targetName,
 				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--archive-path", archivePath,
 				sizeArg, pvcSize,
+				"--storage-class", storageClass,
 				"--force-bind",
 				insecureArg)
 

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -301,9 +301,14 @@ var _ = SIGDescribe("Memory dump", func() {
 
 	memoryDumpVirtctlCreatePVC := func(name, namespace, claimName string) {
 		By("Invoking virtctl memory dump with create flag")
+		storageClass, exists := libstorage.GetRWOFileSystemStorageClass()
+		if !exists {
+			Skip("Skip test when Filesystem storage is not present")
+		}
 		commandAndArgs := []string{commandMemoryDump, "get", name, virtCtlNamespace, namespace}
 		commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlClaimName, claimName))
 		commandAndArgs = append(commandAndArgs, virtCtlCreate)
+		commandAndArgs = append(commandAndArgs, fmt.Sprintf(virtCtlStorageClass, storageClass))
 		memorydumpCommand := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 		Eventually(func() error {
 			err := memorydumpCommand()


### PR DESCRIPTION
We have some instances where we don't specify a storage class, so we end up testing whatever the default is in the cluster, instead of what we're interested in.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
