### PR TITLE
Do not set selinux context for virt-launcher binary.

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -71,9 +71,6 @@ xattrs(
             "cap_net_bind_service",
         ],
     },
-    selinux_labels = {
-        "/usr/bin/virt-launcher": "system_u:object_r:container_file_t:s0",
-    },
     tar = ":virt-launcher-tar",
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't not need to set the selinux context for virt-launcher binary. Uploading the PR to test if it is actually required or not.

No matter what we set, we end up with the selinux labels for all files in the container:

```bash
$ kubectlexec -it virt-launcher-vmi-nocloud-t5pxv -- /bin/sh
sh-5.1$ ls -lhZ /usr/bin/virt-launcher
-r-xr-xr-x. 1 root root system_u:object_r:container_file_t:s0:c76,c631 56M Jan  1  1970 /usr/bin/virt-launcher
sh-5.1$ ls -lhZ /
total 4.0K
dr-xr-xr-x.   2 root root system_u:object_r:container_file_t:s0:c76,c631    6 Jan  1  1970 afs
lrwxrwxrwx.   1 root root system_u:object_r:container_file_t:s0:c76,c631    7 Jan  1  1970 bin -> usr/bin
dr-xr-xr-x.   2 root root system_u:object_r:container_file_t:s0:c76,c631    6 Jan  1  1970 boot
drwxr-xr-x.   6 root root system_u:object_r:container_file_t:s0:c76,c631  420 Dec 12 18:46 dev
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
