### PR TITLE
pointer: Introduce a generic pointer package

### DIFF
--- a/pkg/pointer/BUILD.bazel
+++ b/pkg/pointer/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pointer.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/pointer",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/pointer/pointer.go
+++ b/pkg/pointer/pointer.go
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package pointer
+
+func P[T any](t T) *T {
+	return &t
+}

--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/containerdisk:go_default_library",
@@ -26,6 +27,5 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -24,9 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 // Option represents an action that enables an option.
@@ -147,7 +148,7 @@ func WithUefi(secureBoot bool) Option {
 		if vmi.Spec.Domain.Firmware.Bootloader.EFI == nil {
 			vmi.Spec.Domain.Firmware.Bootloader.EFI = &v1.EFI{}
 		}
-		vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.Bool(secureBoot)
+		vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot = pointer.P(secureBoot)
 		// secureBoot Requires SMM to be enabled
 		if secureBoot {
 			if vmi.Spec.Domain.Features == nil {
@@ -156,7 +157,7 @@ func WithUefi(secureBoot bool) Option {
 			if vmi.Spec.Domain.Features.SMM == nil {
 				vmi.Spec.Domain.Features.SMM = &v1.FeatureState{}
 			}
-			vmi.Spec.Domain.Features.SMM.Enabled = pointer.Bool(secureBoot)
+			vmi.Spec.Domain.Features.SMM.Enabled = pointer.P(secureBoot)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The pointer package has a single P function that returns the address of the given value.

It is aimed to replace `k8s.io/utils/pointer` with a generic version. Unlike the previous version, the generic one accepts any type.

To illustrate its usage, the initial usage is done in the e2e tests, at the libvmi package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
A more extensive work has been proposed on the original util implementation: https://github.com/kubernetes/utils/pull/269
However, that work is blocked until all its consumers will support generics.

**Release note**:
```release-note
NONE
```
