### PR TITLE
Add VirtualMachine foreground finalizer

### DIFF
--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -149,9 +149,15 @@ var _ = Describe("VirtualMachine", func() {
 		})
 
 		shouldExpectVMIFinalizerRemoval := func(vmi *virtv1.VirtualMachineInstance) {
-			patch := `[{ "op": "test", "path": "/metadata/finalizers", "value": ["kubevirt.io/virtualMachineControllerFinalize"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, virtv1.VirtualMachineControllerFinalizer)
 
 			vmiInterface.EXPECT().Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vmi, nil)
+		}
+
+		shouldExpectVMFinalizerRemoval := func(vm *virtv1.VirtualMachine) {
+			patch := fmt.Sprintf(`[{ "op": "test", "path": "/metadata/finalizers", "value": ["%s"] }, { "op": "replace", "path": "/metadata/finalizers", "value": [] }]`, virtv1.VirtualMachineControllerFinalizer)
+
+			vmInterface.EXPECT().Patch(vm.Name, types.JSONPatchType, []byte(patch), &metav1.PatchOptions{}).Return(vm, nil)
 		}
 
 		shouldExpectDataVolumeCreationPriorityClass := func(uid types.UID, labels map[string]string, annotations map[string]string, priorityClassName string, idx *int) {
@@ -328,12 +334,12 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
 				Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes[0].Name).To(Equal("vol1"))
-			}).Return(nil, nil)
+			}).Return(vm, nil)
 
 			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) {
 				// vol request shouldn't be cleared until update status observes the new volume change
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
-			}).Return(nil, nil)
+			}).Return(vm, nil)
 
 			controller.Execute()
 		},
@@ -377,12 +383,12 @@ var _ = Describe("VirtualMachine", func() {
 
 			vmInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
 				Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes).To(BeEmpty())
-			}).Return(nil, nil)
+			}).Return(vm, nil)
 
 			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Do(func(arg interface{}) {
 				// vol request shouldn't be cleared until update status observes the new volume change occured
 				Expect(arg.(*virtv1.VirtualMachine).Status.VolumeRequests).To(HaveLen(1))
-			}).Return(nil, nil)
+			}).Return(vm, nil)
 
 			controller.Execute()
 		},
@@ -1873,7 +1879,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				vmInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
 					Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes[0].Name).To(Equal(testPVCName))
-				}).Return(nil, nil)
+				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
 
 				controller.Execute()
@@ -2088,7 +2094,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				vmInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
 					Expect(arg.(*virtv1.VirtualMachine).Spec.Template.Spec.Volumes).To(BeEmpty())
-				}).Return(nil, nil)
+				}).Return(vm, nil)
 				vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
 
 				controller.Execute()
@@ -2658,6 +2664,7 @@ var _ = Describe("VirtualMachine", func() {
 
 					addVirtualMachine(vm)
 
+					shouldExpectVMFinalizerRemoval(vm)
 					vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Do(func(obj interface{}) {
 						objVM := obj.(*virtv1.VirtualMachine)
 						Expect(objVM.Status.PrintableStatus).To(Equal(virtv1.VirtualMachineStatusTerminating))
@@ -3993,6 +4000,7 @@ func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string)
 	vmi.Status.Phase = virtv1.Running
 	vmi.Finalizers = append(vmi.Finalizers, virtv1.VirtualMachineControllerFinalizer)
 	vm := VirtualMachineFromVMI(vmName, vmi, started)
+	vm.Finalizers = append(vm.Finalizers, virtv1.VirtualMachineControllerFinalizer)
 	vmi.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
 		Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1198,7 +1198,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 						}, BeNil()),
 						WithTransform(func(vm *v1.VirtualMachine) []string {
 							return vm.Finalizers
-						}, BeEmpty())),
+						}, BeEquivalentTo([]string{v1.VirtualMachineControllerFinalizer}))),
 					"SnapshotInProgress should be empty")
 
 				Expect(snapshot.Status.CreationTime).To(BeNil())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -2246,6 +2246,82 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 2*time.Minute, 5*time.Second).Should(BeNil())
 		})
 	})
+
+	Context("VirtualMachineControllerFinalizer", func() {
+		const customFinalizer = "customFinalizer"
+
+		var (
+			vmi *v1.VirtualMachineInstance
+			vm  *v1.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			vmi = tests.NewRandomVMI()
+
+			By("Creating VirtualMachine")
+			vm = tests.NewRandomVirtualMachine(vmi, true)
+			Expect(vm.Finalizers).To(HaveLen(0))
+
+		})
+
+		AfterEach(func() {
+			if controller.HasFinalizer(vm, customFinalizer) {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				var ops []string
+				oldFinalizers, err := json.Marshal(vm.GetFinalizers())
+				Expect(err).ToNot(HaveOccurred())
+				newVm := vm.DeepCopy()
+				controller.RemoveFinalizer(newVm, customFinalizer)
+				newFinalizers, err := json.Marshal(newVm.GetFinalizers())
+				Expect(err).ToNot(HaveOccurred())
+				ops = append(ops, fmt.Sprintf(`{ "op": "test", "path": "/metadata/finalizers", "value": %s }`, string(oldFinalizers)))
+				ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/metadata/finalizers", "value": %s }`, string(newFinalizers)))
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), &metav1.PatchOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(vm.Name, &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Ensure the vm has disappeared")
+			Eventually(func() bool {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				return errors.IsNotFound(err)
+			}, 2*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("vm %s is not deleted", vm.Name))
+		})
+
+		It("should be added when the vm is created", func() {
+			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeTrue())
+			}, 2*time.Minute, 1*time.Second)
+		})
+
+		It("should be removed when the vm is being deleted", func() {
+			vm.Finalizers = append(vm.Finalizers, customFinalizer)
+			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeTrue())
+			}, 2*time.Minute, 1*time.Second)
+
+			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(vm.Name, &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeFalse())
+			}, 2*time.Minute, 1*time.Second)
+		})
+	})
 })
 
 func getExpectedPodName(vm *v1.VirtualMachine) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, when deleting a vm which has an associated vmi,
the vm object is immediately removed, while the vmi object wait
for the pod deletion first.
This can cause a misunderstanding in case the vmi is not deleted
due to some errors. For example, the subsequent creation of a vm
with the same name results in the adoption of the pending vmi.
Adding a finalizer on the vm object prevents new vm creation with
the same name to be avoided, since the original vm object remains
in a terminating state, until the vmi object is gone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2132873

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added foreground finalizer to  virtual machine
```
