### PR TITLE
Add e2e tests for KubeVirtComponentExceedsRequestedCPU and KubeVirtComponentExceedsRequestedMemory alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -9,18 +9,18 @@ tests:
   # Pod is using more CPU than expected
   - interval: 1m
     input_series:
-      - series: 'node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="ci",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
-        values: '2+0x10'
+      - series: 'container_cpu_usage_seconds_total{namespace="ci",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
+        values: '1+1x6'
       - series: 'kube_pod_container_resource_requests{namespace="ci",container="virt-controller",resource="cpu",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
         values: '0+0x6'
 
     alert_rule_test:
-      - eval_time: 5m
+      - eval_time: 6m
         alertname: KubeVirtComponentExceedsRequestedCPU
         exp_alerts:
           - exp_annotations:
-              description: "Container virt-controller in pod virt-controller-8546c99968-x9jgg cpu usage exceeds the CPU requested"
-              summary: "The container is using more CPU than what is defined in the containers resource requests"
+              description: "Pod virt-controller-8546c99968-x9jgg cpu usage exceeds the CPU requested"
+              summary: "The containers in the pod are using more CPU than what is defined in the containers resource requests"
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtComponentExceedsRequestedCPU"
             exp_labels:
               severity: "warning"
@@ -28,18 +28,14 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               pod: "virt-controller-8546c99968-x9jgg"
-              container: "virt-controller"
-              namespace: ci
-              node: node1
-              resource: cpu
 
   # Pod is using more memory than expected
   - interval: 1m
     input_series:
       - series: 'container_memory_working_set_bytes{namespace="ci",container="",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
-        values: "157286400 157286400 157286400 157286400 157286400 157286400 157286400 157286400"
+        values: "157286400+0x5"
       - series: 'kube_pod_container_resource_requests{namespace="ci",container="virt-controller",resource="memory",pod="virt-controller-8546c99968-x9jgg",node="node1"}'
-        values: "118325248 118325248 118325248 118325248 118325248 118325248 118325248 118325248"
+        values: "118325248+0x5"
 
     alert_rule_test:
       - eval_time: 5m

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -478,8 +478,11 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "KubeVirtComponentExceedsRequestedMemory",
-						Expr:  intstr.FromString(fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="%s"}) < 0`, ns, ns)),
-						For:   "5m",
+						Expr: intstr.FromString(
+							// In 'container_memory_working_set_bytes', 'container=""' filters the accumulated metric for the pod slice to measure total Memory usage for all containers within the pod
+							fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="memory"}) - on(pod) group_left(node) container_memory_working_set_bytes{container="",namespace="%s"}) < 0`, ns, ns),
+						),
+						For: "5m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory usage exceeds the memory requested",
 							"summary":     "The container is using more memory than what is defined in the containers resource requests",
@@ -493,12 +496,13 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					{
 						Alert: "KubeVirtComponentExceedsRequestedCPU",
 						Expr: intstr.FromString(
-							fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="cpu"}) - on(pod) group_left(node) node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="%s"}) < 0`, ns, ns),
+							// In 'container_cpu_usage_seconds_total', 'container=""' filters the accumulated metric for the pod slice to measure total CPU usage for all containers within the pod
+							fmt.Sprintf(`((kube_pod_container_resource_requests{namespace="%s",container=~"virt-controller|virt-api|virt-handler|virt-operator",resource="cpu"}) - on(pod) sum(rate(container_cpu_usage_seconds_total{container="",namespace="%s"}[5m])) by (pod)) < 0`, ns, ns),
 						),
 						For: "5m",
 						Annotations: map[string]string{
-							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} cpu usage exceeds the CPU requested",
-							"summary":     "The container is using more CPU than what is defined in the containers resource requests",
+							"description": "Pod {{ $labels.pod }} cpu usage exceeds the CPU requested",
+							"summary":     "The containers in the pod are using more CPU than what is defined in the containers resource requests",
 							"runbook_url": fmt.Sprintf(runbookURLTemplate, "KubeVirtComponentExceedsRequestedCPU"),
 						},
 						Labels: map[string]string{

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "monitoring.go",
         "prometheus_utils.go",
+        "scaling_utils.go",
         "vm_monitoring.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/monitoring",

--- a/tests/monitoring/BUILD.bazel
+++ b/tests/monitoring/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "component_monitoring.go",
         "monitoring.go",
         "prometheus_utils.go",
         "scaling_utils.go",
@@ -11,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/monitoring",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/virtctl/pause:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -31,12 +33,14 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/prometheus/client_golang/api/prometheus/v1:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
     ],

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -1,0 +1,341 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package monitoring
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+type alerts struct {
+	deploymentName       string
+	downAlert            string
+	noReadyAlert         string
+	restErrorsBurtsAlert string
+	restErrorsHighAlert  string
+	lowCountAlert        string
+}
+
+var (
+	virtApi = alerts{
+		deploymentName:       "virt-api",
+		downAlert:            "VirtAPIDown",
+		restErrorsBurtsAlert: "VirtApiRESTErrorsBurst",
+		restErrorsHighAlert:  "VirtApiRESTErrorsHigh",
+		lowCountAlert:        "LowVirtAPICount",
+	}
+	virtController = alerts{
+		deploymentName:       "virt-controller",
+		downAlert:            "VirtControllerDown",
+		noReadyAlert:         "NoReadyVirtController",
+		restErrorsBurtsAlert: "VirtControllerRESTErrorsBurst",
+		restErrorsHighAlert:  "VirtControllerRESTErrorsHigh",
+		lowCountAlert:        "LowVirtControllersCount",
+	}
+	virtHandler = alerts{
+		deploymentName:       "virt-handler",
+		restErrorsBurtsAlert: "VirtHandlerRESTErrorsBurst",
+		restErrorsHighAlert:  "VirtHandlerRESTErrorsHigh",
+	}
+	virtOperator = alerts{
+		deploymentName:       "virt-operator",
+		downAlert:            "VirtOperatorDown",
+		noReadyAlert:         "NoReadyVirtOperator",
+		restErrorsBurtsAlert: "VirtOperatorRESTErrorsBurst",
+		restErrorsHighAlert:  "VirtOperatorRESTErrorsHigh",
+		lowCountAlert:        "LowVirtOperatorCount",
+	}
+)
+
+var _ = Describe("[Serial][sig-monitoring]Component Monitoring", Serial, decorators.SigMonitoring, func() {
+	var err error
+	var virtClient kubecli.KubevirtClient
+	var scales *Scaling
+
+	BeforeEach(func() {
+		virtClient = kubevirt.Client()
+	})
+
+	increaseRateLimit := func() {
+		rateLimitConfig := &v1.ReloadableComponentConfiguration{
+			RestClient: &v1.RESTClientConfiguration{
+				RateLimiter: &v1.RateLimiter{
+					TokenBucketRateLimiter: &v1.TokenBucketRateLimiter{
+						Burst: 300,
+						QPS:   300,
+					},
+				},
+			},
+		}
+		originalKubeVirt := util.GetCurrentKv(virtClient)
+		originalKubeVirt.Spec.Configuration.ControllerConfiguration = rateLimitConfig
+		originalKubeVirt.Spec.Configuration.HandlerConfiguration = rateLimitConfig
+		tests.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
+	}
+
+	reduceAlertPendingTime := func() {
+		By("Reducing alert pending time")
+		newRules := getPrometheusAlerts(virtClient)
+		var re = regexp.MustCompile("\\[\\d+m\\]")
+
+		var gs []promv1.RuleGroup
+		for _, group := range newRules.Spec.Groups {
+			var rs []promv1.Rule
+			for _, rule := range group.Rules {
+				var r promv1.Rule
+				rule.DeepCopyInto(&r)
+				if r.Alert != "" {
+					r.For = "0m"
+					r.Expr = intstr.FromString(re.ReplaceAllString(r.Expr.String(), `[1m]`))
+					r.Expr = intstr.FromString(strings.ReplaceAll(r.Expr.String(), ">= 300", ">= 0"))
+				}
+				rs = append(rs, r)
+			}
+
+			gs = append(gs, promv1.RuleGroup{
+				Name:  group.Name,
+				Rules: rs,
+			})
+		}
+		newRules.Spec.Groups = gs
+
+		updatePromRules(virtClient, &newRules)
+	}
+
+	Context("Up metrics", func() {
+		BeforeEach(func() {
+			scales = NewScaling(virtClient, []string{virtOperator.deploymentName, virtController.deploymentName, virtApi.deploymentName})
+			scales.UpdateScale(virtOperator.deploymentName, int32(0))
+
+			reduceAlertPendingTime()
+		})
+
+		AfterEach(func() {
+			scales.RestoreAllScales()
+
+			time.Sleep(10 * time.Second)
+			alerts := []string{
+				virtOperator.downAlert, virtOperator.noReadyAlert, virtOperator.lowCountAlert,
+				virtController.downAlert, virtController.noReadyAlert, virtController.lowCountAlert,
+				virtApi.downAlert, virtApi.noReadyAlert, virtApi.lowCountAlert,
+			}
+			waitUntilAlertDoesNotExist(virtClient, alerts...)
+		})
+
+		It("VirtOperatorDown and NoReadyVirtOperator should be triggered when virt-operator is down", func() {
+			verifyAlertExist(virtClient, virtOperator.downAlert)
+			verifyAlertExist(virtClient, virtOperator.noReadyAlert)
+		})
+
+		It("LowVirtOperatorCount should be triggered when virt-operator count is low", decorators.RequiresTwoSchedulableNodes, func() {
+			verifyAlertExist(virtClient, virtOperator.lowCountAlert)
+		})
+
+		It("VirtControllerDown and NoReadyVirtController should be triggered when virt-controller is down", func() {
+			scales.UpdateScale(virtController.deploymentName, int32(0))
+			verifyAlertExist(virtClient, virtController.downAlert)
+			verifyAlertExist(virtClient, virtController.noReadyAlert)
+		})
+
+		It("LowVirtControllersCount should be triggered when virt-controller count is low", decorators.RequiresTwoSchedulableNodes, func() {
+			scales.UpdateScale(virtController.deploymentName, int32(0))
+			verifyAlertExist(virtClient, virtController.lowCountAlert)
+		})
+
+		It("VirtApiDown should be triggered when virt-api is down", func() {
+			scales.UpdateScale(virtApi.deploymentName, int32(0))
+			verifyAlertExist(virtClient, virtApi.downAlert)
+		})
+
+		It("LowVirtAPICount should be triggered when virt-api count is low", decorators.RequiresTwoSchedulableNodes, func() {
+			scales.UpdateScale(virtApi.deploymentName, int32(0))
+			verifyAlertExist(virtClient, virtApi.lowCountAlert)
+		})
+	})
+
+	Context("Errors metrics", func() {
+		var crb *rbacv1.ClusterRoleBinding
+
+		BeforeEach(func() {
+			virtClient = kubevirt.Client()
+
+			crb, err = virtClient.RbacV1().ClusterRoleBindings().Get(context.Background(), "kubevirt-operator", metav1.GetOptions{})
+			util.PanicOnError(err)
+
+			increaseRateLimit()
+
+			scales = NewScaling(virtClient, []string{virtOperator.deploymentName})
+			scales.UpdateScale(virtOperator.deploymentName, int32(0))
+
+			reduceAlertPendingTime()
+		})
+
+		AfterEach(func() {
+			crb.Annotations = nil
+			crb.ObjectMeta.ResourceVersion = ""
+			crb.ObjectMeta.UID = ""
+			_, err = virtClient.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
+			if !errors.IsAlreadyExists(err) {
+				util.PanicOnError(err)
+			}
+			scales.RestoreAllScales()
+
+			time.Sleep(10 * time.Second)
+			waitUntilAlertDoesNotExist(virtClient, virtOperator.downAlert, virtApi.downAlert, virtController.downAlert, virtHandler.downAlert)
+		})
+
+		It("VirtApiRESTErrorsBurst and VirtApiRESTErrorsHigh should be triggered when requests to virt-api are failing", func() {
+			randVmName := rand.String(6)
+
+			Eventually(func(g Gomega) {
+				cmd := clientcmd.NewVirtctlCommand("vnc", randVmName)
+				err := cmd.Execute()
+				Expect(err).To(HaveOccurred())
+
+				g.Expect(checkAlertExists(virtClient, virtApi.restErrorsBurtsAlert)).To(BeTrue())
+				g.Expect(checkAlertExists(virtClient, virtApi.restErrorsHighAlert)).To(BeTrue())
+			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+		})
+
+		It("VirtOperatorRESTErrorsBurst and VirtOperatorRESTErrorsHigh should be triggered when requests to virt-operator are failing", func() {
+			scales.RestoreScale(virtOperator.deploymentName)
+			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), crb.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				g.Expect(checkAlertExists(virtClient, virtOperator.restErrorsBurtsAlert)).To(BeTrue())
+				g.Expect(checkAlertExists(virtClient, virtOperator.restErrorsHighAlert)).To(BeTrue())
+			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+		})
+
+		It("VirtControllerRESTErrorsBurst and VirtControllerRESTErrorsHigh should be triggered when requests to virt-controller are failing", func() {
+			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-controller", metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi := tests.NewRandomVMI()
+
+			Eventually(func(g Gomega) {
+				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
+				_ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
+
+				g.Expect(checkAlertExists(virtClient, virtController.restErrorsBurtsAlert)).To(BeTrue())
+				g.Expect(checkAlertExists(virtClient, virtController.restErrorsHighAlert)).To(BeTrue())
+			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+		})
+
+		It("VirtHandlerRESTErrorsBurst and VirtHandlerRESTErrorsHigh should be triggered when requests to virt-handler are failing", func() {
+			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-handler", metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi := tests.NewRandomVMI()
+
+			Eventually(func(g Gomega) {
+				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
+				_ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
+
+				g.Expect(checkAlertExists(virtClient, virtHandler.restErrorsBurtsAlert)).To(BeTrue())
+				g.Expect(checkAlertExists(virtClient, virtHandler.restErrorsHighAlert)).To(BeTrue())
+			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+		})
+	})
+
+	Context("Resource metrics", func() {
+		var resourceAlerts = []string{
+			"KubeVirtComponentExceedsRequestedCPU",
+			"KubeVirtComponentExceedsRequestedMemory",
+		}
+
+		BeforeEach(func() {
+			virtClient = kubevirt.Client()
+			scales = NewScaling(virtClient, []string{virtOperator.deploymentName})
+			scales.UpdateScale(virtOperator.deploymentName, int32(0))
+			reduceAlertPendingTime()
+		})
+
+		AfterEach(func() {
+			scales.RestoreAllScales()
+			time.Sleep(10 * time.Second)
+			waitUntilAlertDoesNotExist(virtClient, resourceAlerts...)
+		})
+
+		It("KubeVirtComponentExceedsRequestedCPU should be triggered when virt-api exceeds requested CPU", func() {
+			By("updating virt-api deployment CPU and Memory requests")
+			updateDeploymentResourcesRequest(virtClient, virtApi.deploymentName, resource.MustParse("0m"), resource.MustParse("0Mi"))
+
+			By("waiting for KubeVirtComponentExceedsRequestedCPU and KubeVirtComponentExceedsRequestedMemory alerts")
+			verifyAlertExist(virtClient, "KubeVirtComponentExceedsRequestedCPU")
+			verifyAlertExist(virtClient, "KubeVirtComponentExceedsRequestedMemory")
+		})
+	})
+})
+
+func updateDeploymentResourcesRequest(virtClient kubecli.KubevirtClient, deploymentName string, cpu, memory resource.Quantity) {
+	deployment, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	deployment.Spec.Template.Spec.Containers[0].Resources.Requests = k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    cpu,
+		k8sv1.ResourceMemory: memory,
+	}
+
+	patchDeployment(virtClient, deployment)
+}
+
+func patchDeployment(virtClient kubecli.KubevirtClient, deployment *appsv1.Deployment) {
+	patchOp := patch.PatchOperation{
+		Op:    "replace",
+		Path:  "/spec",
+		Value: deployment.Spec,
+	}
+
+	payload, err := patch.GeneratePatchPayload(patchOp)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), deployment.Name, types.JSONPatchType, payload, metav1.PatchOptions{})
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -23,8 +23,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,17 +30,11 @@ import (
 
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -52,169 +44,10 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-type alerts struct {
-	deploymentName       string
-	downAlert            string
-	noReadyAlert         string
-	restErrorsBurtsAlert string
-	restErrorsHighAlert  string
-	lowCountAlert        string
-}
-
-var (
-	virtApi = alerts{
-		deploymentName:       "virt-api",
-		downAlert:            "VirtAPIDown",
-		restErrorsBurtsAlert: "VirtApiRESTErrorsBurst",
-		restErrorsHighAlert:  "VirtApiRESTErrorsHigh",
-		lowCountAlert:        "LowVirtAPICount",
-	}
-	virtController = alerts{
-		deploymentName:       "virt-controller",
-		downAlert:            "VirtControllerDown",
-		noReadyAlert:         "NoReadyVirtController",
-		restErrorsBurtsAlert: "VirtControllerRESTErrorsBurst",
-		restErrorsHighAlert:  "VirtControllerRESTErrorsHigh",
-		lowCountAlert:        "LowVirtControllersCount",
-	}
-	virtHandler = alerts{
-		deploymentName:       "virt-handler",
-		restErrorsBurtsAlert: "VirtHandlerRESTErrorsBurst",
-		restErrorsHighAlert:  "VirtHandlerRESTErrorsHigh",
-	}
-	virtOperator = alerts{
-		deploymentName:       "virt-operator",
-		downAlert:            "VirtOperatorDown",
-		noReadyAlert:         "NoReadyVirtOperator",
-		restErrorsBurtsAlert: "VirtOperatorRESTErrorsBurst",
-		restErrorsHighAlert:  "VirtOperatorRESTErrorsHigh",
-		lowCountAlert:        "LowVirtOperatorCount",
-	}
-)
-
 var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMonitoring, func() {
-
 	var err error
 	var virtClient kubecli.KubevirtClient
-	var scales *Scaling
 	var prometheusRule *promv1.PrometheusRule
-
-	checkAlert := func(alertName string) error {
-		alerts, err := getAlerts(virtClient)
-		if err != nil {
-			return err
-		}
-		for _, alert := range alerts {
-			if string(alert.Labels["alertname"]) == alertName {
-				return nil
-			}
-		}
-		return fmt.Errorf("alert doesn't exist: %v", alertName)
-	}
-
-	verifyAlertExistWithCustomTime := func(alertName string, timeout time.Duration) {
-		Eventually(func() error {
-			return checkAlert(alertName)
-		}, timeout, 10*time.Second).Should(BeNil())
-	}
-
-	verifyAlertExist := func(alertName string) {
-		verifyAlertExistWithCustomTime(alertName, 120*time.Second)
-	}
-
-	waitUntilAlertDoesNotExist := func(alertName string) {
-		Eventually(func() error {
-			alerts, err := getAlerts(virtClient)
-			if err != nil {
-				return err
-			}
-			for _, alert := range alerts {
-				if alertName == string(alert.Labels["alertname"]) {
-					return fmt.Errorf("alert exist: %v", alertName)
-				}
-			}
-			return nil
-		}, 5*time.Minute, 1*time.Second).Should(BeNil())
-	}
-
-	increaseRateLimit := func() {
-		rateLimitConfig := &v1.ReloadableComponentConfiguration{
-			RestClient: &v1.RESTClientConfiguration{
-				RateLimiter: &v1.RateLimiter{
-					TokenBucketRateLimiter: &v1.TokenBucketRateLimiter{
-						Burst: 300,
-						QPS:   300,
-					},
-				},
-			},
-		}
-		originalKubeVirt := util.GetCurrentKv(virtClient)
-		originalKubeVirt.Spec.Configuration.ControllerConfiguration = rateLimitConfig
-		originalKubeVirt.Spec.Configuration.HandlerConfiguration = rateLimitConfig
-		tests.UpdateKubeVirtConfigValueAndWait(originalKubeVirt.Spec.Configuration)
-	}
-
-	updatePromRules := func(newRules *promv1.PrometheusRule) {
-		err = virtClient.
-			PrometheusClient().MonitoringV1().
-			PrometheusRules(flags.KubeVirtInstallNamespace).
-			Delete(context.Background(), "prometheus-kubevirt-rules", metav1.DeleteOptions{})
-
-		Expect(err).ToNot(HaveOccurred())
-
-		_, err = virtClient.
-			PrometheusClient().MonitoringV1().
-			PrometheusRules(flags.KubeVirtInstallNamespace).
-			Create(context.Background(), newRules, metav1.CreateOptions{})
-
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	getPrometheusAlerts := func() promv1.PrometheusRule {
-		promRules, err := virtClient.
-			PrometheusClient().MonitoringV1().
-			PrometheusRules(flags.KubeVirtInstallNamespace).
-			Get(context.Background(), "prometheus-kubevirt-rules", metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		var newRules promv1.PrometheusRule
-		promRules.DeepCopyInto(&newRules)
-
-		newRules.Annotations = nil
-		newRules.ObjectMeta.ResourceVersion = ""
-		newRules.ObjectMeta.UID = ""
-
-		return newRules
-	}
-
-	reduceAlertPendingTime := func() {
-		By("Reducing alert pending time")
-		newRules := getPrometheusAlerts()
-		var re = regexp.MustCompile("\\[\\d+m\\]")
-
-		var gs []promv1.RuleGroup
-		for _, group := range newRules.Spec.Groups {
-			var rs []promv1.Rule
-			for _, rule := range group.Rules {
-				var r promv1.Rule
-				rule.DeepCopyInto(&r)
-				if r.Alert != "" {
-					r.For = "0m"
-					r.Expr = intstr.FromString(re.ReplaceAllString(r.Expr.String(), `[1m]`))
-					r.Expr = intstr.FromString(strings.ReplaceAll(r.Expr.String(), ">= 300", ">= 0"))
-				}
-				rs = append(rs, r)
-			}
-
-			gs = append(gs, promv1.RuleGroup{
-				Name:  group.Name,
-				Rules: rs,
-			})
-		}
-		newRules.Spec.Groups = gs
-
-		updatePromRules(&newRules)
-	}
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -249,148 +82,6 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 		})
 	})
 
-	Context("Up metrics", func() {
-		BeforeEach(func() {
-			scales = NewScaling(virtClient, []string{virtOperator.deploymentName, virtController.deploymentName, virtApi.deploymentName})
-			scales.UpdateScale(virtOperator.deploymentName, int32(0))
-
-			reduceAlertPendingTime()
-		})
-
-		AfterEach(func() {
-			scales.RestoreAllScales()
-
-			time.Sleep(10 * time.Second)
-			alerts := []string{
-				virtOperator.downAlert, virtOperator.noReadyAlert, virtOperator.lowCountAlert,
-				virtController.downAlert, virtController.noReadyAlert, virtController.lowCountAlert,
-				virtApi.downAlert, virtApi.noReadyAlert, virtApi.lowCountAlert,
-			}
-			for _, alert := range alerts {
-				waitUntilAlertDoesNotExist(alert)
-			}
-		})
-
-		It("VirtOperatorDown and NoReadyVirtOperator should be triggered when virt-operator is down", func() {
-			verifyAlertExist(virtOperator.downAlert)
-			verifyAlertExist(virtOperator.noReadyAlert)
-		})
-
-		It("LowVirtOperatorCount should be triggered when virt-operator count is low", decorators.RequiresTwoSchedulableNodes, func() {
-			verifyAlertExist(virtOperator.lowCountAlert)
-		})
-
-		It("VirtControllerDown and NoReadyVirtController should be triggered when virt-controller is down", func() {
-			scales.UpdateScale(virtController.deploymentName, int32(0))
-			verifyAlertExist(virtController.downAlert)
-			verifyAlertExist(virtController.noReadyAlert)
-		})
-
-		It("LowVirtControllersCount should be triggered when virt-controller count is low", decorators.RequiresTwoSchedulableNodes, func() {
-			scales.UpdateScale(virtController.deploymentName, int32(0))
-			verifyAlertExist(virtController.lowCountAlert)
-		})
-
-		It("VirtApiDown should be triggered when virt-api is down", func() {
-			scales.UpdateScale(virtApi.deploymentName, int32(0))
-			verifyAlertExist(virtApi.downAlert)
-		})
-
-		It("LowVirtAPICount should be triggered when virt-api count is low", decorators.RequiresTwoSchedulableNodes, func() {
-			scales.UpdateScale(virtApi.deploymentName, int32(0))
-			verifyAlertExist(virtApi.lowCountAlert)
-		})
-	})
-
-	Context("Errors metrics", func() {
-		var crb *rbacv1.ClusterRoleBinding
-
-		BeforeEach(func() {
-			virtClient = kubevirt.Client()
-
-			crb, err = virtClient.RbacV1().ClusterRoleBindings().Get(context.Background(), "kubevirt-operator", metav1.GetOptions{})
-			util.PanicOnError(err)
-
-			increaseRateLimit()
-
-			scales = NewScaling(virtClient, []string{virtOperator.deploymentName})
-			scales.UpdateScale(virtOperator.deploymentName, int32(0))
-
-			reduceAlertPendingTime()
-		})
-
-		AfterEach(func() {
-			crb.Annotations = nil
-			crb.ObjectMeta.ResourceVersion = ""
-			crb.ObjectMeta.UID = ""
-			_, err = virtClient.RbacV1().ClusterRoleBindings().Create(context.Background(), crb, metav1.CreateOptions{})
-			if !errors.IsAlreadyExists(err) {
-				util.PanicOnError(err)
-			}
-			scales.RestoreAllScales()
-
-			time.Sleep(10 * time.Second)
-			waitUntilAlertDoesNotExist(virtOperator.downAlert)
-			waitUntilAlertDoesNotExist(virtApi.downAlert)
-			waitUntilAlertDoesNotExist(virtController.downAlert)
-			waitUntilAlertDoesNotExist(virtHandler.downAlert)
-		})
-
-		It("VirtApiRESTErrorsBurst and VirtApiRESTErrorsHigh should be triggered when requests to virt-api are failing", func() {
-			randVmName := rand.String(6)
-
-			Eventually(func(g Gomega) {
-				cmd := clientcmd.NewVirtctlCommand("vnc", randVmName)
-				err := cmd.Execute()
-				Expect(err).To(HaveOccurred())
-
-				g.Expect(checkAlert(virtApi.restErrorsBurtsAlert)).To(Not(HaveOccurred()))
-				g.Expect(checkAlert(virtApi.restErrorsHighAlert)).To(Not(HaveOccurred()))
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
-		})
-
-		It("VirtOperatorRESTErrorsBurst and VirtOperatorRESTErrorsHigh should be triggered when requests to virt-operator are failing", func() {
-			scales.RestoreScale(virtOperator.deploymentName)
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), crb.Name, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func(g Gomega) {
-				g.Expect(checkAlert(virtOperator.restErrorsBurtsAlert)).To(Not(HaveOccurred()))
-				g.Expect(checkAlert(virtOperator.restErrorsHighAlert)).To(Not(HaveOccurred()))
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
-		})
-
-		It("VirtControllerRESTErrorsBurst and VirtControllerRESTErrorsHigh should be triggered when requests to virt-controller are failing", func() {
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-controller", metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi := tests.NewRandomVMI()
-
-			Eventually(func(g Gomega) {
-				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
-				_ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
-
-				g.Expect(checkAlert(virtController.restErrorsBurtsAlert)).To(Not(HaveOccurred()))
-				g.Expect(checkAlert(virtController.restErrorsHighAlert)).To(Not(HaveOccurred()))
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
-		})
-
-		It("VirtHandlerRESTErrorsBurst and VirtHandlerRESTErrorsHigh should be triggered when requests to virt-handler are failing", func() {
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), "kubevirt-handler", metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			vmi := tests.NewRandomVMI()
-
-			Eventually(func(g Gomega) {
-				_, _ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
-				_ = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
-
-				g.Expect(checkAlert(virtHandler.restErrorsBurtsAlert)).To(Not(HaveOccurred()))
-				g.Expect(checkAlert(virtHandler.restErrorsHighAlert)).To(Not(HaveOccurred()))
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
-		})
-	})
-
 	Context("Migration Alerts", decorators.SigComputeMigrations, func() {
 		It("KubeVirtVMIExcessiveMigrations should be triggered when a VMI has been migrated more than 12 times during the last 24 hours", func() {
 			By("Starting the VirtualMachineInstance")
@@ -408,7 +99,7 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			}
 
 			By("Verifying KubeVirtVMIExcessiveMigration alert exists")
-			verifyAlertExist("KubeVirtVMIExcessiveMigrations")
+			verifyAlertExist(virtClient, "KubeVirtVMIExcessiveMigrations")
 
 			// delete VMI
 			By("Deleting the VMI")
@@ -473,11 +164,11 @@ var _ = Describe("[Serial][sig-monitoring]Monitoring", Serial, decorators.SigMon
 			kv := disableVirtHandler()
 
 			By("Verifying KubeVirtNoAvailableNodesToRunVMs alert exists if emulation is disabled")
-			verifyAlertExistWithCustomTime("KubeVirtNoAvailableNodesToRunVMs", 10*time.Minute)
+			verifyAlertExistWithCustomTime(virtClient, "KubeVirtNoAvailableNodesToRunVMs", 10*time.Minute)
 
 			By("Restoring virt-handler")
 			restoreVirtHandler(kv)
-			waitUntilAlertDoesNotExist("KubeVirtNoAvailableNodesToRunVMs")
+			waitUntilAlertDoesNotExist(virtClient, "KubeVirtNoAvailableNodesToRunVMs")
 		})
 	})
 

--- a/tests/monitoring/scaling_utils.go
+++ b/tests/monitoring/scaling_utils.go
@@ -1,0 +1,85 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/flags"
+)
+
+type Scaling struct {
+	virtClient kubecli.KubevirtClient
+	scales     map[string]*autoscalingv1.Scale
+}
+
+func NewScaling(virtClient kubecli.KubevirtClient, deployments []string) *Scaling {
+	s := &Scaling{
+		virtClient: virtClient,
+		scales:     make(map[string]*autoscalingv1.Scale, len(deployments)),
+	}
+
+	for _, operatorName := range deployments {
+		s.BackupScale(operatorName)
+	}
+
+	return s
+}
+
+func (s *Scaling) BackupScale(operatorName string) {
+	By("Backing up scale for " + operatorName)
+	Eventually(func() error {
+		virtOperatorCurrentScale, err := s.virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).GetScale(context.TODO(), operatorName, metav1.GetOptions{})
+		if err == nil {
+			s.scales[operatorName] = virtOperatorCurrentScale
+		}
+		return err
+	}, 30*time.Second, 1*time.Second).Should(BeNil())
+}
+
+func (s *Scaling) UpdateScale(operatorName string, replicas int32) {
+	By(fmt.Sprintf("Updating scale for %s to %d", operatorName, replicas))
+	scale := s.scales[operatorName].DeepCopy()
+	scale.Spec.Replicas = replicas
+
+	Eventually(func() error {
+		_, err := s.virtClient.
+			AppsV1().
+			Deployments(flags.KubeVirtInstallNamespace).
+			UpdateScale(context.TODO(), operatorName, scale, metav1.UpdateOptions{})
+		return err
+	}, 30*time.Second, 1*time.Second).Should(BeNil(), "failed to update scale for %s", operatorName)
+
+	Eventually(func() int32 {
+		deployment, err := s.virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(context.TODO(), operatorName, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return deployment.Status.ReadyReplicas
+	}, 30*time.Second, 1*time.Second).Should(Equal(replicas), "failed to verify updated replicas for %s", operatorName)
+}
+
+func (s *Scaling) RestoreAllScales() {
+	for operatorName := range s.scales {
+		s.RestoreScale(operatorName)
+	}
+}
+
+func (s *Scaling) RestoreScale(operatorName string) {
+	By("Restoring scale for " + operatorName)
+	revert := s.scales[operatorName].DeepCopy()
+	revert.ResourceVersion = ""
+	Eventually(func() error {
+		_, err := s.virtClient.
+			AppsV1().
+			Deployments(flags.KubeVirtInstallNamespace).
+			UpdateScale(context.TODO(), operatorName, revert, metav1.UpdateOptions{})
+		return err
+	}, 30*time.Second, 1*time.Second).Should(BeNil(), "failed to restore scale for %s", operatorName)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add e2e tests for KubeVirtComponentExceedsRequestedCPU and KubeVirtComponentExceedsRequestedMemory alerts

I found that the KubeVirtComponentExceedsRequestedCPU and KubeVirtComponentExceedsRequestedMemory alerts were not being triggered when I added tests. The expressions used in these alerts used mixins not available on all clusters. Whenever I ran the expressions in Prometheus, the result was always empty. As a result, I updated the expressions and also updated the unit tests to reflect the new labels that were required.

jira-ticket: CNV-22403

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
