### PR TITLE
Dequarantine test_id 8482

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3620,7 +3620,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	})
 
-	Context("[QUARANTINE][test_id:8482] Migration Metrics", func() {
+	Context("[test_id:8482] Migration Metrics", func() {
 		It("exposed to prometheus during VM migration", func() {
 			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR https://github.com/kubevirt/kubevirt/pull/8586 fixed issues related to test_id 8482.
According to our [quarantine policy](https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md), this test can now be taken out of quarantine.

Test grid: https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.24-sig-compute-migrations&width=5

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
