### PR TITLE
Fix read-only validation for sata hard-drives

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -2330,6 +2330,14 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 					})
 
 				}
+				// sata disks (in contrast to sata cdroms) don't support readOnly
+				if disk.Disk != nil && bus == v1.DiskBusSATA && disk.Disk.ReadOnly {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: fmt.Sprintf("%s hard-disks do not support read-only.", bus),
+						Field:   field.Index(idx).Child("disk", "bus").String(),
+					})
+				}
 			}
 
 			// Reject defining DedicatedIOThread to a disk with SATA bus since this configuration

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2857,6 +2857,23 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[0].Field).To(Equal("fake[1].name"))
 		})
 
+		It("should reject disks with SATA and read-only set", func() {
+			vmi := api.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{
+						Bus:      v1.DiskBusSATA,
+						ReadOnly: true,
+					},
+				},
+			})
+			causes := validateDisks(k8sfield.NewPath("disks"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("disks[0].disk.bus"))
+		})
+
 		It("should reject disks with PCI address on a non-virtio bus ", func() {
 			vmi := api.NewMinimalVMI("testvmi")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

SATA hard-drives, in contranst to SATA cdroms, can't not have read only set because the SATA bus does not support it for disks.

This validation fix avoids running into libvirt sync errors like this:

```
command SyncVMI failed: "LibvirtError(Code=67, Domain=10, Message='unsupported configuration: readonly sata disks are not supported')"
```

More information can be found in https://bugzilla.redhat.com/show_bug.cgi?id=915162.

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix read-only sata disk validation
```
