### PR TITLE
tests, libnet/cluster: Stop passing the virt-client

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -898,7 +898,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		})
 
 		DescribeTable("should throttle the Prometheus metrics access", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -944,7 +944,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include the metrics for a running VM", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -960,7 +960,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -998,7 +998,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1024,7 +1024,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1061,7 +1061,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include VMI phase metrics for all running VMs", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1080,7 +1080,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include VMI eviction blocker status for all running VMs", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(controllerMetricIPs, family)
 
@@ -1098,7 +1098,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 		)
 
 		DescribeTable("should include kubernetes labels to VMI metrics", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 
@@ -1121,7 +1121,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, func() {
 
 		// explicit test fo swap metrics as test_id:4144 doesn't catch if they are missing
 		DescribeTable("should include swap metrics", func(family k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+			libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 			ip := getSupportedIP(handlerMetricIPs, family)
 

--- a/tests/libnet/cluster/cluster.go
+++ b/tests/libnet/cluster/cluster.go
@@ -22,37 +22,37 @@ var onceIPv6 sync.Once
 var clusterSupportsIpv6 bool
 var errIPv6 error
 
-func DualStack(virtClient kubecli.KubevirtClient) (bool, error) {
-	supportsIpv4, err := SupportsIpv4(virtClient)
+func DualStack() (bool, error) {
+	supportsIpv4, err := SupportsIpv4()
 	if err != nil {
 		return false, err
 	}
 
-	supportsIpv6, err := SupportsIpv6(virtClient)
+	supportsIpv6, err := SupportsIpv6()
 	if err != nil {
 		return false, err
 	}
 	return supportsIpv4 && supportsIpv6, nil
 }
 
-func SupportsIpv4(virtClient kubecli.KubevirtClient) (bool, error) {
+func SupportsIpv4() (bool, error) {
 	onceIPv4.Do(func() {
-		clusterSupportsIpv4, errIPv4 = clusterAnswersIPCondition(virtClient, netutils.IsIPv4String)
+		clusterSupportsIpv4, errIPv4 = clusterAnswersIPCondition(netutils.IsIPv4String)
 	})
 	return clusterSupportsIpv4, errIPv4
 }
 
-func SupportsIpv6(virtClient kubecli.KubevirtClient) (bool, error) {
+func SupportsIpv6() (bool, error) {
 	onceIPv6.Do(func() {
-		clusterSupportsIpv6, errIPv6 = clusterAnswersIPCondition(virtClient, netutils.IsIPv6String)
+		clusterSupportsIpv6, errIPv6 = clusterAnswersIPCondition(netutils.IsIPv6String)
 	})
 	return clusterSupportsIpv6, errIPv6
 }
 
-func clusterAnswersIPCondition(virtClient kubecli.KubevirtClient, ipCondition func(ip string) bool) (bool, error) {
+func clusterAnswersIPCondition(ipCondition func(ip string) bool) (bool, error) {
 	// grab us some neat kubevirt pod; let's say virt-handler is our target.
 	targetPodType := "virt-handler"
-	virtHandlerPod, err := getPodByKubeVirtRole(virtClient, targetPodType)
+	virtHandlerPod, err := getPodByKubeVirtRole(targetPodType)
 	if err != nil {
 		return false, err
 	}
@@ -65,7 +65,12 @@ func clusterAnswersIPCondition(virtClient kubecli.KubevirtClient, ipCondition fu
 	return false, nil
 }
 
-func getPodByKubeVirtRole(virtClient kubecli.KubevirtClient, kubevirtPodRole string) (*k8sv1.Pod, error) {
+func getPodByKubeVirtRole(kubevirtPodRole string) (*k8sv1.Pod, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		panic(err)
+	}
+
 	labelSelectorValue := fmt.Sprintf("%s = %s", v1.AppLabel, kubevirtPodRole)
 	pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(
 		context.Background(),

--- a/tests/libnet/skips.go
+++ b/tests/libnet/skips.go
@@ -6,38 +6,36 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/tests/libnet/cluster"
-
-	"kubevirt.io/client-go/kubecli"
 )
 
-func SkipWhenNotDualStackCluster(virtClient kubecli.KubevirtClient) {
-	isClusterDualStack, err := cluster.DualStack(virtClient)
+func SkipWhenNotDualStackCluster() {
+	isClusterDualStack, err := cluster.DualStack()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
 	if !isClusterDualStack {
 		Skip("This test requires a dual stack network config.")
 	}
 }
 
-func SkipWhenClusterNotSupportIpv4(virtClient kubecli.KubevirtClient) {
-	clusterSupportsIpv4, err := cluster.SupportsIpv4(virtClient)
+func SkipWhenClusterNotSupportIpv4() {
+	clusterSupportsIpv4, err := cluster.SupportsIpv4()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv4")
 	if !clusterSupportsIpv4 {
 		Skip("This test requires an ipv4 network config.")
 	}
 }
 
-func SkipWhenClusterNotSupportIpv6(virtClient kubecli.KubevirtClient) {
-	clusterSupportsIpv6, err := cluster.SupportsIpv6(virtClient)
+func SkipWhenClusterNotSupportIpv6() {
+	clusterSupportsIpv6, err := cluster.SupportsIpv6()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster supports ipv6")
 	if !clusterSupportsIpv6 {
 		Skip("This test requires an ipv6 network config.")
 	}
 }
 
-func SkipWhenClusterNotSupportIPFamily(virtClient kubecli.KubevirtClient, ipFamily k8sv1.IPFamily) {
+func SkipWhenClusterNotSupportIPFamily(ipFamily k8sv1.IPFamily) {
 	if ipFamily == k8sv1.IPv4Protocol {
-		SkipWhenClusterNotSupportIpv4(virtClient)
+		SkipWhenClusterNotSupportIpv4()
 	} else {
-		SkipWhenClusterNotSupportIpv6(virtClient)
+		SkipWhenClusterNotSupportIpv6()
 	}
 }

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -6,27 +6,17 @@ import (
 
 	"kubevirt.io/kubevirt/tests/libnet/cluster"
 
-	"kubevirt.io/client-go/kubecli"
-
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
 var _ = SIGDescribe("Dual stack cluster network configuration", func() {
-	var virtClient kubecli.KubevirtClient
-
-	BeforeEach(func() {
-		var err error
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
-	})
-
 	Context("when dual stack cluster configuration is enabled", func() {
 		Specify("the cluster must be dual stack", func() {
 			if flags.SkipDualStackTests {
 				Skip("user requested the dual stack check on the live cluster to be skipped")
 			}
 
-			isClusterDualStack, err := cluster.DualStack(virtClient)
+			isClusterDualStack, err := cluster.DualStack()
 			Expect(err).NotTo(HaveOccurred(), "must be able to infer the dual stack configuration from the live cluster")
 			Expect(isClusterDualStack).To(BeTrue(), "the live cluster should be in dual stack mode")
 		})

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -109,10 +109,10 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	skipIfNotSupportedCluster := func(ipFamily ipFamily) {
 		if includesIpv4(ipFamily) {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 		}
 		if inlcudesIpv6(ipFamily) {
-			libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv6()
 		}
 		if isDualStack(ipFamily) {
 			checks.SkipIfVersionBelow("Dual stack service requires v1.20 and above", "1.20")
@@ -327,7 +327,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				checks.SkipIfVersionBelow("IPFamilyPolicy property on a service requires v1.20 and above", "1.20")
 
 				if ipFamiyPolicy == k8sv1.IPFamilyPolicyRequireDualStack {
-					libnet.SkipWhenNotDualStackCluster(virtClient)
+					libnet.SkipWhenNotDualStackCluster()
 				}
 
 				calcNumOfClusterIPs := func() int {
@@ -335,7 +335,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					case k8sv1.IPFamilyPolicySingleStack:
 						return 1
 					case k8sv1.IPFamilyPolicyPreferDualStack:
-						isClusterDualStack, err := cluster.DualStack(virtClient)
+						isClusterDualStack, err := cluster.DualStack()
 						ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should have been able to infer if the cluster is dual stack")
 						if isClusterDualStack {
 							return 2

--- a/tests/network/macvtap.go
+++ b/tests/network/macvtap.go
@@ -252,7 +252,7 @@ var _ = SIGDescribe("Macvtap", func() {
 
 			BeforeEach(func() {
 				// TODO test also the IPv6 address (issue- https://github.com/kubevirt/kubevirt/issues/7506)
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed(), "connectivity is expected *before* migrating the VMI")
 			})
 

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -64,7 +64,7 @@ var _ = SIGDescribe("Port-forward", func() {
 		)
 
 		setup := func(ipFamily k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 			if ipFamily == k8sv1.IPv6Protocol {
 				Skip(skipIPv6Message)

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -85,7 +85,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 					}
 				)
 				BeforeEach(func() {
-					libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+					libnet.SkipWhenClusterNotSupportIpv4()
 					var err error
 
 					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding(libvmi.DefaultInterfaceName))

--- a/tests/network/probes.go
+++ b/tests/network/probes.go
@@ -78,7 +78,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		httpProbe := createHTTPProbe(period, initialSeconds, port)
 
 		DescribeTable("should succeed", func(readinessProbe *v1.Probe, ipFamily corev1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 			if ipFamily == corev1.IPv6Protocol {
 				By("Create a support pod which will reply to kubelet's probes ...")
@@ -180,7 +180,7 @@ var _ = SIGDescribe("[ref_id:1182]Probes", func() {
 		httpProbe := createHTTPProbe(period, initialSeconds, port)
 
 		DescribeTable("should not fail the VMI", func(livenessProbe *v1.Probe, ipFamily corev1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 			if ipFamily == corev1.IPv6Protocol {
 

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("Services", func() {
 		}
 
 		BeforeEach(func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 			subdomain := "vmi"
 			hostname := "inbound"
 
@@ -276,7 +276,7 @@ var _ = SIGDescribe("Services", func() {
 			DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
 				By("setting up resources to expose the VMI via a service", func() {
-					libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+					libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 					if ipFamily == k8sv1.IPv6Protocol {
 						serviceName = serviceName + "v6"
 						service = netservice.BuildIPv6Spec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -132,7 +132,7 @@ var istioTests = func(vmType VmType) {
 			virtClient, err = kubecli.GetKubevirtClient()
 			util.PanicOnError(err)
 
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 
 			By("Create NetworkAttachmentDefinition")
 			nad := generateIstioCNINetworkAttachmentDefinition()

--- a/tests/network/vmi_lifecycle.go
+++ b/tests/network/vmi_lifecycle.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 	Describe("[crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
 		Context("when virt-handler is responsive", func() {
 			It("[Serial]VMIs with Bridge Networking shouldn't fail after the kubelet restarts", Serial, func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				bridgeVMI := vmi
 				// Remove the masquerade interface to use the default bridge one
 				bridgeVMI.Spec.Domain.Devices.Interfaces = nil
@@ -94,7 +94,7 @@ var _ = SIGDescribe("[crit:high][arm64][vendor:cnv-qe@redhat.com][level:componen
 			})
 
 			It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				bridgeVMI := libvmi.NewCirros()
 				// Remove the masquerade interface to use the default bridge one
 				bridgeVMI.Spec.Domain.Devices.Interfaces = nil

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -192,7 +192,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, func() {
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
 			var networkData string
 			BeforeEach(func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				networkData, err = libnet.NewNetworkData(
 					libnet.WithEthernet("eth0",
 						libnet.WithDHCP4Enabled(),
@@ -279,7 +279,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, func() {
 
 		Context("VirtualMachineInstance with multus network as default network", func() {
 			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				networkData, err := libnet.NewNetworkData(
 					libnet.WithEthernet("eth0",
 						libnet.WithDHCP4Enabled(),

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -122,7 +122,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		var inboundVMIWithCustomMacAddress *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 		})
 		Context("with a test outbound VMI", func() {
 			BeforeEach(func() {
@@ -255,7 +255,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 		Context("VirtualMachineInstance with default interface model", func() {
 			BeforeEach(func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				inboundVMI = libvmi.NewCirros()
 				outboundVMI = libvmi.NewCirros()
 
@@ -299,7 +299,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("VirtualMachineInstance with default settings", func() {
 		It("[test_id:1542]should be able to reach the internet", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 			outboundVMI := libvmi.NewCirros()
 			outboundVMI = runVMI(outboundVMI)
 			tests.WaitUntilVMIReady(outboundVMI, console.LoginToCirros)
@@ -360,7 +360,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
 		It("[test_id:1772]should configure custom MAC address", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 			By(checkingEth0MACAddr)
 			masqIface := libvmi.InterfaceDeviceWithMasqueradeBinding()
 			masqIface.MacAddress = "BE-AF-00-00-DE-AD"
@@ -499,7 +499,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("VirtualMachineInstance with learning disabled on pod interface", func() {
 		It("[test_id:1777]should disable learning on pod iface", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 			By("checking learning flag")
 			learningDisabledVMI := libvmi.NewAlpine()
 			learningDisabledVMI, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(learningDisabledVMI)
@@ -512,7 +512,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("VirtualMachineInstance with dhcp options", func() {
 		It("[test_id:1778]should offer extra dhcp options to pod iface", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 			dhcpVMI := libvmi.NewFedora()
 			tests.AddExplicitPodNetworkInterface(dhcpVMI)
 
@@ -555,7 +555,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 	Context("VirtualMachineInstance with custom dns", func() {
 		It("[test_id:1779]should have custom resolv.conf", func() {
-			libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+			libnet.SkipWhenClusterNotSupportIpv4()
 			userData := "#cloud-config\n"
 			dnsVMI := libvmi.NewCirros(libvmi.WithCloudInitNoCloudUserData(userData, false))
 
@@ -685,7 +685,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			}
 
 			DescribeTable("ipv4", func(ports []v1.Port, tcpPort int, networkCIDR string) {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 
 				var clientVMI *v1.VirtualMachineInstance
 				var serverVMI *v1.VirtualMachineInstance
@@ -725,7 +725,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			)
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				ipv4Address := "8.8.8.8"
 				if flags.IPV4ConnectivityCheckAddress != "" {
 					ipv4Address = flags.IPV4ConnectivityCheckAddress
@@ -746,7 +746,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 
 			DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {
-				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv6()
 				var serverVMI *v1.VirtualMachineInstance
 				var clientVMI *v1.VirtualMachineInstance
 
@@ -783,7 +783,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			)
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
-				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv6()
 				// Cluster nodes subnet (docker network gateway)
 				// Docker network subnet cidr definition:
 				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
@@ -840,7 +840,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 
 			DescribeTable("[Conformance] preserves connectivity - IPv4", func(ports []v1.Port) {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 
 				var err error
 
@@ -879,7 +879,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			)
 
 			It("[Conformance] should preserve connectivity - IPv6", func() {
-				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv6()
 
 				var err error
 
@@ -965,7 +965,7 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 			})
 
 			DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
-				libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+				libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 				By("checking k6t-eth0 MTU inside the pod")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -135,7 +135,7 @@ var _ = SIGDescribe("[Serial] Passt", Serial, func() {
 						Expect(console.LoginToAlpine(clientVMI)).To(Succeed())
 					}
 					DescribeTable("Client server connectivity", func(ports []v1.Port, tcpPort int, ipFamily k8sv1.IPFamily) {
-						libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+						libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 						By("starting a client VMI")
 						startClientVMI()
@@ -197,7 +197,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 						}, 60*time.Second)
 					}
 					DescribeTable("Client server connectivity", func(ipFamily k8sv1.IPFamily) {
-						libnet.SkipWhenClusterNotSupportIPFamily(virtClient, ipFamily)
+						libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
 						const SERVER_PORT = 1700
 
@@ -236,7 +236,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 			})
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
-				libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv4()
 				ipv4Address := "8.8.8.8"
 				if flags.IPV4ConnectivityCheckAddress != "" {
 					ipv4Address = flags.IPV4ConnectivityCheckAddress
@@ -261,7 +261,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 			})
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
-				libnet.SkipWhenClusterNotSupportIpv6(virtClient)
+				libnet.SkipWhenClusterNotSupportIpv6()
 				// Cluster nodes subnet (docker network gateway)
 				// Docker network subnet cidr definition:
 				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("Slirp Networking", func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		util.PanicOnError(err)
 
-		libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+		libnet.SkipWhenClusterNotSupportIpv4()
 
 		kv := util.GetCurrentKv(virtClient)
 		currentConfiguration = kv.Spec.Configuration

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -56,7 +56,7 @@ var _ = SIGDescribe("Subdomain", func() {
 		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
 
 		// Should be skipped as long as masquerade binding doesn't have dhcpv6 + ra (issue- https://github.com/kubevirt/kubevirt/issues/7184)
-		libnet.SkipWhenClusterNotSupportIpv4(virtClient)
+		libnet.SkipWhenClusterNotSupportIpv4()
 	})
 
 	Context("with a headless service given", func() {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -264,7 +264,7 @@ var _ = SIGDescribe("Storage", func() {
 					}
 				})
 				DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily, imageOwnedByQEMU bool) {
-					libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+					libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 					var nodeName string
 					// Start the VirtualMachineInstance with the PVC attached
@@ -627,7 +627,7 @@ var _ = SIGDescribe("Storage", func() {
 
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
 				DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily) {
-					libnet.SkipWhenClusterNotSupportIPFamily(virtClient, family)
+					libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {


### PR DESCRIPTION
**What this PR does / why we need it**:

The virt-client is a singleton in the e2e test, therefore, it is preferable to just fetch it each time it is needed directly.

Passing it down the stack is redundant.

This in turn cleans a bit the tests, removing some boilerplate code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
