### PR TITLE
e2e test: Fix flaky test increasing timeout when changing replicas number

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -2726,16 +2726,14 @@ spec:
 				patchKvInfra(infra, false, "")
 
 				By(fmt.Sprintf("Expecting %d replicas of virt-api and virt-controller", replicas))
-				Eventually(func() bool {
+				Eventually(func() []k8sv1.Pod {
 					for _, name := range []string{"virt-api", "virt-controller"} {
 						pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, name)})
 						Expect(err).ToNot(HaveOccurred())
-						if len(pods.Items) != int(replicas) {
-							return false
-						}
+						return pods.Items
 					}
-					return true
-				}, 60*time.Second, 1*time.Second).Should(BeTrue())
+					return nil
+				}, 120*time.Second, 1*time.Second).Should(HaveLen(int(replicas)), fmt.Sprintf("Replicas of virt-api and virt-controller are not %d", replicas))
 
 				if replicas == 1 {
 					By(fmt.Sprintf("Expecting PDBs to disppear"))
@@ -2747,19 +2745,17 @@ spec:
 							}
 						}
 						return true
-					}, 60*time.Second, 1*time.Second).Should(BeTrue())
+					}, 60*time.Second, 1*time.Second).Should(BeTrue(), "PDBs have not disappeared")
 				} else {
 					By(fmt.Sprintf("Expecting minAvailable to become %d on the PDBs", replicas-1))
-					Eventually(func() bool {
+					Eventually(func() int {
 						for _, name := range []string{"virt-api", "virt-controller"} {
 							pdb, err := virtClient.PolicyV1().PodDisruptionBudgets(flags.KubeVirtInstallNamespace).Get(context.Background(), name+"-pdb", metav1.GetOptions{})
 							Expect(err).ToNot(HaveOccurred())
-							if pdb.Spec.MinAvailable.IntValue() != int(replicas-1) {
-								return false
-							}
+							return pdb.Spec.MinAvailable.IntValue()
 						}
-						return true
-					}, 60*time.Second, 1*time.Second).Should(BeTrue())
+						return -1
+					}, 60*time.Second, 1*time.Second).Should(BeEquivalentTo(int(replicas-1)), fmt.Sprintf("minAvailable is not become %d on the PDBs", replicas-1))
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We saw that the pods were terminating and we could see an event of successful delete right after the timeout.
Test results flaky due to the short timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @xpivarc 