### PR TITLE
Add an entrypoint to bump all production relevent image dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ deps-sync:
 rpm-deps:
 	SYNC_VENDOR=true hack/dockerized "CUSTOM_REPO=${CUSTOM_REPO} SINGLE_ARCH=${SINGLE_ARCH} LIBVIRT_VERSION=${LIBVIRT_VERSION} QEMU_VERSION=${QEMU_VERSION} SEABIOS_VERSION=${SEABIOS_VERSION} EDK2_VERSION=${EDK2_VERSION} LIBGUESTFS_VERSION=${LIBGUESTFS_VERSION} PASST_VERSION=${PASST_VERSION} ./hack/rpm-deps.sh"
 
+bump-images:
+	hack/dockerized "./hack/rpm-deps.sh && ./hack/bump-distroless.sh"
+
 verify-rpm-deps:
 	SYNC_VENDOR=true hack/dockerized " ./hack/verify-rpm-deps.sh"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -307,14 +307,14 @@ container_pull(
 # Pull go_image_base
 container_pull(
     name = "go_image_base",
-    digest = "sha256:f65536ce108fcc41cdcd5cb101006fcb82b9a1527409263feb9e34032f00bda0",
+    digest = "sha256:b9b124f955961599e72630654107a0cf04e08e6fa777fa250b8f840728abd770",
     registry = "gcr.io",
     repository = "distroless/base",
 )
 
 container_pull(
     name = "go_image_base_aarch64",
-    digest = "sha256:789c477fbd30a7d85435450306e54f20c53938e40af644284a229d852db30dde",
+    digest = "sha256:3552d4adeabdc6630fe1877198c3b853e977c53c439b0f7afaa7be760ee5ed6d",
     registry = "gcr.io",
     repository = "distroless/base",
 )

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -41,7 +41,8 @@ RUN dnf install -y dnf-plugins-core && \
         jq \
         wget \
         rubygems \
-        diffutils && \
+        diffutils \
+        skopeo && \
     dnf clean -y all
 
 # Avoids the need to install sssd-client by disabling lookups

--- a/hack/bump-distroless.sh
+++ b/hack/bump-distroless.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex -o pipefail
+
+source hack/common.sh
+source hack/bootstrap.sh
+source hack/config.sh
+
+DISTROLESS_AMD64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-amd64 | jq '.Digest' -r)
+DISTROLESS_ARM64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-arm64 | jq '.Digest' -r)
+
+bazel run \
+    --config=${ARCHITECTURE} \
+    -- @com_github_bazelbuild_buildtools//buildozer "set digest \"${DISTROLESS_AMD64_DIGEST}\"" ${KUBEVIRT_DIR}/WORKSPACE:go_image_base
+
+bazel run \
+    --config=${ARCHITECTURE} \
+    -- @com_github_bazelbuild_buildtools//buildozer "set digest \"${DISTROLESS_ARM64_DIGEST}\"" ${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -12,7 +12,7 @@ fi
 
 fail_if_cri_bin_missing
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2210281410-5ec9c2e5f"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2212180911-8818abcfa"
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps automatically:
 * distroless images
 * the rpm based images with their dependencies

That should be all our production ready base-images.

Further the distroless bump was executed right away, so also updating the distroless images.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8940

**Special notes for your reviewer**:

**Release note**:

```release-note
Bump distroless base images
```
