### PR TITLE
Remove validation for runbook URL annotation on alerts

### DIFF
--- a/tests/monitoring/monitoring.go
+++ b/tests/monitoring/monitoring.go
@@ -22,7 +22,6 @@ package monitoring
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -643,9 +642,6 @@ var _ = Describe("[Serial][sig-monitoring]Prometheus Alerts", Serial, func() {
 func checkRequiredAnnotations(rule promv1.Rule) {
 	ExpectWithOffset(1, rule.Annotations).To(HaveKeyWithValue("summary", Not(BeEmpty())),
 		fmt.Sprintf("%s summary is missing or empty", rule.Alert))
-	ExpectWithOffset(1, rule.Annotations).To(HaveKeyWithValue("runbook_url", Not(BeEmpty())),
-		fmt.Sprintf("%s runbook_url is missing or empty", rule.Alert))
-	checkRunbookUrlAvailability(rule)
 }
 
 func checkRequiredLabels(rule promv1.Rule) {
@@ -655,10 +651,4 @@ func checkRequiredLabels(rule promv1.Rule) {
 		fmt.Sprintf("%s kubernetes_operator_part_of label is missing or not valid", rule.Alert))
 	ExpectWithOffset(1, rule.Labels).To(HaveKeyWithValue("kubernetes_operator_component", "kubevirt"),
 		fmt.Sprintf("%s kubernetes_operator_component label is missing or not valid", rule.Alert))
-}
-
-func checkRunbookUrlAvailability(rule promv1.Rule) {
-	resp, err := http.Head(rule.Annotations["runbook_url"])
-	ExpectWithOffset(2, err).ToNot(HaveOccurred(), fmt.Sprintf("%s runbook is not available", rule.Alert))
-	ExpectWithOffset(2, resp.StatusCode).Should(Equal(http.StatusOK), fmt.Sprintf("%s runbook is not available", rule.Alert))
 }


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pull request removes the obligation to include a runbook URL annotation on all alerts. The enforcement of this requirement has been causing delays in the implementation of alerts, adding extra effort in monitoring contributors, and sometimes resulting in inaccurate runbooks. While runbooks are still supported and encouraged, they should be made optional to allow documentation contributors the time and freedom to create accurate and complete runbooks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
