### PR TITLE
SCC: allow unconfined seccomp

### DIFF
--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -76,6 +76,7 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	}
 	scc.SeccompProfiles = []string{
 		"runtime/default",
+		"unconfined",
 	}
 	scc.AllowedCapabilities = []corev1.Capability{
 		// add CAP_SYS_NICE capability to allow setting cpu affinity


### PR DESCRIPTION
**What this PR does / why we need it**:
Not all components are able to run with
runtime default seccomp profile. This will
allow to preserve current behavior -
run as unconfined.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
