### PR TITLE
virt-chroot, tap: set MTU upon TAP creation

### DIFF
--- a/cmd/virt-chroot/tap-device-maker.go
+++ b/cmd/virt-chroot/tap-device-maker.go
@@ -13,7 +13,10 @@ import (
 
 func createTapDevice(name string, owner uint, group uint, queueNumber int, mtu int) error {
 	tapDevice := &netlink.Tuntap{
-		LinkAttrs:  netlink.LinkAttrs{Name: name},
+		LinkAttrs: netlink.LinkAttrs{
+			Name: name,
+			MTU:  mtu,
+		},
 		Mode:       unix.IFF_TAP,
 		NonPersist: false,
 		Queues:     queueNumber,
@@ -38,10 +41,6 @@ func createTapDevice(name string, owner uint, group uint, queueNumber int, mtu i
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create tap device named %s. Reason: %v", name, err)
-	}
-
-	if err := netlink.LinkSetMTU(tapDevice, mtu); err != nil {
-		return fmt.Errorf("failed to set MTU on tap device named %s. Reason: %v", name, err)
 	}
 
 	fmt.Printf("Successfully created tap device %s, attempt %d\n", name, attempt)


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
