### PR TITLE
[bazel]: introduce BUILD_TARGETS to allow building specific targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ bazel-build-verify: bazel-build
 	./hack/dockerized "hack/bazel-test.sh"
 
 bazel-build-images:
-	hack/dockerized "export BUILD_ARCH=${BUILD_ARCH} && DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} DOCKER_TAG_ALT=${DOCKER_TAG_ALT} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT} ./hack/bazel-build-images.sh"
+	hack/dockerized "export BUILD_ARCH=${BUILD_ARCH} && DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} DOCKER_TAG_ALT=${DOCKER_TAG_ALT} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT} BUILD_TARGETS='${BUILD_TARGETS}' ./hack/bazel-build-images.sh"
 
 bazel-push-images:
 	hack/dockerized "export BUILD_ARCH=${BUILD_ARCH} && hack/bazel-fmt.sh && DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} DOCKER_TAG_ALT=${DOCKER_TAG_ALT} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} PUSH_TARGETS='${PUSH_TARGETS}' ./hack/bazel-push-images.sh"

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -23,14 +23,24 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
+BUILD_TARGETS=(${BUILD_TARGETS:-":build-other-images \
+cmd/virt-operator:virt-operator-image \
+cmd/virt-api:virt-api-image \
+cmd/virt-controller:virt-controller-image \
+cmd/virt-handler:virt-handler-image \
+cmd/virt-launcher:virt-launcher-image \
+cmd/libguestfs:libguestfs-tools-image \
+tests:conformance_image"})
+
 # vars are uninteresting for the build step, they are interesting for the push step only
-bazel build \
-    --config=${ARCHITECTURE} \
-    --define container_prefix= \
-    --define image_prefix= \
-    --define container_tag= \
-    //:build-other-images //cmd/virt-operator:virt-operator-image //cmd/virt-api:virt-api-image \
-    //cmd/virt-controller:virt-controller-image //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //cmd/libguestfs:libguestfs-tools-image //tests:conformance_image
+for target in ${BUILD_TARGETS[@]}; do
+  bazel build \
+      --config=${ARCHITECTURE} \
+      --define container_prefix= \
+      --define image_prefix= \
+      --define container_tag= \
+      //${target}
+done
 
 rm -rf ${DIGESTS_DIR}
 mkdir -p ${DIGESTS_DIR}


### PR DESCRIPTION

Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
there are use cases where the virt components are being built using hack/build-go.sh but in order to build the other images we would like to use Bazel. In such cases we would like to choose these images using BUILD_TARGETS, in the same way we can choose which targets to push using the PUSH_TARGETS.

for example, if we want to build only the utility images, we can specify the following:
```
export BUILD_TARGETS=":build-other-images"
export PUSH_TARGETS="other-images"
make bazel-build-images && make bazel-push-images
```

**Release note**:
```release-note
NONE
```
