### PR TITLE
Fix podman CRI detection

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,22 +1,13 @@
 #!/usr/bin/env bash
 
-export KUBEVIRTCI_PODMAN_SOCKET=${KUBEVIRTCI_PODMAN_SOCKET:-"/run/podman/podman.sock"}
-
-detect_podman() {
-    if curl --unix-socket "${KUBEVIRTCI_PODMAN_SOCKET}" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
-        echo "podman --remote --url=unix://${KUBEVIRTCI_PODMAN_SOCKET}"
-    fi
-}
-
 determine_cri_bin() {
     if [ "${KUBEVIRT_CRI}" = "podman" ]; then
-        detect_podman
+        echo podman
     elif [ "${KUBEVIRT_CRI}" = "docker" ]; then
         echo docker
     else
-        local podman=$(detect_podman)
-        if [ -n "$podman" ]; then
-            echo "$podman"
+        if podman ps >/dev/null 2>&1; then
+            echo podman
         elif docker ps >/dev/null 2>&1; then
             echo docker
         else


### PR DESCRIPTION
**What this PR does / why we need it**:
### The bug
Currently, when Podman is available but not Docker, some `make` commands will fail by default (unless a podman.sock is exposed): `make fmt`, `make generate`, etc.

### The fix
It is possible to create a Podman socket that understands Docker API (see https://stackoverflow.com/a/72693093). This is valuable, for example, when trying to use Podman inside Podman/Docker.

Currently, to detect if Podman exists, we check if the podman.sock exists. Since in most scenarios such a socket doesn't exist, this logic doesn't make sense.

Now, to detect if Podman is available, we execute "podman ps" and test its exit code - in the exact same way we detect Docker existance.

**Special notes for your reviewer**:
A similar logic exists in https://github.com/kubevirt/kubevirt/blob/main/cluster-up/cluster/ephemeral-provider-common.sh#L20. But there the socket is needed in order to share it within the container [that's being run](https://github.com/kubevirt/kubevirt/blob/main/cluster-up/cluster/ephemeral-provider-common.sh#L48). Therefore I think that we should keep this logic there.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix podman CRI detection
```
