### PR TITLE
Pick up pod affinities and preferred nod affinities on virt-launcher pods from the cluster config

### DIFF
--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "affinity.go",
         "multus_annotations.go",
         "nodeselectorrenderer.go",
         "rendercontainer.go",
@@ -50,6 +51,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "affinity_test.go",
         "multus_annotations_test.go",
         "nodeselectorrenderer_test.go",
         "rendercontainer_test.go",

--- a/pkg/virt-controller/services/affinity.go
+++ b/pkg/virt-controller/services/affinity.go
@@ -1,0 +1,32 @@
+package services
+
+import v1 "k8s.io/api/core/v1"
+
+// AppendNonDaemonsetApplicableAffinity merges all affinity rules, except for required node affinities and node selectors.
+// This is useful to add affinities which can not be picked up for the virt-handler daemonset to each VMI pod.
+func AppendNonDaemonsetApplicableAffinity(given *v1.Affinity, additional *v1.Affinity) *v1.Affinity {
+	result := given.DeepCopy()
+	if additional.PodAffinity != nil {
+		if result.PodAffinity == nil {
+			result.PodAffinity = &v1.PodAffinity{}
+		}
+		result.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(result.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, additional.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution...)
+		result.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(result.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, additional.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	}
+
+	if additional.PodAntiAffinity != nil {
+		if result.PodAntiAffinity == nil {
+			result.PodAntiAffinity = &v1.PodAntiAffinity{}
+		}
+		result.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(result.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, additional.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution...)
+		result.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(result.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, additional.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	}
+
+	if additional.NodeAffinity != nil {
+		if result.NodeAffinity == nil {
+			result.NodeAffinity = &v1.NodeAffinity{}
+		}
+		result.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(result.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, additional.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	}
+	return result
+}

--- a/pkg/virt-controller/services/affinity_test.go
+++ b/pkg/virt-controller/services/affinity_test.go
@@ -1,0 +1,213 @@
+package services
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Affinity", func() {
+	DescribeTable("should be merged", func(given, additional, desired *v1.Affinity) {
+		Expect(AppendNonDaemonsetApplicableAffinity(given, additional)).To(Equal(desired))
+	},
+		Entry("with empty affinities",
+			&v1.Affinity{},
+			&v1.Affinity{},
+			&v1.Affinity{},
+		),
+		Entry("with minimal given affinity, and fully populated additional affinity, it should ignore required node constraints",
+			&v1.Affinity{},
+			getFullyPopulatedAffinity(),
+			getFullyPopulatedAffinityWithoutNodeRequires(),
+		),
+		Entry("with fully populated given affinity, it should stay unmodified if the additional affinity is empty",
+			getFullyPopulatedAffinity(),
+			&v1.Affinity{},
+			getFullyPopulatedAffinity(),
+		),
+		Entry("with fully populated given affinity, and fully populated additional affinity, it should merge everything except required node constraints",
+			getFullyPopulatedAffinity(),
+			getFullyPopulatedAffinity(),
+			getDoublePopulatedAffinityWithoutDuplicatedRequiredNodeConstraints(),
+		),
+	)
+})
+
+func getFullyPopulatedAffinity() *v1.Affinity {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "KeyA",
+								Operator: "OperatorA",
+								Values:   []string{"ValueA"},
+							},
+						},
+						MatchFields: []v1.NodeSelectorRequirement{
+							{
+								Key:      "KeyB",
+								Operator: "OperatorB",
+								Values:   []string{"ValueB"},
+							},
+						},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				{
+					Weight: 0,
+					Preference: v1.NodeSelectorTerm{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "KeyC",
+								Operator: "OperatorC",
+								Values:   []string{"ValueC"},
+							},
+						},
+						MatchFields: []v1.NodeSelectorRequirement{
+							{
+								Key:      "KeyD",
+								Operator: "OperatorD",
+								Values:   []string{"ValueD"},
+							},
+						},
+					},
+				},
+			},
+		},
+		PodAffinity: &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &v12.LabelSelector{
+						MatchLabels: map[string]string{},
+						MatchExpressions: []v12.LabelSelectorRequirement{
+							{
+								Key:      "KeyE",
+								Operator: "OperatorE",
+								Values:   []string{"ValueE"},
+							},
+						},
+					},
+					Namespaces:  []string{},
+					TopologyKey: "",
+					NamespaceSelector: &v12.LabelSelector{
+						MatchLabels: map[string]string{},
+						MatchExpressions: []v12.LabelSelectorRequirement{
+							{
+								Key:      "KeyF",
+								Operator: "OperatorF",
+								Values:   []string{"ValueF"},
+							},
+						},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+				{
+					Weight: 0,
+					PodAffinityTerm: v1.PodAffinityTerm{
+						LabelSelector: &v12.LabelSelector{
+							MatchLabels: map[string]string{},
+							MatchExpressions: []v12.LabelSelectorRequirement{
+								{
+									Key:      "KeyG",
+									Operator: "OperatorG",
+									Values:   []string{"ValueG"},
+								},
+							},
+						},
+						Namespaces:  []string{},
+						TopologyKey: "",
+						NamespaceSelector: &v12.LabelSelector{
+							MatchLabels: map[string]string{},
+							MatchExpressions: []v12.LabelSelectorRequirement{
+								{
+									Key:      "KeyH",
+									Operator: "OperatorH",
+									Values:   []string{"ValueH"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		PodAntiAffinity: &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &v12.LabelSelector{
+						MatchLabels: map[string]string{},
+						MatchExpressions: []v12.LabelSelectorRequirement{
+							{
+								Key:      "KeyJ",
+								Operator: "OperatorJ",
+								Values:   []string{"ValueJ"},
+							},
+						},
+					},
+					Namespaces:  []string{},
+					TopologyKey: "",
+					NamespaceSelector: &v12.LabelSelector{
+						MatchLabels: map[string]string{},
+						MatchExpressions: []v12.LabelSelectorRequirement{
+							{
+								Key:      "KeyK",
+								Operator: "OperatorK",
+								Values:   []string{"ValueK"},
+							},
+						},
+					},
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+				{
+					Weight: 0,
+					PodAffinityTerm: v1.PodAffinityTerm{
+						LabelSelector: &v12.LabelSelector{
+							MatchLabels: map[string]string{},
+							MatchExpressions: []v12.LabelSelectorRequirement{
+								{
+									Key:      "KeyL",
+									Operator: "OeratorL",
+									Values:   []string{"ValueL"},
+								},
+							},
+						},
+						Namespaces:  []string{},
+						TopologyKey: "something",
+						NamespaceSelector: &v12.LabelSelector{
+							MatchLabels: map[string]string{},
+							MatchExpressions: []v12.LabelSelectorRequirement{
+								{
+									Key:      "KeyM",
+									Operator: "OperatorM",
+									Values:   []string{"ValueL"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getDoublePopulatedAffinityWithoutDuplicatedRequiredNodeConstraints() *v1.Affinity {
+	base := getFullyPopulatedAffinity()
+	base.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(base.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, base.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	base.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(base.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, base.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution...)
+	base.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(base.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, base.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	base.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(base.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, base.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution...)
+	base.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(base.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, base.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	return base
+}
+
+func getFullyPopulatedAffinityWithoutNodeRequires() *v1.Affinity {
+	affinity := getFullyPopulatedAffinity()
+	affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	return affinity
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -524,6 +524,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	setNodeAffinityForPod(vmi, &pod)
+	workloadPlacement := t.clusterConfig.GetConfigFromKubeVirtCR().Spec.Workloads
+	if workloadPlacement != nil && workloadPlacement.NodePlacement != nil {
+		pod.Spec.Affinity = AppendNonDaemonsetApplicableAffinity(pod.Spec.Affinity, workloadPlacement.NodePlacement.Affinity)
+	}
 
 	serviceAccountName := serviceAccount(vmi.Spec.Volumes...)
 	if len(serviceAccountName) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Append cluster-workload-pod affinity and cluster-workload-preferred-node
affinity to the virt-launcher pods when configured on the KubeVirt CR.

Before these fields were just ignored, since they were only
applied to virt-handler, but virt-handler is a daemonset and there these
values have no meaning.

Now all scheduling constraints which have no meaning for virt-handler
are appended to the virt-launcher pod for both, migration, as well
as starting VMs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix workload placement by picking up pod affinity and node preferred affinity. They were accidentally ignored before.
```
