### PR TITLE
Improve the distroless bump script

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -307,14 +307,14 @@ container_pull(
 # Pull go_image_base
 container_pull(
     name = "go_image_base",
-    digest = "sha256:b9b124f955961599e72630654107a0cf04e08e6fa777fa250b8f840728abd770",
+    digest = "sha256:d33b9c8d01976cc9137b32b3022e0d490f68205e7c679cd6e677e0d2588cb25a",
     registry = "gcr.io",
     repository = "distroless/base",
 )
 
 container_pull(
     name = "go_image_base_aarch64",
-    digest = "sha256:3552d4adeabdc6630fe1877198c3b853e977c53c439b0f7afaa7be760ee5ed6d",
+    digest = "sha256:0ee9b89e5440df8ba0e226e09685c191dde5e189ed65b66abf3cebc568501232",
     registry = "gcr.io",
     repository = "distroless/base",
 )

--- a/hack/bump-distroless.sh
+++ b/hack/bump-distroless.sh
@@ -9,10 +9,15 @@ source hack/config.sh
 DISTROLESS_AMD64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-amd64 | jq '.Digest' -r)
 DISTROLESS_ARM64_DIGEST=$(skopeo inspect docker://gcr.io/distroless/base:latest-arm64 | jq '.Digest' -r)
 
-bazel run \
-    --config=${ARCHITECTURE} \
-    -- @com_github_bazelbuild_buildtools//buildozer "set digest \"${DISTROLESS_AMD64_DIGEST}\"" ${KUBEVIRT_DIR}/WORKSPACE:go_image_base
-
-bazel run \
-    --config=${ARCHITECTURE} \
-    -- @com_github_bazelbuild_buildtools//buildozer "set digest \"${DISTROLESS_ARM64_DIGEST}\"" ${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
+# buildozer returns a non-zero exit code (3) if the commands were a success but did not change the file.
+# To make the command idempotent, first set the digest to a kind-of-unique number to work around this behaviour.
+# This way we can assume a zero exit code if no errors occur.
+cat <<EOF | bazel run --config=${ARCHITECTURE} -- @com_github_bazelbuild_buildtools//buildozer -f -
+set digest "$(date +%s)"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
+set digest "$(date +%s)"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
+EOF
+# now set the actual digest
+cat <<EOF | bazel run --config=${ARCHITECTURE} -- @com_github_bazelbuild_buildtools//buildozer -f -
+set digest "${DISTROLESS_AMD64_DIGEST}"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base
+set digest "${DISTROLESS_ARM64_DIGEST}"|${KUBEVIRT_DIR}/WORKSPACE:go_image_base_aarch64
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:

To make the script idempotent, we need to work around the fact that buildozer returns a non-zero exit code (3), if the commands succeeded, but the file was not changed. Now, first the digest is replaced with a timestamp, to force buildozer in having to change the file, even if the actual digest stayed the same since the last run.

Further, since that leads to more buildozer invocations, the commands are changed to take multiple instructions from stdin, to do batch modifications.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8965 


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
