### PR TITLE
[e2e tests]: k8s-reporter: protect artifacts from consequent run cleanup

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -70,6 +70,7 @@ if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
     trap "_out/tests/junit-merger -o ${ARTIFACTS}/junit.functest.xml '${ARTIFACTS}/partial.*.xml'" EXIT
     parallel_test_args=""
     serial_test_args=""
+    k8s_reporter_path="${ARTIFACTS}/k8s-reporter"
 
     if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
         parallel_test_args="${parallel_test_args} --skip=\\[Serial\\]|${KUBEVIRT_E2E_SKIP}"
@@ -89,6 +90,7 @@ if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
     set +e
     functest --nodes=${KUBEVIRT_E2E_PARALLEL_NODES} ${parallel_test_args} ${KUBEVIRT_FUNC_TEST_GINKGO_ARGS}
     return_value="$?"
+    [ -d "${k8s_reporter_path}" ] && mv "${k8s_reporter_path}" "${k8s_reporter_path}"-parallel
     set -e
     if [ "$return_value" -ne 0 ] && ! [ "$KUBEVIRT_E2E_RUN_ALL_SUITES" == "true" ]; then
         exit "$return_value"


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
the e2e suite is called twice, for the parallel tests and again
for the serial tests. In case KUBEVIRT_E2E_RUN_ALL_SUITES is set,
even if the parallel suite had failures, the serial suite will run afterwards.
This situation may cause a loss in k8s-reporter dumps, since they will be deleted
by the cleanup procedure.

Thus move the k8s-reporter to k8s-reporter-parallel before
starting the serial suite.

**Special notes for your reviewer**:
validated using:
```
export KUBEVIRT_E2E_PARALLEL=true
export KUBEVIRT_E2E_RUN_ALL_SUITES=true
export KUBEVIRT_E2E_FOCUS="VMIlifecycle"
```
With assertions in both parallel and serial tests, I saw both 

```
_out/artifacts/k8s-reporter  
_out/artifacts/k8s-reporter-parallel
```

**Release note**:
```release-note
NONE
```
