### PR TITLE
Align with k8s fix for default limit range requirements

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
@@ -93,10 +93,10 @@ func defaultVMIResourceRequirements(limitRange *k8sv1.LimitRange) k8sv1.Resource
 		limit := limitRange.Spec.Limits[i]
 		if limit.Type == k8sv1.LimitTypeContainer {
 			for k, v := range limit.DefaultRequest {
-				requirements.Requests[k8sv1.ResourceName(k)] = v
+				requirements.Requests[k8sv1.ResourceName(k)] = v.DeepCopy()
 			}
 			for k, v := range limit.Default {
-				requirements.Limits[k8sv1.ResourceName(k)] = v
+				requirements.Limits[k8sv1.ResourceName(k)] = v.DeepCopy()
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
defaultVMIResourceRequirements() is a function that is duplicated from Kubernetes' defaultContainerResourceRequirements() [1][2]. In Kubernetes' code, they are DeepCopying the value from the limit range that is applied to the VMI. This commit brings the same DeepCopy to our code. This is probably a bug fix that we aren't synced with.

p.s. since the original function is private we must duplicate it and cannot use it directly.

[1] https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go#L86
[2] https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/limitranger/admission.go#L214

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Align with k8s fix for default limit range requirements
```
