### PR TITLE
[release-0.53]: Use CurrentSpecReport().IsSerial to check for Serial run

### DIFF
--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -257,8 +257,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 				var err error
 				var node *k8sv1.Node
 
-				suiteConfig, _ := GinkgoConfiguration()
-				Expect(suiteConfig.ParallelTotal).To(Equal(1), "stopping / resuming node-labeller is supported for serial tests only")
+				Expect(CurrentSpecReport().IsSerial).To(BeTrue(), "stopping / resuming node-labeller is supported for serial tests only")
 
 				By(fmt.Sprintf("Patching node to %s include %s label", nodeName, v1.LabellerSkipNodeAnnotation))
 				key, value := v1.LabellerSkipNodeAnnotation, "true"


### PR DESCRIPTION
This is a backport of the changes introduced here: https://github.com/kubevirt/kubevirt/pull/8770.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
