### PR TITLE
[WIP][Discussion] Add deprecation policy for API, metadata and feature behaviors.

### DIFF
--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -39,5 +39,28 @@ In order to deprecate a feature gate the following conditions must be met:
 
 After the above deprecation process, the feature gate should remain as a no-op with a warning popping up.
 
+### Metadata (e.g. labels / annotations)
+Kubevirt adds certain labels / annotations to both objects that are created by us (e.g. VMs) and cluster-wide
+objects (e.g. Nodes). This metadata is exposed to the end-user which might use it and depend on it.
+
+Usually, metadata needs to be deprecated if it has a non-intuitive / irrelevant name or reflects data that is no
+longer relevant / useful.
+
+#### Deprecation
+In order to deprecate metadata the following conditions must be met:
+* A mail should be sent to kubevirt-dev mailing list (kubevirt-dev@googlegroups.com) to inform about the deprecation.
+* In case the metadata is being renamed / changed, the new metadata (e.g. label) should be added alongside the deprecated
+one.
+
+For example, if we want to deprecate a label named `kubevirt.io/badNonIntuitiveName` to
+`kubevirt.io/greatNewName`, both labels should appear.
+
+#### Removal
+Deprecated metadata will not be removed for at least 3 release cycles, which means roughly 1 year.
+
+Afterwards, a mail should be sent to kubevirt-dev mailing list (kubevirt-dev@googlegroups.com) to inform
+about the removal. If there are no objections, the metadata can be removed. Otherwise, a new removal date
+can be discussed according to the context.
+
 ## Discussion
 An ongoing discussion takes part in the following issue: https://github.com/kubevirt/kubevirt/issues/7745

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -81,5 +81,17 @@ Afterwards, a mail should be sent to kubevirt-dev mailing list (kubevirt-dev@goo
 about the removal. If there are no objections, the object can be removed. Otherwise, a new removal date
 can be discussed according to the context.
 
+### Feature Behavior
+This refers to any changes in features behavior that might surprise the user or break backwards compatibility.
+
+As an example, let's say that a certain feature can be enabled via Kubevirt CR that affects only worker nodes,
+and that feature is changed to also affect control-plane nodes. This is considered a feature behavior change.
+Internal details that are not exposed to the end-user as guarantees that are part of our API aren't considered
+as feature behavior changes.
+
+The process is identical to the process of deprecating API (see above), except the number of releases before
+the final behavior change should be 3 releases (roughly 1 year).
+
+
 ## Discussion
 An ongoing discussion takes part in the following issue: https://github.com/kubevirt/kubevirt/issues/7745

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -62,5 +62,24 @@ Afterwards, a mail should be sent to kubevirt-dev mailing list (kubevirt-dev@goo
 about the removal. If there are no objections, the metadata can be removed. Otherwise, a new removal date
 can be discussed according to the context.
 
+### API
+Although the following only mentions API objects, it's also relevant for their APIs (e.g. object fields),
+Kubevirt CR configuration, etc. Obviously, for fields / configs deprecation the step about adding a
+deprecated annotations can be skipped. However, a warning should always be triggered for any usage of all
+of the above mentioned.
+
+#### Deprecation
+In order to deprecate an API object the following actions need to be taken:
+* The deprecated object needs to contain a warning about the object being deprecated. The warning should also
+  state whenever the object would be removed (see below).
+* A mail should be sent to kubevirt-dev mailing list (kubevirt-dev@googlegroups.com) to inform about the deprecation.
+
+#### Removal
+A deprecated object will not be removed for at least 5 release cycles, which means roughly 1.5 years.
+
+Afterwards, a mail should be sent to kubevirt-dev mailing list (kubevirt-dev@googlegroups.com) to inform
+about the removal. If there are no objections, the object can be removed. Otherwise, a new removal date
+can be discussed according to the context.
+
 ## Discussion
 An ongoing discussion takes part in the following issue: https://github.com/kubevirt/kubevirt/issues/7745


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a continuation of the effort to have an initial deprecation policy for Kubevirt and continues the work that was done in https://github.com/kubevirt/kubevirt/pull/7791 and https://github.com/kubevirt/kubevirt/issues/7745.

In this PR I'm adding a deprecation policy for API, metadata and feature behaviors. The policy in a human-readable format can be found here: https://github.com/kubevirt/kubevirt/blob/556046ea8c0050eeef65ac4ca975b2f4492eba43/docs/deprecation.md.

This document is not meant to be final, quite the contrary, it is aimed to serve as a starting point for a "live document" that would be continuously reshaped according to our needs.

The deprecation policy is inspired by Kubernetes' deprecation policy: https://kubernetes.io/docs/reference/using-api/deprecation-policy/.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7745

Paves the way to fix #8583

**Special notes for your reviewer**:
In [Kubernetes' deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/) the versioned API is used a lot. 

Let's please discuss this in [this comment](https://github.com/kubevirt/kubevirt/pull/9012#discussion_r1229514274).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add deprecation policy for API, metadata and feature behaviors.
```
