### PR TITLE
[virt-launcher] Cleanups and socket specification deletion

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -194,7 +194,7 @@ container_image(
         "//conditions:default": "amd64",
     }),
     base = ":version-container",
-    entrypoint = ["/usr/bin/virt-launcher"],
+    entrypoint = ["/usr/bin/virt-launcher-monitor"],
     tars = [":setcaps"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -114,7 +114,7 @@ func createLibvirtConnection(runWithNonRoot bool) virtcli.Connection {
 	user := ""
 	if runWithNonRoot {
 		user = putil.NonRootUserString
-		libvirtUri = "qemu+unix:///session?socket=/var/run/libvirt/virtqemud-sock"
+		libvirtUri = "qemu:///session"
 	}
 
 	domainConn, err := virtcli.NewConnection(libvirtUri, user, "", 10*time.Second)
@@ -127,7 +127,6 @@ func createLibvirtConnection(runWithNonRoot bool) virtcli.Connection {
 
 func startDomainEventMonitoring(
 	notifier *notifyclient.Notifier,
-	virtShareDir string,
 	domainConn virtcli.Connection,
 	deleteNotificationSent chan watch.Event,
 	vmi *v1.VirtualMachineInstance,
@@ -450,7 +449,7 @@ func main() {
 
 	events := make(chan watch.Event, 2)
 	// Send domain notifications to virt-handler
-	startDomainEventMonitoring(notifier, *virtShareDir, domainConn, events, vmi, domainName, &agentStore, *qemuAgentSysInterval, *qemuAgentFileInterval, *qemuAgentUserInterval, *qemuAgentVersionInterval, *qemuAgentFSFreezeStatusInterval)
+	startDomainEventMonitoring(notifier, domainConn, events, vmi, domainName, &agentStore, *qemuAgentSysInterval, *qemuAgentFileInterval, *qemuAgentUserInterval, *qemuAgentVersionInterval, *qemuAgentFSFreezeStatusInterval)
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1462,7 +1462,7 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	command := []string{"virsh"}
 	if kutil.IsNonRootVMI(freshVMI) {
 		command = append(command, "-c")
-		command = append(command, "qemu+unix:///session?socket=/var/run/libvirt/virtqemud-sock")
+		command = append(command, "qemu:///session")
 	}
 	command = append(command, []string{"dumpxml", vmi.Namespace + "_" + vmi.Name}...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a follow up PR based on https://github.com/kubevirt/kubevirt/pull/8619#issuecomment-1297316476
There are 3 things that are performed:

1. Alignment between virt-launcher `entrypoint` and command executed from virt-handler when creating the pod
2. Aligning behavior between session and system mode when creating libvirt connection (It is not mandatory to specify the socket in session mode).
3. Deletion of an unused parameter in `startDomainEventMonitoring` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @andreabolognani 