### PR TITLE
Add VMPool status/scale subresources for HPA Support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20245,6 +20245,10 @@
       "description": "Canonical form of the label selector for HPA which consumes it through the scale subresource.",
       "type": "string"
      },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32"
+     },
      "replicas": {
       "type": "integer",
       "format": "int32"

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -603,6 +603,8 @@ spec:
           resources:
           - virtualmachinepools
           - virtualmachinepools/finalizers
+          - virtualmachinepools/status
+          - virtualmachinepools/scale
           verbs:
           - watch
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -522,6 +522,8 @@ rules:
   resources:
   - virtualmachinepools
   - virtualmachinepools/finalizers
+  - virtualmachinepools/status
+  - virtualmachinepools/scale
   verbs:
   - watch
   - list

--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -100,6 +100,11 @@ func (d *VirtualMachineConditionManager) HasCondition(vm *v1.VirtualMachine, con
 	return d.GetCondition(vm, cond) != nil
 }
 
+func (d *VirtualMachineConditionManager) HasConditionWithStatus(vm *v1.VirtualMachine, cond v1.VirtualMachineConditionType, status k8sv1.ConditionStatus) bool {
+	c := d.GetCondition(vm, cond)
+	return c != nil && c.Status == status
+}
+
 func (d *VirtualMachineConditionManager) RemoveCondition(vm *v1.VirtualMachine, cond v1.VirtualMachineConditionType) {
 	var conds []v1.VirtualMachineCondition
 	for _, c := range vm.Status.Conditions {

--- a/pkg/util/status/BUILD.bazel
+++ b/pkg/util/status/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/virt-controller/watch/pool.go
+++ b/pkg/virt-controller/watch/pool.go
@@ -1219,6 +1219,12 @@ func (c *PoolController) updateStatus(origPool *poolv1.VirtualMachinePool, vms [
 	}
 
 	pool.Status.Replicas = int32(len(vms))
+	pool.Status.ReadyReplicas = 0
+	for _, vm := range vms {
+		if vm.Status.Ready {
+			pool.Status.ReadyReplicas++
+		}
+	}
 
 	if !equality.Semantic.DeepEqual(pool.Status, origPool.Status) {
 		err := c.statusUpdater.UpdateStatus(pool)

--- a/pkg/virt-controller/watch/pool.go
+++ b/pkg/virt-controller/watch/pool.go
@@ -1236,11 +1236,9 @@ func (c *PoolController) updateStatus(origPool *poolv1.VirtualMachinePool, vms [
 	}
 
 	pool.Status.Replicas = int32(len(vms))
-	if pool.Status.Replicas != pool.Status.ReadyReplicas {
-		pool.Status.ReadyReplicas = int32(len(c.filterReadyVMs(vms)))
-	}
+	pool.Status.ReadyReplicas = int32(len(c.filterReadyVMs(vms)))
 
-	if !equality.Semantic.DeepEqual(pool.Status, origPool.Status) {
+	if !equality.Semantic.DeepEqual(pool.Status, origPool.Status) || pool.Status.Replicas != pool.Status.ReadyReplicas {
 		err := c.statusUpdater.UpdateStatus(pool)
 		if err != nil {
 			return err

--- a/pkg/virt-controller/watch/pool_test.go
+++ b/pkg/virt-controller/watch/pool_test.go
@@ -265,6 +265,7 @@ var _ = Describe("Pool", func() {
 		It("should update VM when VM template changes, but not VMI unless VMI template changes", func() {
 			pool, vm := DefaultPool(1)
 			pool.Status.Replicas = 1
+			pool.Status.ReadyReplicas = 1
 			poolRevision := createPoolRevision(pool)
 
 			pool.Generation = 123
@@ -288,6 +289,8 @@ var _ = Describe("Pool", func() {
 				BlockOwnerDeletion: &t,
 			}}
 
+			markVmAsReady(vm)
+			markAsReady(vmi)
 			addPool(pool)
 			addVM(vm)
 			addCR(poolRevision)
@@ -323,6 +326,7 @@ var _ = Describe("Pool", func() {
 		It("should update VM and VMI with both VM and VMI template change", func() {
 			pool, vm := DefaultPool(1)
 			pool.Status.Replicas = 1
+			pool.Status.ReadyReplicas = 1
 
 			oldPoolRevision := createPoolRevision(pool)
 
@@ -334,6 +338,7 @@ var _ = Describe("Pool", func() {
 
 			vm = injectPoolRevisionLabelsIntoVM(vm, newPoolRevision.Name)
 			vm.Name = fmt.Sprintf("%s-0", pool.Name)
+			markVmAsReady(vm)
 
 			vmi := api.NewMinimalVMI(vm.Name)
 			vmi.Spec = vm.Spec.Template.Spec
@@ -372,8 +377,10 @@ var _ = Describe("Pool", func() {
 
 			poolRevision := createPoolRevision(pool)
 			vm = injectPoolRevisionLabelsIntoVM(vm, poolRevision.Name)
+			markVmAsReady(vm)
 
 			pool.Status.Replicas = 1
+			pool.Status.ReadyReplicas = 1
 			addPool(pool)
 			addVM(vm)
 			addCR(poolRevision)
@@ -387,11 +394,13 @@ var _ = Describe("Pool", func() {
 
 			poolRevision := createPoolRevision(pool)
 			vm = injectPoolRevisionLabelsIntoVM(vm, poolRevision.Name)
+			markVmAsReady(vm)
 
 			oldPoolRevision := poolRevision.DeepCopy()
 			oldPoolRevision.Name = "madeup"
 
 			pool.Status.Replicas = 1
+			pool.Status.ReadyReplicas = 1
 			addPool(pool)
 			addVM(vm)
 			addCR(poolRevision)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -4009,3 +4009,7 @@ func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string)
 func DefaultVirtualMachine(started bool) (*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) {
 	return DefaultVirtualMachineWithNames(started, "testvmi", "testvmi")
 }
+
+func markVmAsReady(vm *virtv1.VirtualMachine) {
+	virtcontroller.NewVirtualMachineConditionManager().UpdateCondition(vm, &virtv1.VirtualMachineCondition{Type: virtv1.VirtualMachineReady, Status: k8sv1.ConditionTrue})
+}

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -393,6 +393,7 @@ func NewKubeVirtCrd() (*extv1.CustomResourceDefinition, error) {
 
 func NewVirtualMachinePoolCrd() (*extv1.CustomResourceDefinition, error) {
 	crd := newBlankCrd()
+	labelSelector := ".status.labelSelector"
 
 	crd.ObjectMeta.Name = VIRTUALMACHINEPOOL
 	crd.Spec = extv1.CustomResourceDefinitionSpec{
@@ -414,6 +415,27 @@ func NewVirtualMachinePoolCrd() (*extv1.CustomResourceDefinition, error) {
 				"all",
 			},
 		},
+	}
+
+	err := addFieldsToAllVersions(crd,
+		[]extv1.CustomResourceColumnDefinition{
+			{Name: "Desired", Type: "integer", JSONPath: ".spec.replicas",
+				Description: "Number of desired VirtualMachines"},
+			{Name: "Current", Type: "integer", JSONPath: ".status.replicas",
+				Description: "Number of managed and not final or deleted VirtualMachines"},
+			{Name: "Ready", Type: "integer", JSONPath: ".status.readyReplicas",
+				Description: "Number of managed VirtualMachines which are ready to receive traffic"},
+			{Name: "Age", Type: "date", JSONPath: creationTimestampJSONPath},
+		}, &extv1.CustomResourceSubresources{
+			Scale: &extv1.CustomResourceSubresourceScale{
+				SpecReplicasPath:   ".spec.replicas",
+				StatusReplicasPath: ".status.replicas",
+				LabelSelectorPath:  &labelSelector,
+			},
+			Status: &extv1.CustomResourceSubresourceStatus{},
+		})
+	if err != nil {
+		return nil, err
 	}
 
 	if err := patchValidationForAllVersions(crd); err != nil {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -19373,6 +19373,9 @@ var CRDsValidation map[string]string = map[string]string{
           description: Canonical form of the label selector for HPA which consumes
             it through the scale subresource.
           type: string
+        readyReplicas:
+          format: int32
+          type: integer
         replicas:
           format: int32
           type: integer

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -327,6 +327,8 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"virtualmachinepools",
 					"virtualmachinepools/finalizers",
+					"virtualmachinepools/status",
+					"virtualmachinepools/scale",
 				},
 
 				Verbs: []string{

--- a/staging/src/kubevirt.io/api/pool/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/pool/v1alpha1/types.go
@@ -82,6 +82,8 @@ type VirtualMachinePoolCondition struct {
 type VirtualMachinePoolStatus struct {
 	Replicas int32 `json:"replicas,omitempty" optional:"true"`
 
+	ReadyReplicas int32 `json:"readyReplicas,omitempty" optional:"true"`
+
 	// +listType=atomic
 	Conditions []VirtualMachinePoolCondition `json:"conditions,omitempty" optional:"true"`
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25645,6 +25645,12 @@ func schema_kubevirtio_api_pool_v1alpha1_VirtualMachinePoolStatus(ref common.Ref
 							Format: "int32",
 						},
 					},
+					"readyReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{


### PR DESCRIPTION
This is an attempt to add status/scale subresources to VM Pools. When I get the object, it still doesn't show up the subresources. Any guidance is much appreciated.

Signed-off-by: Marcelo Feitoza Parisi <marcelo@feitoza.com.br>

**What this PR does / why we need it**: This PR tries do add status and scale subresources to VM Pools in order to be able to support HPA.

**Which issue(s) this PR fixes**: *None*

**Special notes for your reviewer**: I would really appreciate any input so I can have this fixed and running accordingly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding support for status/scale subresources so that VirtualMachinePool now supports HorizontalPodAutoscaler
```
