### PR TITLE
virt-handler: Support DHCPv6 on bridge interfaces

### DIFF
--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -147,8 +147,7 @@ func (h *NetworkUtilsHandler) ConfigureIpv4ArpIgnore() error {
 }
 
 func (h *NetworkUtilsHandler) ConfigureIpv6FlushAddrOnDown() error {
-	err := sysctl.New().SetSysctl(sysctl.Ipv6KeepAddrOnDown, "-1")
-	return err
+	return sysctl.New().SetSysctl(sysctl.Ipv6KeepAddrOnDown, "-1")
 }
 
 func (h *NetworkUtilsHandler) ConfigureIpForwarding(ipVersion IPVersion) error {

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -82,6 +82,7 @@ type NetworkHandler interface {
 	ConfigureIpForwarding(ipVersion IPVersion) error
 	ConfigureRouteLocalNet(string) error
 	ConfigureIpv4ArpIgnore() error
+	ConfigureIpv6FlushAddrOnDown() error
 	ConfigurePingGroupRange() error
 	ConfigureUnprivilegedPortStart(string) error
 	NftablesNewChain(ipVersion IPVersion, table, chain string) error
@@ -142,6 +143,11 @@ func (h *NetworkUtilsHandler) LinkSetMaster(link netlink.Link, master *netlink.B
 
 func (h *NetworkUtilsHandler) ConfigureIpv4ArpIgnore() error {
 	err := sysctl.New().SetSysctl(sysctl.Ipv4ArpIgnoreAll, "1")
+	return err
+}
+
+func (h *NetworkUtilsHandler) ConfigureIpv6FlushAddrOnDown() error {
+	err := sysctl.New().SetSysctl(sysctl.Ipv6KeepAddrOnDown, "-1")
 	return err
 }
 

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -263,6 +263,16 @@ func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv4ArpIgnore() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv4ArpIgnore")
 }
 
+func (_m *MockNetworkHandler) ConfigureIpv6FlushAddrOnDown() error {
+	ret := _m.ctrl.Call(_m, "ConfigureIpv6FlushAddrOnDown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv6FlushAddrOnDown() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv6FlushAddrOnDown")
+}
+
 func (_m *MockNetworkHandler) ConfigurePingGroupRange() error {
 	ret := _m.ctrl.Call(_m, "ConfigurePingGroupRange")
 	ret0, _ := ret[0].(error)

--- a/pkg/network/infraconfigurators/bridge_test.go
+++ b/pkg/network/infraconfigurators/bridge_test.go
@@ -884,8 +884,9 @@ var _ = Describe("Bridge infrastructure configurator", func() {
 					MAC:          mac,
 					IPv6:         podIP,
 				}
-				Expect(createBridgeConfiguratorWithIPAM(
-					mac, podIP).GenerateNonRecoverableDHCPConfig()).To(Equal(&expectedDhcpConfig))
+				Expect(
+					createBridgeConfiguratorWithIPAM(mac, podIP).GenerateNonRecoverableDHCPConfig(),
+				).To(Equal(&expectedDhcpConfig))
 			})
 		})
 	})

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -29,6 +29,7 @@ const (
 	NetIPv6Forwarding     = "net/ipv6/conf/all/forwarding"
 	NetIPv4Forwarding     = "net/ipv4/ip_forward"
 	Ipv4ArpIgnoreAll      = "net/ipv4/conf/all/arp_ignore"
+	Ipv6KeepAddrOnDown    = "net/ipv6/conf/all/keep_addr_on_down"
 	PingGroupRange        = "net/ipv4/ping_group_range"
 	IPv4RouteLocalNet     = "net/ipv4/conf/%s/route_localnet"
 	UnprivilegedPortStart = "net/ipv4/ip_unprivileged_port_start"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for DHCPv6 to the bridge interface, building on the work of #4654 which enabled it for masquerade interfaces.

Even with RA support still missing, this is already useful when connecting VMs to external networks that have a router that sends RAs.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support DHCPv6 on bridge interfaces
```
