### PR TITLE
[release-0.58]Fix and arrange libvmi.GetPodByVirtualMachineInstance function to avoid flakiness

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -86,7 +86,8 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		vmi.Spec.Volumes[0].ContainerDisk.ImagePullPolicy = policy
 		vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 		Expect(vmi.Spec.Volumes[0].ContainerDisk.ImagePullPolicy).To(Equal(expectedPolicy))
-		pod := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+		pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+		Expect(err).ToNot(HaveOccurred())
 		container := getContainerDiskContainerOfPod(pod, vmi.Spec.Volumes[0].Name)
 		Expect(container.ImagePullPolicy).To(Equal(expectedPolicy))
 	},
@@ -238,7 +239,8 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
-				pod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 
 				writableImagePath := fmt.Sprintf("/var/run/kubevirt-ephemeral-disks/disk-data/%v/disk.qcow2", vmi.Spec.Domain.Devices.Disks[0].Name)
 

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -259,15 +259,16 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 					EVMCS: featureState,
 				},
 			}
-
-			vmi, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 			Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Should get VMI")
 			Expect(vmi.Spec.Domain.Features.Hyperv.EVMCS).ToNot(BeNil(), "evmcs should not be nil")
 			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil(), "cpu topology can't be nil")
-			pod := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
 			if featureState.Enabled == nil || *featureState.Enabled == true {
 				Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).ToNot(BeNil(), "vapic should not be nil")
 				Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(1), "cpu topology has to contain 1 feature")

--- a/tests/libvmi/status.go
+++ b/tests/libvmi/status.go
@@ -13,7 +13,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 
-func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace string) *k8sv1.Pod {
+func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace string) (*k8sv1.Pod, error) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		panic(err)
@@ -21,7 +21,7 @@ func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace st
 
 	pods, err := virtCli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	var controlledPod *k8sv1.Pod
@@ -34,12 +34,10 @@ func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace st
 	}
 
 	if controlledPod == nil {
-		if err != nil {
-			panic(fmt.Errorf("no controlled pod was found for VMI"))
-		}
+		return nil, fmt.Errorf("no controlled pod was found for VMI")
 	}
 
-	return controlledPod
+	return controlledPod, nil
 }
 
 func IndexInterfaceStatusByName(vmi *v1.VirtualMachineInstance) map[string]v1.VirtualMachineInstanceNetworkInterface {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -407,9 +407,11 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 						}, ipFamily == dualIPv6Primary)
 					}
 					if inlcudesIpv6(ipFamily) {
+						launcher, err := libvmi.GetPodByVirtualMachineInstance(tcpVM, tcpVM.GetNamespace())
+						Expect(err).ToNot(HaveOccurred())
 						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
 							virtClient,
-							libvmi.GetPodByVirtualMachineInstance(tcpVM, tcpVM.GetNamespace()),
+							launcher,
 							node,
 							k8sv1.IPv6Protocol)
 						Expect(err).NotTo(HaveOccurred(), "must have been able to resolve an IP address from the node name")
@@ -520,12 +522,13 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				for _, node := range nodes.Items {
 					Expect(node.Status.Addresses).ToNot(BeEmpty())
 					nodeIP := node.Status.Addresses[0].Address
-
 					var ipv6NodeIP string
 					if inlcudesIpv6(ipFamily) {
+						launcher, err := libvmi.GetPodByVirtualMachineInstance(udpVM, udpVM.GetNamespace())
+						Expect(err).ToNot(HaveOccurred())
 						ipv6NodeIP, err = resolveNodeIPAddrByFamily(
 							virtClient,
-							libvmi.GetPodByVirtualMachineInstance(udpVM, udpVM.GetNamespace()),
+							launcher,
 							node,
 							k8sv1.IPv6Protocol)
 						Expect(err).NotTo(HaveOccurred(), "must have been able to resolve an IP address from the node name")

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -164,7 +164,8 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
-				pod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying SELinux context contains custom type")
 				Expect(pod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(superPrivilegedType))
@@ -198,7 +199,8 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				Expect(err).ToNot(HaveOccurred())
 				emulator := "[/]" + strings.TrimPrefix(domSpec.Devices.Emulator, "/")
 
-				pod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 				qemuProcessSelinuxContext, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					pod,
@@ -236,7 +238,8 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 			tests.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 			By("Fetching virt-launcher Pod")
-			pod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+			pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+			Expect(err).ToNot(HaveOccurred())
 
 			for _, containerSpec := range pod.Spec.Containers {
 				if containerSpec.Name == "compute" {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1762,7 +1762,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					// If the annotation v1.KeepLauncherAfterFailureAnnotation is set to false or not set, the virt-launcher pod will become failed.
 					By("Verify that the virt-launcher pod or its container is in the expected state")
 					newVMI, _ := virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
-					launcherPod := libvmi.GetPodByVirtualMachineInstance(newVMI, newVM.Namespace)
+					launcherPod, err := libvmi.GetPodByVirtualMachineInstance(newVMI, newVM.Namespace)
+					Expect(err).ToNot(HaveOccurred())
 
 					if toKeep, _ := strconv.ParseBool(keepLauncher); toKeep {
 						Consistently(func() bool {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1912,7 +1912,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				WithSchedulerName("my-custom-scheduler"),
 			)
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
-			launcherPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			launcherPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(launcherPod.Spec.SchedulerName).To(Equal("my-custom-scheduler"))
 		})
 	})
@@ -1926,7 +1927,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			)
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
-			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			Expect(err).ToNot(HaveOccurred())
 			computeContainer := tests.GetComputeContainerOfPod(readyPod)
 			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
 			Expect(cpuRequest.String()).To(Equal("500m"))
@@ -1936,7 +1938,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi := tests.NewRandomVMI()
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
-			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			Expect(err).ToNot(HaveOccurred())
 			computeContainer := tests.GetComputeContainerOfPod(readyPod)
 			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
 			Expect(cpuRequest.String()).To(Equal("100m"))
@@ -1953,7 +1956,8 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			vmi := tests.NewRandomVMI()
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
-			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			readyPod, err := libvmi.GetPodByVirtualMachineInstance(runningVMI, util.NamespaceTestDefault)
+			Expect(err).ToNot(HaveOccurred())
 			computeContainer := tests.GetComputeContainerOfPod(readyPod)
 			cpuRequest := computeContainer.Resources.Requests[kubev1.ResourceCPU]
 			Expect(cpuRequest.String()).To(Equal("800m"))

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -90,7 +90,8 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				}
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
-				readyPod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				readyPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 				computeContainer := tests.GetComputeContainerOfPod(readyPod)
 
 				Expect(computeContainer.Resources.Requests.Memory().String()).To(Equal("100M"))
@@ -104,7 +105,8 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				}
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
-				readyPod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				readyPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 				computeContainer := tests.GetComputeContainerOfPod(readyPod)
 
 				Expect(computeContainer.Resources.Requests.Memory().String()).ToNot(Equal("100M"))
@@ -116,10 +118,12 @@ var _ = Describe("[rfe_id:609][sig-compute]VMIheadless", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 				normalVmi = tests.RunVMIAndExpectLaunch(normalVmi, 30)
 
-				readyPod := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				readyPod, err := libvmi.GetPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 				computeContainer := tests.GetComputeContainerOfPod(readyPod)
 
-				normalReadyPod := libvmi.GetPodByVirtualMachineInstance(normalVmi, util.NamespaceTestDefault)
+				normalReadyPod, err := libvmi.GetPodByVirtualMachineInstance(normalVmi, util.NamespaceTestDefault)
+				Expect(err).ToNot(HaveOccurred())
 				normalComputeContainer := tests.GetComputeContainerOfPod(normalReadyPod)
 
 				memDiff := normalComputeContainer.Resources.Requests.Memory()

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -434,7 +434,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					vmi = tests.RunVMIAndExpectScheduling(vmi, 30)
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					launcher := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+					launcher, err := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
+					Expect(err).ToNot(HaveOccurred())
 					watcher.New(launcher).
 						SinceWatchedObjectResourceVersion().
 						Timeout(60*time.Second).
@@ -463,7 +464,8 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 					}
 					By("Starting a VirtualMachineInstance")
 					createdVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
-					launcher := libvmi.GetPodByVirtualMachineInstance(createdVMI, createdVMI.Namespace)
+					launcher, err := libvmi.GetPodByVirtualMachineInstance(createdVMI, createdVMI.Namespace)
+					Expect(err).ToNot(HaveOccurred())
 					// Wait until we see that starting the VirtualMachineInstance is failing
 					By(fmt.Sprintf("Checking that VirtualMachineInstance start failed: starting at %v", time.Now()))
 					ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR is manual backport of  https://github.com/kubevirt/kubevirt/pull/8902/commits/7e53ea9cf346ef6f98217c1be206875a7d7924e8
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
