### PR TITLE
[release-0.58] Take QoS into account in hotplug pod resource requirements

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -524,3 +524,31 @@ func initContainerMinimalRequests() k8sv1.ResourceList {
 		k8sv1.ResourceMemory: resource.MustParse("1M"),
 	}
 }
+
+func hotplugContainerResourceRequirementsForVMI(vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements {
+	if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
+		return k8sv1.ResourceRequirements{
+			Limits:   hotplugContainerMinimalLimits(),
+			Requests: hotplugContainerMinimalLimits(),
+		}
+	} else {
+		return k8sv1.ResourceRequirements{
+			Limits:   hotplugContainerMinimalLimits(),
+			Requests: hotplugContainerMinimalRequests(),
+		}
+	}
+}
+
+func hotplugContainerMinimalLimits() k8sv1.ResourceList {
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    resource.MustParse("100m"),
+		k8sv1.ResourceMemory: resource.MustParse("80M"),
+	}
+}
+
+func hotplugContainerMinimalRequests() k8sv1.ResourceList {
+	return k8sv1.ResourceList{
+		k8sv1.ResourceCPU:    resource.MustParse("10m"),
+		k8sv1.ResourceMemory: resource.MustParse("2M"),
+	}
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -722,19 +722,10 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 		Spec: k8sv1.PodSpec{
 			Containers: []k8sv1.Container{
 				{
-					Name:    hotplugDisk,
-					Image:   t.launcherImage,
-					Command: command,
-					Resources: k8sv1.ResourceRequirements{ //Took the request and limits from containerDisk init container.
-						Limits: map[k8sv1.ResourceName]resource.Quantity{
-							k8sv1.ResourceCPU:    resource.MustParse("100m"),
-							k8sv1.ResourceMemory: resource.MustParse("80M"),
-						},
-						Requests: map[k8sv1.ResourceName]resource.Quantity{
-							k8sv1.ResourceCPU:    resource.MustParse("10m"),
-							k8sv1.ResourceMemory: resource.MustParse("2M"),
-						},
-					},
+					Name:      hotplugDisk,
+					Image:     t.launcherImage,
+					Command:   command,
+					Resources: hotplugContainerResourceRequirementsForVMI(vmi),
 					SecurityContext: &k8sv1.SecurityContext{
 						SELinuxOptions: &k8sv1.SELinuxOptions{
 							// FIXME: Forcing an SELinux level without categories is a security risk
@@ -828,7 +819,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 	return pod, nil
 }
 
-func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, _ *v1.VirtualMachineInstance, pvcName string, isBlock bool, tempPod bool) (*k8sv1.Pod, error) {
+func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock bool, tempPod bool) (*k8sv1.Pod, error) {
 	zero := int64(0)
 	sharedMount := k8sv1.MountPropagationHostToContainer
 	var command []string
@@ -864,19 +855,10 @@ func (t *templateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 		Spec: k8sv1.PodSpec{
 			Containers: []k8sv1.Container{
 				{
-					Name:    hotplugDisk,
-					Image:   t.launcherImage,
-					Command: command,
-					Resources: k8sv1.ResourceRequirements{ //Took the request and limits from containerDisk init container.
-						Limits: map[k8sv1.ResourceName]resource.Quantity{
-							k8sv1.ResourceCPU:    resource.MustParse("100m"),
-							k8sv1.ResourceMemory: resource.MustParse("80M"),
-						},
-						Requests: map[k8sv1.ResourceName]resource.Quantity{
-							k8sv1.ResourceCPU:    resource.MustParse("10m"),
-							k8sv1.ResourceMemory: resource.MustParse("2M"),
-						},
-					},
+					Name:      hotplugDisk,
+					Image:     t.launcherImage,
+					Command:   command,
+					Resources: hotplugContainerResourceRequirementsForVMI(vmi),
 					SecurityContext: &k8sv1.SecurityContext{
 						SELinuxOptions: &k8sv1.SELinuxOptions{
 							Type:  t.clusterConfig.GetSELinuxLauncherType(),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3346,6 +3346,70 @@ var _ = Describe("Template", func() {
 			Expect(false).To(BeTrue())
 		})
 
+		It("should compute the correct resource req according to desired QoS when rendering hotplug pods", func() {
+			vmi := api.NewMinimalVMI("fake-vmi")
+			ownerPod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+				Requests: kubev1.ResourceList{
+					kubev1.ResourceMemory: resource.MustParse("1G"),
+					kubev1.ResourceCPU:    resource.MustParse("1"),
+				},
+				Limits: kubev1.ResourceList{
+					kubev1.ResourceMemory: resource.MustParse("1G"),
+					kubev1.ResourceCPU:    resource.MustParse("1"),
+				},
+			}
+			claimMap := map[string]*kubev1.PersistentVolumeClaim{}
+			pod, err := svc.RenderHotplugAttachmentPodTemplate([]*v1.Volume{}, ownerPod, vmi, claimMap, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pod.Spec.Containers[0].Resources).To(Equal(kubev1.ResourceRequirements{
+				Limits: kubev1.ResourceList{
+					kubev1.ResourceCPU:    resource.MustParse("100m"),
+					kubev1.ResourceMemory: resource.MustParse("80M"),
+				},
+				Requests: kubev1.ResourceList{
+					kubev1.ResourceCPU:    resource.MustParse("100m"),
+					kubev1.ResourceMemory: resource.MustParse("80M"),
+				},
+			}))
+		})
+
+		DescribeTable("hould compute the correct resource req according to desired QoS when rendering hotplug trigger pods", func(isBlock bool) {
+			vmi := api.NewMinimalVMI("fake-vmi")
+			ownerPod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+				Requests: kubev1.ResourceList{
+					kubev1.ResourceMemory: resource.MustParse("1G"),
+					kubev1.ResourceCPU:    resource.MustParse("1"),
+				},
+				Limits: kubev1.ResourceList{
+					kubev1.ResourceMemory: resource.MustParse("1G"),
+					kubev1.ResourceCPU:    resource.MustParse("1"),
+				},
+			}
+			pod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{}, ownerPod, vmi, "test", isBlock, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pod.Spec.Containers[0].Resources).To(Equal(kubev1.ResourceRequirements{
+				Limits: kubev1.ResourceList{
+					kubev1.ResourceCPU:    resource.MustParse("100m"),
+					kubev1.ResourceMemory: resource.MustParse("80M"),
+				},
+				Requests: kubev1.ResourceList{
+					kubev1.ResourceCPU:    resource.MustParse("100m"),
+					kubev1.ResourceMemory: resource.MustParse("80M"),
+				},
+			}))
+		},
+			Entry("when volume is a block device", true),
+			Entry("when volume is a filesystem", false),
+		)
+
 		It("Should run as non-root except compute", func() {
 			vmi := newMinimalWithContainerDisk("ranom")
 


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently the resource requirements are absolutely hardcoded on hotplug pods, which makes it hard to play nicely with LimitRange's maxLimitRequestRatio: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#limitrangeitem-v1-core

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Hotplug pods have hardcoded resource req which don't comply with LimitRange maxLimitRequestRatio of 1
```
