### PR TITLE
Hyperv functest: wait until VM had started successfully

### DIFF
--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -259,7 +259,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, func() 
 					EVMCS: featureState,
 				},
 			}
-			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 			Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
 			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a tiny fix to one of our hyperv functional tests.
At the beginning of the test, a vmi is created and a `tests.RunVMIAndExpectScheduling(vmi, 60)` call is executed.
Afterwards, a `libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)` is executed to get the vmi's running pod.

This exposes a race between the VMI being scheduled and the call to get its running pod.
Instead of `RunVMIAndExpectScheduling()`, now a `RunVMIAndExpectLaunch()` is called to ensure the pod already exists.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
