### PR TITLE
[nodeController]Use polling mechanism instead of watching nodes

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -516,7 +516,7 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 
 		go vca.evacuationController.Run(vca.evacuationControllerThreads, stop)
 		go vca.disruptionBudgetController.Run(vca.disruptionBudgetControllerThreads, stop)
-		go vca.nodeController.Run(vca.nodeControllerThreads, stop)
+		go vca.nodeController.Run(stop)
 		go vca.vmiController.Run(vca.vmiControllerThreads, stop)
 		go vca.rsController.Run(vca.rsControllerThreads, stop)
 		go vca.poolController.Run(vca.poolControllerThreads, stop)
@@ -602,7 +602,7 @@ func (vca *VirtControllerApp) initCommon() {
 	)
 
 	recorder := vca.newRecorder(k8sv1.NamespaceAll, "node-controller")
-	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, recorder)
+	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, recorder)
 	vca.migrationController = NewMigrationController(
 		vca.templateService,
 		vca.vmiInformer,

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
-
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -34,160 +32,54 @@ const (
 // NodeController is the main NodeController struct.
 type NodeController struct {
 	clientset        kubecli.KubevirtClient
-	Queue            workqueue.RateLimitingInterface
 	nodeInformer     cache.SharedIndexInformer
-	vmiInformer      cache.SharedIndexInformer
 	recorder         record.EventRecorder
 	heartBeatTimeout time.Duration
 	recheckInterval  time.Duration
 }
 
 // NewNodeController creates a new instance of the NodeController struct.
-func NewNodeController(clientset kubecli.KubevirtClient, nodeInformer cache.SharedIndexInformer, vmiInformer cache.SharedIndexInformer, recorder record.EventRecorder) *NodeController {
+func NewNodeController(clientset kubecli.KubevirtClient, nodeInformer cache.SharedIndexInformer, recorder record.EventRecorder) *NodeController {
 	c := &NodeController{
 		clientset:        clientset,
-		Queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-node"),
 		nodeInformer:     nodeInformer,
-		vmiInformer:      vmiInformer,
 		recorder:         recorder,
 		heartBeatTimeout: 5 * time.Minute,
 		recheckInterval:  1 * time.Minute,
 	}
-
-	c.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.addNode,
-		DeleteFunc: c.deleteNode,
-		UpdateFunc: c.updateNode,
-	})
-
-	c.vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.addVirtualMachine,
-		DeleteFunc: func(_ interface{}) { /* nothing to do */ },
-		UpdateFunc: c.updateVirtualMachine,
-	})
-
 	return c
 }
 
-func (c *NodeController) addNode(obj interface{}) {
-	c.enqueueNode(obj)
-}
-
-func (c *NodeController) deleteNode(obj interface{}) {
-	c.enqueueNode(obj)
-}
-
-func (c *NodeController) updateNode(_, curr interface{}) {
-	c.enqueueNode(curr)
-}
-
-func (c *NodeController) enqueueNode(obj interface{}) {
-	logger := log.Log
-	node := obj.(*v1.Node)
-	key, err := controller.KeyFunc(node)
-	if err != nil {
-		logger.Object(node).Reason(err).Error("Failed to extract key from node.")
-		return
-	}
-	c.Queue.Add(key)
-}
-
-func (c *NodeController) addVirtualMachine(obj interface{}) {
-	vmi := obj.(*virtv1.VirtualMachineInstance)
-	if vmi.Status.NodeName != "" {
-		c.Queue.Add(vmi.Status.NodeName)
-	}
-}
-
-func (c *NodeController) updateVirtualMachine(_, curr interface{}) {
-	currVMI := curr.(*virtv1.VirtualMachineInstance)
-	if currVMI.Status.NodeName != "" {
-		c.Queue.Add(currVMI.Status.NodeName)
-	}
-}
-
-// Run runs the passed in NodeController.
-func (c *NodeController) Run(threadiness int, stopCh <-chan struct{}) {
+func (c *NodeController) Run(stopCh <-chan struct{}) {
 	defer controller.HandlePanic()
-	defer c.Queue.ShutDown()
 	log.Log.Info("Starting node controller.")
-
-	// Wait for cache sync before we start the node controller
-	cache.WaitForCacheSync(stopCh, c.nodeInformer.HasSynced, c.vmiInformer.HasSynced)
-
-	// Start the actual work
-	for i := 0; i < threadiness; i++ {
-		go wait.Until(c.runWorker, time.Second, stopCh)
-	}
-
-	<-stopCh
-	log.Log.Info("Stopping node controller.")
+	interval := 1 * time.Minute
+	wait.JitterUntil(c.execute, interval, -1, true, stopCh)
 }
 
-func (c *NodeController) runWorker() {
-	for c.Execute() {
-	}
-}
-
-// Execute runs commands from the controller queue, if there is
-// an error it requeues the command. Returns false if the queue
-// is empty.
-func (c *NodeController) Execute() bool {
-	key, quit := c.Queue.Get()
-	if quit {
-		return false
-	}
-	defer c.Queue.Done(key)
-	err := c.execute(key.(string))
-
-	if err != nil {
-		log.Log.Reason(err).Infof("reenqueuing node %v", key)
-		c.Queue.AddRateLimited(key)
-	} else {
-		log.Log.V(4).Infof("processed node %v", key)
-		c.Queue.Forget(key)
-	}
-	return true
-}
-
-func (c *NodeController) execute(key string) error {
+func (c *NodeController) execute() {
 	logger := log.DefaultLogger()
+	nodes := c.nodeInformer.GetStore().List()
 
-	obj, nodeExists, err := c.nodeInformer.GetStore().GetByKey(key)
-	if err != nil {
-		return err
-	}
+	for _, nodeToConvert := range nodes {
+		node := nodeToConvert.(*v1.Node)
+		unresponsive, err := isNodeUnresponsive(node, c.heartBeatTimeout)
+		if err != nil {
+			logger.Reason(err).Error(fmt.Sprintf("NodeController Failed to determine if node %v is responsive", node.Name))
+			continue
+		}
 
-	var node *v1.Node
-	if nodeExists {
-		node = obj.(*v1.Node)
-		logger = logger.Object(node)
-	} else {
-		logger = logger.Key(key, "Node")
-	}
-
-	unresponsive, err := isNodeUnresponsive(node, c.heartBeatTimeout)
-	if err != nil {
-		logger.Reason(err).Error("Failed to determine if node is responsive, will not reenqueue")
-		return nil
-	}
-
-	if unresponsive {
-		if nodeIsSchedulable(node) {
+		if unresponsive && nodeIsSchedulable(node) {
 			if err := c.markNodeAsUnresponsive(node, logger); err != nil {
-				return err
+				continue
+			}
+		} else if unresponsive {
+			err = c.checkNodeForOrphanedAndErroredVMIs(node, logger)
+			if err != nil {
+				continue
 			}
 		}
-
-		err = c.checkNodeForOrphanedAndErroredVMIs(key, node, logger)
-		if err != nil {
-			return err
-		}
 	}
-
-	c.requeueIfExists(key, node)
-
-	return nil
 }
 
 func nodeIsSchedulable(node *v1.Node) bool {
@@ -198,15 +90,14 @@ func nodeIsSchedulable(node *v1.Node) bool {
 	return node.Labels[virtv1.NodeSchedulable] == "true"
 }
 
-func (c *NodeController) checkNodeForOrphanedAndErroredVMIs(nodeName string, node *v1.Node, logger *log.FilteredLogger) error {
-	vmis, err := lookup.ActiveVirtualMachinesOnNode(c.clientset, nodeName)
+func (c *NodeController) checkNodeForOrphanedAndErroredVMIs(node *v1.Node, logger *log.FilteredLogger) error {
+	vmis, err := lookup.ActiveVirtualMachinesOnNode(c.clientset, node.Name)
 	if err != nil {
 		logger.Reason(err).Error("Failed fetching vmis for node")
 		return err
 	}
 
 	if len(vmis) == 0 {
-		c.requeueIfExists(nodeName, node)
 		return nil
 	}
 
@@ -216,7 +107,7 @@ func (c *NodeController) checkNodeForOrphanedAndErroredVMIs(nodeName string, nod
 		return err
 	}
 
-	return c.checkVirtLauncherPodsAndUpdateVMIStatus(nodeName, vmis, logger)
+	return c.checkVirtLauncherPodsAndUpdateVMIStatus(node.Name, vmis, logger)
 }
 
 func (c *NodeController) checkVirtLauncherPodsAndUpdateVMIStatus(nodeName string, vmis []*virtv1.VirtualMachineInstance, logger *log.FilteredLogger) error {
@@ -285,14 +176,6 @@ func generateFailedVMIPatch(reason string) ([]byte, error) {
 	)
 }
 
-func (c *NodeController) requeueIfExists(key string, node *v1.Node) {
-	if node == nil {
-		return
-	}
-
-	c.Queue.AddAfter(key, c.recheckInterval)
-}
-
 func (c *NodeController) markNodeAsUnresponsive(node *v1.Node, logger *log.FilteredLogger) error {
 	c.recorder.Event(node, v1.EventTypeNormal, NodeUnresponsiveReason, "virt-handler is not responsive, marking node as unresponsive")
 	logger.V(4).Infof("Marking node %s as unresponsive", node.Name)
@@ -336,9 +219,8 @@ func (c *NodeController) createEventIfNodeHasOrphanedVMIs(node *v1.Node, vmis []
 	}
 
 	// the virt-handler DaemonsSet is not running as expect so we can't know for sure
-	// if a virt-handler pod will be ran on this node
+	// if a virt-handler pod will be run on this node
 	if !running {
-		c.requeueIfExists(node.GetName(), node)
 		return nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Nodes are modified a lot especially when the cluster is
big or when other operators are deployed.
This commit purpose is to reduce the reconcile workload.
    
With the Polling mechanism we can list the nodes every once
in a while and react.
This way virt-controler workloads will be less affected by
the number of nodes in the cluster and node's updates.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
