### PR TITLE
instancetype: Switch default inference to labels

### DIFF
--- a/staging/src/kubevirt.io/api/instancetype/register.go
+++ b/staging/src/kubevirt.io/api/instancetype/register.go
@@ -37,8 +37,8 @@ const (
 )
 
 const (
-	DefaultInstancetypeAnnotation     = "instancetype.kubevirt.io/default-instancetype"
-	DefaultInstancetypeKindAnnotation = "instancetype.kubevirt.io/default-instancetype-kind"
-	DefaultPreferenceAnnotation       = "instancetype.kubevirt.io/default-preference"
-	DefaultPreferenceKindAnnotation   = "instancetype.kubevirt.io/default-preference-kind"
+	DefaultInstancetypeLabel     = "instancetype.kubevirt.io/default-instancetype"
+	DefaultInstancetypeKindLabel = "instancetype.kubevirt.io/default-instancetype-kind"
+	DefaultPreferenceLabel       = "instancetype.kubevirt.io/default-preference"
+	DefaultPreferenceKindLabel   = "instancetype.kubevirt.io/default-preference-kind"
 )

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -747,11 +747,11 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			sourcePVC = libstorage.NewPVC(pvcSourceName, "1Gi", blockStorageClass)
 			sourcePVCVolumeBlockMode := k8sv1.PersistentVolumeBlock
 			sourcePVC.Spec.VolumeMode = &sourcePVCVolumeBlockMode
-			sourcePVC.Annotations = map[string]string{
-				instancetypeapi.DefaultInstancetypeAnnotation:     instancetype.Name,
-				instancetypeapi.DefaultInstancetypeKindAnnotation: instancetypeapi.SingularResourceName,
-				instancetypeapi.DefaultPreferenceAnnotation:       preference.Name,
-				instancetypeapi.DefaultPreferenceKindAnnotation:   instancetypeapi.SingularPreferenceResourceName,
+			sourcePVC.Labels = map[string]string{
+				instancetypeapi.DefaultInstancetypeLabel:     instancetype.Name,
+				instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
+				instancetypeapi.DefaultPreferenceLabel:       preference.Name,
+				instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
 			}
 			sourcePVC, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Create(context.Background(), sourcePVC, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -822,10 +822,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "datavolume-",
 						Namespace:    util.NamespaceTestDefault,
 						Annotations: map[string]string{
-							instancetypeapi.DefaultInstancetypeAnnotation:     instancetypeName,
-							instancetypeapi.DefaultInstancetypeKindAnnotation: instancetypeapi.SingularResourceName,
-							instancetypeapi.DefaultPreferenceAnnotation:       preferenceName,
-							instancetypeapi.DefaultPreferenceKindAnnotation:   instancetypeapi.SingularPreferenceResourceName,
+							instancetypeapi.DefaultInstancetypeLabel:     instancetypeName,
+							instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
+							instancetypeapi.DefaultPreferenceLabel:       preferenceName,
+							instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
 						},
 					},
 					Spec: cdiv1beta1.DataVolumeSpec{
@@ -920,10 +920,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "datasource-",
 						Namespace:    util.NamespaceTestDefault,
 						Annotations: map[string]string{
-							instancetypeapi.DefaultInstancetypeAnnotation:     instancetypeName,
-							instancetypeapi.DefaultInstancetypeKindAnnotation: instancetypeapi.SingularResourceName,
-							instancetypeapi.DefaultPreferenceAnnotation:       preferenceName,
-							instancetypeapi.DefaultPreferenceKindAnnotation:   instancetypeapi.SingularPreferenceResourceName,
+							instancetypeapi.DefaultInstancetypeLabel:     instancetypeName,
+							instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
+							instancetypeapi.DefaultPreferenceLabel:       preferenceName,
+							instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
 						},
 					},
 					Spec: cdiv1beta1.DataSourceSpec{
@@ -1023,10 +1023,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						GenerateName: "datasource-",
 						Namespace:    util.NamespaceTestDefault,
 						Annotations: map[string]string{
-							instancetypeapi.DefaultInstancetypeAnnotation:     instancetypeName,
-							instancetypeapi.DefaultInstancetypeKindAnnotation: instancetypeapi.SingularResourceName,
-							instancetypeapi.DefaultPreferenceAnnotation:       preferenceName,
-							instancetypeapi.DefaultPreferenceKindAnnotation:   instancetypeapi.SingularPreferenceResourceName,
+							instancetypeapi.DefaultInstancetypeLabel:     instancetypeName,
+							instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
+							instancetypeapi.DefaultPreferenceLabel:       preferenceName,
+							instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
 						},
 					},
 					Spec: cdiv1beta1.DataSourceSpec{


### PR DESCRIPTION
/area instancetype
/cc @davidvossel 
/cc @0xFelix 

**What this PR does / why we need it**:

A requirement has arisen to expose the default instance type and preference metadata as labels to allow users (such as 
 I) to make use of server side filtering. This change moves the recently landed but unreleased implementation for 
 inferring instance type defaults from volumes over to using labels instead of annotations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`inferFromVolume` now uses labels instead of annotations to lookup default instance type and preference details from a referenced `Volume`. This has changed in order to provide users with a way of looking up suitably decorated resources through these labels before pointing to them within the `VirtualMachine`.
```
