### PR TITLE
[release-0.53] Tests: Fix hyperv clean-up

### DIFF
--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -348,7 +348,9 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 
 				for _, node := range nodeList.Items {
 					_, isNodeLabellerStopped := node.Annotations[v1.LabellerSkipNodeAnnotation]
-					Expect(isNodeLabellerStopped).To(BeTrue())
+					if !isNodeLabellerStopped {
+						continue
+					}
 
 					updatedNode := resumeNodeLabeller(node.Name, virtClient)
 					_, isNodeLabellerStopped = updatedNode.Annotations[v1.LabellerSkipNodeAnnotation]


### PR DESCRIPTION
**What this PR does / why we need it**:
The absence of stopped labeller is not a failure

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
