### PR TITLE
Adjust operator functional tests to custom images specification

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -697,12 +697,15 @@ var _ = Describe("[Serial][sig-operator]Operator", Serial, decorators.SigOperato
 
 		// save the operator sha
 		_, _, _, _, version := parseOperatorImage()
+		const errFmt = "version %s is expected to end with %s suffix"
 		if !flags.SkipShasumCheck {
-			Expect(strings.HasPrefix(version, "@")).To(BeTrue())
-			originalOperatorVersion = strings.TrimPrefix(version, "@")
+			const prefix = "@"
+			Expect(strings.HasPrefix(version, "@")).To(BeTrue(), fmt.Sprintf(errFmt, version, prefix))
+			originalOperatorVersion = strings.TrimPrefix(version, prefix)
 		} else {
-			Expect(strings.HasPrefix(version, ":")).To(BeTrue())
-			originalOperatorVersion = strings.TrimPrefix(version, ":")
+			const prefix = ":"
+			Expect(strings.HasPrefix(version, ":")).To(BeTrue(), fmt.Sprintf(errFmt, version, prefix))
+			originalOperatorVersion = strings.TrimPrefix(version, prefix)
 		}
 
 		if libstorage.HasDataVolumeCRD() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Kubevirt now supports any custom image format (see https://github.com/kubevirt/kubevirt/pull/8673) the functional tests need to allow such formats.

In this commit, parseImage() function is changed to adjust to these new capabilities.

I've made the following examples to demonstrate how the new logic works:
see this example for `@sha256` version format: https://go.dev/play/p/oRmW0MqIfgp
see this example for `:my-tag` version format: https://go.dev/play/p/d_tjdC7-0KX

**Special notes for your reviewer**:
See https://github.com/kubevirt/kubevirt/pull/8673, https://github.com/kubevirt/kubevirt/pull/8792, https://github.com/kubevirt/kubevirt/pull/8811, https://github.com/kubevirt/kubevirt/pull/8887 for previous PRs in this area.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adjust operator functional tests to custom images specification
```
