### PR TITLE
Introduce a feature gate to disable the custom SELinux policy

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,18 @@ login`. Your `$HOME/.docker/config.json` should look like:
 
 SELinux-enabled nodes need to have [Container-selinux](https://github.com/containers/container-selinux) version 2.170.0 or newer installed.
 
+#### Disabling the custom SELinux policy
+
+By default, a custom SELinux policy gets installed by virt-handler on every node, and it gets used for VMIs that need it.
+Currently, the only VMIs using it are the ones that enable passt-based networking.  
+However, having KubeVirt install and use a custom SELinux policy is a security concern. It also increases virt-handler boot time 20/30 seconds.  
+Therefore, a feature gate was introduced to disable the installation and usage of that custom SELinux policy: `DisableCustomSELinuxPolicy`.  
+The side effect is that passt-enabled VMIs will fail to start, but only on nodes that use container-selinux version 2.192.0 or lower.  
+container-selinux releases 2.193.0 and newer include the necessary permissions for passt-enabled VMIs to run successfully.
+
+**Note:** adding the `DisableCustomSELinuxPolicy` feature gate to an existing cluster will disable the use of the custom policy for new VMIs,
+but will **not** automatically uninstall the policy from the nodes. That can be done manually if needed, by running `semodule -r virt_launcher` on every node.
+
 ## Building
 
 The KubeVirt build system runs completely inside Docker. 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -55,6 +55,8 @@ const (
 	VSOCKGate                  = "VSOCK"
 	// PSASeccompAllowsUserfaultfd tells us that the seccomp policy on the nodes allow the userfaultfd syscall, which is needed for post-copy migrations
 	PSASeccompAllowsUserfaultfd = "PSASeccompAllowsUserfaultfd"
+	// DisableCustomSELinuxPolicy disables the installation of the custom SELinux policy for virt-launcher
+	DisableCustomSELinuxPolicy = "DisableCustomSELinuxPolicy"
 )
 
 var deprecatedFeatureGates = [...]string{
@@ -65,14 +67,14 @@ var deprecatedFeatureGates = [...]string{
 	PSA,
 }
 
-func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
-	if c.IsFeatureGateDeprecated(featureGate) {
+func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
+	if config.IsFeatureGateDeprecated(featureGate) {
 		// Deprecated feature gates are considered enabled and no-op.
 		// For more info about deprecation policy: https://github.com/kubevirt/kubevirt/blob/main/docs/deprecation.md
 		return true
 	}
 
-	for _, fg := range c.GetConfig().DeveloperConfiguration.FeatureGates {
+	for _, fg := range config.GetConfig().DeveloperConfiguration.FeatureGates {
 		if fg == featureGate {
 			return true
 		}
@@ -80,7 +82,7 @@ func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
 	return false
 }
 
-func (c *ClusterConfig) IsFeatureGateDeprecated(featureGate string) bool {
+func (config *ClusterConfig) IsFeatureGateDeprecated(featureGate string) bool {
 	for _, deprecatedFeatureGate := range deprecatedFeatureGates {
 		if featureGate == deprecatedFeatureGate {
 			return true
@@ -188,4 +190,8 @@ func (config *ClusterConfig) VSOCKEnabled() bool {
 
 func (config *ClusterConfig) PSASeccompAllowsUserfaultfd() bool {
 	return config.isFeatureGateEnabled(PSASeccompAllowsUserfaultfd)
+}
+
+func (config *ClusterConfig) CustomSELinuxPolicyDisabled() bool {
+	return config.isFeatureGateEnabled(DisableCustomSELinuxPolicy)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
By default, a custom SELinux policy gets installed by virt-handler on every node, and it gets used for VMIs that need it.
Currently, the only VMIs using it are the ones that enable passt-based networking.  
However, having KubeVirt install and use a custom SELinux policy is a security concern. It also increases virt-handler boot time 20/30 seconds.  
Therefore, a feature gate was introduced to disable the installation and usage of that custom SELinux policy: `DisableCustomSELinuxPolicy`.  
The side effect is that passt-enabled VMIs will fail to start, but only on nodes that use container-selinux version 2.192.0 or lower.  
container-selinux releases 2.193.0 and newer include the necessary permissions for passt-enabled VMIs to run successfully.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Alternative to https://github.com/kubevirt/kubevirtci/pull/946 + https://github.com/kubevirt/kubevirt/pull/9021

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DisableCustomSELinuxPolicy feature gate introduced to disable our custom SELinux policy
```
