### PR TITLE
Functests: Print exact test flags to ease local debugging and reproduction

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -17,7 +17,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-set -e
+set -ex
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a PR is being posted our CI lanes start to run.
When a test fails on CI the developers is likely to try to locally fix the test/code and re-run the test to ensure it passes after the fixes.

The problem is that it is not trivial to reproduce the environment. For example, it's hard to know which exact tests are being passed to our tests in order to run the test.

This PR adds a `set -x` flag to `functests.sh` in order to print these flags before running any functional tests.

After this change, something like the following will be printed before running the test suite:

`+ _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s _out/tests/tests.test -- -kubeconfig=/home/iholder/kubevirt/_ci-configs/k8s-1.25/.kubeconfig -container-tag=devel -container-tag-alt=devel_alt -container-prefix=registry:5000/kubevirt -image-prefix-alt= -oc-path= -kubectl-path=/home/iholder/kubevirt/_ci-configs/k8s-1.25/.kubectl -gocli-path=/home/iholder/kubevirt/_ci-configs/../cluster-up/cli.sh -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false -config=/home/iholder/kubevirt/tests/default-ceph-config.json --artifacts=/home/iholder/kubevirt/_out/artifacts --operator-manifest-path=/home/iholder/kubevirt/_out/manifests/release/kubevirt-operator.yaml --testing-manifest-path=/home/iholder/kubevirt/_out/manifests/testing --ginkgo.trace -apply-default-e2e-configuration -conn-check-ipv4-address= -conn-check-ipv6-address= -conn-check-dns= -migration-network-nic=eth1 -virtctl-path=/home/iholder/kubevirt/_out/cmd/virtctl/virtctl -example-guest-agent-path=/home/iholder/kubevirt/_out/cmd/example-guest-agent/example-guest-agent`

This exact command can be then run locally to better reproduce the environment on which the test is being run on CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Functests: Print exact test flags to ease local debugging and reproduction
```
