### PR TITLE
network, setup: Iterate over all networks per each step

### DIFF
--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/os/fs:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -85,10 +85,22 @@ func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networks 
 	if err != nil {
 		return err
 	}
-	for _, nic := range nics {
-		if err := nic.PlugPhase1(); err != nil {
-			return fmt.Errorf("failed plugging phase1 at nic '%s': %w", nic.podInterfaceName, err)
-		}
+
+	configState := NewConfigState(n.cacheCreator, string(n.vmi.UID))
+	err = configState.Run(
+		nics,
+		func(nic *podNIC) error {
+			return nic.discoverAndStoreCache()
+		},
+		func(nic *podNIC) error {
+			if nic.infraConfigurator == nil {
+				return nil
+			}
+			return nic.infraConfigurator.PreparePodNetworkInterface()
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed setup pod network phase1: %w", err)
 	}
 	return nil
 }

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -54,6 +54,10 @@ func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int, networks []v1.Net
 		if err != nil {
 			return nil, err
 		}
+		// SR-IOV devices are not part of the phases.
+		if nic.vmiSpecIface.SRIOV != nil {
+			continue
+		}
 		nics = append(nics, *nic)
 	}
 	return nics, nil
@@ -66,6 +70,10 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networks []v1.N
 		nic, err := newPhase2PodNIC(v.vmi, &networks[i], v.handler, v.cacheCreator, domain)
 		if err != nil {
 			return nil, err
+		}
+		// SR-IOV devices are not part of the phases.
+		if nic.vmiSpecIface.SRIOV != nil {
+			continue
 		}
 		nics = append(nics, *nic)
 	}

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -170,20 +170,6 @@ func (l *podNIC) sortIPsBasedOnPrimaryIP(ipv4, ipv6 string) ([]string, error) {
 	return []string{ipv6, ipv4}, nil
 }
 
-func (l *podNIC) PlugPhase1() error {
-	configState := NewConfigState(l.cacheCreator, string(l.vmi.UID))
-	return configState.Run(
-		l.podInterfaceName,
-		l.discoverAndStoreCache,
-		func() error {
-			if l.infraConfigurator == nil {
-				return nil
-			}
-			return l.infraConfigurator.PreparePodNetworkInterface()
-		},
-	)
-}
-
 func (l *podNIC) discoverAndStoreCache() error {
 	if err := l.setPodInterfaceCache(); err != nil {
 		return err

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -171,12 +171,6 @@ func (l *podNIC) sortIPsBasedOnPrimaryIP(ipv4, ipv6 string) ([]string, error) {
 }
 
 func (l *podNIC) PlugPhase1() error {
-
-	// There is nothing to plug for SR-IOV devices
-	if l.vmiSpecIface.SRIOV != nil {
-		return nil
-	}
-
 	configState := NewConfigState(l.cacheCreator, string(l.vmi.UID))
 	return configState.Run(
 		l.podInterfaceName,
@@ -224,11 +218,6 @@ func (l *podNIC) discoverAndStoreCache() error {
 
 func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 	precond.MustNotBeNil(domain)
-
-	// There is nothing to plug for SR-IOV devices
-	if l.vmiSpecIface.SRIOV != nil {
-		return nil
-	}
 
 	if err := l.domainGenerator.Generate(); err != nil {
 		log.Log.Reason(err).Critical("failed to create libvirt configuration")

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 
 	v1 "kubevirt.io/api/core/v1"
-	api2 "kubevirt.io/client-go/api"
 
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/network/cache"
@@ -171,48 +170,6 @@ var _ = Describe("podNIC", func() {
 				Expect(podnic.PlugPhase2(domain)).To(Succeed())
 			})
 
-		})
-	})
-	When("interface binding is SRIOV", func() {
-		var (
-			vmi *v1.VirtualMachineInstance
-		)
-		BeforeEach(func() {
-
-			vmi = api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
-			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name: "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					SRIOV: &v1.InterfaceSRIOV{},
-				},
-			}}
-		})
-		Context("phase1", func() {
-			var (
-				podnic *podNIC
-				err    error
-			)
-			BeforeEach(func() {
-				podnic, err = newPhase1PodNICWithMocks(vmi)
-				Expect(err).ToNot(HaveOccurred())
-			})
-			It("should not crash", func() {
-				Expect(podnic.PlugPhase1()).To(Succeed())
-			})
-		})
-		Context("phase2", func() {
-			var (
-				podnic *podNIC
-				err    error
-			)
-			BeforeEach(func() {
-				podnic, err = newPhase2PodNICWithMocks(vmi)
-				Expect(err).ToNot(HaveOccurred())
-			})
-			It("should not crash", func() {
-				Expect(podnic.PlugPhase2(&api.Domain{})).To(Succeed())
-			})
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The network setup has processed each network/interface one at a time,
passing through all setup steps (discovery, configuration, persisting to
the cache).

This change adjusts the flow so each setup step will process all
networks before proceeding to the next step.

Following this pattern, enables the replacement of entire steps (e.g. configuring the pod networks).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
~~Depends on #9053 (please review only the last 2 commits)~~

**Release note**:
```release-note
NONE
```
