### PR TITLE
virt-config: Increase DefaultDiskVerificationMemoryLimitMBytes

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -68,7 +68,7 @@ const (
 	DefaultAARCH64OVMFPath                          = "/usr/share/AAVMF"
 	DefaultMemBalloonStatsPeriod             uint32 = 10
 	DefaultCPUAllocationRatio                       = 10
-	DefaultDiskVerificationMemoryLimitMBytes        = 1700
+	DefaultDiskVerificationMemoryLimitMBytes        = 2000
 	DefaultVirtAPILogVerbosity                      = 2
 	DefaultVirtControllerLogVerbosity               = 2
 	DefaultVirtHandlerLogVerbosity                  = 2


### PR DESCRIPTION
It was observed that recently memory limit applied to virt-chroot is too low in docker in docker
environemnt on Arm64 platform, which lead to e2e
test crash. Further profiling and optimization are needed.

Signed-off-by: howard zhang <howard.zhang@arm.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-arm64/1611240965291380736

**Release note**:
```release-note
NONE
```
