### PR TITLE
POC: cluster cpu model

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19230,6 +19230,10 @@
       },
       "x-kubernetes-list-type": "atomic"
      },
+     "prefferedModel": {
+      "description": "prefferedModel is the best match cpuModel for the initial node",
+      "type": "string"
+     },
      "qosClass": {
       "description": "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md",
       "type": "string"

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/component-helpers v0.23.5
 	k8s.io/klog/v2 v2.40.1
 	k8s.io/kube-aggregator v0.23.5
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf

--- a/go.sum
+++ b/go.sum
@@ -1833,6 +1833,7 @@ k8s.io/client-go v0.23.5/go.mod h1:flkeinTO1CirYgzMPRWxUCnV0G4Fbu2vLhYCObnt/r4=
 k8s.io/cluster-bootstrap v0.23.5/go.mod h1:8/Gz6VTOMmEDDhn8U/nx0McnQR4YETAqiYXIlqR8hdQ=
 k8s.io/code-generator v0.23.5/go.mod h1:S0Q1JVA+kSzTI1oUvbKAxZY/DYbA/ZUb4Uknog12ETk=
 k8s.io/component-base v0.23.5/go.mod h1:c5Nq44KZyt1aLl0IpHX82fhsn84Sb0jjzwjpcA42bY0=
+k8s.io/component-helpers v0.23.5 h1:6uTMNP6xxJrSzYTC7BCcH2S/PbSZGxSUZG0PG+nT4tM=
 k8s.io/component-helpers v0.23.5/go.mod h1:5riXJgjTIs+ZB8xnf5M2anZ8iQuq37a0B/0BgoPQuSM=
 k8s.io/gengo v0.0.0-20181113154421-fd15ee9cc2f7/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -593,11 +593,14 @@ func (t *templateService) newNodeSelectorRenderer(vmi *v1.VirtualMachineInstance
 		opts = append(opts, WithHyperv(vmi.Spec.Domain.Features))
 	}
 
-	if modelLabel, err := CPUModelLabelFromCPUModel(vmi); err == nil {
-		opts = append(
-			opts,
-			WithModelAndFeatureLabels(modelLabel, CPUFeatureLabelsFromCPUFeatures(vmi)...),
-		)
+	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model != v1.CPUBestMatchModel {
+		modelLabel, err := CPUModelLabelFromCPUModel(vmi)
+		if err == nil {
+			opts = append(
+				opts,
+				WithModelAndFeatureLabels(modelLabel, CPUFeatureLabelsFromCPUFeatures(vmi)...),
+			)
+		}
 	}
 
 	if topology.IsManualTSCFrequencyRequired(vmi) {

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/virt-controller/watch/clone:go_default_library",
         "//pkg/virt-controller/watch/drain/disruptionbudget:go_default_library",
         "//pkg/virt-controller/watch/drain/evacuation:go_default_library",
+        "//pkg/virt-controller/watch/dynamic-cpu-model-matcher:go_default_library",
         "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-controller/watch/util:go_default_library",
         "//pkg/virt-controller/watch/workload-updater:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -600,6 +600,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.vmInformer,
 		vca.kvPodInformer,
 		vca.persistentVolumeClaimInformer,
+		vca.nodeInformer.GetStore(),
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.dataVolumeInformer,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Application", func() {
 			vmInformer,
 			podInformer,
 			pvcInformer,
+			nodeInformer.GetStore(),
 			recorder,
 			virtClient,
 			dataVolumeInformer,

--- a/pkg/virt-controller/watch/dynamic-cpu-model-matcher/BUILD.bazel
+++ b/pkg/virt-controller/watch/dynamic-cpu-model-matcher/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dynamic_cpu_model_matcher.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-controller/watch/dynamic-cpu-model-matcher",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-controller/watch/topology:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/component-helpers/scheduling/corev1/nodeaffinity:go_default_library",
+    ],
+)

--- a/pkg/virt-controller/watch/dynamic-cpu-model-matcher/dynamic_cpu_model_matcher.go
+++ b/pkg/virt-controller/watch/dynamic-cpu-model-matcher/dynamic_cpu_model_matcher.go
@@ -1,0 +1,231 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package watch
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
+
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
+)
+
+var cpuModelToLaunchYear = map[string]int{
+	"Cooperlake":                2020,
+	"qemu64":                    -1,
+	"qemu32":                    -1,
+	"phenom":                    2007,
+	"pentium3":                  1999,
+	"pentium2":                  1997,
+	"pentium":                   1993,
+	"n270":                      2008,
+	"kvm64":                     -1,
+	"kvm32":                     -1,
+	"coreduo":                   2006,
+	"core2duo":                  2006,
+	"athlon":                    1999,
+	"Westmere-IBRS":             2010,
+	"Westmere":                  2010,
+	"Snowridge":                 2019,
+	"Skylake-Server-noTSX-IBRS": 2016,
+	"Skylake-Server-IBRS":       2016,
+	"Skylake-Server":            2016,
+	"Skylake-Client-noTSX-IBRS": 2015,
+	"Skylake-Client-IBRS":       2015,
+	"Skylake-Client":            2015,
+	"SandyBridge-IBRS":          2011,
+	"SandyBridge":               2011,
+	"Penryn":                    2007,
+	"Opteron_G5":                2012,
+	"Opteron_G4":                2011,
+	"Opteron_G3":                2009,
+	"Opteron_G2":                2006,
+	"Opteron_G1":                2004,
+	"Nehalem-IBRS":              2008,
+	"Nehalem":                   2008,
+	"IvyBridge-IBRS":            2012,
+	"IvyBridge":                 2012,
+	"Icelake-Server-noTSX":      2019,
+	"Icelake-Server":            2019,
+	"Icelake-Client-noTSX":      2019,
+	"Icelake-Client":            2019,
+	"Haswell-noTSX-IBRS":        2013,
+	"Haswell-noTSX":             2013,
+	"Haswell-IBRS":              2013,
+	"Haswell":                   2013,
+	"EPYC-Rome":                 2019,
+	"EPYC-Milan":                2021,
+	"EPYC-IBPB":                 2017,
+	"EPYC":                      2017,
+	"Dhyana":                    2018,
+	"Conroe":                    2006,
+	"Cascadelake-Server-noTSX":  2019,
+	"Cascadelake-Server":        2019,
+	"Broadwell-noTSX-IBRS":      2014,
+	"Broadwell-noTSX":           2014,
+	"Broadwell-IBRS":            2014,
+	"Broadwell":                 2014,
+	"486":                       -1,
+}
+
+type DynamicCpuModelMatcher struct {
+	nodeStore         cache.Store
+	minimalLaunchYear int
+}
+
+func NewDynamicCpuModelMatcher(nodeStore cache.Store) *DynamicCpuModelMatcher {
+	dcc := &DynamicCpuModelMatcher{
+		minimalLaunchYear: 2007,
+		nodeStore:         nodeStore,
+	}
+	return dcc
+}
+
+func (dcc *DynamicCpuModelMatcher) GetBestMatchModelForInitialNode(initialNodeName string, vmi *kubevirtv1.VirtualMachineInstance) (string, error) {
+	initialNodeObj, exist, err := dcc.nodeStore.GetByKey(initialNodeName)
+	initialNode := initialNodeObj.(*v1.Node)
+	if !exist {
+		return "", fmt.Errorf(fmt.Sprintf("vmiController can't determine preferred model for node:%v doesn't exist", initialNodeName))
+	} else if err != nil {
+		return "", fmt.Errorf(fmt.Sprintf("vmiController can't determine preferred model for node:%v got error:\n%v", initialNodeName, err.Error()))
+	}
+	vendorLabel := getNodeVendorLabel(initialNode)
+	if vendorLabel == "" {
+		return "", fmt.Errorf(fmt.Sprintf("DynamicConfigurationCalculator couldn't find vendor label for node: %v", initialNode.Name))
+	}
+
+	predicates := []topology.FilterPredicateFunc{
+		withRespectToNodeVendorLabelFilerPredicate(vendorLabel),
+		withRespectToVmiNodeLabelSelectorsFilerPredicate(vmi.Spec.NodeSelector),
+	}
+	if vmi.Spec.Affinity != nil && vmi.Spec.Affinity.NodeAffinity != nil && vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		predicates = append(predicates, withRespectToVmiNodeAffinityFilerPredicate(vmi.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	}
+
+	nodes := topology.FilterNodesFromCache(dcc.nodeStore.List(), predicates...)
+
+	numberOfNodes := len(nodes)
+	thresholdSupport := getMedianNumber(2, numberOfNodes/3, 5)
+	cpuModelCount := countCpuModelsSupportedByPotentialNodes(nodes)
+
+	bestMatchCpuModel := getNewestSupportedModel(initialNode, cpuModelCount, thresholdSupport, dcc.minimalLaunchYear)
+	if bestMatchCpuModel == "" {
+		return "", fmt.Errorf(fmt.Sprintf("DynamicConfigurationCalculator couldn't find bestMatchModel for node: %v", initialNode.Name))
+	}
+
+	return bestMatchCpuModel, nil
+}
+
+func getNewestSupportedModel(node *v1.Node, cpuModelCount map[string]int, thresholdSupport int, minimalLaunchYear int) string {
+	bestMatchCpuModel := ""
+	bestMatchCpuModelLaunchYear := 0
+	for label, _ := range node.Labels {
+		cpuModel := extractCpuModelFromLabel(label)
+		if cpuModel != "" && isCPUModelValid(cpuModel, cpuModelCount, thresholdSupport, minimalLaunchYear) && bestMatchCpuModelLaunchYear < cpuModelToLaunchYear[cpuModel] {
+			bestMatchCpuModelLaunchYear = cpuModelToLaunchYear[cpuModel]
+			bestMatchCpuModel = cpuModel
+		}
+
+	}
+	return bestMatchCpuModel
+}
+func isCPUModelValid(cpuModel string, cpuModelCount map[string]int, thresholdSupport int, minimalLaunchYear int) bool {
+	return cpuModelCount[cpuModel] >= thresholdSupport && cpuModelToLaunchYear[cpuModel] >= minimalLaunchYear
+}
+
+func getNodeVendorLabel(node *v1.Node) string {
+	for label, _ := range node.Labels {
+		if strings.Contains(label, kubevirtv1.CPUModelVendorLabel) {
+			return label
+		}
+	}
+	return ""
+}
+
+func countCpuModelsSupportedByPotentialNodes(nodes []*v1.Node) map[string]int {
+	modelCount := make(map[string]int)
+	for _, node := range nodes {
+		for cpuModelLabel, _ := range node.Labels {
+			cpuModel := extractCpuModelFromLabel(cpuModelLabel)
+			if cpuModel != "" {
+				modelCount[cpuModel]++
+			}
+		}
+	}
+	return modelCount
+}
+
+func withRespectToNodeVendorLabelFilerPredicate(vendorLabel string) topology.FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		if node == nil {
+			return false
+		}
+		otherNodeVendorLabel := getNodeVendorLabel(node)
+		if otherNodeVendorLabel == "" {
+			log.Log.Infof(fmt.Sprintf("DynamicConfigurationCalculator couldn't find vendor label for node: %v", node.Name))
+			return false
+		}
+		return otherNodeVendorLabel == vendorLabel
+	}
+}
+
+func withRespectToVmiNodeLabelSelectorsFilerPredicate(nodeSelectors labels.Set) topology.FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		if node == nil {
+			return false
+		}
+		return labels.SelectorFromSet(nodeSelectors).Matches(labels.Set(node.Labels))
+	}
+}
+
+func withRespectToVmiNodeAffinityFilerPredicate(nodeAffinity *v1.NodeSelector) topology.FilterPredicateFunc {
+	return func(node *v1.Node) bool {
+		if node == nil {
+			return false
+		}
+		nodeSelector, _ := nodeaffinity.NewNodeSelector(nodeAffinity)
+		return nodeSelector.Match(node)
+	}
+}
+
+func getMedianNumber(firstNum int, secondNum int, thirdNum int) int {
+	if firstNum <= secondNum && secondNum <= thirdNum {
+		return secondNum
+	} else if secondNum <= firstNum && firstNum <= thirdNum {
+		return firstNum
+	} else {
+		return thirdNum
+	}
+}
+
+func extractCpuModelFromLabel(label string) string {
+	if strings.Contains(label, kubevirtv1.CPUModelLabel) {
+		return strings.ReplaceAll(label, kubevirtv1.CPUModelLabel, "")
+	}
+	return ""
+}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -82,6 +82,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var kubeClient *fake.Clientset
 	var networkClient *fakenetworkclient.Clientset
 	var pvcInformer cache.SharedIndexInformer
+	var nodeInformer cache.SharedIndexInformer
 	var namespaceStore cache.Store
 
 	var dataVolumeSource *framework.FakeControllerSource
@@ -222,6 +223,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		go vmInformer.Run(stop)
 		go podInformer.Run(stop)
 		go pvcInformer.Run(stop)
+		go nodeInformer.Run(stop)
 
 		go dataVolumeInformer.Run(stop)
 		Expect(cache.WaitForCacheSync(stop,
@@ -229,6 +231,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmInformer.HasSynced,
 			podInformer.HasSynced,
 			pvcInformer.HasSynced,
+			nodeInformer.HasSynced,
 			dataVolumeInformer.HasSynced)).To(BeTrue())
 	}
 
@@ -252,6 +255,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		}
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		nodeInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Node{})
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		namespaceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
@@ -261,6 +265,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmInformer,
 			podInformer,
 			pvcInformer,
+			nodeInformer.GetStore(),
 			recorder,
 			virtClient,
 			dataVolumeInformer,

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1644,6 +1644,11 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		if vmi.Spec.Domain.CPU.Model != "" {
 			if vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostPassthrough {
 				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
+			} else if vmi.Spec.Domain.CPU.Model == v1.CPUBestMatchModel && vmi.Status.PrefferedModel == v1.CPUModeHostModel {
+				domain.Spec.CPU.Mode = vmi.Status.PrefferedModel
+			} else if vmi.Spec.Domain.CPU.Model == v1.CPUBestMatchModel {
+				domain.Spec.CPU.Mode = "custom"
+				domain.Spec.CPU.Model = vmi.Status.PrefferedModel
 			} else {
 				domain.Spec.CPU.Mode = "custom"
 				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11115,6 +11115,9 @@ var CRDsValidation map[string]string = map[string]string{
             type: object
           type: array
           x-kubernetes-list-type: atomic
+        prefferedModel:
+          description: prefferedModel is the best match cpuModel for the initial node
+          type: string
         qosClass:
           description: 'The Quality of Service (QOS) classification assigned to the
             virtual machine instance based on resource requirements See PodQOSClass

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -34,6 +34,7 @@ const (
 	IOThreadsPolicyAuto    IOThreadsPolicy = "auto"
 	CPUModeHostPassthrough                 = "host-passthrough"
 	CPUModeHostModel                       = "host-model"
+	CPUBestMatchModel                      = "best-match-model"
 	DefaultCPUModel                        = CPUModeHostModel
 )
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -269,6 +269,10 @@ type VirtualMachineInstanceStatus struct {
 	// SELinuxContext is the actual SELinux context of the virt-launcher pod
 	// +optional
 	SelinuxContext string `json:"selinuxContext,omitempty"`
+
+	// prefferedModel is the best match cpuModel for the initial node
+	// +optional
+	PrefferedModel string `json:"prefferedModel,omitempty"`
 }
 
 // PersistentVolumeClaimInfo contains the relavant information virt-handler needs cached about a PVC

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -77,6 +77,7 @@ func (VirtualMachineInstanceStatus) SwaggerDoc() map[string]string {
 		"runtimeUser":                   "RuntimeUser is used to determine what user will be used in launcher\n+optional",
 		"VSOCKCID":                      "VSOCKCID is used to track the allocated VSOCK CID in the VM.\n+optional",
 		"selinuxContext":                "SELinuxContext is the actual SELinux context of the virt-launcher pod\n+optional",
+		"prefferedModel":                "prefferedModel is the best match cpuModel for the initial node\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22255,6 +22255,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceStatus(ref common.Refer
 							Format:      "",
 						},
 					},
+					"prefferedModel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "prefferedModel is the best match cpuModel for the initial node",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/vendor/k8s.io/component-helpers/LICENSE
+++ b/vendor/k8s.io/component-helpers/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/BUILD.bazel
+++ b/vendor/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["nodeaffinity.go"],
+    importmap = "kubevirt.io/kubevirt/vendor/k8s.io/component-helpers/scheduling/corev1/nodeaffinity",
+    importpath = "k8s.io/component-helpers/scheduling/corev1/nodeaffinity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/selection:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
+++ b/vendor/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeaffinity
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// NodeSelector is a runtime representation of v1.NodeSelector.
+type NodeSelector struct {
+	lazy LazyErrorNodeSelector
+}
+
+// LazyErrorNodeSelector is a runtime representation of v1.NodeSelector that
+// only reports parse errors when no terms match.
+type LazyErrorNodeSelector struct {
+	terms []nodeSelectorTerm
+}
+
+// NewNodeSelector returns a NodeSelector or aggregate parsing errors found.
+func NewNodeSelector(ns *v1.NodeSelector, opts ...field.PathOption) (*NodeSelector, error) {
+	lazy := NewLazyErrorNodeSelector(ns, opts...)
+	var errs []error
+	for _, term := range lazy.terms {
+		if len(term.parseErrs) > 0 {
+			errs = append(errs, term.parseErrs...)
+		}
+	}
+	if len(errs) != 0 {
+		return nil, errors.Flatten(errors.NewAggregate(errs))
+	}
+	return &NodeSelector{lazy: *lazy}, nil
+}
+
+// NewLazyErrorNodeSelector creates a NodeSelector that only reports parse
+// errors when no terms match.
+func NewLazyErrorNodeSelector(ns *v1.NodeSelector, opts ...field.PathOption) *LazyErrorNodeSelector {
+	p := field.ToPath(opts...)
+	parsedTerms := make([]nodeSelectorTerm, 0, len(ns.NodeSelectorTerms))
+	path := p.Child("nodeSelectorTerms")
+	for i, term := range ns.NodeSelectorTerms {
+		// nil or empty term selects no objects
+		if isEmptyNodeSelectorTerm(&term) {
+			continue
+		}
+		p := path.Index(i)
+		parsedTerms = append(parsedTerms, newNodeSelectorTerm(&term, p))
+	}
+	return &LazyErrorNodeSelector{
+		terms: parsedTerms,
+	}
+}
+
+// Match checks whether the node labels and fields match the selector terms, ORed;
+// nil or empty term matches no objects.
+func (ns *NodeSelector) Match(node *v1.Node) bool {
+	// parse errors are reported in NewNodeSelector.
+	match, _ := ns.lazy.Match(node)
+	return match
+}
+
+// Match checks whether the node labels and fields match the selector terms, ORed;
+// nil or empty term matches no objects.
+// Parse errors are only returned if no terms matched.
+func (ns *LazyErrorNodeSelector) Match(node *v1.Node) (bool, error) {
+	if node == nil {
+		return false, nil
+	}
+	nodeLabels := labels.Set(node.Labels)
+	nodeFields := extractNodeFields(node)
+
+	var errs []error
+	for _, term := range ns.terms {
+		match, tErrs := term.match(nodeLabels, nodeFields)
+		if len(tErrs) > 0 {
+			errs = append(errs, tErrs...)
+			continue
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, errors.Flatten(errors.NewAggregate(errs))
+}
+
+// PreferredSchedulingTerms is a runtime representation of []v1.PreferredSchedulingTerms.
+type PreferredSchedulingTerms struct {
+	terms []preferredSchedulingTerm
+}
+
+// NewPreferredSchedulingTerms returns a PreferredSchedulingTerms or all the parsing errors found.
+// If a v1.PreferredSchedulingTerm has a 0 weight, its parsing is skipped.
+func NewPreferredSchedulingTerms(terms []v1.PreferredSchedulingTerm, opts ...field.PathOption) (*PreferredSchedulingTerms, error) {
+	p := field.ToPath(opts...)
+	var errs []error
+	parsedTerms := make([]preferredSchedulingTerm, 0, len(terms))
+	for i, term := range terms {
+		path := p.Index(i)
+		if term.Weight == 0 || isEmptyNodeSelectorTerm(&term.Preference) {
+			continue
+		}
+		parsedTerm := preferredSchedulingTerm{
+			nodeSelectorTerm: newNodeSelectorTerm(&term.Preference, path),
+			weight:           int(term.Weight),
+		}
+		if len(parsedTerm.parseErrs) > 0 {
+			errs = append(errs, parsedTerm.parseErrs...)
+		} else {
+			parsedTerms = append(parsedTerms, parsedTerm)
+		}
+	}
+	if len(errs) != 0 {
+		return nil, errors.Flatten(errors.NewAggregate(errs))
+	}
+	return &PreferredSchedulingTerms{terms: parsedTerms}, nil
+}
+
+// Score returns a score for a Node: the sum of the weights of the terms that
+// match the Node.
+func (t *PreferredSchedulingTerms) Score(node *v1.Node) int64 {
+	var score int64
+	nodeLabels := labels.Set(node.Labels)
+	nodeFields := extractNodeFields(node)
+	for _, term := range t.terms {
+		// parse errors are reported in NewPreferredSchedulingTerms.
+		if ok, _ := term.match(nodeLabels, nodeFields); ok {
+			score += int64(term.weight)
+		}
+	}
+	return score
+}
+
+func isEmptyNodeSelectorTerm(term *v1.NodeSelectorTerm) bool {
+	return len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0
+}
+
+func extractNodeFields(n *v1.Node) fields.Set {
+	f := make(fields.Set)
+	if len(n.Name) > 0 {
+		f["metadata.name"] = n.Name
+	}
+	return f
+}
+
+type nodeSelectorTerm struct {
+	matchLabels labels.Selector
+	matchFields fields.Selector
+	parseErrs   []error
+}
+
+func newNodeSelectorTerm(term *v1.NodeSelectorTerm, path *field.Path) nodeSelectorTerm {
+	var parsedTerm nodeSelectorTerm
+	var errs []error
+	if len(term.MatchExpressions) != 0 {
+		p := path.Child("matchExpressions")
+		parsedTerm.matchLabels, errs = nodeSelectorRequirementsAsSelector(term.MatchExpressions, p)
+		if errs != nil {
+			parsedTerm.parseErrs = append(parsedTerm.parseErrs, errs...)
+		}
+	}
+	if len(term.MatchFields) != 0 {
+		p := path.Child("matchFields")
+		parsedTerm.matchFields, errs = nodeSelectorRequirementsAsFieldSelector(term.MatchFields, p)
+		if errs != nil {
+			parsedTerm.parseErrs = append(parsedTerm.parseErrs, errs...)
+		}
+	}
+	return parsedTerm
+}
+
+func (t *nodeSelectorTerm) match(nodeLabels labels.Set, nodeFields fields.Set) (bool, []error) {
+	if t.parseErrs != nil {
+		return false, t.parseErrs
+	}
+	if t.matchLabels != nil && !t.matchLabels.Matches(nodeLabels) {
+		return false, nil
+	}
+	if t.matchFields != nil && len(nodeFields) > 0 && !t.matchFields.Matches(nodeFields) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// nodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement api type into a struct that implements
+// labels.Selector.
+func nodeSelectorRequirementsAsSelector(nsm []v1.NodeSelectorRequirement, path *field.Path) (labels.Selector, []error) {
+	if len(nsm) == 0 {
+		return labels.Nothing(), nil
+	}
+	var errs []error
+	selector := labels.NewSelector()
+	for i, expr := range nsm {
+		p := path.Index(i)
+		var op selection.Operator
+		switch expr.Operator {
+		case v1.NodeSelectorOpIn:
+			op = selection.In
+		case v1.NodeSelectorOpNotIn:
+			op = selection.NotIn
+		case v1.NodeSelectorOpExists:
+			op = selection.Exists
+		case v1.NodeSelectorOpDoesNotExist:
+			op = selection.DoesNotExist
+		case v1.NodeSelectorOpGt:
+			op = selection.GreaterThan
+		case v1.NodeSelectorOpLt:
+			op = selection.LessThan
+		default:
+			errs = append(errs, field.NotSupported(p.Child("operator"), expr.Operator, nil))
+			continue
+		}
+		r, err := labels.NewRequirement(expr.Key, op, expr.Values, field.WithPath(p))
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			selector = selector.Add(*r)
+		}
+	}
+	if len(errs) != 0 {
+		return nil, errs
+	}
+	return selector, nil
+}
+
+var validFieldSelectorOperators = []string{
+	string(v1.NodeSelectorOpIn),
+	string(v1.NodeSelectorOpNotIn),
+}
+
+// nodeSelectorRequirementsAsFieldSelector converts the []NodeSelectorRequirement core type into a struct that implements
+// fields.Selector.
+func nodeSelectorRequirementsAsFieldSelector(nsr []v1.NodeSelectorRequirement, path *field.Path) (fields.Selector, []error) {
+	if len(nsr) == 0 {
+		return fields.Nothing(), nil
+	}
+	var errs []error
+
+	var selectors []fields.Selector
+	for i, expr := range nsr {
+		p := path.Index(i)
+		switch expr.Operator {
+		case v1.NodeSelectorOpIn:
+			if len(expr.Values) != 1 {
+				errs = append(errs, field.Invalid(p.Child("values"), expr.Values, "must have one element"))
+			} else {
+				selectors = append(selectors, fields.OneTermEqualSelector(expr.Key, expr.Values[0]))
+			}
+
+		case v1.NodeSelectorOpNotIn:
+			if len(expr.Values) != 1 {
+				errs = append(errs, field.Invalid(p.Child("values"), expr.Values, "must have one element"))
+			} else {
+				selectors = append(selectors, fields.OneTermNotEqualSelector(expr.Key, expr.Values[0]))
+			}
+
+		default:
+			errs = append(errs, field.NotSupported(p.Child("operator"), expr.Operator, validFieldSelectorOperators))
+		}
+	}
+
+	if len(errs) != 0 {
+		return nil, errs
+	}
+	return fields.AndSelectors(selectors...), nil
+}
+
+type preferredSchedulingTerm struct {
+	nodeSelectorTerm
+	weight int
+}
+
+type RequiredNodeAffinity struct {
+	labelSelector labels.Selector
+	nodeSelector  *LazyErrorNodeSelector
+}
+
+// GetRequiredNodeAffinity returns the parsing result of pod's nodeSelector and nodeAffinity.
+func GetRequiredNodeAffinity(pod *v1.Pod) RequiredNodeAffinity {
+	var selector labels.Selector
+	if len(pod.Spec.NodeSelector) > 0 {
+		selector = labels.SelectorFromSet(pod.Spec.NodeSelector)
+	}
+	// Use LazyErrorNodeSelector for backwards compatibility of parsing errors.
+	var affinity *LazyErrorNodeSelector
+	if pod.Spec.Affinity != nil &&
+		pod.Spec.Affinity.NodeAffinity != nil &&
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		affinity = NewLazyErrorNodeSelector(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	}
+	return RequiredNodeAffinity{labelSelector: selector, nodeSelector: affinity}
+}
+
+// Match checks whether the pod is schedulable onto nodes according to
+// the requirements in both nodeSelector and nodeAffinity.
+func (s RequiredNodeAffinity) Match(node *v1.Node) (bool, error) {
+	if s.labelSelector != nil {
+		if !s.labelSelector.Matches(labels.Set(node.Labels)) {
+			return false, nil
+		}
+	}
+	if s.nodeSelector != nil {
+		return s.nodeSelector.Match(node)
+	}
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1114,6 +1114,9 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
+# k8s.io/component-helpers v0.23.5
+## explicit; go 1.16
+k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 # k8s.io/klog/v2 v2.40.1
 ## explicit; go 1.13
 k8s.io/klog/v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
POC for:
https://github.com/kubevirt/community/pull/203

Add ability to find best match for CPU Model dynamically after a vmi is scheduled to a node.

The POC is about calculating non-obsolete CPU Model 
that is supported by enough nodes ( * ) that respect
VMI's nodeAffinity and nodeSelectors.

( * ) Number that is high enough for the VMI's migratability
      but not too high to avoid using obsolete CPU Model that 
      is more likely to be widely supported.


This will allow users to choose CPU Model configuration in
`KubevirtCR` or in`vmi.spec.domain.CPU.model` that will result
dynamic calculation of CPU Model that is relatively
new and migratable in the cluster.

That can be useful when the user's cluster is heterogeneous.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
