### PR TITLE
Fix flaky test 'Export Route should populate external links and cert and contain route host`

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1099,10 +1099,16 @@ var _ = SIGDescribe("Export", func() {
 			Expect(vmExport.Status.Links.External.Cert).To(Equal(testCert))
 			certs, err := certutil.ParseCertsPEM([]byte(vmExport.Status.Links.External.Cert))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(certs).To(HaveLen(1))
+			Expect(certs).ToNot(BeEmpty())
 			prefix := fmt.Sprintf("%s-%s", components.VirtExportProxyServiceName, flags.KubeVirtInstallNamespace)
 			domainName := strings.TrimPrefix(ingress.Spec.Rules[0].Host, prefix)
-			Expect(matchesCNOrAlt(certs[0], domainName)).To(BeTrue())
+			matchesCNOrAltName := false
+			for _, cert := range certs {
+				if matchesCNOrAlt(cert, domainName) {
+					matchesCNOrAltName = true
+				}
+			}
+			Expect(matchesCNOrAltName).To(BeTrue())
 			Expect(vmExport.Status.Links.External.Volumes[0].Formats[0].Url).To(ContainSubstring(ingress.Spec.Rules[0].Host))
 		})
 	})
@@ -1126,6 +1132,7 @@ var _ = SIGDescribe("Export", func() {
 			checkExportSecretRef(vmExport)
 			certs, err := certutil.ParseCertsPEM([]byte(vmExport.Status.Links.External.Cert))
 			Expect(err).ToNot(HaveOccurred())
+			Expect(certs).ToNot(BeEmpty())
 			route := getExportRoute()
 			host := ""
 			if len(route.Status.Ingress) > 0 {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1126,7 +1126,6 @@ var _ = SIGDescribe("Export", func() {
 			checkExportSecretRef(vmExport)
 			certs, err := certutil.ParseCertsPEM([]byte(vmExport.Status.Links.External.Cert))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(certs).To(HaveLen(1))
 			route := getExportRoute()
 			host := ""
 			if len(route.Status.Ingress) > 0 {
@@ -1135,7 +1134,13 @@ var _ = SIGDescribe("Export", func() {
 			Expect(host).ToNot(BeEmpty())
 			prefix := fmt.Sprintf("%s-%s", components.VirtExportProxyServiceName, flags.KubeVirtInstallNamespace)
 			domainName := strings.TrimPrefix(host, prefix)
-			Expect(matchesCNOrAlt(certs[0], domainName)).To(BeTrue())
+			matchesCNOrAltName := false
+			for _, cert := range certs {
+				if matchesCNOrAlt(cert, domainName) {
+					matchesCNOrAltName = true
+				}
+			}
+			Expect(matchesCNOrAltName).To(BeTrue())
 			Expect(vmExport.Status.Links.External.Volumes[0].Formats[0].Url).To(ContainSubstring(host))
 
 		})


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes the flaky test by being less strict about it requirements.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
