### PR TITLE
[release-0.58] virtctl: Manual backport of update functional tests for excludenative build tag

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -378,7 +378,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
     export KUBEVIRT_E2E_SKIP="GPU|MediatedDevices"
   elif [[ $TARGET =~ sig-compute ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-compute\\]"
-    export KUBEVIRT_E2E_SKIP="GPU|MediatedDevices|Migration"
+    export KUBEVIRT_E2E_SKIP="GPU|MediatedDevices|Migration|without\\s--local-ssh\\sflag|local-ssh\\sflag\\sshould\\sbe\\sunavailable"
   elif [[ $TARGET =~ sig-monitoring ]]; then
       export KUBEVIRT_E2E_FOCUS="\\[sig-monitoring\\]"
   elif [[ $TARGET =~ sig-operator ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/kubevirt/pull/8955

This updates the functional virtctl tests for the ssh and scp commands to test local-ssh functionality depending on provided skip regexes.

Conflicts:
  automation/test.sh
  tests/decorators/decorators.go
  tests/virtctl/scp.go
  tests/virtctl/ssh.go

NOTE(0xFelix): The conflict is due to not having decorators and libssh refactorings in release-0.58. The tests are changed to fallback to KUBEVIRT_E2E_SKIP instead.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
