### PR TITLE
[release-0.53] Change KubevirtVmHighMemoryUsage threshold from 20MB to 50MB

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -527,13 +527,13 @@ tests:
         alertname: LowKVMNodesCount
         exp_alerts: []
 
-  # Memory utilization less than 20MB close to requested memory - based on memory working set
+  # Memory utilization less than 50MB close to requested memory - based on memory working set
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
 
@@ -553,7 +553,7 @@ tests:
               container: "compute"
               namespace: "ns-test"
 
-  # Memory utilization less than 20MB close to requested memory - based on memory RSS
+  # Memory utilization less than 50MB close to requested memory - based on memory RSS
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
@@ -561,7 +561,7 @@ tests:
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
         values: "19922944 18874368 18874368 17825792"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
 
     alert_rule_test:
       - eval_time: 1m
@@ -579,15 +579,15 @@ tests:
               container: "compute"
               namespace: "ns-test"
 
-  # Memory utilization less than 20MB close to requested memory - based on memory RSS and memory working set
+  # Memory utilization less than 50MB close to requested memory - based on memory RSS and memory working set
   - interval: 1m
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "47185920 48234496 48234496 49283072"
+        values: "17185920 18234496 18234496 19283072"
 
     alert_rule_test:
       - eval_time: 1m
@@ -605,15 +605,15 @@ tests:
               container: "compute"
               namespace: "ns-test"
 
-  # Memory utilization more than 20MB close to requested memory
+  # Memory utilization more than 50MB close to requested memory
   - interval: 30s
     input_series:
       - series: 'kube_pod_container_resource_requests{pod="virt-launcher-testvm-123", container="compute", resource="memory", namespace="ns-test"}'
         values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "19922944 18874368 18874368 17825792"
+        values: "9922944 8874368 8874368 7825792"
       - series: 'container_memory_rss{pod="virt-launcher-testvm-123", container="compute", namespace="ns-test"}'
-        values: "19922944 18874368 18874368 17825792"
+        values: "9922944 8874368 8874368 7825792"
 
     alert_rule_test:
       - eval_time: 1m

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -542,7 +542,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 20 MB and it is close to requested memory"
+              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 50 MB and it is close to requested memory"
               summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
@@ -568,7 +568,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 20 MB and it is close to requested memory"
+              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 50 MB and it is close to requested memory"
               summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:
@@ -594,7 +594,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 20 MB and it is close to requested memory"
+              description: "Container compute in pod virt-launcher-testvm-123 in namespace ns-test free memory is less than 50 MB and it is close to requested memory"
               summary: "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/KubevirtVmHighMemoryUsage"
             exp_labels:

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -406,7 +406,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 					},
 					{
 						Alert: "KubevirtVmHighMemoryUsage",
-						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 20971520 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 20971520"),
+						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 52428800 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 52428800"),
 						For:   "1m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than 20 MB and it is close to requested memory",

--- a/pkg/virt-operator/resource/generate/components/prometheus.go
+++ b/pkg/virt-operator/resource/generate/components/prometheus.go
@@ -409,7 +409,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *v1.Prometheu
 						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes < 52428800 or kubevirt_vm_container_free_memory_bytes_based_on_rss < 52428800"),
 						For:   "1m",
 						Annotations: map[string]string{
-							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than 20 MB and it is close to requested memory",
+							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} free memory is less than 50 MB and it is close to requested memory",
 							"summary":     "VM is at risk of being evicted and in serious cases of memory exhaustion being terminated by the runtime.",
 							"runbook_url": runbookUrlBasePath + "KubevirtVmHighMemoryUsage",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual cherry-pick of both #8599 and #9073

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change KubevirtVmHighMemoryUsage threshold from 20MB to 50MB
```
