### PR TITLE
Return entire CA PEM if unable to match host/domain for export

### DIFF
--- a/pkg/storage/export/export/links.go
+++ b/pkg/storage/export/export/links.go
@@ -239,7 +239,20 @@ func (ctrl *VMExportController) findCertByHostName(hostName string, certs []*x50
 	if latestCert != nil && latestCert.NotAfter.After(now) && latestCert.NotBefore.Before(now) {
 		return ctrl.buildPemFromCert(latestCert, certs)
 	}
+	if len(certs) > 0 {
+		return ctrl.buildPemFromAllCerts(certs, now)
+	}
 	return "", nil
+}
+
+func (ctrl *VMExportController) buildPemFromAllCerts(allCerts []*x509.Certificate, now time.Time) (string, error) {
+	pemOut := strings.Builder{}
+	for _, cert := range allCerts {
+		if cert.NotAfter.After(now) && cert.NotBefore.Before(now) {
+			pem.Encode(&pemOut, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		}
+	}
+	return strings.TrimSpace(pemOut.String()), nil
 }
 
 func (ctrl *VMExportController) buildPemFromCert(matchingCert *x509.Certificate, allCerts []*x509.Certificate) (string, error) {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If the export code cannot match on the route/Ingress host or domain with wild card, return the entire contents of the config map. Filter out expired or not yet valid certificates. This happens if the `kube-root-ca.crt` only contains the root CA for instance.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
