### PR TITLE
[e2e tests]Add Labels to expose dependencies of tests

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -24,4 +24,7 @@ var (
 	NonRoot              = []interface{}{Label("verify-non-root")}
 	NativeSsh            = []interface{}{Label("native-ssh")}
 	ExcludeNativeSsh     = []interface{}{Label("exclude-native-ssh")}
+	Reenlightenment      = []interface{}{Label("Reenlightenment")}
+	Invtsc               = []interface{}{Label("Invtsc")}
+	PasstGate            = []interface{}{Label("PasstGate")}
 )

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -123,7 +123,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 			})
 		})
 
-		When("TSC frequency is not exposed on the cluster", func() {
+		When("TSC frequency is not exposed on the cluster", decorators.Reenlightenment, func() {
 
 			BeforeEach(func() {
 				if isTSCFrequencyExposed(virtClient) {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -921,7 +921,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(getHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
 			})
 
-			It("[test_id:6842]should migrate with TSC frequency set", func() {
+			It("[test_id:6842]should migrate with TSC frequency set", decorators.Invtsc, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{
@@ -4341,7 +4341,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 90*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("tsc frequency topology hints are expected to exist for vmi %s", vmi.Name))
 			}
 
-			It("invtsc feature exists", func() {
+			It("invtsc feature exists", decorators.Invtsc, func() {
 				vmi := libvmi.New(
 					libvmi.WithResourceMemory("1Mi"),
 					libvmi.WithCPUFeature("invtsc", "require"),
@@ -4351,7 +4351,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectTopologyHintsToBeSet(vmi)
 			})
 
-			It("HyperV reenlightenment is enabled", func() {
+			It("HyperV reenlightenment is enabled", decorators.Reenlightenment, func() {
 				vmi := libvmi.New()
 				vmi.Spec = getWindowsVMISpec()
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -107,7 +107,7 @@ var istioTests = func(vmType VmType) {
 	BeforeEach(func() {
 		namespace = testsuite.GetTestNamespace(nil)
 		if vmType == Passt {
-			checks.SkipTestIfNoFeatureGate(virtconfig.PasstGate)
+			Expect(checks.HasFeature(virtconfig.PasstGate)).To(BeTrue())
 			namespace = testsuite.NamespacePrivileged
 		}
 	})
@@ -484,7 +484,7 @@ var istioTestsWithPasstBinding = func() {
 
 var _ = SIGDescribe("[Serial] Istio with masquerade binding", Serial, istioTestsWithMasqueradeBinding)
 
-var _ = SIGDescribe("[Serial] Istio with passt binding", Serial, istioTestsWithPasstBinding)
+var _ = SIGDescribe("[Serial] Istio with passt binding", decorators.PasstGate, Serial, istioTestsWithPasstBinding)
 
 func istioServiceMeshDeployed() bool {
 	return strings.ToLower(os.Getenv(istioDeployedEnvVariable)) == "true"

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/decorators"
+
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	expect "github.com/google/goexpect"
@@ -45,12 +47,12 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = SIGDescribe("[Serial] Passt", Serial, func() {
+var _ = SIGDescribe("[Serial] Passt", decorators.PasstGate, Serial, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
-		checks.SkipTestIfNoFeatureGate(virtconfig.PasstGate)
+		Expect(checks.HasFeature(virtconfig.PasstGate)).To(BeTrue())
 	})
 
 	BeforeEach(func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1226,7 +1226,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Entry("[Serial][test_id:1671]hugepages-2Mi", Serial, "2Mi", "64Mi", "None", nil, nil),
 				Entry("[Serial][test_id:1672]hugepages-1Gi", Serial, "1Gi", "1Gi", "None", nil, nil),
 				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", Serial, "2Mi", "70Mi", "64Mi", nil, nil),
-				Entry("[Serial]hugepages-2Mi with passt enabled", Serial, "2Mi", "64Mi", "None",
+				Entry("[Serial]hugepages-2Mi with passt enabled", decorators.PasstGate, Serial, "2Mi", "64Mi", "None",
 					libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
 			)
 
@@ -1582,11 +1582,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}
 				return false
 			}
-			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", func() {
+			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", decorators.Invtsc, func() {
 				nodes := libnode.GetAllSchedulableNodes(virtClient)
-				if !featureSupportedInAtLeastOneNode(nodes, "invtsc") {
-					Skip("To run this test at least one node should support invtsc feature")
-				}
+				Expect(featureSupportedInAtLeastOneNode(nodes, "invtsc")).To(BeTrue(), "To run this test at least one node should support invtsc feature")
 				vmi := libvmi.NewCirros()
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{


### PR DESCRIPTION
In some use-cases a user might want to test
KubeVirt within a cluster that is different
from kubevirt-ci therefore we should expose
the tests dependencies.

Please note that this PR goal isn't to replace all the
skips in func tests but to take small steps to this goal.


Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
