### PR TITLE
virtctl: Allow building with older golang versions

### DIFF
--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -46,6 +46,6 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func flagErr(flagName, format string, a ...any) error {
+func flagErr(flagName, format string, a ...interface{}) error {
 	return fmt.Errorf("failed to parse \"--%s\" flag: %w", flagName, fmt.Errorf(format, a...))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows building virtctl with older golang version (1.17+) by maintaining compatibility.

This is helpful in downstream builds.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
