### PR TITLE
Make sure the VSOCK system service loads the correct module

### DIFF
--- a/pkg/virt-handler/vsock/server.go
+++ b/pkg/virt-handler/vsock/server.go
@@ -1,6 +1,7 @@
 package vsock
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -64,6 +65,13 @@ func (h *Hypervisor) start() {
 }
 
 func (h *Hypervisor) serve() {
+	// Load the vhost_vsock module on demand.
+	if fd, err := os.Open("/dev/vhost-vsock"); err != nil {
+		log.DefaultLogger().Reason(err).Error("Failed to open /dev/vhost-vsock.")
+		return
+	} else {
+		fd.Close()
+	}
 	conn, err := vsock.ListenContextID(vsock.Host, h.port, &vsock.Config{})
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Failed to bind to VSOCK port %v.", h.port)


### PR DESCRIPTION
Signed-off-by: Zhuchen Wang <zcwang@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The VSOCK TLS improvement loads a different VSOCK module and causes the VSOCK feature broken
After merging PR #8889, VM creation with `autoattachVSOCK` failed. Libvirt complains about `failed to open vhost-vsock device`.

The host is GCE instance with Ubuntu 20.04 and the guest OS is also Ubuntu 20.04.

After debugging, it turns out that the [code](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/vsock/server.go#L67) doesn't load the correct module in my setup.

```
lsmod | grep vsock
vmw_vsock_virtio_transport_common    32768  0
vmw_vsock_vmci_transport    32768  1
vsock                  36864  3 vmw_vsock_virtio_transport_common,vmw_vsock_vmci_transport
vmw_vmci               69632  1 vmw_vsock_vmci_transport
``` 

The correct modules should be 

```
lsmod | grep vsock
vhost_vsock            24576  0
vmw_vsock_virtio_transport_common    32768  1 vhost_vsock
vhost                  49152  1 vhost_vsock
vsock                  36864  2 vmw_vsock_virtio_transport_common,vhost_vsock
```

Without PR #8889, the `/dev/vhost-vsock` device is accessed during the device plugin startup  and the `vhost_vsock` module should be loaded automatically when the first time the `/dev/vhost-vsock` device is accessed. Now, the VSOCK system service is started before the device plugin. Therefore, with the incorrect module loaded, the `vhost_vsock` module cannot be loaded due to `modprobe: ERROR: could not insert 'vhost_vsock': Device or resource busy`. 

There are two triggers to load vsock modules:

1. A syscall socket(AF_VSOCK, ...)
2. Accessing the vsock device file

In my case, AF_VSOCK on socket calls is used for vmware vsock and for
virtio vsock. The OS decides to load the vmware vsock when AF_VSOCK
syscall happens, and only one of the virtio drivers can be loaded at the same time. Therefore, it causes a problem.

If we access the virtio vsock device file first, udev has a clear signal what we actually want, the virtio vsock driver.

This PR simply opens the `/dev/vhost-vsock` before the system service listening on a VSOCK port to make sure the correct `vhost_vsock` module is loaded.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Open `/dev/vhost-vsock` explicitly to ensure that the right vsock module is loaded
```
