### PR TITLE
Remove tests from quarantine

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -442,7 +442,7 @@ var _ = Describe("[Serial][sig-compute]VirtualMachineClone Tests", Serial, decor
 					expectEqualAnnotations(targetVM, sourceVM)
 				})
 
-				It("[QUARANTINE] should strip firmware UUID", func() {
+				It("should strip firmware UUID", func() {
 					const fakeFirmwareUUID = "fake-uuid"
 
 					sourceVM = createVM(

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2231,7 +2231,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			})
 
-			It("[test_id:6978][QUARANTINE] Should detect a failed migration", func() {
+			It("[test_id:6978] Should detect a failed migration", func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -338,7 +338,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				libstorage.DeleteDataVolume(&dataVolume)
 			})
 
-			It("[QUARANTINE] should accurately report DataVolume provisioning", func() {
+			It("should accurately report DataVolume provisioning", func() {
 				sc, err := libstorage.GetSnapshotStorageClass(virtClient)
 				if err != nil {
 					Skip("no snapshot storage class configured")


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove a couple of tests from quarantine as they have been very stable in the periodic test lanes. 

- `[sig-storage] DataVolume Integration ... Starting a VirtualMachineInstance with a DataVolume as a volume source Alpine import [QUARANTINE] should accurately report DataVolume provisioning`
- `[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration Starting a VirtualMachineInstance [Serial] migration monitor [test_id:6978][QUARANTINE] Should detect a failed migration`
- `VirtualMachineClone Tests VM clone simple VM and cloning operations regarding domain Firmware [QUARANTINE] should strip firmware UUID`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @enp0s3 @xpivarc 
**Release note**:
```release-note
NONE
```
