### PR TITLE
api: Correct default `PreferredCPUTopology` referenced in docs

### DIFF
--- a/staging/src/kubevirt.io/api/instancetype/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha1/types.go
@@ -125,7 +125,7 @@ type CPUInstancetype struct {
 
 	// Required number of vCPUs to expose to the guest.
 	//
-	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.
+	// The resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.
 	Guest uint32 `json:"guest"`
 
 	// Model specifies the CPU model inside the VMI.

--- a/staging/src/kubevirt.io/api/instancetype/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1alpha1/types_swagger_generated.go
@@ -51,7 +51,7 @@ func (VirtualMachineInstancetypeSpec) SwaggerDoc() map[string]string {
 func (CPUInstancetype) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                      "CPUInstancetype contains the CPU related configuration of a given VirtualMachineInstancetypeSpec.\n\nGuest is a required attribute and defines the number of vCPUs to be exposed to the guest by the instancetype.",
-		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+		"guest":                 "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
 		"model":                 "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map.\nIt is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nDefaults to host-model.\n+optional",
 		"dedicatedCPUPlacement": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node\nwith enough dedicated pCPUs and pin the vCPUs to it.\n+optional",
 		"numa":                  "NUMA allows specifying settings for the guest NUMA topology\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23498,7 +23498,7 @@ func schema_kubevirtio_api_instancetype_v1alpha1_CPUInstancetype(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"guest": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferCores.",
+							Description: "Required number of vCPUs to expose to the guest.\n\nThe resulting CPU topology being derived from the optional PreferredCPUTopology attribute of CPUPreferences that itself defaults to PreferSockets.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

This was actually switched to PreferSockets sometime ago by
https://github.com/kubevirt/kubevirt/commit/9d49758fffe76e62c296fbe826619401e1534efc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
