### PR TITLE
Fixed return type for functions in kubevirt_test_utils.go

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
@@ -25,7 +25,7 @@ import (
 // (3) Rest of the kubevirt mocking is automatically generated in generated_mock_kubevirt.go
 
 // MockKubevirtClientInstance is a reference to the kubevirt client that could be manipulated by the test code
-var MockKubevirtClientInstance *MockKubevirtClient
+var MockKubevirtClientInstance KubevirtClient
 
 // GetMockKubevirtClientFromClientConfig is an entry point for testing, could be used to override GetKubevirtClientFromClientConfig
 func GetMockKubevirtClientFromClientConfig(cmdConfig clientcmd.ClientConfig) (KubevirtClient, error) {


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Functions `GetMockKubevirtClientFromClientConfig` and `GetInvalidKubevirtClientFromClientConfig` has return type `KubevirtClient` but return variable has type `MockKubevirtClient`. This fails with latest k8s.io versions.
In this PR, we have fixed return type of above mentioned functions. This enables compiling kubevirt/client-go library with latest versions of k8s.io.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
