### PR TITLE
go_containerregistry download url hash changed

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,14 +256,11 @@ go_repository(
 )
 
 # override rules_docker issue with this dependency
-# rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to
+# rules_docker 0.16 uses 0.1.4, let's grab by commit
 go_repository(
     name = "com_github_google_go_containerregistry",
+    commit = "8a2841911ffee4f6892ca0083e89752fb46c48dd",  # v0.1.4
     importpath = "github.com/google/go-containerregistry",
-    sha256 = "bc0136a33f9c1e4578a700f7afcdaa1241cfff997d6bba695c710d24c5ae26bd",
-    strip_prefix = "google-go-containerregistry-efb2d62",
-    type = "tar.gz",
-    urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/efb2d62d93a7705315b841d0544cb5b13565ff2a"],  # v0.1.4.1
 )
 
 # bazel docker rules


### PR DESCRIPTION
switch to git commit

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Not exactly sure what's going on here but it appears that the contents of `https://api.github.com/repos/google/go-containerregistry/tarball/efb2d62d93a7705315b841d0544cb5b13565ff2a` changed.  Rather than using the new hash, maybe it's better to use git commit like other deps such as `org_golang_x_crypto` `com_github_masterzen_simplexml`, etc

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
