### PR TITLE
virt-*: bump memory requests above highest values seen in testing

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1237,7 +1237,7 @@ spec:
                 resources:
                   requests:
                     cpu: 10m
-                    memory: 400Mi
+                    memory: 450Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -293,7 +293,7 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceMemory: resource.MustParse("325Mi"),
 		},
 	}
 

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -375,7 +375,7 @@ func NewApiServerDeployment(namespace, repository, imagePrefix, version, product
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("400Mi"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
 		},
 	}
 
@@ -472,7 +472,7 @@ func NewControllerDeployment(namespace, repository, imagePrefix, controllerVersi
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("250Mi"),
+			corev1.ResourceMemory: resource.MustParse("275Mi"),
 		},
 	}
 
@@ -594,7 +594,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("400Mi"),
+									corev1.ResourceMemory: resource.MustParse("450Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
**What this PR does / why we need it**:
Testers saw these max usage values:
virt-api: 485Mi
virt-controller: 252Mi
virt-handler: 315Mi
virt-operator: 419Mi
This PR adjusts the memory requests accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
