### PR TITLE
Use ECDSA instead of RSA

### DIFF
--- a/cmd/example-guest-agent/BUILD.bazel
+++ b/cmd/example-guest-agent/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/mdlayher/vsock:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/client-go/util/keyutil:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/cmd/example-guest-agent/main.go
+++ b/cmd/example-guest-agent/main.go
@@ -28,6 +28,8 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/client-go/util/keyutil"
+
 	"github.com/mdlayher/vsock"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
@@ -122,7 +124,11 @@ func setupCert() (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	crt, err := tls.X509KeyPair(cert.EncodeCertPEM(pair.Cert), cert.EncodePrivateKeyPEM(pair.Key))
+	pem, err := keyutil.MarshalPrivateKeyToPEM(pair.Key)
+	if err != nil {
+		return nil, err
+	}
+	crt, err := tls.X509KeyPair(cert.EncodeCertPEM(pair.Cert), pem)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/certificates/triple/cert/cert.go
+++ b/pkg/certificates/triple/cert/cert.go
@@ -18,6 +18,8 @@ package cert
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -51,9 +53,14 @@ type AltNames struct {
 	IPs      []net.IP
 }
 
-// NewPrivateKey creates an RSA private key
-func NewPrivateKey() (*rsa.PrivateKey, error) {
+// NewRSAPrivateKey creates an RSA private key
+func NewRSAPrivateKey() (*rsa.PrivateKey, error) {
 	return rsa.GenerateKey(cryptorand.Reader, rsaKeySize)
+}
+
+// NewECDSAPrivateKey creates an ECDSA private key
+func NewECDSAPrivateKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
 }
 
 // NewSelfSignedCACert creates a CA certificate

--- a/pkg/certificates/triple/triple.go
+++ b/pkg/certificates/triple/triple.go
@@ -16,7 +16,7 @@ limitations under the License.
 package triple
 
 import (
-	"crypto/rsa"
+	"crypto/ecdsa"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -26,12 +26,12 @@ import (
 )
 
 type KeyPair struct {
-	Key  *rsa.PrivateKey
+	Key  *ecdsa.PrivateKey
 	Cert *x509.Certificate
 }
 
 func NewCA(name string, duration time.Duration) (*KeyPair, error) {
-	key, err := certutil.NewPrivateKey()
+	key, err := certutil.NewECDSAPrivateKey()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a private key for a new CA: %v", err)
 	}
@@ -52,7 +52,7 @@ func NewCA(name string, duration time.Duration) (*KeyPair, error) {
 }
 
 func NewServerKeyPair(ca *KeyPair, commonName, svcName, svcNamespace, dnsDomain string, ips, hostnames []string, duration time.Duration) (*KeyPair, error) {
-	key, err := certutil.NewPrivateKey()
+	key, err := certutil.NewECDSAPrivateKey()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a server private key: %v", err)
 	}
@@ -92,7 +92,7 @@ func NewServerKeyPair(ca *KeyPair, commonName, svcName, svcNamespace, dnsDomain 
 }
 
 func NewClientKeyPair(ca *KeyPair, commonName string, organizations []string, duration time.Duration) (*KeyPair, error) {
-	key, err := certutil.NewPrivateKey()
+	key, err := certutil.NewECDSAPrivateKey()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a client private key: %v", err)
 	}

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -21,7 +21,7 @@ package export
 
 import (
 	"context"
-	"crypto/rsa"
+	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -619,7 +619,7 @@ func (ctrl *VMExportController) createCertSecretManifest(vmExport *exportv1.Virt
 
 	caCert := ctrl.caCertManager.Current()
 	caKeyPair := &triple.KeyPair{
-		Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+		Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 		Cert: caCert.Leaf,
 	}
 	keyPair, _ := triple.NewServerKeyPair(

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Export controller", func() {
 		defer GinkgoRecover()
 		caKeyPair, _ := triple.NewCA("kubevirt.io", time.Hour*24*7)
 
-		intermediateKey, err := certutil.NewPrivateKey()
+		intermediateKey, err := certutil.NewECDSAPrivateKey()
 		Expect(err).ToNot(HaveOccurred())
 		intermediateConfig := certutil.Config{
 			CommonName: fmt.Sprintf("%s@%d", "intermediate", time.Now().Unix()),
@@ -321,7 +321,7 @@ var _ = Describe("Export controller", func() {
 		intermediateCert, err := certutil.NewSignedCert(intermediateConfig, intermediateKey, caKeyPair.Cert, caKeyPair.Key, time.Hour)
 		Expect(err).ToNot(HaveOccurred())
 
-		key, err := certutil.NewPrivateKey()
+		key, err := certutil.NewECDSAPrivateKey()
 		Expect(err).ToNot(HaveOccurred())
 
 		config.AltNames.DNSNames = []string{"hahaha.wwoo", "*.apps-crc.testing", "fgdgd.dfsgdf"}
@@ -362,7 +362,7 @@ var _ = Describe("Export controller", func() {
 	}
 
 	generateRouteCert := func() string {
-		key, err := certutil.NewPrivateKey()
+		key, err := certutil.NewECDSAPrivateKey()
 		Expect(err).ToNot(HaveOccurred())
 
 		config := certutil.Config{

--- a/pkg/virt-operator/resource/generate/components/secrets.go
+++ b/pkg/virt-operator/resource/generate/components/secrets.go
@@ -1,7 +1,7 @@
 package components
 
 import (
-	"crypto/rsa"
+	"crypto/ecdsa"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -36,20 +36,20 @@ const (
 	CaClusterLocal                  = "cluster.local"
 )
 
-type CertificateCreationCallback func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey)
+type CertificateCreationCallback func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey)
 
 var populationStrategy = map[string]CertificateCreationCallback{
-	KubeVirtCASecretName: func(secret *k8sv1.Secret, _ *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	KubeVirtCASecretName: func(secret *k8sv1.Secret, _ *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair, _ := triple.NewCA("kubevirt.io", duration)
 		return caKeyPair.Cert, caKeyPair.Key
 	},
-	KubeVirtExportCASecretName: func(secret *k8sv1.Secret, _ *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	KubeVirtExportCASecretName: func(secret *k8sv1.Secret, _ *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair, _ := triple.NewCA("export.kubevirt.io", duration)
 		return caKeyPair.Cert, caKeyPair.Key
 	},
-	VirtOperatorCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	VirtOperatorCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair := &triple.KeyPair{
-			Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+			Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 			Cert: caCert.Leaf,
 		}
 		keyPair, _ := triple.NewServerKeyPair(
@@ -64,9 +64,9 @@ var populationStrategy = map[string]CertificateCreationCallback{
 		)
 		return keyPair.Cert, keyPair.Key
 	},
-	VirtApiCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	VirtApiCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair := &triple.KeyPair{
-			Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+			Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 			Cert: caCert.Leaf,
 		}
 		keyPair, _ := triple.NewServerKeyPair(
@@ -81,9 +81,9 @@ var populationStrategy = map[string]CertificateCreationCallback{
 		)
 		return keyPair.Cert, keyPair.Key
 	},
-	VirtControllerCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	VirtControllerCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair := &triple.KeyPair{
-			Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+			Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 			Cert: caCert.Leaf,
 		}
 		keyPair, _ := triple.NewServerKeyPair(
@@ -98,9 +98,9 @@ var populationStrategy = map[string]CertificateCreationCallback{
 		)
 		return keyPair.Cert, keyPair.Key
 	},
-	VirtHandlerServerCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	VirtHandlerServerCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair := &triple.KeyPair{
-			Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+			Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 			Cert: caCert.Leaf,
 		}
 		keyPair, _ := triple.NewServerKeyPair(
@@ -115,9 +115,9 @@ var populationStrategy = map[string]CertificateCreationCallback{
 		)
 		return keyPair.Cert, keyPair.Key
 	},
-	VirtHandlerCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	VirtHandlerCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair := &triple.KeyPair{
-			Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+			Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 			Cert: caCert.Leaf,
 		}
 		clientKeyPair, _ := triple.NewClientKeyPair(caKeyPair,
@@ -127,9 +127,9 @@ var populationStrategy = map[string]CertificateCreationCallback{
 		)
 		return clientKeyPair.Cert, clientKeyPair.Key
 	},
-	VirtExportProxyCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *rsa.PrivateKey) {
+	VirtExportProxyCertSecretName: func(secret *k8sv1.Secret, caCert *tls.Certificate, duration time.Duration) (cert *x509.Certificate, key *ecdsa.PrivateKey) {
 		caKeyPair := &triple.KeyPair{
-			Key:  caCert.PrivateKey.(*rsa.PrivateKey),
+			Key:  caCert.PrivateKey.(*ecdsa.PrivateKey),
 			Cert: caCert.Leaf,
 		}
 		keyPair, _ := triple.NewServerKeyPair(

--- a/pkg/virt-operator/resource/generate/components/secrets_test.go
+++ b/pkg/virt-operator/resource/generate/components/secrets_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Certificate Management", func() {
 
 // newSelfSignedCert creates a CA certificate
 func newSelfSignedCert(notBefore time.Time, notAfter time.Time) *tls.Certificate {
-	key, err := certutil.NewPrivateKey()
+	key, err := certutil.NewECDSAPrivateKey()
 	Expect(err).ToNot(HaveOccurred())
 	tmpl := x509.Certificate{
 		SerialNumber: new(big.Int).SetInt64(0),

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -382,8 +382,8 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 
 			// FIPS-compliant so we can test on different platforms (otherwise won't revert properly)
 			cipher = &tls.CipherSuite{
-				ID:   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				Name: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				ID:   tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				Name: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 			}
 			kvConfig := util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
 			kvConfig.TLSConfiguration = &v1.TLSConfiguration{

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -998,7 +998,7 @@ var _ = SIGDescribe("Export", func() {
 		})
 
 		generateTestCert := func(hostName string) (string, error) {
-			key, err := certutil.NewPrivateKey()
+			key, err := certutil.NewECDSAPrivateKey()
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, kubevirt generates certificates with RSA signature. ECDSA, in general, create signatures faster than RSA. Also, OLM already uses ECDSA<sup>[1]</sup>, and it would be right to conform. The elliptic curve used is the NIST P-256 (FIPS 186-3, section D.2.3), also known as secp256r1 or prime256v1: this is supported by TLS1.3<sup>[2]</sup>.

<sup>[1]</sup> https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/controller/certs/certs.go#L31:L34
<sup>[2]</sup> https://www.rfc-editor.org/rfc/rfc8446#section-4.2.7

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use ECDSA instead of RSA for key generation
```
