### PR TITLE
Fix check for Serial run

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1435,12 +1435,12 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 			})
 		})
 
-		Context("[Serial]node with obsolete host-model cpuModel", func() {
+		Context("[Serial]node with obsolete host-model cpuModel", Serial, func() {
 
 			expectSerialRun := func() {
-				suiteConfig, _ := GinkgoConfiguration()
-				Expect(suiteConfig.ParallelTotal).To(Equal(1), "this test is supported for serial tests only")
+				Expect(CurrentSpecReport().IsSerial).To(BeTrue(), "this test is supported for serial tests only")
 			}
+
 			expectAtLeastOneEvent := func(eventListOpts metav1.ListOptions, namespace string) *k8sv1.EventList {
 				// This function is dangerous to use from parallel tests as events might override each other.
 				// This can be removed in the future if these functions are used with great caution.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Tests that check for running in serial need to get adapted to use info from the current spec, since there's no more separate running, thus the `ParallelTotal` will stay the same, even if the test is run in Serial mode

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
