### PR TITLE
Fix addvolume removevolume bugs

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -1053,23 +1053,11 @@ func addVolumeRequestExists(request v1.VirtualMachineVolumeRequest, name string)
 }
 
 func volumeHotpluggable(volume v1.Volume) bool {
-	if volume.DataVolume != nil && volume.DataVolume.Hotpluggable {
-		return true
-	}
-
-	if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable {
-		return true
-	}
-
-	return false
+	return (volume.DataVolume != nil && volume.DataVolume.Hotpluggable) || (volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.Hotpluggable)
 }
 
 func volumeNameExists(volume v1.Volume, volumeName string) bool {
-	if volume.Name == volumeName {
-		return true
-	}
-
-	return false
+	return volume.Name == volumeName
 }
 
 func volumeSourceName(volumeSource *v1.HotplugVolumeSource) string {
@@ -1083,21 +1071,12 @@ func volumeSourceName(volumeSource *v1.HotplugVolumeSource) string {
 }
 
 func volumeSourceExists(volume v1.Volume, volumeName string) bool {
-	if volume.DataVolume != nil && volume.DataVolume.Name == volumeName {
-		return true
-	}
-
-	if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == volumeName {
-		return true
-	}
-	return false
+	return (volume.DataVolume != nil && volume.DataVolume.Name == volumeName) ||
+		(volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == volumeName)
 }
 
 func volumeExists(volume v1.Volume, volumeName string) bool {
-	if volumeNameExists(volume, volumeName) {
-		return true
-	}
-	return volumeSourceExists(volume, volumeName)
+	return volumeNameExists(volume, volumeName) || volumeSourceExists(volume, volumeName)
 }
 
 func verifyVolumeOption(volumes []v1.Volume, volumeRequest *v1.VirtualMachineVolumeRequest) error {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -728,9 +728,41 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				request.Request.Body = newRemoveVolumeBody(removeOpts)
 			}
 
+			vmi := api.NewMinimalVMI(request.PathParameter("name"))
+			vmi.Namespace = k8smetav1.NamespaceDefault
+			vmi.Status.Phase = v1.Running
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "existingvol",
+			})
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "hotpluggedPVC",
+			})
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "existingvol",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "testpvcdiskclaim",
+					}},
+				},
+			})
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "hotpluggedPVC",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "hotpluggedPVC",
+						},
+						Hotpluggable: true,
+					},
+				},
+			})
+
 			if isVM {
 				vm := newMinimalVM(request.PathParameter("name"))
 				vm.Namespace = k8smetav1.NamespaceDefault
+				vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				}
 
 				patchedVM := vm.DeepCopy()
 				patchedVM.Status.VolumeRequests = append(patchedVM.Status.VolumeRequests, v1.VirtualMachineVolumeRequest{AddVolumeOptions: addOpts, RemoveVolumeOptions: removeOpts})
@@ -755,21 +787,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 					app.VMRemoveVolumeRequestHandler(request, response)
 				}
 			} else {
-				vmi := api.NewMinimalVMI(request.PathParameter("name"))
-				vmi.Namespace = k8smetav1.NamespaceDefault
-				vmi.Status.Phase = v1.Running
-				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-					Name: "existingvol",
-				})
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: "existingvol",
-					VolumeSource: v1.VolumeSource{
-						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "testpvcdiskclaim",
-						}},
-					},
-				})
-
 				vmiClient.EXPECT().Get(context.Background(), vmi.Name, &k8smetav1.GetOptions{}).Return(vmi, nil).AnyTimes()
 
 				if addOpts != nil {
@@ -816,10 +833,10 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				Disk: &v1.Disk{},
 			}, nil, false, http.StatusBadRequest, true),
 			Entry("VM with a valid remove volume request", nil, &v1.RemoveVolumeOptions{
-				Name: "vol1",
+				Name: "hotpluggedPVC",
 			}, true, http.StatusAccepted, true),
 			Entry("VMI with a valid remove volume request", nil, &v1.RemoveVolumeOptions{
-				Name: "existingvol",
+				Name: "hotpluggedPVC",
 			}, false, http.StatusAccepted, true),
 			Entry("VMI with a invalid remove volume request missing a name", nil, &v1.RemoveVolumeOptions{}, false, http.StatusBadRequest, true),
 			Entry("VMI with a valid remove volume request but no feature gate", nil, &v1.RemoveVolumeOptions{
@@ -858,11 +875,11 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				DryRun: getDryRunOption(),
 			}, nil, false, http.StatusBadRequest, true),
 			Entry("VM with a valid remove volume request with DryRun", nil, &v1.RemoveVolumeOptions{
-				Name:   "vol1",
+				Name:   "hotpluggedPVC",
 				DryRun: getDryRunOption(),
 			}, true, http.StatusAccepted, true),
 			Entry("VMI with a valid remove volume request with DryRun", nil, &v1.RemoveVolumeOptions{
-				Name:   "existingvol",
+				Name:   "hotpluggedPVC",
 				DryRun: getDryRunOption(),
 			}, false, http.StatusAccepted, true),
 			Entry("VMI with a invalid remove volume request missing a name with DryRun", nil, &v1.RemoveVolumeOptions{
@@ -924,24 +941,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				},
 				"[{ \"op\": \"test\", \"path\": \"/spec/volumes\", \"value\": [{\"name\":\"existingvol\",\"persistentVolumeClaim\":{\"claimName\":\"testpvcdiskclaim\"}}]}, { \"op\": \"test\", \"path\": \"/spec/domain/devices/disks\", \"value\": [{\"name\":\"existingvol\"}]}, { \"op\": \"replace\", \"path\": \"/spec/volumes\", \"value\": []}, { \"op\": \"replace\", \"path\": \"/spec/domain/devices/disks\", \"value\": []}]",
 				false),
-			Entry("remove volume that doesn't exist",
-				&v1.VirtualMachineVolumeRequest{
-					RemoveVolumeOptions: &v1.RemoveVolumeOptions{
-						Name: "non-existent",
-					},
-				},
-				"",
-				true),
-			Entry("add a volume that already exists",
-				&v1.VirtualMachineVolumeRequest{
-					AddVolumeOptions: &v1.AddVolumeOptions{
-						Name:         "existingvol",
-						Disk:         &v1.Disk{},
-						VolumeSource: &v1.HotplugVolumeSource{},
-					},
-				},
-				"",
-				true),
 		)
 		DescribeTable("Should generate expected vm patch", func(volumeRequest *v1.VirtualMachineVolumeRequest, existingVolumeRequests []v1.VirtualMachineVolumeRequest, expectedPatch string, expectError bool) {
 
@@ -1050,6 +1049,122 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				},
 				"",
 				true),
+		)
+
+		DescribeTable("Should verify volume option", func(volumeRequest *v1.VirtualMachineVolumeRequest, existingVolumes []v1.Volume, expectedError string) {
+			err := verifyVolumeOption(existingVolumes, volumeRequest)
+			if expectedError != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(expectedError))
+			} else {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		},
+			Entry("add volume name which already exists should fail",
+				&v1.VirtualMachineVolumeRequest{
+					AddVolumeOptions: &v1.AddVolumeOptions{
+						Name:         "vol1",
+						Disk:         &v1.Disk{},
+						VolumeSource: &v1.HotplugVolumeSource{},
+					},
+				},
+				[]v1.Volume{
+					{
+						Name: "vol1",
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
+								Name: "dv1",
+							},
+						},
+					},
+				},
+				"Unable to add volume [vol1] because volume with that name already exists"),
+			Entry("add volume source which already exists should fail(existing dv)",
+				&v1.VirtualMachineVolumeRequest{
+					AddVolumeOptions: &v1.AddVolumeOptions{
+						Name: "dv1",
+						Disk: &v1.Disk{},
+						VolumeSource: &v1.HotplugVolumeSource{
+							DataVolume: &v1.DataVolumeSource{
+								Name: "dv1",
+							},
+						},
+					},
+				},
+				[]v1.Volume{
+					{
+						Name: "vol1",
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
+								Name: "dv1",
+							},
+						},
+					},
+				},
+				"Unable to add volume source [dv1] because it already exists"),
+			Entry("add volume which source already exists should fail(existing pvc)",
+				&v1.VirtualMachineVolumeRequest{
+					AddVolumeOptions: &v1.AddVolumeOptions{
+						Name: "pvc1",
+						Disk: &v1.Disk{},
+						VolumeSource: &v1.HotplugVolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc1",
+							}},
+						},
+					},
+				},
+				[]v1.Volume{
+					{
+						Name: "vol1",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc1",
+							}},
+						},
+					},
+				},
+				"Unable to add volume source [pvc1] because it already exists"),
+			Entry("remove volume which doesnt exist should fail",
+				&v1.VirtualMachineVolumeRequest{
+					RemoveVolumeOptions: &v1.RemoveVolumeOptions{
+						Name: "vol1",
+					},
+				},
+				[]v1.Volume{},
+				"Unable to remove volume [vol1] because it does not exist"),
+			Entry("remove volume which wasnt hotplugged should fail(existing dv)",
+				&v1.VirtualMachineVolumeRequest{
+					RemoveVolumeOptions: &v1.RemoveVolumeOptions{
+						Name: "dv1",
+					},
+				},
+				[]v1.Volume{
+					{
+						Name: "vol1",
+						VolumeSource: v1.VolumeSource{
+							DataVolume: &v1.DataVolumeSource{
+								Name: "dv1",
+							},
+						},
+					},
+				},
+				"Unable to remove volume [vol1] because it is not hotpluggable"),
+			Entry("remove volume which wasnt hotplugged should fail(existing cloudInit)",
+				&v1.VirtualMachineVolumeRequest{
+					RemoveVolumeOptions: &v1.RemoveVolumeOptions{
+						Name: "cloudinitdisk",
+					},
+				},
+				[]v1.Volume{
+					{
+						Name: "cloudinitdisk",
+						VolumeSource: v1.VolumeSource{
+							CloudInitNoCloud: &v1.CloudInitNoCloudSource{},
+						},
+					},
+				},
+				"Unable to remove volume [cloudinitdisk] because it is not hotpluggable"),
 		)
 	})
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -542,7 +542,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		DescribeTable("Should add volumes on an offline VM", func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction) {
 			By("Adding test volumes")
 			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume1, "madeup", v1.DiskBusSCSI, false, "")
-			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume2, "madeup", v1.DiskBusSCSI, false, "")
+			addVolumeFunc(vm.Name, vm.Namespace, testNewVolume2, "madeup2", v1.DiskBusSCSI, false, "")
 			By("Verifying the volumes have been added to the template spec")
 			verifyVolumeAndDiskVMAdded(virtClient, vm, testNewVolume1, testNewVolume2)
 			By("Removing new volumes from VM")

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -64,6 +64,7 @@ import (
 const (
 	dataMessage             = "data/message"
 	addingVolumeRunningVM   = "Adding volume to running VM"
+	addingVolumeAgain       = "Adding the same volume again with different name"
 	verifyingVolumeDiskInVM = "Verifying the volume and disk are in the VM and VMI"
 	removingVolumeFromVM    = "removing volume from VM"
 	verifyingVolumeNotExist = "Verifying the volume no longer exists in VM"
@@ -863,8 +864,47 @@ var _ = SIGDescribe("Hotplug", func() {
 					},
 				}, false, ""))
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("conflicts with an existing volume of the same name on the vmi template"))
+				Expect(err.Error()).To(ContainSubstring("Unable to add volume [disk0] because volume with that name already exists"))
 			})
+
+			It("should reject hotplugging the same volume with an existing volume name", func() {
+				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)
+				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+
+				By(addingVolumeRunningVM)
+				addPVCVolumeVMI(vmi.Name, vmi.Namespace, "testvolume", dvBlock.Name, v1.DiskBusSCSI, false, "")
+
+				By(verifyingVolumeDiskInVM)
+				vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				verifyVolumeAndDiskVMIAdded(virtClient, vmi, "testvolume")
+				verifyVolumeStatus(vmi, v1.VolumeReady, "", "testvolume")
+
+				By(addingVolumeAgain)
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).AddVolume(context.Background(), vmi.Name, getAddVolumeOptions(dvBlock.Name, v1.DiskBusSCSI, &v1.HotplugVolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: dvBlock.Name,
+					},
+				}, false, ""))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Unable to add volume source [%s] because it already exists", dvBlock.Name)))
+			})
+
+			DescribeTable("should reject removing a volume", func(volName, expectedErr string) {
+				vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				libwait.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+
+				By(removingVolumeFromVM)
+				err = virtClient.VirtualMachine(vm.Namespace).RemoveVolume(vm.Name, &v1.RemoveVolumeOptions{Name: volName})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(expectedErr))
+			},
+				Entry("which wasn't hotplugged", "disk0", "Unable to remove volume [disk0] because it is not hotpluggable"),
+				Entry("which doesn't exist", "doesntexist", "Unable to remove volume [doesntexist] because it does not exist"),
+			)
 
 			It("should allow hotplugging both a filesystem and block volume", func() {
 				dvBlock := createDataVolumeAndWaitForImport(sc, corev1.PersistentVolumeBlock)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- Fix bug of allowing to add existing volume pvc/dv with another volume name: the code checked for volume.Name instead of checking the dv/pvc name.
- Fix bug of allowing to remove existing volume which wasnt hotplugged.
-  Add the check of add and remove volume to persistent add/remove volume code path - in case of add/remove to VM the checks should also happen.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Jira: [CNV-23867](https://issues.redhat.com/browse/CNV-23867)
[CNV-24856](https://issues.redhat.com/browse/CNV-24856)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix addvolume not rejecting adding existing volume source, fix removevolume allowing to remove non hotpluggable volume
```
