### PR TITLE
Disable the use of the custom SELinux policy on Centos 9 providers

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -395,28 +395,30 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
   fi
 fi
 
+add_to_label_filter() {
+  local label=$1
+  local separator=$2
+  if [[ -z $label_filter ]]; then
+    label_filter="${1}"
+  else
+    label_filter="${label_filter}${separator}${1}"
+  fi
+}
+
 if [[ $KUBEVIRT_NONROOT =~ true ]]; then
-  if [[ -z $label_filter ]]; then
-    label_filter='(verify-non-root)'
-  else
-    label_filter=$label_filter',(verify-non-root)'
-  fi
+  add_to_label_filter '(verify-non-root)' ','
 else
-  if [[ -z $label_filter ]]; then
-    label_filter='(!verify-non-root)'
-  else
-    label_filter=$label_filter'&&(!verify-non-root)'
-  fi
+  add_to_label_filter '(!verify-non-root)' '&&'
+fi
+
+if [[ $TARGET =~ centos9 ]]; then
+  add_to_label_filter '(!CustomSELinux)' '&&'
 fi
 
 # Single-node single-replica test lanes obviously can't run live migrations,
 # but also currently lack the requirements for SRIOV, GPU, Macvtap and MDEVs.
 if [[ $KUBEVIRT_NUM_NODES = "1" && $KUBEVIRT_INFRA_REPLICAS = "1" ]]; then
-  if [[ -z $label_filter ]]; then
-    label_filter='(!(SRIOV,GPU,Macvtap,VGPU,sig-compute-migrations))'
-  else
-    label_filter=$label_filter'&&(!(SRIOV,GPU,Macvtap,VGPU,sig-compute-migrations))'
-  fi
+  add_to_label_filter '(!(SRIOV,GPU,Macvtap,VGPU,sig-compute-migrations))' '&&'
 fi
 
 # If KUBEVIRT_QUARANTINE is not set, do not run quarantined tests. When it is

--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -50,5 +50,6 @@
     ;
     ; This is needed for passt. This is the only thing for which this policy is actually needed.
     ; The policy will be removed from here once it will be installed via the passt package.
-    (allow process tmpfs_t (filesystem (mount)))
+    (allow process tmpfs_t (filesystem (mount unmount)))
+    (allow process tmpfs_t (file (getattr map)))
 )

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -64,6 +64,10 @@ function functest() {
         echo "Will skip test asserting the cluster is in dual-stack mode."
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi
+    if [[ ${KUBEVIRT_PROVIDER} =~ centos9 ]]; then
+        echo "Will not use the custom SELinux policy"
+        KUBEVIRT_FUNC_TEST_SUITE_ARGS="-disable-custom-selinux-policy ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
+    fi
 
     _out/tests/ginkgo -timeout=3h -r -slow-spec-threshold=60s "$@" _out/tests/tests.test -- -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${kubevirt_test_config} --artifacts=${ARTIFACTS} --operator-manifest-path=${OPERATOR_MANIFEST_PATH} --testing-manifest-path=${TESTING_MANIFEST_PATH} ${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -virtctl-path=${virtctl_path} -example-guest-agent-path=${example_guest_agent_path}
 }

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -33,4 +33,5 @@ var (
 	Reenlightenment  = []interface{}{Label("Reenlightenment")}
 	PasstGate        = []interface{}{Label("PasstGate")}
 	Upgrade          = []interface{}{Label("Upgrade")}
+	CustomSELinux    = []interface{}{Label("CustomSELinux")}
 )

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -61,6 +61,8 @@ var DNSServiceNamespace = ""
 
 var MigrationNetworkNIC = "eth1"
 
+var DisableCustomSELinuxPolicy bool
+
 func init() {
 	kubecli.Init()
 	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
@@ -95,6 +97,7 @@ func init() {
 	flag.StringVar(&DNSServiceName, "dns-service-name", "kube-dns", "cluster DNS service name")
 	flag.StringVar(&DNSServiceNamespace, "dns-service-namespace", "kube-system", "cluster DNS service namespace")
 	flag.StringVar(&MigrationNetworkNIC, "migration-network-nic", "eth1", "NIC to use on cluster nodes to access the dedicated migration network")
+	flag.BoolVar(&DisableCustomSELinuxPolicy, "disable-custom-selinux-policy", false, "disables the installation and use of the custom SELinux policy for virt-launcher")
 }
 
 func NormalizeFlags() {

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -187,7 +187,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", Serial, decorators.Sig
 
 		Context("With selinuxLauncherType defined as virt_launcher.process", func() {
 
-			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", func() {
+			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", decorators.CustomSELinux, func() {
 				config := kubevirtConfiguration.DeepCopy()
 				launcherType := "virt_launcher.process"
 				config.SELinuxLauncherType = launcherType

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -108,6 +108,11 @@ func AdjustKubeVirtResource() {
 		virtconfig.VSOCKGate,
 		virtconfig.KubevirtSeccompProfile,
 	)
+	if flags.DisableCustomSELinuxPolicy {
+		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+			virtconfig.DisableCustomSELinuxPolicy,
+		)
+	}
 
 	if kv.Spec.Configuration.NetworkConfiguration == nil {
 		testDefaultPermitSlirpInterface := true


### PR DESCRIPTION
**What this PR does / why we need it**:
The custom SELinux policy is not required anymore when running recent OSes like Centos 9.
This PR also updates the custom policy with more passt permissions found while testing on Centos 9. Not sure if any of them is critical, but it's better to have them to ensure proper passt behavior when using the custom policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
