### PR TITLE
[e2e]: treat kubevirt CR conditions when preparing the environment

### DIFF
--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
-        "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -133,7 +133,7 @@ func TestCleanup() {
 	testsuite.CleanNamespaces()
 	libnode.CleanNodes()
 	resetToDefaultConfig()
-	testsuite.EnsureKubevirtInfra()
+	testsuite.EnsureKubevirtReady()
 	SetupAlpineHostPath()
 	GinkgoWriter.Println("Global test cleanup ended.")
 }


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
`ensureKubevirtInfra()` ensures that all kubevirt components are synced and ready for testing. Virt-operator does the same, and reports the status via the Kubevirt CR conditions. So it doesn't makes sense to compete virt-operator or to mimic its logic. Its enough to observe the Kubevirt CR conditions, and this change suggests exactly that.

**Release note**:
```release-note
NONE
```
