### PR TITLE
Update performance automation to point to new prometheus svc

### DIFF
--- a/automation/perfscale-test.sh
+++ b/automation/perfscale-test.sh
@@ -86,7 +86,7 @@ export PROMETHEUS_PORT=${PROMETHEUS_PORT:-30007}
 
 # expose prometheus in an external kubernetes cluster
 if [[ (${PERFAUDIT} == "true" || ${PERFAUDIT} == "True") && ${KUBEVIRT_PROVIDER} == "external" ]]; then
-  kubectl -n monitoring port-forward service/prometheus-stack-kube-prom-prometheus ${PROMETHEUS_PORT} &> /dev/null &
+  kubectl -n openshift-monitoring port-forward service/prometheus-operated ${PROMETHEUS_PORT} &> /dev/null &
   _prometheus_port_forward_pid=$1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The performance cluster had to be rebuilt due to issues running the workloads against the cluster.

This update points the port-forward to the new prometheus service in the rebuilt cluster.

Tested locally against the new performance cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @rthallisey 
**Release note**:
```release-note
NONE
```
