### PR TITLE
Show VM name in export status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20146,6 +20146,10 @@
      "ttlExpirationTime": {
       "description": "The time at which the VM Export will be completely removed according to specified TTL Formula is CreationTimestamp + TTL",
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
+     },
+     "virtualMachineName": {
+      "description": "VirtualMachineName shows the name of the source virtual machine if the source is either a VirtualMachine or a VirtualMachineSnapshot. This is mainly to easily identify the source VirtualMachine in case of a VirtualMachineSnapshot",
+      "type": "string"
      }
     }
    },

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1alpha1"
@@ -219,7 +220,7 @@ func (ctrl *VMExportController) updateVMExportVMStatus(vmExport *exportv1.Virtua
 	var requeue time.Duration
 
 	vmExportCopy := vmExport.DeepCopy()
-	vmExportCopy.Status.VirtualMachineName = vmExport.Spec.Source.Name
+	vmExportCopy.Status.VirtualMachineName = pointer.StringPtr(vmExport.Spec.Source.Name)
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
 		return requeue, err
 	}

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -219,6 +219,7 @@ func (ctrl *VMExportController) updateVMExportVMStatus(vmExport *exportv1.Virtua
 	var requeue time.Duration
 
 	vmExportCopy := vmExport.DeepCopy()
+	vmExportCopy.Status.VirtualMachineName = vmExport.Spec.Source.Name
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
 		return requeue, err
 	}

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -191,6 +191,7 @@ func (ctrl *VMExportController) updateVMExporVMSnapshotStatus(vmExport *exportv1
 	for _, pvc := range sourceVolumes.volumes {
 		pvc.Name = strings.TrimPrefix(pvc.Name, fmt.Sprintf("%s-", vmExport.Name))
 	}
+	vmExportCopy.Status.VirtualMachineName = ctrl.getVmNameFromVmSnapshot(vmExport)
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
 		return 0, err
 	}

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -191,7 +191,7 @@ func (ctrl *VMExportController) updateVMExporVMSnapshotStatus(vmExport *exportv1
 	for _, pvc := range sourceVolumes.volumes {
 		pvc.Name = strings.TrimPrefix(pvc.Name, fmt.Sprintf("%s-", vmExport.Name))
 	}
-	vmExportCopy.Status.VirtualMachineName = ctrl.getVmNameFromVmSnapshot(vmExport)
+	vmExportCopy.Status.VirtualMachineName = pointer.StringPtr(ctrl.getVmNameFromVmSnapshot(vmExport))
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
 		return 0, err
 	}

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8080,6 +8080,12 @@ var CRDsValidation map[string]string = map[string]string{
             according to specified TTL Formula is CreationTimestamp + TTL
           format: date-time
           type: string
+        virtualMachineName:
+          description: VirtualMachineName shows the name of the source virtual machine
+            if the source is either a VirtualMachine or a VirtualMachineSnapshot.
+            This is mainly to easily identify the source VirtualMachine in case of
+            a VirtualMachineSnapshot
+          type: string
       type: object
   required:
   - spec

--- a/staging/src/kubevirt.io/api/export/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/deepcopy_generated.go
@@ -223,6 +223,11 @@ func (in *VirtualMachineExportStatus) DeepCopyInto(out *VirtualMachineExportStat
 		in, out := &in.TTLExpirationTime, &out.TTLExpirationTime
 		*out = (*in).DeepCopy()
 	}
+	if in.VirtualMachineName != nil {
+		in, out := &in.VirtualMachineName, &out.VirtualMachineName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]Condition, len(*in))

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types.go
@@ -105,6 +105,12 @@ type VirtualMachineExportStatus struct {
 	ServiceName string `json:"serviceName,omitempty"`
 
 	// +optional
+	// VirtualMachineName shows the name of the source virtual machine if the source is either a VirtualMachine or
+	// a VirtualMachineSnapshot. This is mainly to easily identify the source VirtualMachine in case of a
+	// VirtualMachineSnapshot
+	VirtualMachineName string `json:"virtualMachineName,omitempty"`
+
+	// +optional
 	// +listType=atomic
 	Conditions []Condition `json:"conditions,omitempty"`
 }

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types.go
@@ -108,7 +108,7 @@ type VirtualMachineExportStatus struct {
 	// VirtualMachineName shows the name of the source virtual machine if the source is either a VirtualMachine or
 	// a VirtualMachineSnapshot. This is mainly to easily identify the source VirtualMachine in case of a
 	// VirtualMachineSnapshot
-	VirtualMachineName string `json:"virtualMachineName,omitempty"`
+	VirtualMachineName *string `json:"virtualMachineName,omitempty"`
 
 	// +optional
 	// +listType=atomic

--- a/staging/src/kubevirt.io/api/export/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/export/v1alpha1/types_swagger_generated.go
@@ -26,13 +26,14 @@ func (VirtualMachineExportSpec) SwaggerDoc() map[string]string {
 
 func (VirtualMachineExportStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                  "VirtualMachineExportStatus is the status for a VirtualMachineExport resource",
-		"phase":             "+optional",
-		"links":             "+optional",
-		"tokenSecretRef":    "+optional\nTokenSecretRef is the name of the secret that contains the token used by the export server pod",
-		"ttlExpirationTime": "The time at which the VM Export will be completely removed according to specified TTL\nFormula is CreationTimestamp + TTL",
-		"serviceName":       "+optional\nServiceName is the name of the service created associated with the Virtual Machine export. It will be used to\ncreate the internal URLs for downloading the images",
-		"conditions":        "+optional\n+listType=atomic",
+		"":                   "VirtualMachineExportStatus is the status for a VirtualMachineExport resource",
+		"phase":              "+optional",
+		"links":              "+optional",
+		"tokenSecretRef":     "+optional\nTokenSecretRef is the name of the secret that contains the token used by the export server pod",
+		"ttlExpirationTime":  "The time at which the VM Export will be completely removed according to specified TTL\nFormula is CreationTimestamp + TTL",
+		"serviceName":        "+optional\nServiceName is the name of the service created associated with the Virtual Machine export. It will be used to\ncreate the internal URLs for downloading the images",
+		"virtualMachineName": "+optional\nVirtualMachineName shows the name of the source virtual machine if the source is either a VirtualMachine or\na VirtualMachineSnapshot. This is mainly to easily identify the source VirtualMachine in case of a\nVirtualMachineSnapshot",
+		"conditions":         "+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23400,6 +23400,13 @@ func schema_kubevirtio_api_export_v1alpha1_VirtualMachineExportStatus(ref common
 							Format:      "",
 						},
 					},
+					"virtualMachineName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VirtualMachineName shows the name of the source virtual machine if the source is either a VirtualMachine or a VirtualMachineSnapshot. This is mainly to easily identify the source VirtualMachine in case of a VirtualMachineSnapshot",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1173,10 +1173,10 @@ var _ = SIGDescribe("Export", func() {
 		Eventually(func() string {
 			export, err := virtClient.VirtualMachineExport(export.Namespace).Get(context.Background(), export.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			if export.Status == nil {
+			if export.Status == nil || export.Status.VirtualMachineName == nil {
 				return ""
 			}
-			return export.Status.VirtualMachineName
+			return *export.Status.VirtualMachineName
 		}, 30*time.Second, time.Second).Should(Equal(name))
 	}
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
For display purposes it is handy to have the VM name of the VM/VMSnapshot available in the export status. Added a new field containing the name and populating it during the standard reconcile loop.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Show VirtualMachine name in the VMExport status
```
