### PR TITLE
[WIP] Tag VMs network Name Scheme

### DIFF
--- a/pkg/network/multus/BUILD.bazel
+++ b/pkg/network/multus/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["networkstatus.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network/multus",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
+    ],
+)

--- a/pkg/network/multus/networkstatus.go
+++ b/pkg/network/multus/networkstatus.go
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package multus
+
+import (
+	"encoding/json"
+	"fmt"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+)
+
+func MapInterfaceNameToNetworkStatus(networkStatusAnnotationValue string) (map[string]networkv1.NetworkStatus, error) {
+	if networkStatusAnnotationValue == "" {
+		return nil, fmt.Errorf("network-status annotation is not present")
+	}
+	var networkStatusList []networkv1.NetworkStatus
+	if err := json.Unmarshal([]byte(networkStatusAnnotationValue), &networkStatusList); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal network-status annotation: %v", err)
+	}
+
+	multusInterfaceNameToNetworkStatusMap := map[string]networkv1.NetworkStatus{}
+	for _, networkStatus := range networkStatusList {
+		multusInterfaceNameToNetworkStatusMap[networkStatus.Interface] = networkStatus
+	}
+
+	return multusInterfaceNameToNetworkStatusMap, nil
+}

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -20,37 +20,44 @@
 package namescheme
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-const PrimaryPodInterfaceName = "eth0"
+const (
+	// MaxIfaceNameLen equals max kernel interface name len (15) - length("-nic")
+	// which is the suffix used for the bridge binding interface with IPAM.
+	// (the interface created to hold the pod's IP address - and thus appease CNI).
+	MaxIfaceNameLen         = 11
+	PrimaryPodInterfaceName = "eth0"
+)
 
 // CreateNetworkNameScheme iterates over the VMI's Networks, and creates for each a pod interface name.
 // The returned map associates between the network name and the generated pod interface name.
-// Primary network will use "eth0" and the secondary ones will use "net<id>" format, where id is an enumeration
-// from 1 to n.
+// Primary network will use "eth0" and the secondary ones will be named "net<id>" where id is the network name sha256.
 func CreateNetworkNameScheme(vmiNetworks []v1.Network) map[string]string {
 	networkNameSchemeMap := mapMultusNonDefaultNetworksToPodInterfaceName(vmiNetworks)
-
 	if multusDefaultNetwork := vmispec.LookUpDefaultNetwork(vmiNetworks); multusDefaultNetwork != nil {
 		networkNameSchemeMap[multusDefaultNetwork.Name] = PrimaryPodInterfaceName
 	}
-
 	return networkNameSchemeMap
 }
 
 func mapMultusNonDefaultNetworksToPodInterfaceName(networks []v1.Network) map[string]string {
 	networkNameSchemeMap := map[string]string{}
-	for i, network := range vmispec.FilterMultusNonDefaultNetworks(networks) {
-		networkNameSchemeMap[network.Name] = secondaryInterfaceName(i + 1)
+	for _, network := range vmispec.FilterMultusNonDefaultNetworks(networks) {
+		networkNameSchemeMap[network.Name] = hashNetworkName(network.Name)
 	}
 	return networkNameSchemeMap
 }
 
-func secondaryInterfaceName(idx int) string {
-	return fmt.Sprintf("net%d", idx)
+func hashNetworkName(networkName string) string {
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, networkName)
+	return fmt.Sprintf("%x", hash.Sum(nil))[:MaxIfaceNameLen]
 }

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Network Name Scheme", func() {
 				},
 				map[string]string{
 					"network0": namescheme.PrimaryPodInterfaceName,
-					"network1": "net1",
-					"network2": "net2",
+					"network1": "a7662f44d65",
+					"network2": "27f4a77f94e",
 				}),
 		)
 	})

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -99,7 +99,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(nics).To(BeEmpty())
 			})
 			It("should configure networking with multus", func() {
-				const multusInterfaceName = "net1"
+				const multusInterfaceName = "37a8eec1ce1"
 				vmi := newVMIBridgeInterface("testnamespace", "testVmName")
 				iface := v1.DefaultBridgeNetworkInterface()
 				cniNet := &v1.Network{
@@ -185,14 +185,14 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						vmi:              vm,
 						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[0],
 						vmiSpecNetwork:   additionalCNINet1,
-						podInterfaceName: "net1",
+						podInterfaceName: "e56ef68384a",
 						handler:          vmNetworkConfigurator.handler,
 						cacheCreator:     vmNetworkConfigurator.cacheCreator,
 						launcherPID:      &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[0],
-							generateInPodBridgeInterfaceName("net1"),
+							generateInPodBridgeInterfaceName("e56ef68384a"),
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},
@@ -215,14 +215,14 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						vmi:              vm,
 						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[2],
 						vmiSpecNetwork:   additionalCNINet2,
-						podInterfaceName: "net2",
+						podInterfaceName: "9f531ef99d2",
 						handler:          vmNetworkConfigurator.handler,
 						cacheCreator:     vmNetworkConfigurator.cacheCreator,
 						launcherPID:      &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[2],
-							generateInPodBridgeInterfaceName("net2"),
+							generateInPodBridgeInterfaceName("9f531ef99d2"),
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},

--- a/pkg/network/sriov/BUILD.bazel
+++ b/pkg/network/sriov/BUILD.bazel
@@ -6,11 +6,11 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/network/sriov",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/multus:go_default_library",
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
     ],
 )
 
@@ -23,6 +23,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/network/sriov/sriov_test.go
+++ b/pkg/network/sriov/sriov_test.go
@@ -20,6 +20,8 @@
 package sriov_test
 
 import (
+	"fmt"
+
 	"kubevirt.io/kubevirt/pkg/network/sriov"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,7 +31,12 @@ import (
 )
 
 var _ = Describe("SRIOV", func() {
-	networkStatusWithOneSRIOVNetwork := `
+
+	const (
+		booVMNetworkPodIfaceName = "6446d58d6df"
+		fooVMNetworkPodIfaceName = "2c26b46b68f"
+	)
+	networkStatusWithOneSRIOVNetwork := fmt.Sprintf(`
 [
 {
   "name": "kindnet",
@@ -43,7 +50,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net1",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -53,8 +60,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`
-	networkStatusWithTwoSRIOVNetworks := `
+]`, fooVMNetworkPodIfaceName)
+	networkStatusWithTwoSRIOVNetworks := fmt.Sprintf(`
 [
 {
   "name": "kindnet",
@@ -68,7 +75,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net1",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -80,7 +87,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad2",
-  "interface": "net2",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -90,8 +97,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`
-	networkStatusWithOneBridgeOneSRIOVNetworks := `
+]`, fooVMNetworkPodIfaceName, booVMNetworkPodIfaceName)
+	networkStatusWithOneBridgeOneSRIOVNetworks := fmt.Sprintf(`
 [
 {
   "name": "kindnet",
@@ -105,13 +112,13 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/bridge-network",
-  "interface": "net1",
+  "interface": "%s",
   "mac": "8a:37:d9:e7:0f:18",
   "dns": {}
 },
 {
   "name": "default/sriov-network-vlan100",
-  "interface": "net2",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -121,7 +128,7 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`
+]`, booVMNetworkPodIfaceName, fooVMNetworkPodIfaceName)
 	networkStatusWithTwoSRIOVNetworksButOneWithNoPCIData := `
 [
 {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -979,9 +979,9 @@ var _ = Describe("Template", func() {
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
 				expectedIfaces := ("[" +
-					"{\"interface\":\"net1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"net2\",\"name\":\"test1\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"net3\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
+					"{\"interface\":\"37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"49dba5c72f0\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})
@@ -1019,7 +1019,7 @@ var _ = Describe("Template", func() {
 				Expect(value).To(Equal("default"))
 				value, ok = pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
-				Expect(value).To(Equal("[{\"interface\":\"net1\",\"name\":\"test1\",\"namespace\":\"default\"}]"))
+				Expect(value).To(Equal("[{\"interface\":\"1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}]"))
 			})
 			It("should add MAC address in the pod annotation", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1062,8 +1062,8 @@ var _ = Describe("Template", func() {
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
 				expectedIfaces := ("[" +
-					"{\"interface\":\"net1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"net2\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
+					"{\"interface\":\"37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"1b4f0e98519\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -29,6 +29,8 @@ go_library(
         "//pkg/monitoring/profiler:go_default_library",
         "//pkg/monitoring/vmistats:go_default_library",
         "//pkg/monitoring/vmstats:go_default_library",
+        "//pkg/network/multus:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/psa:go_default_library",

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -784,7 +784,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 			{
 			"name": "` + netAttachDefName + `",
-			"interface": "net1",
+			"interface": "a7662f44d65",
 			"dns": {},
 			"device-info": {
 			  "type": "pci",

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/hotplug-disk:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/errors:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/safepath:go_default_library",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
     deps = [
         "//pkg/cloud-init:go_default_library",
         "//pkg/network/istio:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -522,7 +522,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 						virtClient,
 						vmiPod,
 						"compute",
-						[]string{"cat", "/sys/class/net/net1/mtu"},
+						[]string{"cat", "/sys/class/net/72ad293a5c9/mtu"},
 					)
 					ExpectWithOffset(1, err).ToNot(HaveOccurred())
 

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -433,7 +433,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				Entry("with default network and secondary network with IPAM", []v1.Interface{defaultInterface, linuxBridgeInterfaceWithIPAM}, []v1.Network{defaultNetwork, linuxBridgeWithIPAMNetwork}, "eth1", "", ""),
 			)
 
-			It("should be labeled with network interface name scheme label", func() {
+			FIt("should be labeled with network interface name scheme label", func() {
 				testVmi := libvmi.NewAlpine(
 					libvmi.WithInterface(defaultInterface),
 					libvmi.WithNetwork(&defaultNetwork),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Depends on https://github.com/kubevirt/kubevirt/pull/8899

With this PR changes VMs will be labeled with their underlying pod network interfaces name-scheme.

For example: 
A VM with secondary NICs launcher pod with hashed network interfaces names: 
```
...
5: 624e67c956a@if139: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master k6t-624e67c state UP group default 
    link/ether 0e:c8:c1:30:53:33 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet6 fe80::cc8:c1ff:fe30:5333/64 scope link 
       valid_lft forever preferred_lft forever
8: k6t-624e67c: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 0e:c8:c1:30:53:33 brd ff:ff:ff:ff:ff:ff
    inet 169.254.75.11/32 scope global k6t-624e67c
       valid_lft forever preferred_lft forever
    inet6 fe80::cc8:c1ff:fe30:5333/64 scope link 
       valid_lft forever preferred_lft forever
9: tap624e67c956a: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master k6t-624e67c state UP group default qlen 1000
    link/ether d2:8b:ce:ae:09:c6 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::d08b:ceff:feae:9c6/64 scope link 
       valid_lft forever preferred_lft forever
...
```
Will be labeled with `kubevirt.io/launcherNetworkInterfacesNameScheme=Hashed`

VMs with indexed network name scheme (net1, net2, ..netX) with be labeled with `kubevirt.io/launcherNetworkInterfacesNameScheme=Indexed`

Having the network name scheme labeled in-place, enables the controller/handler to decide whether to hotplug/unplug a network interface or migrate the VM.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
