### PR TITLE
Add missing ports to istio reseved ports list

### DIFF
--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Pod Network", func() {
 				}
 				specGenerator = NewPasstLibvirtSpecGenerator(
 					passtIface, nil, istioVmi)
-				Expect(getPorts(specGenerator)).To(Equal("-t ~15000,~15001,~15006,~15008,~15020,~15021,~15090 -u all"))
+				Expect(getPorts(specGenerator)).To(Equal("-t ~15000,~15001,~15004,~15006,~15008,~15009,~15020,~15021,~15053,~15090 -u all"))
 			})
 		})
 	})

--- a/pkg/network/istio/ports.go
+++ b/pkg/network/istio/ports.go
@@ -24,10 +24,13 @@ import "fmt"
 const (
 	EnvoyAdminPort                     = 15000
 	EnvoyOutboundPort                  = 15001
+	EnvoyDebugPort                     = 15004
 	EnvoyInboundPort                   = 15006
 	EnvoyTunnelPort                    = 15008
+	EnvoySecureNetworkPort             = 15009
 	EnvoyMergedPrometheusTelemetryPort = 15020
 	EnvoyHealthCheckPort               = 15021
+	EnvoyDNSPort                       = 15053
 	EnvoyPrometheusTelemetryPort       = 15090
 	SshPort                            = 22
 )
@@ -36,10 +39,13 @@ func ReservedPorts() []string {
 	return []string{
 		fmt.Sprint(EnvoyAdminPort),
 		fmt.Sprint(EnvoyOutboundPort),
+		fmt.Sprint(EnvoyDebugPort),
 		fmt.Sprint(EnvoyInboundPort),
 		fmt.Sprint(EnvoyTunnelPort),
+		fmt.Sprint(EnvoySecureNetworkPort),
 		fmt.Sprint(EnvoyMergedPrometheusTelemetryPort),
 		fmt.Sprint(EnvoyHealthCheckPort),
+		fmt.Sprint(EnvoyDNSPort),
 		fmt.Sprint(EnvoyPrometheusTelemetryPort),
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
istio documentation specify the list of ports istio is using - https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio

kubevirt is using this list to avoid forwarding traffic to the vm on those ports in case of masquerade binding. And to avoid opening socket on those ports in case of passt.

Some ports were missing in the list kubevirt is using, this PR adding the missing ports.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
