### PR TITLE
Force to use the virtio non-transitional for VSOCK device.

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1822,7 +1822,9 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	// Handle VSOCK CID
 	if vmi.Status.VSOCKCID != nil {
 		domain.Spec.Devices.VSOCK = &api.VSOCK{
-			Model: translateModel(c, "virtio"),
+			// Force virtio v1 for vhost-vsock-pci.
+			// https://gitlab.com/qemu-project/qemu/-/commit/6209070503989cf4f28549f228989419d4f0b236
+			Model: "virtio-non-transitional",
 			CID: api.CID{
 				Auto:    "no",
 				Address: *vmi.Status.VSOCKCID,

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1953,16 +1953,21 @@ var _ = Describe("Converter", func() {
 			Entry("disabled - virtLauncherLogVerbosity variable is not defined", false, -1, false),
 		)
 
-		It("should add VSOCK section when present", func() {
-			cid := uint32(100)
-			vmi.Status.VSOCKCID = &cid
-			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
-			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
-			Expect(domainSpec.Devices.VSOCK).ToNot(BeNil())
-			Expect(domainSpec.Devices.VSOCK.Model).To(Equal("virtio-non-transitional"))
-			Expect(domainSpec.Devices.VSOCK.CID.Auto).To(Equal("no"))
-			Expect(domainSpec.Devices.VSOCK.CID.Address).To(BeNumerically("==", 100))
-		})
+		DescribeTable("should add VSOCK section when present",
+			func(useVirtioTransitional bool) {
+				cid := uint32(100)
+				vmi.Status.VSOCKCID = &cid
+				vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
+				c.UseVirtioTransitional = useVirtioTransitional
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+				Expect(domainSpec.Devices.VSOCK).ToNot(BeNil())
+				Expect(domainSpec.Devices.VSOCK.Model).To(Equal("virtio-non-transitional"))
+				Expect(domainSpec.Devices.VSOCK.CID.Auto).To(Equal("no"))
+				Expect(domainSpec.Devices.VSOCK.CID.Address).To(BeNumerically("==", 100))
+			},
+			Entry("use virtio transitional", true),
+			Entry("use virtio non-transitional", false),
+		)
 
 	})
 	Context("Network convert", func() {

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -59,9 +59,10 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 	})
 
 	Context("VM creation", func() {
-		It("should expose a VSOCK device", func() {
+		DescribeTable("should expose a VSOCK device", func(useVirtioTransitional bool) {
 			By("Creating a VMI with VSOCK enabled")
 			vmi := tests.NewRandomFedoraVMI()
+			vmi.Spec.Domain.Devices.UseVirtioTransitional = &useVirtioTransitional
 			vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 			Expect(vmi.Status.VSOCKCID).NotTo(BeNil())
@@ -88,7 +89,10 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 				&expect.BSnd{S: "ls /dev/vsock\n"},
 				&expect.BExp{R: "/dev/vsock"},
 			}, 300)).To(Succeed(), "Could not find a vsock device")
-		})
+		},
+			Entry("Use virtio transitional", true),
+			Entry("Use virtio non-transitional", false),
+		)
 	})
 
 	Context("Live migration", func() {


### PR DESCRIPTION
Qemu removes the support for virtio transitional in https://gitlab.com/qemu-project/qemu/-/commit/6209070503989cf4f28549f228989419d4f0b236

Signed-off-by: Zhuchen Wang <zcwang@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: 
The VSOCK feature is broken when using virtio transitional.
QEMU gives the error `'vhost-vsock-pci-transitional' is not a valid device model name`.
After debugging, I found `vhost-vsock-pci-transitional` is removed from QEMU in https://gitlab.com/qemu-project/qemu/-/commit/6209070503989cf4f28549f228989419d4f0b236

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
