### PR TITLE
Allow to run conformance tests with default conf

### DIFF
--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -48,6 +48,10 @@ func execute() error {
 	if value, exists := os.LookupEnv("CONTAINER_TAG"); exists {
 		args = append(args, "--container-tag", value)
 	}
+	if _, exists := os.LookupEnv("KUBEVIRT_CI"); exists {
+		args = append(args, "--apply-default-e2e-configuration")
+	}
+
 	args = append(args, "--config", "/conformance-config.json")
 
 	cmd := exec.Command("/usr/bin/go_default_test", args...)


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to be able to run conformance tests on
PSA enabled Kubernetes cluster we need to enable
Seccomp configuration.

This commit is for the convenience of KubevirtCI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
