### PR TITLE
Revert "Add checks of dedicatedCPUPlacement to validation webhook"

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/instancetype-admitter_test.go
@@ -47,30 +47,6 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
 	})
-
-	It("should reject unsupported group", func() {
-		ar := createInstancetypeAdmissionReview(instancetypeObj)
-		ar.Request.Resource.Group = "unsupportedgroup"
-		response := admitter.Admit(ar)
-
-		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
-		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
-	})
-
-	It("should reject instancetype with dedicatedCPUPlacement", func() {
-		instancetypeObj.Spec = instancetypev1alpha2.VirtualMachineInstancetypeSpec{
-			CPU: instancetypev1alpha2.CPUInstancetype{
-				DedicatedCPUPlacement: true,
-			},
-		}
-		ar := createInstancetypeAdmissionReview(instancetypeObj)
-		response := admitter.Admit(ar)
-
-		Expect(response.Allowed).To(BeFalse(), "Expect instancetype to not be allowed")
-		Expect(response.Result.Details.Causes).To(HaveLen(1))
-		Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-		Expect(response.Result.Details.Causes[0].Message).To(Equal("dedicatedCPUPlacement is not currently supported"))
-	})
 })
 
 var _ = Describe("Validating ClusterInstancetype Admitter", func() {
@@ -103,30 +79,6 @@ var _ = Describe("Validating ClusterInstancetype Admitter", func() {
 
 		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
 		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
-	})
-
-	It("should reject unsupported resource", func() {
-		ar := createClusterInstancetypeAdmissionReview(clusterInstancetypeObj)
-		ar.Request.Resource.Resource = "unsupportedresource"
-		response := admitter.Admit(ar)
-
-		Expect(response.Allowed).To(BeFalse(), "Expected instancetype to not be allowed")
-		Expect(response.Result.Code).To(Equal(int32(http.StatusBadRequest)), "Expected error 400: BadRequest")
-	})
-
-	It("should reject cluster instancetype with dedicatedCPUPlacement", func() {
-		clusterInstancetypeObj.Spec = instancetypev1alpha2.VirtualMachineInstancetypeSpec{
-			CPU: instancetypev1alpha2.CPUInstancetype{
-				DedicatedCPUPlacement: true,
-			},
-		}
-		ar := createClusterInstancetypeAdmissionReview(clusterInstancetypeObj)
-		response := admitter.Admit(ar)
-
-		Expect(response.Allowed).To(BeFalse(), "Expect instancetype to not be allowed")
-		Expect(response.Result.Details.Causes).To(HaveLen(1))
-		Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-		Expect(response.Result.Details.Causes[0].Message).To(Equal("dedicatedCPUPlacement is not currently supported"))
 	})
 })
 


### PR DESCRIPTION
/area instancetype
/cc @opokornyy 
/cc @davidvossel 

**What this PR does / why we need it**:

This reverts commit 48a2adea3eec3aa267fdaa7139c8e74ca06fb07a.

Thanks to e7898af39b54298043adef02ae578d825743120e [1][2] we now apply defaults to a copy of the VirtualMachineInstanceSpec before running the associated validations in the VirtualMachine validation webhook. This actually resolves the original issue with enabling dedicatedCPUPlacement from instance types [3] as it ensures any guest visible memory is expressed as resources requests before we attempt to validate.

As such we can drop the blocking validations from the instance type webhooks and allow `dedicatedCPUPlacement` to be set once again.

[1] https://github.com/kubevirt/kubevirt/pull/9103 
[2] https://github.com/kubevirt/kubevirt/issues/9102 
[3] https://github.com/kubevirt/kubevirt/issues/8867

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

With this commit reverted in a test environment the following examples work once again:

```
$ ./cluster-up/kubectl.sh apply -f - << EOF
apiVersion: instancetype.kubevirt.io/v1alpha2
kind: VirtualMachineClusterInstancetype
metadata:
 name: dedicatedcpuplacement
spec:
 cpu:
  dedicatedCPUPlacement: true
  guest: 1
 memory: 
  guest: 128Mi
EOF
selecting docker as container runtime
virtualmachineclusterinstancetype.instancetype.kubevirt.io/dedicatedcpuplacement created
$ ./cluster-up/kubectl.sh apply -f - << EOF
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  labels:
    kubevirt.io/vm: vm-cirros
  name: vm-cirros
spec:
  instancetype:
    name: dedicatedcpuplacement
  running: true
  template:
    spec:
      domain:
        devices: {}
      terminationGracePeriodSeconds: 0
      volumes:
      - containerDisk:
          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
        name: containerdisk
EOF
selecting docker as container runtime
virtualmachine.kubevirt.io/vm-cirros configured
```

**Release note**:
```release-note
The `dedicatedCPUPlacement` attribute is once again supported within the `VirtualMachineInstancetype` and `VirtualMachineClusterInstancetype` CRDs after a recent bugfix improved `VirtualMachine` validations, ensuring defaults are applied before any attempt to validate.
```
