### PR TITLE
Improve handling of clone DataVolumes without source PVC

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -171,8 +171,12 @@ func GenerateDataVolumeFromTemplate(clientset kubecli.KubevirtClient, dataVolume
 		return nil, err
 	}
 
-	if cloneSource != nil && newDataVolume.Spec.SourceRef != nil {
-		newDataVolume.Spec.SourceRef = nil
+	if cloneSource != nil {
+		// If SourceRef is set, populate spec.Source with data from the DataSource
+		// If not, update the field anyway to account for possible namespace changes
+		if newDataVolume.Spec.SourceRef != nil {
+			newDataVolume.Spec.SourceRef = nil
+		}
 		newDataVolume.Spec.Source = &cdiv1.DataVolumeSource{
 			PVC: &cdiv1.DataVolumeSourcePVC{
 				Namespace: cloneSource.Namespace,
@@ -183,6 +187,7 @@ func GenerateDataVolumeFromTemplate(clientset kubecli.KubevirtClient, dataVolume
 
 	return newDataVolume, nil
 }
+
 func GetDataVolumeFromCache(namespace, name string, dataVolumeInformer cache.SharedInformer) (*cdiv1.DataVolume, error) {
 	key := controller.NamespacedKey(namespace, name)
 	obj, exists, err := dataVolumeInformer.GetStore().GetByKey(key)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

For consistency with other k8s objects, we allow creating clone DataVolumes even when the source PVC doesn't exist. This means that a VirtualMachine can be successfully created with volumes that may remain unpopulated until the source PVC is created.

This PR improves the handling of this case, so we check if the source PVC exists and, if not, we trigger an event to let users know.

**Which issue(s) this PR fixes**:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=2145223

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
