### PR TITLE
[e2e]: improve vmpool tests 

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -192,6 +192,7 @@ func (r *KubernetesReporter) dumpNamespaces(duration time.Duration, vmiNamespace
 	r.logVMICommands(virtCli, vmiNamespaces)
 
 	r.logCloudInit(virtCli, vmiNamespaces)
+	r.logVirtualMachinePools(virtCli)
 }
 
 // Cleanup cleans up the current content of the artifactsDir
@@ -1327,4 +1328,14 @@ func isDataVolumeEnabled(clientset kubecli.KubevirtClient) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (r *KubernetesReporter) logVirtualMachinePools(virtCli kubecli.KubevirtClient) {
+	pools, err := virtCli.VirtualMachinePool(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch vm exports: %v\n", err)
+		return
+	}
+
+	r.logObjects(virtCli, pools, "virtualmachinepools")
 }


### PR DESCRIPTION
* The `status.Replicas` field indicate the amount VMs created for the pool. The `status.ReadyReplicas` indicated the number of running VMs that are ready. Therefore for tests that require a VM to reach its ready state the eventual poll will use `status.ReadyReplicas` 
* In test cases where scale in happens, make sure that the VMs that are left are owned by the actual pool. This will help with analyzing some situations where there are VMs that are not related to the pool.
* Add the `VirtualMachinePool` objects to the reporter logs


Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
Tests that involved persistent storage were failing on some environments when those were bit overloaded.

**Release note**:
```release-note
NONE
```
