### PR TITLE
virt-handler: fix a possible panic when handling UID

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1885,7 +1885,7 @@ func (d *VirtualMachineController) execute(key string) error {
 
 	// As a last effort, if the UID still can't be determined attempt
 	// to retrieve it from the ghost record
-	if string(vmi.UID) == "" {
+	if vmiExists && string(vmi.UID) == "" {
 		uid := virtcache.LastKnownUIDFromGhostRecordCache(key)
 		if uid != "" {
 			log.Log.Object(vmi).V(3).Infof("ghost record cache provided %s as UID", uid)


### PR DESCRIPTION
The `getVMIFromCache` may create a empty object to return, After that, it will entry `if string(vmi.UID) == ""` branch, the `WatchdogFileGetUID` will panic by `precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())`. At this point vmiExists is false.

Signed-off-by: wanglei01 <wllenyj@linux.alibaba.com>

kubernetes version v1.22.3

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
