### PR TITLE
[release-0.49] [Bug-fix]: Windows VM HyperV Reenlightenment enabled fails to migrate

### DIFF
--- a/pkg/virt-controller/watch/topology/BUILD.bazel
+++ b/pkg/virt-controller/watch/topology/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",

--- a/pkg/virt-controller/watch/topology/hinter.go
+++ b/pkg/virt-controller/watch/topology/hinter.go
@@ -28,7 +28,7 @@ type topologyHinter struct {
 }
 
 func (t *topologyHinter) TopologyHintsRequiredForVMI(vmi *k6tv1.VirtualMachineInstance) bool {
-	return t.arch == "amd64" && VMIHasInvTSCFeature(vmi)
+	return t.arch == "amd64" && IsManualTSCFrequencyRequired(vmi)
 }
 
 func (t *topologyHinter) TopologyHintsForVMI(vmi *k6tv1.VirtualMachineInstance) (hints *k6tv1.TopologyHints, err error) {

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -5,6 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
+	"k8s.io/utils/pointer"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/tests/libvmi"
+
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
@@ -68,6 +74,28 @@ var _ = Describe("TSC", func() {
 			[]int64{2, 4},
 		),
 	)
+
+	Context("needs to be set when", func() {
+
+		It("invtsc feature exists", func() {
+			vmi := libvmi.New(
+				libvmi.WithCPUFeature("invtsc", "require"),
+			)
+
+			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+		})
+
+		It("HyperV reenlightenment is enabled", func() {
+			vmi := libvmi.New()
+			vmi.Spec.Domain.Features = &v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Reenlightenment: &v1.FeatureState{Enabled: pointer.Bool(true)},
+				},
+			}
+
+			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+		})
+	})
 })
 
 func tscFrequencyLabel(freq int64) string {

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -78,9 +78,10 @@ var _ = Describe("TSC", func() {
 	Context("needs to be set when", func() {
 
 		It("invtsc feature exists", func() {
-			vmi := libvmi.New(
-				libvmi.WithCPUFeature("invtsc", "require"),
-			)
+			vmi := libvmi.New()
+			vmi.Spec.Domain.CPU = &v1.CPU{Features: []v1.CPUFeature{
+				{Name: "invtsc", Policy: "require"},
+			}}
 
 			Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
 		})

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -441,7 +441,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			vmiCopy.Status.Phase = virtv1.Failed
 		} else {
 			vmiCopy.Status.Phase = virtv1.Pending
-			if vmi.Status.TopologyHints == nil && c.topologyHinter.TopologyHintsRequiredForVMI(vmi) {
+			if vmi.Status.TopologyHints == nil {
 				if topologyHints, err := c.topologyHinter.TopologyHintsForVMI(vmi); err != nil {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedGatherhingClusterTopologyHints, err.Error())
 					return &syncErrorImpl{err, FailedGatherhingClusterTopologyHints}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -210,7 +212,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
-		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
+		kubevirtFakeConfig := &virtv1.KubeVirtConfiguration{
+			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
+				MinimumClusterTSCFrequency: pointer.Int64(12345),
+			},
+		}
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kubevirtFakeConfig)
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		cdiInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
 		cdiConfigInformer, _ = testutils.NewFakeInformerFor(&cdiv1.CDIConfig{})
@@ -2630,6 +2637,54 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 			Expect(vmi.Status.Phase).To(Equal(virtv1.Running))
+		})
+	})
+
+	Context("topology hints", func() {
+
+		Context("needs to be set when", func() {
+
+			expectTopologyHintsUpdate := func() {
+				var vmi *virtv1.VirtualMachineInstance
+				vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+					vmi = arg.(*virtv1.VirtualMachineInstance)
+					Expect(topology.IsManualTSCFrequencyRequired(vmi)).To(BeTrue())
+				}).Return(vmi, nil)
+			}
+
+			runController := func(vmi *virtv1.VirtualMachineInstance) {
+				addVirtualMachine(vmi)
+				shouldExpectPodCreation(vmi.UID)
+				controller.Execute()
+			}
+
+			It("invtsc feature exists", func() {
+				vmi := NewPendingVirtualMachine("testvmi")
+				vmi.Spec.Domain.CPU = &virtv1.CPU{
+					Features: []virtv1.CPUFeature{
+						{
+							Name:   "invtsc",
+							Policy: "require",
+						},
+					},
+				}
+
+				expectTopologyHintsUpdate()
+				runController(vmi)
+			})
+
+			It("HyperV reenlightenment is enabled", func() {
+				vmi := NewPendingVirtualMachine("testvmi")
+				vmi.Spec.Domain.Features = &virtv1.Features{
+					Hyperv: &virtv1.FeatureHyperv{
+						Reenlightenment: &virtv1.FeatureState{Enabled: pointer.Bool(true)},
+					},
+				}
+
+				expectTopologyHintsUpdate()
+				runController(vmi)
+			})
+
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1700,7 +1700,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		// Make use of the tsc frequency topology hint
-		if topology.VMIHasInvTSCFeature(vmi) && vmi.Status.TopologyHints != nil && vmi.Status.TopologyHints.TSCFrequency != nil {
+		if topology.IsManualTSCFrequencyRequired(vmi) && topology.AreTSCFrequencyTopologyHintsDefined(vmi) {
 			freq := *vmi.Status.TopologyHints.TSCFrequency
 			clock := domain.Spec.Clock
 			if clock == nil {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -198,6 +198,7 @@ go_test(
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler:go_default_library",
         "//pkg/virt-handler/device-manager:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -3667,10 +3667,10 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			}
 
 			It("invtsc feature exists", func() {
-				vmi := libvmi.New(
-					libvmi.WithResourceMemory("1Mi"),
-					libvmi.WithCPUFeature("invtsc", "require"),
-				)
+				vmi := libvmi.New(libvmi.WithResourceMemory("1Mi"))
+				vmi.Spec.Domain.CPU = &v1.CPU{Features: []v1.CPUFeature{
+					{Name: "invtsc", Policy: "require"},
+				}}
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				expectTopologyHintsToBeSet(vmi)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
 	"kubevirt.io/kubevirt/tests/libnode"
 
 	"kubevirt.io/kubevirt/pkg/util/hardware"
@@ -3650,6 +3651,44 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 			}, time.Second*30, time.Second*1).Should(BeNumerically("<=", 1))
 		})
+	})
+
+	Context("topology hints", func() {
+
+		Context("needs to be set when", func() {
+
+			expectTopologyHintsToBeSet := func(vmi *v1.VirtualMachineInstance) {
+				EventuallyWithOffset(1, func() bool {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					return topology.AreTSCFrequencyTopologyHintsDefined(vmi)
+				}, 90*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("tsc frequency topology hints are expected to exist for vmi %s", vmi.Name))
+			}
+
+			It("invtsc feature exists", func() {
+				vmi := libvmi.New(
+					libvmi.WithResourceMemory("1Mi"),
+					libvmi.WithCPUFeature("invtsc", "require"),
+				)
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				expectTopologyHintsToBeSet(vmi)
+			})
+
+			It("HyperV reenlightenment is enabled", func() {
+				vmi := libvmi.New()
+				vmi.Spec = getWindowsVMISpec()
+				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}
+				vmi.Spec.Volumes = []v1.Volume{}
+				vmi.Spec.Domain.Features.Hyperv.Reenlightenment = &v1.FeatureState{Enabled: pointer.Bool(true)}
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				expectTopologyHintsToBeSet(vmi)
+			})
+
+		})
+
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of this PR: https://github.com/kubevirt/kubevirt/pull/8201.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Bug-fix]: Windows VM with WSL2 guest fails to migrate
```
