### PR TITLE
Separate vm commands into single files

### DIFF
--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "add_volume.go",
         "expand.go",
+        "fs_list.go",
         "migrate.go",
         "migrate_cancel.go",
         "remove_volume.go",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "add_volume.go",
+        "common.go",
         "expand.go",
         "fs_list.go",
         "guestosinfo.go",
@@ -14,7 +15,6 @@ go_library(
         "start.go",
         "stop.go",
         "user_list.go",
-        "vm.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/vm",
     visibility = ["//visibility:public"],

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["vm.go"],
+    srcs = [
+        "expand.go",
+        "vm.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/vm",
     visibility = ["//visibility:public"],
     deps = [
@@ -12,6 +15,7 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "expand.go",
+        "migrate.go",
         "start.go",
         "vm.go",
     ],

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "restart.go",
         "start.go",
         "stop.go",
+        "user_list.go",
         "vm.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/vm",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "add_volume.go",
         "expand.go",
         "migrate.go",
         "migrate_cancel.go",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "expand.go",
         "migrate.go",
         "start.go",
+        "stop.go",
         "vm.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/vm",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "add_volume.go",
         "expand.go",
         "fs_list.go",
+        "guestosinfo.go",
         "migrate.go",
         "migrate_cancel.go",
         "remove_volume.go",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "expand.go",
         "migrate.go",
+        "migrate_cancel.go",
         "remove_volume.go",
         "restart.go",
         "start.go",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "expand.go",
         "migrate.go",
+        "remove_volume.go",
         "restart.go",
         "start.go",
         "stop.go",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "expand.go",
         "migrate.go",
+        "restart.go",
         "start.go",
         "stop.go",
         "vm.go",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "expand.go",
+        "start.go",
         "vm.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/vm",

--- a/pkg/virtctl/vm/add_volume.go
+++ b/pkg/virtctl/vm/add_volume.go
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const (
+	COMMAND_ADDVOLUME = "addvolume"
+	serialArg         = "serial"
+	cacheArg          = "cache"
+)
+
+var (
+	serial string
+	cache  string
+)
+
+func NewAddVolumeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "addvolume VMI",
+		Short:   "add a volume to a running VM",
+		Example: usageAddVolume(),
+		Args:    templates.ExactArgs("addvolume", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_ADDVOLUME, clientConfig: clientConfig}
+			return c.addVolumeRun(args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	cmd.Flags().StringVar(&volumeName, volumeNameArg, "", "name used in volumes section of spec")
+	cmd.MarkFlagRequired(volumeNameArg)
+	cmd.Flags().StringVar(&serial, serialArg, "", "serial number you want to assign to the disk")
+	cmd.Flags().StringVar(&cache, cacheArg, "", "caching options attribute control the cache mechanism")
+	cmd.Flags().BoolVar(&persist, persistArg, false, "if set, the added volume will be persisted in the VM spec (if it exists)")
+	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
+
+	return cmd
+}
+
+func usageAddVolume() string {
+	return `  #Dynamically attach a volume to a running VM.
+  {{ProgramName}} addvolume fedora-dv --volume-name=example-dv
+
+  #Dynamically attach a volume to a running VM giving it a serial number to identify the volume inside the guest.
+  {{ProgramName}} addvolume fedora-dv --volume-name=example-dv --serial=1234567890
+
+  #Dynamically attach a volume to a running VM and persisting it in the VM spec. At next VM restart the volume will be attached like any other volume.
+  {{ProgramName}} addvolume fedora-dv --volume-name=example-dv --persist
+
+  #Dynamically attach a volume with 'none' cache attribute to a running VM.
+  {{ProgramName}} addvolume fedora-dv --volume-name=example-dv --cache=none
+  `
+}
+
+func (o *Command) addVolumeRun(args []string) error {
+	var dryRunOption []string
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		dryRunOption = []string{metav1.DryRunAll}
+		fmt.Printf("Dry Run execution\n")
+	}
+
+	return addVolume(args[0], volumeName, namespace, virtClient, &dryRunOption)
+}
+
+func getVolumeSourceFromVolume(volumeName, namespace string, virtClient kubecli.KubevirtClient) (*v1.HotplugVolumeSource, error) {
+	//Check if data volume exists.
+	_, err := virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.TODO(), volumeName, metav1.GetOptions{})
+	if err == nil {
+		return &v1.HotplugVolumeSource{
+			DataVolume: &v1.DataVolumeSource{
+				Name:         volumeName,
+				Hotpluggable: true,
+			},
+		}, nil
+	}
+	// DataVolume not found, try PVC
+	_, err = virtClient.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), volumeName, metav1.GetOptions{})
+	if err == nil {
+		return &v1.HotplugVolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+					ClaimName: volumeName,
+				},
+				Hotpluggable: true,
+			},
+		}, nil
+	}
+	// Neither return error
+	return nil, fmt.Errorf("Volume %s is not a DataVolume or PersistentVolumeClaim", volumeName)
+}
+
+func addVolume(vmiName, volumeName, namespace string, virtClient kubecli.KubevirtClient, dryRunOption *[]string) error {
+	volumeSource, err := getVolumeSourceFromVolume(volumeName, namespace, virtClient)
+	if err != nil {
+		return fmt.Errorf("error adding volume, %v", err)
+	}
+	hotplugRequest := &v1.AddVolumeOptions{
+		Name: volumeName,
+		Disk: &v1.Disk{
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Bus: "scsi",
+				},
+			},
+		},
+		VolumeSource: volumeSource,
+		DryRun:       *dryRunOption,
+	}
+	if serial != "" {
+		hotplugRequest.Disk.Serial = serial
+	} else {
+		hotplugRequest.Disk.Serial = volumeName
+	}
+	if cache != "" {
+		hotplugRequest.Disk.Cache = v1.DriverCache(cache)
+		// Verify if cache mode is valid
+		if hotplugRequest.Disk.Cache != v1.CacheNone &&
+			hotplugRequest.Disk.Cache != v1.CacheWriteThrough &&
+			hotplugRequest.Disk.Cache != v1.CacheWriteBack {
+			return fmt.Errorf("error adding volume, invalid cache value %s", cache)
+		}
+	}
+	if !persist {
+		err = virtClient.VirtualMachineInstance(namespace).AddVolume(context.Background(), vmiName, hotplugRequest)
+	} else {
+		err = virtClient.VirtualMachine(namespace).AddVolume(context.Background(), vmiName, hotplugRequest)
+	}
+	if err != nil {
+		return fmt.Errorf("error adding volume, %v", err)
+	}
+	fmt.Printf("Successfully submitted add volume request to VM %s for volume %s\n", vmiName, volumeName)
+	return nil
+}

--- a/pkg/virtctl/vm/expand.go
+++ b/pkg/virtctl/vm/expand.go
@@ -1,0 +1,165 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	yml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const (
+	COMMAND_EXPAND       = "expand"
+	vmArg                = "vm"
+	filePathArg          = "file"
+	filePathArgShort     = "f"
+	outputFormatArg      = "output"
+	outputFormatArgShort = "o"
+)
+
+var (
+	vmName       string
+	filePath     string
+	outputFormat string
+)
+
+func NewExpandCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "expand (VM)",
+		Short:   "Return the VirtualMachine object with expanded instancetype and preference.",
+		Example: usageExpand(),
+		Args:    cobra.MatchAll(cobra.ExactArgs(0), expandArgs()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{clientConfig: clientConfig}
+			return c.expandRun(args, cmd)
+		},
+	}
+	cmd.Flags().StringVar(&vmName, vmArg, "", "Specify VirtualMachine name that should be expanded. Mutually exclusive with \"--file\" flag.")
+	cmd.Flags().StringVarP(&filePath, filePathArg, filePathArgShort, "", "If present, the Virtual Machine spec in provided file will be expanded. Mutually exclusive with \"--vm\" flag.")
+	cmd.Flags().StringVarP(&outputFormat, outputFormatArg, outputFormatArgShort, YAML, "Specify a format that will be used to display output.")
+	cmd.MarkFlagsMutuallyExclusive(filePathArg, vmArg)
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) expandRun(args []string, cmd *cobra.Command) error {
+	var expandedVm *v1.VirtualMachine
+	var err error
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if vmName != "" {
+		expandedVm, err = virtClient.VirtualMachine(namespace).GetWithExpandedSpec(context.Background(), vmName)
+		if err != nil {
+			return fmt.Errorf("error expanding VirtualMachine - %s in namespace - %s: %w", vmName, namespace, err)
+		}
+	} else {
+		vm, err := readVMFromFile(filePath)
+		if err != nil {
+			return err
+		}
+
+		expandedVm, err = virtClient.ExpandSpec(namespace).ForVirtualMachine(vm)
+		if err != nil {
+			return fmt.Errorf("error expanding VirtualMachine - %s in namespace - %s: %w", vm.Name, namespace, err)
+		}
+	}
+
+	output, err := applyOutputFormat(outputFormat, expandedVm)
+	if err != nil {
+		return err
+	}
+
+	cmd.Print(output)
+	return nil
+}
+
+func usageExpand() string {
+	return `  #Expand a virtual machine called 'myvm'.
+  {{ProgramName}} expand --vm myvm
+  
+  # Expand a virtual machine from file called myvm.yaml.
+  {{ProgramName}} expand --file myvm.yaml
+
+  # Expand a virtual machine called myvm and display output in json format.
+  {{ProgramName}} expand --vm myvm --output json
+  `
+}
+
+func expandArgs() cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if filePath == "" && vmName == "" {
+			return fmt.Errorf("error invalid arguments - VirtualMachine name or file must be provided")
+		}
+
+		if outputFormat != YAML && outputFormat != JSON {
+			return fmt.Errorf("error not supported output format defined: %s", outputFormat)
+		}
+
+		return nil
+	}
+}
+
+func readVMFromFile(filePath string) (*v1.VirtualMachine, error) {
+	vm := &v1.VirtualMachine{}
+
+	readFile, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %+w", err)
+	}
+
+	err = yml.NewYAMLOrJSONDecoder(bytes.NewReader(readFile), 1024).Decode(&vm)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding VirtualMachine %+w", err)
+	}
+
+	return vm, nil
+}
+
+func applyOutputFormat(outputFormat string, expandedVm *v1.VirtualMachine) (string, error) {
+	var formatedOutput []byte
+	var err error
+
+	switch outputFormat {
+	case JSON:
+		formatedOutput, err = json.MarshalIndent(expandedVm, "", " ")
+	case YAML:
+		formatedOutput, err = yaml.Marshal(expandedVm)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(formatedOutput), nil
+}

--- a/pkg/virtctl/vm/fs_list.go
+++ b/pkg/virtctl/vm/fs_list.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_FSLIST = "fslist"
+
+func NewFSListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "fslist (VMI)",
+		Short:   "Return full list of filesystems available on the guest machine.",
+		Example: usage(COMMAND_FSLIST),
+		Args:    templates.ExactArgs("fslist", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{clientConfig: clientConfig}
+			return c.fsListRun(args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) fsListRun(args []string) error {
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	fslist, err := virtClient.VirtualMachineInstance(namespace).FilesystemList(context.Background(), vmiName)
+	if err != nil {
+		return fmt.Errorf("Error listing filesystems of VirtualMachineInstance %s, %v", vmiName, err)
+	}
+
+	data, err := json.MarshalIndent(fslist, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Cannot marshal filesystem list %v", err)
+	}
+
+	fmt.Printf("%s\n", string(data))
+	return nil
+}

--- a/pkg/virtctl/vm/guestosinfo.go
+++ b/pkg/virtctl/vm/guestosinfo.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_GUESTOSINFO = "guestosinfo"
+
+func NewGuestOsInfoCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "guestosinfo (VMI)",
+		Short:   "Return guest agent info about operating system.",
+		Example: usage(COMMAND_GUESTOSINFO),
+		Args:    templates.ExactArgs("guestosinfo", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{clientConfig: clientConfig}
+			return c.guestOsInfoRun(args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) guestOsInfoRun(args []string) error {
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	guestosinfo, err := virtClient.VirtualMachineInstance(namespace).GuestOsInfo(context.Background(), vmiName)
+	if err != nil {
+		return fmt.Errorf("Error getting guestosinfo of VirtualMachineInstance %s, %v", vmiName, err)
+	}
+
+	data, err := json.MarshalIndent(guestosinfo, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Cannot marshal guestosinfo %v", err)
+	}
+
+	fmt.Printf("%s\n", string(data))
+	return nil
+}

--- a/pkg/virtctl/vm/migrate.go
+++ b/pkg/virtctl/vm/migrate.go
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_MIGRATE = "migrate"
+
+func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "migrate (VM)",
+		Short:   "Migrate a virtual machine.",
+		Example: usage(COMMAND_MIGRATE),
+		Args:    templates.ExactArgs("migrate", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_MIGRATE, clientConfig: clientConfig}
+			return c.migrateRun(args)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) migrateRun(args []string) error {
+	var dryRunOption []string
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		dryRunOption = []string{metav1.DryRunAll}
+		fmt.Printf("Dry Run execution\n")
+	}
+
+	err = virtClient.VirtualMachine(namespace).Migrate(context.Background(), vmiName, &v1.MigrateOptions{DryRun: dryRunOption})
+	if err != nil {
+		return fmt.Errorf("Error migrating VirtualMachine %v", err)
+	}
+
+	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
+
+	return nil
+}

--- a/pkg/virtctl/vm/migrate_cancel.go
+++ b/pkg/virtctl/vm/migrate_cancel.go
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_MIGRATE_CANCEL = "migrate-cancel"
+
+func NewMigrateCancelCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "migrate-cancel (VM)",
+		Short:   "Cancel migration of a virtual machine.",
+		Example: usage(COMMAND_MIGRATE_CANCEL),
+		Args:    templates.ExactArgs("migrate-cancel", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_MIGRATE_CANCEL, clientConfig: clientConfig}
+			return c.migrateCancelRun(args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) migrateCancelRun(args []string) error {
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	// get a list of migrations for vmiName (use LabelSelector filter)
+	labelselector := fmt.Sprintf("%s==%s", v1.MigrationSelectorLabel, vmiName)
+	migrations, err := virtClient.VirtualMachineInstanceMigration(namespace).List(&metav1.ListOptions{
+		LabelSelector: labelselector})
+	if err != nil {
+		return fmt.Errorf("Error fetching virtual machine instance migration list  %v", err)
+	}
+
+	// There may be a single active migrations but several completed/failed ones
+	// go over the migrations list and find the active one
+	done := false
+	for _, mig := range migrations.Items {
+		migname := mig.ObjectMeta.Name
+
+		if !mig.IsFinal() {
+			// Cancel the active migration by calling Delete
+			err = virtClient.VirtualMachineInstanceMigration(namespace).Delete(migname, &metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("Error canceling migration %s of a VirtualMachine %s: %v", migname, vmiName, err)
+			}
+			done = true
+			break
+		}
+	}
+
+	if !done {
+		return fmt.Errorf("Found no migration to cancel for %s", vmiName)
+	}
+
+	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
+
+	return nil
+}

--- a/pkg/virtctl/vm/remove_volume.go
+++ b/pkg/virtctl/vm/remove_volume.go
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_REMOVEVOLUME = "removevolume"
+
+func NewRemoveVolumeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "removevolume VMI",
+		Short:   "remove a volume from a running VM",
+		Example: usageRemoveVolume(),
+		Args:    templates.ExactArgs("removevolume", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{clientConfig: clientConfig}
+			return c.removeVolumeRun(args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	cmd.Flags().StringVar(&volumeName, volumeNameArg, "", "name used in volumes section of spec")
+	cmd.MarkFlagRequired(volumeNameArg)
+	cmd.Flags().BoolVar(&persist, persistArg, false, "if set, the added volume will be persisted in the VM spec (if it exists)")
+	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
+	return cmd
+}
+
+func usageRemoveVolume() string {
+	return `  #Remove volume that was dynamically attached to a running VM.
+  {{ProgramName}} removevolume fedora-dv --volume-name=example-dv
+
+  #Remove volume dynamically attached to a running VM and persisting it in the VM spec.
+  {{ProgramName}} removevolume fedora-dv --volume-name=example-dv --persist
+  `
+}
+
+func (o *Command) removeVolumeRun(args []string) error {
+	var err error
+	var dryRunOption []string
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		dryRunOption = []string{metav1.DryRunAll}
+		fmt.Printf("Dry Run execution\n")
+	}
+
+	if !persist {
+		err = virtClient.VirtualMachineInstance(namespace).RemoveVolume(context.Background(), vmiName, &v1.RemoveVolumeOptions{
+			Name:   volumeName,
+			DryRun: dryRunOption,
+		})
+	} else {
+		err = virtClient.VirtualMachine(namespace).RemoveVolume(context.Background(), vmiName, &v1.RemoveVolumeOptions{
+			Name:   volumeName,
+			DryRun: dryRunOption,
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("error removing volume, %v", err)
+	}
+	fmt.Printf("Successfully submitted remove volume request to VM %s for volume %s\n", vmiName, volumeName)
+	return nil
+}

--- a/pkg/virtctl/vm/restart.go
+++ b/pkg/virtctl/vm/restart.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_RESTART = "restart"
+
+func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "restart (VM)",
+		Short:   "Restart a virtual machine.",
+		Example: usage(COMMAND_RESTART),
+		Args:    templates.ExactArgs("restart", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
+			return c.restartRun(args, cmd)
+		},
+	}
+	cmd.Flags().BoolVar(&forceRestart, forceArg, false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
+	cmd.Flags().Int64Var(&gracePeriod, gracePeriodArg, -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) restartRun(args []string, cmd *cobra.Command) error {
+	var dryRunOption []string
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		dryRunOption = []string{metav1.DryRunAll}
+		fmt.Printf("Dry Run execution\n")
+	}
+
+	if cmd.Flags().Changed(gracePeriodArg) && !forceRestart {
+		return fmt.Errorf("Can not set gracePeriod without --force=true")
+	}
+
+	if forceRestart {
+		if cmd.Flags().Changed(gracePeriodArg) {
+			err = virtClient.VirtualMachine(namespace).ForceRestart(context.Background(), vmiName, &v1.RestartOptions{GracePeriodSeconds: &gracePeriod, DryRun: dryRunOption})
+			if err != nil {
+				return fmt.Errorf("Error restarting VirtualMachine, %v", err)
+			}
+		} else if !cmd.Flags().Changed(gracePeriodArg) {
+			return fmt.Errorf("Can not force restart without gracePeriod")
+		}
+	} else {
+		err = virtClient.VirtualMachine(namespace).Restart(context.Background(), vmiName, &v1.RestartOptions{DryRun: dryRunOption})
+		if err != nil {
+			return fmt.Errorf("Error restarting VirtualMachine %v", err)
+		}
+
+	}
+
+	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
+
+	return nil
+}

--- a/pkg/virtctl/vm/start.go
+++ b/pkg/virtctl/vm/start.go
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const (
+	COMMAND_START = "start"
+	pausedArg     = "paused"
+)
+
+var (
+	startPaused bool
+)
+
+func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "start (VM)",
+		Short:   "Start a virtual machine.",
+		Example: usage(COMMAND_START),
+		Args:    templates.ExactArgs("start", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_START, clientConfig: clientConfig}
+			return c.startRun(args)
+		},
+	}
+	cmd.Flags().BoolVar(&startPaused, pausedArg, false, "--paused=false: If set to true, start virtual machine in paused state")
+	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) startRun(args []string) error {
+	var dryRunOption []string
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		dryRunOption = []string{metav1.DryRunAll}
+		fmt.Printf("Dry Run execution\n")
+	}
+
+	err = virtClient.VirtualMachine(namespace).Start(context.Background(), vmiName, &v1.StartOptions{Paused: startPaused, DryRun: dryRunOption})
+	if err != nil {
+		return fmt.Errorf("Error starting VirtualMachine %v", err)
+	}
+
+	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
+
+	return nil
+}

--- a/pkg/virtctl/vm/stop.go
+++ b/pkg/virtctl/vm/stop.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_STOP = "stop"
+
+func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "stop (VM)",
+		Short:   "Stop a virtual machine.",
+		Example: usage(COMMAND_STOP),
+		Args:    templates.ExactArgs("stop", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
+			return c.stopRun(args, cmd)
+		},
+	}
+
+	cmd.Flags().BoolVar(&forceRestart, forceArg, false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
+	cmd.Flags().Int64Var(&gracePeriod, gracePeriodArg, -1, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
+	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) stopRun(args []string, cmd *cobra.Command) error {
+	var dryRunOption []string
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		dryRunOption = []string{metav1.DryRunAll}
+		fmt.Printf("Dry Run execution\n")
+	}
+
+	if cmd.Flags().Changed(gracePeriodArg) && forceRestart == false {
+		return fmt.Errorf("Can not set gracePeriod without --force=true")
+	}
+
+	if forceRestart {
+		if cmd.Flags().Changed(gracePeriodArg) {
+			err = virtClient.VirtualMachine(namespace).ForceStop(context.Background(), vmiName, &v1.StopOptions{GracePeriod: &gracePeriod, DryRun: dryRunOption})
+			if err != nil {
+				return fmt.Errorf("Error force stopping VirtualMachine, %v", err)
+			}
+		} else if !cmd.Flags().Changed(gracePeriodArg) {
+			return fmt.Errorf("Can not force stop without gracePeriod")
+		}
+	} else {
+		err = virtClient.VirtualMachine(namespace).Stop(context.Background(), vmiName, &v1.StopOptions{DryRun: dryRunOption})
+		if err != nil {
+			return fmt.Errorf("Error stopping VirtualMachine %v", err)
+		}
+	}
+
+	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
+
+	return nil
+}

--- a/pkg/virtctl/vm/user_list.go
+++ b/pkg/virtctl/vm/user_list.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+const COMMAND_USERLIST = "userlist"
+
+func NewUserListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "userlist (VMI)",
+		Short:   "Return full list of logged in users on the guest machine.",
+		Example: usage(COMMAND_USERLIST),
+		Args:    templates.ExactArgs("userlist", 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{clientConfig: clientConfig}
+			return c.userListRun(args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func (o *Command) userListRun(args []string) error {
+	vmiName := args[0]
+
+	virtClient, namespace, err := GetNamespaceAndClient(o.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	userlist, err := virtClient.VirtualMachineInstance(namespace).UserList(context.Background(), vmiName)
+	if err != nil {
+		return fmt.Errorf("Error listing users of VirtualMachineInstance %s, %v", vmiName, err)
+	}
+
+	data, err := json.MarshalIndent(userlist, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Cannot marshal userlist %v", err)
+	}
+
+	fmt.Printf("%s\n", string(data))
+	return nil
+}

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -38,7 +38,6 @@ import (
 const (
 	COMMAND_GUESTOSINFO = "guestosinfo"
 	COMMAND_USERLIST    = "userlist"
-	COMMAND_FSLIST      = "fslist"
 
 	volumeNameArg         = "volume-name"
 	notDefinedGracePeriod = -1
@@ -85,21 +84,6 @@ func NewUserListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Args:    templates.ExactArgs("userlist", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_USERLIST, clientConfig: clientConfig}
-			return c.Run(args)
-		},
-	}
-	cmd.SetUsageTemplate(templates.UsageTemplate())
-	return cmd
-}
-
-func NewFSListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "fslist (VMI)",
-		Short:   "Return full list of filesystems available on the guest machine.",
-		Example: usage(COMMAND_FSLIST),
-		Args:    templates.ExactArgs("fslist", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Command{command: COMMAND_FSLIST, clientConfig: clientConfig}
 			return c.Run(args)
 		},
 	}
@@ -178,19 +162,6 @@ func (o *Command) Run(args []string) error {
 		data, err := json.MarshalIndent(userlist, "", "  ")
 		if err != nil {
 			return fmt.Errorf("Cannot marshal userlist %v", err)
-		}
-
-		fmt.Printf("%s\n", string(data))
-		return nil
-	case COMMAND_FSLIST:
-		fslist, err := virtClient.VirtualMachineInstance(namespace).FilesystemList(context.Background(), vmiName)
-		if err != nil {
-			return fmt.Errorf("Error listing filesystems of VirtualMachineInstance %s, %v", vmiName, err)
-		}
-
-		data, err := json.MarshalIndent(fslist, "", "  ")
-		if err != nil {
-			return fmt.Errorf("Cannot marshal filesystem list %v", err)
 		}
 
 		fmt.Printf("%s\n", string(data))

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	COMMAND_START          = "start"
 	COMMAND_STOP           = "stop"
 	COMMAND_RESTART        = "restart"
 	COMMAND_MIGRATE        = "migrate"
@@ -54,7 +53,6 @@ const (
 	dryRunCommandUsage    = "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes."
 
 	dryRunArg      = "dry-run"
-	pausedArg      = "paused"
 	forceArg       = "force"
 	gracePeriodArg = "grace-period"
 	serialArg      = "serial"
@@ -72,27 +70,9 @@ var (
 	volumeName   string
 	serial       string
 	persist      bool
-	startPaused  bool
 	dryRun       bool
 	cache        string
 )
-
-func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "start (VM)",
-		Short:   "Start a virtual machine.",
-		Example: usage(COMMAND_START),
-		Args:    templates.ExactArgs("start", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Command{command: COMMAND_START, clientConfig: clientConfig}
-			return c.Run(args)
-		},
-	}
-	cmd.Flags().BoolVar(&startPaused, pausedArg, false, "--paused=false: If set to true, start virtual machine in paused state")
-	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
-	cmd.SetUsageTemplate(templates.UsageTemplate())
-	return cmd
-}
 
 func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
@@ -411,11 +391,6 @@ func (o *Command) Run(args []string) error {
 		fmt.Printf("Dry Run execution\n")
 	}
 	switch o.command {
-	case COMMAND_START:
-		err = virtClient.VirtualMachine(namespace).Start(context.Background(), vmiName, &v1.StartOptions{Paused: startPaused, DryRun: dryRunOption})
-		if err != nil {
-			return fmt.Errorf("Error starting VirtualMachine %v", err)
-		}
 	case COMMAND_STOP:
 		if gracePeriodIsSet(gracePeriod) && forceRestart == false {
 			return fmt.Errorf("Can not set gracePeriod without --force=true")

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	COMMAND_GUESTOSINFO = "guestosinfo"
-	COMMAND_USERLIST    = "userlist"
+	COMMAND_USERLIST = "userlist"
 
 	volumeNameArg         = "volume-name"
 	notDefinedGracePeriod = -1
@@ -60,21 +59,6 @@ var (
 	persist      bool
 	dryRun       bool
 )
-
-func NewGuestOsInfoCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "guestosinfo (VMI)",
-		Short:   "Return guest agent info about operating system.",
-		Example: usage(COMMAND_GUESTOSINFO),
-		Args:    templates.ExactArgs("guestosinfo", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Command{command: COMMAND_GUESTOSINFO, clientConfig: clientConfig}
-			return c.Run(args)
-		},
-	}
-	cmd.SetUsageTemplate(templates.UsageTemplate())
-	return cmd
-}
 
 func NewUserListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
@@ -140,19 +124,6 @@ func (o *Command) Run(args []string) error {
 		fmt.Printf("Dry Run execution\n")
 	}
 	switch o.command {
-	case COMMAND_GUESTOSINFO:
-		guestosinfo, err := virtClient.VirtualMachineInstance(namespace).GuestOsInfo(context.Background(), vmiName)
-		if err != nil {
-			return fmt.Errorf("Error getting guestosinfo of VirtualMachineInstance %s, %v", vmiName, err)
-		}
-
-		data, err := json.MarshalIndent(guestosinfo, "", "  ")
-		if err != nil {
-			return fmt.Errorf("Cannot marshal guestosinfo %v", err)
-		}
-
-		fmt.Printf("%s\n", string(data))
-		return nil
 	case COMMAND_USERLIST:
 		userlist, err := virtClient.VirtualMachineInstance(namespace).UserList(context.Background(), vmiName)
 		if err != nil {

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -20,8 +20,6 @@
 package vm
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -31,13 +29,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"kubevirt.io/client-go/kubecli"
-
-	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
 const (
-	COMMAND_USERLIST = "userlist"
-
 	volumeNameArg         = "volume-name"
 	notDefinedGracePeriod = -1
 	dryRunCommandUsage    = "--dry-run=false: Flag used to set whether to perform a dry run or not. If true the command will be executed without performing any changes."
@@ -59,21 +53,6 @@ var (
 	persist      bool
 	dryRun       bool
 )
-
-func NewUserListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "userlist (VMI)",
-		Short:   "Return full list of logged in users on the guest machine.",
-		Example: usage(COMMAND_USERLIST),
-		Args:    templates.ExactArgs("userlist", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Command{command: COMMAND_USERLIST, clientConfig: clientConfig}
-			return c.Run(args)
-		},
-	}
-	cmd.SetUsageTemplate(templates.UsageTemplate())
-	return cmd
-}
 
 type Command struct {
 	clientConfig clientcmd.ClientConfig
@@ -122,21 +101,6 @@ func (o *Command) Run(args []string) error {
 	dryRunOption := getDryRunOption(dryRun)
 	if len(dryRunOption) > 0 && dryRunOption[0] == metav1.DryRunAll {
 		fmt.Printf("Dry Run execution\n")
-	}
-	switch o.command {
-	case COMMAND_USERLIST:
-		userlist, err := virtClient.VirtualMachineInstance(namespace).UserList(context.Background(), vmiName)
-		if err != nil {
-			return fmt.Errorf("Error listing users of VirtualMachineInstance %s, %v", vmiName, err)
-		}
-
-		data, err := json.MarshalIndent(userlist, "", "  ")
-		if err != nil {
-			return fmt.Errorf("Cannot marshal userlist %v", err)
-		}
-
-		fmt.Printf("%s\n", string(data))
-		return nil
 	}
 
 	fmt.Printf("VM %s was scheduled to %s\n", vmiName, o.command)

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -40,7 +40,6 @@ import (
 const (
 	COMMAND_STOP           = "stop"
 	COMMAND_RESTART        = "restart"
-	COMMAND_MIGRATE        = "migrate"
 	COMMAND_MIGRATE_CANCEL = "migrate-cancel"
 	COMMAND_GUESTOSINFO    = "guestosinfo"
 	COMMAND_USERLIST       = "userlist"
@@ -106,22 +105,6 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&forceRestart, forceArg, false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
 	cmd.Flags().Int64Var(&gracePeriod, gracePeriodArg, notDefinedGracePeriod, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
-	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
-	cmd.SetUsageTemplate(templates.UsageTemplate())
-	return cmd
-}
-
-func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "migrate (VM)",
-		Short:   "Migrate a virtual machine.",
-		Example: usage(COMMAND_MIGRATE),
-		Args:    templates.ExactArgs("migrate", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Command{command: COMMAND_MIGRATE, clientConfig: clientConfig}
-			return c.Run(args)
-		},
-	}
 	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
@@ -428,11 +411,6 @@ func (o *Command) Run(args []string) error {
 		err = virtClient.VirtualMachine(namespace).Restart(context.Background(), vmiName, &v1.RestartOptions{DryRun: dryRunOption})
 		if err != nil {
 			return fmt.Errorf("Error restarting VirtualMachine %v", err)
-		}
-	case COMMAND_MIGRATE:
-		err = virtClient.VirtualMachine(namespace).Migrate(context.Background(), vmiName, &v1.MigrateOptions{DryRun: dryRunOption})
-		if err != nil {
-			return fmt.Errorf("Error migrating VirtualMachine %v", err)
 		}
 	case COMMAND_MIGRATE_CANCEL:
 		// get a list of migrations for vmiName (use LabelSelector filter)

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	COMMAND_RESTART        = "restart"
 	COMMAND_MIGRATE_CANCEL = "migrate-cancel"
 	COMMAND_GUESTOSINFO    = "guestosinfo"
 	COMMAND_USERLIST       = "userlist"
@@ -71,24 +70,6 @@ var (
 	dryRun       bool
 	cache        string
 )
-
-func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "restart (VM)",
-		Short:   "Restart a virtual machine.",
-		Example: usage(COMMAND_RESTART),
-		Args:    templates.ExactArgs("restart", 1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
-			return c.Run(args)
-		},
-	}
-	cmd.Flags().BoolVar(&forceRestart, forceArg, false, "--force=false: Only used when grace-period=0. If true, immediately remove VMI pod from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
-	cmd.Flags().Int64Var(&gracePeriod, gracePeriodArg, notDefinedGracePeriod, "--grace-period=-1: Period of time in seconds given to the VMI to terminate gracefully. Can only be set to 0 when --force is true (force deletion). Currently only setting 0 is supported.")
-	cmd.Flags().BoolVar(&dryRun, dryRunArg, false, dryRunCommandUsage)
-	cmd.SetUsageTemplate(templates.UsageTemplate())
-	return cmd
-}
 
 func NewMigrateCancelCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
@@ -354,25 +335,6 @@ func (o *Command) Run(args []string) error {
 		fmt.Printf("Dry Run execution\n")
 	}
 	switch o.command {
-	case COMMAND_RESTART:
-		if gracePeriod != notDefinedGracePeriod && forceRestart == false {
-			return fmt.Errorf("Can not set gracePeriod without --force=true")
-		}
-		if forceRestart {
-			if gracePeriod != notDefinedGracePeriod {
-				err = virtClient.VirtualMachine(namespace).ForceRestart(context.Background(), vmiName, &v1.RestartOptions{GracePeriodSeconds: &gracePeriod, DryRun: dryRunOption})
-				if err != nil {
-					return fmt.Errorf("Error restarting VirtualMachine, %v", err)
-				}
-			} else if gracePeriod == notDefinedGracePeriod {
-				return fmt.Errorf("Can not force restart without gracePeriod")
-			}
-			break
-		}
-		err = virtClient.VirtualMachine(namespace).Restart(context.Background(), vmiName, &v1.RestartOptions{DryRun: dryRunOption})
-		if err != nil {
-			return fmt.Errorf("Error restarting VirtualMachine %v", err)
-		}
 	case COMMAND_MIGRATE_CANCEL:
 		// get a list of migrations for vmiName (use LabelSelector filter)
 		labelselector := fmt.Sprintf("%s==%s", v1.MigrationSelectorLabel, vmiName)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR separates VirtualMachine related commands from one single file `vm.go` into it's own file. It should break the complexity of a original `vm.go` file.

**Release note**:
```None

```

Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>