### PR TITLE
Tests: Fix seccomp on psa enabled clusters

### DIFF
--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/selection:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"k8s.io/utils/pointer"
@@ -3035,7 +3036,39 @@ spec:
 
 				By("Checking launcher seccomp policy")
 				vmi := libvmi.NewCirros()
-				vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
+				vmi = tests.RunVMI(vmi, 60)
+				fetchVMI := matcher.ThisVMI(vmi)
+				psaRelatedErrorDetected := false
+				err := wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
+					vmi, err := fetchVMI()
+					if err != nil {
+						return done, err
+					}
+
+					if vmi.Status.Phase != v1.Pending {
+						return true, nil
+					}
+
+					for _, condition := range vmi.Status.Conditions {
+						if condition.Type == v1.VirtualMachineInstanceSynchronized {
+							if condition.Status == k8sv1.ConditionFalse && strings.Contains(condition.Reason, "needs a privileged namespace") {
+								psaRelatedErrorDetected = true
+								return true, nil
+							}
+						}
+					}
+					return
+				})
+				Expect(err).NotTo(HaveOccurred())
+				// In case we are running on PSA cluster, the case were we don't specify seccomp will violate the policy.
+				// Therefore the VMIs Pod will fail to be created and we can't check its configuration.
+				// In that case the loop above needs to see that VMI contains PSA related error.
+				// This is enough and we declare this test as passed.
+				if psaRelatedErrorDetected && virtualMachineProfile == nil {
+					return
+				}
+				Eventually(matcher.ThisVMI(vmi)).Should(BeInPhase(v1.Scheduled))
+
 				pod, err := libvmi.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 				var podProfile *k8sv1.SeccompProfile


### PR DESCRIPTION
**What this PR does / why we need it**:
We can't perform a check if Pod was created without Seccomp
profile on clusters where PSA is enabled because the Pod
will be denied.

Therefore we need to verify we at least see PSA related error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
