### PR TITLE
WIP: host-disk: remove SELinux categories during migration

### DIFF
--- a/pkg/host-disk/BUILD.bazel
+++ b/pkg/host-disk/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -45,7 +45,7 @@ func expectMigrationSuccessWithOffset(offset int, virtClient kubecli.KubevirtCli
 		}
 		return fmt.Errorf("migration is in the phase: %s", migration.Status.Phase)
 
-	}, timeout, 1*time.Second).ShouldNot(HaveOccurred(), fmt.Sprintf("migration should succeed after %d s", timeout))
+	}, time.Duration(timeout)*time.Second, 1*time.Second).ShouldNot(HaveOccurred(), fmt.Sprintf("migration should succeed after %d s", timeout))
 	return migration
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrating a VMI with a RWX disk requires both the source and target virt-launchers to have access to the disk.
That is not possible when SELinux categories are used inside the PVC.
This PR removes the categories at the beginning of the migration, then sets them to the correct values at the end of the migration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
WIP, current preferred solution is https://github.com/kubevirt/kubevirt/pull/9246
- Needs finalizeMigration to be called only once the migration has finished
- Needs functional and unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed migration issue for VMIs that have RWX disks backed by filesystem storage classes.
```
