### PR TITLE
set Completed migration result in virt-launcher

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -591,6 +591,7 @@ func (d *VirtualMachineController) setMigrationProgressStatus(vmi *v1.VirtualMac
 		vmi.Status.MigrationState.EndTimestamp = migrationMetadata.EndTimestamp
 	}
 	vmi.Status.MigrationState.AbortStatus = v1.MigrationAbortStatus(migrationMetadata.AbortStatus)
+
 	vmi.Status.MigrationState.Completed = migrationMetadata.Completed
 	vmi.Status.MigrationState.Failed = migrationMetadata.Failed
 	vmi.Status.MigrationState.Mode = migrationMetadata.Mode
@@ -2517,6 +2518,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.Vir
 			return err
 		}
 
+		log.Log.Object(vmi).Infof("Starting VirtualMachineInstance migration")
 		err = client.MigrateVirtualMachine(vmi, options)
 		if err != nil {
 			return err
@@ -3176,6 +3178,7 @@ func (d *VirtualMachineController) handleMigrationAbort(vmi *v1.VirtualMachineIn
 		return nil
 	}
 
+	log.Log.Object(vmi).Infof("Cancelling VMI migration")
 	err := client.CancelVirtualMachineMigration(vmi)
 	if err != nil && err.Error() == migrations.CancelMigrationFailedVmiNotMigratingErr {
 		// If migration did not even start there is no need to cancel it


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, migration results are being set by the migration monitor.
However, in most cases, the monitor will miss the DOMAIN_JOB_COMPLETED job state
, which quickly switches to DOMAIN_JOB_NONE, and will not set the Complete migration result.

We haven't seen issues yet, since virt-handler will set the Completed status in [1].
However, it does it based on an assumption and not as a direct report from the virt-launcher.

This PR set the migration result immediately when the migration function exists without errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```
