### PR TITLE
virt-handler: Add live-migration bridge pod net annotation

### DIFF
--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -67,6 +67,15 @@ func IsPodNetworkWithMasqueradeBindingInterface(networks []v1.Network, ifaces []
 	return true
 }
 
+func IsPodNetworkWithBridgeBindingInterface(networks []v1.Network, ifaces []v1.Interface) bool {
+	if podNetwork := LookupPodNetwork(networks); podNetwork != nil {
+		if podInterface := LookupInterfaceByNetwork(ifaces, podNetwork); podInterface != nil {
+			return podInterface.Bridge != nil
+		}
+	}
+	return true
+}
+
 func PopInterfaceByNetwork(statusIfaces []v1.VirtualMachineInstanceNetworkInterface, network *v1.Network) (*v1.VirtualMachineInstanceNetworkInterface, []v1.VirtualMachineInstanceNetworkInterface) {
 	if network == nil {
 		return nil, statusIfaces

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2493,7 +2493,28 @@ var _ = Describe("VirtualMachineInstance", func() {
 			conditionManager := virtcontroller.NewVirtualMachineInstanceConditionManager()
 			controller.updateLiveMigrationConditions(vmi, conditionManager)
 
-			testutils.ExpectEvent(recorder, "cannot migrate VMI which does not use masquerade to connect to the pod network")
+			testutils.ExpectEvent(recorder, fmt.Sprintf("cannot migrate VMI which does not use masquerade to connect to the pod network or bridge with %s VM annotation", v1.AllowPodBridgeNetworkLiveMigrationAnnotation))
+		})
+		Context("with AllowLiveMigrationBridgePodNetwork annotation", func() {
+			It("should allow to live-migrate if the VMI use bridge to connect to the pod network", func() {
+				vmi := api2.NewMinimalVMI("testvmi")
+
+				vmi.Annotations = map[string]string{v1.AllowPodBridgeNetworkLiveMigrationAnnotation: ""}
+
+				strategy := v1.EvictionStrategyLiveMigrate
+				vmi.Spec.EvictionStrategy = &strategy
+
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+				vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+
+				conditionManager := virtcontroller.NewVirtualMachineInstanceConditionManager()
+				controller.updateLiveMigrationConditions(vmi, conditionManager)
+				Expect(vmi.Status.Conditions).To(ContainElement(v1.VirtualMachineInstanceCondition{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				}))
+				Expect(vmi.Status.MigrationMethod).To(Equal(v1.LiveMigration))
+			})
 		})
 
 		Context("check that migration is not supported when using Host Devices", func() {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -905,6 +905,10 @@ const (
 	// PVCMemoryDumpAnnotation is the name of the memory dump representing the vm name,
 	// pvc name and the timestamp the memory dump was collected
 	PVCMemoryDumpAnnotation string = "kubevirt.io/memory-dump"
+
+	// AllowPodBridgeNetworkLiveMigrationAnnotation allow to run live migration when the
+	// vm has the pod networking bind with a bridge
+	AllowPodBridgeNetworkLiveMigrationAnnotation string = "kubevirt.io/allow-pod-bridge-network-live-migration"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {


### PR DESCRIPTION
**What this PR does / why we need it**:
At some scenarios like hypershift kubevirt provider the CNI will support        
doing live-migration when the VM net interface is bridged to the pod            
network. This change add a annotation to allow live migration is                
configured so on those scenarios.        

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add annotation for live migration and bridged pod interface
```
