### PR TITLE
tests: Refactor storage skips

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -664,13 +664,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	Context("with inferFromVolume enabled", Ordered, func() {
 
 		var (
-			err                     error
-			vm                      *v1.VirtualMachine
-			instancetype            *instancetypev1alpha2.VirtualMachineInstancetype
-			preference              *instancetypev1alpha2.VirtualMachinePreference
-			sourcePVC               *k8sv1.PersistentVolumeClaim
-			blockStorageClass       string
-			blockStorageClassExists bool
+			err               error
+			vm                *v1.VirtualMachine
+			instancetype      *instancetypev1alpha2.VirtualMachineInstancetype
+			preference        *instancetypev1alpha2.VirtualMachinePreference
+			sourcePVC         *k8sv1.PersistentVolumeClaim
+			blockStorageClass string
 		)
 
 		const (
@@ -717,10 +716,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				Skip("instance type and preference inferFromVolume tests require CDI to be installed providing the DataVolume and DataSource CRDs")
 			}
 
-			blockStorageClass, blockStorageClassExists = libstorage.GetRWOBlockStorageClass()
-			if !blockStorageClassExists {
-				Skip("Skip test when RWOBlock storage class is not present")
-			}
+			blockStorageClass = libstorage.GetRWOBlockStorageClassOrSkip()
 
 			By("Creating a VirtualMachineInstancetype")
 			instancetype = newVirtualMachineInstancetype(nil)

--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -26,7 +26,6 @@ import (
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -160,10 +159,7 @@ func createPVC(pvc *k8sv1.PersistentVolumeClaim, namespace string) *k8sv1.Persis
 }
 
 func CreateFSPVC(name, namespace, size string, labels map[string]string) *k8sv1.PersistentVolumeClaim {
-	sc, exists := GetRWOFileSystemStorageClass()
-	if !exists {
-		Skip("Skip test when RWOFileSystem storage class is not present")
-	}
+	sc := GetRWOFileSystemStorageClassOrSkip()
 	pvc := NewPVC(name, size, sc)
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 	pvc.Spec.VolumeMode = &volumeMode
@@ -179,10 +175,7 @@ func CreateFSPVC(name, namespace, size string, labels map[string]string) *k8sv1.
 }
 
 func CreateBlockPVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
-	sc, exists := GetRWOBlockStorageClass()
-	if !exists {
-		Skip("Skip test when RWOBlock storage class is not present")
-	}
+	sc := GetRWOBlockStorageClassOrSkip()
 	pvc := NewPVC(name, size, sc)
 	volumeMode := k8sv1.PersistentVolumeBlock
 	pvc.Spec.VolumeMode = &volumeMode
@@ -391,10 +384,7 @@ func CreateNFSPvAndPvc(name string, namespace string, size string, nfsTargetIP s
 func newNFSPV(name string, namespace string, size string, nfsTargetIP string, os string) *k8sv1.PersistentVolume {
 	quantity := resource.MustParse(size)
 
-	storageClass, exists := GetRWOFileSystemStorageClass()
-	if !exists {
-		Skip("Skip test when Filesystem storage is not present")
-	}
+	storageClass := GetRWOFileSystemStorageClassOrSkip()
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 
 	nfsTargetIP = ip.NormalizeIPAddress(nfsTargetIP)
@@ -428,10 +418,7 @@ func newNFSPVC(name string, namespace string, size string, os string) *k8sv1.Per
 	quantity, err := resource.ParseQuantity(size)
 	util.PanicOnError(err)
 
-	storageClass, exists := GetRWOFileSystemStorageClass()
-	if !exists {
-		Skip("Skip test when Filesystem storage is not present")
-	}
+	storageClass := GetRWOFileSystemStorageClassOrSkip()
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 
 	return &k8sv1.PersistentVolumeClaim{

--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -21,6 +21,7 @@ package libstorage
 
 import (
 	"context"
+	"fmt"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
@@ -138,9 +139,25 @@ func GetRWXFileSystemStorageClass() (string, bool) {
 	return storageRWXFileSystem, storageRWXFileSystem != ""
 }
 
+func GetRWXFileSystemStorageClassOrSkip() string {
+	sc, exists := GetRWXFileSystemStorageClass()
+	if !exists {
+		Skip("Skip test when RWX Filesystem storage is not present")
+	}
+	return sc
+}
+
 func GetRWOFileSystemStorageClass() (string, bool) {
 	storageRWOFileSystem := Config.StorageRWOFileSystem
 	return storageRWOFileSystem, storageRWOFileSystem != ""
+}
+
+func GetRWOFileSystemStorageClassOrSkip() string {
+	sc, exists := GetRWOFileSystemStorageClass()
+	if !exists {
+		Skip("Skip test when RWO Filesystem storage is not present")
+	}
+	return sc
 }
 
 func GetRWOBlockStorageClass() (string, bool) {
@@ -148,9 +165,25 @@ func GetRWOBlockStorageClass() (string, bool) {
 	return storageRWOBlock, storageRWOBlock != ""
 }
 
+func GetRWOBlockStorageClassOrSkip() string {
+	sc, exists := GetRWOBlockStorageClass()
+	if !exists {
+		Skip("Skip test when RWO Block storage is not present")
+	}
+	return sc
+}
+
 func GetRWXBlockStorageClass() (string, bool) {
 	storageRWXBlock := Config.StorageRWXBlock
 	return storageRWXBlock, storageRWXBlock != ""
+}
+
+func GetRWXBlockStorageClassOrSkip() string {
+	sc, exists := GetRWXBlockStorageClass()
+	if !exists {
+		Skip("Skip test when RWX Block storage is not present")
+	}
+	return sc
 }
 
 func GetBlockStorageClass(accessMode k8sv1.PersistentVolumeAccessMode) (string, bool) {
@@ -160,6 +193,14 @@ func GetBlockStorageClass(accessMode k8sv1.PersistentVolumeAccessMode) (string, 
 	}
 
 	return sc, foundSC
+}
+
+func GetBlockStorageClassOrSkip(accessMode k8sv1.PersistentVolumeAccessMode) string {
+	sc, exists := GetBlockStorageClass(accessMode)
+	if !exists {
+		Skip(fmt.Sprintf("Skip test when %s Block storage is not present", accessMode))
+	}
+	return sc
 }
 
 // GetNoVolumeSnapshotStorageClass goes over all the existing storage classes

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1444,10 +1444,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
-				sc, foundSC := libstorage.GetRWOFileSystemStorageClass()
-				if !foundSC {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
@@ -1662,11 +1659,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			BeforeEach(func() {
-				var foundSC bool
-				storageClass, foundSC = libstorage.GetRWXFileSystemStorageClass()
-				if !foundSC {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				storageClass = libstorage.GetRWXFileSystemStorageClassOrSkip()
 			})
 
 			AfterEach(func() {
@@ -1704,10 +1697,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 		createDataVolumePVCAndChangeDiskImgPermissions := func(namespace, size string) *cdiv1.DataVolume {
 			// Create DV and alter permission of disk.img
-			sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
-			if !foundSC {
-				Skip("Skip test when Filesystem storage is not present")
-			}
+			sc := libstorage.GetRWXFileSystemStorageClassOrSkip()
 
 			dv := libdv.NewDataVolume(
 				libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
@@ -2106,10 +2096,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var dv *cdiv1.DataVolume
 
 			BeforeEach(func() {
-				sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
-				if !foundSC {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWXFileSystemStorageClassOrSkip()
 
 				By("Allowing post-copy and limit migration bandwidth")
 				config := getCurrentKv()
@@ -2611,10 +2598,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 
-				sc, foundSC := libstorage.GetBlockStorageClass(k8sv1.ReadWriteMany)
-				if !foundSC {
-					Skip("Skip test when Block storage is not present")
-				}
+				sc := libstorage.GetBlockStorageClassOrSkip(k8sv1.ReadWriteMany)
 
 				dv := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling), cdiv1.RegistryPullNode),

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -100,17 +100,10 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Skip("Skip DataVolume tests when CDI is not present")
 			}
 			var sc string
-			exists := false
 			if volumeMode == k8sv1.PersistentVolumeBlock {
-				sc, exists = libstorage.GetRWOBlockStorageClass()
-				if !exists {
-					Skip("Skip test when Block storage is not present")
-				}
+				sc = libstorage.GetRWOBlockStorageClassOrSkip()
 			} else {
-				sc, exists = libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc = libstorage.GetRWOFileSystemStorageClassOrSkip()
 			}
 			volumeExpansionAllowed := volumeExpansionAllowed(sc)
 			if !volumeExpansionAllowed {
@@ -171,10 +164,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			It("should succesfully start", func() {
 				// Create DV and alter permission of disk.img
-				sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
-				if !foundSC {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWXFileSystemStorageClassOrSkip()
 
 				dv := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
@@ -229,10 +219,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			})
 
 			It("[test_id:3189]should be successfully started and stopped multiple times", func() {
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
@@ -268,10 +255,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 
 			It("[test_id:6686]should successfully start multiple concurrent VMIs", func() {
 
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				imageUrl := cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)
 
@@ -308,10 +292,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			})
 
 			It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", func() {
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
@@ -442,10 +423,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with an invalid DataVolume", func() {
 		Context("using DataVolume with invalid URL", func() {
 			It("should be possible to stop VM if datavolume is crashing", func() {
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(InvalidDataVolumeUrl, cdiv1.RegistryPullPod),
@@ -491,10 +469,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 				Eventually(ThisVMIWith(vm.Namespace, vm.Name), 100).Should(BeInPhase(v1.Pending))
 			})
 			It("[test_id:3190]should correctly handle eventually consistent DataVolumes", func() {
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				realRegistryName := flags.KubeVirtUtilityRepoPrefix
 				realRegistryPort := ""
@@ -755,11 +730,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			var vm *v1.VirtualMachine
 
 			BeforeEach(func() {
-				var exists bool
-				storageClass, exists = libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when RWOFileSystem storage class is not present")
-				}
+				storageClass = libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 				dataVolume = libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
@@ -1048,10 +1019,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			return dv
 		}
 		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
-			sc, exists := libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
-			}
+			sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 
 			dataVolume := libdv.NewDataVolume(
 				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskFedoraTestTooling)),

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -538,17 +538,14 @@ var _ = SIGDescribe("Export", func() {
 
 	type populateFunction func(string, k8sv1.PersistentVolumeMode) (*k8sv1.PersistentVolumeClaim, string)
 	type verifyFunction func(string, string, *k8sv1.Pod, k8sv1.PersistentVolumeMode)
-	type storageClassFunction func() (string, bool)
+	type storageClassFunction func() string
 	type caBundleGenerator func(string, string, *exportv1.VirtualMachineExport) *k8sv1.ConfigMap
 	type urlGenerator func(exportv1.ExportVolumeFormat, string, string, string, *exportv1.VirtualMachineExport) (string, string)
 
 	DescribeTable("should make a PVC export available", func(populateFunction populateFunction, verifyFunction verifyFunction,
 		storageClassFunction storageClassFunction, caBundleGenerator caBundleGenerator, urlGenerator urlGenerator,
 		expectedFormat exportv1.ExportVolumeFormat, urlTemplate string, volumeMode k8sv1.PersistentVolumeMode) {
-		sc, exists := storageClassFunction()
-		if !exists {
-			Skip("Skip test when right storage is not present")
-		}
+		sc := storageClassFunction()
 		pvc, comparison := populateFunction(sc, volumeMode)
 		By("Creating the export token, we can export volumes using this token")
 		// For testing the token is the name of the source pvc.
@@ -620,17 +617,17 @@ var _ = SIGDescribe("Export", func() {
 		verifyFunction(fileName, comparison, downloadPod, volumeMode)
 	},
 		// "internal" tests
-		Entry("with RAW kubevirt content type", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with RAW gzipped kubevirt content type", populateKubeVirtContent, verifyKubeVirtGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with archive content type", populateArchiveContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.Dir, archiveDircontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with archive tarred gzipped content type", populateArchiveContent, verifyArchiveGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.ArchiveGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with RAW kubevirt content type block", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClass, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
+		Entry("with RAW kubevirt content type", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with RAW gzipped kubevirt content type", populateKubeVirtContent, verifyKubeVirtGzContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with archive content type", populateArchiveContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapInternal, urlGeneratorInternal, exportv1.Dir, archiveDircontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with archive tarred gzipped content type", populateArchiveContent, verifyArchiveGzContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapInternal, urlGeneratorInternal, exportv1.ArchiveGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with RAW kubevirt content type block", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClassOrSkip, createCaConfigMapInternal, urlGeneratorInternal, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
 		// "proxy" tests
-		Entry("with RAW kubevirt content type PROXY", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with RAW gzipped kubevirt content type PROXY", populateKubeVirtContent, verifyKubeVirtGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with archive content type PROXY", populateArchiveContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.Dir, archiveDircontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with archive tarred gzipped content type PROXY", populateArchiveContent, verifyArchiveGzContent, libstorage.GetRWOFileSystemStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.ArchiveGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
-		Entry("with RAW kubevirt content type block PROXY", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClass, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
+		Entry("with RAW kubevirt content type PROXY", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with RAW gzipped kubevirt content type PROXY", populateKubeVirtContent, verifyKubeVirtGzContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with archive content type PROXY", populateArchiveContent, verifyKubeVirtRawContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapProxy, urlGeneratorProxy, exportv1.Dir, archiveDircontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with archive tarred gzipped content type PROXY", populateArchiveContent, verifyArchiveGzContent, libstorage.GetRWOFileSystemStorageClassOrSkip, createCaConfigMapProxy, urlGeneratorProxy, exportv1.ArchiveGz, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeFilesystem),
+		Entry("with RAW kubevirt content type block PROXY", populateKubeVirtContent, verifyKubeVirtRawContent, libstorage.GetRWOBlockStorageClassOrSkip, createCaConfigMapProxy, urlGeneratorProxy, exportv1.KubeVirtRaw, kubevirtcontentUrlTemplate, k8sv1.PersistentVolumeBlock),
 	)
 
 	createPVCExportObject := func(name, namespace string, token *k8sv1.Secret) *exportv1.VirtualMachineExport {
@@ -752,10 +749,7 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	It("Should recreate the exporter pod and secret if the pod fails", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
 		By("looking up the exporter pod and secret name")
@@ -797,10 +791,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("Should recreate the exporter pod if the pod is deleted", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
 		By("looking up the exporter pod and secret name")
@@ -816,10 +807,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("Should recreate the service if the service is deleted", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
 		By("looking up the exporter pod and secret name")
@@ -835,10 +823,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("Should handle no pvc existing when export created, then creating and populating the pvc", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		dv := libdv.NewDataVolume(
 			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros), cdiv1.RegistryPullNode),
 			libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
@@ -881,10 +866,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("should be possibe to observe exportserver pod exiting", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 		checkExportSecretRef(vmExport)
 		By("looking up the exporter pod")
@@ -918,11 +900,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("Should handle populating an export without a previously defined tokenSecretRef", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
-
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
 		export := createPVCExportObjectWithoutSecret(pvc.Name, pvc.Namespace)
 		By("Making sure the export becomes ready")
@@ -940,11 +918,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("Should honor TTL by cleaning up the the VMExport altogether", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
-
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		pvc, _ := populateKubeVirtContent(sc, k8sv1.PersistentVolumeFilesystem)
 		ttl := &metav1.Duration{Duration: 2 * time.Minute}
 		export := &exportv1.VirtualMachineExport{
@@ -1095,10 +1069,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		It("should populate external links and cert and contain ingress host", func() {
-			sc, exists := libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
-			}
+			sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 			testCert, err := createIngressTLSSecret(tlsSecretName)
 			Expect(err).NotTo(HaveOccurred())
 			ingress := createIngress(tlsSecretName)
@@ -1129,10 +1100,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		It("should populate external links and cert and contain route host", func() {
-			sc, exists := libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
-			}
+			sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 			if !checks.IsOpenShift() {
 				Skip("Not on openshift")
 			}
@@ -1474,10 +1442,7 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	It("should report export pending if VM is running, and start the VM export if the VM is not running, then stop again once VM started", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(
 			cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
 			testsuite.GetTestNamespace(nil),
@@ -1515,10 +1480,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("should report export pending if PVC is in use because of VMI using it, and start the VM export if the PVC is not in use, then stop again once pvc in use again", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		dataVolume := libdv.NewDataVolume(
 			libdv.WithNamespace(testsuite.GetTestNamespace(nil)),
 			libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
@@ -1707,10 +1669,7 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	It("should generate updated DataVolumeTemplates on http endpoint when exporting", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), util.NamespaceTestDefault, sc, k8sv1.ReadWriteOnce)
 		vm.Spec.Running = pointer.BoolPtr(true)
 		vm = createVM(vm)
@@ -1769,10 +1728,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("Should generate DVs and expanded VM definition on http endpoint with multiple volumes", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		clusterInstancetype := &instancetypev1alpha2.VirtualMachineClusterInstancetype{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "VirtualMachineClusterInstancetype",
@@ -1922,10 +1878,7 @@ var _ = SIGDescribe("Export", func() {
 	})
 
 	It("should mark the status phase skipped on VM without volumes", func() {
-		sc, exists := libstorage.GetRWOFileSystemStorageClass()
-		if !exists {
-			Skip("Skip test when Filesystem storage is not present")
-		}
+		sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 		vm := tests.NewRandomVMWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 		vm = createVM(vm)
 		// For testing the token is the name of the source VM.
@@ -1998,10 +1951,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		It("should recreate exportserver pod when KubeVirt cert params updated", func() {
-			sc, exists := libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
-			}
+			sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 			vmExport := createRunningPVCExport(sc, k8sv1.PersistentVolumeFilesystem)
 			checkExportSecretRef(vmExport)
 			By("looking up the exporter pod")
@@ -2046,11 +1996,7 @@ var _ = SIGDescribe("Export", func() {
 		}
 
 		BeforeEach(func() {
-			storageClass, exists := libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip test when Filesystem storage is not present")
-			}
-			sc = storageClass
+			sc = libstorage.GetRWOFileSystemStorageClassOrSkip()
 			vmeName = fmt.Sprintf(defaultVMEName, rand.String(12))
 		})
 

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -158,10 +158,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 
 	Context("[storage-req] Upload an image and start a VMI with PVC", decorators.StorageReq, func() {
 		DescribeTable("[test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
-			sc, exists := libstorage.GetRWOBlockStorageClass()
-			if !exists {
-				Skip("Skip test when RWOBlock storage class is not present")
-			}
+			sc := libstorage.GetRWOBlockStorageClassOrSkip()
 			defer deleteFunc(targetName)
 
 			By("Upload image")

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -402,11 +402,7 @@ var _ = SIGDescribe("Memory dump", func() {
 		)
 
 		BeforeEach(func() {
-			var exists bool
-			sc, exists = libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip no filesystem storage class available")
-			}
+			sc = libstorage.GetRWOFileSystemStorageClassOrSkip()
 			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 
 			vm = createAndStartVM()
@@ -528,11 +524,7 @@ var _ = SIGDescribe("Memory dump", func() {
 		)
 
 		BeforeEach(func() {
-			var exists bool
-			sc, exists = libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip no filesystem storage class available")
-			}
+			sc = libstorage.GetRWOFileSystemStorageClassOrSkip()
 			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 
 			vm = createAndStartVM()
@@ -677,10 +669,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			if !checks.IsOpenShift() {
 				Skip("Need ingress to run this test which we only have on openshift")
 			}
-			sc, exists := libstorage.GetRWOFileSystemStorageClass()
-			if !exists {
-				Skip("Skip no filesystem storage class available")
-			}
+			sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 
 			vm = createAndStartVM()

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -396,7 +396,7 @@ var _ = SIGDescribe("Storage", func() {
 			pvc1 := "pvc-1"
 			pvc2 := "pvc-2"
 			createPVC := func(name string) {
-				sc, _ := libstorage.GetRWXFileSystemStorageClass()
+				sc := libstorage.GetRWXFileSystemStorageClassOrSkip()
 				pvc := libstorage.NewPVC(name, "1Gi", sc)
 				_, err = virtClient.CoreV1().PersistentVolumeClaims(testsuite.NamespacePrivileged).Create(context.Background(), pvc, metav1.CreateOptions{})
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -529,11 +529,7 @@ var _ = SIGDescribe("Storage", func() {
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
-
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 				dataVolume = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
 					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),
@@ -1283,11 +1279,7 @@ var _ = SIGDescribe("Storage", func() {
 				vmi1, vmi2 *virtv1.VirtualMachineInstance
 			)
 			BeforeEach(func() {
-				sc, exists := libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Skip test when Filesystem storage is not present")
-				}
-
+				sc := libstorage.GetRWOFileSystemStorageClassOrSkip()
 				dv = libdv.NewDataVolume(
 					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
 					libdv.WithPVC(libdv.PVCWithStorageClass(sc)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Initially, I wanted to fix some tests that were ignoring the nonexistent storage class:

https://github.com/kubevirt/kubevirt/blob/1bd0fb414531b432d1ee3438e9a57e49b773e5c2/tests/storage/storage.go#L399-L400

Such tests cause failures in CI environments without proper storage and produce unnecessary 'noise' (instead of being just skipped).

But since the typical use pattern:

```go
        sc, exists := Get*StorageClass()
        if !exists {
            Skip(...)
        }
```
is pretty common and used a lot across the tests codebase, I decided to propose a simplification to smth like:

```go
    sc := Get*StorageClassOrSkip()
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
