### PR TITLE
[release-0.49] Fix Live Migration for reenlightenment VMIs

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -328,6 +328,9 @@ func (app *virtHandlerApp) Run() {
 		return
 	}
 
+	vmiInformer := factory.VMI()
+	nodeInformer := factory.KubeVirtNode()
+
 	vmController := virthandler.NewController(
 		recorder,
 		app.virtCli,
@@ -339,6 +342,8 @@ func (app *virtHandlerApp) Run() {
 		vmiTargetInformer,
 		domainSharedInformer,
 		gracefulShutdownInformer,
+		vmiInformer,
+		nodeInformer,
 		int(app.WatchdogTimeoutDuration.Seconds()),
 		app.MaxDevices,
 		app.clusterConfig,
@@ -374,6 +379,8 @@ func (app *virtHandlerApp) Run() {
 	factory.Start(stop)
 	go gracefulShutdownInformer.Run(stop)
 	go domainSharedInformer.Run(stop)
+	go vmiInformer.Run(stop)
+	go nodeInformer.Run(stop)
 
 	se, exists, err := selinux.NewSELinux()
 	if err == nil && exists {

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",


### PR DESCRIPTION
This is needed to avoid breaking the LiveMigration condition for existing VMIs when upgrading from 0.49 to 0.53+.

Without this patch the existing VMIs with reenlightenment enabled will become non-live-migratable as they're missing topologyHints.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Live Migration for reenlightenment VMIs
```
