### PR TITLE
WIP: Fix DVT generated DV sourceRef

### DIFF
--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -166,23 +166,13 @@ func GenerateDataVolumeFromTemplate(clientset kubecli.KubevirtClient, dataVolume
 		newDataVolume.Spec.PriorityClassName = priorityClassName
 	}
 
-	cloneSource, err := GetCloneSource(context.TODO(), clientset, namespace, &newDataVolume.Spec)
-	if err != nil {
+	if _, err := GetCloneSource(context.TODO(), clientset, namespace, &newDataVolume.Spec); err != nil {
 		return nil, err
-	}
-
-	if cloneSource != nil && newDataVolume.Spec.SourceRef != nil {
-		newDataVolume.Spec.SourceRef = nil
-		newDataVolume.Spec.Source = &cdiv1.DataVolumeSource{
-			PVC: &cdiv1.DataVolumeSourcePVC{
-				Namespace: cloneSource.Namespace,
-				Name:      cloneSource.Name,
-			},
-		}
 	}
 
 	return newDataVolume, nil
 }
+
 func GetDataVolumeFromCache(namespace, name string, dataVolumeInformer cache.SharedInformer) (*cdiv1.DataVolume, error) {
 	key := controller.NamespacedKey(namespace, name)
 	obj, exists, err := dataVolumeInformer.GetStore().GetByKey(key)


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Fix `DataVolumeTemplate`-generated `DataVolume` `SourceRef` to `DataSource`, which was mistakenly replaced to `Source.PVC`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix DataVolumeTemplate generated DataVolume SourceRef to DataSource
```
