### PR TITLE
[release-0.58] virt-launcher: use our custom SELinux type only when necessary

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -54,7 +54,9 @@
     (allow process proc_t (dir (mounton)))
     (allow process proc_t (filesystem (mount unmount)))
     ;
-    ; This is needed for passt.
+    ; This is needed for passt when running with this policy.
+    ; container_t is compatible with passt without needing any additional rule.
+    ; This rule is therefore only needed for VMs that use both virtiofs/hugetables and passt.
     ; The policy will be removed from here once it will be installed via the passt package.
     (allow process tmpfs_t (filesystem (mount)))
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -89,6 +89,16 @@ func IsVFIOVMI(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
+// Check if the VMI includes passt network interface(s)
+func IsPasstVMI(vmi *v1.VirtualMachineInstance) bool {
+	for _, net := range vmi.Spec.Domain.Devices.Interfaces {
+		if net.Passt != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // Check if a VMI spec requests AMD SEV
 func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -62,7 +62,7 @@ const (
 	SmbiosConfigDefaultManufacturer                 = "KubeVirt"
 	SmbiosConfigDefaultProduct                      = "None"
 	DefaultPermitBridgeInterfaceOnPodNetwork        = true
-	DefaultSELinuxLauncherType                      = "virt_launcher.process"
+	DefaultSELinuxLauncherType                      = ""
 	SupportedGuestAgentVersions                     = "2.*,3.*,4.*,5.*"
 	DefaultARCHOVMFPath                             = "/usr/share/OVMF"
 	DefaultAARCH64OVMFPath                          = "/usr/share/AAVMF"

--- a/tests/network/vmi_passt.go
+++ b/tests/network/vmi_passt.go
@@ -58,7 +58,7 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 
 		It("should report the IP to the status", func() {
 			vmi := libvmi.NewAlpineWithTestTooling(
-				withPasstInterfaceWithPort(),
+				libvmi.WithPasstInterfaceWithPort(),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 
@@ -126,7 +126,7 @@ var _ = SIGDescribe("[Serial] Passt", func() {
 
 					startClientVMI := func() {
 						clientVMI = libvmi.NewAlpineWithTestTooling(
-							withPasstInterfaceWithPort(),
+							libvmi.WithPasstInterfaceWithPort(),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						)
 
@@ -249,7 +249,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 				}
 
 				vmi := libvmi.NewAlpineWithTestTooling(
-					withPasstInterfaceWithPort(),
+					libvmi.WithPasstInterfaceWithPort(),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
 				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
@@ -273,7 +273,7 @@ EOL`, inetSuffix, serverIP, serverPort)
 				}
 
 				vmi := libvmi.NewAlpineWithTestTooling(
-					withPasstInterfaceWithPort(),
+					libvmi.WithPasstInterfaceWithPort(),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -295,8 +295,4 @@ func withPasstExtendedResourceMemory(ports ...v1.Port) libvmi.Option {
 	}
 	return func(vmi *v1.VirtualMachineInstance) {
 	}
-}
-
-func withPasstInterfaceWithPort() libvmi.Option {
-	return libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding([]v1.Port{{Port: 1234, Protocol: "TCP"}}...))
 }

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -423,7 +423,7 @@ var _ = SIGDescribe("Storage", func() {
 				libstorage.DeletePVC(pvc2)
 			})
 
-			It("should be successfully started and accessible", func() {
+			DescribeTable("should be successfully started and accessible", func(option1, option2 libvmi.Option) {
 
 				virtiofsMountPath := func(pvcName string) string { return fmt.Sprintf("/mnt/virtiofs_%s", pvcName) }
 				virtiofsTestFile := func(virtiofsMountPath string) string { return fmt.Sprintf("%s/virtiofs_test", virtiofsMountPath) }
@@ -442,6 +442,7 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithCloudInitNoCloudUserData(mountVirtiofsCommands, true),
 					libvmi.WithFilesystemPVC(pvc1),
 					libvmi.WithFilesystemPVC(pvc2),
+					option1, option2,
 				)
 
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
@@ -473,7 +474,10 @@ var _ = SIGDescribe("Storage", func() {
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Trim(podVirtioFsFileExist, "\n")).To(Equal("exist"))
-			})
+			},
+				Entry("", func(instance *virtv1.VirtualMachineInstance) {}, func(instance *virtv1.VirtualMachineInstance) {}),
+				Entry("with passt enabled", libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
+			)
 
 		})
 		Context("VirtIO-FS with an empty PVC", func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -992,7 +992,10 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				hugepagesVmi = libvmi.NewCirros()
 			})
 
-			DescribeTable("should consume hugepages ", func(hugepageSize string, memory string, guestMemory string) {
+			DescribeTable("should consume hugepages ", func(hugepageSize string, memory string, guestMemory string, option1, option2 libvmi.Option) {
+				if option1 != nil && option2 != nil {
+					hugepagesVmi = libvmi.NewCirros(option1, option2)
+				}
 				hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + hugepageSize)
 				v, err := cluster.GetKubernetesVersion()
 				Expect(err).ShouldNot(HaveOccurred())
@@ -1039,9 +1042,11 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				By("Checking that the VM memory equals to a number of consumed hugepages")
 				Eventually(func() bool { return verifyHugepagesConsumption() }, 30*time.Second, 5*time.Second).Should(BeTrue())
 			},
-				Entry("[Serial][test_id:1671]hugepages-2Mi", "2Mi", "64Mi", "None"),
-				Entry("[Serial][test_id:1672]hugepages-1Gi", "1Gi", "1Gi", "None"),
-				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", "2Mi", "70Mi", "64Mi"),
+				Entry("[Serial][test_id:1671]hugepages-2Mi", "2Mi", "64Mi", "None", nil, nil),
+				Entry("[Serial][test_id:1672]hugepages-1Gi", "1Gi", "1Gi", "None", nil, nil),
+				Entry("[Serial][test_id:1672]hugepages-2Mi with guest memory set explicitly", "2Mi", "70Mi", "64Mi", nil, nil),
+				Entry("[Serial]hugepages-2Mi with passt enabled", "2Mi", "64Mi", "None",
+					libvmi.WithPasstInterfaceWithPort(), libvmi.WithNetwork(v1.DefaultPodNetwork())),
 			)
 
 			Context("with unsupported page size", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/8402

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
It is a big oversight that this PR was not included in the original release.
This will break platform upgrades to recent OSes like Centos9. (and already breaks the upgrade test in release-0.59 on Centos 9 lanes)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Most VMIs now run under the SELinux type container_t
```
