### PR TITLE
[e2e] Add "labels" parameter to CreateFSPVC helper function

### DIFF
--- a/tests/libstorage/pvc.go
+++ b/tests/libstorage/pvc.go
@@ -159,7 +159,7 @@ func createPVC(pvc *k8sv1.PersistentVolumeClaim, namespace string) *k8sv1.Persis
 	return createdPvc
 }
 
-func CreateFSPVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
+func CreateFSPVC(name, namespace, size string, labels map[string]string) *k8sv1.PersistentVolumeClaim {
 	sc, exists := GetRWOFileSystemStorageClass()
 	if !exists {
 		Skip("Skip test when RWOFileSystem storage class is not present")
@@ -167,6 +167,13 @@ func CreateFSPVC(name, namespace, size string) *k8sv1.PersistentVolumeClaim {
 	pvc := NewPVC(name, size, sc)
 	volumeMode := k8sv1.PersistentVolumeFilesystem
 	pvc.Spec.VolumeMode = &volumeMode
+	if labels != nil && pvc.Labels == nil {
+		pvc.Labels = map[string]string{}
+	}
+
+	for key, value := range labels {
+		pvc.Labels[key] = value
+	}
 
 	return createPVC(pvc, namespace)
 }

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -411,7 +411,7 @@ var _ = SIGDescribe("Memory dump", func() {
 
 			vm = createAndStartVM()
 
-			memoryDumpPVC = libstorage.CreateFSPVC(memoryDumpPVCName, testsuite.GetTestNamespace(vm), "500Mi")
+			memoryDumpPVC = libstorage.CreateFSPVC(memoryDumpPVCName, testsuite.GetTestNamespace(vm), "500Mi", nil)
 		})
 
 		AfterEach(func() {
@@ -462,7 +462,7 @@ var _ = SIGDescribe("Memory dump", func() {
 			By("Running remove memory dump to pvc: " + memoryDumpPVCName)
 			removeMemoryDumpAndVerify(vm, memoryDumpPVCName, previousOutput, removeMemoryDumpVirtctl)
 
-			memoryDumpPVC2 = libstorage.CreateFSPVC(memoryDumpPVCName2, testsuite.GetTestNamespace(vm), "500Mi")
+			memoryDumpPVC2 = libstorage.CreateFSPVC(memoryDumpPVCName2, testsuite.GetTestNamespace(vm), "500Mi", nil)
 			By("Running memory dump to other pvc: " + memoryDumpPVCName2)
 			previousOutput = createMemoryDumpAndVerify(vm, memoryDumpPVCName2, previousOutput, memoryDumpVirtctl)
 
@@ -508,7 +508,7 @@ var _ = SIGDescribe("Memory dump", func() {
 
 		It("[test_id:8501]Run memory dump with pvc too small should fail", func() {
 			By("Trying to get memory dump with small pvc")
-			memoryDumpSmallPVC = libstorage.CreateFSPVC(memoryDumpSmallPVCName, testsuite.GetTestNamespace(vm), "200Mi")
+			memoryDumpSmallPVC = libstorage.CreateFSPVC(memoryDumpSmallPVCName, testsuite.GetTestNamespace(vm), "200Mi", nil)
 			commandAndArgs := []string{commandMemoryDump, "get", vm.Name, fmt.Sprintf(virtCtlClaimName, memoryDumpSmallPVCName), virtCtlNamespace, vm.Namespace}
 			memorydumpCommand := clientcmd.NewRepeatableVirtctlCommand(commandAndArgs...)
 			Eventually(func() string {

--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -63,7 +63,7 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 			instancetype := createInstancetype(virtClient)
 			preference := createPreference(virtClient)
 			dataSource := createDataSource(virtClient)
-			pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), util.NamespaceTestDefault, "128M")
+			pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), util.NamespaceTestDefault, "128M", nil)
 			userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudInitUserData))
 
 			out, err := runCmd(
@@ -162,7 +162,7 @@ var _ = Describe("[sig-compute][virtctl]create vm", func() {
 			vmName := "vm-" + rand.String(5)
 			instancetype := createInstancetype(virtClient)
 			preference := createPreference(virtClient)
-			pvc := createAnnotatedSourcePVC(virtClient, instancetype.Name, preference.Name)
+			pvc := createAnnotatedSourcePVC(instancetype.Name, preference.Name)
 			userDataB64 := base64.StdEncoding.EncodeToString([]byte(cloudInitUserData))
 
 			out, err := runCmd(
@@ -298,15 +298,13 @@ func createDataSource(virtClient kubecli.KubevirtClient) *v1beta1.DataSource {
 	return dataSource
 }
 
-func createAnnotatedSourcePVC(virtClient kubecli.KubevirtClient, instancetypeName, preferenceName string) *k8sv1.PersistentVolumeClaim {
-	pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), util.NamespaceTestDefault, "128M")
-	pvc.Labels = map[string]string{
+func createAnnotatedSourcePVC(instancetypeName, preferenceName string) *k8sv1.PersistentVolumeClaim {
+	pvcLabels := map[string]string{
 		apiinstancetype.DefaultInstancetypeLabel:     instancetypeName,
 		apiinstancetype.DefaultInstancetypeKindLabel: apiinstancetype.SingularResourceName,
 		apiinstancetype.DefaultPreferenceLabel:       preferenceName,
 		apiinstancetype.DefaultPreferenceKindLabel:   apiinstancetype.SingularPreferenceResourceName,
 	}
-	pvc, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	pvc := libstorage.CreateFSPVC("vm-pvc-"+rand.String(5), util.NamespaceTestDefault, "128M", pvcLabels)
 	return pvc
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`CreateFSPVC` is a helper function that creates a PVC. If you want to add some labels to the PVC, you are forced to Update the PVC just after the creation. This can cause some collisions during update because the object has been modified. Adding the `labels` parameter allows us to save an `Update` operation and avoid such collisions described above.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @akalenyu @enp0s3 