### PR TITLE
Tests: Fix seccomp test typo

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -3051,7 +3051,7 @@ spec:
 
 					for _, condition := range vmi.Status.Conditions {
 						if condition.Type == v1.VirtualMachineInstanceSynchronized {
-							if condition.Status == k8sv1.ConditionFalse && strings.Contains(condition.Reason, "needs a privileged namespace") {
+							if condition.Status == k8sv1.ConditionFalse && strings.Contains(condition.Message, "needs a privileged namespace") {
 								psaRelatedErrorDetected = true
 								return true, nil
 							}


### PR DESCRIPTION
**What this PR does / why we need it**:
The PSA violation is in the Message not in
the Reason

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
