### PR TITLE
Updated READMEs to reflect the proper FROM and ADD in the example Dockerfile(s)

### DIFF
--- a/containerimages/container-disk-images.md
+++ b/containerimages/container-disk-images.md
@@ -45,14 +45,14 @@ We can do that with `virt-sysprep`:
 ￼
 
 Once the image is ready it is necessary to convert it to   
-container image with `kubevirt/container-disk-v1alpha` layer, 
+container image with `scratch` layer, 
 so KubeVirt VM's can consume it according to  
 https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
 
 ```bash
 cat > Dockerfile <<EOF
-FROM kubevirt/container-disk-v1alpha
-ADD fedora32.qcow2 /disk/
+FROM scratch
+ADD --chown=107:107 fedora32.qcow2 /disk/
 EOF
 
 docker build -t kubevirt/fedora-sriov-testing:latest .

--- a/docs/container-register-disks.md
+++ b/docs/container-register-disks.md
@@ -59,11 +59,13 @@ wrapper container image. By default, the base wrapper container KubeVirt
 provides will serve up any VMI disk placed in the /disk directory as a block
 device consumable by libvirt.
 
+Note: The containerDisk needs to be readable for the user with the UID 107 (qemu).
+
 Example:
 ```
 cat << END > Dockerfile
 FROM scratch
-ADD fedora25.qcow2 /disk/
+ADD --chown=107:107 fedora25.qcow2 /disk/
 END
 docker build -t vmdisks/fedora25:latest .
 docker push vmdisks/fedora25:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Updated READMEs as it caused slight confusion on my end. The corrections were pointed out and taken from the official documentation: https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated the example Dockerfile to properly reflect the official kubevirt.io documentation
```
