### PR TITLE
[e2e-tests]If Reenlightenment is enabled Freq must be exposed

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -149,6 +149,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//tests:go_default_library",
+        "//tests/decorators:go_default_library",
         "//tests/libvmi:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/tests/decorators"
+
 	"k8s.io/utils/pointer"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -2868,7 +2870,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 	})
 
-	Context("topology hints", func() {
+	Context("topology hints", decorators.TscFrequencies, func() {
 
 		getVmiWithInvTsc := func() *virtv1.VirtualMachineInstance {
 			vmi := NewPendingVirtualMachine("testvmi")

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -31,6 +31,7 @@ var (
 	NativeSsh        = []interface{}{Label("native-ssh")}
 	ExcludeNativeSsh = []interface{}{Label("exclude-native-ssh")}
 	Reenlightenment  = []interface{}{Label("Reenlightenment")}
+	TscFrequencies   = []interface{}{Label("TscFrequencies")}
 	PasstGate        = []interface{}{Label("PasstGate")}
 	Upgrade          = []interface{}{Label("Upgrade")}
 	CustomSELinux    = []interface{}{Label("CustomSELinux")}

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -123,7 +123,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", Serial, decorat
 			})
 		})
 
-		When("TSC frequency is not exposed on the cluster", decorators.Reenlightenment, func() {
+		When("TSC frequency is not exposed on the cluster", decorators.Reenlightenment, decorators.TscFrequencies, func() {
 
 			BeforeEach(func() {
 				if isTSCFrequencyExposed(virtClient) {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -921,7 +921,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(getHostnameFromMetrics(metrics)).To(Equal(vmi.Status.NodeName))
 			})
 
-			It("[test_id:6842]should migrate with TSC frequency set", decorators.Invtsc, func() {
+			It("[test_id:6842]should migrate with TSC frequency set", decorators.Invtsc, decorators.TscFrequencies, func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Features: []v1.CPUFeature{
@@ -4330,7 +4330,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 	})
 
-	Context("topology hints", func() {
+	Context("topology hints", decorators.Reenlightenment, decorators.TscFrequencies, func() {
 
 		Context("needs to be set when", func() {
 
@@ -4353,7 +4353,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				expectTopologyHintsToBeSet(vmi)
 			})
 
-			It("HyperV reenlightenment is enabled", decorators.Reenlightenment, func() {
+			It("HyperV reenlightenment is enabled", func() {
 				vmi := libvmi.New()
 				vmi.Spec = getWindowsVMISpec()
 				vmi.Spec.Domain.Devices.Disks = []v1.Disk{}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1455,7 +1455,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				}
 				return false
 			}
-			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", decorators.Invtsc, func() {
+			It("[test_id:6843]should set a TSC fequency and have the CPU flag avaliable in the guest", decorators.Invtsc, decorators.TscFrequencies, func() {
 				nodes := libnode.GetAllSchedulableNodes(virtClient)
 				Expect(featureSupportedInAtLeastOneNode(nodes, "invtsc")).To(BeTrue(), "To run this test at least one node should support invtsc feature")
 				vmi := libvmi.NewCirros()


### PR DESCRIPTION
when tests require Reenlightenment they should require to expose Freq as well.

Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
