### PR TITLE
Replace `HaveLen(0)` with `BeEmpty()`

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1086,7 +1086,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should apply to VMI", func() {
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.IOThreadsPolicy).To(Equal(*instancetypeSpec.IOThreadsPolicy))
 			})
@@ -1112,7 +1112,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should apply to VMI", func() {
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.LaunchSecurity).To(Equal(*instancetypeSpec.LaunchSecurity))
 			})
@@ -1144,7 +1144,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply to VMI", func() {
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.GPUs).To(Equal(instancetypeSpec.GPUs))
 
@@ -1182,7 +1182,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply to VMI", func() {
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.HostDevices).To(Equal(instancetypeSpec.HostDevices))
 
@@ -1313,7 +1313,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply to VMI", func() {
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeFalse())
 				Expect(*vmi.Spec.Domain.Devices.AutoattachMemBalloon).To(BeFalse())
@@ -1357,7 +1357,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk = nil
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(preferenceSpec.Devices.PreferredDiskBus))
 
@@ -1411,7 +1411,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should apply to VMI", func() {
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Features.ACPI).To(Equal(*preferenceSpec.Features.PreferredAcpi))
 				Expect(*vmi.Spec.Domain.Features.APIC).To(Equal(*preferenceSpec.Features.PreferredApic))
@@ -1432,7 +1432,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled).To(BeFalse())
 
@@ -1452,7 +1452,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial).To(Equal(*preferenceSpec.Firmware.PreferredUseBiosSerial))
 			})
@@ -1468,7 +1468,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(Equal(*preferenceSpec.Firmware.PreferredUseSecureBoot))
 			})
@@ -1484,7 +1484,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Machine.Type).To(Equal(preferenceSpec.Machine.PreferredMachineType))
 			})
@@ -1506,7 +1506,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*&vmi.Spec.Domain.Clock.ClockOffset).To(Equal(*preferenceSpec.Clock.PreferredClockOffset))
 				Expect(*vmi.Spec.Domain.Clock.Timer).To(Equal(*preferenceSpec.Clock.PreferredTimer))

--- a/pkg/storage/export/virt-exportserver/exportserver_test.go
+++ b/pkg/storage/export/virt-exportserver/exportserver_test.go
@@ -625,7 +625,7 @@ var _ = Describe("exportserver", func() {
 			err = yaml.Unmarshal([]byte(out[1]), resVm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resVm.Name).To(Equal(testVm.Name))
-			Expect(resVm.Spec.DataVolumeTemplates).To(HaveLen(0))
+			Expect(resVm.Spec.DataVolumeTemplates).To(BeEmpty())
 			resDv := &cdiv1.DataVolume{}
 			err = yaml.Unmarshal([]byte(out[2]), resDv)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3785,12 +3785,12 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		Context("feature gate enabled", func() {
 			It("should accept vmi with no vsocks defined", func() {
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			})
 			It("should accept vmi with vsocks defined", func() {
 				vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			})
 		})
 		Context("feature gate disabled", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -2360,7 +2360,7 @@ status:
 
 			By("Creating VirtualMachine")
 			vm = tests.NewRandomVirtualMachine(vmi, true)
-			Expect(vm.Finalizers).To(HaveLen(0))
+			Expect(vm.Finalizers).To(BeEmpty())
 
 		})
 


### PR DESCRIPTION
This PR is a preparation for the next version of the ginkgolinter, that will enforce this change.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

```release-note
None
```
