### PR TITLE
[release-0.49] tests: libvmi.New: no explicit name

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -75,7 +75,7 @@ func newFedora(containerDisk cd.ContainerDisk, opts ...Option) *kvirtv1.VirtualM
 		WithContainerImage(cd.ContainerDiskFor(containerDisk)),
 	}
 	opts = append(fedoraOptions, opts...)
-	return New(RandName(DefaultVmiName), opts...)
+	return New(opts...)
 }
 
 // NewCirros instantiates a new CirrOS based VMI configuration
@@ -87,5 +87,5 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
-	return New(RandName(DefaultVmiName), cirrosOpts...)
+	return New(cirrosOpts...)
 }

--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -35,8 +35,8 @@ type Option func(vmi *kvirtv1.VirtualMachineInstance)
 
 // New instantiates a new VMI configuration,
 // building its properties based on the specified With* options.
-func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
-	vmi := baseVmi(name)
+func New(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	vmi := baseVmi(randName())
 
 	for _, f := range opts {
 		f(vmi)
@@ -48,6 +48,11 @@ func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 // RandName returns a random name by concatenating the given name with a hyphen and a random string.
 func RandName(name string) string {
 	return name + "-" + rand.String(5)
+}
+
+// randName returns a random name for a virtual machine
+func randName() string {
+	return "testvmi" + "-" + rand.String(5)
 }
 
 // WithLabel sets a label with specified value


### PR DESCRIPTION
 This is partial cherry-pick of [#7858](https://github.com/kubevirt/kubevirt/pull/7858)

Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
Eliminate boilerplate of dealing with VMI names. They better to be random, in order to avoid side-effects.

**Fixes:**
#8423 

**Release note**:
```release-note
NONE
```
