### PR TITLE
[release-0.59] Fix inconsistency between export-server and vmexport status links

### DIFF
--- a/pkg/storage/export/export/links.go
+++ b/pkg/storage/export/export/links.go
@@ -54,13 +54,13 @@ const (
 	external              = "external"
 )
 
-func (ctrl *VMExportController) getInteralLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, service *corev1.Service) (*exportv1.VirtualMachineExportLink, error) {
+func (ctrl *VMExportController) getInteralLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, service *corev1.Service, export *exportv1.VirtualMachineExport) (*exportv1.VirtualMachineExportLink, error) {
 	internalCert, err := ctrl.internalExportCa()
 	if err != nil {
 		return nil, err
 	}
 	host := fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace)
-	return ctrl.getLinks(pvcs, exporterPod, host, internal, internalCert)
+	return ctrl.getLinks(pvcs, exporterPod, export, host, internal, internalCert)
 }
 
 func (ctrl *VMExportController) getExternalLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, export *exportv1.VirtualMachineExport) (*exportv1.VirtualMachineExportLink, error) {
@@ -68,12 +68,12 @@ func (ctrl *VMExportController) getExternalLinks(pvcs []*corev1.PersistentVolume
 	externalLinkHost, cert := ctrl.getExternalLinkHostAndCert()
 	if externalLinkHost != "" {
 		hostAndBase := path.Join(externalLinkHost, urlPath)
-		return ctrl.getLinks(pvcs, exporterPod, hostAndBase, external, cert)
+		return ctrl.getLinks(pvcs, exporterPod, export, hostAndBase, external, cert)
 	}
 	return nil, nil
 }
 
-func (ctrl *VMExportController) getLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, hostAndBase, linkType, cert string) (*exportv1.VirtualMachineExportLink, error) {
+func (ctrl *VMExportController) getLinks(pvcs []*corev1.PersistentVolumeClaim, exporterPod *corev1.Pod, export *exportv1.VirtualMachineExport, hostAndBase, linkType, cert string) (*exportv1.VirtualMachineExportLink, error) {
 	const scheme = "https://"
 	exportLink := &exportv1.VirtualMachineExportLink{
 		Volumes: []exportv1.VirtualMachineExportVolume{},
@@ -94,7 +94,7 @@ func (ctrl *VMExportController) getLinks(pvcs []*corev1.PersistentVolumeClaim, e
 
 			if ctrl.isKubevirtContentType(pvc) {
 				exportLink.Volumes = append(exportLink.Volumes, exportv1.VirtualMachineExportVolume{
-					Name: pvc.Name,
+					Name: ctrl.getExportVolumeName(pvc, export),
 					Formats: []exportv1.VirtualMachineExportVolumeFormat{
 						{
 							Format: exportv1.KubeVirtRaw,
@@ -108,7 +108,7 @@ func (ctrl *VMExportController) getLinks(pvcs []*corev1.PersistentVolumeClaim, e
 				})
 			} else {
 				exportLink.Volumes = append(exportLink.Volumes, exportv1.VirtualMachineExportVolume{
-					Name: pvc.Name,
+					Name: ctrl.getExportVolumeName(pvc, export),
 					Formats: []exportv1.VirtualMachineExportVolumeFormat{
 						{
 							Format: exportv1.Dir,

--- a/pkg/storage/export/export/pvc-source.go
+++ b/pkg/storage/export/export/pvc-source.go
@@ -141,7 +141,7 @@ func (ctrl *VMExportController) updateVMExportPvcStatus(vmExport *exportv1.Virtu
 
 	vmExportCopy := vmExport.DeepCopy()
 
-	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
+	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes, getVolumeName); err != nil {
 		return requeue, err
 	}
 

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -219,7 +219,7 @@ func (ctrl *VMExportController) updateVMExportVMStatus(vmExport *exportv1.Virtua
 	var requeue time.Duration
 
 	vmExportCopy := vmExport.DeepCopy()
-	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
+	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes, getVolumeName); err != nil {
 		return requeue, err
 	}
 	if len(sourceVolumes.volumes) == 0 {

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -22,7 +22,6 @@ package export
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -186,11 +185,6 @@ func (ctrl *VMExportController) getOrCreatePVCFromSnapshot(vmExport *exportv1.Vi
 func (ctrl *VMExportController) updateVMExporVMSnapshotStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, sourceVolumes *sourceVolumes) (time.Duration, error) {
 	vmExportCopy := vmExport.DeepCopy()
 
-	// Change the names of the returned pvcs by removing the prefix we used to create the PVCs, this matches
-	// the volumes of the source VM
-	for _, pvc := range sourceVolumes.volumes {
-		pvc.Name = strings.TrimPrefix(pvc.Name, fmt.Sprintf("%s-", vmExport.Name))
-	}
 	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, sourceVolumes); err != nil {
 		return 0, err
 	}

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -541,7 +541,7 @@ var _ = Describe("VMSnapshot source", func() {
 
 	It("Should update status with correct links from snapshot with kubevirt content type", func() {
 		testVMExport := createSnapshotVMExport()
-		restoreName := testVolumesnapshotName
+		restoreName := fmt.Sprintf("%s-%s", testVMExport.Name, testVolumesnapshotName)
 		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			update, ok := action.(testing.UpdateAction)
 			Expect(ok).To(BeTrue())
@@ -592,7 +592,7 @@ var _ = Describe("VMSnapshot source", func() {
 
 	It("Should update status with correct links from snapshot with other content type", func() {
 		testVMExport := createSnapshotVMExport()
-		restoreName := testVolumesnapshotName
+		restoreName := fmt.Sprintf("%s-%s", testVMExport.Name, testVolumesnapshotName)
 		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			update, ok := action.(testing.UpdateAction)
 			Expect(ok).To(BeTrue())

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1340,7 +1340,7 @@ var _ = SIGDescribe("Export", func() {
 		export := createRunningVMSnapshotExport(snapshot)
 		Expect(export).ToNot(BeNil())
 		checkExportSecretRef(export)
-		restoreName := vm.Spec.Template.Spec.Volumes[0].DataVolume.Name
+		restoreName := fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
 		verifyKubevirtInternal(export, export.Name, export.Namespace, restoreName)
 	})
 
@@ -1415,9 +1415,9 @@ var _ = SIGDescribe("Export", func() {
 		export := createRunningVMSnapshotExport(snapshot)
 		Expect(export).ToNot(BeNil())
 		checkExportSecretRef(export)
-		restoreName := vm.Spec.Template.Spec.Volumes[0].DataVolume.Name
+		restoreName := fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
 		// [1] is the cloud init
-		restoreName2 := vm.Spec.Template.Spec.Volumes[2].DataVolume.Name
+		restoreName2 := fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[2].DataVolume.Name)
 		verifyMultiKubevirtInternal(export, export.Name, export.Namespace, restoreName, restoreName2)
 	})
 
@@ -1740,7 +1740,7 @@ var _ = SIGDescribe("Export", func() {
 		export := createRunningVMSnapshotExport(snapshot)
 		Expect(export).ToNot(BeNil())
 		export = waitForReadyExport(export)
-		verifyKubevirtInternal(export, export.Name, export.Namespace, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name)
+		verifyKubevirtInternal(export, export.Name, export.Namespace, fmt.Sprintf("%s-%s", export.Name, vm.Spec.Template.Spec.Volumes[0].DataVolume.Name))
 		Expect(export.Status).ToNot(BeNil())
 		Expect(export.Status.Links).ToNot(BeNil())
 		Expect(export.Status.Links.Internal).ToNot(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/kubevirt/pull/9123.

This PR fixes an inconsistency between the links displayed in the vmexport status and the actual path in the export-server when exporting snapshots.

While the links are still generated using the restore PVC name, the volume name displayed in the status matches the original volume as appears in the VM, so users can easily identify their download target.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
