### PR TITLE
Fix OOM virtiofs container limit

### DIFF
--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -40,7 +40,7 @@ func resourcesForVirtioFSContainer(dedicatedCPUs bool, guaranteedQOS bool) k8sv1
 
 	// TODO: Find out correct values
 	resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("10m")
-	resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("40M")
+	resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("80M")
 
 	if dedicatedCPUs || guaranteedQOS {
 		resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("10m")
@@ -49,7 +49,7 @@ func resourcesForVirtioFSContainer(dedicatedCPUs bool, guaranteedQOS bool) k8sv1
 	}
 
 	if guaranteedQOS {
-		resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("40M")
+		resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("80M")
 	} else {
 		resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1M")
 	}


### PR DESCRIPTION
Signed-off-by: Romà Llorens <roma.llorens@gmail.com>

**What this PR does / why we need it**:
We found that with intensive disk usage, virtiofs container OOMs at the current limit (40M)
Bumping this limit to 80M solved our issue (Max usage observed is 71M)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Issue discussed on Slack Channel with @xpivarc

**Release note**:
```release-note
Bump virtiofs container limit
```
