### PR TITLE
Move away from fedora 31 and use distroless/base instead

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -280,27 +280,6 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
-# Pull base image fedora31
-# WARNING: please update any automated process to push this image to quay.io
-# instead of index.docker.io
-container_pull(
-    name = "fedora",
-    digest = "sha256:5e2b864cfe165fa7da6606b29a9e60549eb7cc9ae7fb574614110d1494b0f0c2",
-    registry = "quay.io",
-    repository = "kubevirtci/fedora",
-    tag = "31",
-)
-
-# As rpm package in https://dl.fedoraproject.org/pub/fedora/linux/releases/31 is empty, we use fedora 32 here.
-# TODO add fedora image to quay.io
-container_pull(
-    name = "fedora_aarch64",
-    digest = "sha256:425676dd30f2c85ba3593b82040ce03341cd6dc4e38838e57c8bc5eef95b5f81",
-    registry = "index.docker.io",
-    repository = "library/fedora",
-    tag = "32",
-)
-
 # Pull go_image_base
 container_pull(
     name = "go_image_base",

--- a/cmd/example-cloudinit-hook-sidecar/BUILD.bazel
+++ b/cmd/example-cloudinit-hook-sidecar/BUILD.bazel
@@ -28,15 +28,19 @@ load(
 )
 
 container_image(
+    name = "version-container",
+    base = "//:passwd-image",
+    directory = "/",
+    files = ["//:get-version"],
+)
+
+container_image(
     name = "example-cloudinit-hook-sidecar-image",
     architecture = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    base = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora_aarch64//image",
-        "//conditions:default": "@fedora//image",
-    }),
+    base = ":version-container",
     directory = "/",
     entrypoint = ["/example-cloudinit-hook-sidecar"],
     files = [":example-cloudinit-hook-sidecar"],

--- a/cmd/example-disk-mutation-hook-sidecar/BUILD.bazel
+++ b/cmd/example-disk-mutation-hook-sidecar/BUILD.bazel
@@ -29,15 +29,19 @@ load(
 )
 
 container_image(
+    name = "version-container",
+    base = "//:passwd-image",
+    directory = "/",
+    files = ["//:get-version"],
+)
+
+container_image(
     name = "example-disk-mutation-hook-sidecar-image",
     architecture = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    base = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora_aarch64//image",
-        "//conditions:default": "@fedora//image",
-    }),
+    base = ":version-container",
     directory = "/",
     entrypoint = ["/example-disk-mutation-hook-sidecar"],
     files = [":example-disk-mutation-hook-sidecar"],

--- a/cmd/example-hook-sidecar/BUILD.bazel
+++ b/cmd/example-hook-sidecar/BUILD.bazel
@@ -30,15 +30,19 @@ load(
 )
 
 container_image(
+    name = "version-container",
+    base = "//:passwd-image",
+    directory = "/",
+    files = ["//:get-version"],
+)
+
+container_image(
     name = "example-hook-sidecar-image",
     architecture = select({
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    base = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora_aarch64//image",
-        "//conditions:default": "@fedora//image",
-    }),
+    base = ":version-container",
     directory = "/",
     entrypoint = ["/example-hook-sidecar"],
     files = [":example-hook-sidecar"],

--- a/images/winrmcli/BUILD.bazel
+++ b/images/winrmcli/BUILD.bazel
@@ -13,10 +13,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    base = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora_aarch64//image",
-        "//conditions:default": "@fedora//image",
-    }),
+    base = "//images:kubevirt-testing-base",
     directory = "/usr/bin",
     files = [
         "@com_github_masterzen_winrmcli//:winrm-cli",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -83,10 +83,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    base = select({
-        "@io_bazel_rules_go//go/platform:linux_arm64": "@fedora_aarch64//image",
-        "//conditions:default": "@fedora//image",
-    }),
+    base = "//:passwd-image",
     directory = "/",
     files = [
         ":conformance-config.json",


### PR DESCRIPTION
**What this PR does / why we need it**:

While creating a binary in my local Fedora 37 and pushing it to Fedora31 container, it would not run due conflict with libc. Fedora 31 was EOL in 2020-11-24, so the base image is overdue to an upgrade.

Further discussion in slack,  it was suggested to use distroless/base image as that is something we update more often.

**Release note**:
```release-note
NONE
```
