### PR TITLE
Add observed and desired generation to the vm status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19436,9 +19436,19 @@
       "description": "Created indicates if the virtual machine is created in the cluster",
       "type": "boolean"
      },
+     "desiredGeneration": {
+      "description": "DesiredGeneration is the generation which is desired for the VMI. This will be used in comparisons with ObservedGeneration to understand when the VMI is out of sync. This will be changed at the same time as ObservedGeneration to remove errors which could occur if Generation is updated through an Update() before ObservedGeneration in Status.",
+      "type": "integer",
+      "format": "int64"
+     },
      "memoryDumpRequest": {
       "description": "MemoryDumpRequest tracks memory dump request phase and info of getting a memory dump to the given pvc",
       "$ref": "#/definitions/v1.VirtualMachineMemoryDumpRequest"
+     },
+     "observedGeneration": {
+      "description": "ObservedGeneration is the generation observed by the vmi when started.",
+      "type": "integer",
+      "format": "int64"
      },
      "printableStatus": {
       "description": "PrintableStatus is a human readable, high-level representation of the status of the virtual machine",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6725,6 +6725,14 @@ var CRDsValidation map[string]string = map[string]string{
           description: Created indicates if the virtual machine is created in the
             cluster
           type: boolean
+        desiredGeneration:
+          description: DesiredGeneration is the generation which is desired for the
+            VMI. This will be used in comparisons with ObservedGeneration to understand
+            when the VMI is out of sync. This will be changed at the same time as
+            ObservedGeneration to remove errors which could occur if Generation is
+            updated through an Update() before ObservedGeneration in Status.
+          format: int64
+          type: integer
         memoryDumpRequest:
           description: MemoryDumpRequest tracks memory dump request phase and info
             of getting a memory dump to the given pvc
@@ -6760,6 +6768,11 @@ var CRDsValidation map[string]string = map[string]string{
           - claimName
           - phase
           type: object
+        observedGeneration:
+          description: ObservedGeneration is the generation observed by the vmi when
+            started.
+          format: int64
+          type: integer
         printableStatus:
           description: PrintableStatus is a human readable, high-level representation
             of the status of the virtual machine
@@ -24382,6 +24395,15 @@ var CRDsValidation map[string]string = map[string]string{
                       description: Created indicates if the virtual machine is created
                         in the cluster
                       type: boolean
+                    desiredGeneration:
+                      description: DesiredGeneration is the generation which is desired
+                        for the VMI. This will be used in comparisons with ObservedGeneration
+                        to understand when the VMI is out of sync. This will be changed
+                        at the same time as ObservedGeneration to remove errors which
+                        could occur if Generation is updated through an Update() before
+                        ObservedGeneration in Status.
+                      format: int64
+                      type: integer
                     memoryDumpRequest:
                       description: MemoryDumpRequest tracks memory dump request phase
                         and info of getting a memory dump to the given pvc
@@ -24420,6 +24442,11 @@ var CRDsValidation map[string]string = map[string]string{
                       - claimName
                       - phase
                       type: object
+                    observedGeneration:
+                      description: ObservedGeneration is the generation observed by
+                        the vmi when started.
+                      format: int64
+                      type: integer
                     printableStatus:
                       description: PrintableStatus is a human readable, high-level
                         representation of the status of the virtual machine

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -905,6 +905,9 @@ const (
 	// AllowPodBridgeNetworkLiveMigrationAnnotation allow to run live migration when the
 	// vm has the pod networking bind with a bridge
 	AllowPodBridgeNetworkLiveMigrationAnnotation string = "kubevirt.io/allow-pod-bridge-network-live-migration"
+
+	// VirtualMachineGenerationAnnotation is the generation of a Virtual Machine.
+	VirtualMachineGenerationAnnotation string = "kubevirt.io/vm-generation"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {
@@ -1454,6 +1457,18 @@ type VirtualMachineStatus struct {
 	// +nullable
 	// +optional
 	MemoryDumpRequest *VirtualMachineMemoryDumpRequest `json:"memoryDumpRequest,omitempty" optional:"true"`
+
+	// ObservedGeneration is the generation observed by the vmi when started.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" optional:"true"`
+
+	// DesiredGeneration is the generation which is desired for the VMI.
+	// This will be used in comparisons with ObservedGeneration to understand when
+	// the VMI is out of sync. This will be changed at the same time as
+	// ObservedGeneration to remove errors which could occur if Generation is
+	// updated through an Update() before ObservedGeneration in Status.
+	// +optional
+	DesiredGeneration int64 `json:"desiredGeneration,omitempty" optional:"true"`
 }
 
 type VolumeSnapshotStatus struct {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -351,6 +351,8 @@ func (VirtualMachineStatus) SwaggerDoc() map[string]string {
 		"volumeSnapshotStatuses": "VolumeSnapshotStatuses indicates a list of statuses whether snapshotting is\nsupported by each volume.",
 		"startFailure":           "StartFailure tracks consecutive VMI startup failures for the purposes of\ncrash loop backoffs\n+nullable\n+optional",
 		"memoryDumpRequest":      "MemoryDumpRequest tracks memory dump request phase and info of getting a memory\ndump to the given pvc\n+nullable\n+optional",
+		"observedGeneration":     "ObservedGeneration is the generation observed by the vmi when started.\n+optional",
+		"desiredGeneration":      "DesiredGeneration is the generation which is desired for the VMI.\nThis will be used in comparisons with ObservedGeneration to understand when\nthe VMI is out of sync. This will be changed at the same time as\nObservedGeneration to remove errors which could occur if Generation is\nupdated through an Update() before ObservedGeneration in Status.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22651,6 +22651,20 @@ func schema_kubevirtio_api_core_v1_VirtualMachineStatus(ref common.ReferenceCall
 							Ref:         ref("kubevirt.io/api/core/v1.VirtualMachineMemoryDumpRequest"),
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration is the generation observed by the vmi when started.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"desiredGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DesiredGeneration is the generation which is desired for the VMI. This will be used in comparisons with ObservedGeneration to understand when the VMI is out of sync. This will be changed at the same time as ObservedGeneration to remove errors which could occur if Generation is updated through an Update() before ObservedGeneration in Status.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Provides clarity regarding if the vmi is out of date of the vm. 

Add observed and desired generation into the vm status which will track the observed generation that the vmi is updated with, as well as the desired generation for the vmi to be updated to.

Add vm generation into metadata of vmi, and add logic to backfill this from a vm controller revision if needed.

Previously there was no clear definition regarding if a vmi is out of sync with the vm. The controller revision name could be used, but this was not well defined and would also not be bumped if the spec stays the same. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```Added ObservedGeneration and DesiredGeneration fields into the VirtualMachineStatus for clarity on which VirtualMachine Generation the VirtualMachineInstance is in sync with.
```

Signed-off-by: Kyle Lane <kylelane@google.com>