### PR TITLE
Test: Fix PSA issue on OKD

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -310,6 +310,7 @@ func GetLabelsForNamespace(namespace string) map[string]string {
 	if namespace == NamespacePrivileged {
 		labels["pod-security.kubernetes.io/enforce"] = "privileged"
 		labels["pod-security.kubernetes.io/warn"] = "privileged"
+		labels["security.openshift.io/scc.podSecurityLabelSync"] = "false"
 	}
 
 	return labels


### PR DESCRIPTION
**What this PR does / why we need it**:
Privileged namespace is meant to be allowed to run
any privileged Pod required by our test suit.

Okd/Openshift does have a mechanism that overrides a defined level of enforcement.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
