### PR TITLE
Respect GS_IMAGE in virtctl guestfs

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1113,6 +1113,7 @@ func (app *virtAPIApp) GetGsInfo() func(_ *restful.Request, response *restful.Re
 			Tag:         kv.Status.ObservedKubeVirtVersion,
 			Digest:      kvConfig.GsSha,
 			ImagePrefix: kvConfig.GetImagePrefix(),
+			GsImage:     kvConfig.GsImage,
 		})
 		return
 	}

--- a/pkg/virtctl/guestfs/guestfs.go
+++ b/pkg/virtctl/guestfs/guestfs.go
@@ -48,17 +48,17 @@ const (
 )
 
 var (
-	pvc           string
-	image         string
-	ExportedImage string
-	timeout       = 500 * time.Second
-	pullPolicy    string
-	kvm           bool
-	podName       string
-	root          bool
-	fsGroup       string
-	uid           string
-	gid           string
+	pvc        string
+	image      string
+	ImagePtr   = &image
+	timeout    = 500 * time.Second
+	pullPolicy string
+	kvm        bool
+	podName    string
+	root       bool
+	fsGroup    string
+	uid        string
+	gid        string
 )
 
 type guestfsCommand struct {
@@ -222,6 +222,11 @@ func setImage(virtClient kubecli.KubevirtClient) error {
 	if err != nil {
 		return fmt.Errorf("could not get guestfs image info: %v", err)
 	}
+	if info.GsImage != "" {
+		// custom image set, no need to assemble url
+		image = info.GsImage
+		return nil
+	}
 	// Set image name including prefix if available
 	imageName = fmt.Sprintf("%s%s", info.ImagePrefix, defaultImageName)
 	// Set the image version.
@@ -238,7 +243,6 @@ func setImage(virtClient kubecli.KubevirtClient) error {
 	if info.Registry != "" {
 		image = fmt.Sprintf("%s/%s", info.Registry, imageName)
 	}
-	ExportedImage = image
 
 	return nil
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/guestfs.go
@@ -35,6 +35,7 @@ type GuestfsInfo struct {
 	Tag         string `json:"tag"`
 	Digest      string `json:"digest"`
 	ImagePrefix string `json:"imagePrefix"`
+	GsImage     string `json:"gsImage"`
 }
 
 func (k *kubevirt) GuestfsVersion() *GuestfsVersion {


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If the custom override exists, there is really no reason to assemble the url ourselves.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2158515

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Guestfs image url not constructed correctly
```
