### PR TITLE
fix(virtctl): Make create vm cmd e2e-test more robust

### DIFF
--- a/tests/virtctl/create_vm.go
+++ b/tests/virtctl/create_vm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -306,7 +307,10 @@ func createAnnotatedSourcePVC(virtClient kubecli.KubevirtClient, instancetypeNam
 		apiinstancetype.DefaultPreferenceLabel:       preferenceName,
 		apiinstancetype.DefaultPreferenceKindLabel:   apiinstancetype.SingularPreferenceResourceName,
 	}
-	pvc, err := virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		var err error
+		pvc, err = virtClient.CoreV1().PersistentVolumeClaims(util.NamespaceTestDefault).Update(context.Background(), pvc, metav1.UpdateOptions{})
+		return err
+	}, 60*time.Second, 1*time.Second).Should(Succeed())
 	return pvc
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the create vm command e2e-test more robust by using Eventually around the PVC update call to allow retries when the PVC was changed in the meanwhile.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
