### PR TITLE
Remove verbose fn calls to Warn & Error

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -188,7 +188,7 @@ func (app *virtHandlerApp) markNodeAsUnschedulable(logger *log.FilteredLogger) {
 	data := []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "false"}}}`, v1.NodeSchedulable))
 	_, err := app.virtCli.CoreV1().Nodes().Patch(context.Background(), app.HostOverride, types.StrategicMergePatchType, data, metav1.PatchOptions{})
 	if err != nil {
-		logger.Level(log.ERROR).Log("Unable to mark node as unschedulable", err.Error())
+		logger.Reason(err).Error("Unable to mark node as unschedulable")
 	}
 }
 
@@ -207,7 +207,7 @@ func (app *virtHandlerApp) Run() {
 	}
 
 	logger := log.Log
-	logger.V(1).Level(log.INFO).Log("hostname", app.HostOverride)
+	logger.V(1).Infof("hostname %s", app.HostOverride)
 	var err error
 
 	// Copy container-disk binary

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -188,7 +188,7 @@ func (app *virtHandlerApp) markNodeAsUnschedulable(logger *log.FilteredLogger) {
 	data := []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "false"}}}`, v1.NodeSchedulable))
 	_, err := app.virtCli.CoreV1().Nodes().Patch(context.Background(), app.HostOverride, types.StrategicMergePatchType, data, metav1.PatchOptions{})
 	if err != nil {
-		logger.V(1).Level(log.ERROR).Log("Unable to mark node as unschedulable", err.Error())
+		logger.Level(log.ERROR).Log("Unable to mark node as unschedulable", err.Error())
 	}
 }
 

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -304,8 +304,7 @@ func readFileFromDir(basedir, file string) (string, error) {
 	// #nosec No risk for path injection: basedir & secretFile are static strings
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Log.V(2).Reason(err).
-			Errorf("could not read data from source: %s", filePath)
+		log.Log.Reason(err).Errorf("could not read data from source: %s", filePath)
 		return "", err
 	}
 	return string(data), nil
@@ -423,7 +422,7 @@ func defaultIsoFunc(isoOutFile, volumeID string, inDir string) error {
 
 	err := cmd.Start()
 	if err != nil {
-		log.Log.V(2).Reason(err).Errorf("%s cmd failed to start while generating iso file %s", isoBinary, isoOutFile)
+		log.Log.Reason(err).Errorf("%s cmd failed to start while generating iso file %s", isoBinary, isoOutFile)
 		return err
 	}
 
@@ -435,11 +434,11 @@ func defaultIsoFunc(isoOutFile, volumeID string, inDir string) error {
 	for {
 		select {
 		case <-timeout:
-			log.Log.V(2).Errorf("Timed out generating cloud-init iso at path %s", isoOutFile)
+			log.Log.Errorf("Timed out generating cloud-init iso at path %s", isoOutFile)
 			cmd.Process.Kill()
 		case err := <-done:
 			if err != nil {
-				log.Log.V(2).Reason(err).Errorf("%s returned non-zero exit code while generating iso file %s with args '%s'", isoBinary, isoOutFile, strings.Join(cmd.Args, " "))
+				log.Log.Reason(err).Errorf("%s returned non-zero exit code while generating iso file %s with args '%s'", isoBinary, isoOutFile, strings.Join(cmd.Args, " "))
 				return err
 			}
 			return nil
@@ -524,7 +523,7 @@ func GenerateEmptyIso(vmiName string, namespace string, data *CloudInitData, siz
 
 	err = util.MkdirAllWithNosec(path.Dir(isoStaging))
 	if err != nil {
-		log.Log.V(2).Reason(err).Errorf("unable to create cloud-init base path %s", path.Dir(isoStaging))
+		log.Log.Reason(err).Errorf("unable to create cloud-init base path %s", path.Dir(isoStaging))
 		return err
 	}
 
@@ -613,7 +612,7 @@ func GenerateLocalData(vmi *v1.VirtualMachineInstance, instanceType string, data
 
 	err = util.MkdirAllWithNosec(dataPath)
 	if err != nil {
-		log.Log.V(2).Reason(err).Errorf("unable to create cloud-init base path %s", domainBasePath)
+		log.Log.Reason(err).Errorf("unable to create cloud-init base path %s", domainBasePath)
 		return err
 	}
 

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -111,7 +111,7 @@ func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVol
 	file := getPVCDiskImgPath(volumeName, "disk.img")
 	capacity := volumeStatus.PersistentVolumeClaimInfo.Capacity[k8sv1.ResourceStorage]
 	// The host-disk must be 1MiB-aligned. If the volume specifies a misaligned size, shrink it down to the nearest multiple of 1MiB
-	size := util.AlignImageSizeTo1MiB(capacity.Value(), log.Log.V(2))
+	size := util.AlignImageSizeTo1MiB(capacity.Value(), log.Log)
 	if size == 0 {
 		return fmt.Errorf("the size for volume %s is too low, must be at least 1MiB", volumeName)
 	}

--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -68,7 +68,7 @@ func GenerateIgnitionLocalData(vmi *v1.VirtualMachineInstance, namespace string)
 	domainBasePath := GetDomainBasePath(vmi.Name, namespace)
 	err := util.MkdirAllWithNosec(domainBasePath)
 	if err != nil {
-		log.Log.V(2).Reason(err).Errorf("unable to create Ignition base path %s", domainBasePath)
+		log.Log.Reason(err).Errorf("unable to create Ignition base path %s", domainBasePath)
 		return err
 	}
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -69,7 +69,7 @@ var (
 
 func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch chan<- prometheus.Metric) {
 	if err != nil {
-		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", desc, err)
+		log.Log.Warningf("Error creating the new const metric for %s: %s", desc, err)
 		return
 	}
 	ch <- mv
@@ -245,7 +245,7 @@ func (metrics *vmiMetrics) updateCPUAffinity(cpuMap [][]bool) {
 
 func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCPUStats *stats.DomainStatsCPU) {
 	if !domainCPUStats.TimeSet && !domainCPUStats.UserSet && !domainCPUStats.SystemSet {
-		log.Log.V(4).Warningf("No domain CPU stats is set for %s VMI.", vmi.Name)
+		log.Log.Warningf("No domain CPU stats is set for %s VMI.", vmi.Name)
 	}
 
 	if domainCPUStats.TimeSet {
@@ -307,7 +307,7 @@ func (metrics *vmiMetrics) updateVcpu(vcpuStats []stats.DomainStatsVcpu) {
 func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 	for blockIdx, block := range blkStats {
 		if !block.NameSet {
-			log.Log.V(4).Warningf("Name not set for block device#%d", blockIdx)
+			log.Log.Warningf("Name not set for block device#%d", blockIdx)
 			continue
 		}
 
@@ -674,7 +674,7 @@ func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachine
 	// Since this is a known failure condition, let's handle it explicitly.
 	defer func() {
 		if err := recover(); err != nil {
-			log.Log.V(2).Warningf("collector goroutine panicked for VM %s: %s", socketFile, err)
+			log.Log.Warningf("collector goroutine panicked for VM %s: %s", socketFile, err)
 		}
 	}()
 

--- a/pkg/monitoring/migrationstats/collector.go
+++ b/pkg/monitoring/migrationstats/collector.go
@@ -144,7 +144,7 @@ func (ps *prometheusScraper) pushMetric(desc *prometheus.Desc, value float64, la
 		labelValues...,
 	)
 	if err != nil {
-		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", desc, err)
+		log.Log.Warningf("Error creating the new const metric for %s: %s", desc, err)
 		return
 	}
 

--- a/pkg/monitoring/vmstats/collector.go
+++ b/pkg/monitoring/vmstats/collector.go
@@ -175,7 +175,7 @@ func (ps *prometheusScraper) pushMetric(desc *prometheus.Desc, value float64, la
 		labelValues...,
 	)
 	if err != nil {
-		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", desc, err)
+		log.Log.Warningf("Error creating the new const metric for %s: %s", desc, err)
 		return
 	}
 	ps.ch <- mv

--- a/pkg/network/dhcp/serverv6/serverv6.go
+++ b/pkg/network/dhcp/serverv6/serverv6.go
@@ -80,12 +80,12 @@ func (h *DHCPv6Handler) ServeDHCPv6(conn net.PacketConn, peer net.Addr, m dhcpv6
 
 	response, err := h.buildResponse(m)
 	if err != nil {
-		log.Log.V(4).Reason(err).Error("DHCPv6 failed building a response to the client")
+		log.Log.Reason(err).Error("DHCPv6 failed building a response to the client")
 
 	}
 
 	if _, err := conn.WriteTo(response.ToBytes(), peer); err != nil {
-		log.Log.V(4).Reason(err).Error("DHCPv6 failed sending a response to the client")
+		log.Log.Reason(err).Error("DHCPv6 failed sending a response to the client")
 	}
 }
 

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -817,7 +817,7 @@ func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.Virtual
 func (ctrl *VMExportController) getExporterPod(vmExport *exportv1.VirtualMachineExport) (*corev1.Pod, bool, error) {
 	key := controller.NamespacedKey(vmExport.Namespace, ctrl.getExportPodName(vmExport))
 	if obj, exists, err := ctrl.PodInformer.GetStore().GetByKey(key); err != nil {
-		log.Log.V(3).Errorf("error %v", err)
+		log.Log.Errorf("error %v", err)
 		return nil, false, err
 	} else if !exists {
 		return nil, exists, nil
@@ -831,7 +831,7 @@ func (ctrl *VMExportController) createExporterPod(vmExport *exportv1.VirtualMach
 	log.Log.V(3).Infof("Checking if pod exists: %s/%s", vmExport.Namespace, ctrl.getExportPodName(vmExport))
 	key := controller.NamespacedKey(vmExport.Namespace, ctrl.getExportPodName(vmExport))
 	if obj, exists, err := ctrl.PodInformer.GetStore().GetByKey(key); err != nil {
-		log.Log.V(3).Errorf("error %v", err)
+		log.Log.Errorf("error %v", err)
 		return nil, err
 	} else if !exists {
 		manifest, err := ctrl.createExporterPodManifest(vmExport, service, pvcs)

--- a/pkg/virt-api/rest/interfacehotplug.go
+++ b/pkg/virt-api/rest/interfacehotplug.go
@@ -296,7 +296,7 @@ func (app *SubresourceAPIApp) vmiInterfacePatch(vmName string, namespace string,
 
 	log.Log.Object(vmi).V(4).Infof("Patching VMI: %s", patch)
 	if _, err := app.virtCli.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{}); err != nil {
-		log.Log.Object(vmi).V(1).Errorf("unable to patch vmi: %v", err)
+		log.Log.Object(vmi).Errorf("unable to patch vmi: %v", err)
 		var statusError *errors.StatusError
 		if goerrors.As(err, &statusError) {
 			return statusError
@@ -323,7 +323,7 @@ func (app *SubresourceAPIApp) vmInterfacePatchStatus(vmName string, namespace st
 
 	log.Log.Object(vm).V(4).Infof("Patching VM: %s", patch)
 	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{}); err != nil {
-		log.Log.Object(vm).V(1).Errorf("unable to patch vm status: %v", err)
+		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
 				return statErr

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -1282,7 +1282,7 @@ func (app *SubresourceAPIApp) vmiVolumePatch(name, namespace string, volumeReque
 	dryRunOption := app.getDryRunOption(volumeRequest)
 	log.Log.Object(vmi).V(4).Infof("Patching VMI: %s", patch)
 	if _, err := app.virtCli.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
-		log.Log.Object(vmi).V(1).Errorf("unable to patch vmi: %v", err)
+		log.Log.Object(vmi).Errorf("unable to patch vmi: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
 				return statErr
@@ -1312,7 +1312,7 @@ func (app *SubresourceAPIApp) vmVolumePatchStatus(name, namespace string, volume
 	dryRunOption := app.getDryRunOption(volumeRequest)
 	log.Log.Object(vm).V(4).Infof(patchingVMFmt, patch)
 	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{DryRun: dryRunOption}); err != nil {
-		log.Log.Object(vm).V(1).Errorf("unable to patch vm status: %v", err)
+		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
 				return statErr
@@ -1527,7 +1527,7 @@ func (app *SubresourceAPIApp) vmMemoryDumpRequestPatchStatus(name, namespace str
 
 	log.Log.Object(vm).V(4).Infof(patchingVMFmt, patch)
 	if err := app.statusUpdater.PatchStatus(vm, types.JSONPatchType, []byte(patch), &k8smetav1.PatchOptions{}); err != nil {
-		log.Log.Object(vm).V(1).Errorf("unable to patch vm status: %v", err)
+		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
 				return statErr

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -753,7 +753,7 @@ func (c *MigrationController) handleMigrationBackoff(key string, vmi *virtv1.Vir
 	backoff = outOffBackoffTS.Sub(time.Now())
 
 	if backoff > 0 {
-		log.Log.Object(vmi).V(2).Errorf("vmi in migration backoff, re-enqueueing after %v", backoff)
+		log.Log.Object(vmi).Errorf("vmi in migration backoff, re-enqueueing after %v", backoff)
 		c.Queue.AddAfter(key, backoff)
 		return migrationBackoffError
 	}
@@ -1594,7 +1594,7 @@ func (c *MigrationController) garbageCollectFinalizedMigrations(vmi *virtv1.Virt
 			// scenarios that the migration we're trying to garbage
 			// collect has already disappeared. Let's log it as debug
 			// and suppress the error in this situation.
-			log.Log.V(3).Reason(err).Infof("error encountered when garbage collecting migration object %s/%s", vmi.Namespace, finalizedMigrations[i])
+			log.Log.Reason(err).Infof("error encountered when garbage collecting migration object %s/%s", vmi.Namespace, finalizedMigrations[i])
 		} else if err != nil {
 			return err
 		}
@@ -1674,7 +1674,7 @@ func (c *MigrationController) updateVMI(old, cur interface{}) {
 
 	migrations, err := c.listMigrationsMatchingVMI(curVMI.Namespace, curVMI.Name)
 	if err != nil {
-		log.Log.V(4).Object(curVMI).Errorf("Error encountered during datavolume update: %v", err)
+		log.Log.Object(curVMI).Errorf("Error encountered during datavolume update: %v", err)
 		return
 	}
 	for _, migration := range migrations {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -600,7 +600,7 @@ func (c *VMController) handleMemoryDumpRequest(vm *virtv1.VirtualMachine, vmi *v
 			return nil
 		}
 		if err := c.generateVMIMemoryDumpVolumePatch(vmi, vm.Status.MemoryDumpRequest, true); err != nil {
-			log.Log.Object(vmi).V(1).Errorf("unable to patch vmi to add memory dump volume: %v", err)
+			log.Log.Object(vmi).Errorf("unable to patch vmi to add memory dump volume: %v", err)
 			return err
 		}
 	case virtv1.MemoryDumpUnmounting, virtv1.MemoryDumpFailed:
@@ -614,7 +614,7 @@ func (c *VMController) handleMemoryDumpRequest(vm *virtv1.VirtualMachine, vmi *v
 		}
 
 		if err := c.generateVMIMemoryDumpVolumePatch(vmi, vm.Status.MemoryDumpRequest, false); err != nil {
-			log.Log.Object(vmi).V(1).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
+			log.Log.Object(vmi).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
 			return err
 		}
 	case virtv1.MemoryDumpDissociating:
@@ -622,7 +622,7 @@ func (c *VMController) handleMemoryDumpRequest(vm *virtv1.VirtualMachine, vmi *v
 		// if it still there remove it to make it unmount from virt launcher
 		if _, exists := vmiVolumeMap[vm.Status.MemoryDumpRequest.ClaimName]; exists {
 			if err := c.generateVMIMemoryDumpVolumePatch(vmi, vm.Status.MemoryDumpRequest, false); err != nil {
-				log.Log.Object(vmi).V(1).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
+				log.Log.Object(vmi).Errorf("unable to patch vmi to remove memory dump volume: %v", err)
 				return err
 			}
 		}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1337,7 +1337,7 @@ func (c *VMIController) updatePVC(old, cur interface{}) {
 
 	vmis, err := c.listVMIsMatchingDV(curPVC.Namespace, curPVC.Name)
 	if err != nil {
-		log.Log.V(4).Object(curPVC).Errorf("Error encountered getting VMIs for DataVolume: %v", err)
+		log.Log.Object(curPVC).Errorf("Error encountered getting VMIs for DataVolume: %v", err)
 		return
 	}
 
@@ -1388,7 +1388,7 @@ func (c *VMIController) updateDataVolume(old, cur interface{}) {
 
 	vmis, err := c.listVMIsMatchingDV(curDataVolume.Namespace, curDataVolume.Name)
 	if err != nil {
-		log.Log.V(4).Object(curDataVolume).Errorf("Error encountered during datavolume update: %v", err)
+		log.Log.Object(curDataVolume).Errorf("Error encountered during datavolume update: %v", err)
 		return
 	}
 	for _, vmi := range vmis {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1124,7 +1124,7 @@ func (d *VirtualMachineController) updateMemoryDumpInfo(vmi *v1.VirtualMachineIn
 			volumeStatus.MemoryDumpVolume.StartTimestamp = memoryDumpMetadata.StartTimestamp
 		}
 		if memoryDumpMetadata.EndTimestamp != nil && memoryDumpMetadata.Failed {
-			log.Log.Object(vmi).V(3).Errorf("Memory dump to pvc %s failed: %v", volumeStatus.Name, memoryDumpMetadata.FailureReason)
+			log.Log.Object(vmi).Errorf("Memory dump to pvc %s failed: %v", volumeStatus.Name, memoryDumpMetadata.FailureReason)
 			volumeStatus.Message = fmt.Sprintf("Memory dump to pvc %s failed: %v", volumeStatus.Name, memoryDumpMetadata.FailureReason)
 			volumeStatus.Phase = v1.MemoryDumpVolumeFailed
 			volumeStatus.MemoryDumpVolume.EndTimestamp = memoryDumpMetadata.EndTimestamp
@@ -1192,7 +1192,7 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 		}
 	}
 	if podUID == "" {
-		log.DefaultLogger().V(2).Warningf("failed to find pod UID for VMI %s", vmi.Name)
+		log.DefaultLogger().Warningf("failed to find pod UID for VMI %s", vmi.Name)
 		return
 	}
 
@@ -1204,7 +1204,7 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 	for _, disk := range vmi.Spec.Domain.Devices.Disks {
 		volume, ok := volumes[disk.Name]
 		if !ok {
-			log.DefaultLogger().V(2).Warningf("No matching volume with name %s found", disk.Name)
+			log.DefaultLogger().Warningf("No matching volume with name %s found", disk.Name)
 			continue
 		}
 
@@ -1215,24 +1215,24 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 
 		res, err := d.podIsolationDetector.Detect(vmi)
 		if err != nil {
-			log.DefaultLogger().V(2).Reason(err).Warningf("failed to detect VMI %s", vmi.Name)
+			log.DefaultLogger().Reason(err).Warningf("failed to detect VMI %s", vmi.Name)
 			continue
 		}
 
 		rootPath, err := res.MountRoot()
 		if err != nil {
-			log.DefaultLogger().V(2).Reason(err).Warningf("failed to detect VMI %s", vmi.Name)
+			log.DefaultLogger().Reason(err).Warningf("failed to detect VMI %s", vmi.Name)
 			continue
 		}
 
 		safeVolPath, err := rootPath.AppendAndResolveWithRelativeRoot(volPath)
 		if err != nil {
-			log.DefaultLogger().V(2).Warningf("failed to determine file size for volume %s", volPath)
+			log.DefaultLogger().Warningf("failed to determine file size for volume %s", volPath)
 			continue
 		}
 		fileInfo, err := safepath.StatAtNoFollow(safeVolPath)
 		if err != nil {
-			log.DefaultLogger().V(2).Warningf("failed to determine file size for volume %s", volPath)
+			log.DefaultLogger().Warningf("failed to determine file size for volume %s", volPath)
 			continue
 		}
 
@@ -1902,7 +1902,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 
 		// `syncErr` will be propagated anyway, and it will be logged in `re-enqueueing`
 		// so there is no need to log it twice in hot path without increased verbosity.
-		log.Log.Object(vmi).V(3).Reason(syncErr).Error("Synchronizing the VirtualMachineInstance failed.")
+		log.Log.Object(vmi).Reason(syncErr).Error("Synchronizing the VirtualMachineInstance failed.")
 	}
 
 	// Update the VirtualMachineInstance status, if the VirtualMachineInstance exists

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -492,7 +492,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(failed bool, completed b
 		}
 	})
 
-	logger := log.Log
+	logger := log.Log.V(2)
 	if !failed {
 		logger = logger.V(4)
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -300,7 +300,7 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) erro
 					case libvirt.ERR_AGENT_UNRESPONSIVE:
 						const unresponsive = "failed to set time: QEMU agent unresponsive"
 						latestErr = fmt.Errorf("%s, %s", unresponsive, err)
-						log.Log.Object(vmi).Reason(err).V(9).Warning(unresponsive)
+						log.Log.Object(vmi).Reason(err).V(9).Info(unresponsive)
 					case libvirt.ERR_OPERATION_UNSUPPORTED:
 						// no need to retry as this opertaion is not supported
 						log.Log.Object(vmi).Reason(err).Warning("failed to set time: not supported")
@@ -311,7 +311,7 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) erro
 						return
 					default:
 						latestErr = fmt.Errorf("%s, %s", failedSyncGuestTime, err)
-						log.Log.Object(vmi).Reason(err).V(9).Warning(failedSyncGuestTime)
+						log.Log.Object(vmi).Reason(err).V(9).Info(failedSyncGuestTime)
 					}
 				} else {
 					latestErr = nil

--- a/staging/src/kubevirt.io/client-go/log/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/log/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
         "//staging/src/github.com/golang/glog:go_default_library",
         "//vendor/github.com/go-kit/kit/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -162,24 +162,24 @@ func TestVerbosity(t *testing.T) {
 	assert(t, logCalled, "Log entry (V=2) should have been recorded")
 
 	logCalled = false
-	log = log.V(4)
-	log.Log("This is a verbosity level 4 message")
+	vLog := log.V(4)
+	vLog.Log("This is a verbosity level 4 message")
 	assert(t, !logCalled, "Log entry (V=4) should not have been recorded")
 
 	// this call should be ignored. repeat last test to prove it
 	logCalled = false
-	log = log.V(-1)
-	log.Log("This is a verbosity level 4 message")
+	vLog = vLog.V(-1)
+	vLog.Log("This is a verbosity level 4 message")
 	assert(t, !logCalled, "Log entry (V=4) should not have been recorded")
 
 	logCalled = false
-	log.V(3).Log("This is a verbosity level 3 message")
+	vLog.V(3).Log("This is a verbosity level 3 message")
 	assert(t, logCalled, "Log entry (V=3) should have been recorded")
 
 	// once again, this call should do nothing.
 	logCalled = false
-	log = log.V(-1)
-	log.Log("This is a verbosity level 4 message")
+	vLog = vLog.V(-1)
+	vLog.Log("This is a verbosity level 4 message")
 	assert(t, !logCalled, "Log entry (V=4) should not have been recorded")
 	tearDown()
 }
@@ -359,30 +359,6 @@ func TestLogVerbosity(t *testing.T) {
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[4].(string) == "pos", "Logged line did not contain pos")
 	assert(t, strings.HasPrefix(logEntry[5].(string), "log_test.go"), "Logged line referenced wrong module")
-	tearDown()
-}
-
-func TestMsgVerbosity(t *testing.T) {
-	setUp()
-	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(INFO)
-	log.SetVerbosityLevel(2)
-	log.V(2).msg("test")
-
-	logEntry := logParams[0].([]interface{})
-	assert(t, logEntry[4].(string) == "pos", "Logged line did not contain pos")
-	tearDown()
-}
-
-func TestMsgfVerbosity(t *testing.T) {
-	setUp()
-	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(INFO)
-	log.SetVerbosityLevel(2)
-	log.V(2).msgf("%s", "test")
-
-	logEntry := logParams[0].([]interface{})
-	assert(t, logEntry[4].(string) == "pos", "Logged line did not contain pos")
 	tearDown()
 }
 

--- a/tools/perfscale-load-generator/load-generator.go
+++ b/tools/perfscale-load-generator/load-generator.go
@@ -57,7 +57,7 @@ func main() {
 	} else if workload.Type == "steady-state" {
 		lg = &steadyState.SteadyStateLoadGenerator{Done: timeout, UUID: testUUID}
 	} else {
-		log.Log.V(1).Errorf("Load Generator doesn't have type %s", workload.Type)
+		log.Log.Errorf("Load Generator doesn't have type %s", workload.Type)
 		return
 	}
 

--- a/tools/perfscale-load-generator/object/namespace.go
+++ b/tools/perfscale-load-generator/object/namespace.go
@@ -45,7 +45,7 @@ func CreateNamespaceIfNotExist(virtCli kubecli.KubevirtClient, name, scenarioLab
 	_, err := virtCli.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 	if !errors.IsAlreadyExists(err) {
 		if err != nil {
-			log.Log.V(2).Errorf("Error creating namespace %s: %v", name, err)
+			log.Log.Errorf("Error creating namespace %s: %v", name, err)
 			return err
 		}
 	}

--- a/tools/perfscale-load-generator/object/unstructured.go
+++ b/tools/perfscale-load-generator/object/unstructured.go
@@ -50,7 +50,7 @@ func DeleteObject(virtCli kubecli.KubevirtClient, obj unstructured.Unstructured,
 		Body(&metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}).
 		Do(context.Background()).Error()
 	if err != nil && !errors.IsNotFound(err) {
-		log.Log.V(2).Errorf("Error deleting obj %s %s: %v", resourceKind, obj.GetName(), err)
+		log.Log.Errorf("Error deleting obj %s %s: %v", resourceKind, obj.GetName(), err)
 	}
 	return
 }

--- a/tools/perfscale-load-generator/watcher/watcher.go
+++ b/tools/perfscale-load-generator/watcher/watcher.go
@@ -116,19 +116,19 @@ func (w *ObjListWatcher) handleUpdate(obj interface{}) {
 	case objUtils.VMIResource:
 		vmi, ok := obj.(*kvv1.VirtualMachineInstance)
 		if !ok {
-			log.Log.V(2).Errorf("Could not convert VirtualMachineInstance obj: %v", w.ResourceKind)
+			log.Log.Errorf("Could not convert VirtualMachineInstance obj: %v", w.ResourceKind)
 		}
 		if vmi.Status.Phase == kvv1.Running {
 			w.addObj(w.getID(vmi))
 		}
 		if vmi.Status.Phase == kvv1.Succeeded || vmi.Status.Phase == kvv1.Failed {
-			log.Log.V(4).Errorf("VirtualMachineInstance obj: %s is a final state, waiting for garbage collection", fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name))
+			log.Log.Errorf("VirtualMachineInstance obj: %s is a final state, waiting for garbage collection", fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name))
 		}
 
 	case objUtils.VMResource:
 		vm, ok := obj.(*kvv1.VirtualMachine)
 		if !ok {
-			log.Log.V(2).Errorf("Could not convert VirtualMachine obj: %v", w.ResourceKind)
+			log.Log.Errorf("Could not convert VirtualMachine obj: %v", w.ResourceKind)
 		}
 		if vm.Status.Ready {
 			w.addObj(w.getID(vm))
@@ -137,12 +137,12 @@ func (w *ObjListWatcher) handleUpdate(obj interface{}) {
 	case objUtils.VMIReplicaSetResource:
 		replicaSet, ok := obj.(*kvv1.VirtualMachineInstanceReplicaSet)
 		if !ok {
-			log.Log.V(2).Errorf("Could not convert VirtualMachineInstanceReplicaSet obj: %v", w.ResourceKind)
+			log.Log.Errorf("Could not convert VirtualMachineInstanceReplicaSet obj: %v", w.ResourceKind)
 		}
 		w.addObj(w.getID(replicaSet))
 
 	default:
-		log.Log.V(2).Errorf("Watcher does not support object type %s", w.ResourceKind)
+		log.Log.Errorf("Watcher does not support object type %s", w.ResourceKind)
 		return
 	}
 }
@@ -152,15 +152,15 @@ func (w *ObjListWatcher) handleDeleted(obj interface{}) {
 	case objUtils.VMResource:
 		vm, ok := obj.(*kvv1.VirtualMachine)
 		if !ok {
-			log.Log.V(2).Errorf("Could not convert VirtualMachine obj: %v", w.ResourceKind)
+			log.Log.Errorf("Could not convert VirtualMachine obj: %v", w.ResourceKind)
 			return
 		}
 		isGarbageCollected, err := w.isGarbageCollected(vm)
 		if err != nil {
-			log.Log.V(2).Errorf("Could not get VirtualMachine: %v, err: %#v", fmt.Sprintf("%s/%s", vm.Namespace, vm.Name), err)
+			log.Log.Errorf("Could not get VirtualMachine: %v, err: %#v", fmt.Sprintf("%s/%s", vm.Namespace, vm.Name), err)
 		}
 		if !isGarbageCollected {
-			log.Log.V(4).Errorf("VirtualMachine obj: %v has not been garbage collected yet", fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
+			log.Log.Errorf("VirtualMachine obj: %v has not been garbage collected yet", fmt.Sprintf("%s/%s", vm.Namespace, vm.Name))
 			return
 		}
 		w.deleteObj(w.getID(vm))
@@ -168,30 +168,30 @@ func (w *ObjListWatcher) handleDeleted(obj interface{}) {
 	case objUtils.VMIReplicaSetResource:
 		replicaSet, ok := obj.(*kvv1.VirtualMachineInstanceReplicaSet)
 		if !ok {
-			log.Log.V(2).Errorf("Could not convert VirtualMachineInstanceReplicaSet obj: %v", w.ResourceKind)
+			log.Log.Errorf("Could not convert VirtualMachineInstanceReplicaSet obj: %v", w.ResourceKind)
 			return
 		}
 		isGarbageCollected, err := w.isGarbageCollected(replicaSet)
 		if err != nil {
-			log.Log.V(2).Errorf("Could not get VirtualMachineInstanceReplicaSet: %v, err: %#v", fmt.Sprintf("%s/%s", replicaSet.Namespace, replicaSet.Name), err)
+			log.Log.Errorf("Could not get VirtualMachineInstanceReplicaSet: %v, err: %#v", fmt.Sprintf("%s/%s", replicaSet.Namespace, replicaSet.Name), err)
 		}
 		if !isGarbageCollected {
-			log.Log.V(4).Errorf("VirtualMachineInstanceReplicaSet obj: %v has not been garbage collected yet", fmt.Sprintf("%s/%s", replicaSet.Namespace, replicaSet.Name))
+			log.Log.Errorf("VirtualMachineInstanceReplicaSet obj: %v has not been garbage collected yet", fmt.Sprintf("%s/%s", replicaSet.Namespace, replicaSet.Name))
 			return
 		}
 		w.deleteObj(w.getID(replicaSet))
 	case objUtils.VMIResource:
 		vmi, ok := obj.(*kvv1.VirtualMachineInstance)
 		if !ok {
-			log.Log.V(2).Errorf("Could not convert VirtualMachineInstance obj: %v", w.ResourceKind)
+			log.Log.Errorf("Could not convert VirtualMachineInstance obj: %v", w.ResourceKind)
 			return
 		}
 		isGarbageCollected, err := w.isGarbageCollected(vmi)
 		if err != nil {
-			log.Log.V(2).Errorf("Could not get VirtualMachineInstance: %v, err: %#v", fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name), err)
+			log.Log.Errorf("Could not get VirtualMachineInstance: %v, err: %#v", fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name), err)
 		}
 		if !isGarbageCollected {
-			log.Log.V(4).Errorf("VirtualMachineInstance obj: %v has not been garbage collected yet", fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name))
+			log.Log.Errorf("VirtualMachineInstance obj: %v has not been garbage collected yet", fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name))
 			return
 		}
 		w.deleteObj(w.getID(vmi))
@@ -265,19 +265,19 @@ func (w *ObjListWatcher) getRunningCount() int {
 func (w *ObjListWatcher) isGarbageCollected(obj interface{}) (bool, error) {
 	objKey, err := controller.KeyFunc(obj)
 	if err != nil {
-		log.Log.V(2).Errorf("Error getting obj key for %s err: %v", obj, err)
+		log.Log.Errorf("Error getting obj key for %s err: %v", obj, err)
 		return false, err
 	}
 	_, exists, err := w.informer.GetStore().GetByKey(objKey)
 	switch {
 	case err != nil:
-		log.Log.V(2).Errorf("Error getting obj %s from cache err: %v", obj, err)
+		log.Log.Errorf("Error getting obj %s from cache err: %v", obj, err)
 		return false, err
 	case !exists:
-		log.Log.V(4).Errorf("Obj %s not found in cache", objKey)
+		log.Log.Errorf("Obj %s not found in cache", objKey)
 		return true, nil
 	default:
-		log.Log.V(4).Errorf("Obj %s found in cache", objKey)
+		log.Log.Errorf("Obj %s found in cache", objKey)
 		return false, nil
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
These are redundant function calls that set the verbosity level of the log message that are warning or error. Verbosity level are only interesting for Info messages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #8164

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
