### PR TITLE
migration: match SELinux level of source pod on target pod

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17976,6 +17976,10 @@
       "description": "When set to true, DisableTLS will disable the additional layer of live migration encryption provided by KubeVirt. This is usually a bad idea. Defaults to false",
       "type": "boolean"
      },
+     "matchSELinuxLevelOnMigration": {
+      "description": "By default, the SELinux level of target virt-launcher pods is forced to the level of the source virt-launcher. When set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign a random level to the target. That will ensure the target virt-launcher doesn't share categories with another pod on the node. However, migrations will fail when using RWX volumes that don't automatically deal with SELinux levels.",
+      "type": "boolean"
+     },
      "network": {
       "description": "Network is the name of the CNI network to use for live migrations. By default, migrations go through the pod network.",
       "type": "string"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -494,6 +494,16 @@ spec:
                           additional layer of live migration encryption provided by
                           KubeVirt. This is usually a bad idea. Defaults to false
                         type: boolean
+                      matchSELinuxLevelOnMigration:
+                        description: By default, the SELinux level of target virt-launcher
+                          pods is forced to the level of the source virt-launcher.
+                          When set to true, MatchSELinuxLevelOnMigration lets the
+                          CRI auto-assign a random level to the target. That will
+                          ensure the target virt-launcher doesn't share categories
+                          with another pod on the node. However, migrations will fail
+                          when using RWX volumes that don't automatically deal with
+                          SELinux levels.
+                        type: boolean
                       network:
                         description: Network is the name of the CNI network to use
                           for live migrations. By default, migrations go through the
@@ -3423,6 +3433,16 @@ spec:
                         description: When set to true, DisableTLS will disable the
                           additional layer of live migration encryption provided by
                           KubeVirt. This is usually a bad idea. Defaults to false
+                        type: boolean
+                      matchSELinuxLevelOnMigration:
+                        description: By default, the SELinux level of target virt-launcher
+                          pods is forced to the level of the source virt-launcher.
+                          When set to true, MatchSELinuxLevelOnMigration lets the
+                          CRI auto-assign a random level to the target. That will
+                          ensure the target virt-launcher doesn't share categories
+                          with another pod on the node. However, migrations will fail
+                          when using RWX volumes that don't automatically deal with
+                          SELinux levels.
                         type: boolean
                       network:
                         description: Network is the name of the CNI network to use

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//vendor/github.com/emicklei/go-restful/v3:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1:go_default_library",
+        "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1027,6 +1027,15 @@ var CRDsValidation map[string]string = map[string]string{
                     layer of live migration encryption provided by KubeVirt. This
                     is usually a bad idea. Defaults to false
                   type: boolean
+                matchSELinuxLevelOnMigration:
+                  description: By default, the SELinux level of target virt-launcher
+                    pods is forced to the level of the source virt-launcher. When
+                    set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign
+                    a random level to the target. That will ensure the target virt-launcher
+                    doesn't share categories with another pod on the node. However,
+                    migrations will fail when using RWX volumes that don't automatically
+                    deal with SELinux levels.
+                  type: boolean
                 network:
                   description: Network is the name of the CNI network to use for live
                     migrations. By default, migrations go through the pod network.
@@ -11532,6 +11541,15 @@ var CRDsValidation map[string]string = map[string]string{
                     layer of live migration encryption provided by KubeVirt. This
                     is usually a bad idea. Defaults to false
                   type: boolean
+                matchSELinuxLevelOnMigration:
+                  description: By default, the SELinux level of target virt-launcher
+                    pods is forced to the level of the source virt-launcher. When
+                    set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign
+                    a random level to the target. That will ensure the target virt-launcher
+                    doesn't share categories with another pod on the node. However,
+                    migrations will fail when using RWX volumes that don't automatically
+                    deal with SELinux levels.
+                  type: boolean
                 network:
                   description: Network is the name of the CNI network to use for live
                     migrations. By default, migrations go through the pod network.
@@ -11910,6 +11928,15 @@ var CRDsValidation map[string]string = map[string]string{
                   description: When set to true, DisableTLS will disable the additional
                     layer of live migration encryption provided by KubeVirt. This
                     is usually a bad idea. Defaults to false
+                  type: boolean
+                matchSELinuxLevelOnMigration:
+                  description: By default, the SELinux level of target virt-launcher
+                    pods is forced to the level of the source virt-launcher. When
+                    set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign
+                    a random level to the target. That will ensure the target virt-launcher
+                    doesn't share categories with another pod on the node. However,
+                    migrations will fail when using RWX volumes that don't automatically
+                    deal with SELinux levels.
                   type: boolean
                 network:
                   description: Network is the name of the CNI network to use for live

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2806,6 +2806,11 @@ func (in *MigrationConfiguration) DeepCopyInto(out *MigrationConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MatchSELinuxLevelOnMigration != nil {
+		in, out := &in.MatchSELinuxLevelOnMigration, &out.MatchSELinuxLevelOnMigration
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2484,6 +2484,11 @@ type MigrationConfiguration struct {
 	// Network is the name of the CNI network to use for live migrations. By default, migrations go
 	// through the pod network.
 	Network *string `json:"network,omitempty"`
+	// By default, the SELinux level of target virt-launcher pods is forced to the level of the source virt-launcher.
+	// When set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign a random level to the target.
+	// That will ensure the target virt-launcher doesn't share categories with another pod on the node.
+	// However, migrations will fail when using RWX volumes that don't automatically deal with SELinux levels.
+	MatchSELinuxLevelOnMigration *bool `json:"matchSELinuxLevelOnMigration,omitempty"`
 }
 
 // DiskVerification holds container disks verification limits

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -791,6 +791,7 @@ func (MigrationConfiguration) SwaggerDoc() map[string]string {
 		"allowPostCopy":                     "AllowPostCopy enables post-copy live migrations. Such migrations allow even the busiest VMIs\nto successfully live-migrate. However, events like a network failure can cause a VMI crash.\nIf set to true, migrations will still start in pre-copy, but switch to post-copy when\nCompletionTimeoutPerGiB triggers. Defaults to false",
 		"disableTLS":                        "When set to true, DisableTLS will disable the additional layer of live migration encryption\nprovided by KubeVirt. This is usually a bad idea. Defaults to false",
 		"network":                           "Network is the name of the CNI network to use for live migrations. By default, migrations go\nthrough the pod network.",
+		"matchSELinuxLevelOnMigration":      "By default, the SELinux level of target virt-launcher pods is forced to the level of the source virt-launcher.\nWhen set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign a random level to the target.\nThat will ensure the target virt-launcher doesn't share categories with another pod on the node.\nHowever, migrations will fail when using RWX volumes that don't automatically deal with SELinux levels.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19827,6 +19827,13 @@ func schema_kubevirtio_api_core_v1_MigrationConfiguration(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"matchSELinuxLevelOnMigration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "By default, the SELinux level of target virt-launcher pods is forced to the level of the source virt-launcher. When set to true, MatchSELinuxLevelOnMigration lets the CRI auto-assign a random level to the target. That will ensure the target virt-launcher doesn't share categories with another pod on the node. However, migrations will fail when using RWX volumes that don't automatically deal with SELinux levels.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
When VMIs use RWX disks based on some storage classes, like cephfs, both the source and target pods of a migration need to have access to the files.
There are 2 ways to achieve that:
- either remove the SELinux categories on the files for the duration of  the migration (see https://github.com/kubevirt/kubevirt/pull/9190)
- or match the source categories of the source pod on the target pod

Both solutions have negative security implications, but they're the only way to deal with shared resources.
I believe this is the best approach, as it doesn't mess with the disk and doesn't expose files to the entire node/cluster for the duration of the migration.
The only downside here is that the target node could (have) create(d) a pod with the same categories.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed migration issue for VMIs that have RWX disks backed by filesystem storage classes.
```
