### PR TITLE
device manager: externally provided mediated devices should not be removed

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -58,6 +58,9 @@ const (
 	// KubevirtSeccompProfile indicate that Kubevirt will install its custom profile and
 	// user can tell Kubevirt to use it
 	KubevirtSeccompProfile = "KubevirtSeccompProfile"
+	// DisableMediatedDevicesHandling disables the handling of mediated
+	// devices, its creation and deletion
+	DisableMediatedDevicesHandling = "DisableMDEVConfiguration"
 )
 
 var deprecatedFeatureGates = [...]string{
@@ -191,6 +194,10 @@ func (config *ClusterConfig) VSOCKEnabled() bool {
 
 func (config *ClusterConfig) CustomSELinuxPolicyDisabled() bool {
 	return config.isFeatureGateEnabled(DisableCustomSELinuxPolicy)
+}
+
+func (config *ClusterConfig) MediatedDevicesHandlingDisabled() bool {
+	return config.isFeatureGateEnabled(DisableMediatedDevicesHandling)
 }
 
 func (config *ClusterConfig) KubevirtSeccompProfileEnabled() bool {

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -289,6 +289,11 @@ func (c *DeviceController) getExternallyProvidedMdevs() map[string]struct{} {
 }
 
 func (c *DeviceController) refreshMediatedDeviceTypes() bool {
+	// the handling of mediated device is disabled
+	if c.virtConfig.MediatedDevicesHandlingDisabled() {
+		return false
+	}
+
 	requiresDevicePluginsUpdate := false
 	node, err := c.clientset.Nodes().Get(context.Background(), c.host, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/virt-handler/device-manager/mediated_devices_types_test.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types_test.go
@@ -286,10 +286,11 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			os.RemoveAll(fakeMdevBasePath)
 		})
 		DescribeTable("should create and remove relevant mdev types", func(scenario func() *scenarioValues) {
+			noExternallyConfiguredMdevs := make(map[string]struct{})
 			sc := scenario()
 			createTempMDEVSysfsStructure(sc.pciMDEVDevicesMap)
 			mdevManager := NewMDEVTypesManager()
-			_, err := mdevManager.updateMDEVTypesConfiguration(sc.desiredDevicesList)
+			_, err := mdevManager.updateMDEVTypesConfiguration(sc.desiredDevicesList, noExternallyConfiguredMdevs)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("creating the desired mdev types")
@@ -320,7 +321,7 @@ var _ = Describe("Mediated Devices Types configuration", func() {
 			}
 
 			By("removing all created mdevs")
-			_, err = mdevManager.updateMDEVTypesConfiguration([]string{})
+			_, err = mdevManager.updateMDEVTypesConfiguration([]string{}, noExternallyConfiguredMdevs)
 			Expect(err).ToNot(HaveOccurred())
 			files, err := os.ReadDir(fakeMdevDevicesPath)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -150,7 +150,9 @@ func (h *HeartBeat) do() {
 	// and a MediatedDevicesConfiguration in KubeVirt CR.
 	// When labels change we should initialize a refresh to create/remove mdev types and start/stop
 	// relevant device plugins. This operation should be async.
-	h.deviceManagerController.RefreshMediatedDeviceTypes()
+	if !h.clusterConfig.MediatedDevicesHandlingDisabled() {
+		h.deviceManagerController.RefreshMediatedDeviceTypes()
+	}
 	log.DefaultLogger().V(4).Infof("Heartbeat sent")
 }
 

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -119,6 +119,62 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 			return 0
 		}, 2*time.Minute, 5*time.Second).Should(BeZero(), "wait for the kubelet to stop promoting unconfigured devices")
 	}
+
+	Context("with externally provided mediated devices", func() {
+		var deviceName = "nvidia.com/GRID_T4-1B"
+		var mdevSelector = "GRID T4-1B"
+		var desiredMdevTypeName = "nvidia-222"
+		var expectedInstancesNum = 16
+		var config v1.KubeVirtConfiguration
+
+		BeforeEach(func() {
+			kv := util.GetCurrentKv(virtClient)
+
+			By("Creating a configuration for mediated devices")
+			config = kv.Spec.Configuration
+			config.DeveloperConfiguration.FeatureGates = append(config.DeveloperConfiguration.FeatureGates, virtconfig.GPUGate)
+			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{
+				MediatedDeviceTypes: []string{desiredMdevTypeName},
+			}
+			tests.UpdateKubeVirtConfigValueAndWait(config)
+
+			By("Verifying that an expected amount of devices has been created")
+			Eventually(checkAllMDEVCreated(desiredMdevTypeName, expectedInstancesNum), 3*time.Minute, 15*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
+		})
+
+		cleanupConfiguredMdevs := func() {
+			By("Removing the configuration of mediated devices")
+			config.PermittedHostDevices = &v1.PermittedHostDevices{}
+			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{}
+			tests.UpdateKubeVirtConfigValueAndWait(config)
+			By("Verifying that an expected amount of devices has been created")
+			noGPUDevicesAreAvailable()
+		}
+
+		AfterEach(func() {
+			cleanupConfiguredMdevs()
+		})
+		It("Should make sure that externally provided mdevs are not removed by virt-handler", func() {
+
+			By("Listing the created mdevs as externally provided ")
+			config.PermittedHostDevices = &v1.PermittedHostDevices{
+				MediatedDevices: []v1.MediatedHostDevice{
+					{
+						MDEVNameSelector:         mdevSelector,
+						ResourceName:             deviceName,
+						ExternalResourceProvider: true,
+					},
+				},
+			}
+			tests.UpdateKubeVirtConfigValueAndWait(config)
+
+			By("Removing the mediated devices configuration and expecting not devices being removed")
+			config.MediatedDevicesConfiguration = &v1.MediatedDevicesConfiguration{}
+			tests.UpdateKubeVirtConfigValueAndWait(config)
+			Eventually(checkAllMDEVCreated(desiredMdevTypeName, expectedInstancesNum), 3*time.Minute, 15*time.Second).Should(BeInPhase(k8sv1.PodSucceeded))
+		})
+	})
+
 	Context("with mediated devices configuration", func() {
 		var vmi *v1.VirtualMachineInstance
 		var deviceName = "nvidia.com/GRID_T4-1B"


### PR DESCRIPTION
**What this PR does / why we need it**:

virt-handler is deleting any mediated device that is created on the system even if it explicitly 
configured as an externally provided resource.

```
permittedHostDevices:
  mediatedDevices:
  - externalResourceProvider: true
    mdevNameSelector: NVIDIA A10-24Q
    resourceName: nvidia.com/NVIDIA_A10-24Q
```

This PR prevents the deletion of externally configured mediated devices.

Mediated devices handling can be disabled altogether by setting a `DisableMDEVConfiguration` feature gate.
In this case, no mediated devices will be created or removed.

```
apiVersion: kubevirt.io/v1
kind: KubeVirt
metadata:
  name: kubevirt
  namespace: kubevirt
spec:
  configuration:
    developerConfiguration: 
      featureGates:
        - DisableMDEVConfiguration
        - .....
        - .....
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [rhbz#2169880](https://bugzilla.redhat.com/show_bug.cgi?id=2169880)

**Special notes for your reviewer**:

**Release note**:
```release-note
externally created mediated devices will not be deleted by virt-handler  
```
