### PR TITLE
Sharing config volumes using virtiofs

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )
 

--- a/pkg/config/config-map.go
+++ b/pkg/config/config-map.go
@@ -23,8 +23,6 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
-
-	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 // GetConfigMapSourcePath returns a path to ConfigMap mounted on a pod
@@ -37,30 +35,22 @@ func GetConfigMapDiskPath(volumeName string) string {
 	return filepath.Join(ConfigMapDisksDir, volumeName+".iso")
 }
 
+type confgMapVolumeInfo struct{}
+
+func (i confgMapVolumeInfo) isValidType(v *v1.Volume) bool {
+	return v.ConfigMap != nil
+}
+func (i confgMapVolumeInfo) getSourcePath(v *v1.Volume) string {
+	return GetConfigMapSourcePath(v.Name)
+}
+func (i confgMapVolumeInfo) getIsoPath(v *v1.Volume) string {
+	return GetConfigMapDiskPath(v.Name)
+}
+func (i confgMapVolumeInfo) getLabel(v *v1.Volume) string {
+	return v.ConfigMap.VolumeLabel
+}
+
 // CreateConfigMapDisks creates ConfigMap iso disks which are attached to vmis
 func CreateConfigMapDisks(vmi *v1.VirtualMachineInstance, emptyIso bool) error {
-	for _, volume := range vmi.Spec.Volumes {
-		if volume.ConfigMap != nil {
-			var filesPath []string
-			filesPath, err := getFilesLayout(GetConfigMapSourcePath(volume.Name))
-			if err != nil {
-				return err
-			}
-
-			disk := GetConfigMapDiskPath(volume.Name)
-			vmiIsoSize, err := findIsoSize(vmi, &volume, emptyIso)
-			if err != nil {
-				return err
-			}
-			if err := createIsoConfigImage(disk, volume.ConfigMap.VolumeLabel, filesPath, vmiIsoSize); err != nil {
-				return err
-			}
-
-			if err := ephemeraldiskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(disk); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return createIsoDisksForConfigVolumes(vmi, emptyIso, confgMapVolumeInfo{})
 }

--- a/pkg/config/config-map_test.go
+++ b/pkg/config/config-map_test.go
@@ -64,11 +64,33 @@ var _ = Describe("ConfigMap", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "configmap-volume",
+		})
 
 		err := CreateConfigMapDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = os.Stat(filepath.Join(ConfigMapDisksDir, "configmap-volume.iso"))
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should not create a new config map iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "configmap-volume",
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: k8sv1.LocalObjectReference{
+						Name: "test-config",
+					},
+				},
+			},
+		})
+
+		err := CreateConfigMapDisks(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(filepath.Join(ConfigMapDisksDir, "configmap-volume.iso"))
+		Expect(err).To(HaveOccurred())
 	})
 
 })

--- a/pkg/config/downwardapi_test.go
+++ b/pkg/config/downwardapi_test.go
@@ -70,6 +70,9 @@ var _ = Describe("DownwardAPI", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "downwardapi-volume",
+		})
 
 		err := CreateDownwardAPIDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -77,4 +80,27 @@ var _ = Describe("DownwardAPI", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should create a new downwardapi iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "downwardapi-volume",
+			VolumeSource: v1.VolumeSource{
+				DownwardAPI: &v1.DownwardAPIVolumeSource{
+					Fields: []k8sv1.DownwardAPIVolumeFile{
+						{
+							Path: "labels",
+							FieldRef: &k8sv1.ObjectFieldSelector{
+								FieldPath: "metadata.labels",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		err := CreateDownwardAPIDisks(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(filepath.Join(DownwardAPIDisksDir, "downwardapi-volume.iso"))
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -61,6 +61,9 @@ var _ = Describe("Secret", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "secret-volume",
+		})
 
 		err := CreateSecretDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -68,4 +71,20 @@ var _ = Describe("Secret", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should not create a new secret iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "secret-volume",
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: "test-secret",
+				},
+			},
+		})
+
+		err := CreateSecretDisks(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(filepath.Join(SecretDisksDir, "secret-volume.iso"))
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/pkg/config/service-account_test.go
+++ b/pkg/config/service-account_test.go
@@ -61,6 +61,9 @@ var _ = Describe("ServiceAccount", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "serviceaccount-volume",
+		})
 
 		err := CreateServiceAccountDisk(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -68,4 +71,20 @@ var _ = Describe("ServiceAccount", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should create a new service account iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "serviceaccount-volume",
+			VolumeSource: v1.VolumeSource{
+				ServiceAccount: &v1.ServiceAccountVolumeSource{
+					ServiceAccountName: "testaccount",
+				},
+			},
+		})
+
+		err := CreateServiceAccountDisk(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(filepath.Join(ServiceAccountDiskDir, ServiceAccountDiskName))
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -499,7 +499,7 @@ func (vr *VolumeRenderer) handleHostDisk(volume v1.Volume) {
 func (vr *VolumeRenderer) handleSecret(volume v1.Volume) {
 	vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
 		Name:      volume.Name,
-		MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
+		MountPath: config.GetSecretSourcePath(volume.Name),
 		ReadOnly:  true,
 	})
 	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
@@ -516,7 +516,7 @@ func (vr *VolumeRenderer) handleSecret(volume v1.Volume) {
 func (vr *VolumeRenderer) handleConfigMap(volume v1.Volume) {
 	vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
 		Name:      volume.Name,
-		MountPath: filepath.Join(config.ConfigMapSourceDir, volume.Name),
+		MountPath: config.GetConfigMapSourcePath(volume.Name),
 		ReadOnly:  true,
 	})
 	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
@@ -534,7 +534,7 @@ func (vr *VolumeRenderer) handleDownwardAPI(volume v1.Volume) {
 	// attach a Secret to the pod
 	vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
 		Name:      volume.Name,
-		MountPath: filepath.Join(config.DownwardAPISourceDir, volume.Name),
+		MountPath: config.GetDownwardAPISourcePath(volume.Name),
 		ReadOnly:  true,
 	})
 	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"kubevirt.io/kubevirt/pkg/config"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
@@ -86,8 +88,30 @@ func securityContextVirtioFS() *k8sv1.SecurityContext {
 	}
 }
 
-func virtioFSMountPoint(volumeName string) string {
-	return fmt.Sprintf("/%s", volumeName)
+func isConfig(volume *v1.Volume) bool {
+	return volume.ConfigMap != nil || volume.Secret != nil ||
+		volume.ServiceAccount != nil || volume.DownwardAPI != nil
+}
+
+func isAutomount(volume *v1.Volume) bool {
+	// The template service sets pod.Spec.AutomountServiceAccountToken as true
+	return volume.ServiceAccount != nil
+}
+
+func virtioFSMountPoint(volume *v1.Volume) string {
+	volumeMountPoint := fmt.Sprintf("/%s", volume.Name)
+
+	if volume.ConfigMap != nil {
+		volumeMountPoint = config.GetConfigMapSourcePath(volume.Name)
+	} else if volume.Secret != nil {
+		volumeMountPoint = config.GetSecretSourcePath(volume.Name)
+	} else if volume.ServiceAccount != nil {
+		volumeMountPoint = config.ServiceAccountSourceDir
+	} else if volume.DownwardAPI != nil {
+		volumeMountPoint = config.GetDownwardAPISourcePath(volume.Name)
+	}
+
+	return volumeMountPoint
 }
 
 func VirtioFSSocketPath(volumeName string) string {
@@ -99,8 +123,27 @@ func generateContainerFromVolume(volume *v1.Volume, image string) k8sv1.Containe
 	resources := resourcesForVirtioFSContainer(false, false)
 
 	socketPathArg := fmt.Sprintf("--socket-path=%s", VirtioFSSocketPath(volume.Name))
-	sourceArg := fmt.Sprintf("source=%s", virtioFSMountPoint(volume.Name))
-	args := []string{socketPathArg, "-o", sourceArg, "-o", "sandbox=chroot", "-o", "xattr", "-o", "xattrmap=:map::user.virtiofsd.:"}
+	sourceArg := fmt.Sprintf("--shared-dir=%s", virtioFSMountPoint(volume))
+	args := []string{socketPathArg, sourceArg, "--cache=auto", "--sandbox=chroot"}
+
+	if !isConfig(volume) {
+		args = append(args, "--xattr")
+	}
+
+	volumeMounts := []k8sv1.VolumeMount{
+		// This is required to pass socket to compute
+		{
+			Name:      virtiofs.VirtioFSContainers,
+			MountPath: virtiofs.VirtioFSContainersMountBaseDir,
+		},
+	}
+
+	if !isAutomount(volume) {
+		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+			Name:      volume.Name,
+			MountPath: virtioFSMountPoint(volume),
+		})
+	}
 
 	return k8sv1.Container{
 		Name:            fmt.Sprintf("virtiofs-%s", volume.Name),
@@ -108,17 +151,7 @@ func generateContainerFromVolume(volume *v1.Volume, image string) k8sv1.Containe
 		ImagePullPolicy: k8sv1.PullIfNotPresent,
 		Command:         []string{"/usr/libexec/virtiofsd"},
 		Args:            args,
-		VolumeMounts: []k8sv1.VolumeMount{
-			// This is required to pass socket to compute
-			{
-				Name:      virtiofs.VirtioFSContainers,
-				MountPath: virtiofs.VirtioFSContainersMountBaseDir,
-			},
-			{
-				Name:      volume.Name,
-				MountPath: virtioFSMountPoint(volume.Name),
-			},
-		},
+		VolumeMounts:    volumeMounts,
 		Resources:       resources,
 		SecurityContext: securityContextVirtioFS(),
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1134,9 +1134,19 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 		return
 	}
 
+	volumes := map[string]*v1.Volume{}
 	for _, volume := range vmi.Spec.Volumes {
+		volumes[volume.Name] = volume.DeepCopy()
+	}
 
-		volPath, found := IsoGuestVolumePath(vmi, &volume)
+	for _, disk := range vmi.Spec.Domain.Devices.Disks {
+		volume := volumes[disk.Name]
+		if volume == nil {
+			log.DefaultLogger().V(2).Warningf("No matching volume with name %s found", disk.Name)
+			continue
+		}
+
+		volPath, found := IsoGuestVolumePath(vmi, volume)
 		if !found {
 			continue
 		}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -110,7 +109,6 @@ type netstat interface {
 
 const (
 	failedDetectIsolationFmt              = "failed to detect isolation for launcher pod: %v"
-	kubevirtPrivate                       = "kubevirt-private"
 	unableCreateVirtLauncherConnectionFmt = "unable to create virt-launcher client connection: %v"
 )
 
@@ -1103,15 +1101,15 @@ func IsoGuestVolumePath(vmi *v1.VirtualMachineInstance, volume *v1.Volume) (stri
 	} else if volume.CloudInitConfigDrive != nil {
 		volPath = filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "configdrive.iso")
 	} else if volume.ConfigMap != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.ConfigMapDisksDir), volume.Name+".iso")
+		volPath = config.GetConfigMapDiskPath(volume.Name)
 	} else if volume.DownwardAPI != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.DownwardAPIDisksDir), volume.Name+".iso")
+		volPath = config.GetDownwardAPIDiskPath(volume.Name)
 	} else if volume.Secret != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.SecretDisksDir), volume.Name+".iso")
+		volPath = config.GetSecretDiskPath(volume.Name)
 	} else if volume.ServiceAccount != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.ServiceAccountDiskDir), config.ServiceAccountDiskName)
+		volPath = config.GetServiceAccountDiskPath()
 	} else if volume.Sysprep != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.SysprepDisksDir), volume.Name+".iso")
+		volPath = config.GetSysprepDiskPath(volume.Name)
 	} else {
 		return "", false
 	}

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -364,6 +364,11 @@ func classifyVolumesForMigration(vmi *v1.VirtualMachineInstance) *migrationDisks
 			(volSrc.HostDisk != nil && *volSrc.HostDisk.Shared) {
 			disks.shared[volume.Name] = true
 		}
+
+		// Some volumes may not have an associated Disk (e.g., accessed using Filesystem),
+		// so they do not have an .iso file to be copied during migration. However, we don't
+		// need to check that they have it, since getDiskTargetsForMigration() will traverse
+		// through the disks.
 		if volSrc.ConfigMap != nil || volSrc.Secret != nil || volSrc.DownwardAPI != nil ||
 			volSrc.ServiceAccount != nil || volSrc.CloudInitNoCloud != nil ||
 			volSrc.CloudInitConfigDrive != nil || volSrc.ContainerDisk != nil {

--- a/pkg/virtiofs/virtiofs.go
+++ b/pkg/virtiofs/virtiofs.go
@@ -1,7 +1,6 @@
 package virtiofs
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"kubevirt.io/kubevirt/pkg/util"
@@ -10,8 +9,3 @@ import (
 // This is empty dir
 var VirtioFSContainers = "virtiofs-containers"
 var VirtioFSContainersMountBaseDir = filepath.Join(util.VirtShareDir, VirtioFSContainers)
-
-func VirtioFSSocketPath(volumeName string) string {
-	socketName := fmt.Sprintf("%s.sock", volumeName)
-	return filepath.Join(VirtioFSContainersMountBaseDir, socketName)
-}

--- a/tests/libvmi/storage.go
+++ b/tests/libvmi/storage.go
@@ -72,7 +72,7 @@ func WithCDRom(cdRomName string, bus v1.DiskBus, claimName string) Option {
 // WithFilesystemPVC specifies a filesystem backed by a PVC to be used.
 func WithFilesystemPVC(claimName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addFilesystem(vmi, newFilesystem(claimName))
+		addFilesystem(vmi, NewVirtiofsFilesystem(claimName))
 		addVolume(vmi, newPersistentVolumeClaimVolume(claimName, claimName))
 	}
 }
@@ -80,8 +80,16 @@ func WithFilesystemPVC(claimName string) Option {
 // WithFilesystemDV specifies a filesystem backed by a DV to be used.
 func WithFilesystemDV(dataVolumeName string) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		addFilesystem(vmi, newFilesystem(dataVolumeName))
+		addFilesystem(vmi, NewVirtiofsFilesystem(dataVolumeName))
 		addVolume(vmi, newDataVolume(dataVolumeName, dataVolumeName))
+	}
+}
+
+// NewVirtiofsFilesystem specifies a virtiofs filesystem
+func NewVirtiofsFilesystem(name string) v1.Filesystem {
+	return v1.Filesystem{
+		Name:     name,
+		Virtiofs: &v1.FilesystemVirtiofs{},
 	}
 }
 
@@ -160,13 +168,6 @@ func newCDRom(name string, bus v1.DiskBus) v1.Disk {
 				Bus: bus,
 			},
 		},
-	}
-}
-
-func newFilesystem(name string) v1.Filesystem {
-	return v1.Filesystem{
-		Name:     name,
-		Virtiofs: &v1.FilesystemVirtiofs{},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, using a virtiofs filesystem you can share ConfigMaps, Secrets and DownwardAPI volumes with the VM, but a ServiceAccount volume cannot be shared.  Also, even if we share those volumes using virtiofs all the iso files are created since some parts of the code assumes that those volumes always have a Disk associated.

This PR allows sharing ServiceAccount using a virtiofs filesystem and also mounts the config volumes in the source path defined for each of them. And also it doesn't create the iso files if it's not necessary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
