### PR TITLE
Improve error message when virt-freezer fails on paused VM

### DIFF
--- a/cmd/virt-freezer/main.go
+++ b/cmd/virt-freezer/main.go
@@ -102,7 +102,7 @@ func main() {
 	log.Log.Infof("Guest agent version is %s", info.GAVersion)
 
 	if !isVmRunning(client) {
-		log.Log.Reason(err).Error("VM is not running")
+		log.Log.Error("Paused VM, unable to freeze/unfreeze")
 		os.Exit(1)
 	}
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -816,7 +816,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 				By("Calling Velero pre-backup hook")
 				_, stderr, err := callVeleroHook(vmi, VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION, VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION)
 				Expect(err).To(HaveOccurred())
-				Expect(stderr).Should(ContainSubstring("not running"))
+				Expect(stderr).Should(ContainSubstring("Paused VM"))
 			})
 
 			Context("with memory dump", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As discussed in https://issues.redhat.com/browse/CNV-21659, this Pull Request updates the error message when virt-freezer fails on paused VMs so it's more descriptive.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
