### PR TITLE
Calculate hotplug attachment pod requests/limits based on VMI ratio

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -566,12 +566,12 @@ func calculateHotplugContainerRequests(vmi *v1.VirtualMachineInstance) k8sv1.Res
 	defaultMemoryRequest := resource.MustParse("2M")
 
 	return k8sv1.ResourceList{
-		k8sv1.ResourceCPU:    calculateVMIResourceRatio(resources.Requests.Cpu(), resources.Limits.Cpu(), &defaultCpuRequest, cpuLimit, resource.Milli),
-		k8sv1.ResourceMemory: calculateVMIResourceRatio(resources.Requests.Memory(), resources.Limits.Memory(), &defaultMemoryRequest, memLimit, 0),
+		k8sv1.ResourceCPU:    calculateVMIResourceQuantity(resources.Requests.Cpu(), resources.Limits.Cpu(), &defaultCpuRequest, cpuLimit, resource.Milli),
+		k8sv1.ResourceMemory: calculateVMIResourceQuantity(resources.Requests.Memory(), resources.Limits.Memory(), &defaultMemoryRequest, memLimit, 0),
 	}
 }
 
-func calculateVMIResourceRatio(req, lim, defaultValue *resource.Quantity, limitValue int64, scale resource.Scale) resource.Quantity {
+func calculateVMIResourceQuantity(req, lim, defaultValue *resource.Quantity, limitValue int64, scale resource.Scale) resource.Quantity {
 	if req == nil || req.IsZero() || lim == nil || lim.IsZero() {
 		return *defaultValue
 	}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -335,6 +335,10 @@ var _ = Describe("Resource pod spec renderer", func() {
 			kubev1.ResourceCPU:    resource.MustParse("17m"),
 			kubev1.ResourceMemory: resource.MustParse("40M"),
 		}),
+		Entry("Cpu request and limit at ratio 3, nil mem request/limit, with large number", nil, resource.NewQuantity(2000000, resource.DecimalSI), nil, resource.NewQuantity(6000000, resource.DecimalSI), kubev1.ResourceList{
+			kubev1.ResourceCPU:    resource.MustParse("34m"),
+			kubev1.ResourceMemory: resource.MustParse("2M"),
+		}),
 	)
 })
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3635,7 +3635,6 @@ var _ = Describe("Template", func() {
 			pod, err := svc.RenderHotplugAttachmentPodTemplate([]*v1.Volume{}, ownerPod, vmi, claimMap, false)
 			Expect(err).ToNot(HaveOccurred())
 			verifyPodRequestLimits1to1Ratio(pod)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		DescribeTable("hould compute the correct resource req according to desired QoS when rendering hotplug trigger pods", func(isBlock bool) {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3597,22 +3597,18 @@ var _ = Describe("Template", func() {
 		)
 
 		verifyPodRequestLimits1to1Ratio := func(pod *kubev1.Pod) {
-			cpuLimit, _ := pod.Spec.Containers[0].Resources.Limits.Cpu().AsInt64()
-			memLimit, _ := pod.Spec.Containers[0].Resources.Limits.Memory().AsInt64()
-			cpuReq, _ := pod.Spec.Containers[0].Resources.Requests.Cpu().AsInt64()
-			memReq, _ := pod.Spec.Containers[0].Resources.Requests.Memory().AsInt64()
+			cpuLimit := pod.Spec.Containers[0].Resources.Limits.Cpu().Value()
+			memLimit := pod.Spec.Containers[0].Resources.Limits.Memory().Value()
+			cpuReq := pod.Spec.Containers[0].Resources.Requests.Cpu().Value()
+			memReq := pod.Spec.Containers[0].Resources.Requests.Memory().Value()
 			expCpuLimitQ := resource.MustParse("100m")
-			expCpuLimit, _ := expCpuLimitQ.AsInt64()
-			Expect(cpuLimit).To(Equal(expCpuLimit))
+			Expect(cpuLimit).To(Equal(expCpuLimitQ.Value()))
 			expMemLimitQ := resource.MustParse("80M")
-			expMemLimit, _ := expMemLimitQ.AsInt64()
-			Expect(memLimit).To(Equal(expMemLimit))
+			Expect(memLimit).To(Equal(expMemLimitQ.Value()))
 			expCpuReqQ := resource.MustParse("100m")
-			expCpuReq, _ := expCpuReqQ.AsInt64()
-			Expect(cpuReq).To(Equal(expCpuReq))
+			Expect(cpuReq).To(Equal(expCpuReqQ.Value()))
 			expMemReqQ := resource.MustParse("80M")
-			expMemReq, _ := expMemReqQ.AsInt64()
-			Expect(memReq).To(Equal(expMemReq))
+			Expect(memReq).To(Equal(expMemReqQ.Value()))
 		}
 
 		It("should compute the correct resource req according to desired QoS when rendering hotplug pods", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Have the hotplug attachment pod request/limit ratio follow the request/limit ratio of the VMI it is associated with. So if the request/limit ratio is 1 on the VMI, then the attachment pod will also have that ratio. This ONLY fixes the hotplug attachment pod for any ratio (ratios can be fractions as well). With higher ratios and a minimum request set in a LimitRange, it is possible this will result in the request value being below the minimum in the LimitRange, and the pod creation is rejected.

This change will result in most requests in the attachment pods being higher than the hard coded value before due to making sure we respect the ratio.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
