### PR TITLE
Non-ordinal pod network interfaces name scheme

### DIFF
--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -32,13 +32,12 @@ type BridgePodNetworkConfigurator struct {
 	vmi                 *v1.VirtualMachineInstance
 }
 
-func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, launcherPID int, handler netdriver.NetworkHandler) *BridgePodNetworkConfigurator {
+func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, launcherPID int, handler netdriver.NetworkHandler) *BridgePodNetworkConfigurator {
 	return &BridgePodNetworkConfigurator{
-		vmi:                 vmi,
-		vmiSpecIface:        vmiSpecIface,
-		bridgeInterfaceName: bridgeIfaceName,
-		launcherPID:         launcherPID,
-		handler:             handler,
+		vmi:          vmi,
+		vmiSpecIface: vmiSpecIface,
+		launcherPID:  launcherPID,
+		handler:      handler,
 	}
 }
 
@@ -65,6 +64,7 @@ func (b *BridgePodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceName 
 		}
 	}
 
+	b.bridgeInterfaceName = virtnetlink.GenerateBridgeName(podIfaceName)
 	b.tapDeviceName = virtnetlink.GenerateTapDeviceName(podIfaceName)
 
 	b.vmMac, err = virtnetlink.RetrieveMacAddressFromVMISpecIface(b.vmiSpecIface)

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -42,14 +42,13 @@ type MasqueradePodNetworkConfigurator struct {
 	vmIPv6Addr          netlink.Addr
 }
 
-func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmiSpecNetwork *v1.Network, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
+func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, vmiSpecNetwork *v1.Network, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
 	return &MasqueradePodNetworkConfigurator{
-		vmi:                 vmi,
-		vmiSpecIface:        vmiSpecIface,
-		vmiSpecNetwork:      vmiSpecNetwork,
-		bridgeInterfaceName: bridgeIfaceName,
-		launcherPID:         launcherPID,
-		handler:             handler,
+		vmi:            vmi,
+		vmiSpecIface:   vmiSpecIface,
+		vmiSpecNetwork: vmiSpecNetwork,
+		launcherPID:    launcherPID,
+		handler:        handler,
 	}
 }
 
@@ -60,6 +59,7 @@ func (b *MasqueradePodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceN
 		return err
 	}
 	b.podNicLink = link
+	b.bridgeInterfaceName = virtnetlink.GenerateBridgeName(link.Attrs().Name)
 
 	ipv4Enabled, err := b.handler.HasIPv4GlobalUnicastAddress(podIfaceName)
 	if err != nil {

--- a/pkg/network/link/BUILD.bazel
+++ b/pkg/network/link/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/network/cache:go_default_library",
         "//pkg/network/driver:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/network/link/BUILD.bazel
+++ b/pkg/network/link/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "address.go",
+        "discovery.go",
         "names.go",
         "reserved_macs.go",
     ],
@@ -24,6 +25,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "address_test.go",
+        "discovery_test.go",
         "link_suite_test.go",
         "names_test.go",
     ],
@@ -34,6 +36,7 @@ go_test(
         "//pkg/network/namescheme:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",

--- a/pkg/network/link/discovery.go
+++ b/pkg/network/link/discovery.go
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package link
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/driver"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
+)
+
+// DiscoverByNetwork return the pod interface link of the given network name.
+// If link not found, it will try to get the link using the pod interface's ordinal name (net1, net2,...)
+// based on the subject network position in the given networks slice.
+func DiscoverByNetwork(handler driver.NetworkHandler, networks []v1.Network, subjectNetwork v1.Network) (netlink.Link, error) {
+	ifaceNames, err := networkInterfaceNames(networks, subjectNetwork)
+	if err != nil {
+		return nil, err
+	}
+
+	return linkByNames(handler, ifaceNames)
+}
+
+func networkInterfaceNames(networks []v1.Network, subjectNetwork v1.Network) ([]string, error) {
+	ifaceName := namescheme.HashedPodInterfaceName(subjectNetwork)
+	ordinalIfaceName := namescheme.OrdinalPodInterfaceName(subjectNetwork.Name, networks)
+	if ordinalIfaceName == "" {
+		return nil, fmt.Errorf("could not find the pod interface ordinal name for network [%s]", subjectNetwork.Name)
+	}
+
+	return []string{ifaceName, ordinalIfaceName}, nil
+}
+
+func linkByNames(handler driver.NetworkHandler, names []string) (netlink.Link, error) {
+	var errs []string
+	for _, name := range names {
+		link, err := handler.LinkByName(name)
+		if err == nil {
+			return link, nil
+		}
+		errs = append(errs, fmt.Sprintf("could not get link with name %q: %v", name, err))
+	}
+	return nil, fmt.Errorf(strings.Join(errs, ", "))
+}

--- a/pkg/network/link/discovery_test.go
+++ b/pkg/network/link/discovery_test.go
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package link
+
+import (
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vishvananda/netlink"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
+)
+
+var _ = Describe("DiscoverByNetwork", func() {
+	const (
+		testNetworkName         = "blue"
+		testNetIfaceName        = "pod16477688c0e"
+		testNetOrdinalIfaceName = "net1"
+	)
+
+	var (
+		ctrl               *gomock.Controller
+		mockNetworkHandler *netdriver.MockNetworkHandler
+	)
+
+	testNetworks := func() []v1.Network {
+		return []v1.Network{
+			*v1.DefaultPodNetwork(),
+			multusNetwork(testNetworkName),
+			multusNetwork("A"),
+		}
+	}
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockNetworkHandler = netdriver.NewMockNetworkHandler(ctrl)
+	})
+
+	It("should fail when the given no networks", func() {
+		_, err := DiscoverByNetwork(mockNetworkHandler, nil, v1.Network{Name: "ensp1f2"})
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail given a network name that not exist in networks slice", func() {
+		_, err := DiscoverByNetwork(mockNetworkHandler, testNetworks(), v1.Network{Name: "ensp1f2"})
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail when link not found", func() {
+		mockNetworkHandler.EXPECT().LinkByName(testNetIfaceName).Return(nil, errors.New("test fail"))
+		mockNetworkHandler.EXPECT().LinkByName(testNetOrdinalIfaceName).Return(nil, errors.New("test fail"))
+
+		_, err := DiscoverByNetwork(mockNetworkHandler, testNetworks(), multusNetwork(testNetworkName))
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should get default network iface link", func() {
+		mockNetworkHandler.EXPECT().LinkByName("eth0").Return(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}, nil)
+
+		actualLink, err := DiscoverByNetwork(mockNetworkHandler, testNetworks(), *v1.DefaultPodNetwork())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actualLink.Attrs().Name).To(Equal("eth0"))
+	})
+
+	It("should get network iface link", func() {
+		mockNetworkHandler.EXPECT().LinkByName(testNetIfaceName).Return(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: testNetIfaceName}}, nil)
+
+		actualLink, err := DiscoverByNetwork(mockNetworkHandler, testNetworks(), multusNetwork(testNetworkName))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actualLink.Attrs().Name).To(Equal(testNetIfaceName))
+	})
+
+	It("when network iface link not found, should get link using ordinal iface name", func() {
+		mockNetworkHandler.EXPECT().LinkByName(testNetIfaceName).Return(nil, errors.New("test fail"))
+		mockNetworkHandler.EXPECT().LinkByName(testNetOrdinalIfaceName).Return(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: testNetOrdinalIfaceName}}, nil)
+
+		actualLink, err := DiscoverByNetwork(mockNetworkHandler, testNetworks(), multusNetwork(testNetworkName))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(actualLink.Attrs().Name).To(Equal(testNetOrdinalIfaceName))
+	})
+})
+
+func multusNetwork(name string) v1.Network {
+	return v1.Network{
+		Name:          name,
+		NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: name + "net"}},
+	}
+}

--- a/pkg/network/link/names.go
+++ b/pkg/network/link/names.go
@@ -21,6 +21,9 @@ package link
 
 import (
 	"fmt"
+	"strings"
+
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 )
 
 func GenerateTapDeviceName(podInterfaceName string) string {
@@ -28,6 +31,6 @@ func GenerateTapDeviceName(podInterfaceName string) string {
 }
 
 func GenerateNewBridgedVmiInterfaceName(originalPodInterfaceName string) string {
-	return fmt.Sprintf("%s-nic", originalPodInterfaceName)
-
+	trimmedName := strings.TrimPrefix(originalPodInterfaceName, namescheme.HashedIfacePrefix)
+	return fmt.Sprintf("%s-nic", trimmedName)
 }

--- a/pkg/network/link/names.go
+++ b/pkg/network/link/names.go
@@ -30,6 +30,11 @@ func GenerateTapDeviceName(podInterfaceName string) string {
 	return "tap" + podInterfaceName[3:]
 }
 
+func GenerateBridgeName(podInterfaceName string) string {
+	trimmedName := strings.TrimPrefix(podInterfaceName, namescheme.HashedIfacePrefix)
+	return "k6t-" + trimmedName
+}
+
 func GenerateNewBridgedVmiInterfaceName(originalPodInterfaceName string) string {
 	trimmedName := strings.TrimPrefix(originalPodInterfaceName, namescheme.HashedIfacePrefix)
 	return fmt.Sprintf("%s-nic", trimmedName)

--- a/pkg/network/link/names_test.go
+++ b/pkg/network/link/names_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 var _ = Describe("Common Methods", func() {
+	const maxInterfaceNameLength = 15
+
 	Context("GenerateTapDeviceName function", func() {
 		It("Should return a tap device name with one digit suffix", func() {
 			Expect(virtnetlink.GenerateTapDeviceName("eth0")).To(Equal("tap0"))
@@ -37,6 +39,11 @@ var _ = Describe("Common Methods", func() {
 		It("Should return a tap device name with three digits suffix", func() {
 			Expect(virtnetlink.GenerateTapDeviceName("eth123")).To(Equal("tap123"))
 		})
+		It("Should return hash network name tap device name", func() {
+			hashedIfaceName := virtnetlink.GenerateTapDeviceName("pod16477688c0e")
+			Expect(len(hashedIfaceName)).To(BeNumerically("<=", maxInterfaceNameLength))
+			Expect(hashedIfaceName).To(Equal("tap16477688c0e"))
+		})
 	})
 	Context("GenerateNewBridgedVmiInterfaceName function", func() {
 		It("Should return the new bridge interface name", func() {
@@ -44,6 +51,11 @@ var _ = Describe("Common Methods", func() {
 		})
 		It("Should return another new bridge interface name", func() {
 			Expect(virtnetlink.GenerateNewBridgedVmiInterfaceName("net12")).To(Equal("net12-nic"))
+		})
+		It("Should return hash network name bridge interface name", func() {
+			hashedIfaceName := virtnetlink.GenerateNewBridgedVmiInterfaceName("pod16477688c0e")
+			Expect(len(hashedIfaceName)).To(BeNumerically("<=", maxInterfaceNameLength))
+			Expect(hashedIfaceName).To(Equal("16477688c0e-nic"))
 		})
 	})
 })

--- a/pkg/network/link/names_test.go
+++ b/pkg/network/link/names_test.go
@@ -58,4 +58,17 @@ var _ = Describe("Common Methods", func() {
 			Expect(hashedIfaceName).To(Equal("16477688c0e-nic"))
 		})
 	})
+	Context("GenerateBridgeName function", func() {
+		It("Should return the new bridge interface name", func() {
+			Expect(virtnetlink.GenerateBridgeName("eth0")).To(Equal("k6t-eth0"))
+		})
+		It("Should return another new bridge interface name", func() {
+			Expect(virtnetlink.GenerateBridgeName("net12")).To(Equal("k6t-net12"))
+		})
+		It("Should return hash network name bridge interface name", func() {
+			hashedIfaceName := virtnetlink.GenerateBridgeName("pod16477688c0e")
+			Expect(len(hashedIfaceName)).To(BeNumerically("<=", maxInterfaceNameLength))
+			Expect(hashedIfaceName).To(Equal("k6t-16477688c0e"))
+		})
+	})
 })

--- a/pkg/network/namescheme/BUILD.bazel
+++ b/pkg/network/namescheme/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
     ],
 )
 
@@ -21,6 +22,7 @@ go_test(
         ":go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -55,6 +55,14 @@ func CreateHashedNetworkNameScheme(vmiNetworks []v1.Network) map[string]string {
 	return networkNameSchemeMap
 }
 
+func HashedPodInterfaceName(network v1.Network) string {
+	if vmispec.IsSecondaryMultusNetwork(network) {
+		return generateHashedInterfaceName(network.Name)
+	}
+
+	return PrimaryPodInterfaceName
+}
+
 func mapMultusNonDefaultNetworksToPodInterfaceName(networks []v1.Network) map[string]string {
 	networkNameSchemeMap := map[string]string{}
 	for _, network := range vmispec.FilterMultusNonDefaultNetworks(networks) {
@@ -82,6 +90,20 @@ func CreateOrdinalNetworkNameScheme(vmiNetworks []v1.Network) map[string]string 
 	}
 
 	return networkNameSchemeMap
+}
+
+func OrdinalPodInterfaceName(name string, networks []v1.Network) string {
+	for i, network := range networks {
+		if network.Name == name {
+			if vmispec.IsSecondaryMultusNetwork(network) {
+				return generateOrdinalInterfaceName(i)
+			}
+
+			return PrimaryPodInterfaceName
+		}
+	}
+
+	return ""
 }
 
 func mapMultusNonDefaultNetworksToPodInterfaceOrdinalName(networks []v1.Network) map[string]string {

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -20,20 +20,29 @@
 package namescheme
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-const PrimaryPodInterfaceName = "eth0"
+const (
+	// maxIfaceNameLen equals max kernel interface name len (15) - length("-nic")
+	// which is the suffix used for the bridge binding interface with IPAM.
+	// (the interface created to hold the pod's IP address - and thus appease CNI).
+	maxIfaceNameLen   = 11
+	HashedIfacePrefix = "pod"
 
-// CreateNetworkNameScheme iterates over the VMI's Networks, and creates for each a pod interface name.
+	PrimaryPodInterfaceName = "eth0"
+)
+
+// CreateHashedNetworkNameScheme iterates over the VMI's Networks, and creates for each a pod interface name.
 // The returned map associates between the network name and the generated pod interface name.
-// Primary network will use "eth0" and the secondary ones will use "net<id>" format, where id is an enumeration
-// from 1 to n.
-func CreateNetworkNameScheme(vmiNetworks []v1.Network) map[string]string {
+// Primary network will use "eth0" and the secondary ones will be named with the hashed network name.
+func CreateHashedNetworkNameScheme(vmiNetworks []v1.Network) map[string]string {
 	networkNameSchemeMap := mapMultusNonDefaultNetworksToPodInterfaceName(vmiNetworks)
 
 	if multusDefaultNetwork := vmispec.LookUpDefaultNetwork(vmiNetworks); multusDefaultNetwork != nil {
@@ -45,12 +54,20 @@ func CreateNetworkNameScheme(vmiNetworks []v1.Network) map[string]string {
 
 func mapMultusNonDefaultNetworksToPodInterfaceName(networks []v1.Network) map[string]string {
 	networkNameSchemeMap := map[string]string{}
-	for i, network := range vmispec.FilterMultusNonDefaultNetworks(networks) {
-		networkNameSchemeMap[network.Name] = secondaryInterfaceName(i + 1)
+	for _, network := range vmispec.FilterMultusNonDefaultNetworks(networks) {
+		networkNameSchemeMap[network.Name] = generateHashedInterfaceName(network.Name)
 	}
 	return networkNameSchemeMap
 }
 
-func secondaryInterfaceName(idx int) string {
-	return fmt.Sprintf("net%d", idx)
+func generateHashedInterfaceName(networkName string) string {
+	hash := sha256.New()
+	_, _ = io.WriteString(hash, networkName)
+	hashedName := fmt.Sprintf("%x", hash.Sum(nil))[:maxIfaceNameLen]
+	return fmt.Sprintf("%s%s", HashedIfacePrefix, hashedName)
+}
+
+func generateOrdinalInterfaceName(idx int) string {
+	const ordinalIfacePrefix = "net"
+	return fmt.Sprintf("%s%d", ordinalIfacePrefix, idx)
 }

--- a/pkg/network/namescheme/networknamescheme.go
+++ b/pkg/network/namescheme/networknamescheme.go
@@ -103,15 +103,15 @@ func generateOrdinalInterfaceName(idx int) string {
 // In case the pod network status has at least one interface with ordinal interface name it returns the ordinal network
 // name-scheme, Otherwise, returns the hashed network name scheme.
 func CreateNetworkNameSchemeByPodNetworkStatus(networks []v1.Network, networkStatus map[string]networkv1.NetworkStatus) map[string]string {
-	if podHasOrdinalInterfaceName(networkStatus) {
+	if PodHasOrdinalInterfaceName(networkStatus) {
 		return CreateOrdinalNetworkNameScheme(networks)
 	}
 
 	return CreateHashedNetworkNameScheme(networks)
 }
 
-// podHasOrdinalInterfaceName check if the given pod network status has at least one pod interface with ordinal name
-func podHasOrdinalInterfaceName(podNetworkStatus map[string]networkv1.NetworkStatus) bool {
+// PodHasOrdinalInterfaceName check if the given pod network status has at least one pod interface with ordinal name
+func PodHasOrdinalInterfaceName(podNetworkStatus map[string]networkv1.NetworkStatus) bool {
 	for _, networkStatus := range podNetworkStatus {
 		if ordinalSecondaryInterfaceName(networkStatus.Interface) {
 			return true

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -29,10 +29,10 @@ import (
 )
 
 var _ = Describe("Network Name Scheme", func() {
-	Context("CreateNetworkNameScheme", func() {
-		DescribeTable("should return the expected NetworkNameSchemeMap",
+	Context("CreateHashedNetworkNameScheme", func() {
+		DescribeTable("create hashed pod interfaces name scheme",
 			func(networkList []virtv1.Network, expectedNetworkNameSchemeMap map[string]string) {
-				podIfacesNameScheme := namescheme.CreateNetworkNameScheme(networkList)
+				podIfacesNameScheme := namescheme.CreateHashedNetworkNameScheme(networkList)
 
 				Expect(podIfacesNameScheme).To(Equal(expectedNetworkNameSchemeMap))
 			},
@@ -52,8 +52,19 @@ var _ = Describe("Network Name Scheme", func() {
 				},
 				map[string]string{
 					"network0": namescheme.PrimaryPodInterfaceName,
-					"network1": "net1",
-					"network2": "net2",
+					"network1": "poda7662f44d65",
+					"network2": "pod27f4a77f94e",
+				}),
+			Entry("when default pod networks exist",
+				[]virtv1.Network{
+					newPodNetwork("default"),
+					createMultusSecondaryNetwork("network1", "default/nad1"),
+					createMultusSecondaryNetwork("network2", "default/nad2"),
+				},
+				map[string]string{
+					"default":  namescheme.PrimaryPodInterfaceName,
+					"network1": "poda7662f44d65",
+					"network2": "pod27f4a77f94e",
 				}),
 		)
 	})

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	virtv1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
@@ -102,7 +104,72 @@ var _ = Describe("Network Name Scheme", func() {
 				"network2": "net2",
 			}),
 	)
+
+	Context("CreateNetworkNameSchemeByPodNetworkStatus", func() {
+		const (
+			redNetworkName      = "red"
+			redIfaceHashedName  = "podb1f51a511f1"
+			redIfaceOrdinalName = "net1"
+
+			greenNetworkName      = "green"
+			greenIfaceHashedName  = "podba4788b226a"
+			greenIfaceOrdinalName = "net2"
+		)
+
+		DescribeTable("should return mapping between VMI networks and the pod interfaces names according to Multus network-status annotation",
+			func(networks []virtv1.Network, networkStatus map[string]networkv1.NetworkStatus, expectedNameScheme map[string]string) {
+				Expect(namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, networkStatus)).To(Equal(expectedNameScheme))
+			},
+			Entry("when Multus network-status annotation is absent",
+				multusNetworks(redNetworkName, greenNetworkName),
+				map[string]networkv1.NetworkStatus{},
+				map[string]string{
+					redNetworkName:   redIfaceHashedName,
+					greenNetworkName: greenIfaceHashedName,
+				},
+			),
+			Entry("given only pod network",
+				[]virtv1.Network{newPodNetwork("default")},
+				map[string]networkv1.NetworkStatus{
+					"default": {Interface: namescheme.PrimaryPodInterfaceName},
+				},
+				map[string]string{
+					"default": namescheme.PrimaryPodInterfaceName,
+				},
+			),
+			Entry("when the annotation reflects the pod interfaces naming is hashed",
+				multusNetworks(redNetworkName, greenNetworkName),
+				map[string]networkv1.NetworkStatus{
+					redNetworkName:   {Interface: redIfaceHashedName},
+					greenNetworkName: {Interface: greenIfaceHashedName},
+				},
+				map[string]string{
+					redNetworkName:   redIfaceHashedName,
+					greenNetworkName: greenIfaceHashedName,
+				},
+			),
+			Entry("when the annotation reflects the pod interface naming is ordinal",
+				multusNetworks(redNetworkName, greenNetworkName),
+				map[string]networkv1.NetworkStatus{
+					redNetworkName:   {Interface: redIfaceOrdinalName},
+					greenNetworkName: {Interface: greenIfaceOrdinalName},
+				},
+				map[string]string{
+					redNetworkName:   redIfaceOrdinalName,
+					greenNetworkName: greenIfaceOrdinalName,
+				},
+			),
+		)
+	})
 })
+
+func multusNetworks(names ...string) []virtv1.Network {
+	var networks []virtv1.Network
+	for _, name := range names {
+		networks = append(networks, createMultusNetwork(name, name+"net"))
+	}
+	return networks
+}
 
 func createMultusSecondaryNetwork(name, networkName string) virtv1.Network {
 	return createMultusNetwork(name, networkName)

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -191,6 +191,76 @@ var _ = Describe("Network Name Scheme", func() {
 			}),
 		)
 	})
+	Context("HashedPodInterfaceName", func() {
+		DescribeTable("should return the given network name's hashed pod interface name",
+			func(network virtv1.Network, expectedPodIfaceName string) {
+				Expect(namescheme.HashedPodInterfaceName(network)).To(Equal(expectedPodIfaceName))
+			},
+			Entry("given default network name when default is pod network",
+				newPodNetwork("default"),
+				"eth0",
+			),
+			Entry("given default network name when default is Multus default network",
+				createMultusDefaultNetwork("overlay-network", "pod-net-br"),
+				"eth0",
+			),
+			Entry("given secondary network name",
+				createMultusSecondaryNetwork("red", "test-br"),
+				"podb1f51a511f1",
+			),
+		)
+	})
+	Context("OrdinalPodInterfaceName", func() {
+		DescribeTable("should return empty string",
+			func(networkName string, networks []virtv1.Network) {
+				Expect(namescheme.OrdinalPodInterfaceName(networkName, networks)).To(BeEmpty())
+			},
+			Entry("given no networks",
+				"red",
+				nil,
+			),
+			Entry("given invalid network name",
+				"blah",
+				[]virtv1.Network{
+					newPodNetwork("default"),
+					createMultusSecondaryNetwork("blue", "test-br"),
+					createMultusSecondaryNetwork("red", "test-br"),
+				}),
+		)
+
+		DescribeTable("should return ordinal pod interface name",
+			func(networkName string, networks []virtv1.Network, expectedPodIfaceName string) {
+				Expect(namescheme.OrdinalPodInterfaceName(networkName, networks)).To(Equal(expectedPodIfaceName))
+			},
+			Entry("given default network name and default is pod network",
+				"default",
+				[]virtv1.Network{
+					newPodNetwork("default"),
+					createMultusSecondaryNetwork("blue", "test-br"),
+					createMultusSecondaryNetwork("red", "test-br"),
+				},
+				"eth0",
+			),
+			Entry("given default network name and default is Multus default network",
+				"overlay",
+				[]virtv1.Network{
+					createMultusDefaultNetwork("overlay", "pod-net-br"),
+					createMultusSecondaryNetwork("blue", "test-br"),
+					createMultusSecondaryNetwork("red", "test-br"),
+				},
+				"eth0",
+			),
+			Entry("given secondary network name",
+				"red",
+				[]virtv1.Network{
+					newPodNetwork("default"),
+					createMultusSecondaryNetwork("blue", "test-br"),
+					createMultusSecondaryNetwork("red", "test-br"),
+				},
+				"net2",
+			),
+		)
+	})
 })
 
 func multusNetworks(names ...string) []virtv1.Network {

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -161,6 +161,36 @@ var _ = Describe("Network Name Scheme", func() {
 			),
 		)
 	})
+	Context("PodHasOrdinalInterfaceName", func() {
+		DescribeTable("should return TRUE, given network status with ordinal interface names",
+			func(podNetworkStatus map[string]networkv1.NetworkStatus) {
+				Expect(namescheme.PodHasOrdinalInterfaceName(podNetworkStatus)).To(BeTrue())
+			},
+			Entry("with primary pod network interface", map[string]networkv1.NetworkStatus{
+				"A": {Interface: "eth0"},
+				"B": {Interface: "net1"},
+				"C": {Interface: "net2"},
+			}),
+			Entry("without primary pod network interface", map[string]networkv1.NetworkStatus{
+				"A": {Interface: "net1"},
+				"B": {Interface: "net2"},
+			}),
+		)
+		DescribeTable("should return FALSE, given network status with hashed interface names",
+			func(podNetworkStatus map[string]networkv1.NetworkStatus) {
+				Expect(namescheme.PodHasOrdinalInterfaceName(podNetworkStatus)).To(BeFalse())
+			},
+			Entry("with primary pod network interface", map[string]networkv1.NetworkStatus{
+				"A": {Interface: "eth0"},
+				"B": {Interface: "podb1f51a511f1"},
+				"C": {Interface: "pod16477688c0e"},
+			}),
+			Entry("without primary pod network interface", map[string]networkv1.NetworkStatus{
+				"A": {Interface: "podb1f51a511f1"},
+				"B": {Interface: "pod16477688c0e"},
+			}),
+		)
+	})
 })
 
 func multusNetworks(names ...string) []virtv1.Network {

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/network/driver:go_default_library",
         "//pkg/network/errors:go_default_library",
         "//pkg/network/infraconfigurators:go_default_library",
+        "//pkg/network/link:go_default_library",
         "//pkg/network/namescheme:go_default_library",
         "//pkg/network/netns:go_default_library",
         "//pkg/network/sriov:go_default_library",

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -98,7 +98,7 @@ func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, l
 }
 
 func upgradeConfigStateCache(stateCache *ConfigStateCache, networks []v1.Network) (*ConfigStateCache, error) {
-	for networkName, podIfaceName := range namescheme.CreateNetworkNameScheme(networks) {
+	for networkName, podIfaceName := range namescheme.CreateOrdinalNetworkNameScheme(networks) {
 		exists, err := stateCache.Exists(podIfaceName)
 		if err != nil {
 			return nil, err

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -329,6 +329,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 		})
 
 		It("fails setup during network discovery", func() {
+			mockNetworkH.EXPECT().LinkByName(gomock.Any()).Return(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: namescheme.PrimaryPodInterfaceName}}, nil)
 			mockNetworkH.EXPECT().ReadIPAddressesFromLink(gomock.Any()).Return("", "", fmt.Errorf("discovery error"))
 
 			err := vmNetworkConfigurator.SetupPodNetworkPhase1(0, vmi.Spec.Networks, configState)
@@ -338,6 +339,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 		})
 
 		It("fails (critically) setup during network preparation (config)", func() {
+			mockNetworkH.EXPECT().LinkByName(gomock.Any()).Return(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: namescheme.PrimaryPodInterfaceName}}, nil)
 			mockNetworkH.EXPECT().ReadIPAddressesFromLink(gomock.Any()).Return("1.2.3.4", "2001::1", nil)
 			mockNetworkH.EXPECT().IsIpv4Primary().Return(true, nil)
 			mockNetworkH.EXPECT().LinkByName(gomock.Any()).Return(&netlink.Bridge{}, nil)
@@ -353,6 +355,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 
 		It("is passing setup successfully (and persists cache data)", func() {
 			linkIP4, linkIP6 := "1.2.3.4", "2001::1"
+			mockNetworkH.EXPECT().LinkByName(gomock.Any()).Return(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: namescheme.PrimaryPodInterfaceName}}, nil)
 			mockNetworkH.EXPECT().ReadIPAddressesFromLink(gomock.Any()).Return(linkIP4, linkIP6, nil)
 			mockNetworkH.EXPECT().IsIpv4Primary().Return(true, nil)
 			mockNetworkH.EXPECT().LinkByName(gomock.Any()).Return(&netlink.Bridge{}, nil)

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -102,7 +102,6 @@ var _ = Describe("VMNetworkConfigurator", func() {
 					infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 						vm,
 						iface,
-						generateInPodBridgeInterfaceName(namescheme.PrimaryPodInterfaceName),
 						launcherPID,
 						vmNetworkConfigurator.handler),
 				}}))
@@ -136,7 +135,6 @@ var _ = Describe("VMNetworkConfigurator", func() {
 					infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 						vmi,
 						iface,
-						generateInPodBridgeInterfaceName(multusInterfaceName),
 						launcherPID,
 						vmNetworkConfigurator.handler),
 				}}))
@@ -204,7 +202,6 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[0],
-							generateInPodBridgeInterfaceName("pode56ef68384a"),
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},
@@ -219,7 +216,6 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[1],
-							generateInPodBridgeInterfaceName("eth0"),
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},
@@ -232,9 +228,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						cacheCreator:     vmNetworkConfigurator.cacheCreator,
 						launcherPID:      &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
-							vm,
-							&vm.Spec.Domain.Devices.Interfaces[2],
-							generateInPodBridgeInterfaceName("pod9f531ef99d2"),
+							vm, &vm.Spec.Domain.Devices.Interfaces[2],
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},
@@ -273,10 +267,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 					infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 						vmi,
 						&hotplugInterface,
-						generateInPodBridgeInterfaceName(expectedPodIfaceName),
 						launcherPID,
-						vmNetworkConfigurator.handler,
-					),
+						vmNetworkConfigurator.handler),
 				}))
 			})
 

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -92,13 +92,12 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, vm.Spec.Networks)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
-					vmi:              vm,
-					podInterfaceName: namescheme.PrimaryPodInterfaceName,
-					vmiSpecIface:     iface,
-					vmiSpecNetwork:   defaultNet,
-					handler:          vmNetworkConfigurator.handler,
-					cacheCreator:     vmNetworkConfigurator.cacheCreator,
-					launcherPID:      &launcherPID,
+					vmi:            vm,
+					vmiSpecIface:   iface,
+					vmiSpecNetwork: defaultNet,
+					handler:        vmNetworkConfigurator.handler,
+					cacheCreator:   vmNetworkConfigurator.cacheCreator,
+					launcherPID:    &launcherPID,
 					infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 						vm,
 						iface,
@@ -115,7 +114,6 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(nics).To(BeEmpty())
 			})
 			It("should configure networking with multus", func() {
-				const multusInterfaceName = "pod37a8eec1ce1"
 				vmi := newVMIBridgeInterface("testnamespace", "testVmName")
 				iface := v1.DefaultBridgeNetworkInterface()
 				cniNet := vmiPrimaryNetwork()
@@ -125,13 +123,12 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, vmi.Spec.Networks)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
-					vmi:              vmi,
-					vmiSpecIface:     iface,
-					vmiSpecNetwork:   cniNet,
-					podInterfaceName: multusInterfaceName,
-					handler:          vmNetworkConfigurator.handler,
-					cacheCreator:     vmNetworkConfigurator.cacheCreator,
-					launcherPID:      &launcherPID,
+					vmi:            vmi,
+					vmiSpecIface:   iface,
+					vmiSpecNetwork: cniNet,
+					handler:        vmNetworkConfigurator.handler,
+					cacheCreator:   vmNetworkConfigurator.cacheCreator,
+					launcherPID:    &launcherPID,
 					infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 						vmi,
 						iface,
@@ -192,13 +189,12 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ContainElements([]podNIC{
 					{
-						vmi:              vm,
-						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[0],
-						vmiSpecNetwork:   additionalCNINet1,
-						podInterfaceName: "pode56ef68384a",
-						handler:          vmNetworkConfigurator.handler,
-						cacheCreator:     vmNetworkConfigurator.cacheCreator,
-						launcherPID:      &launcherPID,
+						vmi:            vm,
+						vmiSpecIface:   &vm.Spec.Domain.Devices.Interfaces[0],
+						vmiSpecNetwork: additionalCNINet1,
+						handler:        vmNetworkConfigurator.handler,
+						cacheCreator:   vmNetworkConfigurator.cacheCreator,
+						launcherPID:    &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[0],
@@ -206,13 +202,12 @@ var _ = Describe("VMNetworkConfigurator", func() {
 							vmNetworkConfigurator.handler),
 					},
 					{
-						vmi:              vm,
-						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[1],
-						vmiSpecNetwork:   cniNet,
-						podInterfaceName: "eth0",
-						handler:          vmNetworkConfigurator.handler,
-						cacheCreator:     vmNetworkConfigurator.cacheCreator,
-						launcherPID:      &launcherPID,
+						vmi:            vm,
+						vmiSpecIface:   &vm.Spec.Domain.Devices.Interfaces[1],
+						vmiSpecNetwork: cniNet,
+						handler:        vmNetworkConfigurator.handler,
+						cacheCreator:   vmNetworkConfigurator.cacheCreator,
+						launcherPID:    &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[1],
@@ -220,13 +215,12 @@ var _ = Describe("VMNetworkConfigurator", func() {
 							vmNetworkConfigurator.handler),
 					},
 					{
-						vmi:              vm,
-						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[2],
-						vmiSpecNetwork:   additionalCNINet2,
-						podInterfaceName: "pod9f531ef99d2",
-						handler:          vmNetworkConfigurator.handler,
-						cacheCreator:     vmNetworkConfigurator.cacheCreator,
-						launcherPID:      &launcherPID,
+						vmi:            vm,
+						vmiSpecIface:   &vm.Spec.Domain.Devices.Interfaces[2],
+						vmiSpecNetwork: additionalCNINet2,
+						handler:        vmNetworkConfigurator.handler,
+						cacheCreator:   vmNetworkConfigurator.cacheCreator,
+						launcherPID:    &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm, &vm.Spec.Domain.Devices.Interfaces[2],
 							launcherPID,
@@ -252,18 +246,16 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				launcherPID := 0
 
-				const expectedPodIfaceName = "pod45b3499a170"
 				Expect(vmNetworkConfigurator.getPhase1NICs(
 					&launcherPID,
 					[]v1.Network{networkToHotplug(ifaceToHotplug)},
 				)).To(ConsistOf(podNIC{
-					vmi:              vmi,
-					podInterfaceName: expectedPodIfaceName,
-					launcherPID:      &launcherPID,
-					vmiSpecIface:     &hotplugInterface,
-					vmiSpecNetwork:   &hotplugNetwork,
-					handler:          vmNetworkConfigurator.handler,
-					cacheCreator:     vmNetworkConfigurator.cacheCreator,
+					vmi:            vmi,
+					launcherPID:    &launcherPID,
+					vmiSpecIface:   &hotplugInterface,
+					vmiSpecNetwork: &hotplugNetwork,
+					handler:        vmNetworkConfigurator.handler,
+					cacheCreator:   vmNetworkConfigurator.cacheCreator,
 					infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 						vmi,
 						&hotplugInterface,

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -116,7 +116,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(nics).To(BeEmpty())
 			})
 			It("should configure networking with multus", func() {
-				const multusInterfaceName = "net1"
+				const multusInterfaceName = "pod37a8eec1ce1"
 				vmi := newVMIBridgeInterface("testnamespace", "testVmName")
 				iface := v1.DefaultBridgeNetworkInterface()
 				cniNet := vmiPrimaryNetwork()
@@ -197,14 +197,14 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						vmi:              vm,
 						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[0],
 						vmiSpecNetwork:   additionalCNINet1,
-						podInterfaceName: "net1",
+						podInterfaceName: "pode56ef68384a",
 						handler:          vmNetworkConfigurator.handler,
 						cacheCreator:     vmNetworkConfigurator.cacheCreator,
 						launcherPID:      &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[0],
-							generateInPodBridgeInterfaceName("net1"),
+							generateInPodBridgeInterfaceName("pode56ef68384a"),
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},
@@ -227,14 +227,14 @@ var _ = Describe("VMNetworkConfigurator", func() {
 						vmi:              vm,
 						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[2],
 						vmiSpecNetwork:   additionalCNINet2,
-						podInterfaceName: "net2",
+						podInterfaceName: "pod9f531ef99d2",
 						handler:          vmNetworkConfigurator.handler,
 						cacheCreator:     vmNetworkConfigurator.cacheCreator,
 						launcherPID:      &launcherPID,
 						infraConfigurator: infraconfigurators.NewBridgePodNetworkConfigurator(
 							vm,
 							&vm.Spec.Domain.Devices.Interfaces[2],
-							generateInPodBridgeInterfaceName("net2"),
+							generateInPodBridgeInterfaceName("pod9f531ef99d2"),
 							launcherPID,
 							vmNetworkConfigurator.handler),
 					},
@@ -258,7 +258,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				launcherPID := 0
 
-				const expectedPodIfaceName = "net1"
+				const expectedPodIfaceName = "pod45b3499a170"
 				Expect(vmNetworkConfigurator.getPhase1NICs(
 					&launcherPID,
 					[]v1.Network{networkToHotplug(ifaceToHotplug)},

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -37,7 +37,6 @@ import (
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/network/infraconfigurators"
 	"kubevirt.io/kubevirt/pkg/network/link"
-	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -115,20 +114,13 @@ func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, handler netd
 		return nil, fmt.Errorf("no iface matching with network %s", network.Name)
 	}
 
-	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
-	podInterfaceName, exists := networkNameScheme[network.Name]
-	if !exists {
-		return nil, fmt.Errorf("pod interface name not found for network %s", network.Name)
-	}
-
 	return &podNIC{
-		cacheCreator:     cacheCreator,
-		handler:          handler,
-		vmi:              vmi,
-		vmiSpecNetwork:   network,
-		podInterfaceName: podInterfaceName,
-		vmiSpecIface:     correspondingNetworkIface,
-		launcherPID:      launcherPID,
+		cacheCreator:   cacheCreator,
+		handler:        handler,
+		vmi:            vmi,
+		vmiSpecNetwork: network,
+		vmiSpecIface:   correspondingNetworkIface,
+		launcherPID:    launcherPID,
 	}, nil
 }
 

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -22,6 +22,7 @@ package network
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -110,7 +111,7 @@ func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, handler netd
 		return nil, fmt.Errorf("no iface matching with network %s", network.Name)
 	}
 
-	networkNameScheme := namescheme.CreateNetworkNameScheme(vmi.Spec.Networks)
+	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
 	podInterfaceName, exists := networkNameScheme[network.Name]
 	if !exists {
 		return nil, fmt.Errorf("pod interface name not found for network %s", network.Name)
@@ -304,7 +305,8 @@ func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
 }
 
 func generateInPodBridgeInterfaceName(podInterfaceName string) string {
-	return fmt.Sprintf("k6t-%s", podInterfaceName)
+	trimmedName := strings.TrimPrefix(podInterfaceName, namescheme.HashedIfacePrefix)
+	return fmt.Sprintf("k6t-%s", trimmedName)
 }
 
 func getPIDString(pid *int) string {

--- a/pkg/network/setup/podnic_test.go
+++ b/pkg/network/setup/podnic_test.go
@@ -100,6 +100,7 @@ var _ = Describe("podNIC", func() {
 				podnic.domainGenerator = &fakeLibvirtSpecGenerator{
 					shouldGenerateFail: false,
 				}
+				podnic.podInterfaceName = namescheme.PrimaryPodInterfaceName
 			})
 			It("phase2 should succeed", func() {
 				Expect(podnic.PlugPhase2(domain)).To(Succeed())

--- a/pkg/network/sriov/sriov.go
+++ b/pkg/network/sriov/sriov.go
@@ -61,7 +61,7 @@ func mapNetworkNameToPCIAddress(networks []v1.Network, interfaces []v1.Interface
 	if err != nil {
 		return nil, err
 	}
-	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(networks)
+	networkNameScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(networks, multusInterfaceNameToNetworkStatusMap)
 
 	networkPCIMap := map[string]string{}
 	for _, sriovIface := range vmispec.FilterSRIOVInterfaces(interfaces) {

--- a/pkg/network/sriov/sriov.go
+++ b/pkg/network/sriov/sriov.go
@@ -61,7 +61,7 @@ func mapNetworkNameToPCIAddress(networks []v1.Network, interfaces []v1.Interface
 	if err != nil {
 		return nil, err
 	}
-	networkNameScheme := namescheme.CreateNetworkNameScheme(networks)
+	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(networks)
 
 	networkPCIMap := map[string]string{}
 	for _, sriovIface := range vmispec.FilterSRIOVInterfaces(interfaces) {

--- a/pkg/network/sriov/sriov_test.go
+++ b/pkg/network/sriov/sriov_test.go
@@ -20,6 +20,8 @@
 package sriov_test
 
 import (
+	"fmt"
+
 	"kubevirt.io/kubevirt/pkg/network/sriov"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,7 +31,12 @@ import (
 )
 
 var _ = Describe("SRIOV", func() {
-	networkStatusWithOneSRIOVNetwork := `
+
+	const (
+		booHashedIfaceName = "pod6446d58d6df"
+		fooHashedIfaceName = "pod2c26b46b68f"
+	)
+	networkStatusWithOneSRIOVNetwork := fmt.Sprintf(`
 [
 {
   "name": "kindnet",
@@ -43,7 +50,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net1",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -53,8 +60,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`
-	networkStatusWithTwoSRIOVNetworks := `
+]`, fooHashedIfaceName)
+	networkStatusWithTwoSRIOVNetworks := fmt.Sprintf(`
 [
 {
   "name": "kindnet",
@@ -68,7 +75,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net1",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -80,7 +87,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad2",
-  "interface": "net2",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -90,8 +97,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`
-	networkStatusWithOneBridgeOneSRIOVNetworks := `
+]`, fooHashedIfaceName, booHashedIfaceName)
+	networkStatusWithOneBridgeOneSRIOVNetworks := fmt.Sprintf(`
 [
 {
   "name": "kindnet",
@@ -105,13 +112,13 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/bridge-network",
-  "interface": "net1",
+  "interface": "%s",
   "mac": "8a:37:d9:e7:0f:18",
   "dns": {}
 },
 {
   "name": "default/sriov-network-vlan100",
-  "interface": "net2",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -121,7 +128,7 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`
+]`, booHashedIfaceName, fooHashedIfaceName)
 	networkStatusWithTwoSRIOVNetworksButOneWithNoPCIData := `
 [
 {

--- a/pkg/network/sriov/sriov_test.go
+++ b/pkg/network/sriov/sriov_test.go
@@ -33,10 +33,12 @@ import (
 var _ = Describe("SRIOV", func() {
 
 	const (
-		booHashedIfaceName = "pod6446d58d6df"
-		fooHashedIfaceName = "pod2c26b46b68f"
+		booHashedIfaceName  = "pod6446d58d6df"
+		fooHashedIfaceName  = "pod2c26b46b68f"
+		fooOrdinalIfaceName = "net1"
+		booOrdinalIfaceName = "net2"
 	)
-	networkStatusWithOneSRIOVNetwork := fmt.Sprintf(`
+	networkStatusWithOneSRIOVNetworkFmt := `
 [
 {
   "name": "kindnet",
@@ -60,8 +62,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`, fooHashedIfaceName)
-	networkStatusWithTwoSRIOVNetworks := fmt.Sprintf(`
+]`
+	networkStatusWithTwoSRIOVNetworksFmt := `
 [
 {
   "name": "kindnet",
@@ -97,8 +99,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`, fooHashedIfaceName, booHashedIfaceName)
-	networkStatusWithOneBridgeOneSRIOVNetworks := fmt.Sprintf(`
+]`
+	networkStatusWithOneBridgeOneSRIOVNetworksFmt := `
 [
 {
   "name": "kindnet",
@@ -128,8 +130,8 @@ var _ = Describe("SRIOV", func() {
     }
   }
 }
-]`, booHashedIfaceName, fooHashedIfaceName)
-	networkStatusWithTwoSRIOVNetworksButOneWithNoPCIData := `
+]`
+	networkStatusWithTwoSRIOVNetworksButOneWithNoPCIDataFmt := `
 [
 {
   "name": "kindnet",
@@ -143,7 +145,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net1",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -155,7 +157,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net2",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -163,7 +165,7 @@ var _ = Describe("SRIOV", func() {
   }
 }
 ]`
-	networkStatusWithTwoSRIOVNetworksButOneWithNoDeviceInfoData := `
+	networkStatusWithTwoSRIOVNetworksButOneWithNoDeviceInfoDataFmt := `
 [
 {
   "name": "kindnet",
@@ -177,7 +179,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net1",
+  "interface": "%s",
   "dns": {},
   "device-info": {
     "type": "pci",
@@ -189,7 +191,7 @@ var _ = Describe("SRIOV", func() {
 },
 {
   "name": "default/nad1",
-  "interface": "net2",
+  "interface": "%s",
   "dns": {}
 }
 ]`
@@ -212,7 +214,7 @@ var _ = Describe("SRIOV", func() {
 				newSRIOVInterface("foo"),
 				newSRIOVInterface("boo"),
 			},
-			networkStatusWithOneSRIOVNetwork,
+			fmt.Sprintf(networkStatusWithOneSRIOVNetworkFmt, fooHashedIfaceName),
 		),
 		Entry("when networkStatusAnnotation is valid but with no pci data on one of the SRIOV interfaces",
 			[]virtv1.Network{
@@ -223,7 +225,7 @@ var _ = Describe("SRIOV", func() {
 				newSRIOVInterface("foo"),
 				newSRIOVInterface("boo"),
 			},
-			networkStatusWithTwoSRIOVNetworksButOneWithNoPCIData,
+			fmt.Sprintf(networkStatusWithTwoSRIOVNetworksButOneWithNoPCIDataFmt, fooHashedIfaceName, booHashedIfaceName),
 		),
 		Entry("when networkStatusAnnotation is valid but with no device-info data on one of the SRIOV interfaces",
 			[]virtv1.Network{
@@ -234,7 +236,7 @@ var _ = Describe("SRIOV", func() {
 				newSRIOVInterface("foo"),
 				newSRIOVInterface("boo"),
 			},
-			networkStatusWithTwoSRIOVNetworksButOneWithNoDeviceInfoData,
+			fmt.Sprintf(networkStatusWithTwoSRIOVNetworksButOneWithNoDeviceInfoDataFmt, fooHashedIfaceName, booHashedIfaceName),
 		),
 	)
 
@@ -245,7 +247,7 @@ var _ = Describe("SRIOV", func() {
 		Entry("when given Interfaces{1X masquarade(primary),1X SRIOV}; Networks{1X masquarade(primary),1X Multus} 1xNAD",
 			[]virtv1.Network{newMasqueradeDefaultNetwork("testmasquerade"), newMultusNetwork("foo", "default/nad1")},
 			[]virtv1.Interface{newMasqueradePrimaryInterface("testmasquerade"), newSRIOVInterface("foo")},
-			networkStatusWithOneSRIOVNetwork,
+			fmt.Sprintf(networkStatusWithOneSRIOVNetworkFmt, fooHashedIfaceName),
 			`{"foo":"0000:04:02.5"}`,
 		),
 		Entry("when given Interfaces{1X masquarade(primary),2X SRIOV}, Networks{1X masquarade(primary),2X Multus}, 2xNAD",
@@ -258,7 +260,7 @@ var _ = Describe("SRIOV", func() {
 				newMasqueradePrimaryInterface("testmasquerade"),
 				newSRIOVInterface("boo"), newSRIOVInterface("foo"),
 			},
-			networkStatusWithTwoSRIOVNetworks,
+			fmt.Sprintf(networkStatusWithTwoSRIOVNetworksFmt, fooHashedIfaceName, booHashedIfaceName),
 			`{"boo":"0000:04:02.2","foo":"0000:04:02.5"}`,
 		),
 		Entry("when given Interfaces{1X masquarade(primary),1X SRIOV, 1X Bridge}  Networks{1X masquarade(primary),2X Multus}, 2xNAD",
@@ -271,7 +273,39 @@ var _ = Describe("SRIOV", func() {
 				newMasqueradePrimaryInterface("testmasquerade"),
 				newBridgeInterface("boo"), newSRIOVInterface("foo"),
 			},
-			networkStatusWithOneBridgeOneSRIOVNetworks,
+			fmt.Sprintf(networkStatusWithOneBridgeOneSRIOVNetworksFmt, booHashedIfaceName, fooHashedIfaceName),
+			`{"foo":"0000:65:00.2"}`,
+		),
+		Entry("given 1 primary masquerade, 1 SR-IOV interfaces and pod network status with ordinal names",
+			[]virtv1.Network{newMasqueradeDefaultNetwork("testmasquerade"), newMultusNetwork("foo", "default/nad1")},
+			[]virtv1.Interface{newMasqueradePrimaryInterface("testmasquerade"), newSRIOVInterface("foo")},
+			fmt.Sprintf(networkStatusWithOneSRIOVNetworkFmt, fooOrdinalIfaceName),
+			`{"foo":"0000:04:02.5"}`,
+		),
+		Entry("given 1 primary masquerade, 2 SR-IOV interfaces and pod network status with ordinal names",
+			[]virtv1.Network{
+				newMasqueradeDefaultNetwork("testmasquerade"),
+				newMultusNetwork("foo", "default/nad1"),
+				newMultusNetwork("boo", "default/nad2"),
+			},
+			[]virtv1.Interface{
+				newMasqueradePrimaryInterface("testmasquerade"),
+				newSRIOVInterface("boo"), newSRIOVInterface("foo"),
+			},
+			fmt.Sprintf(networkStatusWithTwoSRIOVNetworksFmt, fooOrdinalIfaceName, booOrdinalIfaceName),
+			`{"boo":"0000:04:02.2","foo":"0000:04:02.5"}`,
+		),
+		Entry("given 1 primary masquerade, 1 SR-IOV, 1 bridge interfaces and pod network status with ordinal names",
+			[]virtv1.Network{
+				newMasqueradeDefaultNetwork("testmasquerade"),
+				newMultusNetwork("boo", "default/nad1"),
+				newMultusNetwork("foo", "default/nad2"),
+			},
+			[]virtv1.Interface{
+				newMasqueradePrimaryInterface("testmasquerade"),
+				newBridgeInterface("boo"), newSRIOVInterface("foo"),
+			},
+			fmt.Sprintf(networkStatusWithOneBridgeOneSRIOVNetworksFmt, fooOrdinalIfaceName, booOrdinalIfaceName),
 			`{"foo":"0000:65:00.2"}`,
 		),
 	)

--- a/pkg/virt-controller/services/multus_annotations.go
+++ b/pkg/virt-controller/services/multus_annotations.go
@@ -59,7 +59,7 @@ func (mnap multusNetworkAnnotationPool) toString() (string, error) {
 func GenerateMultusCNIAnnotation(vmi *v1.VirtualMachineInstance) (string, error) {
 	multusNetworkAnnotationPool := multusNetworkAnnotationPool{}
 
-	networkNameScheme := namescheme.CreateNetworkNameScheme(vmi.Spec.Networks)
+	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
 	for _, network := range vmi.Spec.Networks {
 		if vmispec.IsSecondaryMultusNetwork(network) {
 			podInterfaceName := networkNameScheme[network.Name]

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -43,6 +43,7 @@ import (
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/network/istio"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
 	"kubevirt.io/kubevirt/pkg/storage/types"
@@ -260,6 +261,16 @@ func (t *templateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance
 	if err != nil {
 		return nil, err
 	}
+
+	if namescheme.PodHasOrdinalInterfaceName(NonDefaultMultusNetworksIndexedByIfaceName(pod)) {
+		ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
+		multusNetworksAnnotation, err := GenerateMultusCNIAnnotationFromNameScheme(vmi, ordinalNameScheme)
+		if err != nil {
+			return nil, err
+		}
+		podManifest.Annotations[networkv1.NetworkAttachmentAnnot] = multusNetworksAnnotation
+	}
+
 	return podManifest, err
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1065,6 +1065,73 @@ var _ = Describe("Template", func() {
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})
+			DescribeTable("should add Multus networks annotation to the migration target pod with interface name scheme similar to the migration source pod",
+				func(migrationSourcePodNetworksAnnotation, expectedTargetPodMultusNetworksAnnotation map[string]string) {
+					config, kvInformer, svc = configFactory(defaultArch)
+
+					vmi := &v1.VirtualMachineInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testvmi",
+							Namespace: "default",
+							UID:       "1234",
+						},
+						Spec: v1.VirtualMachineInstanceSpec{
+							Networks: []v1.Network{
+								{Name: "default",
+									NetworkSource: v1.NetworkSource{
+										Pod: &v1.PodNetwork{},
+									}},
+								{Name: "blue",
+									NetworkSource: v1.NetworkSource{
+										Multus: &v1.MultusNetwork{NetworkName: "test1"},
+									}},
+								{Name: "red",
+									NetworkSource: v1.NetworkSource{
+										Multus: &v1.MultusNetwork{NetworkName: "other-namespace/test1"},
+									}},
+							},
+						},
+					}
+
+					sourcePod, err := svc.RenderLaunchManifest(vmi)
+					Expect(err).ToNot(HaveOccurred())
+					sourcePod.ObjectMeta.Annotations[networkv1.NetworkStatusAnnot] = migrationSourcePodNetworksAnnotation[networkv1.NetworkStatusAnnot]
+
+					targetPod, err := svc.RenderMigrationManifest(vmi, sourcePod)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(targetPod.Annotations[MultusNetworksAnnotation]).To(MatchJSON(expectedTargetPodMultusNetworksAnnotation[MultusNetworksAnnotation]))
+				},
+				Entry("when the migration source Multus network-status annotation has ordinal naming",
+					map[string]string{
+						networkv1.NetworkStatusAnnot: `[
+							{"interface":"eth0", "name":"default"},
+							{"interface":"net1", "name":"test1", "namespace":"default"},
+							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
+						]`,
+					},
+					map[string]string{
+						MultusNetworksAnnotation: `[
+							{"interface":"net1", "name":"test1", "namespace":"default"},
+							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
+						]`,
+					},
+				),
+				Entry("when the migration source Multus network-status annotation has hashed naming",
+					map[string]string{
+						networkv1.NetworkStatusAnnot: `[
+							{"interface":"pod16477688c0e", "name":"test1", "namespace":"default"},
+							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"}
+						]`,
+					},
+					map[string]string{
+						MultusNetworksAnnotation: `[
+							{"interface":"pod16477688c0e", "name":"test1", "namespace":"default"},
+							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"}
+						]`,
+					},
+				),
+			)
 		})
 		Context("with masquerade interface", func() {
 			It("should add the istio annotation", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -977,9 +977,9 @@ var _ = Describe("Template", func() {
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
 				expectedIfaces := ("[" +
-					"{\"interface\":\"net1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"net2\",\"name\":\"test1\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"net3\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
+					"{\"interface\":\"pod37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"pod49dba5c72f0\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})
@@ -1017,7 +1017,7 @@ var _ = Describe("Template", func() {
 				Expect(value).To(Equal("default"))
 				value, ok = pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
-				Expect(value).To(Equal("[{\"interface\":\"net1\",\"name\":\"test1\",\"namespace\":\"default\"}]"))
+				Expect(value).To(Equal("[{\"interface\":\"pod1b4f0e98519\",\"name\":\"test1\",\"namespace\":\"default\"}]"))
 			})
 			It("should add MAC address in the pod annotation", func() {
 				config, kvInformer, svc = configFactory(defaultArch)
@@ -1060,8 +1060,8 @@ var _ = Describe("Template", func() {
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(BeTrue())
 				expectedIfaces := ("[" +
-					"{\"interface\":\"net1\",\"name\":\"default\",\"namespace\":\"default\"}," +
-					"{\"interface\":\"net2\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
+					"{\"interface\":\"pod37a8eec1ce1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"pod1b4f0e98519\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2254,7 +2254,9 @@ func (c *VMIController) getVolumePhaseMessageReason(volume *virtv1.Volume, names
 func (c *VMIController) handleDynamicInterfaceRequests(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
 	podAnnotations := pod.GetAnnotations()
 
-	multusAnnotations, err := services.GenerateMultusCNIAnnotation(vmi)
+	indexedMultusStatusIfaces := services.NonDefaultMultusNetworksIndexedByIfaceName(pod)
+	networkToPodIfaceMap := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
+	multusAnnotations, err := services.GenerateMultusCNIAnnotationFromNameScheme(vmi, networkToPodIfaceMap)
 	if err != nil {
 		return err
 	}
@@ -2277,7 +2279,7 @@ func (c *VMIController) handleDynamicInterfaceRequests(vmi *virtv1.VirtualMachin
 }
 
 func (c *VMIController) updateInterfaceStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
-	indexedMultusStatusIfaces := nonDefaultMultusNetworksIndexedByIfaceName(pod)
+	indexedMultusStatusIfaces := services.NonDefaultMultusNetworksIndexedByIfaceName(pod)
 	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)
@@ -2306,28 +2308,4 @@ func generateInterfaceStatusPatchRequest(oldInterfaceStatus []byte, newInterface
 		fmt.Sprintf(`{ "op": "test", "path": "/status/interfaces", "value": %s }`, string(oldInterfaceStatus)),
 		fmt.Sprintf(`{ "op": "add", "path": "/status/interfaces", "value": %s }`, string(newInterfaceStatus)),
 	}
-}
-
-func nonDefaultMultusNetworksIndexedByIfaceName(pod *k8sv1.Pod) map[string]networkv1.NetworkStatus {
-	indexedNetworkStatus := map[string]networkv1.NetworkStatus{}
-	podNetworkStatus, found := pod.Annotations[networkv1.NetworkStatusAnnot]
-
-	if !found {
-		return indexedNetworkStatus
-	}
-
-	var networkStatus []networkv1.NetworkStatus
-	if err := json.Unmarshal([]byte(podNetworkStatus), &networkStatus); err != nil {
-		log.Log.Errorf("failed to unmarshall pod network status: %v", err)
-		return indexedNetworkStatus
-	}
-
-	for _, ns := range networkStatus {
-		if ns.Default {
-			continue
-		}
-		indexedNetworkStatus[ns.Interface] = ns
-	}
-
-	return indexedNetworkStatus
 }

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2277,8 +2277,8 @@ func (c *VMIController) handleDynamicInterfaceRequests(vmi *virtv1.VirtualMachin
 }
 
 func (c *VMIController) updateInterfaceStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
-	ifaceNamingScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
 	indexedMultusStatusIfaces := nonDefaultMultusNetworksIndexedByIfaceName(pod)
+	ifaceNamingScheme := namescheme.CreateNetworkNameSchemeByPodNetworkStatus(vmi.Spec.Networks, indexedMultusStatusIfaces)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)
 		podIfaceName, wasFound := ifaceNamingScheme[network.Name]

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2277,7 +2277,7 @@ func (c *VMIController) handleDynamicInterfaceRequests(vmi *virtv1.VirtualMachin
 }
 
 func (c *VMIController) updateInterfaceStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
-	ifaceNamingScheme := namescheme.CreateNetworkNameScheme(vmi.Spec.Networks)
+	ifaceNamingScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
 	indexedMultusStatusIfaces := nonDefaultMultusNetworksIndexedByIfaceName(pod)
 	for _, network := range vmi.Spec.Networks {
 		vmiIfaceStatus := vmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, network.Name)

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3219,6 +3219,59 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						networkv1.NetworkAttachmentAnnot,
 						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"},{"interface":"pod48802102d24","name":"net1","namespace":"default"}]`)),
 			)
+			DescribeTable("the subject interface name, in the pod networks annotation, should be in similar form as other interfaces",
+				func(testPodNetworkStatus []networkv1.NetworkStatus, expectedMultusNetworksAnnotation string) {
+					vmi = api.NewMinimalVMI(vmName)
+					vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, v1.Interface{
+						Name:                   "red",
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
+					})
+					vmi.Spec.Networks = append(vmi.Spec.Networks, v1.Network{
+						Name:          "red",
+						NetworkSource: v1.NetworkSource{Multus: &virtv1.MultusNetwork{NetworkName: "red-net"}}},
+					)
+
+					pod = NewPodForVirtualMachine(vmi, k8sv1.PodRunning, testPodNetworkStatus...)
+					prependInjectPodPatch(pod)
+
+					addOpts := []virtv1.AddInterfaceOptions{
+						{
+							NetworkAttachmentDefinitionName: "blue-net",
+							Name:                            "blue",
+						},
+					}
+
+					fakeHotPlugRequest(vmi, addOpts)
+					Expect(controller.handleDynamicInterfaceRequests(vmi, pod)).To(Succeed())
+
+					Expect(pod.Annotations).To(HaveKey(networkv1.NetworkAttachmentAnnot))
+					Expect(pod.Annotations[networkv1.NetworkAttachmentAnnot]).To(MatchJSON(expectedMultusNetworksAnnotation))
+				},
+				Entry("when Multus network-status annotation interfaces has ordinal names",
+					[]networkv1.NetworkStatus{
+						{
+							Interface: "net1", Name: "red-net",
+						},
+					},
+					// expected Multus network annotation
+					`[
+							{"interface":"net1", "name":"red-net", "namespace": "default"},
+							{"interface":"net2", "name":"blue-net", "namespace": "default"}
+					]`,
+				),
+				Entry("when Multus network-status annotation interfaces has hashed names",
+					[]networkv1.NetworkStatus{
+						{
+							Interface: "podb1f51a511f1", Name: "red-net",
+						},
+					},
+					// expected Multus network annotation
+					`[
+							{"interface":"podb1f51a511f1", "name":"red-net", "namespace": "default"},
+							{"interface":"pod16477688c0e", "name":"blue-net", "namespace": "default"}
+					]`,
+				),
+			)
 		})
 
 		Context("interface status", func() {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -792,7 +792,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 			{
 			"name": "` + netAttachDefName + `",
-			"interface": "net1",
+			"interface": "poda7662f44d65",
 			"dns": {},
 			"device-info": {
 			  "type": "pci",
@@ -3206,7 +3206,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
-						`[{"interface":"net1","name":"net1","namespace":"default"}]`)),
+						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"}]`)),
 				Entry("hotplug multiple interfaces",
 					[]virtv1.AddInterfaceOptions{{
 						NetworkAttachmentDefinitionName: "net1",
@@ -3217,7 +3217,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
-						`[{"interface":"net1","name":"net1","namespace":"default"},{"interface":"net2","name":"net1","namespace":"default"}]`)),
+						`[{"interface":"pod7e0055a6880","name":"net1","namespace":"default"},{"interface":"pod48802102d24","name":"net1","namespace":"default"}]`)),
 			)
 		})
 
@@ -3258,8 +3258,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					PodVmIfaceStatus{
 						vmIfaceStatus: readyHotpluggedIfaceStatus(ifaceName),
 						podIfaceStatus: &networkv1.NetworkStatus{
-							Name:      "meganet",
-							Interface: "net1",
+							Name:      networkName,
+							Interface: "pod7e0055a6880",
 						},
 					}),
 				Entry("VMI with a guest agent interface",

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3262,6 +3262,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 							Interface: "pod7e0055a6880",
 						},
 					}),
+				Entry("VMI with an interface on spec, (matched on status), with the pod interface ready and ordinal name",
+					newVMIWithOneIface(api.NewMinimalVMI(vmName), networkName, ifaceName),
+					PodVmIfaceStatus{
+						vmIfaceStatus: readyHotpluggedIfaceStatus(ifaceName),
+						podIfaceStatus: &networkv1.NetworkStatus{
+							Name:      networkName,
+							Interface: "net1",
+						},
+					}),
 				Entry("VMI with a guest agent interface",
 					newVMIWithGuestAgentInterface(
 						newVMIWithOneIface(api.NewMinimalVMI(vmName), networkName, ifaceName),

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
     timeout = "long",
     srcs = [
         "migration_test.go",
+        "non-root_test.go",
         "realtime_test.go",
         "retry_manager_test.go",
         "virt_handler_suite_test.go",
@@ -91,6 +92,7 @@ go_test(
         "//pkg/network/errors:go_default_library",
         "//pkg/safepath:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/unsafepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -106,7 +106,7 @@ func (d *VirtualMachineController) prepareStorage(vmi *v1.VirtualMachineInstance
 	return changeOwnershipOfHostDisks(vmi, res)
 }
 
-func getTapDevices(vmi *v1.VirtualMachineInstance) ([]string, error) {
+func getTapDevices(vmi *v1.VirtualMachineInstance) (map[string]string, error) {
 	macvtap := map[string]struct{}{}
 	for _, inf := range vmi.Spec.Domain.Devices.Interfaces {
 		if inf.Macvtap != nil {
@@ -115,11 +115,11 @@ func getTapDevices(vmi *v1.VirtualMachineInstance) ([]string, error) {
 	}
 
 	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
-	tapDevices := []string{}
+	tapDevices := map[string]string{}
 	for _, net := range vmi.Spec.Networks {
 		_, isMacvtapNetwork := macvtap[net.Name]
 		if podInterfaceName, exists := networkNameScheme[net.Name]; isMacvtapNetwork && exists {
-			tapDevices = append(tapDevices, podInterfaceName)
+			tapDevices[net.Name] = podInterfaceName
 		} else if isMacvtapNetwork && !exists {
 			return nil, fmt.Errorf("network %q not found in naming scheme: this should never happen", net.Name)
 		}
@@ -128,12 +128,12 @@ func getTapDevices(vmi *v1.VirtualMachineInstance) ([]string, error) {
 }
 
 func (d *VirtualMachineController) prepareTap(vmi *v1.VirtualMachineInstance, res isolation.IsolationResult) error {
-	tapDevices, err := getTapDevices(vmi)
+	networkToTapDeviceNames, err := getTapDevices(vmi)
 	if err != nil {
 		return err
 	}
-	for _, tap := range tapDevices {
-		path, err := isolation.SafeJoin(res, "sys", "class", "net", tap, "ifindex")
+	for networkName, tapName := range networkToTapDeviceNames {
+		path, err := FindInterfaceIndexPath(res, tapName, networkName, vmi.Spec.Networks)
 		if err != nil {
 			return err
 		}
@@ -165,6 +165,32 @@ func (d *VirtualMachineController) prepareTap(vmi *v1.VirtualMachineInstance, re
 	}
 	return nil
 
+}
+
+// FindInterfaceIndexPath return the ifindex path of the given interface name (e.g.: enp0f1p2 -> /sys/class/net/enp0f1p2/ifindex).
+// If path not found it will try to find the path using ordinal interface name based on its position in the given
+// networks slice (e.g.: net1 -> /sys/class/net/net1/ifindex).
+func FindInterfaceIndexPath(res isolation.IsolationResult, podIfaceName string, networkName string, networks []v1.Network) (*safepath.Path, error) {
+	var errs []string
+	path, err := isolation.SafeJoin(res, "sys", "class", "net", podIfaceName, "ifindex")
+	if err == nil {
+		return path, nil
+	}
+	errs = append(errs, err.Error())
+
+	// fall back to ordinal pod interface names
+	ordinalPodIfaceName := namescheme.OrdinalPodInterfaceName(networkName, networks)
+	if ordinalPodIfaceName == "" {
+		errs = append(errs, fmt.Sprintf("failed to find network %q pod interface name", networkName))
+	} else {
+		path, err := isolation.SafeJoin(res, "sys", "class", "net", ordinalPodIfaceName, "ifindex")
+		if err == nil {
+			return path, nil
+		}
+		errs = append(errs, err.Error())
+	}
+
+	return nil, fmt.Errorf(strings.Join(errs, ", "))
 }
 
 func (*VirtualMachineController) prepareVFIO(vmi *v1.VirtualMachineInstance, res isolation.IsolationResult) error {

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -114,7 +114,7 @@ func getTapDevices(vmi *v1.VirtualMachineInstance) ([]string, error) {
 		}
 	}
 
-	networkNameScheme := namescheme.CreateNetworkNameScheme(vmi.Spec.Networks)
+	networkNameScheme := namescheme.CreateHashedNetworkNameScheme(vmi.Spec.Networks)
 	tapDevices := []string{}
 	for _, net := range vmi.Spec.Networks {
 		_, isMacvtapNetwork := macvtap[net.Name]

--- a/pkg/virt-handler/non-root_test.go
+++ b/pkg/virt-handler/non-root_test.go
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package virthandler
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/safepath"
+	"kubevirt.io/kubevirt/pkg/unsafepath"
+	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
+)
+
+var _ = Describe("FindTapDeviceIfindexPath", func() {
+	var mockIsolationResult *isolation.MockIsolationResult
+	var testsRootDir string
+
+	BeforeEach(func() {
+		var err error
+		testsRootDir, err = os.MkdirTemp("", "ifindex-tests-")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { Expect(os.RemoveAll(testsRootDir)).To(Succeed()) })
+
+		mockIsolationResult = isolation.NewMockIsolationResult(gomock.NewController(GinkgoT()))
+		mockIsolationResult.EXPECT().Pid().Return(1).AnyTimes()
+
+		testsRootDirPath, err := safepath.JoinAndResolveWithRelativeRoot(testsRootDir)
+		Expect(err).ToNot(HaveOccurred())
+		mockIsolationResult.EXPECT().MountRoot().Return(testsRootDirPath, nil).AnyTimes()
+	})
+
+	createFileInTestsRootDir := func(path string) *unsafepath.Path {
+		testIfaceIndexAbsolutePath := fmt.Sprintf("%s/%s", testsRootDir, path)
+		Expect(os.MkdirAll(testIfaceIndexAbsolutePath, 0777)).To(Succeed())
+
+		return unsafepath.New(testsRootDir, path)
+	}
+
+	DescribeTable("should return pod interface ifindex path given",
+		func(networkName, podIfaceName string) {
+			testsNetworks := []v1.Network{
+				podNetwork(),
+				multusNetwork(networkName),
+			}
+			podIfaceIndexPath := fmt.Sprintf("/sys/class/net/%s/ifindex", podIfaceName)
+			expectedPodIfaceIndexPath := createFileInTestsRootDir(podIfaceIndexPath)
+
+			path, err := FindInterfaceIndexPath(mockIsolationResult, podIfaceName, networkName, testsNetworks)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(path.Raw()).To(Equal(expectedPodIfaceIndexPath))
+		},
+		Entry("hashed pod interface", "red", "b1f51a511f1"),
+		Entry("ordinal pod interface", "red", "net1"),
+	)
+
+	It("when path not found using hashed pod interface, fall back using ordinal pod interface name", func() {
+		testsNetworks := []v1.Network{
+			podNetwork(),
+			multusNetwork("red"),
+		}
+		const existingOrdinalNamePodIfaceIndexPath = "/sys/class/net/net1/ifindex"
+		expectedOrdinalNamePodIfaceIndexPath := createFileInTestsRootDir(existingOrdinalNamePodIfaceIndexPath)
+
+		path, err := FindInterfaceIndexPath(mockIsolationResult, "b1f51a511f1", "red", testsNetworks)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(path.Raw()).To(Equal(expectedOrdinalNamePodIfaceIndexPath))
+	})
+
+	It("should fail when path not found using hashed pod interface, and ordinal pod interface name not found", func() {
+		const existingOrdinalNamePodIfaceIndexPath = "/sys/class/net/net1/ifindex"
+		createFileInTestsRootDir(existingOrdinalNamePodIfaceIndexPath)
+
+		testsNetworks := []v1.Network{
+			podNetwork(),
+			multusNetwork("red"),
+		}
+
+		const hashedPodIfaceName = "b1f51a511f1"
+		_, err := FindInterfaceIndexPath(mockIsolationResult, hashedPodIfaceName, "wrong-network-name", testsNetworks)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to find network \"wrong-network-name\" pod interface name"))
+	})
+
+	It("should fail when ifindex not found using both hashed and ordinal pod interface names", func() {
+		createFileInTestsRootDir("/sys/class/net/b1f51a511f1")
+
+		testsNetworks := []v1.Network{
+			podNetwork(),
+			multusNetwork("red"),
+		}
+
+		_, err := FindInterfaceIndexPath(mockIsolationResult, "b1f51a511f1", "red", testsNetworks)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("/sys/class/net/b1f51a511f1/ifindex: no such file or directory"))
+		Expect(err.Error()).To(ContainSubstring("/sys/class/net/net1: no such file or directory"))
+	})
+})
+
+func multusNetwork(name string) v1.Network {
+	return v1.Network{
+		Name: name,
+		NetworkSource: v1.NetworkSource{
+			Multus: &v1.MultusNetwork{NetworkName: name + "vnet"},
+		},
+	}
+}
+
+func podNetwork() v1.Network {
+	return v1.Network{
+		Name: "default",
+		NetworkSource: v1.NetworkSource{
+			Pod: &v1.PodNetwork{},
+		},
+	}
+}

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -526,7 +526,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 						virtClient,
 						vmiPod,
 						"compute",
-						[]string{"cat", "/sys/class/net/net1/mtu"},
+						[]string{"cat", "/sys/class/net/pod72ad293a5c9/mtu"},
 					)
 					ExpectWithOffset(1, err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**Summary:**
This PR implements the next phase of hotplug NICs feature, changing the VM pod network interfaces name scheme.
https://github.com/kubevirt/community/blob/main/design-proposals/nic-hotplug/nic-hotplug.md#virtctl-1

This PR changes are necessary to enable unplug interface functionality in KubeVirt.

**Why we need it:**
As of today, virt-launcher pod interface names have an ordinal factor (net1, net2, …, netX), which is derived from the interfaces ordering in the VMI spec.

Mapping between the VMI spec interfaces and virt-launcher pod interfaces  (in `pod k8s.v1.cni.cncf.io/networks` annotation) depends on the fact that pod interface names derive from the order of the VMI spec interfaces.

The fact that pod interface names have ordinal factor is not sustainable for introducing the complimentary unplug interfaces functionality:
Given a VM with three secondary interfaces:
```
spec:
  networks:
  - name: blue-network
    multus: ...
  - name: red-network
    multus: ...
  - name: green-network
    multus: ...
```
The pod's Multus networks annotation will look like so:
```
  k8s.v1.cni.cncf.io/networks: [
            {interface: net1, ...},
            {interface: net2,  ...},
            {interface: net3,  ...}
    ]
```
In the scenario where "blue-network" interface is unplugged, the annotation will change  as follows:
```
  k8s.v1.cni.cncf.io/networks: [
            {interface: net1, ...},
            {interface: net3,  ...}
    ]
```
But now its no longer possible to associate between all VMI spec and pod interfaces.

**What this PR does:**
Continuing https://github.com/kubevirt/kubevirt/pull/8899, change virt-launcher pod network interfaces (e.g.: bridge, tap-device) naming to non-ordinal form, where pod interface names will derive from their corresponding VMI spec network name (instead of their position)

Following the example above, with non-ordinal name scheme the pod's  Multus networks annotation will look as follows:
```
annotations: 
    k8s.v1.cni.cncf.io/networks: [
            {interface: pod7e0055a6880, ...},
            {interface: pod3c12b9d89fa, ...},
            {interface: pod4574e35ef8e, ...}
    ]
```
Unplugging any interface will not break the association between the VMI spec and pod interfaces.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- Testing legacy VM with secondary NICs migration following Kubevirt upgrade is covered by the operator upgrade tests (thanks to #9017).

- Kubevirt maintains legacy VMs (running VM from prior version to this PR changes) pod's interfaces ordinal name scheme (net1, net2...):
    - hotplugged interfaces will have ordinal names (as other interfaces in the pod).
    - migration pods will be created with similar interface names as the migration source pod.

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher pods network interfaces name scheme is changed to hashed names (SHA256), based on the VMI spec network names.
```
