### PR TITLE
Add chroot capability to rsync container in hack/dockerized

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -53,7 +53,7 @@ $KUBEVIRT_CRI run ${CONTAINER_ENV} -v "${BUILDER}:/root:rw${selinux_bind_options
 mkdir -p ${OUT_DIR}
 
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID=$($KUBEVIRT_CRI run ${CONTAINER_ENV} -d -v "${BUILDER}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID=$($KUBEVIRT_CRI run ${CONTAINER_ENV} -d -v "${BUILDER}:/root:rw${selinux_bind_options}" --security-opt "label=disable" --cap-add SYS_CHROOT --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
     $KUBEVIRT_CRI stop --time 1 ${RSYNC_CID} >/dev/null 2>&1


### PR DESCRIPTION
**What this PR does / why we need it**:
The latest version of podman (>v4.4.0) has dropped the CHROOT capability from the default configuration[1]. The rsync container used as part of cluster-sync requires chroot capabilities so this causes it to fail.[2]

The update allows it to run successfully with podman >v4.4.0.

Also tested the docker flow and this change has no impact on users running with docker.

[1] https://blog.podman.io/2022/12/dropping-capabilities-making-containers-more-secure/
[2] https://github.com/kubevirt/kubevirt/issues/9279

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9279 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
