### PR TITLE
DownwardMetrics: Fix bug in path selection.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,11 @@ var (
 	// ServiceAccountSourceDir represents the location where the ServiceAccount token is attached to the pod
 	ServiceAccountSourceDir = "/var/run/secrets/kubernetes.io/serviceaccount/"
 
+	// ServiceAccountDiskName represents the name of the ServiceAccount iso image
+	ServiceAccountDiskName = "service-account.iso"
+	// VhostmdDiskName represents the name of the vhostmd file
+	VhostmdDiskName = "vhostmd0"
+
 	// ConfigMapDisksDir represents a path to ConfigMap iso images
 	ConfigMapDisksDir = filepath.Join(mountBaseDir, "config-map-disks")
 	// SecretDisksDir represents a path to Secrets iso images
@@ -78,12 +83,10 @@ var (
 	DownwardAPIDisksDir = filepath.Join(mountBaseDir, "downwardapi-disks")
 	// DownwardMetricDisksDir represents a path to DownwardMetric block disk
 	DownwardMetricDisksDir = filepath.Join(mountBaseDir, "downwardmetric-disk")
-	// DownwardMetricDisks represents the disk location for the DownwardMetric disk
-	DownwardMetricDisk = filepath.Join(DownwardAPIDisksDir, "vhostmd0")
+	// DownwardMetricDisk represents the disk location for the DownwardMetric disk
+	DownwardMetricDisk = filepath.Join(DownwardMetricDisksDir, VhostmdDiskName)
 	// ServiceAccountDiskDir represents a path to the ServiceAccount iso image
 	ServiceAccountDiskDir = filepath.Join(mountBaseDir, "service-account-disk")
-	// ServiceAccountDiskName represents the name of the ServiceAccount iso image
-	ServiceAccountDiskName = "service-account.iso"
 
 	createISOImage      = defaultCreateIsoImage
 	createEmptyISOImage = defaultCreateEmptyIsoImage

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/downwardmetrics/vhostmd/api:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
@@ -33,6 +34,7 @@ go_library(
         "//vendor/github.com/Masterminds/semver:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/google/go-github/v32/github:go_default_library",
+        "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the path selection of DonwardMetrics disk.

The chosen path for writing the DownwardMetrics inside the virt-launcher is /var/run/kubevirt-private/downwardapi-disk instead of /var/run/kubevirt-private/downwardmetric-disk.

As it is, if users want use both DownwardMetrics and DownwardAPI just one of them will be available.

Please, note that this change is transparent to the guest. Therefore, there's no need to change current configurations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9284 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
