### PR TITLE
e2e: Update dual stack assertion

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -60,7 +60,7 @@ function functest() {
 	    -conn-check-dns=${conn_check_dns} \
 	    -migration-network-nic=${migration_network_nic} \
 	    ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
-    if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|(k8s-sriov)|(ipv6).* ]]; then
+    if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-sriov).* ]] || [[ ${KUBEVIRT_SINGLE_STACK} == "true" ]]; then
         echo "Will skip test asserting the cluster is in dual-stack mode."
         KUBEVIRT_FUNC_TEST_SUITE_ARGS="-skip-dual-stack-test ${KUBEVIRT_FUNC_TEST_SUITE_ARGS}"
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt dual stack assertion to be skipped for
KUBEVIRT_SINGLE_STACK instead if the provider is x.yz-ipv6, since we support robust stack providers now.

Remove legacy providers from the condition as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
