### PR TITLE
Indication of when target pod hosts active qemu instance during live migration

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18974,6 +18974,10 @@
       "description": "The Target Node has seen the Domain Start Event",
       "type": "boolean"
      },
+     "targetNodeDomainReadyTimestamp": {
+      "description": "The timestamp at which the target node detects the domain is active",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
+     },
      "targetNodeTopology": {
       "description": "If the VMI requires dedicated CPUs, this field will hold the numa topology on the target node",
       "type": "string"

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	apimachpatch "kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 
@@ -164,6 +165,21 @@ var _ = Describe("Migration watcher", func() {
 			}
 
 			return true, pdb, nil
+		})
+	}
+
+	shouldExpectPodAnnotationTimestamp := func(vmi *virtv1.VirtualMachineInstance) {
+		kubeClient.Fake.PrependReactor("patch", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
+			patchAction, ok := action.(testing.PatchAction)
+			Expect(ok).To(BeTrue())
+			Expect(patchAction.GetPatchType()).To(Equal(types.JSONPatchType))
+
+			key := patch.EscapeJSONPointer(virtv1.MigrationTargetReadyTimestamp)
+			expectedPatch := fmt.Sprintf(`[{ "op": "add", "path": "/metadata/annotations/%s", "value": "%s" }]`, key, vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp.String())
+
+			Expect(string(patchAction.GetPatch())).To(Equal(expectedPatch))
+
+			return true, nil, nil
 		})
 	}
 
@@ -1201,19 +1217,21 @@ var _ = Describe("Migration watcher", func() {
 			pod.Spec.NodeName = "node01"
 
 			vmi.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
-				MigrationUID:      migration.UID,
-				TargetNode:        "node01",
-				SourceNode:        "node02",
-				TargetNodeAddress: "10.10.10.10:1234",
-				StartTimestamp:    now(),
-				EndTimestamp:      now(),
-				Failed:            false,
-				Completed:         true,
+				MigrationUID:                   migration.UID,
+				TargetNode:                     "node01",
+				SourceNode:                     "node02",
+				TargetNodeAddress:              "10.10.10.10:1234",
+				StartTimestamp:                 now(),
+				EndTimestamp:                   now(),
+				TargetNodeDomainReadyTimestamp: now(),
+				Failed:                         false,
+				Completed:                      true,
 			}
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			podFeeder.Add(pod)
 
+			shouldExpectPodAnnotationTimestamp(vmi)
 			shouldExpectMigrationCompletedState(migration)
 
 			controller.Execute()

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -241,6 +241,7 @@ func newWatchEventError(err error) watch.Event {
 func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEvent, client *Notifier, events chan watch.Event,
 	interfaceStatus []api.InterfaceStatus, osInfo *api.GuestOSInfo, vmi *v1.VirtualMachineInstance, fsFreezeStatus *api.FSFreeze,
 	metadataCache *metadata.Cache) {
+
 	d, err := c.LookupDomainByName(util.DomainFromNamespaceName(domain.ObjectMeta.Namespace, domain.ObjectMeta.Name))
 	if err != nil {
 		if !domainerrors.IsNotFound(err) {
@@ -460,7 +461,8 @@ func (n *Notifier) StartDomainNotifier(
 	}()
 
 	domainEventLifecycleCallback := func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventLifecycle) {
-		log.Log.Infof("DomainLifecycle event %d with reason %d received", event.Event, event.Detail)
+
+		log.Log.Infof("DomainLifecycle event %s with event id %d reason %d received", event.String(), event.Event, event.Detail)
 		name, err := d.GetName()
 		if err != nil {
 			log.Log.Reason(err).Info(cantDetermineLibvirtDomainName)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11142,6 +11142,11 @@ var CRDsValidation map[string]string = map[string]string{
             targetNodeDomainDetected:
               description: The Target Node has seen the Domain Start Event
               type: boolean
+            targetNodeDomainReadyTimestamp:
+              description: The timestamp at which the target node detects the domain
+                is active
+              format: date-time
+              type: string
             targetNodeTopology:
               description: If the VMI requires dedicated CPUs, this field will hold
                 the numa topology on the target node
@@ -11516,6 +11521,11 @@ var CRDsValidation map[string]string = map[string]string{
             targetNodeDomainDetected:
               description: The Target Node has seen the Domain Start Event
               type: boolean
+            targetNodeDomainReadyTimestamp:
+              description: The timestamp at which the target node detects the domain
+                is active
+              format: date-time
+              type: string
             targetNodeTopology:
               description: If the VMI requires dedicated CPUs, this field will hold
                 the numa topology on the target node

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -4357,6 +4357,10 @@ func (in *VirtualMachineInstanceMigrationState) DeepCopyInto(out *VirtualMachine
 		in, out := &in.EndTimestamp, &out.EndTimestamp
 		*out = (*in).DeepCopy()
 	}
+	if in.TargetNodeDomainReadyTimestamp != nil {
+		in, out := &in.TargetNodeDomainReadyTimestamp, &out.TargetNodeDomainReadyTimestamp
+		*out = (*in).DeepCopy()
+	}
 	if in.TargetDirectMigrationNodePorts != nil {
 		in, out := &in.TargetDirectMigrationNodePorts, &out.TargetDirectMigrationNodePorts
 		*out = make(map[string]int, len(*in))

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -609,6 +609,8 @@ type VirtualMachineInstanceMigrationState struct {
 	// +nullable
 	EndTimestamp *metav1.Time `json:"endTimestamp,omitempty"`
 
+	// The timestamp at which the target node detects the domain is active
+	TargetNodeDomainReadyTimestamp *metav1.Time `json:"targetNodeDomainReadyTimestamp,omitempty"`
 	// The Target Node has seen the Domain Start Event
 	TargetNodeDomainDetected bool `json:"targetNodeDomainDetected,omitempty"`
 	// The address of the target node to use for the migration
@@ -908,6 +910,10 @@ const (
 
 	// VirtualMachineGenerationAnnotation is the generation of a Virtual Machine.
 	VirtualMachineGenerationAnnotation string = "kubevirt.io/vm-generation"
+
+	// MigrationTargetReadyTimestamp indicates the time at which the target node
+	// detected that the VMI became active on the target during live migration.
+	MigrationTargetReadyTimestamp string = "kubevirt.io/migration-target-ready-timestamp"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -169,6 +169,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"":                               "+k8s:openapi-gen=true",
 		"startTimestamp":                 "The time the migration action began\n+nullable",
 		"endTimestamp":                   "The time the migration action ended\n+nullable",
+		"targetNodeDomainReadyTimestamp": "The timestamp at which the target node detects the domain is active",
 		"targetNodeDomainDetected":       "The Target Node has seen the Domain Start Event",
 		"targetNodeAddress":              "The address of the target node to use for the migration",
 		"targetDirectMigrationNodePorts": "The list of ports opened for live migration on the destination node",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21245,6 +21245,12 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceMigrationState(ref comm
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"targetNodeDomainReadyTimestamp": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The timestamp at which the target node detects the domain is active",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 					"targetNodeDomainDetected": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Target Node has seen the Domain Start Event",

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -90,6 +90,7 @@ func ConfirmVMIPostMigration(virtClient kubecli.KubevirtClient, vmi *v1.VirtualM
 	Expect(vmi.Status.MigrationState).ToNot(BeNil(), "should have been able to retrieve the VMIs `Status::MigrationState`")
 	Expect(vmi.Status.MigrationState.StartTimestamp).ToNot(BeNil(), "the VMIs `Status::MigrationState` should have a StartTimestamp")
 	Expect(vmi.Status.MigrationState.EndTimestamp).ToNot(BeNil(), "the VMIs `Status::MigrationState` should have a EndTimestamp")
+	Expect(vmi.Status.MigrationState.TargetNodeDomainReadyTimestamp).ToNot(BeNil(), "the VMIs `Status::MigrationState` should have a TargetNodeDomainReadyTimestamp")
 	Expect(vmi.Status.MigrationState.TargetNode).To(Equal(vmi.Status.NodeName), "the VMI should have migrated to the desired node")
 	Expect(vmi.Status.MigrationState.TargetNode).NotTo(Equal(vmi.Status.MigrationState.SourceNode), "the VMI must have migrated to a different node from the one it originated from")
 	Expect(vmi.Status.MigrationState.Completed).To(BeTrue(), "the VMI migration state must have completed")


### PR DESCRIPTION
When a live migration is in progress, we need a reliable indication that can tell us when the target pod is hosting the active qemu instance. We will be using this indication in OVNKubernetes to determine when to update the pod IP routes. 

The result of this PR is that the target pod will receive an annotation indicating the timestamp of when virt-handler detects the domain is running on the target node.

```release-note
NONE
```
