### PR TITLE
Bug fix: Allow paused VM to migrate

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -310,7 +310,7 @@ func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, 
 			return
 		}
 	}
-	vm, err := app.fetchVirtualMachine(name, namespace)
+	_, err := app.fetchVirtualMachine(name, namespace)
 	if err != nil {
 		writeError(err, response)
 		return
@@ -325,13 +325,6 @@ func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, 
 	if vmi.Status.Phase != v1.Running {
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf(vmNotRunning)), response)
 		return
-	}
-
-	for _, c := range vm.Status.Conditions {
-		if c.Type == v1.VirtualMachinePaused && c.Status == v12.ConditionTrue {
-			writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("VM is paused")), response)
-			return
-		}
 	}
 
 	createMigrationJob := func() *errors.StatusError {

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -356,19 +356,6 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			})
 
-			It("[test_id:3086]should not be migrated", func() {
-				By("Pausing the VM")
-				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)
-				Expect(command()).To(Succeed())
-				Eventually(matcher.ThisVM(vm), 30*time.Second, time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachinePaused))
-
-				By("Trying to migrate the VM")
-				command = clientcmd.NewRepeatableVirtctlCommand("migrate", "--namespace", vm.Namespace, vm.Name)
-				err = command()
-				Expect(err.Error()).To(ContainSubstring("VM is paused"))
-
-			})
-
 			It("[test_id:3083]should connect to serial console", func() {
 				By("Pausing the VM")
 				command := clientcmd.NewRepeatableVirtctlCommand("pause", "vm", "--namespace", vm.Namespace, vm.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow paused VM to migrate. This is currently possible only through VMIM API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Bug fix: API and virtctl invoked migration is not rejected when the VM is paused
```
