### PR TITLE
[WIP] POC Use virtio-scsi as the default storage controller

### DIFF
--- a/pkg/virt-api/webhooks/amd64.go
+++ b/pkg/virt-api/webhooks/amd64.go
@@ -25,24 +25,11 @@ import (
 )
 
 func setDefaultAmd64DisksBus(spec *v1.VirtualMachineInstanceSpec) {
-	// Setting SATA as the default bus since it is typically supported out of the box by
+	// Setting SATA as the default bus for all Disk types since it is typically supported out of the box by
 	// guest operating systems (we support only q35 and therefore IDE is not supported)
-	// TODO: consider making this OS-specific (VIRTIO for linux, SATA for others)
-	bus := v1.DiskBusSATA
-
-	for i := range spec.Domain.Devices.Disks {
-		disk := &spec.Domain.Devices.Disks[i].DiskDevice
-
-		if disk.Disk != nil && disk.Disk.Bus == "" {
-			disk.Disk.Bus = bus
-		}
-		if disk.CDRom != nil && disk.CDRom.Bus == "" {
-			disk.CDRom.Bus = bus
-		}
-		if disk.LUN != nil && disk.LUN.Bus == "" {
-			disk.LUN.Bus = bus
-		}
-	}
+	// TODO: consider making this OS-specific (SCSI for linux, SATA for others)
+	defaultBus := v1.DiskBusSATA
+	setDefaultDisksBus(spec, defaultBus)
 }
 
 // SetAmd64Defaults is mutating function for mutating-webhook

--- a/pkg/virt-api/webhooks/arm64.go
+++ b/pkg/virt-api/webhooks/arm64.go
@@ -129,24 +129,13 @@ func setDefaultArm64Bootloader(spec *v1.VirtualMachineInstanceSpec) {
 	}
 }
 
-// setDefaultDisksBus set default Disks Bus, because sata is not supported by qemu-kvm of Arm64
 func setDefaultArm64DisksBus(spec *v1.VirtualMachineInstanceSpec) {
-	bus := v1.DiskBusVirtio
-
-	for i := range spec.Domain.Devices.Disks {
-		disk := &spec.Domain.Devices.Disks[i].DiskDevice
-
-		if disk.Disk != nil && disk.Disk.Bus == "" {
-			disk.Disk.Bus = bus
-		}
-		if disk.CDRom != nil && disk.CDRom.Bus == "" {
-			disk.CDRom.Bus = bus
-		}
-		if disk.LUN != nil && disk.LUN.Bus == "" {
-			disk.LUN.Bus = bus
-		}
-	}
-
+	// - Setting SCSI as the default bus for Disks and LUNs, so we use virtio-scsi as the default storage interface.
+	//   Virtio-blk disks consume addresses on the PCI bus. Since performance parity has been shown between virtio-blk and
+	//   virtio-scsi, it makes sense to standardize the former.
+	// - Using SCSI too as default bus for CDRoms since SATA is not supported by qemu-kvm of Arm64.
+	defaultBus := v1.DiskBusSCSI
+	setDefaultDisksBus(spec, defaultBus)
 }
 
 // SetArm64Defaults is mutating function for mutating-webhook

--- a/pkg/virt-api/webhooks/defaults.go
+++ b/pkg/virt-api/webhooks/defaults.go
@@ -113,6 +113,22 @@ func setDefaultPullPoliciesOnContainerDisks(clusterConfig *virtconfig.ClusterCon
 	}
 }
 
+func setDefaultDisksBus(spec *v1.VirtualMachineInstanceSpec, defaultBus v1.DiskBus) {
+	for i := range spec.Domain.Devices.Disks {
+		disk := &spec.Domain.Devices.Disks[i].DiskDevice
+
+		if disk.Disk != nil && disk.Disk.Bus == "" {
+			disk.Disk.Bus = defaultBus
+		}
+		if disk.CDRom != nil && disk.CDRom.Bus == "" {
+			disk.CDRom.Bus = defaultBus
+		}
+		if disk.LUN != nil && disk.LUN.Bus == "" {
+			disk.LUN.Bus = defaultBus
+		}
+	}
+}
+
 func setDefaultResourceRequests(clusterConfig *virtconfig.ClusterConfig, spec *v1.VirtualMachineInstanceSpec) {
 	resources := &spec.Domain.Resources
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -983,6 +983,9 @@ var _ = Describe("Converter", func() {
       <target name="org.qemu.guest_agent.0" type="virtio"></target>
     </channel>
     <controller type="usb" index="0" model="qemu-xhci"></controller>
+    <controller type="scsi" index="0" model="virtio-non-transitional">
+      <driver iothread="1" queues="1"></driver>
+    </controller>
     <controller type="virtio-serial" index="0" model="virtio-non-transitional"></controller>
     <video>
       <model type="virtio" heads="1"></model>
@@ -1005,74 +1008,81 @@ var _ = Describe("Converter", func() {
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
-      <target bus="virtio" dev="vdc" tray="closed"></target>
+      <target bus="scsi" dev="sda" tray="closed"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/cdrom_tray_open/disk.img"></source>
-      <target bus="virtio" dev="vdd" tray="open"></target>
+      <target bus="scsi" dev="sdb" tray="open"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
-    <disk device="disk" type="file" model="virtio-non-transitional">
+    <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/should_default_to_disk/disk.img"></source>
-      <target bus="virtio" dev="vde"></target>
+      <target bus="scsi" dev="sdc"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-should_default_to_disk"></alias>
+      <address type="drive" bus="0" controller="0" unit="2"></address>
     </disk>
-    <disk device="disk" type="file" model="virtio-non-transitional">
+    <disk device="disk" type="file">
       <source file="/var/run/libvirt/kubevirt-ephemeral-disk/ephemeral_pvc/disk.qcow2"></source>
-      <target bus="virtio" dev="vdf"></target>
+      <target bus="scsi" dev="sdd"></target>
       <driver cache="none" error_policy="stop" name="qemu" type="qcow2" iothread="1" discard="unmap"></driver>
       <alias name="ua-ephemeral_pvc"></alias>
       <backingStore type="file">
         <format type="raw"></format>
         <source file="/var/run/kubevirt-private/vmi-disks/ephemeral_pvc/disk.img"></source>
       </backingStore>
+      <address type="drive" bus="0" controller="0" unit="3"></address>
     </disk>
-    <disk device="disk" type="file" model="virtio-non-transitional">
+    <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/secret-disks/secret_test.iso"></source>
-      <target bus="virtio" dev="vdg"></target>
+      <target bus="scsi" dev="sde"></target>
       <serial>D23YZ9W6WA5DJ487</serial>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-secret_test"></alias>
+      <address type="drive" bus="0" controller="0" unit="4"></address>
     </disk>
-    <disk device="disk" type="file" model="virtio-non-transitional">
+    <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/config-map-disks/configmap_test.iso"></source>
-      <target bus="virtio" dev="vdh"></target>
+      <target bus="scsi" dev="sdf"></target>
       <serial>CVLY623300HK240D</serial>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-configmap_test"></alias>
+      <address type="drive" bus="0" controller="0" unit="5"></address>
     </disk>
-    <disk device="disk" type="block" model="virtio-non-transitional">
+    <disk device="disk" type="block">
       <source dev="/dev/pvc_block_test" name="pvc_block_test"></source>
-      <target bus="virtio" dev="vdi"></target>
+      <target bus="scsi" dev="sdg"></target>
       <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-pvc_block_test"></alias>
+      <address type="drive" bus="0" controller="0" unit="6"></address>
     </disk>
-    <disk device="disk" type="block" model="virtio-non-transitional">
+    <disk device="disk" type="block">
       <source dev="/dev/dv_block_test" name="dv_block_test"></source>
-      <target bus="virtio" dev="vdj"></target>
+      <target bus="scsi" dev="sdh"></target>
       <driver cache="writethrough" error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-dv_block_test"></alias>
+      <address type="drive" bus="0" controller="0" unit="7"></address>
     </disk>
-    <disk device="disk" type="file" model="virtio-non-transitional">
+    <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
-      <target bus="virtio" dev="vdk"></target>
+      <target bus="scsi" dev="sdi"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1" discard="unmap"></driver>
       <alias name="ua-serviceaccount_test"></alias>
+      <address type="drive" bus="0" controller="0" unit="8"></address>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep.iso"></source>
-      <target bus="virtio" dev="vdl" tray="closed"></target>
+      <target bus="scsi" dev="sdj" tray="closed"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-sysprep"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/sysprep-disks/sysprep_secret.iso"></source>
-      <target bus="virtio" dev="vdm" tray="closed"></target>
+      <target bus="scsi" dev="sdk" tray="closed"></target>
       <driver error_policy="stop" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-sysprep_secret"></alias>
     </disk>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Virtio-blk disks consume addresses on the PCI bus, and this can become an important limitation. Since performance parity has been shown between virtio-scsi and virtio-blk, it makes sense to standardize the former.

This Pulll Request updates the mutating webhook for VMs/VMIs so, by default, disks are created using SCSI bus when possible. It also addresses some comments on said webhook so we improve bus assignation depending on OS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-21636

**Special notes for your reviewer**: Work in progress.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
