### PR TITLE
node-labeller: Check arch on the handler side

### DIFF
--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
+
+# nodelabeller currently only support x86.
+if ! uname -m | grep x86_64; then
+  exit 0
+fi
 
 KVM_MINOR=$(grep -w 'kvm' /proc/misc | cut -f 1 -d' ')
 VIRTTYPE=qemu

--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/clone:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"runtime"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -12,7 +11,6 @@ import (
 
 	virtv1 "kubevirt.io/api/core/v1"
 
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 
@@ -83,30 +81,28 @@ func NewHandlerDaemonSet(namespace, repository, imagePrefix, version, launcherVe
 	pod.ServiceAccountName = HandlerServiceAccountName
 	pod.HostPID = true
 
-	// nodelabeller currently only support x86
-	if virtconfig.IsAMD64(runtime.GOARCH) {
-		pod.InitContainers = []corev1.Container{
-			{
-				Command: []string{
-					"/bin/sh",
-					"-c",
-				},
-				Image: launcherImage,
-				Name:  "virt-launcher",
-				Args: []string{
-					"node-labeller.sh",
-				},
-				SecurityContext: &corev1.SecurityContext{
-					Privileged: boolPtr(true),
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "node-labeller",
-						MountPath: nodeLabellerVolumePath,
-					},
+	// nodelabeller currently only support x86. The arch check will be done in node-labller.sh
+	pod.InitContainers = []corev1.Container{
+		{
+			Command: []string{
+				"/bin/sh",
+				"-c",
+			},
+			Image: launcherImage,
+			Name:  "virt-launcher",
+			Args: []string{
+				"node-labeller.sh",
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: boolPtr(true),
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "node-labeller",
+					MountPath: nodeLabellerVolumePath,
 				},
 			},
-		}
+		},
 	}
 
 	// If there is any image pull secret added to the `virt-handler` deployment


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In a cluster with mixed x86 and arm workloads, the operator job deployment can not generate the daemonset spec properly for both x86 and arm handler nodes, as it has only one `runtime.GOARCH`.

So it's better to create the init container for all handler pods and do the arch check in node-labeller.sh instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
node-labeller: Check arch on the handler side
```
