### PR TITLE
Add guest-to-request memory headroom ratio

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16825,6 +16825,10 @@
     "description": "KubeVirtConfiguration holds all kubevirt configurations",
     "type": "object",
     "properties": {
+     "additionalGuestMemoryOverheadRatio": {
+      "description": "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure overhead. This is useful, since the calculation of this overhead is not accurate and cannot be entirely known in advance. The ratio that is being set determines by which factor to increase the overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised by node pressures, but would mean that fewer VMs could be scheduled to a node. If not set, the default is 1.",
+      "type": "string"
+     },
      "apiConfiguration": {
       "$ref": "#/definitions/v1.ReloadableComponentConfiguration"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -90,6 +90,16 @@ spec:
               configuration:
                 description: holds kubevirt configurations. same as the virt-configMap
                 properties:
+                  additionalGuestMemoryOverheadRatio:
+                    description: AdditionalGuestMemoryOverheadRatio can be used to
+                      increase the virtualization infrastructure overhead. This is
+                      useful, since the calculation of this overhead is not accurate
+                      and cannot be entirely known in advance. The ratio that is being
+                      set determines by which factor to increase the overhead calculated
+                      by Kubevirt. A higher ratio means that the VMs would be less
+                      compromised by node pressures, but would mean that fewer VMs
+                      could be scheduled to a node. If not set, the default is 1.
+                    type: string
                   apiConfiguration:
                     description: ReloadableComponentConfiguration holds all generic
                       k8s configuration options which can be reloaded by components
@@ -2842,6 +2852,16 @@ spec:
               configuration:
                 description: holds kubevirt configurations. same as the virt-configMap
                 properties:
+                  additionalGuestMemoryOverheadRatio:
+                    description: AdditionalGuestMemoryOverheadRatio can be used to
+                      increase the virtualization infrastructure overhead. This is
+                      useful, since the calculation of this overhead is not accurate
+                      and cannot be entirely known in advance. The ratio that is being
+                      set determines by which factor to increase the overhead calculated
+                      by Kubevirt. A higher ratio means that the VMs would be less
+                      compromised by node pressures, but would mean that fewer VMs
+                      could be scheduled to a node. If not set, the default is 1.
+                    type: string
                   apiConfiguration:
                     description: ReloadableComponentConfiguration holds all generic
                       k8s configuration options which can be reloaded by components

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -126,7 +126,7 @@ func WithoutDedicatedCPU(cpu *v1.CPU, cpuAllocationRatio int) ResourceRendererOp
 	}
 }
 
-func WithHugePages(vmMemory *v1.Memory, memoryOverhead *resource.Quantity) ResourceRendererOption {
+func WithHugePages(vmMemory *v1.Memory, memoryOverhead resource.Quantity) ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		hugepageType := k8sv1.ResourceName(k8sv1.ResourceHugePagesPrefix + vmMemory.Hugepages.PageSize)
 		hugepagesMemReq := renderer.vmRequests.Memory()
@@ -160,25 +160,25 @@ func WithHugePages(vmMemory *v1.Memory, memoryOverhead *resource.Quantity) Resou
 			}
 		}
 		// Set requested memory equals to overhead memory
-		reqMemDiff.Add(*memoryOverhead)
+		reqMemDiff.Add(memoryOverhead)
 		renderer.vmRequests[k8sv1.ResourceMemory] = *reqMemDiff
 		if _, ok := renderer.vmLimits[k8sv1.ResourceMemory]; ok {
-			limMemDiff.Add(*memoryOverhead)
+			limMemDiff.Add(memoryOverhead)
 			renderer.vmLimits[k8sv1.ResourceMemory] = *limMemDiff
 		}
 	}
 }
 
-func WithMemoryOverhead(guestResourceSpec v1.ResourceRequirements, memoryOverhead *resource.Quantity) ResourceRendererOption {
+func WithMemoryOverhead(guestResourceSpec v1.ResourceRequirements, memoryOverhead resource.Quantity) ResourceRendererOption {
 	return func(renderer *ResourceRenderer) {
 		memoryRequest := renderer.vmRequests[k8sv1.ResourceMemory]
 		if !guestResourceSpec.OvercommitGuestOverhead {
-			memoryRequest.Add(*memoryOverhead)
+			memoryRequest.Add(memoryOverhead)
 		}
 		renderer.vmRequests[k8sv1.ResourceMemory] = memoryRequest
 
 		if memoryLimit, ok := renderer.vmLimits[k8sv1.ResourceMemory]; ok {
-			memoryLimit.Add(*memoryOverhead)
+			memoryLimit.Add(memoryOverhead)
 			renderer.vmLimits[k8sv1.ResourceMemory] = memoryLimit
 		}
 	}
@@ -272,11 +272,11 @@ func copyResources(srcResources, dstResources k8sv1.ResourceList) {
 // Note: This is the best estimation we were able to come up with
 //
 //	and is still not 100% accurate
-func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additionalOverheadRatio *string) *resource.Quantity {
+func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additionalOverheadRatio *string) resource.Quantity {
 	domain := vmi.Spec.Domain
 	vmiMemoryReq := domain.Resources.Requests.Memory()
 
-	overhead := resource.NewScaledQuantity(0, resource.Kilo)
+	overhead := *resource.NewScaledQuantity(0, resource.Kilo)
 
 	// Add the memory needed for pagetables (one bit for every 512b of RAM size)
 	pagetableMemory := resource.NewScaledQuantity(vmiMemoryReq.ScaledValue(resource.Kilo), resource.Kilo)
@@ -346,7 +346,7 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 		overhead.Add(resource.MustParse("1Mi"))
 	}
 
-	addProbeOverheads(vmi, overhead)
+	addProbeOverheads(vmi, &overhead)
 
 	// Consider memory overhead for SEV guests.
 	// Additional information can be found here: https://libvirt.org/kbase/launch_security_sev.html#memory
@@ -377,7 +377,7 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additiona
 			return overhead
 		}
 
-		overhead = multiplyMemory(*overhead, ratio)
+		overhead = multiplyMemory(overhead, ratio)
 	}
 
 	return overhead
@@ -565,10 +565,10 @@ func hotplugContainerMinimalLimits() k8sv1.ResourceList {
 	}
 }
 
-func multiplyMemory(mem resource.Quantity, multiplication float64) *resource.Quantity {
+func multiplyMemory(mem resource.Quantity, multiplication float64) resource.Quantity {
 	overheadAddition := float64(mem.ScaledValue(resource.Kilo)) * (multiplication - 1.0)
 	additionalOverhead := resource.NewScaledQuantity(int64(overheadAddition), resource.Kilo)
 
 	mem.Add(*additionalOverhead)
-	return &mem
+	return mem
 }

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 			rr = NewResourceRenderer(
 				userSpecifiedMemory,
 				userSpecifiedMemory,
-				WithMemoryOverhead(requestedVMRequirements, &memOverhead),
+				WithMemoryOverhead(requestedVMRequirements, memOverhead),
 			)
 			Expect(rr.Requests()).To(HaveKeyWithValue(
 				kubev1.ResourceMemory,
@@ -97,7 +97,7 @@ var _ = Describe("Resource pod spec renderer", func() {
 					Requests:                nil,
 					Limits:                  nil,
 					OvercommitGuestOverhead: true,
-				}, &memOverhead))
+				}, memOverhead))
 				Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceMemory, baseMemory))
 				Expect(rr.Limits()).To(HaveKeyWithValue(
 					kubev1.ResourceMemory,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1304,7 +1304,7 @@ func checkForKeepLauncherAfterFailure(vmi *v1.VirtualMachineInstance) bool {
 }
 
 func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, networkToResourceMap map[string]string) VMIResourcePredicates {
-	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch())
+	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch(), t.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 	return VMIResourcePredicates{
 		vmi: vmi,
 		resourceRules: []VMIResourceRule{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2590,7 +2590,7 @@ var _ = Describe("Template", func() {
 				arch := config.GetClusterCPUArch()
 				Expect(err).ToNot(HaveOccurred())
 				expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
-				expectedMemory.Add(*GetMemoryOverhead(vmi, arch))
+				expectedMemory.Add(GetMemoryOverhead(vmi, arch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
 				expectedMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
 			})
@@ -2618,7 +2618,7 @@ var _ = Describe("Template", func() {
 				arch := config.GetClusterCPUArch()
 				Expect(err).ToNot(HaveOccurred())
 				expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
-				expectedMemory.Add(*GetMemoryOverhead(vmi1, arch))
+				expectedMemory.Add(GetMemoryOverhead(vmi1, arch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
 				expectedMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
 				Expect(pod1.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
@@ -3710,7 +3710,7 @@ var _ = Describe("Template", func() {
 				arch := config.GetClusterCPUArch()
 				Expect(err).ToNot(HaveOccurred())
 				expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
-				expectedMemory.Add(*GetMemoryOverhead(vmi, arch))
+				expectedMemory.Add(GetMemoryOverhead(vmi, arch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
 				expectedMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
 			})
@@ -3781,6 +3781,47 @@ var _ = Describe("Template", func() {
 				})
 			})
 		})
+
+		Context("with guest-to-request memory headroom", func() {
+			BeforeEach(func() {
+				config, kvInformer, svc = configFactory(defaultArch)
+			})
+
+			newVmi := func() *v1.VirtualMachineInstance {
+				vmi := api.NewMinimalVMI("test-vmi")
+
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceMemory: resource.MustParse("1G"),
+						kubev1.ResourceCPU:    resource.MustParse("1"),
+					},
+				}
+
+				return vmi
+			}
+
+			DescribeTable("should add guest-to-memory headroom when configured with ratio", func(ratioStr string) {
+				vmi := newVmi()
+
+				ratio, err := strconv.ParseFloat(ratioStr, 64)
+				Expect(err).ToNot(HaveOccurred())
+
+				originalOverhead := GetMemoryOverhead(vmi, config.GetClusterCPUArch(), nil)
+				actualOverheadWithHeadroom := GetMemoryOverhead(vmi, config.GetClusterCPUArch(), pointer.String(ratioStr))
+				expectedOverheadWithHeadroom := multiplyMemory(originalOverhead, ratio)
+
+				const errFmt = "overhead without headroom: %s, ratio: %s, actual overhead with headroom: %s, expected overhead with headroom: %s"
+				Expect(newVmi()).To(Equal(vmi), "vmi object should not be changed")
+				Expect(actualOverheadWithHeadroom.Cmp(expectedOverheadWithHeadroom)).To(Equal(0),
+					fmt.Sprintf(errFmt, originalOverhead.String(), ratioStr, actualOverheadWithHeadroom.String(), expectedOverheadWithHeadroom.String()))
+			},
+				Entry("2.332", "2.332"),
+				Entry("1.234", "1.234"),
+				Entry("1.0", "1.0"),
+			)
+
+		})
+
 	})
 
 	Describe("ServiceAccountName", func() {

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -1067,7 +1067,7 @@ func (i *mockIsolationDetector) Allowlist(_ []string) isolation.PodIsolationDete
 	return i
 }
 
-func (i *mockIsolationDetector) AdjustResources(_ *v1.VirtualMachineInstance) error {
+func (i *mockIsolationDetector) AdjustResources(_ *v1.VirtualMachineInstance, _ *string) error {
 	return nil
 }
 

--- a/pkg/virt-handler/isolation/generated_mock_detector.go
+++ b/pkg/virt-handler/isolation/generated_mock_detector.go
@@ -61,12 +61,12 @@ func (_mr *_MockPodIsolationDetectorRecorder) Allowlist(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Allowlist", arg0)
 }
 
-func (_m *MockPodIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "AdjustResources", vm)
+func (_m *MockPodIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
+	ret := _m.ctrl.Call(_m, "AdjustResources", vm, additionalOverheadRatio)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockPodIsolationDetectorRecorder) AdjustResources(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AdjustResources", arg0)
+func (_mr *_MockPodIsolationDetectorRecorder) AdjustResources(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AdjustResources", arg0, arg1)
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2793,7 +2793,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		}
 
 		// set runtime limits as needed
-		err = d.podIsolationDetector.AdjustResources(vmi)
+		err = d.podIsolationDetector.AdjustResources(vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 		if err != nil {
 			return fmt.Errorf("failed to adjust resources: %v", err)
 		}
@@ -2872,7 +2872,7 @@ func (d *VirtualMachineController) hotplugSriovInterfacesCommand(vmi *v1.Virtual
 		return fmt.Errorf("%s: %v", errMsgPrefix, err)
 	}
 
-	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi); err != nil {
+	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
 		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), err.Error())
 		return fmt.Errorf("%s: %v", errMsgPrefix, err)
 	}
@@ -3076,7 +3076,7 @@ func (d *VirtualMachineController) finalizeMigration(vmi *v1.VirtualMachineInsta
 
 	// adjust QEMU process memlock limits in order to enable old virt-launcher pod's to
 	// perform hotplug host-devices on post migration.
-	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi); err != nil {
+	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
 		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), errorMessage)
 	}
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -199,7 +199,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 		mockIsolationDetector = isolation.NewMockPodIsolationDetector(ctrl)
 		mockIsolationDetector.EXPECT().Detect(gomock.Any()).Return(mockIsolationResult, nil).AnyTimes()
-		mockIsolationDetector.EXPECT().AdjustResources(gomock.Any()).Return(nil).AnyTimes()
+		mockIsolationDetector.EXPECT().AdjustResources(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		mockContainerDiskMounter = container_disk.NewMockMounter(ctrl)
 		mockHotplugVolumeMounter = hotplug_volume.NewMockVolumeMounter(ctrl)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -572,6 +572,16 @@ var CRDsValidation map[string]string = map[string]string{
         configuration:
           description: holds kubevirt configurations. same as the virt-configMap
           properties:
+            additionalGuestMemoryOverheadRatio:
+              description: AdditionalGuestMemoryOverheadRatio can be used to increase
+                the virtualization infrastructure overhead. This is useful, since
+                the calculation of this overhead is not accurate and cannot be entirely
+                known in advance. The ratio that is being set determines by which
+                factor to increase the overhead calculated by Kubevirt. A higher ratio
+                means that the VMs would be less compromised by node pressures, but
+                would mean that fewer VMs could be scheduled to a node. If not set,
+                the default is 1.
+              type: string
             apiConfiguration:
               description: ReloadableComponentConfiguration holds all generic k8s
                 configuration options which can be reloaded by components without

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
@@ -76,6 +77,7 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ar *admissionv1.AdmissionReview) *
 
 	results = append(results, validateCustomizeComponents(newKV.Spec.CustomizeComponents)...)
 	results = append(results, validateCertificates(newKV.Spec.CertificateRotationStrategy.SelfSigned)...)
+	results = append(results, validateGuestToRequestHeadroom(newKV.Spec.Configuration.AdditionalGuestMemoryOverheadRatio)...)
 
 	if !equality.Semantic.DeepEqual(currKV.Spec.Configuration.TLSConfiguration, newKV.Spec.Configuration.TLSConfiguration) {
 		if newKV.Spec.Configuration.TLSConfiguration != nil {
@@ -439,4 +441,30 @@ func warnDeprecatedFeatureGates(featureGates []string, config *virtconfig.Cluste
 	}
 
 	return warnings
+}
+
+func validateGuestToRequestHeadroom(ratioStrPtr *string) (causes []metav1.StatusCause) {
+	if ratioStrPtr == nil {
+		return
+	}
+
+	ratioStr := *ratioStrPtr
+
+	ratio, err := strconv.ParseFloat(ratioStr, 64)
+	if err != nil {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: fmt.Sprintf("ratio provided, %s, cannot be parsed into float: %v", ratioStr, err),
+		})
+		return
+	}
+
+	if ratio < 1.0 {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: fmt.Sprintf("ratio provided, %s, cannot be smaller than 1.0", ratioStr),
+		})
+	}
+
+	return
 }

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -129,6 +129,32 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			),
 		)
 	})
+
+	Context("with AdditionalGuestMemoryOverheadRatio", func() {
+		DescribeTable("the ratio must be parsable to float", func(unparsableRatio string) {
+			causes := validateGuestToRequestHeadroom(&unparsableRatio)
+			Expect(causes).To(HaveLen(1))
+		},
+			Entry("not a number", "abcdefg"),
+			Entry("number with bad formatting", "1.fd3ggx"),
+		)
+
+		DescribeTable("the ratio must be larger than 1", func(lessThanOneRatio string) {
+			causes := validateGuestToRequestHeadroom(&lessThanOneRatio)
+			Expect(causes).ToNot(BeEmpty())
+		},
+			Entry("0.999", "0.999"),
+			Entry("negative number", "-1.3"),
+		)
+
+		DescribeTable("valid values", func(validRatio string) {
+
+		},
+			Entry("1.0", "1.0"),
+			Entry("5", "5"),
+			Entry("1.123", "1.123"),
+		)
+	})
 })
 
 type kubevirtSpecOption func(*v1.KubeVirtSpec)

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2173,6 +2173,11 @@ func (in *KubeVirtConfiguration) DeepCopyInto(out *KubeVirtConfiguration) {
 		*out = new(EvictionStrategy)
 		**out = **in
 	}
+	if in.AdditionalGuestMemoryOverheadRatio != nil {
+		in, out := &in.AdditionalGuestMemoryOverheadRatio, &out.AdditionalGuestMemoryOverheadRatio
+		*out = new(string)
+		**out = **in
+	}
 	if in.SupportedGuestAgentVersions != nil {
 		in, out := &in.SupportedGuestAgentVersions, &out.SupportedGuestAgentVersions
 		*out = make([]string, len(*in))

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2213,6 +2213,14 @@ type KubeVirtConfiguration struct {
 	// field is set it overrides the cluster level one.
 	EvictionStrategy *EvictionStrategy `json:"evictionStrategy,omitempty"`
 
+	// AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure
+	// overhead. This is useful, since the calculation of this overhead is not accurate and cannot
+	// be entirely known in advance. The ratio that is being set determines by which factor to increase
+	// the overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised
+	// by node pressures, but would mean that fewer VMs could be scheduled to a node.
+	// If not set, the default is 1.
+	AdditionalGuestMemoryOverheadRatio *string `json:"additionalGuestMemoryOverheadRatio,omitempty"`
+
 	// deprecated
 	SupportedGuestAgentVersions    []string                          `json:"supportedGuestAgentVersions,omitempty"`
 	MemBalloonStatsPeriod          *uint32                           `json:"memBalloonStatsPeriod,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -683,9 +683,10 @@ func (ReloadableComponentConfiguration) SwaggerDoc() map[string]string {
 
 func (KubeVirtConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                            "KubeVirtConfiguration holds all kubevirt configurations",
-		"evictionStrategy":            "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be\nmigrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific\nfield is set it overrides the cluster level one.",
-		"supportedGuestAgentVersions": "deprecated",
+		"":                                   "KubeVirtConfiguration holds all kubevirt configurations",
+		"evictionStrategy":                   "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be\nmigrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific\nfield is set it overrides the cluster level one.",
+		"additionalGuestMemoryOverheadRatio": "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure\noverhead. This is useful, since the calculation of this overhead is not accurate and cannot\nbe entirely known in advance. The ratio that is being set determines by which factor to increase\nthe overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised\nby node pressures, but would mean that fewer VMs could be scheduled to a node.\nIf not set, the default is 1.",
+		"supportedGuestAgentVersions":        "deprecated",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17688,6 +17688,13 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"additionalGuestMemoryOverheadRatio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure overhead. This is useful, since the calculation of this overhead is not accurate and cannot be entirely known in advance. The ratio that is being set determines by which factor to increase the overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised by node pressures, but would mean that fewer VMs could be scheduled to a node. If not set, the default is 1.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"supportedGuestAgentVersions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "deprecated",


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubevirt computes [[1](https://github.com/kubevirt/kubevirt/blob/v0.59.0-alpha.2/pkg/virt-controller/services/renderresources.go#L272)] the estimation of the total memory overhead needed for infra components inside virt-launcher which are responsible to run the guest (e.g. libvirtd, qemu, etc).

Not only that this overhead currently suffers from known issues and non-accurate calculation which needs to be fixed - this calculation is in essence an educated guess / estimation, and not an accurate calculation. The reason is that even if a careful profiling will take place (which is a very difficult task to do, since the environments on which we would profile makes the results biased), there are still many components we cannot control, e.g. kernel drivers, kernel configuration, inner QEMU buffer allocations, etc.

To solve this problem, we need to both keep improving the overhead estimations, but also provide a solution for the cluster admin to explicitly add some overhead. This is useful in cases where a special configuration is used, or if the cluster-admin chooses to reduce the risk of workloads OOM killed during node pressures in exchange of workloads consuming more memory (therefore less VMIs could be scheduled on a node).

[1] https://github.com/kubevirt/kubevirt/blob/v0.59.0-alpha.2/pkg/virt-controller/services/renderresources.go#L272

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2165618

**Special notes for your reviewer**:
For a reference, you can look at the temporary solution implemented in HCO: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2206

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add guest-to-request memory headroom ratio.
This can be enabled by setting `kubevirt.spec.configuration.guestToRequestMemoryHeadroomRatio = "1.234"`
```
