### PR TITLE
node-labeller: Take CPU features into account when labeling nodes

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -47,7 +47,7 @@ func (n *NodeLabeller) getMinCpuFeature() cpuFeatures {
 	if minCPUModel == "" {
 		minCPUModel = util.DefaultMinCPUModel
 	}
-	return n.cpuInfo.models[minCPUModel]
+	return n.cpuInfo.usableModels[minCPUModel]
 }
 
 func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []string {
@@ -176,7 +176,7 @@ func (n *NodeLabeller) loadCPUInfo() error {
 		}
 	}
 
-	n.cpuInfo.models = models
+	n.cpuInfo.usableModels = models
 	return nil
 }
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -93,11 +93,14 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 		if mode.Name == v1.CPUModeHostModel {
 			n.cpuModelVendor = mode.Vendor.Name
 
-			hostCpuModel := mode.Model[0]
-			if len(mode.Model) > 0 {
+			if len(mode.Model) < 1 {
+				return fmt.Errorf("host model mode is expected to contain a model")
+			}
+			if len(mode.Model) > 1 {
 				log.Log.Warning("host model mode is expected to contain only one model")
 			}
 
+			hostCpuModel := mode.Model[0]
 			n.hostCPUModel.Name = hostCpuModel.Name
 			n.hostCPUModel.fallback = hostCpuModel.Fallback
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(cpuModels).To(HaveLen(3), "number of models must match")
+		Expect(cpuModels).To(HaveLen(5), "number of models must match")
 
 		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -33,7 +33,7 @@ type hostCPUModel struct {
 // hostCapabilities holds informations which provides libvirt,
 // so we don't have to call libvirt at every request
 type cpuInfo struct {
-	models map[string]cpuFeatures
+	usableModels map[string]cpuFeatures
 }
 
 // HostDomCapabilities represents structure for parsing output of virsh capabilities

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -267,15 +267,9 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatu
 	for key := range cpuFeatures {
 		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
 	}
-	_, svmIsSupported := newLabels[kubevirtv1.CPUFeatureLabel+"svm"]
 
 	for _, value := range cpuModels {
-
-		//This workaround is necessary because currently Opteron_G2 require svm by libvirt (see /usr/share/libvirt/cpu_map/x86_Opteron_G2.xml )
-		//But libvirt still marks it as Usable:yes even without `svm` because it is usable by qemu (/var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml)
-		//For more information : https://wiki.qemu.org/Features/CPUModels in "Getting information about CPU models" section
-		//TODO: Delete this workaround once libvirt resolve the disagreement with qemu
-		if value == "Opteron_G2" && svmIsSupported == false {
+		if !n.shouldAddCPUModelLabel(value, &hostCpuModel, newLabels) {
 			continue
 		}
 
@@ -384,4 +378,36 @@ func (n *NodeLabeller) alertIfHostModelIsObsolete(originalNode *v1.Node, hostMod
 	warningMsg := fmt.Sprintf("This node has %v host-model cpu that is included in ObsoleteCPUModels: %v", hostModel, ObsoleteCPUModels)
 	n.recorder.Eventf(originalNode, v1.EventTypeWarning, "HostModelIsObsolete", warningMsg)
 	return nil
+}
+
+func (n *NodeLabeller) shouldAddCPUModelLabel(
+	cpuModelName string,
+	hostCpuModel *hostCPUModel,
+	featureLabels map[string]string,
+) bool {
+	if cpuModelName == hostCpuModel.Name {
+		return true
+	}
+	// The logic below is necessary to handle the scenarios when libvirt's definition of a
+	// particular CPU model differs from hypervisor's definition.
+	// E.g. currently Opteron_G2 requires svm by libvirt:
+	//     /usr/share/libvirt/cpu_map/x86_Opteron_G2.xml
+	// But libvirt marks it as Usable:yes even without svm because it is usable by qemu:
+	//     /var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml
+	// For more information refer to https://wiki.qemu.org/Features/CPUModels, "Getting
+	// information about CPU models" section.
+	// Another similar issue:
+	//     https://gitlab.com/libvirt/libvirt/-/issues/304
+	requiredFeatures, ok := n.cpuInfo.usableModels[cpuModelName]
+	if !ok {
+		n.logger.Warningf("The list of required features for CPU model %s is not defined", cpuModelName)
+		return false
+	}
+	missingFeatures := make([]string, 0)
+	for f, _ := range requiredFeatures {
+		if _, isFeatureSupported := featureLabels[kubevirtv1.CPUFeatureLabel+f]; !isFeatureSupported {
+			missingFeatures = append(missingFeatures, f)
+		}
+	}
+	return len(missingFeatures) == 0
 }

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -62,15 +62,27 @@ var _ = Describe("Node-labeller ", func() {
 		mockQueue.Wait()
 	}
 
-	expectNodePatch := func(expectedPatches ...string) {
+	expectPatch := func(expect bool, expectedPatches ...string) {
 		kubeClient.Fake.PrependReactor("patch", "nodes", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			patch, ok := action.(testing.PatchAction)
 			Expect(ok).To(BeTrue())
 			for _, expectedPatch := range expectedPatches {
-				Expect(string(patch.GetPatch())).To(ContainSubstring(expectedPatch))
+				if expect {
+					Expect(string(patch.GetPatch())).To(ContainSubstring(expectedPatch))
+				} else {
+					Expect(string(patch.GetPatch())).ToNot(ContainSubstring(expectedPatch))
+				}
 			}
 			return true, nil, nil
 		})
+	}
+
+	expectNodePatch := func(expectedPatches ...string) {
+		expectPatch(true, expectedPatches...)
+	}
+
+	doNotExpectNodePatch := func(expectedPatches ...string) {
+		expectPatch(false, expectedPatches...)
 	}
 
 	BeforeEach(func() {
@@ -144,6 +156,34 @@ var _ = Describe("Node-labeller ", func() {
 
 	It("should add SEV label", func() {
 		expectNodePatch(kubevirtv1.SEVLabel)
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+	})
+
+	It("should add usable cpu model labels for the host cpu model", func() {
+		expectNodePatch(
+			kubevirtv1.HostModelCPULabel+"Skylake-Client-IBRS",
+			kubevirtv1.CPUModelLabel+"Skylake-Client-IBRS",
+			kubevirtv1.SupportedHostModelMigrationCPU+"Skylake-Client-IBRS",
+		)
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+	})
+
+	It("should add usable cpu model labels if all required features are supported", func() {
+		expectNodePatch(
+			kubevirtv1.CPUModelLabel+"Penryn",
+			kubevirtv1.SupportedHostModelMigrationCPU+"Penryn",
+		)
+		res := nlController.execute()
+		Expect(res).To(BeTrue())
+	})
+
+	It("should not add usable cpu model labels if some features are not suported (svm)", func() {
+		doNotExpectNodePatch(
+			kubevirtv1.CPUModelLabel+"Opteron_G2",
+			kubevirtv1.SupportedHostModelMigrationCPU+"Opteron_G2",
+		)
 		res := nlController.execute()
 		Expect(res).To(BeTrue())
 	})

--- a/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Opteron_G2.xml
+++ b/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Opteron_G2.xml
@@ -1,0 +1,8 @@
+<cpus>
+  <model name='Opteron_G2'>
+    <decode host='on' guest='on'/>
+    <signature family='15' model='6'/> <!-- 100e60 -->
+    <vendor name='AMD'/>
+    <feature name='svm'/>
+  </model>
+</cpus>

--- a/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Skylake-Client-IBRS.xml
+++ b/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Skylake-Client-IBRS.xml
@@ -1,0 +1,76 @@
+<cpus>
+  <model name='Skylake-Client-IBRS'>
+    <decode host='on' guest='on'/>
+    <signature family='6' model='94'/> <!-- 0506e0 -->
+    <signature family='6' model='78'/> <!-- 0406e0 -->
+    <!-- These are Kaby Lake and Coffee Lake successors to Skylake,
+         but we don't have specific models for them. -->
+    <signature family='6' model='142'/> <!-- 0806e0 -->
+    <signature family='6' model='158'/> <!-- 0906e0 -->
+    <vendor name='Intel'/>
+    <feature name='3dnowprefetch'/>
+    <feature name='abm'/>
+    <feature name='adx'/>
+    <feature name='aes'/>
+    <feature name='apic'/>
+    <feature name='arat'/>
+    <feature name='avx'/>
+    <feature name='avx2'/>
+    <feature name='bmi1'/>
+    <feature name='bmi2'/>
+    <feature name='clflush'/>
+    <feature name='cmov'/>
+    <feature name='cx16'/>
+    <feature name='cx8'/>
+    <feature name='de'/>
+    <feature name='erms'/>
+    <feature name='f16c'/>
+    <feature name='fma'/>
+    <feature name='fpu'/>
+    <feature name='fsgsbase'/>
+    <feature name='fxsr'/>
+    <feature name='hle'/>
+    <feature name='invpcid'/>
+    <feature name='lahf_lm'/>
+    <feature name='lm'/>
+    <feature name='mca'/>
+    <feature name='mce'/>
+    <feature name='mmx'/>
+    <feature name='movbe'/>
+    <feature name='mpx'/>
+    <feature name='msr'/>
+    <feature name='mtrr'/>
+    <feature name='nx'/>
+    <feature name='pae'/>
+    <feature name='pat'/>
+    <feature name='pcid'/>
+    <feature name='pclmuldq'/>
+    <feature name='pge'/>
+    <feature name='pni'/>
+    <feature name='popcnt'/>
+    <feature name='pse'/>
+    <feature name='pse36'/>
+    <feature name='rdrand'/>
+    <feature name='rdseed'/>
+    <feature name='rdtscp'/>
+    <feature name='rtm'/>
+    <feature name='sep'/>
+    <feature name='smap'/>
+    <feature name='smep'/>
+    <feature name='spec-ctrl'/>
+    <feature name='sse'/>
+    <feature name='sse2'/>
+    <feature name='sse4.1'/>
+    <feature name='sse4.2'/>
+    <feature name='ssse3'/>
+    <feature name='syscall'/>
+    <feature name='tsc'/>
+    <feature name='tsc-deadline'/>
+    <feature name='vme'/>
+    <feature name='x2apic'/>
+    <feature name='xgetbv1'/>
+    <feature name='xsave'/>
+    <feature name='xsavec'/>
+    <feature name='xsaveopt'/>
+  </model>
+</cpus>

--- a/pkg/virt-handler/node-labeller/testdata/virsh_domcapabilities.xml
+++ b/pkg/virt-handler/node-labeller/testdata/virsh_domcapabilities.xml
@@ -16,6 +16,8 @@
             <model usable='yes'>Penryn</model>
             <model usable='yes'>IvyBridge</model>
             <model usable='yes'>Haswell</model>
+            <model usable='yes'>Skylake-Client-IBRS</model>
+            <model usable='yes'>Opteron_G2</model>
         </mode>
     </cpu>
     <features>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Don't add a label with CPU model if the host does not support the required features. Libvirt may still mark such models as 'usable' as they can be used by qemu, however an attempt to run a VM on such a node will fail since it will not pass validation (KubeVirt does not explicitly disable the checking of CPU features for usable models):

https://libvirt.org/formatdomaincaps.html#cpu-configuration
    
This handles scenarios when cpu_map expects features deprecated on modern CPUs to be present:

https://gitlab.com/libvirt/libvirt/-/issues/304


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is a follow-up of the https://github.com/kubevirt/kubevirt/pull/9239 and https://github.com/kubevirt/kubevirt/pull/8777

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @Barakmor1 @xpivarc 