### PR TITLE
e2e tests: Support k3d SR-IOV lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -28,9 +28,11 @@ readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluste
 
 
 if [ ${CI} == "true" ]; then
-  _delay="$(( ( RANDOM % 180 )))"
-  echo "INFO: Sleeping for ${_delay}s to randomize job startup slighty"
-  sleep ${_delay}
+  if [[ ! $TARGET =~ .*kind.* ]] && [[ ! $TARGET =~ .*k3d.* ]]; then
+    _delay="$(( ( RANDOM % 180 )))"
+    echo "INFO: Sleeping for ${_delay}s to randomize job startup slighty"
+    sleep ${_delay}
+  fi
 fi
 
 if [ -z $TARGET ]; then

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -92,7 +92,9 @@ if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
 fi
 
 if [[ $TARGET =~ sriov.* ]]; then
-  export KUBEVIRT_NUM_NODES=3
+  if [[ $TARGET =~ kind.* ]]; then
+    export KUBEVIRT_NUM_NODES=3
+  fi
   export KUBEVIRT_DEPLOY_CDI="false"
 elif [[ $TARGET =~ vgpu.* ]]; then
   export KUBEVIRT_NUM_NODES=1

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -319,7 +319,7 @@ kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"
 export KUBEVIRT_E2E_PARALLEL=true
-if [[ $TARGET =~ .*kind.* ]]; then
+if [[ $TARGET =~ .*kind.* ]] || [[ $TARGET =~ .*k3d.* ]]; then
   export KUBEVIRT_E2E_PARALLEL=false
 fi
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -239,7 +239,9 @@ export NAMESPACE="${NAMESPACE:-kubevirt}"
 # Make sure that the VM is properly shut down on exit
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM SIGSTOP
 
-make cluster-down
+if [ "$CI" != "true" ]; then
+  make cluster-down
+fi
 
 # Create .bazelrc to use remote cache
 cat >ci.bazelrc <<EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt and optimize test.sh to support k3d provider.

* Support k3d on test.sh - 
  Adapt script to not run SR-IOV in parallel both for kind and k3d providers.
  Do not export number of nodes for k3d, as k3d is fixed 1 control-plane and 2 workers.
* Skip sleep for kind / k3d providers - the sleep was [introduced](https://github.com/kubevirt/kubevirt/pull/8663) in order to reduce stress on disk
in case a lot of jobs start on the same time.
Since there is only one SR-IOV at a time, it is safe to let it start without delay.
The rest of the non SR-IOV jobs will have this sleep.
It will save us time while running SR-IOV jobs, which have very limited resources.
Same for kind vGPU, since it runs only one at a time (has anti affinity). 
* Skip cluster-down on CI start - It is not needed because there isn't a cluster,
and would fail because the k3d binary wasn't downloaded yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
