### PR TITLE
virtctl, expose: Ignore migration target

### DIFF
--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -173,8 +173,9 @@ func (o *Command) RunE(args []string) error {
 		serviceSelector = vmi.ObjectMeta.Labels
 		ports = podNetworkPorts(&vmi.Spec)
 		// remove unwanted labels
-		delete(serviceSelector, "kubevirt.io/nodeName")
+		delete(serviceSelector, virtv1.NodeNameLabel)
 		delete(serviceSelector, virtv1.VirtualMachinePoolRevisionName)
+		delete(serviceSelector, virtv1.MigrationTargetNodeNameLabel)
 	case "vm", "vms", "virtualmachine", "virtualmachines":
 		// get the VM
 		vm, err := virtClient.VirtualMachine(namespace).Get(context.Background(), vmName, &options)


### PR DESCRIPTION
**What this PR does / why we need it**:
VMI live migration changes the label kubevirt.io/migrationTargetNodeName
and the selector the VMI's service will no longer match. This change
remove that label from the selector similar to "kubevirt.io/nodeName".

/kind bug

**Release note**:

```release-note
Skip label kubevirt.io/migrationTargetNodeName from virtctl expose service selector
```
