### PR TITLE
[virt-controller] fix out-of-bound slice index in evacuation controller

### DIFF
--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",


### PR DESCRIPTION
virt-controller panic can happen if we play with migration configuration in Kubevirt CR.  Steps for reproduction can be
found in the BZ link below. 

**What this PR does / why we need it**:
In case the user drained a node with evictable VMs, migrations have started according to the configured maximum concurrent migrations per node. While the migrations are active the user decides lower the configured maximum per node. In this case the virt-controller can panic, although there are no free spots, there are no migration candidates either (because all VMs have active migrations). The execution loop continues with negative index.

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2171395

**Special notes for the reviewer**:
```
  runtime error: slice bounds out of range [:-9]

  Full Stack Trace
    kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation.(*EvacuationController).sync(0xc000712300, 0xc000032000, {0xc0001c0000?, 0xa, 0x10}, {0xc0001c0080?, 0xa, 0x10})
    	/home/ibezukh/go/src/kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation/evacuation.go:417 +0x997
    kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation.(*EvacuationController).execute(0xc000712300, {0x18f07d9, 0x6})
    	/home/ibezukh/go/src/kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation/evacuation.go:337 +0x176
    kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation.(*EvacuationController).Execute(0xc000712300)
    	/home/ibezukh/go/src/kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation/evacuation.go:298 +0x108
    kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation_test.glob..func1.7.4()
    	/home/ibezukh/go/src/kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go:334 +0x4ad
```
Reproduced with the new unit test from this PR
**Release note**:
```release-note
NONE
```
