### PR TITLE
Create iso files only if Disk is present

### DIFF
--- a/pkg/config/config-map.go
+++ b/pkg/config/config-map.go
@@ -23,8 +23,6 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
-
-	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 // GetConfigMapSourcePath returns a path to ConfigMap mounted on a pod
@@ -37,30 +35,22 @@ func GetConfigMapDiskPath(volumeName string) string {
 	return filepath.Join(ConfigMapDisksDir, volumeName+".iso")
 }
 
+type confgMapVolumeInfo struct{}
+
+func (i confgMapVolumeInfo) isValidType(v *v1.Volume) bool {
+	return v.ConfigMap != nil
+}
+func (i confgMapVolumeInfo) getSourcePath(v *v1.Volume) string {
+	return GetConfigMapSourcePath(v.Name)
+}
+func (i confgMapVolumeInfo) getIsoPath(v *v1.Volume) string {
+	return GetConfigMapDiskPath(v.Name)
+}
+func (i confgMapVolumeInfo) getLabel(v *v1.Volume) string {
+	return v.ConfigMap.VolumeLabel
+}
+
 // CreateConfigMapDisks creates ConfigMap iso disks which are attached to vmis
 func CreateConfigMapDisks(vmi *v1.VirtualMachineInstance, emptyIso bool) error {
-	for _, volume := range vmi.Spec.Volumes {
-		if volume.ConfigMap != nil {
-			var filesPath []string
-			filesPath, err := getFilesLayout(GetConfigMapSourcePath(volume.Name))
-			if err != nil {
-				return err
-			}
-
-			disk := GetConfigMapDiskPath(volume.Name)
-			vmiIsoSize, err := findIsoSize(vmi, &volume, emptyIso)
-			if err != nil {
-				return err
-			}
-			if err := createIsoConfigImage(disk, volume.ConfigMap.VolumeLabel, filesPath, vmiIsoSize); err != nil {
-				return err
-			}
-
-			if err := ephemeraldiskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(disk); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return createIsoDisksForConfigVolumes(vmi, emptyIso, confgMapVolumeInfo{})
 }

--- a/pkg/config/config-map_test.go
+++ b/pkg/config/config-map_test.go
@@ -64,6 +64,9 @@ var _ = Describe("ConfigMap", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "configmap-volume",
+		})
 
 		err := CreateConfigMapDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -71,4 +74,22 @@ var _ = Describe("ConfigMap", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should not create a new config map iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "configmap-volume",
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: k8sv1.LocalObjectReference{
+						Name: "test-config",
+					},
+				},
+			},
+		})
+
+		err := CreateConfigMapDisks(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		files, _ := os.ReadDir(ConfigMapDisksDir)
+		Expect(files).To(BeEmpty())
+	})
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
 	"kubevirt.io/kubevirt/pkg/util"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -181,4 +183,49 @@ func findIsoSize(vmi *v1.VirtualMachineInstance, volume *v1.Volume, emptyIso boo
 		return 0, fmt.Errorf("failed to find the status of volume %s", volume.Name)
 	}
 	return 0, nil
+}
+
+type volumeInfo interface {
+	isValidType(*v1.Volume) bool
+	getSourcePath(*v1.Volume) string
+	getIsoPath(*v1.Volume) string
+	getLabel(*v1.Volume) string
+}
+
+func createIsoDisksForConfigVolumes(vmi *v1.VirtualMachineInstance, emptyIso bool, info volumeInfo) error {
+	volumes := make(map[string]v1.Volume)
+	for _, volume := range vmi.Spec.Volumes {
+		if info.isValidType(&volume) {
+			volumes[volume.Name] = volume
+		}
+	}
+
+	for _, disk := range vmi.Spec.Domain.Devices.Disks {
+		volume, ok := volumes[disk.Name]
+		if !ok {
+			continue
+		}
+
+		filesPath, err := getFilesLayout(info.getSourcePath(&volume))
+		if err != nil {
+			return err
+		}
+
+		isoPath := info.getIsoPath(&volume)
+		vmiIsoSize, err := findIsoSize(vmi, &volume, emptyIso)
+		if err != nil {
+			return err
+		}
+
+		label := info.getLabel(&volume)
+		if err := createIsoConfigImage(isoPath, label, filesPath, vmiIsoSize); err != nil {
+			return err
+		}
+
+		if err := ephemeraldiskutils.DefaultOwnershipManager.UnsafeSetFileOwnership(isoPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/config/downwardapi_test.go
+++ b/pkg/config/downwardapi_test.go
@@ -70,6 +70,9 @@ var _ = Describe("DownwardAPI", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "downwardapi-volume",
+		})
 
 		err := CreateDownwardAPIDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -77,4 +80,27 @@ var _ = Describe("DownwardAPI", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should create a new downwardapi iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "downwardapi-volume",
+			VolumeSource: v1.VolumeSource{
+				DownwardAPI: &v1.DownwardAPIVolumeSource{
+					Fields: []k8sv1.DownwardAPIVolumeFile{
+						{
+							Path: "labels",
+							FieldRef: &k8sv1.ObjectFieldSelector{
+								FieldPath: "metadata.labels",
+							},
+						},
+					},
+				},
+			},
+		})
+
+		err := CreateDownwardAPIDisks(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		files, _ := os.ReadDir(DownwardAPIDisksDir)
+		Expect(files).To(BeEmpty())
+	})
 })

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -61,6 +61,9 @@ var _ = Describe("Secret", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "secret-volume",
+		})
 
 		err := CreateSecretDisks(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -68,4 +71,20 @@ var _ = Describe("Secret", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should not create a new secret iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "secret-volume",
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: "test-secret",
+				},
+			},
+		})
+
+		err := CreateSecretDisks(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		files, _ := os.ReadDir(SecretDisksDir)
+		Expect(files).To(BeEmpty())
+	})
 })

--- a/pkg/config/service-account_test.go
+++ b/pkg/config/service-account_test.go
@@ -61,6 +61,9 @@ var _ = Describe("ServiceAccount", func() {
 				},
 			},
 		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "serviceaccount-volume",
+		})
 
 		err := CreateServiceAccountDisk(vmi, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -68,4 +71,20 @@ var _ = Describe("ServiceAccount", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("Should create a new service account iso disk without a Disk device", func() {
+		vmi := api.NewMinimalVMI("fake-vmi")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "serviceaccount-volume",
+			VolumeSource: v1.VolumeSource{
+				ServiceAccount: &v1.ServiceAccountVolumeSource{
+					ServiceAccountName: "testaccount",
+				},
+			},
+		})
+
+		err := CreateServiceAccountDisk(vmi, false)
+		Expect(err).NotTo(HaveOccurred())
+		files, _ := os.ReadDir(ServiceAccountDiskDir)
+		Expect(files).To(BeEmpty())
+	})
 })

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -499,7 +499,7 @@ func (vr *VolumeRenderer) handleHostDisk(volume v1.Volume) {
 func (vr *VolumeRenderer) handleSecret(volume v1.Volume) {
 	vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
 		Name:      volume.Name,
-		MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
+		MountPath: config.GetSecretSourcePath(volume.Name),
 		ReadOnly:  true,
 	})
 	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
@@ -516,7 +516,7 @@ func (vr *VolumeRenderer) handleSecret(volume v1.Volume) {
 func (vr *VolumeRenderer) handleConfigMap(volume v1.Volume) {
 	vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
 		Name:      volume.Name,
-		MountPath: filepath.Join(config.ConfigMapSourceDir, volume.Name),
+		MountPath: config.GetConfigMapSourcePath(volume.Name),
 		ReadOnly:  true,
 	})
 	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
@@ -534,7 +534,7 @@ func (vr *VolumeRenderer) handleDownwardAPI(volume v1.Volume) {
 	// attach a Secret to the pod
 	vr.podVolumeMounts = append(vr.podVolumeMounts, k8sv1.VolumeMount{
 		Name:      volume.Name,
-		MountPath: filepath.Join(config.DownwardAPISourceDir, volume.Name),
+		MountPath: config.GetDownwardAPISourcePath(volume.Name),
 		ReadOnly:  true,
 	})
 	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1134,7 +1134,17 @@ func (d *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 		return
 	}
 
+	volumes := make(map[string]v1.Volume)
 	for _, volume := range vmi.Spec.Volumes {
+		volumes[volume.Name] = volume
+	}
+
+	for _, disk := range vmi.Spec.Domain.Devices.Disks {
+		volume, ok := volumes[disk.Name]
+		if !ok {
+			log.DefaultLogger().V(2).Warningf("No matching volume with name %s found", disk.Name)
+			continue
+		}
 
 		volPath, found := IsoGuestVolumePath(vmi, &volume)
 		if !found {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -110,7 +109,6 @@ type netstat interface {
 
 const (
 	failedDetectIsolationFmt              = "failed to detect isolation for launcher pod: %v"
-	kubevirtPrivate                       = "kubevirt-private"
 	unableCreateVirtLauncherConnectionFmt = "unable to create virt-launcher client connection: %v"
 )
 
@@ -1103,15 +1101,15 @@ func IsoGuestVolumePath(vmi *v1.VirtualMachineInstance, volume *v1.Volume) (stri
 	} else if volume.CloudInitConfigDrive != nil {
 		volPath = filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "configdrive.iso")
 	} else if volume.ConfigMap != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.ConfigMapDisksDir), volume.Name+".iso")
+		volPath = config.GetConfigMapDiskPath(volume.Name)
 	} else if volume.DownwardAPI != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.DownwardAPIDisksDir), volume.Name+".iso")
+		volPath = config.GetDownwardAPIDiskPath(volume.Name)
 	} else if volume.Secret != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.SecretDisksDir), volume.Name+".iso")
+		volPath = config.GetSecretDiskPath(volume.Name)
 	} else if volume.ServiceAccount != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.ServiceAccountDiskDir), config.ServiceAccountDiskName)
+		volPath = config.GetServiceAccountDiskPath()
 	} else if volume.Sysprep != nil {
-		volPath = filepath.Join(basepath, kubevirtPrivate, path.Base(config.SysprepDisksDir), volume.Name+".iso")
+		volPath = config.GetSysprepDiskPath(volume.Name)
 	} else {
 		return "", false
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, using a virtiofs filesystem you can share ConfigMaps, Secrets and DownwardAPI volumes with the VM.  And if we share those volumes using virtiofs all the iso files are created since some parts of the code assumes that those volumes always have a Disk associated.

This PR refactors the code, so the iso files are not created if it's not necessary. It also removes the duplication of source/iso disk path calculation.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This is PR was part of #9254, but as requested we only included the refactoring commits

**Release note**:
-->
```release-note
NONE
```
