### PR TITLE
[Docs] Update Docs for Docker Authentication in Mac

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,11 +33,10 @@ kubectl create -f _out/manifests/release/kubevirt-cr.yaml
 The Bazel build system does not support the macOS keychain. Docker uses `osxkeychain`, which is the default [credential helper](https://github.com/docker/docker-credential-helpers) 
 for mac.
 
-We need to modify the `$HOME/.docker/config.json` file to include 
+Modify the `$HOME/.docker/config.json` file to include the following snippet:
 
 ```json
 {
-  ...
 	"credHelpers": {
 		"https://index.docker.io/v1/": ""
 	}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,19 +30,35 @@ kubectl create -f _out/manifests/release/kubevirt-cr.yaml
 
 ### Docker Desktop for Mac
 
-The Bazel build system does not support the macOS keychain. Please ensure that
-you deactivate the option `Securely store Docker logins in macOS keychain` in
-the Docker preferences. After restarting the Docker service, log in with `docker
-login`. Your `$HOME/.docker/config.json` should look like:
+The Bazel build system does not support the macOS keychain. Docker uses `osxkeychain`, which is the default [credential helper](https://github.com/docker/docker-credential-helpers) 
+for mac.
+
+We need to modify the `$HOME/.docker/config.json` file to include 
 
 ```json
 {
-  "auths" : {
-    "https://index.docker.io/v1/" : {
-      "auth" : "XXXXXXXXXX"
-    }
-  },
-  "credSstore" : ""
+  ...
+	"credHelpers": {
+		"https://index.docker.io/v1/": ""
+	}
+}
+```
+
+This makes sure that no credential helpers are used for the specified registry and hence the credentials will be stored in the config.json file itself.
+
+Now log in with `docker login`. You will get a warning message saying that no credential helper is configured. Your `$HOME/.docker/config.json` should look like:
+
+```json
+{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "XXXXXXXXXX"
+		}
+	},
+	"credsStore": "desktop",
+	"credHelpers": {
+		"https://index.docker.io/v1/": ""
+	}
 }
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since Bazel does not support OSX keychain, the current documentation asks mac users to deactivate the `Securely store Docker logins in macOS keychain` option in Docker Desktop's preferences. This is misleading since the option is no longer present in the Docker Desktop's preferences.


<img width="1268" alt="Screenshot 2023-03-01 at 10 37 27 PM" src="https://user-images.githubusercontent.com/75248557/222211316-05bc8731-0d73-45a4-b739-6f93d2cd1f3f.png">


 There are some nuances with the way docker handles authentication and [credential helpers](https://github.com/docker/docker-credential-helpers). This PR captures my learnings and updates the docs to be in sync with the way the system behaves now. 

In order to make docker store the credentials in the config.json file (so that Bazel can make use of it), we have to disable all the credential helpers. There appears to be no way to generally disable the credential helpers for all registries. But there is a way to do this on a registry-to-registry basis, which is what the updated documentation suggests we do. 

**Special notes for your reviewer**:
References: 
1. Stack Overflow - https://stackoverflow.com/a/69730718/21174500
2. Github Issue - https://github.com/docker/for-mac/issues/6295

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
``` 
None
```