### PR TITLE
[release-0.58][e2e]: improve cloud-init user-data specs

### DIFF
--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -51,11 +51,11 @@ import (
 )
 
 const (
-	sshAuthorizedKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key"
-	fedoraPassword   = "fedora"
-	expectedUserData = "printed from cloud-init userdata"
-	testNetworkData  = "#Test networkData"
-	testUserData     = "#cloud-config"
+	sshAuthorizedKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkT test-ssh-key"
+	fedoraPassword       = "fedora"
+	expectedUserDataFile = "cloud-init-userdata-executed"
+	testNetworkData      = "#Test networkData"
+	testUserData         = "#cloud-config"
 )
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]CloudInit UserData", func() {
@@ -127,15 +127,15 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		Context("with cloudInitNoCloud userDataBase64 source", func() {
 			It("[test_id:1615]should have cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-
+				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-				LaunchVMI(vmi)
+
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
+
+				By("Checking whether the user-data script had created the file")
+				Expect(console.RunCommand(vmi, fmt.Sprintf("cat /%s\n", expectedUserDataFile), time.Second*120)).To(Succeed())
 			})
 
 			Context("with injected ssh-key", func() {
@@ -149,6 +149,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					LaunchVMI(vmi)
 					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
+
 					VerifyUserDataVMI(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
 						&expect.BExp{R: "login:"},
@@ -165,15 +166,15 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("with cloudInitConfigDrive userDataBase64 source", func() {
 			It("[test_id:3178]should have cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-
+				userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-				LaunchVMI(vmi)
+
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
+
+				By("Checking whether the user-data script had created the file")
+				Expect(console.RunCommand(vmi, fmt.Sprintf("cat /%s\n", expectedUserDataFile), time.Second*120)).To(Succeed())
 			})
 
 			Context("with injected ssh-key", func() {
@@ -187,6 +188,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					LaunchVMI(vmi)
 					CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
+
 					VerifyUserDataVMI(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
 						&expect.BExp{R: "login:"},
@@ -253,54 +255,44 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("with cloudInitNoCloud userData source", func() {
-			It("[test_id:1617]should process provided cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
+		Context("should process provided cloud-init data", func() {
+			userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 
-				vmi = LaunchVMI(vmi)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-				By("executing a user-data script")
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
+			runTest := func(vmi *v1.VirtualMachineInstance, dsType cloudinit.DataSourceType) {
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
 
-				By("applying the hostname from meta-data")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
+				By("waiting until login appears")
+				tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
+				By("validating cloud-init disk is 4k aligned")
+				CheckCloudInitIsoSize(vmi, dsType)
+
+				By("Checking whether the user-data script had created the file")
+				Expect(console.RunCommand(vmi, fmt.Sprintf("cat /%s\n", expectedUserDataFile), time.Second*120)).To(Succeed())
+
+				By("validating the hostname matches meta-data")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
 					&expect.BExp{R: dns.SanitizeHostname(vmi)},
 				}, 10)).To(Succeed())
+			}
+
+			It("[test_id:1617] with cloudInitNoCloud userData source", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(
+					cd.ContainerDiskFor(cd.ContainerDiskCirros),
+					userData)
+				runTest(vmi, cloudinit.DataSourceNoCloud)
 			})
-		})
-
-		Context("with cloudInitConfigDrive userData source", func() {
-			It("[test_id:3180]should process provided cloud-init data", func() {
-				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
-				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), userData)
-
-				vmi = LaunchVMI(vmi)
-				CheckCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
-				By("executing a user-data script")
-				VerifyUserDataVMI(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: expectedUserData},
-				}, time.Second*120)
-
-				By("applying the hostname from meta-data")
-				Expect(console.LoginToCirros(vmi)).To(Succeed())
-
-				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "hostname\n"},
-					&expect.BExp{R: dns.SanitizeHostname(vmi)},
-				}, 10)).To(Succeed())
+			It("[test_id:3180] with cloudInitConfigDrive userData source", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(
+					cd.ContainerDiskFor(cd.ContainerDiskCirros),
+					userData)
+				runTest(vmi, cloudinit.DataSourceConfigDrive)
 			})
 		})
 
 		It("[test_id:1618]should take user-data from k8s secret", func() {
-			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
+			userData := fmt.Sprintf("#!/bin/sh\n\ntouch /%s\n", expectedUserDataFile)
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "")
 
 			idx := 0
@@ -333,12 +325,14 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred())
 				break
 			}
-			LaunchVMI(vmi)
+
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 60)
+			tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
 			CheckCloudInitIsoSize(vmi, cloudinit.DataSourceNoCloud)
-			VerifyUserDataVMI(vmi, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: expectedUserData},
-			}, time.Second*120)
+
+			By("Checking whether the user-data script had created the file")
+			Expect(console.RunCommand(vmi, fmt.Sprintf("cat /%s\n", expectedUserDataFile), time.Second*120)).To(Succeed())
 
 			// Expect that the secret is not present on the vmi itself
 			vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/9242
`libwait` package was introduced later than realease-0.58, so here we still use the package `tests`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @enp0s3