### PR TITLE
[release-0.59] Set mem/cpu request and limits on hotplug attachment pod container to 1 to 1 ratio

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -537,16 +537,9 @@ func initContainerMinimalRequests() k8sv1.ResourceList {
 }
 
 func hotplugContainerResourceRequirementsForVMI(vmi *v1.VirtualMachineInstance) k8sv1.ResourceRequirements {
-	if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
-		return k8sv1.ResourceRequirements{
-			Limits:   hotplugContainerMinimalLimits(),
-			Requests: hotplugContainerMinimalLimits(),
-		}
-	} else {
-		return k8sv1.ResourceRequirements{
-			Limits:   hotplugContainerMinimalLimits(),
-			Requests: hotplugContainerMinimalRequests(),
-		}
+	return k8sv1.ResourceRequirements{
+		Limits:   hotplugContainerMinimalLimits(),
+		Requests: hotplugContainerMinimalLimits(),
 	}
 }
 
@@ -554,12 +547,5 @@ func hotplugContainerMinimalLimits() k8sv1.ResourceList {
 	return k8sv1.ResourceList{
 		k8sv1.ResourceCPU:    resource.MustParse("100m"),
 		k8sv1.ResourceMemory: resource.MustParse("80M"),
-	}
-}
-
-func hotplugContainerMinimalRequests() k8sv1.ResourceList {
-	return k8sv1.ResourceList{
-		k8sv1.ResourceCPU:    resource.MustParse("10m"),
-		k8sv1.ResourceMemory: resource.MustParse("2M"),
 	}
 }

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1188,10 +1188,10 @@ var _ = SIGDescribe("Hotplug", func() {
 			vm.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceMemory] = *memLimitQuantity
 			vm.Spec.Template.Spec.Domain.Resources.Limits[corev1.ResourceCPU] = *cpuLimitQuantity
 			vm.Spec.Running = pointer.BoolPtr(true)
-			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm)
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(vm)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
-				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Get(vm.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return vm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Manual backport of #9312

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
