### PR TITLE
Fix tolerations for virt-operator-strategy-dumper job

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -745,6 +745,19 @@ func (c *KubeVirtController) generateInstallStrategyJob(infraPlacement *v1.Compo
 					},
 				},
 				Spec: k8sv1.PodSpec{
+					Tolerations: []k8sv1.Toleration{{Operator: k8sv1.TolerationOpExists}},
+					Affinity: &k8sv1.Affinity{PodAffinity: &k8sv1.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{{
+							TopologyKey: "kubernetes.io/hostname",
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{{
+									Key:      v1.AppLabel,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{VirtOperator},
+								}},
+							},
+						}},
+					}},
 					ServiceAccountName: "kubevirt-operator",
 					RestartPolicy:      k8sv1.RestartPolicyNever,
 					ImagePullSecrets:   config.GetImagePullSecrets(),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR specifies:

```yaml
tolerations:
- operator: "Exists"
affinity:
  podAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchExpressions:
        - key: kubevirt.io
          operator: In
          values:
          - virt-operator
      topologyKey: "kubernetes.io/hostname"
```

for virt-operator-strategy-dumper job

**Which issue(s) this PR fixes** 

There is a problem when all nodes in cluster have taints, KubeVirt can't run virt-operator-strategy-dumper job.
The provided fix will always run the job in same place where `virt-operator` runs

**Special notes for your reviewer**:

**Release note**:

```release-note
Schedule virt-operator-strategy-dumper job into the same node with virt-operator
```
