### PR TITLE
[release-0.49] Add guest-to-request memory headroom ratio

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13793,6 +13793,10 @@
     "description": "KubeVirtConfiguration holds all kubevirt configurations",
     "type": "object",
     "properties": {
+     "additionalGuestMemoryOverheadRatio": {
+      "description": "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure overhead. This is useful, since the calculation of this overhead is not accurate and cannot be entirely known in advance. The ratio that is being set determines by which factor to increase the overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised by node pressures, but would mean that fewer VMs could be scheduled to a node. If not set, the default is 1.",
+      "type": "string"
+     },
      "apiConfiguration": {
       "$ref": "#/definitions/v1.ReloadableComponentConfiguration"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -90,6 +90,16 @@ spec:
               configuration:
                 description: holds kubevirt configurations. same as the virt-configMap
                 properties:
+                  additionalGuestMemoryOverheadRatio:
+                    description: AdditionalGuestMemoryOverheadRatio can be used to
+                      increase the virtualization infrastructure overhead. This is
+                      useful, since the calculation of this overhead is not accurate
+                      and cannot be entirely known in advance. The ratio that is being
+                      set determines by which factor to increase the overhead calculated
+                      by Kubevirt. A higher ratio means that the VMs would be less
+                      compromised by node pressures, but would mean that fewer VMs
+                      could be scheduled to a node. If not set, the default is 1.
+                    type: string
                   apiConfiguration:
                     description: ReloadableComponentConfiguration holds all generic
                       k8s configuration options which can be reloaded by components
@@ -2689,6 +2699,16 @@ spec:
               configuration:
                 description: holds kubevirt configurations. same as the virt-configMap
                 properties:
+                  additionalGuestMemoryOverheadRatio:
+                    description: AdditionalGuestMemoryOverheadRatio can be used to
+                      increase the virtualization infrastructure overhead. This is
+                      useful, since the calculation of this overhead is not accurate
+                      and cannot be entirely known in advance. The ratio that is being
+                      set determines by which factor to increase the overhead calculated
+                      by Kubevirt. A higher ratio means that the VMs would be less
+                      compromised by node pressures, but would mean that fewer VMs
+                      could be scheduled to a node. If not set, the default is 1.
+                    type: string
                   apiConfiguration:
                     description: ReloadableComponentConfiguration holds all generic
                       k8s configuration options which can be reloaded by components

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -69,5 +69,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -874,7 +874,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	gracePeriodKillAfter := gracePeriodSeconds + int64(15)
 
 	// Get memory overhead
-	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch())
+	memoryOverhead := GetMemoryOverhead(vmi, t.clusterConfig.GetClusterCPUArch(), t.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 
 	// Consider CPU and memory requests and limits for pod scheduling
 	resources := k8sv1.ResourceRequirements{}
@@ -1853,8 +1853,9 @@ func appendUniqueImagePullSecret(secrets []k8sv1.LocalObjectReference, newsecret
 // The return value is overhead memory quantity
 //
 // Note: This is the best estimation we were able to come up with
-//       and is still not 100% accurate
-func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource.Quantity {
+//
+//	and is still not 100% accurate
+func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string, additionalOverheadRatio *string) *resource.Quantity {
 	domain := vmi.Spec.Domain
 	vmiMemoryReq := domain.Resources.Requests.Memory()
 
@@ -1933,6 +1934,18 @@ func GetMemoryOverhead(vmi *v1.VirtualMachineInstance, cpuArch string) *resource
 	// Additional information can be found here: https://libvirt.org/kbase/launch_security_sev.html#memory
 	if util.IsSEVVMI(vmi) {
 		overhead.Add(resource.MustParse("256Mi"))
+	}
+
+	// Multiplying the ratio is expected to be the last calculation before returning overhead
+	if additionalOverheadRatio != nil {
+		ratio, err := strconv.ParseFloat(*additionalOverheadRatio, 64)
+		if err != nil {
+			// This error should never happen as it's already validated by webhooks
+			log.Log.Warningf("cannot add additional overhead to virt infra overhead calculation: %v", err)
+			return overhead
+		}
+
+		overhead = multiplyMemory(*overhead, ratio)
 	}
 
 	return overhead
@@ -2243,4 +2256,12 @@ func checkForKeepLauncherAfterFailure(vmi *v1.VirtualMachineInstance) bool {
 		}
 	}
 	return keepLauncherAfterFailure
+}
+
+func multiplyMemory(mem resource.Quantity, multiplication float64) *resource.Quantity {
+	overheadAddition := float64(mem.ScaledValue(resource.Kilo)) * (multiplication - 1.0)
+	additionalOverhead := resource.NewScaledQuantity(int64(overheadAddition), resource.Kilo)
+
+	mem.Add(*additionalOverhead)
+	return &mem
 }

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -1135,7 +1135,7 @@ func (i *mockIsolationDetector) Allowlist(_ []string) isolation.PodIsolationDete
 	return i
 }
 
-func (i *mockIsolationDetector) AdjustResources(_ *v1.VirtualMachineInstance) error {
+func (i *mockIsolationDetector) AdjustResources(_ *v1.VirtualMachineInstance, _ *string) error {
 	return nil
 }
 

--- a/pkg/virt-handler/isolation/detector.go
+++ b/pkg/virt-handler/isolation/detector.go
@@ -55,7 +55,7 @@ type PodIsolationDetector interface {
 	Allowlist(controller []string) PodIsolationDetector
 
 	// Adjust system resources to run the passed VM
-	AdjustResources(vm *v1.VirtualMachineInstance) error
+	AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error
 }
 
 const isolationDialTimeout = 5
@@ -117,7 +117,7 @@ func (s *socketBasedIsolationDetector) Allowlist(controller []string) PodIsolati
 	return s
 }
 
-func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance) error {
+func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
 	// only VFIO attached or with lock guest memory domains require MEMLOCK adjustment
 	if !util.IsVFIOVMI(vm) && !vm.IsRealtimeEnabled() && !util.IsSEVVMI(vm) {
 		return nil
@@ -147,7 +147,7 @@ func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInst
 		}
 
 		// make the best estimate for memory required by libvirt
-		memlockSize := services.GetMemoryOverhead(vm, runtime.GOARCH)
+		memlockSize := services.GetMemoryOverhead(vm, runtime.GOARCH, additionalOverheadRatio)
 		// Add base memory requested for the VM
 		vmiMemoryReq := vm.Spec.Domain.Resources.Requests.Memory()
 		memlockSize.Add(*resource.NewScaledQuantity(vmiMemoryReq.ScaledValue(resource.Kilo), resource.Kilo))
@@ -165,7 +165,7 @@ func (s *socketBasedIsolationDetector) AdjustResources(vm *v1.VirtualMachineInst
 // AdjustQemuProcessMemoryLimits adjusts QEMU process MEMLOCK rlimits that runs inside
 // virt-launcher pod on the given VMI according to its spec.
 // Only VMI's with VFIO devices (e.g: SRIOV, GPU), SEV or RealTime workloads require QEMU process MEMLOCK adjustment.
-func AdjustQemuProcessMemoryLimits(podIsoDetector PodIsolationDetector, vmi *v1.VirtualMachineInstance) error {
+func AdjustQemuProcessMemoryLimits(podIsoDetector PodIsolationDetector, vmi *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
 	if !util.IsVFIOVMI(vmi) && !vmi.IsRealtimeEnabled() && !util.IsSEVVMI(vmi) {
 		return nil
 	}
@@ -186,7 +186,7 @@ func AdjustQemuProcessMemoryLimits(podIsoDetector PodIsolationDetector, vmi *v1.
 	qemuProcessPid := qemuProcess.Pid()
 
 	// make the best estimate for memory required by libvirt
-	memlockSize := services.GetMemoryOverhead(vmi, runtime.GOARCH)
+	memlockSize := services.GetMemoryOverhead(vmi, runtime.GOARCH, additionalOverheadRatio)
 	// Add base memory requested for the VM
 	vmiMemoryReq := vmi.Spec.Domain.Resources.Requests.Memory()
 	memlockSize.Add(*resource.NewScaledQuantity(vmiMemoryReq.ScaledValue(resource.Kilo), resource.Kilo))

--- a/pkg/virt-handler/isolation/generated_mock_detector.go
+++ b/pkg/virt-handler/isolation/generated_mock_detector.go
@@ -62,12 +62,12 @@ func (_mr *_MockPodIsolationDetectorRecorder) Allowlist(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Allowlist", arg0)
 }
 
-func (_m *MockPodIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "AdjustResources", vm)
+func (_m *MockPodIsolationDetector) AdjustResources(vm *v1.VirtualMachineInstance, additionalOverheadRatio *string) error {
+	ret := _m.ctrl.Call(_m, "AdjustResources", vm, additionalOverheadRatio)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockPodIsolationDetectorRecorder) AdjustResources(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AdjustResources", arg0)
+func (_mr *_MockPodIsolationDetectorRecorder) AdjustResources(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AdjustResources", arg0, arg1)
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2584,7 +2584,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		}
 
 		// set runtime limits as needed
-		err = d.podIsolationDetector.AdjustResources(vmi)
+		err = d.podIsolationDetector.AdjustResources(vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio)
 		if err != nil {
 			return fmt.Errorf("failed to adjust resources: %v", err)
 		}
@@ -2647,7 +2647,7 @@ func (d *VirtualMachineController) hotplugSriovInterfacesCommand(vmi *v1.Virtual
 		return fmt.Errorf("%s: %v", errMsgPrefix, err)
 	}
 
-	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi); err != nil {
+	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
 		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), err.Error())
 		return fmt.Errorf("%s: %v", errMsgPrefix, err)
 	}
@@ -2823,7 +2823,7 @@ func (d *VirtualMachineController) finalizeMigration(vmi *v1.VirtualMachineInsta
 
 	// adjust QEMU process memlock limits in order to enable old virt-launcher pod's to
 	// perform hotplug host-devices on post migration.
-	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi); err != nil {
+	if err := isolation.AdjustQemuProcessMemoryLimits(d.podIsolationDetector, vmi, d.clusterConfig.GetConfig().AdditionalGuestMemoryOverheadRatio); err != nil {
 		d.recorder.Event(vmi, k8sv1.EventTypeWarning, err.Error(), errorMessage)
 	}
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -200,7 +200,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 		mockIsolationDetector = isolation.NewMockPodIsolationDetector(ctrl)
 		mockIsolationDetector.EXPECT().Detect(gomock.Any()).Return(mockIsolationResult, nil).AnyTimes()
-		mockIsolationDetector.EXPECT().AdjustResources(gomock.Any()).Return(nil).AnyTimes()
+		mockIsolationDetector.EXPECT().AdjustResources(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		mockContainerDiskMounter = container_disk.NewMockMounter(ctrl)
 		mockHotplugVolumeMounter = hotplug_volume.NewMockVolumeMounter(ctrl)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -519,6 +519,16 @@ var CRDsValidation map[string]string = map[string]string{
         configuration:
           description: holds kubevirt configurations. same as the virt-configMap
           properties:
+            additionalGuestMemoryOverheadRatio:
+              description: AdditionalGuestMemoryOverheadRatio can be used to increase
+                the virtualization infrastructure overhead. This is useful, since
+                the calculation of this overhead is not accurate and cannot be entirely
+                known in advance. The ratio that is being set determines by which
+                factor to increase the overhead calculated by Kubevirt. A higher ratio
+                means that the VMs would be less compromised by node pressures, but
+                would mean that fewer VMs could be scheduled to a node. If not set,
+                the default is 1.
+              type: string
             apiConfiguration:
               description: ReloadableComponentConfiguration holds all generic k8s
                 configuration options which can be reloaded by components without

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -64,4 +64,30 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 			},
 		}, 0),
 	)
+
+	Context("with AdditionalGuestMemoryOverheadRatio", func() {
+		table.DescribeTable("the ratio must be parsable to float", func(unparsableRatio string) {
+			causes := validateGuestToRequestHeadroom(&unparsableRatio)
+			Expect(causes).To(HaveLen(1))
+		},
+			table.Entry("not a number", "abcdefg"),
+			table.Entry("number with bad formatting", "1.fd3ggx"),
+		)
+
+		table.DescribeTable("the ratio must be larger than 1", func(lessThanOneRatio string) {
+			causes := validateGuestToRequestHeadroom(&lessThanOneRatio)
+			Expect(causes).ToNot(BeEmpty())
+		},
+			table.Entry("0.999", "0.999"),
+			table.Entry("negative number", "-1.3"),
+		)
+
+		table.DescribeTable("valid values", func(validRatio string) {
+
+		},
+			table.Entry("1.0", "1.0"),
+			table.Entry("5", "5"),
+			table.Entry("1.123", "1.123"),
+		)
+	})
 })

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2103,6 +2103,11 @@ func (in *KubeVirtConfiguration) DeepCopyInto(out *KubeVirtConfiguration) {
 		*out = new(SMBiosConfiguration)
 		**out = **in
 	}
+	if in.AdditionalGuestMemoryOverheadRatio != nil {
+		in, out := &in.AdditionalGuestMemoryOverheadRatio, &out.AdditionalGuestMemoryOverheadRatio
+		*out = new(string)
+		**out = **in
+	}
 	if in.SupportedGuestAgentVersions != nil {
 		in, out := &in.SupportedGuestAgentVersions, &out.SupportedGuestAgentVersions
 		*out = make([]string, len(*in))

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2044,6 +2044,15 @@ type KubeVirtConfiguration struct {
 	SELinuxLauncherType    string                  `json:"selinuxLauncherType,omitempty"`
 	DefaultRuntimeClass    string                  `json:"defaultRuntimeClass,omitempty"`
 	SMBIOSConfig           *SMBiosConfiguration    `json:"smbios,omitempty"`
+
+	// AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure
+	// overhead. This is useful, since the calculation of this overhead is not accurate and cannot
+	// be entirely known in advance. The ratio that is being set determines by which factor to increase
+	// the overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised
+	// by node pressures, but would mean that fewer VMs could be scheduled to a node.
+	// If not set, the default is 1.
+	AdditionalGuestMemoryOverheadRatio *string `json:"additionalGuestMemoryOverheadRatio,omitempty"`
+
 	// deprecated
 	SupportedGuestAgentVersions    []string                          `json:"supportedGuestAgentVersions,omitempty"`
 	MemBalloonStatsPeriod          *uint32                           `json:"memBalloonStatsPeriod,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -632,8 +632,9 @@ func (ReloadableComponentConfiguration) SwaggerDoc() map[string]string {
 
 func (KubeVirtConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                            "KubeVirtConfiguration holds all kubevirt configurations",
-		"supportedGuestAgentVersions": "deprecated",
+		"":                                   "KubeVirtConfiguration holds all kubevirt configurations",
+		"additionalGuestMemoryOverheadRatio": "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure\noverhead. This is useful, since the calculation of this overhead is not accurate and cannot\nbe entirely known in advance. The ratio that is being set determines by which factor to increase\nthe overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised\nby node pressures, but would mean that fewer VMs could be scheduled to a node.\nIf not set, the default is 1.",
+		"supportedGuestAgentVersions":        "deprecated",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17096,6 +17096,13 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 							Ref: ref("kubevirt.io/api/core/v1.SMBiosConfiguration"),
 						},
 					},
+					"additionalGuestMemoryOverheadRatio": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalGuestMemoryOverheadRatio can be used to increase the virtualization infrastructure overhead. This is useful, since the calculation of this overhead is not accurate and cannot be entirely known in advance. The ratio that is being set determines by which factor to increase the overhead calculated by Kubevirt. A higher ratio means that the VMs would be less compromised by node pressures, but would mean that fewer VMs could be scheduled to a node. If not set, the default is 1.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"supportedGuestAgentVersions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "deprecated",

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -51,6 +52,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
+	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	kubevirt_hooks_v1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
@@ -1544,6 +1546,61 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				By("Checking for absence of runtimeClassName")
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				Expect(pod.Spec.RuntimeClassName).To(BeNil())
+			})
+		})
+
+		Context("[Serial]with geust-to-request memory ", func() {
+			setHeadroom := func(ratioStr string) {
+				kv := util.GetCurrentKv(virtClient)
+
+				config := kv.Spec.Configuration
+				config.AdditionalGuestMemoryOverheadRatio = &ratioStr
+				tests.UpdateKubeVirtConfigValueAndWait(config)
+			}
+
+			getComputeMemoryRequest := func(vmi *virtv1.VirtualMachineInstance) resource.Quantity {
+				launcherPod := tests.GetPodByVirtualMachineInstance(vmi)
+				computeContainer := tests.GetComputeContainerOfPod(launcherPod)
+				return computeContainer.Resources.Requests[kubev1.ResourceMemory]
+			}
+
+			It("should add guest-to-memory headroom", func() {
+				const guestMemoryStr = "1024M"
+				origVmiWithoutHeadroom := libvmi.New(libvmi.WithResourceMemory(guestMemoryStr))
+				origVmiWithHeadroom := libvmi.New(libvmi.WithResourceMemory(guestMemoryStr))
+
+				By("Running a vmi without additional headroom")
+				vmiWithoutHeadroom := tests.RunVMIAndExpectScheduling(origVmiWithoutHeadroom, 60)
+
+				By("Setting a headroom ratio in Kubevirt CR")
+				const ratio = "1.567"
+				setHeadroom(ratio)
+
+				By("Running a vmi with additional headroom")
+				vmiWithHeadroom := tests.RunVMIAndExpectScheduling(origVmiWithHeadroom, 60)
+
+				requestWithoutHeadroom := getComputeMemoryRequest(vmiWithoutHeadroom)
+				requestWithHeadroom := getComputeMemoryRequest(vmiWithHeadroom)
+
+				overheadWithoutHeadroom := services.GetMemoryOverhead(vmiWithoutHeadroom, runtime.GOARCH, nil)
+				overheadWithHeadroom := services.GetMemoryOverhead(vmiWithoutHeadroom, runtime.GOARCH, pointer.String(ratio))
+
+				expectedDiffBetweenRequests := overheadWithHeadroom.DeepCopy()
+				expectedDiffBetweenRequests.Sub(overheadWithoutHeadroom)
+
+				actualDiffBetweenRequests := requestWithHeadroom.DeepCopy()
+				actualDiffBetweenRequests.Sub(requestWithoutHeadroom)
+
+				By("Ensuring memory request is as expected")
+				const errFmt = "ratio: %s, request without headroom: %s, request with headroom: %s, overhead without headroom: %s, overhead with headroom: %s, expected diff between requests: %s, actual diff between requests: %s"
+				Expect(actualDiffBetweenRequests.Cmp(expectedDiffBetweenRequests)).To(Equal(0),
+					fmt.Sprintf(errFmt, ratio, requestWithoutHeadroom.String(), requestWithHeadroom.String(), overheadWithoutHeadroom.String(), overheadWithHeadroom.String(), expectedDiffBetweenRequests.String(), actualDiffBetweenRequests.String()))
+
+				By("Ensure no memory specifications had been changed on VMIs")
+				Expect(origVmiWithHeadroom.Spec.Domain.Resources).To(Equal(vmiWithHeadroom.Spec.Domain.Resources), "vmi resources are not expected to change")
+				Expect(origVmiWithHeadroom.Spec.Domain.Memory).To(Equal(vmiWithHeadroom.Spec.Domain.Memory), "vmi guest memory is not expected to change")
+				Expect(origVmiWithoutHeadroom.Spec.Domain.Resources).To(Equal(vmiWithoutHeadroom.Spec.Domain.Resources), "vmi resources are not expected to change")
+				Expect(origVmiWithoutHeadroom.Spec.Domain.Memory).To(Equal(vmiWithoutHeadroom.Spec.Domain.Memory), "vmi guest memory is not expected to change")
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of: https://github.com/kubevirt/kubevirt/pull/9364.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add guest-to-request memory headroom ratio.
This can be enabled by setting `kubevirt.spec.configuration.additinalGuestMemoryOverheadRatio = "1.234"`
```
