### PR TITLE
e2e: fix flakiness of vm foreground finalizer test

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -2365,9 +2365,9 @@ status:
 		})
 
 		AfterEach(func() {
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			if controller.HasFinalizer(vm, customFinalizer) {
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, &k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
 				var ops []string
 				oldFinalizers, err := json.Marshal(vm.GetFinalizers())
 				Expect(err).ToNot(HaveOccurred())
@@ -2381,8 +2381,10 @@ status:
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(context.Background(), vm.Name, &metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			if vm.DeletionTimestamp == nil {
+				err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(context.Background(), vm.Name, &metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			By("Ensure the vm has disappeared")
 			Eventually(func() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The AfterEach function deletes the vm created in the It spec.
This is used from two tests; in one of them the deletion is already performed,
but the vm does not disappear since it has a custom finalizer.
In AfterEach, before the vm deletion, the custom finalizer is removed from the vm.
Since the deletion was already fired the subsequent deletion may fail due to:
`Message: "virtualmachines.kubevirt.io \"testvmi-hcx9l\" not found",`
This fix prevents this flakiness by ignoring the "Not found" error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
