### PR TITLE
Add VM instancetype and preference label to vmi_phase_count metric

### DIFF
--- a/pkg/monitoring/vmistats/BUILD.bazel
+++ b/pkg/monitoring/vmistats/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/monitoring/vmistats/BUILD.bazel
+++ b/pkg/monitoring/vmistats/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -514,7 +514,12 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 			vca.vmControllerThreads, vca.migrationControllerThreads, vca.evacuationControllerThreads,
 			vca.disruptionBudgetControllerThreads)
 
-		vmiprom.SetupVMICollector(vca.vmiInformer, vca.clusterInstancetypeInformer, vca.instancetypeInformer, vca.clusterConfig)
+		vmiprom.SetupVMICollector(
+			vca.vmiInformer,
+			vca.clusterInstancetypeInformer, vca.instancetypeInformer,
+			vca.clusterPreferenceInformer, vca.preferenceInformer,
+			vca.clusterConfig,
+		)
 		vmprom.SetupVMCollector(vca.vmInformer)
 		perfscale.RegisterPerfScaleMetrics(vca.vmiInformer)
 		if vca.migrationInformer == nil {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -514,7 +514,7 @@ func (vca *VirtControllerApp) onStartedLeading() func(ctx context.Context) {
 			vca.vmControllerThreads, vca.migrationControllerThreads, vca.evacuationControllerThreads,
 			vca.disruptionBudgetControllerThreads)
 
-		vmiprom.SetupVMICollector(vca.vmiInformer, vca.clusterConfig)
+		vmiprom.SetupVMICollector(vca.vmiInformer, vca.clusterInstancetypeInformer, vca.instancetypeInformer, vca.clusterConfig)
 		vmprom.SetupVMCollector(vca.vmInformer)
 		perfscale.RegisterPerfScaleMetrics(vca.vmiInformer)
 		if vca.migrationInformer == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Recently Instancetypes and Preferences were added to simplify and reuse VM configurations. In this PR we will collect the Instancetypes and Preferences used in the `vmi_phase_count`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VM instancetype and preference label to vmi_phase_count metric
```

jira-ticket: https://issues.redhat.com/browse/CNV-22079