### PR TITLE
e2e: Introduce wait for namespace scc annotations

### DIFF
--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//tests/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/openshift/api/security/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
When running kubevirt on an Openshift cluster, the namespace_scc_allocation_controller - which is part of the cluster-policy-controller - is [setting an annotation](https://github.com/openshift/cluster-policy-controller/blob/master/pkg/security/controller/namespace_scc_allocation_controller.go#L141) needed in order for the virt-launcher pod to receive a restricted UID (see [here](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html#example-security-context-constraints)). 

This PR is introducing a wait for this annotation on openshift clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
