### PR TITLE
Remove user and group from security context of launcher pod

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -353,6 +353,7 @@ func generateContainerFromVolume(vmi *v1.VirtualMachineInstance, config *virtcon
 		Resources: resources,
 		SecurityContext: &kubev1.SecurityContext{
 			RunAsUser:                &userId,
+			RunAsGroup:               &userId,
 			RunAsNonRoot:             &nonRoot,
 			AllowPrivilegeEscalation: &noPrivilegeEscalation,
 			Capabilities: &kubev1.Capabilities{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -3666,19 +3666,12 @@ var _ = Describe("Template", func() {
 		},
 			Entry("on a root virt-launcher", func() *v1.VirtualMachineInstance {
 				return api.NewMinimalVMI("fake-vmi")
-			}, &kubev1.PodSecurityContext{
-				RunAsUser: new(int64),
-			}),
+			}, &kubev1.PodSecurityContext{}),
 			Entry("on a non-root virt-launcher", func() *v1.VirtualMachineInstance {
 				vmi := api.NewMinimalVMI("fake-vmi")
 				vmi.Status.RuntimeUser = uint64(nonRootUser)
 				return vmi
-			}, &kubev1.PodSecurityContext{
-				RunAsUser:    &nonRootUser,
-				RunAsGroup:   &nonRootUser,
-				RunAsNonRoot: pointer.Bool(true),
-				FSGroup:      &nonRootUser,
-			}),
+			}, &kubev1.PodSecurityContext{}),
 			Entry("on a passt vmi", func() *v1.VirtualMachineInstance {
 				nonRootUser := util.NonRootUID
 				vmi := api.NewMinimalVMI("fake-vmi")
@@ -3690,10 +3683,6 @@ var _ = Describe("Template", func() {
 				}}
 				return vmi
 			}, &kubev1.PodSecurityContext{
-				RunAsUser:    &nonRootUser,
-				RunAsGroup:   &nonRootUser,
-				RunAsNonRoot: pointer.Bool(true),
-				FSGroup:      &nonRootUser,
 				SELinuxOptions: &kubev1.SELinuxOptions{
 					Type: "virt_launcher.process",
 				},
@@ -3706,12 +3695,7 @@ var _ = Describe("Template", func() {
 					Virtiofs: &v1.FilesystemVirtiofs{},
 				}}
 				return vmi
-			}, &kubev1.PodSecurityContext{
-				RunAsUser:    &nonRootUser,
-				RunAsGroup:   &nonRootUser,
-				RunAsNonRoot: pointer.Bool(true),
-				FSGroup:      &nonRootUser,
-			}),
+			}, &kubev1.PodSecurityContext{}),
 		)
 
 		It("should compute the correct security context when rendering hotplug attachment pods", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Security context of launcher pod have user and group fields that gets overridden by all containers in the pod as they all specify a user and a group too in their security context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#8968 

**Special notes for your reviewer**:
I didn't remove the seccomp profile and selinux because they aren't defined in all containers so they won't be overridden.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
