### PR TITLE
Set sig-network lane run tests with Multus v3

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -46,6 +46,7 @@ elif [[ $TARGET =~ cnao ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-cnao/}
   export KUBEVIRT_DEPLOY_CDI=false
 elif [[ $TARGET =~ sig-network ]]; then
+  export KUBEVIRT_WITH_MULTUS_V3="${KUBEVIRT_WITH_MULTUS_V3:-true}"
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_DEPLOY_CDI=false
   # FIXME: https://github.com/kubevirt/kubevirt/issues/9158

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -22,19 +22,20 @@ var (
 	Invtsc     = []interface{}{Label("Invtsc")}
 
 	// Features
-	Sysprep          = []interface{}{Label("Sysprep")}
-	Windows          = []interface{}{Label("Windows")}
-	Networking       = []interface{}{Label("Networking")}
-	VMIlifecycle     = []interface{}{Label("VMIlifecycle")}
-	Expose           = []interface{}{Label("Expose")}
-	NonRoot          = []interface{}{Label("verify-non-root")}
-	NativeSsh        = []interface{}{Label("native-ssh")}
-	ExcludeNativeSsh = []interface{}{Label("exclude-native-ssh")}
-	Reenlightenment  = []interface{}{Label("Reenlightenment")}
-	TscFrequencies   = []interface{}{Label("TscFrequencies")}
-	PasstGate        = []interface{}{Label("PasstGate")}
-	VMX              = []interface{}{Label("VMX")}
-	Upgrade          = []interface{}{Label("Upgrade")}
-	CustomSELinux    = []interface{}{Label("CustomSELinux")}
-	Istio            = []interface{}{Label("Istio")}
+	Sysprep            = []interface{}{Label("Sysprep")}
+	Windows            = []interface{}{Label("Windows")}
+	Networking         = []interface{}{Label("Networking")}
+	VMIlifecycle       = []interface{}{Label("VMIlifecycle")}
+	Expose             = []interface{}{Label("Expose")}
+	NonRoot            = []interface{}{Label("verify-non-root")}
+	NativeSsh          = []interface{}{Label("native-ssh")}
+	ExcludeNativeSsh   = []interface{}{Label("exclude-native-ssh")}
+	Reenlightenment    = []interface{}{Label("Reenlightenment")}
+	TscFrequencies     = []interface{}{Label("TscFrequencies")}
+	PasstGate          = []interface{}{Label("PasstGate")}
+	VMX                = []interface{}{Label("VMX")}
+	Upgrade            = []interface{}{Label("Upgrade")}
+	CustomSELinux      = []interface{}{Label("CustomSELinux")}
+	Istio              = []interface{}{Label("Istio")}
+	InPlaceHotplugNICs = []interface{}{Label("in-place-hotplug-NICs")}
 )

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -32,6 +32,8 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -44,6 +46,10 @@ import (
 )
 
 var _ = SIGDescribe("nic-hotplug", decorators.InPlaceHotplugNICs, func() {
+	BeforeEach(func() {
+		Expect(checks.HasFeature(virtconfig.HotplugNetworkIfacesGate)).To(BeTrue())
+	})
+
 	const (
 		bridgeName  = "supadupabr"
 		ifaceName   = "iface1"

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -34,6 +34,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -42,7 +43,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = SIGDescribe("nic-hotplug", func() {
+var _ = SIGDescribe("nic-hotplug", decorators.InPlaceHotplugNICs, func() {
 	const (
 		bridgeName  = "supadupabr"
 		ifaceName   = "iface1"

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -484,7 +484,7 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 				Expect(libnet.PingFromVMConsole(vmiOne, ptpSubnetIP2)).To(Succeed())
 			})
 
-			It("vmi with an hotplugged interface has connectivity over the secondary network", func() {
+			It("vmi with an hotplugged interface has connectivity over the secondary network", decorators.InPlaceHotplugNICs, func() {
 				By("Creating another VM with only the masquerade interface")
 				vmiOne := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -45,6 +45,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
@@ -485,6 +487,8 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 			})
 
 			It("vmi with an hotplugged interface has connectivity over the secondary network", decorators.InPlaceHotplugNICs, func() {
+				Expect(checks.HasFeature(virtconfig.HotplugNetworkIfacesGate)).To(BeTrue())
+
 				By("Creating another VM with only the masquerade interface")
 				vmiOne := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, the sig-network gating lanes run tests with Multus v4.0.0-alpha (thick plugin form) which is not GAed yet.
In order to improve the sig-network lanes' integrity, set the lanes to run Multus v3 which is a GA'ed version.

Since the hotplug NICs tests depend on Multus v4 (thick plugin form) this PR set the e2e tests suite to check the env var `KUBEVIRT_WITH_MULTUS_V3`, if 'true', set the test suite to **not** run the in-place hotplug NICs tests.

This PR changes the sig-network lanes to run with Multus v3 (from manifests) instead of Multus v4 (using CNAO).

The hotplug NICs tests will run on a different periodic lane that runs Multus v4 https://github.com/kubevirt/project-infra/pull/2641
It also enable running sig-network tests with Multus v4 on a PR by commenting `/test pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
