### PR TITLE
add custom json marshaller for legacy fields in cloudinit ConfigDriveMetadata struct

### DIFF
--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cloud-init.go"],
+    srcs = [
+        "cloud-init.go",
+        "types.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/cloud-init",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -45,69 +45,13 @@ import (
 
 const isoStagingFmt = "%s.staging"
 
-type IsoCreationFunc func(isoOutFile, volumeID string, inDir string) error
-
 var cloudInitLocalDir = "/var/run/libvirt/cloud-init-dir"
-var cloudInitIsoFunc = defaultIsoFunc
 
 // Locations of data source disk files
 const (
 	noCloudFile     = "noCloud.iso"
 	configDriveFile = "configdrive.iso"
 )
-
-type DataSourceType string
-type DeviceMetadataType string
-
-const (
-	DataSourceNoCloud     DataSourceType     = "noCloud"
-	DataSourceConfigDrive DataSourceType     = "configDrive"
-	NICMetadataType       DeviceMetadataType = "nic"
-	HostDevMetadataType   DeviceMetadataType = "hostdev"
-)
-
-// CloudInitData is a data source independent struct that
-// holds cloud-init user and network data
-type CloudInitData struct {
-	DataSource          DataSourceType
-	NoCloudMetaData     *NoCloudMetadata
-	ConfigDriveMetaData *ConfigDriveMetadata
-	UserData            string
-	NetworkData         string
-	DevicesData         *[]DeviceData
-	VolumeName          string
-}
-
-type PublicSSHKey struct {
-	string
-}
-
-type NoCloudMetadata struct {
-	InstanceType  string `json:"instance-type,omitempty"`
-	InstanceID    string `json:"instance-id"`
-	LocalHostname string `json:"local-hostname,omitempty"`
-}
-
-type ConfigDriveMetadata struct {
-	InstanceType  string            `json:"instance_type,omitempty"`
-	InstanceID    string            `json:"instance_id"`
-	LocalHostname string            `json:"local_hostname,omitempty"`
-	Hostname      string            `json:"hostname,omitempty"`
-	UUID          string            `json:"uuid,omitempty"`
-	Devices       *[]DeviceData     `json:"devices,omitempty"`
-	PublicSSHKeys map[string]string `json:"public_keys,omitempty"`
-}
-
-type DeviceData struct {
-	Type        DeviceMetadataType `json:"type"`
-	Bus         string             `json:"bus"`
-	Address     string             `json:"address"`
-	MAC         string             `json:"mac,omitempty"`
-	Serial      string             `json:"serial,omitempty"`
-	NumaNode    uint32             `json:"numaNode,omitempty"`
-	AlignedCPUs []uint32           `json:"alignedCPUs,omitempty"`
-	Tags        []string           `json:"tags"`
-}
 
 // IsValidCloudInitData checks if the given CloudInitData object is valid in the sense that GenerateLocalData can be called with it.
 func IsValidCloudInitData(cloudInitData *CloudInitData) bool {

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -103,6 +103,9 @@ var _ = Describe("CloudInit", func() {
 		Context("verify meta-data model", func() {
 			It("should match the generated configdrive metadata", func() {
 				exampleJSONParsed := `{
+  "instance-type": "fake.fake-instancetype",
+  "instance-id": "fake.fake-namespace",
+  "local-hostname": "fake",
   "instance_type": "fake.fake-instancetype",
   "instance_id": "fake.fake-namespace",
   "local_hostname": "fake",
@@ -146,6 +149,8 @@ var _ = Describe("CloudInit", func() {
 			})
 			It("should match the generated configdrive metadata for hostdev with numaNode", func() {
 				exampleJSONParsed := `{
+  "instance-id": "fake.fake-namespace",
+  "local-hostname": "fake",
   "instance_id": "fake.fake-namespace",
   "local_hostname": "fake",
   "uuid": "fake.fake-namespace",
@@ -181,6 +186,58 @@ var _ = Describe("CloudInit", func() {
 				}
 
 				metadataStruct := ConfigDriveMetadata{
+					InstanceID:    "fake.fake-namespace",
+					LocalHostname: "fake",
+					UUID:          "fake.fake-namespace",
+					Devices:       &devices,
+					PublicSSHKeys: map[string]string{"0": "somekey"},
+				}
+				buf, err := json.MarshalIndent(metadataStruct, "", "  ")
+				Expect(err).ToNot(HaveOccurred())
+				fmt.Println("expected: ", string(buf))
+				fmt.Println("exmapleJsob: ", exampleJSONParsed)
+
+				Expect(string(buf)).To(Equal(exampleJSONParsed))
+			})
+			It("should match the generated configdrive metadata pointer for hostdev with numaNode", func() {
+				exampleJSONParsed := `{
+  "instance-id": "fake.fake-namespace",
+  "local-hostname": "fake",
+  "instance_id": "fake.fake-namespace",
+  "local_hostname": "fake",
+  "uuid": "fake.fake-namespace",
+  "devices": [
+    {
+      "type": "hostdev",
+      "bus": "pci",
+      "address": "0000:65:10:0",
+      "numaNode": 1,
+      "alignedCPUs": [
+        0,
+        1
+      ],
+      "tags": [
+        "testtag1"
+      ]
+    }
+  ],
+  "public_keys": {
+    "0": "somekey"
+  }
+}`
+				devices := []DeviceData{
+					{
+						Type:        HostDevMetadataType,
+						Bus:         api.AddressPCI,
+						Address:     "0000:65:10:0",
+						MAC:         "",
+						NumaNode:    uint32(1),
+						AlignedCPUs: []uint32{0, 1},
+						Tags:        []string{"testtag1"},
+					},
+				}
+
+				metadataStruct := &ConfigDriveMetadata{
 					InstanceID:    "fake.fake-namespace",
 					LocalHostname: "fake",
 					UUID:          "fake.fake-namespace",

--- a/pkg/cloud-init/types.go
+++ b/pkg/cloud-init/types.go
@@ -1,0 +1,82 @@
+package cloudinit
+
+import "encoding/json"
+
+type IsoCreationFunc func(isoOutFile, volumeID string, inDir string) error
+
+var cloudInitIsoFunc = defaultIsoFunc
+
+type DataSourceType string
+type DeviceMetadataType string
+
+const (
+	DataSourceNoCloud     DataSourceType     = "noCloud"
+	DataSourceConfigDrive DataSourceType     = "configDrive"
+	NICMetadataType       DeviceMetadataType = "nic"
+	HostDevMetadataType   DeviceMetadataType = "hostdev"
+)
+
+// CloudInitData is a data source independent struct that
+// holds cloud-init user and network data
+type CloudInitData struct {
+	DataSource          DataSourceType
+	NoCloudMetaData     *NoCloudMetadata
+	ConfigDriveMetaData *ConfigDriveMetadata
+	UserData            string
+	NetworkData         string
+	DevicesData         *[]DeviceData
+	VolumeName          string
+}
+
+type PublicSSHKey struct {
+	string
+}
+
+type NoCloudMetadata struct {
+	InstanceType  string `json:"instance-type,omitempty"`
+	InstanceID    string `json:"instance-id"`
+	LocalHostname string `json:"local-hostname,omitempty"`
+}
+
+type ConfigDriveMetadata struct {
+	InstanceType  string            `json:"instance_type,omitempty"`
+	InstanceID    string            `json:"instance_id"`
+	LocalHostname string            `json:"local_hostname,omitempty"`
+	Hostname      string            `json:"hostname,omitempty"`
+	UUID          string            `json:"uuid,omitempty"`
+	Devices       *[]DeviceData     `json:"devices,omitempty"`
+	PublicSSHKeys map[string]string `json:"public_keys,omitempty"`
+}
+
+type DeviceData struct {
+	Type        DeviceMetadataType `json:"type"`
+	Bus         string             `json:"bus"`
+	Address     string             `json:"address"`
+	MAC         string             `json:"mac,omitempty"`
+	Serial      string             `json:"serial,omitempty"`
+	NumaNode    uint32             `json:"numaNode,omitempty"`
+	AlignedCPUs []uint32           `json:"alignedCPUs,omitempty"`
+	Tags        []string           `json:"tags"`
+}
+
+type legacyConfigDriveMetadataFields struct {
+	InstanceType  string `json:"instance-type,omitempty"`
+	InstanceID    string `json:"instance-id"`
+	LocalHostname string `json:"local-hostname,omitempty"`
+}
+
+func (c ConfigDriveMetadata) MarshalJSON() ([]byte, error) {
+	// its important to have alias type to stop MarshalJSON recursion
+	type aliasConfigDriveMetadata ConfigDriveMetadata
+	return json.Marshal(&struct {
+		*legacyConfigDriveMetadataFields
+		aliasConfigDriveMetadata
+	}{
+		legacyConfigDriveMetadataFields: &legacyConfigDriveMetadataFields{
+			InstanceID:    c.InstanceID,
+			InstanceType:  c.InstanceType,
+			LocalHostname: c.LocalHostname,
+		},
+		aliasConfigDriveMetadata: (aliasConfigDriveMetadata)(c),
+	})
+}


### PR DESCRIPTION
This allows for upgrades from older version on kubevirt to work. Without this patch the applications baked into the VMI image that depend on the metadata fields of the cloudinit metadata json will be broken upon upgrade

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This [change](https://github.com/kubevirt/kubevirt/commit/2420891759bbc576c729988101b6571a1995ee8b#diff-df80969248f844e11fb3100c4242de8379bc714a214eb9817e091a37c4e74ea5R83-R88) updates the hyphen cloud init field instance-id, local-hostname, delimited field to an underscore delimited field (snake case).

Upon upgrade the workloads started failing because the applications in the VMI depended on the old cloudinit fields. It is very hard to go look for each such application in users codebases that depended on these fields and fix it. 

The maintenance burden on introducing the older fields back is relatively significantly smaller. This PR introduces the legacy fields back for smooth upgrades from older versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9292

**Special notes for your reviewer**:
cc @rthallisey @rmohr @xpivarc  

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
introduce custom json marshaller for legacy ConfigDriveMetadata fields in CloudInitData for applications inside VMI to read consistent set of keys for NoCloudMetadata and CloudInitData 
```
