### PR TITLE
Add virtctl vmexport manifest option

### DIFF
--- a/pkg/virtctl/memorydump/memorydump_test.go
+++ b/pkg/virtctl/memorydump/memorydump_test.go
@@ -369,7 +369,7 @@ var _ = Describe("MemoryDump", func() {
 			expectVMEndpointMemoryDump("testvm", "")
 			memorydump.WaitMemoryDumpComplete = waitForMemoryDumpDefault
 
-			vmexport := utils.VMExportSpec(vmexportName, k8smetav1.NamespaceDefault, "pvc", claimName, secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, k8smetav1.NamespaceDefault, claimName, secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    claimName,
@@ -386,7 +386,7 @@ var _ = Describe("MemoryDump", func() {
 
 		It("should call download memory dump", func() {
 			memorydump.WaitMemoryDumpComplete = waitForMemoryDumpDefault
-			vmexport := utils.VMExportSpec(vmexportName, k8smetav1.NamespaceDefault, "pvc", claimName, secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, k8smetav1.NamespaceDefault, claimName, secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    claimName,

--- a/pkg/virtctl/utils/BUILD.bazel
+++ b/pkg/virtctl/utils/BUILD.bazel
@@ -10,7 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virtctl/vmexport:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/export/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/api/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virtctl/utils/test_utils.go
+++ b/pkg/virtctl/utils/test_utils.go
@@ -166,10 +166,10 @@ func GetVMEStatus(volumes []exportv1.VirtualMachineExportVolume, secretName stri
 	}
 }
 
-func WaitExportCompleteDefault(kubecli.KubevirtClient, *vmexport.VMExportInfo, time.Duration, time.Duration, string) error {
+func WaitExportCompleteDefault(kubecli.KubevirtClient, *vmexport.VMExportInfo, time.Duration, time.Duration) error {
 	return nil
 }
 
-func WaitExportCompleteError(kubecli.KubevirtClient, *vmexport.VMExportInfo, time.Duration, time.Duration, string) error {
+func WaitExportCompleteError(kubecli.KubevirtClient, *vmexport.VMExportInfo, time.Duration, time.Duration) error {
 	return fmt.Errorf("processing failed: Test error")
 }

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -2,7 +2,7 @@ package vmexport_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -277,7 +277,6 @@ var _ = Describe("vmexport", func() {
 			Entry("Using 'create' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.CREATE), []string{virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), virtctlvmexport.INSECURE_FLAG}),
 			Entry("Using 'delete' with export type", virtctlvmexport.ErrIncompatibleExportType, []string{virtctlvmexport.DELETE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")}),
 			Entry("Using 'delete' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.DELETE), []string{virtctlvmexport.DELETE, vmexportName, virtctlvmexport.INSECURE_FLAG}),
-			Entry("Using 'download' without required flags", fmt.Sprintf(virtctlvmexport.ErrRequiredFlag, virtctlvmexport.OUTPUT_FLAG, virtctlvmexport.DOWNLOAD), []string{virtctlvmexport.DOWNLOAD, vmexportName}),
 		)
 
 		AfterEach(func() {
@@ -517,13 +516,11 @@ var _ = Describe("vmexport", func() {
 			Expect(err.Error()).Should(Equal(errString))
 		},
 			Entry("No arguments", "argument validation failed"),
-			Entry("Missing arg", "argument validation failed", virtctlvmexport.MANIFEST),
-			Entry("More arguments than expected", "argument validation failed", virtctlvmexport.MANIFEST, virtctlvmexport.DELETE, vmexportName),
-			Entry("Using 'manifest' without export type", virtctlvmexport.ErrSupportedExportType, virtctlvmexport.MANIFEST, vmexportName),
-			Entry("Using 'manifest' with pvc flag", virtctlvmexport.ErrSupportedExportType, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")),
-			Entry("Using 'manifest' with output flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.OUTPUT_FLAG, virtctlvmexport.MANIFEST), virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.OUTPUT_FLAG, "file")),
-			Entry("Using 'manifest' with volume type", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.VOLUME_FLAG, virtctlvmexport.MANIFEST), virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.VOLUME_FLAG, "volume")),
-			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),
+			Entry("Missing arg", "argument validation failed", virtctlvmexport.DOWNLOAD, virtctlvmexport.MANIFEST_FLAG),
+			Entry("More arguments than expected", "argument validation failed", virtctlvmexport.DOWNLOAD, virtctlvmexport.DELETE, virtctlvmexport.MANIFEST_FLAG, vmexportName),
+			Entry("Using 'manifest' with pvc flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.PVC_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.PVC_FLAG, "test")),
+			Entry("Using 'manifest' with volume type", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.VOLUME_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.VOLUME_FLAG, "volume")),
+			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),
 		)
 
 		DescribeTable("should successfully create VirtualMachineExport if proper arg supplied", func(arg, headerValue string) {
@@ -532,7 +529,7 @@ var _ = Describe("vmexport", func() {
 				Expect(headers).To(ContainElements(headerValue))
 				resp := http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader("data")),
+					Body:       io.NopCloser(strings.NewReader("data")),
 				}
 				return &resp, nil
 			}
@@ -557,7 +554,7 @@ var _ = Describe("vmexport", func() {
 
 				return true, vme, nil
 			})
-			args := []string{commandName, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test")}
+			args := []string{commandName, virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test")}
 			if arg != "" {
 				args = append(args, arg)
 			}
@@ -577,7 +574,7 @@ var _ = Describe("vmexport", func() {
 				calls++
 				resp := http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader("data")),
+					Body:       io.NopCloser(strings.NewReader("data")),
 				}
 				return &resp, nil
 			}
@@ -605,7 +602,7 @@ var _ = Describe("vmexport", func() {
 
 				return true, vme, nil
 			})
-			args := []string{commandName, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test")}
+			args := []string{commandName, virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test")}
 			if arg != "" {
 				args = append(args, arg)
 			}
@@ -623,7 +620,7 @@ var _ = Describe("vmexport", func() {
 				Expect(downloadUrl).To(BeElementOf(manifestUrl, secretUrl))
 				resp := http.Response{
 					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(strings.NewReader("")),
+					Body:       io.NopCloser(strings.NewReader("")),
 				}
 				return &resp, nil
 			}
@@ -651,7 +648,7 @@ var _ = Describe("vmexport", func() {
 
 				return true, vme, nil
 			})
-			args := []string{commandName, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test")}
+			args := []string{commandName, virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test")}
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
 			err := cmd()
 			Expect(err).To(HaveOccurred())

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -262,7 +262,7 @@ var _ = Describe("vmexport", func() {
 			Expect(err.Error()).Should(Equal("if any flags in the group [vm snapshot pvc] are set none of the others can be; [pvc snapshot vm] were all set"))
 		})
 
-		DescribeTable("Invalid arguments/flags", func(errString string, args []string) {
+		DescribeTable("Invalid arguments/flags", func(errString string, args ...string) {
 			testInit(http.StatusOK)
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
@@ -270,13 +270,17 @@ var _ = Describe("vmexport", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal(errString))
 		},
-			Entry("No arguments", "argument validation failed", []string{}),
-			Entry("Missing arg", "argument validation failed", []string{virtctlvmexport.CREATE, setflag(virtctlvmexport.PVC_FLAG, vmexportName)}),
-			Entry("More arguments than expected", "argument validation failed", []string{virtctlvmexport.CREATE, virtctlvmexport.DELETE, vmexportName}),
-			Entry("Using 'create' without export type", virtctlvmexport.ErrRequiredExportType, []string{virtctlvmexport.CREATE, vmexportName}),
-			Entry("Using 'create' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.CREATE), []string{virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), virtctlvmexport.INSECURE_FLAG}),
-			Entry("Using 'delete' with export type", virtctlvmexport.ErrIncompatibleExportType, []string{virtctlvmexport.DELETE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")}),
-			Entry("Using 'delete' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.DELETE), []string{virtctlvmexport.DELETE, vmexportName, virtctlvmexport.INSECURE_FLAG}),
+			Entry("No arguments", "argument validation failed"),
+			Entry("Missing arg", "argument validation failed", virtctlvmexport.CREATE, setflag(virtctlvmexport.PVC_FLAG, vmexportName)),
+			Entry("More arguments than expected create", "argument validation failed", virtctlvmexport.CREATE, virtctlvmexport.DELETE, vmexportName),
+			Entry("Using 'create' without export type", virtctlvmexport.ErrRequiredExportType, virtctlvmexport.CREATE, vmexportName),
+			Entry("Using 'create' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.CREATE), virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), virtctlvmexport.INSECURE_FLAG),
+			Entry("Using 'delete' with export type", virtctlvmexport.ErrIncompatibleExportType, virtctlvmexport.DELETE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")),
+			Entry("Using 'delete' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.DELETE), virtctlvmexport.DELETE, vmexportName, virtctlvmexport.INSECURE_FLAG),
+			Entry("More arguments than expected download and 'manifest'", "argument validation failed", virtctlvmexport.DOWNLOAD, virtctlvmexport.DELETE, virtctlvmexport.MANIFEST_FLAG, vmexportName),
+			Entry("Using 'manifest' with pvc flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.PVC_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.PVC_FLAG, "test")),
+			Entry("Using 'manifest' with volume type", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.VOLUME_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.VOLUME_FLAG, "volume")),
+			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),
 		)
 
 		AfterEach(func() {
@@ -506,22 +510,6 @@ var _ = Describe("vmexport", func() {
 			virtctlvmexport.HandleHTTPRequest = orgHttpFunc
 			testDone()
 		})
-
-		DescribeTable("Invalid arguments/flags", func(errString string, args ...string) {
-			testInit(http.StatusOK)
-			args = append([]string{commandName}, args...)
-			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
-			err := cmd()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal(errString))
-		},
-			Entry("No arguments", "argument validation failed"),
-			Entry("Missing arg", "argument validation failed", virtctlvmexport.DOWNLOAD, virtctlvmexport.MANIFEST_FLAG),
-			Entry("More arguments than expected", "argument validation failed", virtctlvmexport.DOWNLOAD, virtctlvmexport.DELETE, virtctlvmexport.MANIFEST_FLAG, vmexportName),
-			Entry("Using 'manifest' with pvc flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.PVC_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.PVC_FLAG, "test")),
-			Entry("Using 'manifest' with volume type", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.VOLUME_FLAG, virtctlvmexport.MANIFEST_FLAG), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.VOLUME_FLAG, "volume")),
-			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.DOWNLOAD, vmexportName, virtctlvmexport.MANIFEST_FLAG, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),
-		)
 
 		DescribeTable("should successfully create VirtualMachineExport if proper arg supplied", func(arg, headerValue string) {
 			virtctlvmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {

--- a/pkg/virtctl/vmexport/vmexport_test.go
+++ b/pkg/virtctl/vmexport/vmexport_test.go
@@ -2,8 +2,10 @@ package vmexport_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -20,8 +22,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/utils"
-	"kubevirt.io/kubevirt/pkg/virtctl/vmexport"
-	. "kubevirt.io/kubevirt/pkg/virtctl/vmexport"
+	virtctlvmexport "kubevirt.io/kubevirt/pkg/virtctl/vmexport"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 )
 
@@ -30,6 +31,9 @@ const (
 	vmexportName = "test-vme"
 	volumeName   = "test-volume"
 	secretName   = "secret-test-vme"
+
+	manifestUrl = "https://test.something.somewhere/test/all"
+	secretUrl   = "https://test.something.somewhere/test/secret"
 )
 
 var _ = Describe("vmexport", func() {
@@ -83,23 +87,23 @@ var _ = Describe("vmexport", func() {
 			w.WriteHeader(statusCode)
 		}))
 
-		vmexport.ExportProcessingComplete = utils.WaitExportCompleteDefault
-		vmexport.SetHTTPClientCreator(func(*http.Transport, bool) *http.Client {
+		virtctlvmexport.ExportProcessingComplete = utils.WaitExportCompleteDefault
+		virtctlvmexport.SetHTTPClientCreator(func(*http.Transport, bool) *http.Client {
 			return server.Client()
 		})
 	}
 
 	testDone := func() {
-		vmexport.SetDefaultHTTPClientCreator()
+		virtctlvmexport.SetDefaultHTTPClientCreator()
 		server.Close()
 	}
 
 	Context("VMExport fails", func() {
 		It("VirtualMachineExport already exists when using 'create'", func() {
 			testInit(http.StatusOK)
-			vmexport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, CREATE, vmexportName, setflag(PVC_FLAG, "test-pvc"))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("VirtualMachineExport 'default/test-vme' already exists"))
@@ -107,16 +111,16 @@ var _ = Describe("vmexport", func() {
 
 		It("VirtualMachineExport doesn't exist when using 'download' without source type", func() {
 			testInit(http.StatusOK)
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(VOLUME_FLAG, volumeName), setflag(OUTPUT_FLAG, "output.img"))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.OUTPUT_FLAG, "output.img"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("Unable to get 'default/test-vme' VirtualMachineExport"))
+			Expect(err.Error()).Should(ContainSubstring("unable to get 'default/test-vme' VirtualMachineExport"))
 		})
 
 		It("VirtualMachineExport processing fails when using 'download'", func() {
 			testInit(http.StatusOK)
-			vmexport.ExportProcessingComplete = utils.WaitExportCompleteError
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(PVC_FLAG, "test-pvc"), setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			virtctlvmexport.ExportProcessingComplete = utils.WaitExportCompleteError
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"), setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal("processing failed: Test error"))
@@ -124,20 +128,20 @@ var _ = Describe("vmexport", func() {
 
 		It("VirtualMachineExport download fails when there's no volume available", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus(nil, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			expectedError := fmt.Sprintf("Unable to access the volume info from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
+			expectedError := fmt.Sprintf("unable to access the volume info from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
 		It("VirtualMachineExport download fails when the volumes have a different name than expected", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    "no-test-volume",
@@ -150,16 +154,16 @@ var _ = Describe("vmexport", func() {
 			}, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			expectedError := fmt.Sprintf("Unable to get a valid URL from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
+			expectedError := fmt.Sprintf("unable to get a valid URL from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
 		It("VirtualMachineExport download fails when there are multiple volumes and no volume name has been specified", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    "no-test-volume",
@@ -172,29 +176,29 @@ var _ = Describe("vmexport", func() {
 			}, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			expectedError := fmt.Sprintf("Detected more than one downloadable volume in '%s/%s' VirtualMachineExport: Select the expected volume using the --volume flag", metav1.NamespaceDefault, vmexportName)
+			expectedError := fmt.Sprintf("detected more than one downloadable volume in '%s/%s' VirtualMachineExport: Select the expected volume using the --volume flag", metav1.NamespaceDefault, vmexportName)
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
 		It("VirtualMachineExport download fails when no format is available", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{{Name: volumeName}}, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			expectedError := fmt.Sprintf("Unable to get a valid URL from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
+			expectedError := fmt.Sprintf("unable to get a valid URL from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
 		It("VirtualMachineExport download fails when the only available format is incompatible with download", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -203,16 +207,16 @@ var _ = Describe("vmexport", func() {
 			}, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			expectedError := fmt.Sprintf("Unable to get a valid URL from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
+			expectedError := fmt.Sprintf("unable to get a valid URL from '%s/%s' VirtualMachineExport", metav1.NamespaceDefault, vmexportName)
 			Expect(err.Error()).Should(ContainSubstring(expectedError))
 		})
 
 		It("VirtualMachineExport download fails when the secret token is not attainable", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -223,7 +227,7 @@ var _ = Describe("vmexport", func() {
 			// Adding a new reactor so the client returns a nil secret
 			kubeClient.Fake.PrependReactor("create", "secrets", func(action testing.Action) (handled bool, obj runtime.Object, err error) { return false, nil, nil })
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			expectedError := fmt.Sprintf("secrets \"%s\" not found", secretName)
@@ -232,7 +236,7 @@ var _ = Describe("vmexport", func() {
 
 		It("VirtualMachineExport download fails if the server returns a bad status", func() {
 			testInit(http.StatusInternalServerError)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -242,15 +246,15 @@ var _ = Describe("vmexport", func() {
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 			utils.HandleSecretGet(kubeClient, secretName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(Equal("Bad status: 500 Internal Server Error"))
+			Expect(err.Error()).Should(Equal("bad status: 500 Internal Server Error"))
 		})
 
 		It("Bad flag combination", func() {
 			testInit(http.StatusOK)
-			args := []string{CREATE, vmexportName, setflag(PVC_FLAG, "test"), setflag(VM_FLAG, "test2"), setflag(SNAPSHOT_FLAG, "test3")}
+			args := []string{virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), setflag(virtctlvmexport.VM_FLAG, "test2"), setflag(virtctlvmexport.SNAPSHOT_FLAG, "test3")}
 			args = append([]string{commandName}, args...)
 			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
 			err := cmd()
@@ -267,13 +271,13 @@ var _ = Describe("vmexport", func() {
 			Expect(err.Error()).Should(Equal(errString))
 		},
 			Entry("No arguments", "argument validation failed", []string{}),
-			Entry("Missing arg", "argument validation failed", []string{CREATE, setflag(PVC_FLAG, vmexportName)}),
-			Entry("More arguments than expected", "argument validation failed", []string{CREATE, DELETE, vmexportName}),
-			Entry("Using 'create' without export type", ErrRequiredExportType, []string{CREATE, vmexportName}),
-			Entry("Using 'create' with invalid flag", fmt.Sprintf(ErrIncompatibleFlag, INSECURE_FLAG, CREATE), []string{CREATE, vmexportName, setflag(PVC_FLAG, "test"), INSECURE_FLAG}),
-			Entry("Using 'delete' with export type", ErrIncompatibleExportType, []string{DELETE, vmexportName, setflag(PVC_FLAG, "test")}),
-			Entry("Using 'delete' with invalid flag", fmt.Sprintf(ErrIncompatibleFlag, INSECURE_FLAG, DELETE), []string{DELETE, vmexportName, INSECURE_FLAG}),
-			Entry("Using 'download' without required flags", fmt.Sprintf(ErrRequiredFlag, OUTPUT_FLAG, DOWNLOAD), []string{DOWNLOAD, vmexportName}),
+			Entry("Missing arg", "argument validation failed", []string{virtctlvmexport.CREATE, setflag(virtctlvmexport.PVC_FLAG, vmexportName)}),
+			Entry("More arguments than expected", "argument validation failed", []string{virtctlvmexport.CREATE, virtctlvmexport.DELETE, vmexportName}),
+			Entry("Using 'create' without export type", virtctlvmexport.ErrRequiredExportType, []string{virtctlvmexport.CREATE, vmexportName}),
+			Entry("Using 'create' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.CREATE), []string{virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test"), virtctlvmexport.INSECURE_FLAG}),
+			Entry("Using 'delete' with export type", virtctlvmexport.ErrIncompatibleExportType, []string{virtctlvmexport.DELETE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")}),
+			Entry("Using 'delete' with invalid flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.INSECURE_FLAG, virtctlvmexport.DELETE), []string{virtctlvmexport.DELETE, vmexportName, virtctlvmexport.INSECURE_FLAG}),
+			Entry("Using 'download' without required flags", fmt.Sprintf(virtctlvmexport.ErrRequiredFlag, virtctlvmexport.OUTPUT_FLAG, virtctlvmexport.DOWNLOAD), []string{virtctlvmexport.DOWNLOAD, vmexportName}),
 		)
 
 		AfterEach(func() {
@@ -289,7 +293,7 @@ var _ = Describe("vmexport", func() {
 		// Create tests
 		It("VirtualMachineExport is created succesfully", func() {
 			utils.HandleVMExportCreate(vmExportClient, nil)
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, CREATE, vmexportName, setflag(PVC_FLAG, "test-pvc"))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"))
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -297,21 +301,21 @@ var _ = Describe("vmexport", func() {
 		// Delete tests
 		It("VirtualMachineExport is deleted succesfully", func() {
 			handleVMExportDelete(vmExportClient, vmexportName)
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DELETE, vmexportName)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DELETE, vmexportName)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("VirtualMachineExport doesn't exist when using 'delete'", func() {
 			testInit(http.StatusOK)
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DELETE, vmexportName)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DELETE, vmexportName)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		// Download tests
 		It("Succesfully download from an already existing VirtualMachineExport", func() {
-			vmexport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -321,13 +325,13 @@ var _ = Describe("vmexport", func() {
 			utils.HandleSecretGet(kubeClient, secretName)
 			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(VOLUME_FLAG, volumeName), setflag(OUTPUT_FLAG, "test-pvc"), INSECURE_FLAG)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.OUTPUT_FLAG, "test-pvc"), virtctlvmexport.INSECURE_FLAG)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Succesfully create and download a VirtualMachineExport", func() {
-			vmexport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -337,13 +341,13 @@ var _ = Describe("vmexport", func() {
 			utils.HandleSecretGet(kubeClient, secretName)
 			utils.HandleVMExportCreate(vmExportClient, vmexport)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(PVC_FLAG, "test-pvc"), setflag(VOLUME_FLAG, volumeName), setflag(OUTPUT_FLAG, "test-pvc"), INSECURE_FLAG)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.OUTPUT_FLAG, "test-pvc"), virtctlvmexport.INSECURE_FLAG)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Succesfully download a VirtualMachineExport with just 'raw' links", func() {
-			vmexport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -353,14 +357,14 @@ var _ = Describe("vmexport", func() {
 			utils.HandleSecretGet(kubeClient, secretName)
 			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(VOLUME_FLAG, volumeName), setflag(OUTPUT_FLAG, "test-pvc"), INSECURE_FLAG)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.VOLUME_FLAG, volumeName), setflag(virtctlvmexport.OUTPUT_FLAG, "test-pvc"), virtctlvmexport.INSECURE_FLAG)
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("VirtualMachineExport download succeeds when the volume has a different name than expected but there's only one volume", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    "no-test-volume",
@@ -370,14 +374,14 @@ var _ = Describe("vmexport", func() {
 			utils.HandleSecretGet(kubeClient, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"), setflag(VOLUME_FLAG, volumeName))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"), setflag(virtctlvmexport.VOLUME_FLAG, volumeName))
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("VirtualMachineExport download succeeds when there's only one volume and no --volume has been specified", func() {
 			testInit(http.StatusOK)
-			vme := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vme := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vme.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    "no-test-volume",
@@ -387,13 +391,13 @@ var _ = Describe("vmexport", func() {
 			utils.HandleSecretGet(kubeClient, secretName)
 			utils.HandleVMExportGet(vmExportClient, vme, vmexportName)
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, DOWNLOAD, vmexportName, setflag(OUTPUT_FLAG, "disk.img"))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.DOWNLOAD, vmexportName, setflag(virtctlvmexport.OUTPUT_FLAG, "disk.img"))
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Succesfully create VirtualMachineExport with TTL", func() {
-			vmexport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmexport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
@@ -411,7 +415,7 @@ var _ = Describe("vmexport", func() {
 				return true, vme, nil
 			})
 
-			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, CREATE, vmexportName, setflag(PVC_FLAG, "test-pvc"), setflag(TTL_FLAG, "1m"))
+			cmd := clientcmd.NewRepeatableVirtctlCommand(commandName, virtctlvmexport.CREATE, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test-pvc"), setflag(virtctlvmexport.TTL_FLAG, "1m"))
 			err := cmd()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -423,13 +427,13 @@ var _ = Describe("vmexport", func() {
 
 	Context("getUrlFromVirtualMachineExport", func() {
 		// Mocking the minimum viable VMExportInfo struct
-		vmeinfo := &VMExportInfo{
+		vmeinfo := &virtctlvmexport.VMExportInfo{
 			Name:       vmexportName,
 			VolumeName: volumeName,
 		}
 
 		It("Should get compressed URL even when there's multiple URLs", func() {
-			vmExport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmExport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmExport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name: volumeName,
@@ -453,39 +457,204 @@ var _ = Describe("vmexport", func() {
 					},
 				},
 			}, secretName)
-			url, err := vmexport.GetUrlFromVirtualMachineExport(vmExport, vmeinfo)
+			url, err := virtctlvmexport.GetUrlFromVirtualMachineExport(vmExport, vmeinfo)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(url).Should(Equal("compressed"))
 		})
 
 		It("Should get raw URL when there's no other option", func() {
-			vmExport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmExport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmExport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
 					Formats: utils.GetExportVolumeFormat("raw", exportv1.KubeVirtRaw),
 				},
 			}, secretName)
-			url, err := vmexport.GetUrlFromVirtualMachineExport(vmExport, vmeinfo)
+			url, err := virtctlvmexport.GetUrlFromVirtualMachineExport(vmExport, vmeinfo)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(url).Should(Equal("raw"))
 		})
 
 		It("Should not get any URL when there's no valid options", func() {
-			vmExport := utils.VMExportSpec(vmexportName, metav1.NamespaceDefault, "pvc", "test-pvc", secretName)
+			vmExport := utils.VMExportSpecPVC(vmexportName, metav1.NamespaceDefault, "test-pvc", secretName)
 			vmExport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
 				{
 					Name:    volumeName,
 					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.Dir),
 				},
 			}, secretName)
-			url, err := vmexport.GetUrlFromVirtualMachineExport(vmExport, vmeinfo)
+			url, err := virtctlvmexport.GetUrlFromVirtualMachineExport(vmExport, vmeinfo)
 			Expect(err).To(HaveOccurred())
 			Expect(url).To(Equal(""))
 		})
 
 		AfterEach(func() {
 			testDone()
+		})
+	})
+
+	Context("Manifest", func() {
+		var (
+			orgHttpFunc virtctlvmexport.HandleHTTPRequestFunc
+		)
+
+		BeforeEach(func() {
+			orgHttpFunc = virtctlvmexport.HandleHTTPRequest
+			testInit(http.StatusOK)
+		})
+
+		AfterEach(func() {
+			virtctlvmexport.HandleHTTPRequest = orgHttpFunc
+			testDone()
+		})
+
+		DescribeTable("Invalid arguments/flags", func(errString string, args ...string) {
+			testInit(http.StatusOK)
+			args = append([]string{commandName}, args...)
+			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
+			err := cmd()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(Equal(errString))
+		},
+			Entry("No arguments", "argument validation failed"),
+			Entry("Missing arg", "argument validation failed", virtctlvmexport.MANIFEST),
+			Entry("More arguments than expected", "argument validation failed", virtctlvmexport.MANIFEST, virtctlvmexport.DELETE, vmexportName),
+			Entry("Using 'manifest' without export type", virtctlvmexport.ErrSupportedExportType, virtctlvmexport.MANIFEST, vmexportName),
+			Entry("Using 'manifest' with pvc flag", virtctlvmexport.ErrSupportedExportType, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.PVC_FLAG, "test")),
+			Entry("Using 'manifest' with output flag", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.OUTPUT_FLAG, virtctlvmexport.MANIFEST), virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.OUTPUT_FLAG, "file")),
+			Entry("Using 'manifest' with volume type", fmt.Sprintf(virtctlvmexport.ErrIncompatibleFlag, virtctlvmexport.VOLUME_FLAG, virtctlvmexport.MANIFEST), virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test"), setflag(virtctlvmexport.VOLUME_FLAG, "volume")),
+			Entry("Using 'manifest' with invalid output_format_flag", fmt.Sprintf(virtctlvmexport.ErrInvalidValue, virtctlvmexport.OUTPUT_FORMAT_FLAG, "json/yaml"), virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, "invalid")),
+		)
+
+		DescribeTable("should successfully create VirtualMachineExport if proper arg supplied", func(arg, headerValue string) {
+			virtctlvmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {
+				Expect(downloadUrl).To(Equal(manifestUrl))
+				Expect(headers).To(ContainElements(headerValue))
+				resp := http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader("data")),
+				}
+				return &resp, nil
+			}
+			vmexport := utils.VMExportSpecVM(vmexportName, metav1.NamespaceDefault, "test", secretName)
+			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
+				{
+					Name:    volumeName,
+					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.KubeVirtGz),
+				},
+			}, secretName)
+			vmexport.Status.Links.External.Manifests = append(vmexport.Status.Links.External.Manifests, exportv1.VirtualMachineExportManifest{
+				Type: exportv1.AllManifests,
+				Url:  manifestUrl,
+			})
+			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
+			utils.HandleSecretGet(kubeClient, secretName)
+			vmExportClient.Fake.PrependReactor("create", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				create, ok := action.(testing.CreateAction)
+				Expect(ok).To(BeTrue())
+				vme, ok := create.GetObject().(*exportv1.VirtualMachineExport)
+				Expect(ok).To(BeTrue())
+
+				return true, vme, nil
+			})
+			args := []string{commandName, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test")}
+			if arg != "" {
+				args = append(args, arg)
+			}
+			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
+			err := cmd()
+			Expect(err).ToNot(HaveOccurred())
+		},
+			Entry("no output format arguments", "", virtctlvmexport.APPLICATION_YAML),
+			Entry("output format json", setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, virtctlvmexport.OUTPUT_FORMAT_JSON), virtctlvmexport.APPLICATION_JSON),
+			Entry("output format yaml", setflag(virtctlvmexport.OUTPUT_FORMAT_FLAG, virtctlvmexport.OUTPUT_FORMAT_YAML), virtctlvmexport.APPLICATION_YAML),
+		)
+
+		DescribeTable("should call both manifest and secret url if argument supplied", func(arg string, callCount int) {
+			calls := 0
+			virtctlvmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {
+				Expect(downloadUrl).To(BeElementOf(manifestUrl, secretUrl))
+				calls++
+				resp := http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader("data")),
+				}
+				return &resp, nil
+			}
+			vmexport := utils.VMExportSpecVM(vmexportName, metav1.NamespaceDefault, "test", secretName)
+			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
+				{
+					Name:    volumeName,
+					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.KubeVirtGz),
+				},
+			}, secretName)
+			vmexport.Status.Links.External.Manifests = append(vmexport.Status.Links.External.Manifests, exportv1.VirtualMachineExportManifest{
+				Type: exportv1.AllManifests,
+				Url:  manifestUrl,
+			}, exportv1.VirtualMachineExportManifest{
+				Type: exportv1.AuthHeader,
+				Url:  secretUrl,
+			})
+			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
+			utils.HandleSecretGet(kubeClient, secretName)
+			vmExportClient.Fake.PrependReactor("create", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				create, ok := action.(testing.CreateAction)
+				Expect(ok).To(BeTrue())
+				vme, ok := create.GetObject().(*exportv1.VirtualMachineExport)
+				Expect(ok).To(BeTrue())
+
+				return true, vme, nil
+			})
+			args := []string{commandName, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test")}
+			if arg != "" {
+				args = append(args, arg)
+			}
+			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
+			err := cmd()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(calls).To(Equal(callCount))
+		},
+			Entry("without --include-secret", "", 1),
+			Entry("with --include-secret", virtctlvmexport.INCLUDE_SECRET_FLAG, 2),
+		)
+
+		It("should error if http status is error", func() {
+			virtctlvmexport.HandleHTTPRequest = func(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport, downloadUrl string, insecure bool, exportURL string, headers map[string]string) (*http.Response, error) {
+				Expect(downloadUrl).To(BeElementOf(manifestUrl, secretUrl))
+				resp := http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       ioutil.NopCloser(strings.NewReader("")),
+				}
+				return &resp, nil
+			}
+			vmexport := utils.VMExportSpecVM(vmexportName, metav1.NamespaceDefault, "test", secretName)
+			vmexport.Status = utils.GetVMEStatus([]exportv1.VirtualMachineExportVolume{
+				{
+					Name:    volumeName,
+					Formats: utils.GetExportVolumeFormat(server.URL, exportv1.KubeVirtGz),
+				},
+			}, secretName)
+			vmexport.Status.Links.External.Manifests = append(vmexport.Status.Links.External.Manifests, exportv1.VirtualMachineExportManifest{
+				Type: exportv1.AllManifests,
+				Url:  manifestUrl,
+			}, exportv1.VirtualMachineExportManifest{
+				Type: exportv1.AuthHeader,
+				Url:  secretUrl,
+			})
+			utils.HandleVMExportGet(vmExportClient, vmexport, vmexportName)
+			utils.HandleSecretGet(kubeClient, secretName)
+			vmExportClient.Fake.PrependReactor("create", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				create, ok := action.(testing.CreateAction)
+				Expect(ok).To(BeTrue())
+				vme, ok := create.GetObject().(*exportv1.VirtualMachineExport)
+				Expect(ok).To(BeTrue())
+
+				return true, vme, nil
+			})
+			args := []string{commandName, virtctlvmexport.MANIFEST, vmexportName, setflag(virtctlvmexport.VM_FLAG, "test")}
+			cmd := clientcmd.NewRepeatableVirtctlCommand(args...)
+			err := cmd()
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/tests/monitoring/prometheus_utils.go
+++ b/tests/monitoring/prometheus_utils.go
@@ -147,8 +147,8 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 			if err := cmd.Start(); err != nil {
 				return err
 			}
-			waitForPortForwardCmd(stdout, sourcePort, targetPort)
-			defer killPortForwardCommand(cmd)
+			WaitForPortForwardCmd(stdout, sourcePort, targetPort)
+			defer KillPortForwardCommand(cmd)
 
 			url := fmt.Sprintf("http://localhost:%d", sourcePort)
 			resp := doHttpRequest(url, endpoint, token)
@@ -243,7 +243,7 @@ func getMonitoringNs(cli kubecli.KubevirtClient) string {
 	return "monitoring"
 }
 
-func waitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
+func WaitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
 	Eventually(func() string {
 		tmp := make([]byte, 1024)
 		_, err := stdout.Read(tmp)
@@ -253,7 +253,7 @@ func waitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
 	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Forwarding from 127.0.0.1:%d -> %d", src, dst)))
 }
 
-func killPortForwardCommand(portForwardCmd *exec.Cmd) error {
+func KillPortForwardCommand(portForwardCmd *exec.Cmd) error {
 	if portForwardCmd == nil {
 		return nil
 	}

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//tests/libstorage:go_default_library",
         "//tests/libvmi:go_default_library",
         "//tests/libwait:go_default_library",
+        "//tests/monitoring:go_default_library",
         "//tests/testsuite:go_default_library",
         "//tests/util:go_default_library",
         "//tests/watcher:go_default_library",

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -26,7 +26,9 @@ import (
 	"encoding/pem"
 	goerrors "errors"
 	"fmt"
+	"io"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -34,6 +36,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/monitoring"
 
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -2370,6 +2373,108 @@ var _ = SIGDescribe("Export", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+
+		Context("Get export manifest from vmexport", func() {
+			var (
+				forwardCmd *osexec.Cmd
+			)
+
+			AfterEach(func() {
+				err = monitoring.KillPortForwardCommand(forwardCmd)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			DescribeTable("manifest should be successfully retrieved on running VM export", func(expectedObjects int, extraArgs ...string) {
+				// Create a populated VM
+				vm := tests.NewRandomVMWithDataVolumeWithRegistryImport(
+					cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine),
+					testsuite.GetTestNamespace(nil),
+					sc,
+					k8sv1.ReadWriteOnce)
+				vm.Spec.Running = pointer.BoolPtr(true)
+				vm = createVM(vm)
+				Eventually(func() virtv1.VirtualMachineInstancePhase {
+					vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, &metav1.GetOptions{})
+					if errors.IsNotFound(err) {
+						return ""
+					}
+					Expect(err).ToNot(HaveOccurred())
+					return vmi.Status.Phase
+				}, 180*time.Second, time.Second).Should(Equal(virtv1.Running))
+
+				By("Stopping VM, we should get the export ready eventually")
+				vm = stopVM(vm)
+
+				// Run vmexport
+				By("Running vmexport create command")
+				virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(commandName,
+					"create",
+					vmeName,
+					"--vm", vm.Name,
+					"--namespace", testsuite.GetTestNamespace(vm))
+				err = virtctlCmd()
+				Expect(err).ToNot(HaveOccurred())
+
+				exportReady := exportv1.Ready
+				Eventually(func() *exportv1.VirtualMachineExportPhase {
+					vme, err := virtClient.VirtualMachineExport(vm.Namespace).Get(context.Background(), vmeName, metav1.GetOptions{})
+					if errors.IsNotFound(err) {
+						return nil
+					}
+					Expect(err).ToNot(HaveOccurred())
+					if vme.Status == nil {
+						return nil
+					}
+					return &vme.Status.Phase
+				}, 180*time.Second, time.Second).Should(Equal(&exportReady))
+				vme, err := virtClient.VirtualMachineExport(vm.Namespace).Get(context.Background(), vmeName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				cmdArgs := []string{
+					commandName,
+					"manifest",
+					vmeName,
+					"--namespace",
+					testsuite.GetTestNamespace(vm),
+				}
+				if vme.Status.Links.External == nil {
+					targetPort := 37548 + rand.Intn(6000)
+					_, forwardCmd, err = clientcmd.CreateCommandWithNS(vm.Namespace, clientcmd.GetK8sCmdClient(),
+						"port-forward", fmt.Sprintf("service/virt-export-%s", vmeName), fmt.Sprintf("%d:443", targetPort))
+					Expect(err).ToNot(HaveOccurred())
+					go func() {
+						defer GinkgoRecover()
+						Expect(err).ToNot(HaveOccurred())
+						stdout, err := forwardCmd.StdoutPipe()
+						Expect(err).ToNot(HaveOccurred())
+						err = forwardCmd.Start()
+						Expect(err).ToNot(HaveOccurred())
+						waitForPortForwardCmd(stdout, 443, targetPort)
+					}()
+
+					cmdArgs = append(cmdArgs, "--export-url", fmt.Sprintf("127.0.0.1:%d", targetPort),
+						"--insecure")
+				}
+				cmdArgs = append(cmdArgs, extraArgs...)
+				virtctlCmdOut := clientcmd.NewRepeatableVirtctlCommandWithOut(cmdArgs...)
+
+				var out []byte
+				By("Running vmexport manifest command")
+				Eventually(func() error {
+					out, err = virtctlCmdOut()
+					return err
+				}, 30*time.Second, time.Second).Should(BeNil())
+				Expect(out).NotTo(BeEmpty())
+				split := strings.Split(string(out), "\n---\n")
+				// Add one for the --- at the end.
+				Expect(split).To(HaveLen(expectedObjects + 1))
+				resVM := &virtv1.VirtualMachine{}
+				err = yaml.Unmarshal([]byte(split[1]), resVM)
+				Expect(err).ToNot(HaveOccurred())
+			},
+				Entry("without --include-secret", 2),
+				Entry("with --include-secret", 3, "--include-secret"),
+			)
+		})
 	})
 })
 
@@ -2405,4 +2510,14 @@ func (matcher *ConditionNoTimeMatcher) FailureMessage(actual interface{}) (messa
 
 func (matcher *ConditionNoTimeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "not to match without time", matcher.Cond)
+}
+
+func waitForPortForwardCmd(stdout io.ReadCloser, src, dst int) {
+	Eventually(func() string {
+		tmp := make([]byte, 1024)
+		_, err := stdout.Read(tmp)
+		Expect(err).NotTo(HaveOccurred())
+
+		return string(tmp)
+	}, 30*time.Second, 1*time.Second).Should(ContainSubstring(fmt.Sprintf("Handling connection for %d", dst)))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to make it easier to copy VM (+1 disks) from one cluster to another, virtctl supports a new manifest flag for the `download` argument that allows one to get a manifest that you can directly apply to the target cluster if the target cluster can connect to the source cluster. The URLs associated with the disks will contain the export URLs, and the appropriate certificate config map and header secret are available.

Examples:
```bash
# get manifest for existing export, that will NOT include header secret
virtctl vmexport download export --manifest
# create vm export for vm example, and get the manifest, it will NOT include header secret
virtctl vmexport download export --manifest --vm=example
# create vm export for vm snapshot example, and get the manifest, it will NOT include header secret
virtctl vmexport download export --manifest --snap=example
# get manifest for existing export, that will include the header secret
virtctl vmexport download export --manifest --include-secret
# get manifest for existing export, that will NOT include the header secret, in json format
virtctl vmexport download export --manifest --manifest-output-format=json
# get manifest for existing export, that will include the header secret writing to a file
virtctl vmexport download export --manifest --include-secret --output=manifest.yaml
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Included specifying `--service-url`, which allows one to connect to a different url than specified in the vm export status. This is mainly for functional tests or situations where there is no proper Ingress/Route into the source cluster. The manifest will return disk URLs that point to the internal links of the export. If not specified and there is no external URLs, the manifests will not be returned because the command will wait until the external resource are available

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl supports retrieving vm manifest for VM export
```
