### PR TITLE
WIP Virt-handler heartbeat sets nodes with NoSchedule taint to unschedulable

### DIFF
--- a/pkg/virt-handler/heartbeat/BUILD.bazel
+++ b/pkg/virt-handler/heartbeat/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/virt-handler/device-manager:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
@@ -36,6 +37,8 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When setting a `control-plane` node to schedulable and then unschedulable, two issues arise, as seen in [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=2070033):
1) There is a mismatch between the number of `virt-handler` daemonsets listed and the number of existing `virt-handler` pods.
2) The `control-plane` nodes continue to be set to schedulable.

This PR aims to fix the second issue that arises here. Regarding the first issue, it was recommended that we ultimately do not kill the` virt-handlers` created as a result of setting the `control-plane` nodes to schedulable to prevent the orphaning of any VMIs that may still be running on the node from when it was schedulable.
When the `control-plane` node is set to schedulable, the `NoSchedule` taint is removed, and then re-added when the node is set to unschedulable. While there are no issues when the `control-plane` nodes are initially created and unschedulable, the heartbeat that is running on the `virt-handler` that was created when setting the node to schedulable would continuously set the node to schedulable as long as the heartbeat and `virt-handler` were still running. This PR now has the heartbeat check for the `NoSchedule` taint, and sets schedulable to false if it is present.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
