### PR TITLE
Hotplug network ifaces based on the current domain info, rather than on the interface status

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "manager_test.go",
+        "nichotplug_test.go",
         "virtwrap_suite_test.go",
     ],
     embed = [":go_default_library"],
@@ -74,6 +75,7 @@ go_test(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/ephemeral-disk/fake:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -996,7 +996,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 	}
 
 	if vmi.IsRunning() {
-		if err := hotplugVirtioInterface(vmi, c, dom, domain); err != nil {
+		if err := hotplugVirtioInterface(vmi, dom, &api.Domain{Spec: oldSpec}, domain); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/nichotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug_test.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package virtwrap
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+var _ = Describe("nic hotplug on virt-launcher", func() {
+	const (
+		nadName     = "n1n"
+		networkName = "n1"
+	)
+
+	DescribeTable("networksToHotplugWhoseInterfacesAreNotInTheDomain", func(vmi *v1.VirtualMachineInstance, domainIfaces map[string]api.Interface, expectedNetworks []v1.Network) {
+		Expect(
+			networksToHotplugWhoseInterfacesAreNotInTheDomain(vmi, domainIfaces),
+		).To(ConsistOf(expectedNetworks))
+	},
+		Entry("vmi with no networks, and no interfaces in the domain",
+			&v1.VirtualMachineInstance{Spec: v1.VirtualMachineInstanceSpec{Networks: []v1.Network{}}},
+			map[string]api.Interface{},
+			nil,
+		),
+		Entry("vmi with 1 network, and an associated interface in the domain",
+			&v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{Networks: []v1.Network{generateNetwork(networkName, nadName)}},
+			},
+			map[string]api.Interface{networkName: {Alias: api.NewUserDefinedAlias(networkName)}},
+			nil,
+		),
+		Entry("vmi with 1 network (when the pod interface is *not* ready), with no interfaces in the domain",
+			&v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{Networks: []v1.Network{generateNetwork(networkName, nadName)}},
+			},
+			map[string]api.Interface{},
+			nil,
+		),
+		Entry("vmi with 1 network (when the pod interface *is* ready), but already present in the domain",
+			&v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{Networks: []v1.Network{generateNetwork(networkName, nadName)}},
+				Status: v1.VirtualMachineInstanceStatus{
+					Interfaces: []v1.VirtualMachineInstanceNetworkInterface{{
+						Name:       networkName,
+						InfoSource: vmispec.InfoSourceMultusStatus,
+					}},
+				},
+			},
+			map[string]api.Interface{networkName: {Alias: api.NewUserDefinedAlias(networkName)}},
+			nil,
+		),
+		Entry("vmi with 1 network (when the pod interface *is* ready), but no interfaces in the domain",
+			&v1.VirtualMachineInstance{
+				Spec: v1.VirtualMachineInstanceSpec{Networks: []v1.Network{generateNetwork(networkName, nadName)}},
+				Status: v1.VirtualMachineInstanceStatus{
+					Interfaces: []v1.VirtualMachineInstanceNetworkInterface{{
+						Name:       networkName,
+						InfoSource: vmispec.InfoSourceMultusStatus,
+					}},
+				},
+			},
+			map[string]api.Interface{},
+			[]v1.Network{generateNetwork(networkName, nadName)},
+		),
+	)
+})
+
+func generateNetwork(name string, nadName string) v1.Network {
+	return v1.Network{
+		Name: name,
+		NetworkSource: v1.NetworkSource{
+			Multus: &v1.MultusNetwork{NetworkName: nadName}},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We were currently hotplugging interfaces based on the interfaces present
in the `VMI.Spec.Interfaces`, but not present in the
`VMI.Status.Interfaces`, having its `PodConfigDone` attribute enabled.

This commit changes this, by hotplugging based on interfaces present in
the `VMI.Spec.Interfaces`, but not presently available in the
**domain**, which is more accurate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
/sig network

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Compute the interfaces to be hotplugged based on the current domain info, rather than on the interface status.
```
