### PR TITLE
virt-launcher, converter: Drop network validation

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1996,19 +1996,6 @@ var _ = Describe("Converter", func() {
 			}
 		})
 
-		It("should fail to convert if non network source are present", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			name := "otherName"
-			iface := v1.DefaultBridgeNetworkInterface()
-			net := v1.DefaultPodNetwork()
-			iface.Name = name
-			net.Name = name
-			net.Pod = nil
-			vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, *iface)
-			vmi.Spec.Networks = append(vmi.Spec.Networks, *net)
-			Expect(Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, &api.Domain{}, c)).ToNot(Succeed())
-		})
-
 		It("should add tcp if protocol not exist", func() {
 			iface := v1.Interface{Name: "test", InterfaceBindingMethod: v1.InterfaceBindingMethod{}, Ports: []v1.Port{{Port: 80}}}
 			iface.InterfaceBindingMethod.Slirp = &v1.InterfaceSlirp{}

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -37,10 +37,6 @@ import (
 )
 
 func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext, virtioNetProhibited bool, ifacesToPlug ...v1.Interface) ([]api.Interface, error) {
-	if err := validateNetworksTypes(vmi.Spec.Networks); err != nil {
-		return nil, err
-	}
-
 	var domainInterfaces []api.Interface
 
 	networks := indexNetworksByName(vmi.Spec.Networks)
@@ -158,18 +154,6 @@ func GetInterfaceType(iface *v1.Interface) string {
 		return iface.Model
 	}
 	return v1.VirtIO
-}
-
-func validateNetworksTypes(networks []v1.Network) error {
-	for _, network := range networks {
-		switch {
-		case network.Pod != nil && network.Multus != nil:
-			return fmt.Errorf("network %s must have only one network type", network.Name)
-		case network.Pod == nil && network.Multus == nil:
-			return fmt.Errorf("network %s must have a network type", network.Name)
-		}
-	}
-	return nil
 }
 
 func indexNetworksByName(networks []v1.Network) map[string]*v1.Network {


### PR DESCRIPTION
**What this PR does / why we need it**:

The networks are already validated in the admission webhook, specifically the type part [1] which this change focuses on.

Such configuration validations on the VMI spec should not be needed at this layer of processing. The validation should be left higher in the stack, close to the API as possible.

[1] https://github.com/kubevirt/kubevirt/blob/2f3661e7d4de89ef9c61ec2692ae9db36db36e40/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go#L940

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
