### PR TITLE
virt-api, iface-hotplug: Drop redundant conditions

### DIFF
--- a/pkg/virt-api/rest/interfacehotplug.go
+++ b/pkg/virt-api/rest/interfacehotplug.go
@@ -111,25 +111,20 @@ func generateVMInterfaceRequestPatch(vm *v1.VirtualMachine, interfaceRequest *v1
 
 func addAddInterfaceRequests(vm *v1.VirtualMachine, ifaceRequest *v1.VirtualMachineInterfaceRequest, vmCopy *v1.VirtualMachine) {
 	canonicalIfaceName := dynamicIfaceName(ifaceRequest)
-	if ifaceRequest.AddInterfaceOptions != nil {
-		existingIface := filterInterfaceRequests(
-			vm.Status.InterfaceRequests,
-			func(ifaceReq v1.VirtualMachineInterfaceRequest) bool {
-				return dynamicIfaceName(&ifaceReq) == canonicalIfaceName
-			},
-		)
+	existingIface := filterInterfaceRequests(
+		vm.Status.InterfaceRequests,
+		func(ifaceReq v1.VirtualMachineInterfaceRequest) bool {
+			return dynamicIfaceName(&ifaceReq) == canonicalIfaceName
+		},
+	)
 
-		if len(existingIface) == 0 {
-			vmCopy.Status.InterfaceRequests = append(vm.Status.InterfaceRequests, *ifaceRequest)
-		}
+	if len(existingIface) == 0 {
+		vmCopy.Status.InterfaceRequests = append(vm.Status.InterfaceRequests, *ifaceRequest)
 	}
 }
 
 func dynamicIfaceName(plugRequest *v1.VirtualMachineInterfaceRequest) string {
-	if plugRequest.AddInterfaceOptions != nil {
-		return plugRequest.AddInterfaceOptions.InterfaceName
-	}
-	panic(fmt.Errorf("must provide the `AddInterfaceOptions.InterfaceName` attribute"))
+	return plugRequest.AddInterfaceOptions.InterfaceName
 }
 
 func ApplyInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineInterfaceRequest) *v1.VirtualMachineInstanceSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `request.AddInterfaceOptions != nil` has been used in a defensive manner on functions which are dedicated to adding an vNIC. I.e. the code flow would have reached these functions only if the operation has been recognized as a hotplug, implying that the request has this data and there is no need to re-check it again in the stack.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
