### PR TITLE
network: Refactor network handling to integrate hotplug

### DIFF
--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -46,14 +46,11 @@ func NewVMNetworkConfigurator(vmi *v1.VirtualMachineInstance, cacheCreator cache
 	return newVMNetworkConfiguratorWithHandlerAndCache(vmi, &netdriver.NetworkUtilsHandler{}, cacheCreator)
 }
 
-func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int, networksToPlug ...v1.Network) ([]podNIC, error) {
+func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int, networks []v1.Network) ([]podNIC, error) {
 	var nics []podNIC
 
-	if len(networksToPlug) == 0 {
-		networksToPlug = v.vmi.Spec.Networks
-	}
-	for i := range networksToPlug {
-		nic, err := newPhase1PodNIC(v.vmi, &networksToPlug[i], v.handler, v.cacheCreator, launcherPID)
+	for i := range networks {
+		nic, err := newPhase1PodNIC(v.vmi, &networks[i], v.handler, v.cacheCreator, launcherPID)
 		if err != nil {
 			return nil, err
 		}
@@ -62,14 +59,11 @@ func (v VMNetworkConfigurator) getPhase1NICs(launcherPID *int, networksToPlug ..
 	return nics, nil
 }
 
-func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networksToPlug ...v1.Network) ([]podNIC, error) {
+func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networks []v1.Network) ([]podNIC, error) {
 	var nics []podNIC
 
-	if len(networksToPlug) == 0 {
-		networksToPlug = v.vmi.Spec.Networks
-	}
-	for i := range networksToPlug {
-		nic, err := newPhase2PodNIC(v.vmi, &networksToPlug[i], v.handler, v.cacheCreator, domain)
+	for i := range networks {
+		nic, err := newPhase2PodNIC(v.vmi, &networks[i], v.handler, v.cacheCreator, domain)
 		if err != nil {
 			return nil, err
 		}
@@ -78,8 +72,8 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networksToPlug 
 	return nics, nil
 }
 
-func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networksToPlug ...v1.Network) error {
-	nics, err := n.getPhase1NICs(&launcherPID, networksToPlug...)
+func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networks []v1.Network) error {
+	nics, err := n.getPhase1NICs(&launcherPID, networks)
 	if err != nil {
 		return err
 	}
@@ -91,8 +85,8 @@ func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networksT
 	return nil
 }
 
-func (n *VMNetworkConfigurator) SetupPodNetworkPhase2(domain *api.Domain, networksToPlug ...v1.Network) error {
-	nics, err := n.getPhase2NICs(domain, networksToPlug...)
+func (n *VMNetworkConfigurator) SetupPodNetworkPhase2(domain *api.Domain, networks []v1.Network) error {
+	nics, err := n.getPhase2NICs(domain, networks)
 	if err != nil {
 		return err
 	}

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -55,12 +55,12 @@ var _ = Describe("VMNetworkConfigurator", func() {
 			})
 			It("should propagate errors when phase1 is called", func() {
 				launcherPID := 0
-				err := vmNetworkConfigurator.SetupPodNetworkPhase1(launcherPID)
+				err := vmNetworkConfigurator.SetupPodNetworkPhase1(launcherPID, vmi.Spec.Networks)
 				Expect(err).To(MatchError("Network not implemented"))
 			})
 			It("should propagate errors when phase2 is called", func() {
 				var domain *api.Domain
-				err := vmNetworkConfigurator.SetupPodNetworkPhase2(domain)
+				err := vmNetworkConfigurator.SetupPodNetworkPhase2(domain, vmi.Spec.Networks)
 				Expect(err).To(MatchError("Network not implemented"))
 			})
 		})
@@ -72,7 +72,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				iface := v1.DefaultBridgeNetworkInterface()
 				defaultNet := v1.DefaultPodNetwork()
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, vm.Spec.Networks)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
 					vmi:              vm,
@@ -94,7 +94,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				vmi := api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, vmi.Spec.Networks)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(BeEmpty())
 			})
@@ -106,7 +106,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				vmi.Spec.Networks = []v1.Network{*cniNet}
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, vmi.Spec.Networks)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
 					vmi:              vmi,
@@ -173,7 +173,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 
 				vmNetworkConfigurator := NewVMNetworkConfigurator(vm, &baseCacheCreator)
 				launcherPID := 0
-				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID)
+				nics, err := vmNetworkConfigurator.getPhase1NICs(&launcherPID, vm.Spec.Networks)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ContainElements([]podNIC{
 					{
@@ -244,7 +244,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				const expectedPodIfaceName = "net1"
 				Expect(vmNetworkConfigurator.getPhase1NICs(
 					&launcherPID,
-					networkToHotplug(ifaceToHotplug),
+					[]v1.Network{networkToHotplug(ifaceToHotplug)},
 				)).To(ConsistOf(podNIC{
 					vmi:              vmi,
 					podInterfaceName: expectedPodIfaceName,

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -576,7 +576,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		}
 	}
 
-	err = netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}).SetupPodNetworkPhase2(domain)
+	err = netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}).SetupPodNetworkPhase2(domain, vmi.Spec.Networks)
 	if err != nil {
 		return domain, fmt.Errorf("preparing the pod network failed: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -52,7 +52,7 @@ func hotplugVirtioInterface(vmi *v1.VirtualMachineInstance, converterContext *co
 		}
 
 		domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, domainInterfaces...)
-		if err := vmConfigurator.SetupPodNetworkPhase2(domain, network); err != nil {
+		if err := vmConfigurator.SetupPodNetworkPhase2(domain, []v1.Network{network}); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Embed most of the hotplug logic into the existing network setup flow.

This includes the logic of identifying if hotplug should be done and on which networks. Functions signatures have been adjusted to fit both the regular and hotplug setups.

The change handles both phase 1 and phase 2.

Future changes should strive to unify the logic, such that even a regular network setup can reconcile by hot-plugging the missing networks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
