### PR TITLE
Hotplug controller read guest agent iface status

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/network/sriov:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/rest:go_default_library",
         "//pkg/storage/export/export:go_default_library",
         "//pkg/storage/snapshot:go_default_library",

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -32,7 +32,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -43,17 +42,13 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 )
 
-var _ = SIGDescribe("nic-hotplug", Serial, func() {
+var _ = SIGDescribe("nic-hotplug", func() {
 	const (
 		bridgeName  = "supadupabr"
 		ifaceName   = "iface1"
 		networkName = "skynet"
 		vmIfaceName = "eth1"
 	)
-
-	BeforeEach(func() {
-		tests.EnableFeatureGate(virtconfig.HotplugNetworkIfacesGate)
-	})
 
 	Context("a running VMI", func() {
 		var vmi *v1.VirtualMachineInstance

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -45,7 +45,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
@@ -439,7 +438,6 @@ var _ = SIGDescribe("[Serial]Multus", Serial, decorators.Multus, func() {
 			customMacAddress := "50:00:00:00:90:0d"
 
 			BeforeEach(func() {
-				tests.EnableFeatureGate(virtconfig.HotplugNetworkIfacesGate)
 				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
 				vmiTwo := libvmi.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -107,6 +107,7 @@ func AdjustKubeVirtResource() {
 		virtconfig.VMExportGate,
 		virtconfig.VSOCKGate,
 		virtconfig.KubevirtSeccompProfile,
+		virtconfig.HotplugNetworkIfacesGate,
 	)
 	if flags.DisableCustomSELinuxPolicy {
 		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The guest agent interfaces are only computed from the virt-handler,
thus, we need to carry them over from the current status. Otherwise, we
would get caught in a reconcile storm between these two components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9396 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
