### PR TITLE
Run clone tests that require special storage in storage lane

### DIFF
--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -470,7 +470,7 @@ var _ = Describe("[Serial][sig-compute]VirtualMachineClone Tests", Serial, decor
 
 		})
 
-		Context("with more complicated VM", func() {
+		Context("[sig-storage]with more complicated VM", func() {
 
 			expectVMRunnable := func(vm *virtv1.VirtualMachine) *virtv1.VirtualMachine {
 				return expectVMRunnable(vm, console.LoginToAlpine)


### PR DESCRIPTION
This tests needs snapshotable storage class which we have only in the sig-storage lane. so far this tests were always skipped.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
