### PR TITLE
[release-0.49] virt-*: bump memory requests above highest values seen in testing

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1081,7 +1081,7 @@ spec:
                 resources:
                   requests:
                     cpu: 10m
-                    memory: 400Mi
+                    memory: 450Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -263,7 +263,7 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceMemory: resource.MustParse("325Mi"),
 		},
 	}
 

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -330,7 +330,7 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("300Mi"),
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
 		},
 	}
 
@@ -416,7 +416,7 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("150Mi"),
+			corev1.ResourceMemory: resource.MustParse("200Mi"),
 		},
 	}
 
@@ -531,7 +531,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("10m"),
-									corev1.ResourceMemory: resource.MustParse("400Mi"),
+									corev1.ResourceMemory: resource.MustParse("450Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
This is a manual cherry-pick of #9125

Note: the values were adjusted to match actual release-0.49 testing

Fixes [rhbz#2151170](https://bugzilla.redhat.com/show_bug.cgi?id=2151170)

```release-note
NONE
```
