### PR TITLE
Add virtctl create preference command

### DIFF
--- a/pkg/virtctl/create/BUILD.bazel
+++ b/pkg/virtctl/create/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virtctl/create/instancetype:go_default_library",
+        "//pkg/virtctl/create/preference:go_default_library",
         "//pkg/virtctl/create/vm:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kubevirt.io/kubevirt/pkg/virtctl/create/instancetype"
+	"kubevirt.io/kubevirt/pkg/virtctl/create/preference"
 	"kubevirt.io/kubevirt/pkg/virtctl/create/vm"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
@@ -41,6 +42,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(vm.NewCommand())
+	cmd.AddCommand(preference.NewCommand())
 	cmd.AddCommand(instancetype.NewCommand())
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 

--- a/pkg/virtctl/create/preference/BUILD.bazel
+++ b/pkg/virtctl/create/preference/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["preference.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/create/preference",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virtctl/create/params:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "preference_suite_test.go",
+        "preference_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/clientcmd:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)

--- a/pkg/virtctl/create/preference/preference.go
+++ b/pkg/virtctl/create/preference/preference.go
@@ -1,0 +1,205 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package preference
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/create/params"
+)
+
+const (
+	Preference = "preference"
+
+	CPUTopologyFlag        = "cpu-topology"
+	VolumeStorageClassFlag = "volume-storage-class"
+	MachineTypeFlag        = "machine-type"
+	NameFlag               = "name"
+	NamespacedFlag         = "namespaced"
+	CPUTopologyErr         = "CPU topology must have a value of preferCores, preferSockets or preferThreads"
+
+	stringPreferCores   = string(instancetypev1alpha2.PreferCores)
+	stringPreferSockets = string(instancetypev1alpha2.PreferSockets)
+	stringPreferThreads = string(instancetypev1alpha2.PreferThreads)
+)
+
+type createPreference struct {
+	name                  string
+	namespaced            bool
+	CPUTopology           string
+	machineType           string
+	preferredStorageClass string
+}
+
+type optionFn func(*createPreference, *instancetypev1alpha2.VirtualMachinePreferenceSpec) error
+
+var optFns = map[string]optionFn{
+	VolumeStorageClassFlag: withVolumeStorageClass,
+	MachineTypeFlag:        withMachineType,
+	CPUTopologyFlag:        withCPUTopology,
+}
+
+func NewCommand() *cobra.Command {
+	c := createPreference{}
+	cmd := &cobra.Command{
+		Use:     Preference,
+		Short:   "Create a VirtualMachinePreference or VirtualMachineClusterPreference manifest.",
+		Example: c.usage(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.run(cmd)
+		},
+	}
+	cmd.Flags().BoolVar(&c.namespaced, NamespacedFlag, c.namespaced, "Specify if VirtualMachinePreference should be created. By default VirtualMachineClusterPreference is created.")
+	cmd.Flags().StringVar(&c.name, NameFlag, c.name, "Specify the name of the Preference.")
+	cmd.Flags().StringVar(&c.preferredStorageClass, VolumeStorageClassFlag, c.preferredStorageClass, "Defines the preferred storage class")
+	cmd.Flags().StringVar(&c.machineType, MachineTypeFlag, c.machineType, "Defines the preferred machine type to use.")
+	cmd.Flags().StringVar(&c.CPUTopology, CPUTopologyFlag, c.CPUTopology, "Defines the preferred guest visible CPU topology.")
+
+	return cmd
+}
+
+func (c *createPreference) setDefaults(cmd *cobra.Command) {
+	if cmd.Flags().Changed(NameFlag) {
+		return
+	}
+
+	if c.namespaced {
+		c.name = "preference-" + rand.String(5)
+	} else {
+		c.name = "clusterpreference-" + rand.String(5)
+	}
+}
+
+func withVolumeStorageClass(c *createPreference, preferenceSpec *instancetypev1alpha2.VirtualMachinePreferenceSpec) error {
+	preferenceSpec.Volumes = &instancetypev1alpha2.VolumePreferences{
+		PreferredStorageClassName: c.preferredStorageClass,
+	}
+	return nil
+}
+
+func withMachineType(c *createPreference, preferenceSpec *instancetypev1alpha2.VirtualMachinePreferenceSpec) error {
+	preferenceSpec.Machine = &instancetypev1alpha2.MachinePreferences{
+		PreferredMachineType: c.machineType,
+	}
+	return nil
+}
+
+func withCPUTopology(c *createPreference, preferenceSpec *instancetypev1alpha2.VirtualMachinePreferenceSpec) error {
+	if c.CPUTopology != stringPreferCores &&
+		c.CPUTopology != stringPreferSockets &&
+		c.CPUTopology != stringPreferThreads {
+		return params.FlagErr(CPUTopologyFlag, CPUTopologyErr)
+	}
+
+	preferenceSpec.CPU = &instancetypev1alpha2.CPUPreferences{
+		PreferredCPUTopology: instancetypev1alpha2.PreferredCPUTopology(c.CPUTopology),
+	}
+	return nil
+}
+
+func (c *createPreference) usage() string {
+	return `  # Create a manifest for a ClusterPreference with a random name:
+  {{ProgramName}} create preference
+	
+  # Create a manifest for a ClusterPreference with a specified CPU topology:
+  {{ProgramName}} create preference --cpu preferSockets
+
+  # Create a manifest for a Preference with a specified CPU topology:
+  {{ProgramName}} create preference --cpu preferSockets --namespaced
+	
+  # Create a manifest for a ClusterPreference and use it to create a resource with kubectl
+  {{ProgramName}} create preference --volume hostpath-provisioner | kubectl create -f -`
+}
+
+func (c *createPreference) newClusterPreference() *instancetypev1alpha2.VirtualMachineClusterPreference {
+	return &instancetypev1alpha2.VirtualMachineClusterPreference{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachineClusterPreference",
+			APIVersion: instancetypev1alpha2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.name,
+		},
+	}
+}
+
+func (c *createPreference) newPreference() *instancetypev1alpha2.VirtualMachinePreference {
+	return &instancetypev1alpha2.VirtualMachinePreference{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachinePreference",
+			APIVersion: instancetypev1alpha2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.name,
+		},
+	}
+}
+
+func (c *createPreference) applyFlags(cmd *cobra.Command, preferenceSpec *instancetypev1alpha2.VirtualMachinePreferenceSpec) error {
+	for flag := range optFns {
+		if cmd.Flags().Changed(flag) {
+			if err := optFns[flag](c, preferenceSpec); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *createPreference) run(cmd *cobra.Command) error {
+	var out []byte
+	var err error
+
+	c.setDefaults(cmd)
+
+	if c.namespaced {
+		preference := c.newPreference()
+
+		if err = c.applyFlags(cmd, &preference.Spec); err != nil {
+			return err
+		}
+
+		out, err = yaml.Marshal(preference)
+		if err != nil {
+			return err
+		}
+	} else {
+		clusterPreference := c.newClusterPreference()
+
+		if err = c.applyFlags(cmd, &clusterPreference.Spec); err != nil {
+			return err
+		}
+
+		out, err = yaml.Marshal(clusterPreference)
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd.Print(string(out))
+
+	return nil
+}

--- a/pkg/virtctl/create/preference/preference_suite_test.go
+++ b/pkg/virtctl/create/preference/preference_suite_test.go
@@ -1,0 +1,11 @@
+package preference_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCreate(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/create/preference/preference_test.go
+++ b/pkg/virtctl/create/preference/preference_test.go
@@ -1,0 +1,130 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+package preference_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
+	generatedscheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
+
+	. "kubevirt.io/kubevirt/pkg/virtctl/create/preference"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+)
+
+const (
+	create     = "create"
+	namespaced = "--namespaced"
+)
+
+var _ = Describe("create", func() {
+	Context("preference without arguments", func() {
+		DescribeTable("should succeed", func(namespacedFlag string, namespaced bool) {
+			err := clientcmd.NewRepeatableVirtctlCommand(create, Preference, namespacedFlag)()
+			Expect(err).ToNot(HaveOccurred())
+		},
+			Entry("VirtualMachinePreference", namespaced, true),
+			Entry("VirtualMachineClusterPreference", "", false),
+		)
+	})
+
+	Context("preference with arguments", func() {
+		var preferenceSpec *instancetypev1alpha2.VirtualMachinePreferenceSpec
+
+		DescribeTable("should succeed with defined preferred storage class", func(namespacedFlag, PreferredstorageClass string, namespaced bool) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag,
+				setFlag(VolumeStorageClassFlag, PreferredstorageClass),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			preferenceSpec, err = getPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(preferenceSpec.Volumes.PreferredStorageClassName).To(Equal(PreferredstorageClass))
+		},
+			Entry("VirtualMachinePreference", namespaced, "testing-storage", true),
+			Entry("VirtualMachineClusterPreference", "", "hostpath-provisioner", false),
+		)
+
+		DescribeTable("should succeed with defined machine type", func(namespacedFlag, machineType string, namespaced bool) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag,
+				setFlag(MachineTypeFlag, machineType),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			preferenceSpec, err = getPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(preferenceSpec.Machine.PreferredMachineType).To(Equal(machineType))
+		},
+			Entry("VirtualMachinePreference", namespaced, "pc-i440fx-2.10", true),
+			Entry("VirtualMachineClusterPreference", "", "pc-q35-2.10", false),
+		)
+
+		DescribeTable("should succeed with defined CPU topology", func(namespacedFlag, CPUTopology string, namespaced bool) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag,
+				setFlag(CPUTopologyFlag, CPUTopology),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			preferenceSpec, err = getPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(preferenceSpec.CPU.PreferredCPUTopology).To(Equal(instancetypev1alpha2.PreferredCPUTopology(CPUTopology)))
+		},
+			Entry("VirtualMachinePreference", namespaced, "preferCores", true),
+			Entry("VirtualMachineClusterPreference", "", "preferThreads", false),
+		)
+
+		DescribeTable("should fail with invalid CPU topology values", func(namespacedFlag, CPUTopology string, namespaced bool) {
+			err := clientcmd.NewRepeatableVirtctlCommand(create, Preference, namespacedFlag,
+				setFlag(CPUTopologyFlag, CPUTopology),
+			)()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("failed to parse \"--cpu-topology\" flag: CPU topology must have a value of preferCores, preferSockets or preferThreads"))
+		},
+			Entry("VirtualMachinePreference", namespaced, "invalidCPU", true),
+			Entry("VirtualMachineClusterPreference", "", "clusterInvalidCPU", false),
+		)
+
+	})
+})
+
+func setFlag(flag, parameter string) string {
+	return fmt.Sprintf("--%s=%s", flag, parameter)
+}
+
+func getPreferenceSpec(bytes []byte, namespaced bool) (*instancetypev1alpha2.VirtualMachinePreferenceSpec, error) {
+	decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	switch obj := decodedObj.(type) {
+	case *instancetypev1alpha2.VirtualMachinePreference:
+		ExpectWithOffset(1, namespaced).To(BeTrue(), "expected VirtualMachinePreference to be created")
+		ExpectWithOffset(1, obj.Kind).To(Equal("VirtualMachinePreference"))
+		return &obj.Spec, nil
+	case *instancetypev1alpha2.VirtualMachineClusterPreference:
+		ExpectWithOffset(1, namespaced).To(BeFalse(), "expected VirtualMachineClusterPreference to be created")
+		ExpectWithOffset(1, obj.Kind).To(Equal("VirtualMachineClusterPreference"))
+		return &obj.Spec, nil
+	default:
+		return nil, fmt.Errorf("object must be VirtualMachinePreference or VirtualMachineClusterPreference")
+	}
+}

--- a/tests/virtctl/BUILD.bazel
+++ b/tests/virtctl/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "create_instancetype.go",
+        "create_preference.go",
         "create_vm.go",
         "scp.go",
         "ssh.go",
@@ -12,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virtctl/create/instancetype:go_default_library",
+        "//pkg/virtctl/create/preference:go_default_library",
         "//pkg/virtctl/create/vm:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",

--- a/tests/virtctl/create_preference.go
+++ b/tests/virtctl/create_preference.go
@@ -1,0 +1,107 @@
+package virtctl
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
+	generatedscheme "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/scheme"
+	"kubevirt.io/client-go/kubecli"
+
+	. "kubevirt.io/kubevirt/pkg/virtctl/create/preference"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = Describe("[sig-compute] create preference", decorators.SigCompute, func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	createPreferenceSpec := func(bytes []byte, namespaced bool) (*instancetypev1alpha2.VirtualMachinePreferenceSpec, error) {
+		decodedObj, err := runtime.Decode(generatedscheme.Codecs.UniversalDeserializer(), bytes)
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		switch obj := decodedObj.(type) {
+		case *instancetypev1alpha2.VirtualMachinePreference:
+			ExpectWithOffset(1, namespaced).To(BeTrue(), "expected VirtualMachinePreference to be created")
+			ExpectWithOffset(1, obj.Kind).To(Equal("VirtualMachinePreference"))
+			preference, err := virtClient.VirtualMachinePreference(util.NamespaceTestDefault).Create(context.Background(), (*instancetypev1alpha2.VirtualMachinePreference)(obj), metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			return &preference.Spec, nil
+		case *instancetypev1alpha2.VirtualMachineClusterPreference:
+			ExpectWithOffset(1, namespaced).To(BeFalse(), "expected VirtualMachineClusterPreference to be created")
+			ExpectWithOffset(1, obj.Kind).To(Equal("VirtualMachineClusterPreference"))
+			clusterPreference, err := virtClient.VirtualMachineClusterPreference().Create(context.Background(), (*instancetypev1alpha2.VirtualMachineClusterPreference)(obj), metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			return &clusterPreference.Spec, nil
+		default:
+			return nil, fmt.Errorf("object must be VirtualMachinePreference or VirtualMachineClusterPreference")
+		}
+	}
+
+	Context("should create valid preference manifest", func() {
+		DescribeTable("without arguments", func(namespacedFlag string, namespaced bool) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag)()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = createPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+		},
+			Entry("VirtualMachinePreference", namespaced, true),
+			Entry("VirtualMachineClusterPreference", "", false),
+		)
+
+		DescribeTable("when machine type defined", func(namespacedFlag, machineType string, namespaced bool) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag,
+				setFlag(MachineTypeFlag, machineType),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			preferenceSpec, err := createPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(preferenceSpec.Machine.PreferredMachineType).To(Equal(machineType))
+		},
+			Entry("VirtualMachinePreference", namespaced, "pc-i440fx-2.10", true),
+			Entry("VirtualMachineClusterPreference", "", "pc-q35-2.10", false),
+		)
+
+		DescribeTable("when preferred storageClass defined", func(namespacedFlag, PreferredStorageClass string, namespaced bool) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag,
+				setFlag(VolumeStorageClassFlag, PreferredStorageClass),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			preferenceSpec, err := createPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(preferenceSpec.Volumes.PreferredStorageClassName).To(Equal(PreferredStorageClass))
+		},
+			Entry("VirtualMachinePreference", namespaced, "hostpath-provisioner", true),
+			Entry("VirtualMachineClusterPreference", "", "local", false),
+		)
+
+		DescribeTable("when cpu topology defined", func(namespacedFlag, CPUTopology string, namespaced bool, topology instancetypev1alpha2.PreferredCPUTopology) {
+			bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(create, Preference, namespacedFlag,
+				setFlag(CPUTopologyFlag, CPUTopology),
+			)()
+			Expect(err).ToNot(HaveOccurred())
+
+			preferenceSpec, err := createPreferenceSpec(bytes, namespaced)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(preferenceSpec.CPU.PreferredCPUTopology).To(Equal(topology))
+		},
+			Entry("VirtualMachinePreference", namespaced, "preferCores", true, instancetypev1alpha2.PreferCores),
+			Entry("VirtualMachineClusterPreference", "", "preferThreads", false, instancetypev1alpha2.PreferThreads),
+		)
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds virtctl create preference command. This implementation does not cover all parameters that can be defined in a VirtualMachinePreference. Instead, it can be used as a starting point for users to streamline the creation of their own VirtualMachinePreference specifications.

**Special notes for your reviewer**:

**Release note**:
```
Add 'create preference' command to virtctl
```
