### PR TITLE
should set velero backup hook annotations when GuestAgent has connected

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1263,10 +1263,14 @@ func generatePodAnnotations(vmi *v1.VirtualMachineInstance) (map[string]string, 
 
 func UpdateVeleroBackupHookPodAnnotations(vmi *v1.VirtualMachineInstance, podAnnotations map[string]string) {
 	if !guestAgentConnected(vmi) {
-		podAnnotations[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
-		podAnnotations[VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = ""
-		podAnnotations[VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
-		podAnnotations[VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION] = ""
+		for _, key := range []string{
+			VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION,
+			VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION,
+			VELERO_POSTBACKUP_HOOK_CONTAINER_ANNOTATION,
+			VELERO_POSTBACKUP_HOOK_COMMAND_ANNOTATION,
+		} {
+			delete(podAnnotations, key)
+		}
 	} else {
 		podAnnotations[VELERO_PREBACKUP_HOOK_CONTAINER_ANNOTATION] = "compute"
 		podAnnotations[VELERO_PREBACKUP_HOOK_COMMAND_ANNOTATION] = fmt.Sprintf(

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -406,9 +406,9 @@ var _ = Describe("Template", func() {
 					"test":                                    "shouldBeInPod",
 					hooks.HookSidecarListAnnotationName:       `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
 					"pre.hook.backup.velero.io/container":     "compute",
-					"pre.hook.backup.velero.io/command":       "[\"/usr/bin/virt-freezer\", \"--freeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+					"pre.hook.backup.velero.io/command":       "",
 					"post.hook.backup.velero.io/container":    "compute",
-					"post.hook.backup.velero.io/command":      "[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", \"testvmi\", \"--namespace\", \"testns\"]",
+					"post.hook.backup.velero.io/command":      "",
 					"kubevirt.io/migrationTransportUnix":      "true",
 					"kubectl.kubernetes.io/default-container": "compute",
 				}))

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1214,6 +1214,16 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 				}
 			}
 		}
+
+		if pod.DeletionTimestamp == nil {
+			newAnnotations := pod.ObjectMeta.DeepCopy().Annotations
+			services.UpdateVeleroBackupHookPodAnnotations(vmi, newAnnotations)
+			patchedPod, err := c.syncPodAnnotations(pod, newAnnotations)
+			if err != nil {
+				return &syncErrorImpl{err, FailedPodPatchReason}
+			}
+			*pod = *patchedPod
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Set velero backup hook pod annotation only if GuestAgent has connected. 
It can avoid velero backup report failure if GuestOS does not connect GuestAgent.

**Which issue(s) this PR fixes**:
Fixes #9423

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
should set velero backup hook annotations when GuestAgent has connected
```
