### PR TITLE
launcher, nic hotplug: use recommended attach device func

### DIFF
--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -67,7 +67,7 @@ func hotplugVirtioInterface(vmi *v1.VirtualMachineInstance, converterContext *co
 			return err
 		}
 
-		if err := dom.AttachDevice(strings.ToLower(string(ifaceXML))); err != nil {
+		if err := dom.AttachDeviceFlags(strings.ToLower(string(ifaceXML)), affectLiveAndConfigLibvirtFlags); err != nil {
 			log.Log.Reason(err).Errorf("libvirt failed to attach interface %s: %v", network.Name, err)
 			return err
 		}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reading the libvirt documentation it is clearly stated the `AttachDeviceFlags` command is preferred to the `AttachedDevice` call - [0]:

> For compatibility, this method can also be used to change the media in an
existing CDROM/Floppy device, however, applications are recommended to use the virDomainUpdateDeviceFlags method instead.

[0] - https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainAttachDevice

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
