### PR TITLE
launcher: fix virtIONet prohibited func

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -36,7 +36,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 )
 
-func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext, virtioNetProhibited bool, ifacesToPlug ...v1.Interface) ([]api.Interface, error) {
+func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext, ifacesToPlug ...v1.Interface) ([]api.Interface, error) {
+	isVirtioNetProhibited, err := c.IsVirtIONetProhibited()
+	if err != nil {
+		return nil, err
+	}
+
 	var domainInterfaces []api.Interface
 
 	networks := indexNetworksByName(vmi.Spec.Networks)
@@ -64,7 +69,7 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 
 		// if AllowEmulation unset and at least one NIC model is virtio,
 		// /dev/vhost-net must be present as we should have asked for it.
-		if ifaceType == v1.VirtIO && virtioNetProhibited {
+		if ifaceType == v1.VirtIO && isVirtioNetProhibited {
 			return nil, fmt.Errorf("In-kernel virtio-net device emulation '/dev/vhost-net' not present")
 		}
 

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -46,7 +46,7 @@ func hotplugVirtioInterface(vmi *v1.VirtualMachineInstance, converterContext *co
 			return fmt.Errorf("could not find a matching interface for network: %s", network.Name)
 		}
 
-		domainInterfaces, err := converter.CreateDomainInterfaces(vmi, domain, converterContext, converter.IsVirtioNetProhibited(), ifaceToHotplug)
+		domainInterfaces, err := converter.CreateDomainInterfaces(vmi, domain, converterContext, ifaceToHotplug)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR exports the `isVirtIOProhibited` into a function.

It also changes the code to invoke this from within the `CreateDomainInterfaces` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
