### PR TITLE
Launcher nic hotplug unit tests

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -997,7 +997,9 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 	}
 
 	if vmi.IsRunning() {
-		if err := hotplugVirtioInterface(vmi, dom, &api.Domain{Spec: oldSpec}, domain); err != nil {
+		networkInterfaceManager := newVirtIOInterfaceManager(
+			dom, netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}))
+		if err := networkInterfaceManager.hotplugVirtioInterface(vmi, &api.Domain{Spec: oldSpec}, domain); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
launcher, nic hotplug: refactor allowing unit tests

This refactor allows us to unit test the virt-launcher part of the nic
hotplug  feature.

We introduce a simple mock of the `VMNetworkConfigurator` struct, via
which we can simulate failures; a mock of the libvirtClient is also
used, to control both success and failures of the `AttachDevice` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Inner refactor to increase unit test coverage.
/sig network
Depends-on: #9428 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
