### PR TITLE
Ensure node label values are not empty

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -177,5 +177,5 @@ func addNodeSelector(vmi *v1.VirtualMachineInstance, label string) {
 	if vmi.Spec.NodeSelector == nil {
 		vmi.Spec.NodeSelector = map[string]string{}
 	}
-	vmi.Spec.NodeSelector[label] = ""
+	vmi.Spec.NodeSelector[label] = "true"
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -1041,7 +1041,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Realtime: &v1.Realtime{}}
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).NotTo(BeNil())
-		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.RealtimeLabel: ""}))
+		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.RealtimeLabel: "true"}))
 	})
 	It("should not add realtime node label selector when no realtime workload", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Realtime: nil}
@@ -1053,14 +1053,14 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Realtime: &v1.Realtime{}}
 		vmi.Spec.NodeSelector = map[string]string{v1.NodeSchedulable: "true"}
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
-		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true", v1.RealtimeLabel: ""}))
+		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true", v1.RealtimeLabel: "true"}))
 	})
 
 	It("should add SEV node label selector with SEV workload", func() {
 		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{SEV: &v1.SEV{}}
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.NodeSelector).NotTo(BeNil())
-		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.SEVLabel: ""}))
+		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.SEVLabel: "true"}))
 	})
 
 	It("should not add SEV node label selector when no SEV workload", func() {
@@ -1074,6 +1074,6 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmi.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{SEV: &v1.SEV{}}
 		vmi.Spec.NodeSelector = map[string]string{v1.NodeSchedulable: "true"}
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
-		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true", v1.SEVLabel: ""}))
+		Expect(vmiSpec.NodeSelector).To(BeEquivalentTo(map[string]string{v1.NodeSchedulable: "true", v1.SEVLabel: "true"}))
 	})
 })

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -311,11 +311,11 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatu
 		n.logger.Reason(err).Error("failed to identify if a node is capable of running realtime workloads")
 	}
 	if capable {
-		newLabels[kubevirtv1.RealtimeLabel] = ""
+		newLabels[kubevirtv1.RealtimeLabel] = "true"
 	}
 
 	if n.SEV.Supported == "yes" {
-		newLabels[kubevirtv1.SEVLabel] = ""
+		newLabels[kubevirtv1.SEVLabel] = "true"
 	}
 
 	return newLabels

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -33,10 +33,8 @@ func IsCPUManagerPresent(node *v1.Node) bool {
 
 func IsRealtimeCapable(node *v1.Node) bool {
 	gomega.Expect(node).ToNot(gomega.BeNil())
-	for label, _ := range node.Labels {
-		if label == v12.RealtimeLabel {
-			return true
-		}
+	if val, ok := node.Labels[v12.RealtimeLabel]; ok && val == "true" {
+		return true
 	}
 	return false
 }
@@ -67,10 +65,8 @@ func HasFeature(feature string) bool {
 
 func IsSEVCapable(node *v1.Node) bool {
 	gomega.Expect(node).ToNot(gomega.BeNil())
-	for label, _ := range node.Labels {
-		if label == v12.SEVLabel {
-			return true
-		}
+	if val, ok := node.Labels[v12.SEVLabel]; ok && val == "true" {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Both the SEV and cpu realtime node labels were using empty values, they now set their label value to true when applicable
This makes it more clear when reading a node's description and aligns these two labels with the rest of the node labels

**Special notes for your reviewer**: Blocks #7742 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
