### PR TITLE
VMExport test: don't expect `kill 1` to succeed without error

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -781,8 +781,7 @@ var _ = SIGDescribe("Export", func() {
 			"-c",
 			"kill 1",
 		}
-		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, exporterPod, exporterPod.Spec.Containers[0].Name, command)
-		Expect(err).ToNot(HaveOccurred(), "out[%s], err[%s]", out, stderr)
+		_, _, _ = exec.ExecuteCommandOnPodWithResults(virtClient, exporterPod, exporterPod.Spec.Containers[0].Name, command)
 		By("Verifying the pod is killed and a new secret created")
 		Eventually(func() types.UID {
 			exporterPod = getExporterPod(vmExport)


### PR DESCRIPTION
Sometimes, the kernel kills the initial process and its children (such as the kill process) before the kill process returns, and it exits with error code 137 (processed SIGKILL'd).

Don't fail the test over this.

**What this PR does / why we need it**:
Motivated by this test flaking, for example [here](https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9376/pull-kubevirt-e2e-k8s-1.26-sig-storage/1632764098540212224).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
