### PR TITLE
Check for PVC and DataVolume existence in a central place

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -183,6 +183,7 @@ func NewVMIController(templateService services.TemplateService,
 	})
 
 	c.pvcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addPVC,
 		UpdateFunc: c.updatePVC,
 	})
 
@@ -192,6 +193,10 @@ func NewVMIController(templateService services.TemplateService,
 type syncError interface {
 	error
 	Reason() string
+	// RequiresRequeue indicates if the sync error should trigger a requeue, or
+	// if information should just be added to the sync condition and a regular controller
+	// wakeup will resolve the situation.
+	RequiresRequeue() bool
 }
 
 type syncErrorImpl struct {
@@ -205,6 +210,27 @@ func (e *syncErrorImpl) Error() string {
 
 func (e *syncErrorImpl) Reason() string {
 	return e.reason
+}
+
+func (e *syncErrorImpl) RequiresRequeue() bool {
+	return true
+}
+
+type informalSyncError struct {
+	err    error
+	reason string
+}
+
+func (i informalSyncError) Error() string {
+	return i.err.Error()
+}
+
+func (i informalSyncError) Reason() string {
+	return i.reason
+}
+
+func (i informalSyncError) RequiresRequeue() bool {
+	return false
 }
 
 type VMIController struct {
@@ -345,7 +371,7 @@ func (c *VMIController) execute(key string) error {
 		return err
 	}
 
-	if syncErr != nil {
+	if syncErr != nil && syncErr.RequiresRequeue() {
 		return syncErr
 	}
 
@@ -1144,7 +1170,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		}
 		if _, ok := err.(storagetypes.PvcNotFoundError); ok {
 			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedPvcNotFoundReason, failedToRenderLaunchManifestErrFormat, err)
-			return &syncErrorImpl{fmt.Errorf(failedToRenderLaunchManifestErrFormat, err), FailedPvcNotFoundReason}
+			return &informalSyncError{fmt.Errorf(failedToRenderLaunchManifestErrFormat, err), FailedPvcNotFoundReason}
 		} else if err != nil {
 			return &syncErrorImpl{fmt.Errorf(failedToRenderLaunchManifestErrFormat, err), FailedCreatePodReason}
 		}
@@ -1232,7 +1258,7 @@ func (c *VMIController) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance
 					// due to the eventually consistent nature of controllers, CDI or users may need some time to actually crate the PVC.
 					// We wait for them to appear.
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedPvcNotFoundReason, "PVC %s/%s does not exist, waiting for it to appear", vmi.Namespace, storagetypes.PVCNameFromVirtVolume(&volume))
-					return false, false, &syncErrorImpl{err: fmt.Errorf("PVC %s/%s does not exist, waiting for it to appear", vmi.Namespace, storagetypes.PVCNameFromVirtVolume(&volume)), reason: FailedPvcNotFoundReason}
+					return false, false, &informalSyncError{err: fmt.Errorf("PVC %s/%s does not exist, waiting for it to appear", vmi.Namespace, storagetypes.PVCNameFromVirtVolume(&volume)), reason: FailedPvcNotFoundReason}
 				} else {
 					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedPvcNotFoundReason, "Error determining if volume is ready: %v", err)
 					return false, false, &syncErrorImpl{err: fmt.Errorf("Error determining if volume is ready %v", err), reason: FailedDataVolumeImportReason}
@@ -1245,6 +1271,22 @@ func (c *VMIController) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance
 	}
 
 	return ready, wffc, nil
+}
+
+func (c *VMIController) addPVC(obj interface{}) {
+	pvc := obj.(*k8sv1.PersistentVolumeClaim)
+	if pvc.DeletionTimestamp != nil {
+		return
+	}
+
+	vmis, err := c.listVMIsMatchingDV(pvc.Namespace, pvc.Name)
+	if err != nil {
+		return
+	}
+	for _, vmi := range vmis {
+		log.Log.V(4).Object(pvc).Infof("PVC created for vmi %s", vmi.Name)
+		c.enqueueVirtualMachine(vmi)
+	}
 }
 
 func (c *VMIController) updatePVC(old, cur interface{}) {
@@ -1292,6 +1334,7 @@ func (c *VMIController) addDataVolume(obj interface{}) {
 		c.enqueueVirtualMachine(vmi)
 	}
 }
+
 func (c *VMIController) updateDataVolume(old, cur interface{}) {
 	curDataVolume := cur.(*cdiv1.DataVolume)
 	oldDataVolume := old.(*cdiv1.DataVolume)

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1059,7 +1059,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 				controller.Execute()
 				Expect(controller.Queue.Len()).To(Equal(0))
-				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(1))
+				// When the PVC appears, we will automatically be retriggered, it is not an error condition
+				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(BeZero())
+				addVirtualMachine(vmi)
 
 				// make sure that during next iteration we do not add the same condition again
 				vmiInterface.EXPECT().Update(context.Background(), gomock.Any()).Do(func(ctx context.Context, vmi *virtv1.VirtualMachineInstance) {
@@ -1068,7 +1070,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 				controller.Execute()
 				Expect(controller.Queue.Len()).To(Equal(0))
-				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(2))
+				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(BeZero())
 			},
 			Entry("when PVC does not exist", FailedPvcNotFoundReason,
 				virtv1.VolumeSource{

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1009,7 +1009,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 		})
-		DescribeTable("should create PodScheduled and Synchronized conditions exactly once each for repeated FailedPvcNotFoundReason sync errors",
+		DescribeTable("should never proceed to creating the launcher pod if not all PVCs are there to determine if they are WFFC and/or an import is done",
 			func(syncReason string, volumeSource virtv1.VolumeSource) {
 
 				expectConditions := func(vmi *virtv1.VirtualMachineInstance) {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1168,7 +1168,7 @@ var _ = SIGDescribe("Storage", func() {
 									WithTransform(getType, Equal(string(k8sv1.PodScheduled))),
 									WithTransform(getReason, Equal(k8sv1.PodReasonUnschedulable)),
 									WithTransform(getStatus, Equal(k8sv1.ConditionFalse)),
-									WithTransform(getMessage, Equal(fmt.Sprintf("failed to render launch manifest: didn't find PVC %v", pvcName))),
+									WithTransform(getMessage, Equal(fmt.Sprintf("PVC %v/%v does not exist, waiting for it to appear", vmi.Namespace, pvcName))),
 								),
 							),
 						)


### PR DESCRIPTION
Only proceed to template rendering when all PVCs are present.  The template renderer also checks for PVC existence, but if the PVC appeared between the check and the template rendering, the limited render-check will miss subtleties like checking if the PVC belongs to a DV and an import needs to be finished before creating the launcher pod.

This fixes a race, where sometimes a launcher pod for a VMI could already be created while the DV was in the middle of creating the PVC and importing.

As a consequence the VMI controller thinks that the import is already done and will just proceed with the VM start, which leads to a broken import and a failing VMI start.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Ensure existence of all PVCs attached to the VMI before creating the VM target pod.
```
