### PR TITLE
instancetype: Handle DataVolumeSourceRef without namespace when inferring defaults

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -654,6 +654,10 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should infer defaults from DataVolume, DataVolumeSourceRef", func(sourceRefName, sourceRefKind, sourceRefNamespace string, instancetypeMatcher, expectedInstancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher, expectedPreferenceMatcher *v1.PreferenceMatcher) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
+			var sourceRefNamespacePointer *string
+			if sourceRefNamespace != "" {
+				sourceRefNamespacePointer = &sourceRefNamespace
+			}
 			dvWithSourceRef := &v1beta1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
@@ -663,7 +667,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 					SourceRef: &v1beta1.DataVolumeSourceRef{
 						Name:      sourceRefName,
 						Kind:      sourceRefKind,
-						Namespace: &sourceRefNamespace,
+						Namespace: sourceRefNamespacePointer,
 					},
 				},
 			}
@@ -716,6 +720,48 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			),
 			Entry("and DataSource with annotations for PreferenceMatcher",
 				dsWithAnnotationsName, "DataSource", k8sv1.NamespaceDefault,
+				nil, nil,
+				&v1.PreferenceMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.PreferenceMatcher{
+					Name: defaultInferedNameFromDS,
+					Kind: defaultInferedKindFromDS,
+				},
+			),
+			Entry(",DataSource without namespace and PersistentVolumeClaim for InstancetypeMatcher",
+				dsWithSourcePVCName, "DataSource", "",
+				&v1.InstancetypeMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.InstancetypeMatcher{
+					Name: defaultInferedNameFromPVC,
+					Kind: defaultInferedKindFromPVC,
+				}, nil, nil,
+			),
+			Entry(",DataSource without namespace and PersistentVolumeClaim for PreferenceMatcher",
+				dsWithSourcePVCName, "DataSource", "",
+				nil, nil,
+				&v1.PreferenceMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.PreferenceMatcher{
+					Name: defaultInferedNameFromPVC,
+					Kind: defaultInferedKindFromPVC,
+				},
+			),
+			Entry("and DataSource without namespace with annotations for InstancetypeMatcher",
+				dsWithAnnotationsName, "DataSource", "",
+				&v1.InstancetypeMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.InstancetypeMatcher{
+					Name: defaultInferedNameFromDS,
+					Kind: defaultInferedKindFromDS,
+				}, nil, nil,
+			),
+			Entry("and DataSource without namespace with annotations for PreferenceMatcher",
+				dsWithAnnotationsName, "DataSource", "",
 				nil, nil,
 				&v1.PreferenceMatcher{
 					InferFromVolume: inferVolumeName,

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -892,6 +892,44 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 				},
 			),
+			Entry(", DataVolumeSourceRef without namespace and DataSource",
+				&cdiv1beta1.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datavolume-",
+						Namespace:    util.NamespaceTestDefault,
+					},
+					Spec: cdiv1beta1.DataVolumeSpec{
+						SourceRef: &cdiv1beta1.DataVolumeSourceRef{
+							Name:      dataSourceName,
+							Kind:      "DataSource",
+							Namespace: nil,
+						},
+						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
+						Storage: &cdiv1beta1.StorageSpec{
+							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+							Resources: k8sv1.ResourceRequirements{
+								Requests: k8sv1.ResourceList{
+									"storage": resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+				&cdiv1beta1.DataSource{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datasource-",
+						Namespace:    util.NamespaceTestDefault,
+					},
+					Spec: cdiv1beta1.DataSourceSpec{
+						Source: cdiv1beta1.DataSourceSource{
+							PVC: &cdiv1beta1.DataVolumeSourcePVC{
+								Name:      pvcSourceName,
+								Namespace: util.NamespaceTestDefault,
+							},
+						},
+					},
+				},
+			),
 			Entry(", DataVolumeSourceRef and DataSource with annotations",
 				&cdiv1beta1.DataVolume{
 					ObjectMeta: metav1.ObjectMeta{
@@ -903,6 +941,50 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Name:      dataSourceName,
 							Kind:      "DataSource",
 							Namespace: &util.NamespaceTestDefault,
+						},
+						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
+						Storage: &cdiv1beta1.StorageSpec{
+							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+							Resources: k8sv1.ResourceRequirements{
+								Requests: k8sv1.ResourceList{
+									"storage": resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+				&cdiv1beta1.DataSource{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datasource-",
+						Namespace:    util.NamespaceTestDefault,
+						Annotations: map[string]string{
+							instancetypeapi.DefaultInstancetypeLabel:     instancetypeName,
+							instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
+							instancetypeapi.DefaultPreferenceLabel:       preferenceName,
+							instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
+						},
+					},
+					Spec: cdiv1beta1.DataSourceSpec{
+						Source: cdiv1beta1.DataSourceSource{
+							PVC: &cdiv1beta1.DataVolumeSourcePVC{
+								Name:      pvcSourceName,
+								Namespace: util.NamespaceTestDefault,
+							},
+						},
+					},
+				},
+			),
+			Entry(", DataVolumeSourceRef without namespace and DataSource with annotations",
+				&cdiv1beta1.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datavolume-",
+						Namespace:    util.NamespaceTestDefault,
+					},
+					Spec: cdiv1beta1.DataVolumeSpec{
+						SourceRef: &cdiv1beta1.DataVolumeSourceRef{
+							Name:      dataSourceName,
+							Kind:      "DataSource",
+							Namespace: nil,
 						},
 						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
 						Storage: &cdiv1beta1.StorageSpec{


### PR DESCRIPTION
/area instancetype
/cc @0xFelix 

**What this PR does / why we need it**:

As set out in issue #9431 it is valid for a DataVolumeSourceRef to not provide a namespace, the assumption being that the resource it points to is in the same namespace as the VirtualMachine.

This change handles this by switching to the namespace of the VirtualMachine when no namespace is provided by the DataVolumeSourceRef, avoiding a previous panic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9431

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
