### PR TITLE
network, api: Replace `podConfigDone` field with `infoSource`

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19016,7 +19016,7 @@
     "type": "object",
     "properties": {
      "infoSource": {
-      "description": "Specifies the origin of the interface data collected. values: domain, guest-agent, or both",
+      "description": "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
       "type": "string"
      },
      "interfaceName": {
@@ -19041,10 +19041,6 @@
      "name": {
       "description": "Name of the interface, corresponds to name of the network assigned to the interface",
       "type": "string"
-     },
-     "podConfigDone": {
-      "description": "PodConfigDone specifies if the corresponding pod interface is properly configured by CNI",
-      "type": "boolean"
      },
      "queueCount": {
       "description": "Specifies how many queues are allocated by MultiQueue",

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -110,8 +110,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -135,7 +135,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, int32(queueCount)),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, "", "", netvmispec.InfoSourceDomain, int32(queueCount)),
 			}), "queue count and the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -167,8 +167,51 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secondaryNetworkName, []string{secondaryGaIPv4, secondaryGaIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, []string{secondaryGaIPv4, secondaryGaIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+			}), "the guest-agent IP/s should be reported in the status")
+
+			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
+			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, secondaryNetworkName)).To(BeTrue())
+		})
+
+		It("run status and expect 2 interfaces to be reported based on multus status and guest-agent data", func() {
+			Expect(
+				setup.addNetworkInterface(
+					newVMISpecIfaceWithBridgeBinding(primaryNetworkName),
+					newVMISpecPodNetwork(primaryNetworkName),
+					newDomainSpecIface(primaryNetworkName, primaryMAC),
+					primaryPodIPv4, primaryPodIPv6,
+				),
+			).To(Succeed())
+			Expect(
+				setup.addNetworkInterface(
+					newVMISpecIfaceWithBridgeBinding(secondaryNetworkName),
+					newVMISpecMultusNetwork(secondaryNetworkName),
+					newDomainSpecIface(secondaryNetworkName, secondaryMAC),
+					secondaryPodIPv4, secondaryPodIPv6,
+				),
+			).To(Succeed())
+
+			setup.addGuestAgentInterfaces(
+				newDomainStatusIface([]string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName),
+				newDomainStatusIface([]string{secondaryGaIPv4, secondaryGaIPv6}, secondaryMAC, secondaryIfaceName),
+			)
+
+			setup.Vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
+				{Name: primaryNetworkName, InfoSource: netvmispec.InfoSourceMultusStatus},
+				{Name: secondaryNetworkName, InfoSource: netvmispec.InfoSourceMultusStatus},
+				// Interfaces that exist in the status but are not detected from the domain or GA are dropped.
+				{Name: "foo", InfoSource: netvmispec.InfoSourceMultusStatus},
+			}
+
+			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+			infoSourceDomainGAMultus := netvmispec.NewInfoSource(
+				netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
+			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
+				newVMIStatusIface(primaryNetworkName, []string{primaryGaIPv4, primaryGaIPv6}, primaryMAC, primaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, []string{secondaryGaIPv4, secondaryGaIPv6}, secondaryMAC, secondaryIfaceName, infoSourceDomainGAMultus, netsetup.DefaultInterfaceQueueCount),
 			}), "the guest-agent IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -199,7 +242,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "eth0", netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "eth0", netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
@@ -232,7 +275,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, newDomainMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, newDomainMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}), "the pod IP/s should be reported in the status")
 		})
 
@@ -298,7 +341,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusReadyIface(primaryNetworkName, []string{newGaIPv4, newGaIPv6}, origMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+			newVMIStatusIface(primaryNetworkName, []string{newGaIPv4, newGaIPv6}, origMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 		}), "the pod IP/s should be reported in the status")
 	})
 
@@ -319,7 +362,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusReadyIface(networkName, nil, ifaceMAC, "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
+			newVMIStatusIface(networkName, nil, ifaceMAC, "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
 		}), "the SR-IOV interface should be reported in the status.")
 	})
 
@@ -348,8 +391,8 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-			newVMIStatusReadyIface(networkName, nil, "", "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
+			newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4}, "", "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+			newVMIStatusIface(networkName, nil, "", "", netvmispec.InfoSourceDomain, netsetup.UnknownInterfaceQueueCount),
 		}), "the SR-IOV interface should be reported in the status.")
 	})
 
@@ -373,7 +416,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			newVMIStatusReadyIface(networkName, nil, ifaceMAC, guestIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.UnknownInterfaceQueueCount),
+			newVMIStatusIface(networkName, nil, ifaceMAC, guestIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.UnknownInterfaceQueueCount),
 		}), "the SR-IOV interface should be reported in the status, associated to the network")
 	})
 
@@ -426,8 +469,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secondaryNetworkName, nil, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, nil, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 				newVMIStatusIface("", []string{primaryGaIPv4, primaryGaIPv6}, newMAC1, primaryIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
 				newVMIStatusIface("", []string{secondaryGaIPv4, secondaryGaIPv6}, newMAC2, secondaryIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
 			}))
@@ -447,8 +490,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, secondaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 				newVMIStatusIface("", []string{newGaIPv4, newGaIPv6}, newMAC1, newIfaceName, netvmispec.InfoSourceGuestAgent, netsetup.UnknownInterfaceQueueCount),
 			}))
 		})
@@ -457,8 +500,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(ConsistOf([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryPodIPv4, primaryPodIPv6}, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secondaryNetworkName, []string{secondaryPodIPv4, secondaryPodIPv6}, secondaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 	})
@@ -490,7 +533,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, nil, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, nil, primaryMAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 
@@ -513,7 +556,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(primaryNetworkName, []string{primaryGaIPv4}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(primaryNetworkName, []string{primaryGaIPv4}, primaryMAC, primaryIfaceName, netvmispec.InfoSourceDomainAndGA, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 	})
@@ -570,9 +613,9 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(prNetworkName, []string{podIP}, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secNetworkName1, []string{podIP}, MAC1, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
-				newVMIStatusReadyIface(secNetworkName2, []string{podIP}, MAC2, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(prNetworkName, []string{podIP}, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secNetworkName1, []string{podIP}, MAC1, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(secNetworkName2, []string{podIP}, MAC2, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		},
 			Entry("primary interface defined first in spec", []int{PRIMARY_IFACE_IND, SECONDARY_IFACE1_IND, SECONDARY_IFACE2_IND}),
@@ -593,7 +636,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(networkName, nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(networkName, nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 
@@ -614,7 +657,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
 
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-				newVMIStatusReadyIface(networkName, nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
+				newVMIStatusIface(networkName, nil, MAC, "", netvmispec.InfoSourceDomain, netsetup.DefaultInterfaceQueueCount),
 			}))
 		})
 
@@ -819,10 +862,4 @@ func newVMISpecMultusNetwork(name string) v1.Network {
 				NetworkName: "test.network",
 			}},
 	}
-}
-
-func newVMIStatusReadyIface(name string, IPs []string, mac, ifaceName string, infoSource string, queueCount int32) v1.VirtualMachineInstanceNetworkInterface {
-	vmiIfaceStatus := newVMIStatusIface(name, IPs, mac, ifaceName, infoSource, queueCount)
-	vmiIfaceStatus.PodConfigDone = true
-	return vmiIfaceStatus
 }

--- a/pkg/network/vmispec/BUILD.bazel
+++ b/pkg/network/vmispec/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "hotplug.go",
+        "infosource.go",
         "interface.go",
         "network.go",
     ],
@@ -16,6 +17,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "hotplug_test.go",
+        "infosource_test.go",
         "interface_test.go",
         "network_test.go",
         "vmispec_suite_test.go",

--- a/pkg/network/vmispec/hotplug.go
+++ b/pkg/network/vmispec/hotplug.go
@@ -27,7 +27,7 @@ import (
 
 func NetworksToHotplug(networks []v1.Network, interfaceStatus []v1.VirtualMachineInstanceNetworkInterface) []v1.Network {
 	var networksToHotplug []v1.Network
-	indexedIfacesFromStatus := indexedInterfacesFromStatus(
+	indexedIfacesFromStatus := IndexInterfacesFromStatus(
 		interfaceStatus,
 		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
 			return true
@@ -41,7 +41,7 @@ func NetworksToHotplug(networks []v1.Network, interfaceStatus []v1.VirtualMachin
 	return networksToHotplug
 }
 
-func indexedInterfacesFromStatus(interfaces []v1.VirtualMachineInstanceNetworkInterface, p func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool) map[string]v1.VirtualMachineInstanceNetworkInterface {
+func IndexInterfacesFromStatus(interfaces []v1.VirtualMachineInstanceNetworkInterface, p func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool) map[string]v1.VirtualMachineInstanceNetworkInterface {
 	indexedInterfaceStatus := map[string]v1.VirtualMachineInstanceNetworkInterface{}
 	for _, iface := range interfaces {
 		if p(iface) {
@@ -53,12 +53,11 @@ func indexedInterfacesFromStatus(interfaces []v1.VirtualMachineInstanceNetworkIn
 
 func NetworksToHotplugWhosePodIfacesAreReady(vmi *v1.VirtualMachineInstance) []v1.Network {
 	var networksToHotplug []v1.Network
-	interfacesToHoplug := indexedInterfacesFromStatus(
+	interfacesToHoplug := IndexInterfacesFromStatus(
 		vmi.Status.Interfaces,
 		func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool {
-			return ifaceStatus.PodConfigDone && !strings.Contains(
-				ifaceStatus.InfoSource, InfoSourceDomain,
-			)
+			return strings.Contains(ifaceStatus.InfoSource, InfoSourceMultusStatus) &&
+				!strings.Contains(ifaceStatus.InfoSource, InfoSourceDomain)
 		},
 	)
 

--- a/pkg/network/vmispec/hotplug_test.go
+++ b/pkg/network/vmispec/hotplug_test.go
@@ -152,7 +152,7 @@ func dummyVMIWithMultipleNetworksAndIfacesOnSpec(networkName string, nadName str
 func dummyVMIWithAttachmentToPlug(networkName string, netAttachDefName string, guestIfaceName string) *v1.VirtualMachineInstance {
 	vmi := dummyVMIWithoutStatus(networkName, netAttachDefName)
 	vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-		{Name: networkName, InterfaceName: guestIfaceName, PodConfigDone: true},
+		{Name: networkName, InterfaceName: guestIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
 	}
 	return vmi
 }
@@ -160,7 +160,7 @@ func dummyVMIWithAttachmentToPlug(networkName string, netAttachDefName string, g
 func dummyVMIWithAttachmentAlreadyAvailableOnDomain(networkName string, netAttachDefName string, guestIfaceName string) *v1.VirtualMachineInstance {
 	vmi := dummyVMIWithAttachmentToPlug(networkName, netAttachDefName, guestIfaceName)
 	for i := range vmi.Status.Interfaces {
-		vmi.Status.Interfaces[i].InfoSource = vmispec.InfoSourceDomain
+		vmi.Status.Interfaces[i].InfoSource = vmispec.NewInfoSource(vmispec.InfoSourceDomain, vmispec.InfoSourceMultusStatus)
 	}
 	return vmi
 }
@@ -171,7 +171,7 @@ func dummyVMIWithStatusOnly(networkName string, ifaceName string) *v1.VirtualMac
 		{
 			Name:          networkName,
 			InterfaceName: ifaceName,
-			PodConfigDone: true,
+			InfoSource:    vmispec.InfoSourceMultusStatus,
 		},
 	}
 	return vmi

--- a/pkg/network/vmispec/infosource.go
+++ b/pkg/network/vmispec/infosource.go
@@ -1,0 +1,40 @@
+package vmispec
+
+import "strings"
+
+const (
+	InfoSourceDomain       string = "domain"
+	InfoSourceGuestAgent   string = "guest-agent"
+	InfoSourceMultusStatus string = "multus-status"
+	InfoSourceDomainAndGA  string = InfoSourceDomain + ", " + InfoSourceGuestAgent
+
+	seperator = ", "
+)
+
+func AddInfoSource(infoSourceData, name string) string {
+	var infoSources []string
+	if infoSourceData != "" {
+		infoSources = strings.Split(infoSourceData, seperator)
+	}
+	for _, infoSourceName := range infoSources {
+		if infoSourceName == name {
+			return infoSourceData
+		}
+	}
+	infoSources = append(infoSources, name)
+	return NewInfoSource(infoSources...)
+}
+
+func ContainsInfoSource(infoSourceData, name string) bool {
+	infoSources := strings.Split(infoSourceData, seperator)
+	for _, infoSourceName := range infoSources {
+		if infoSourceName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func NewInfoSource(names ...string) string {
+	return strings.Join(names, seperator)
+}

--- a/pkg/network/vmispec/infosource_test.go
+++ b/pkg/network/vmispec/infosource_test.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package vmispec_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+)
+
+const (
+	emptySourceInfo = ""
+)
+
+var _ = Describe("infoSource", func() {
+	DescribeTable("can add an infoSource entry",
+		func(infoSourceData, infoSourceItem, expectedInfoSourceData string) {
+			Expect(vmispec.AddInfoSource(infoSourceData, infoSourceItem)).To(Equal(expectedInfoSourceData))
+		},
+		Entry("given no infoSource entries",
+			emptySourceInfo, vmispec.InfoSourceDomain, vmispec.InfoSourceDomain),
+		Entry("given one infoSource entry",
+			"domain", "guest-agent", "domain, guest-agent"),
+		Entry("given two infoSource entries",
+			"domain, guest-agent", "multus-status", "domain, guest-agent, multus-status"),
+		Entry("given an already existing infoSource entry",
+			"domain, guest-agent, multus-status", "multus-status", "domain, guest-agent, multus-status"),
+	)
+})

--- a/pkg/network/vmispec/interface.go
+++ b/pkg/network/vmispec/interface.go
@@ -23,12 +23,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
-const (
-	InfoSourceDomain      string = "domain"
-	InfoSourceGuestAgent  string = "guest-agent"
-	InfoSourceDomainAndGA string = InfoSourceDomain + ", " + InfoSourceGuestAgent
-)
-
 func FilterSRIOVInterfaces(ifaces []v1.Interface) []v1.Interface {
 	var sriovIfaces []v1.Interface
 	for _, iface := range ifaces {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3576,12 +3576,10 @@ func simpleIfaceStatus(ifaceName string) *virtv1.VirtualMachineInstanceNetworkIn
 	}
 }
 
-func readyHotpluggedIfaceStatus(
-	ifaceName string,
-) *virtv1.VirtualMachineInstanceNetworkInterface {
+func readyHotpluggedIfaceStatus(ifaceName string) *virtv1.VirtualMachineInstanceNetworkInterface {
 	return &virtv1.VirtualMachineInstanceNetworkInterface{
-		Name:          ifaceName,
-		PodConfigDone: true,
+		Name:       ifaceName,
+		InfoSource: vmispec.InfoSourceMultusStatus,
 	}
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -10970,7 +10970,7 @@ var CRDsValidation map[string]string = map[string]string{
             properties:
               infoSource:
                 description: 'Specifies the origin of the interface data collected.
-                  values: domain, guest-agent, or both'
+                  values: domain, guest-agent, multus-status.'
                 type: string
               interfaceName:
                 description: The interface name inside the Virtual Machine
@@ -10991,10 +10991,6 @@ var CRDsValidation map[string]string = map[string]string{
                 description: Name of the interface, corresponds to name of the network
                   assigned to the interface
                 type: string
-              podConfigDone:
-                description: PodConfigDone specifies if the corresponding pod interface
-                  is properly configured by CNI
-                type: boolean
               queueCount:
                 description: Specifies how many queues are allocated by MultiQueue
                 format: int32

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -570,12 +570,10 @@ type VirtualMachineInstanceNetworkInterface struct {
 	IPs []string `json:"ipAddresses,omitempty"`
 	// The interface name inside the Virtual Machine
 	InterfaceName string `json:"interfaceName,omitempty"`
-	// Specifies the origin of the interface data collected. values: domain, guest-agent, or both
+	// Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.
 	InfoSource string `json:"infoSource,omitempty"`
 	// Specifies how many queues are allocated by MultiQueue
 	QueueCount int32 `json:"queueCount,omitempty"`
-	// PodConfigDone specifies if the corresponding pod interface is properly configured by CNI
-	PodConfigDone bool `json:"podConfigDone,omitempty"`
 }
 
 type VirtualMachineInstanceGuestOSInfo struct {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -146,9 +146,8 @@ func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 		"name":          "Name of the interface, corresponds to name of the network assigned to the interface",
 		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface",
 		"interfaceName": "The interface name inside the Virtual Machine",
-		"infoSource":    "Specifies the origin of the interface data collected. values: domain, guest-agent, or both",
+		"infoSource":    "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
 		"queueCount":    "Specifies how many queues are allocated by MultiQueue",
-		"podConfigDone": "PodConfigDone specifies if the corresponding pod interface is properly configured by CNI",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21498,7 +21498,7 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceNetworkInterface(ref co
 					},
 					"infoSource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specifies the origin of the interface data collected. values: domain, guest-agent, or both",
+							Description: "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -21508,13 +21508,6 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceNetworkInterface(ref co
 							Description: "Specifies how many queues are allocated by MultiQueue",
 							Type:        []string{"integer"},
 							Format:      "int32",
-						},
-					},
-					"podConfigDone": {
-						SchemaProps: spec.SchemaProps{
-							Description: "PodConfigDone specifies if the corresponding pod interface is properly configured by CNI",
-							Type:        []string{"boolean"},
-							Format:      "",
 						},
 					},
 				},

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -311,9 +313,9 @@ func interfaceStatusFromInterfaceNames(ifaceNames ...string) []v1.VirtualMachine
 		ifaceStatus = append(ifaceStatus, v1.VirtualMachineInstanceNetworkInterface{
 			Name:          ifaceName,
 			InterfaceName: fmt.Sprintf("eth%d", i+initialIfacesInVMI),
-			InfoSource:    "domain, guest-agent",
-			QueueCount:    1,
-			PodConfigDone: true,
+			InfoSource: vmispec.NewInfoSource(
+				vmispec.InfoSourceDomain, vmispec.InfoSourceGuestAgent, vmispec.InfoSourceMultusStatus),
+			QueueCount: 1,
 		})
 	}
 	return ifaceStatus

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -320,7 +320,8 @@ var _ = Describe("[Serial]SRIOV", Serial, decorators.SRIOV, func() {
 			By("checking virtual machine instance reports the expected info source")
 			networkInterface := vmispec.LookupInterfaceStatusByMac(vmi.Status.Interfaces, mac)
 			Expect(networkInterface).NotTo(BeNil(), "interface not found")
-			Expect(networkInterface.InfoSource).To(Equal(vmispec.InfoSourceDomainAndGA))
+			Expect(networkInterface.InfoSource).To(Equal(vmispec.NewInfoSource(
+				vmispec.InfoSourceDomain, vmispec.InfoSourceGuestAgent, vmispec.InfoSourceMultusStatus)))
 		})
 
 		Context("migration", func() {

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -96,28 +96,30 @@ var _ = SIGDescribe("Infosource", func() {
 		})
 
 		It("should have the expected entries in vmi status", func() {
+			infoSourceDomainAndMultusStatus := netvmispec.NewInfoSource(
+				netvmispec.InfoSourceDomain, netvmispec.InfoSourceMultusStatus)
+			infoSourceDomainAndGAAndMultusStatus := netvmispec.NewInfoSource(
+				netvmispec.InfoSourceDomain, netvmispec.InfoSourceGuestAgent, netvmispec.InfoSourceMultusStatus)
+
 			expectedInterfaces := []kvirtv1.VirtualMachineInstanceNetworkInterface{
 				{
-					InfoSource:    netvmispec.InfoSourceDomain,
-					MAC:           primaryInterfaceMac,
-					Name:          primaryNetwork,
-					QueueCount:    network.DefaultInterfaceQueueCount,
-					PodConfigDone: true,
+					InfoSource: netvmispec.InfoSourceDomain,
+					MAC:        primaryInterfaceMac,
+					Name:       primaryNetwork,
+					QueueCount: network.DefaultInterfaceQueueCount,
 				},
 				{
-					InfoSource:    netvmispec.InfoSourceDomainAndGA,
+					InfoSource:    infoSourceDomainAndGAAndMultusStatus,
 					InterfaceName: "eth1",
 					MAC:           secondaryInterface1Mac,
 					Name:          secondaryInterface1Name,
 					QueueCount:    network.DefaultInterfaceQueueCount,
-					PodConfigDone: true,
 				},
 				{
-					InfoSource:    netvmispec.InfoSourceDomain,
-					MAC:           secondaryInterface2Mac,
-					Name:          secondaryInterface2Name,
-					QueueCount:    network.DefaultInterfaceQueueCount,
-					PodConfigDone: true,
+					InfoSource: infoSourceDomainAndMultusStatus,
+					MAC:        secondaryInterface2Mac,
+					Name:       secondaryInterface2Name,
+					QueueCount: network.DefaultInterfaceQueueCount,
 				},
 				{
 					InfoSource:    netvmispec.InfoSourceGuestAgent,


### PR DESCRIPTION
**What this PR does / why we need it**:

Network detected on the multus networks status pod annotation has been marked on the VMI status interface using a dedicated flag (`podConfigDone`).

This change removed the flag in favor of a new source option in the `inforSource` field.

The virt-controller detects a multus network status on the VMI pod and adds the `multus-status` source to the `infoSource` field. The virt-handler, when calculating the VMI status interfaces, preserves this information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The API change is limited to a field added to the VMI Status interface a few weeks back and was not part of any release. In addition to the fact that this was part of a devel-preview feature (network hotplug), we should have no issue with backward compatibility.

**Release note**:
```release-note
Remove the VMI Status interface `podConfigDone` field in favor of a new source option in `infoSource`.
```
