### PR TITLE
bazeldnf: Update to v0.5.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -134,11 +134,10 @@ http_file(
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "404fc34e6bd3b568a7ca6fbcde70267d43830d0171d3192e3ecd83c14c320cfc",
-    strip_prefix = "bazeldnf-0.5.4",
+    sha256 = "bb4210a87f3f2006edb90fbade6df682979dc0330565f2550373f3eb012d928b",
+    strip_prefix = "bazeldnf-0.5.5",
     urls = [
-        "https://github.com/rmohr/bazeldnf/archive/v0.5.4.tar.gz",
-        "https://storage.googleapis.com/builddeps/404fc34e6bd3b568a7ca6fbcde70267d43830d0171d3192e3ecd83c14c320cfc",
+        "https://github.com/rmohr/bazeldnf/archive/v0.5.5.tar.gz",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This new version of bazeldnf contains a fix for the issue that we had to work around in 8052a7f3e30b ("rpm: Manually fix URL for passt package").

**Release note**:

```release-note
NONE
```
