### PR TITLE
controller, hotplug: use correct sync error code

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2532,8 +2532,8 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachin
 			if err := c.handleInterfaceRequests(vmCopy, vmi); err != nil {
 				log.Log.Object(vm).Errorf("error encountered while handling network interface hotplug request: %v", err)
 				ifaceHotplugError = &syncErrorImpl{
-					err:    fmt.Errorf("error encountered while handling volume hotplug requests: %v", err),
-					reason: HotPlugVolumeErrorReason,
+					err:    fmt.Errorf("error encountered while handling network interface hotplug requests: %v", err),
+					reason: HotPlugNetworkInterfaceErrorReason,
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Due to incorrect copy/paste, the sync error set when we failed to hotplug a network interface was the one meant for *volume* hotplug.

This commit addresses this mistake, by using the correct error - i.e. `HotPlugNetworkInterfaceErrorReason`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
