### PR TITLE
hotplug, e2e: address stopped VM nic hotplug flake

### DIFF
--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -234,10 +234,11 @@ var _ = SIGDescribe("nic-hotplug", decorators.InPlaceHotplugNICs, func() {
 				),
 			).To(Succeed())
 
-			var err error
-			vm, err = kubevirt.Client().VirtualMachine(vm.GetNamespace()).Get(context.Background(), vm.GetName(), &metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vm.Spec.Template.Spec.Networks).To(
+			Eventually(func() []v1.Network {
+				vm, err := kubevirt.Client().VirtualMachine(vm.GetNamespace()).Get(context.Background(), vm.GetName(), &metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return vm.Spec.Template.Spec.Networks
+			}, 30*time.Second).Should(
 				ConsistOf(
 					*v1.DefaultPodNetwork(),
 					v1.Network{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The test following test is currently flaking sometimes:
- `cannot be subject to **hot** plug, but will mutate the template.Spec on behalf of the user`

Since the VM template is mutated by the virt-controller we may need to wait a bit before the change is actually seen in the VM. Thus, I am replacing the occurances of `Expect` by `Eventually` in this test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9446 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
