### PR TITLE
[e2e]: improve the kubevirt health-check function

### DIFF
--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -93,6 +93,7 @@ func SynchronizedBeforeTestSetup() []byte {
 
 	EnsureKVMPresent()
 	AdjustKubeVirtResource()
+	EnsureKubevirtReady()
 
 	return nil
 }
@@ -137,6 +138,10 @@ func EnsureKubevirtReady() {
 	virtClient := kubevirt.Client()
 	kv := util.GetCurrentKv(virtClient)
 
+	Eventually(matcher.ThisDeploymentWith(flags.KubeVirtInstallNamespace, "virt-operator"), 180*time.Second, 1*time.Second).
+		Should(matcher.HaveReadyReplicasNumerically(">", 0),
+			"virt-operator deployment is not ready")
+
 	Eventually(func() *v1.KubeVirt {
 		kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -146,7 +151,10 @@ func EnsureKubevirtReady() {
 			matcher.HaveConditionTrue(v1.KubeVirtConditionAvailable),
 			matcher.HaveConditionFalse(v1.KubeVirtConditionProgressing),
 			matcher.HaveConditionFalse(v1.KubeVirtConditionDegraded),
-		))
+			WithTransform(func(kv *v1.KubeVirt) bool {
+				return kv.ObjectMeta.Generation == *kv.Status.ObservedGeneration
+			}, BeTrue()),
+		), "One of the Kubevirt control-plane components is not ready.")
 
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When updating the Kubevirt CR, It takes time for the virt-operator to process the new desired state and report the status. If the HC function called in that time-frame we may think Kubevirt is synced. Therefore I've added another check, that compares the generation numbers. Its equity is an evidence that the execution loop of virt-operator is finished.

Another improvement is to check whether virt-operator is alive. Since KV CR is owned by a user rather than by virt-operator, if operator was deleted somehow, the CR is left and not cleaned by GC, and the status information there is not relevant.

Also, health-check added to the initial before suite stage (SynchronizedBeforeTestSetup)

**Release note**:
```release-note
NONE
```
