### PR TITLE
Select mount point for hot pluggable volumes by additional PV name match

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17580,6 +17580,10 @@
      "volumeMode": {
       "description": "VolumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
       "type": "string"
+     },
+     "volumeName": {
+      "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+      "type": "string"
      }
     }
    },

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2067,6 +2067,7 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 				pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)
 				status.PersistentVolumeClaimInfo = &virtv1.PersistentVolumeClaimInfo{
 					AccessModes:  pvc.Spec.AccessModes,
+					VolumeName:   pvc.Spec.VolumeName,
 					VolumeMode:   pvc.Spec.VolumeMode,
 					Capacity:     pvc.Status.Capacity,
 					Requests:     pvc.Spec.Resources.Requests,

--- a/pkg/virt-handler/isolation/isolation_test.go
+++ b/pkg/virt-handler/isolation/isolation_test.go
@@ -285,6 +285,42 @@ var _ = Describe("IsolationResult", func() {
 				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root/", tmpDir, "long/filesystem")))
 			})
 
+			It("Should find the mount by persistent volume name", func() {
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/pv1"), os.ModePerm)).To(Succeed())
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/pv2"), os.ModePerm)).To(Succeed())
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/pv3"), os.ModePerm)).To(Succeed())
+				initMountsMock(mockIsolationResultContainer, []*mount.Info{
+					{
+						Major:      1,
+						Minor:      1,
+						Mountpoint: "/pvc",
+						Root:       "/",
+					},
+				})
+				initMountsMock(mockIsolationResultNode, []*mount.Info{
+					{
+						Major:      1,
+						Minor:      1,
+						Mountpoint: "/pv1",
+						Root:       "/",
+					}, {
+						Major:      1,
+						Minor:      1,
+						Mountpoint: "/pv2",
+						Root:       "/",
+					}, {
+						Major:      1,
+						Minor:      1,
+						Mountpoint: "/pv3",
+						Root:       "/",
+					},
+				})
+
+				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "/pvc", "pv2")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root/", tmpDir, "pv2")))
+			})
+
 			It("Should fail when the device does not exist", func() {
 				initMountsMock(mockIsolationResultContainer, []*mount.Info{rootMountPoint})
 				initMountsMock(mockIsolationResultNode, []*mount.Info{

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11253,6 +11253,10 @@ var CRDsValidation map[string]string = map[string]string{
                       by the claim. Value of Filesystem is implied when not included
                       in claim spec.
                     type: string
+                  volumeName:
+                    description: VolumeName is the binding reference to the PersistentVolume
+                      backing this claim.
+                    type: string
                 type: object
               phase:
                 description: Phase is the phase

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -279,6 +279,10 @@ type PersistentVolumeClaimInfo struct {
 	// +optional
 	AccessModes []k8sv1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 
+	// VolumeName is the binding reference to the PersistentVolume backing this claim.
+	// +optional
+	VolumeName string `json:"volumeName,omitempty"`
+
 	// VolumeMode defines what type of volume is required by the claim.
 	// Value of Filesystem is implied when not included in claim spec.
 	// +optional

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -84,6 +84,7 @@ func (PersistentVolumeClaimInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                   "PersistentVolumeClaimInfo contains the relavant information virt-handler needs cached about a PVC",
 		"accessModes":        "AccessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1\n+listType=atomic\n+optional",
+		"volumeName":         "VolumeName is the binding reference to the PersistentVolume backing this claim.\n+optional",
 		"volumeMode":         "VolumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.\n+optional",
 		"capacity":           "Capacity represents the capacity set on the corresponding PVC status\n+optional",
 		"requests":           "Requests represents the resources requested by the corresponding PVC spec\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19039,6 +19039,13 @@ func schema_kubevirtio_api_core_v1_PersistentVolumeClaimInfo(ref common.Referenc
 							},
 						},
 					},
+					"volumeName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"volumeMode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows to find mount points on a node by PV name in case there are multiple mount points returned.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9437 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Select mount point for hot pluggable volumes by additional PV name match
```
