### PR TITLE
[Fix] Avoid nil pointer dereferencing when trying to access `evictionStrategy` 

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -778,7 +778,7 @@ func validateLiveMigration(field *k8sfield.Path, spec *v1.VirtualMachineInstance
 	if !isValidEvictionStrategy(evictionStrategy) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s is set with an unrecognized option: %s", field.Child("evictionStrategy").String(), *spec.EvictionStrategy),
+			Message: fmt.Sprintf("%s is set with an unrecognized option: %s", field.Child("evictionStrategy").String(), *evictionStrategy),
 			Field:   field.Child("evictionStrategy").String(),
 		})
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `evictionStrategy` variable holds the final eviction strategy value obtained based on the values provided by the KubeVirt CR and VMI Spec, whereas `spec.EvictionStrategy` is the value the VMI spec provides. This PR updates the invalidation message to use `evictionStrategy` rather than `spec.EvictionStrategy` since it is appropriate and we don't face nil pointer dereferencing issues (`evictionStrategy` might not have been nil, because of which the thread will enter the if clause, but `spec.EvictionStrategy` might be nil, causing nil pointer dereference)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8421 

**Special notes for your reviewer**:
On setting an invalid value for eviction strategy in the KubeVirt CR ('asdf'), the users will now get the following error message: 
`The request is invalid: spec.evictionStrategy: spec.evictionStrategy is set with an unrecognized option: asdf`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
