### PR TITLE
[Fix] Get rid of noisy logs in `checkVolumesForMigration`

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2364,7 +2364,9 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 				continue
 			}
 
-			log.Log.Object(vmi).Infof("migration is block migration because of %s volume", volume.Name)
+			if vmi.Status.MigrationMethod == "" || vmi.Status.MigrationMethod == v1.LiveMigration {
+				log.Log.Object(vmi).Infof("migration is block migration because of %s volume", volume.Name)
+			}
 			blockMigrate = true
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The fact that the migration method is `BlockMigration` is being logged every time any change occurred in the VMI object (even when the migration method had not changed).
This PR makes it such that the log will be shown only when:
1. We check the volumes for the first time (`vmi.Status.MigrationMethod == ""`)
2. The migration method was `LiveMigration` but it is going to be changed to `BlockMigration` 

<img width="1727" alt="Screenshot 2023-03-18 at 9 19 44 PM" src="https://user-images.githubusercontent.com/75248557/226116274-ba6104ac-11ed-4e54-ba88-93bee3a8cc5a.png">

The updated logs screenshot above shows that the block migration log is shown only once. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7214 



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
None
```
