### PR TITLE
[release-0.53] [e2e-tests]Should remove and restore labeler only from workers

### DIFF
--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -332,10 +332,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 
 			BeforeEach(func() {
 				if isTSCFrequencyExposed(virtClient) {
-					nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					for _, node := range nodeList.Items {
+					for _, node := range libnode.GetAllSchedulableNodes(virtClient).Items {
 						stopNodeLabeller(node.Name, virtClient)
 						removeTSCFrequencyFromNode(node)
 					}
@@ -343,8 +340,7 @@ var _ = Describe("[Serial][sig-compute] Hyper-V enlightenments", func() {
 			})
 
 			AfterEach(func() {
-				nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				nodeList := libnode.GetAllSchedulableNodes(virtClient)
 
 				for _, node := range nodeList.Items {
 					_, isNodeLabellerStopped := node.Annotations[v1.LabellerSkipNodeAnnotation]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherrypick of https://github.com/kubevirt/kubevirt/pull/9215
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
