### PR TITLE
Quarantine flaky storage test that starts VMI with faulty disk

### DIFF
--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -196,7 +196,7 @@ var _ = SIGDescribe("Storage", func() {
 
 		})
 
-		Context("with faulty disk", func() {
+		Context("[QUARANTINE] with faulty disk", func() {
 
 			var (
 				nodeName   string


### PR DESCRIPTION
**What this PR does / why we need it**:

The following test has been impacting the storage test lanes over the past two weeks:

`Storage Starting a VirtualMachineInstance with faulty disk [It] should pause VMI on IO error`

As the impact has been greater than 5% over the past 14 days[1], this test qualifies for quarantine.

This test may also be impacting another storage test[2] so quarantining will allow us to see if this helps to reduce the flakiness.

[1] https://search.ci.kubevirt.io/?search=Starting+a+VirtualMachineInstance+with+faulty+disk&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
[2] https://github.com/kubevirt/kubevirt/blob/main/tests/storage/storage.go#L159
[3] https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2023-03-19-168h.html#row26

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @alicefr @maya-r 

**Release note**:
```release-note
NONE
```
