### PR TITLE
tests: fix racy seccomp test

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2971,18 +2971,18 @@ spec:
 			const expectedSeccompProfilePath = "/proc/1/root/var/lib/kubelet/seccomp/kubevirt/kubevirt.json"
 
 			enableKubevirtProfile := func(enable bool) {
+				nodeName = libnode.GetAllSchedulableNodes(virtClient).Items[0].Name
+
+				By("Removing profile if present")
+				_, err := tests.ExecuteCommandInVirtHandlerPod(nodeName, []string{"/usr/bin/rm", "-f", expectedSeccompProfilePath})
+				Expect(err).NotTo(HaveOccurred())
+
 				By(fmt.Sprintf("Configuring KubevirtSeccompProfile feature gate to %t", enable))
 				if enable {
 					tests.EnableFeatureGate(virtconfig.KubevirtSeccompProfile)
 				} else {
 					tests.DisableFeatureGate(virtconfig.KubevirtSeccompProfile)
 				}
-
-				nodeName = libnode.GetAllSchedulableNodes(virtClient).Items[0].Name
-
-				By("Removing profile if present")
-				_, err := tests.ExecuteCommandInVirtHandlerPod(nodeName, []string{"/usr/bin/rm", "-f", expectedSeccompProfilePath})
-				Expect(err).NotTo(HaveOccurred())
 
 				vmProfile := &v1.VirtualMachineInstanceProfile{
 					CustomProfile: &v1.CustomProfile{


### PR DESCRIPTION
Remove the custom profile before enabling the
feature-gate otherwise we might remove a newly
installed profile.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
