### PR TITLE
Add an example migration policy to `/examples` directory

### DIFF
--- a/examples/example-migration-policy.yaml
+++ b/examples/example-migration-policy.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: migrations.kubevirt.io/v1alpha1
+kind: MigrationPolicy
+metadata:
+  name: example-migration-policy
+spec:
+  allowAutoConverge: false
+  allowPostCopy: false
+  bandwidthPerMigration: 2000Mi
+  completionTimeoutPerGiB: 123456789
+  selectors:
+    namespaceSelector:
+      namespace-key: namespace-value
+    virtualMachineInstanceSelector:
+      vmi-key: vmi-value

--- a/tools/vms-generator/BUILD.bazel
+++ b/tools/vms-generator/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/virt-api/webhooks/validating-webhook/admitters:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
         "//tools/util:go_default_library",
         "//tools/vms-generator/utils:go_default_library",

--- a/tools/vms-generator/utils/BUILD.bazel
+++ b/tools/vms-generator/utils/BUILD.bazel
@@ -9,9 +9,12 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tools/vms-generator/utils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1alpha2:go_default_library",
+        "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/pool/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -25,6 +25,9 @@ import (
 	"os"
 	"strings"
 
+	"kubevirt.io/api/migrations/v1alpha1"
+	"kubevirt.io/client-go/kubecli"
+
 	k8sv1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,6 +41,8 @@ import (
 	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	k6tpointer "kubevirt.io/kubevirt/pkg/pointer"
 )
 
 const (
@@ -112,6 +117,8 @@ const VmPoolCirros = "vm-pool-cirros"
 const VmiPresetSmall = "vmi-preset-small"
 
 const VmiMigration = "migration-job"
+
+const MigrationPolicyName = "example-migration-policy"
 
 const (
 	imageAlpine     = "alpine-container-disk-demo"
@@ -1133,6 +1140,22 @@ func GetVMIMigration() *v1.VirtualMachineInstanceMigration {
 			VMIName: VmiMigratable,
 		},
 	}
+}
+
+func GetMigrationPolicy() *v1alpha1.MigrationPolicy {
+	policy := kubecli.NewMinimalMigrationPolicy(MigrationPolicyName)
+	policy.Spec = v1alpha1.MigrationPolicySpec{
+		AllowAutoConverge:       k6tpointer.P(false),
+		BandwidthPerMigration:   k6tpointer.P(resource.MustParse("2000Mi")),
+		CompletionTimeoutPerGiB: k6tpointer.P(int64(123456789)),
+		AllowPostCopy:           k6tpointer.P(false),
+		Selectors: &v1alpha1.Selectors{
+			NamespaceSelector:              map[string]string{"namespace-key": "namespace-value"},
+			VirtualMachineInstanceSelector: map[string]string{"vmi-key": "vmi-value"},
+		},
+	}
+
+	return policy
 }
 
 func GetVMIPresetSmall() *v1.VirtualMachineInstancePreset {

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"kubevirt.io/api/migrations/v1alpha1"
+
 	"kubevirt.io/kubevirt/tools/util"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -147,6 +149,10 @@ func main() {
 		utils.VmTemplateWindows: utils.GetTemplateWindows(),
 	}
 
+	var migrationPolicies = map[string]*v1alpha1.MigrationPolicy{
+		utils.MigrationPolicyName: utils.GetMigrationPolicy(),
+	}
+
 	handleError := func(err error) {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
@@ -244,6 +250,10 @@ func main() {
 	}
 
 	for name, obj := range priorityClasses {
+		handleError(dumpObject(name, *obj))
+	}
+
+	for name, obj := range migrationPolicies {
 		handleError(dumpObject(name, *obj))
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a migration policy manifest example to our `/examples` directory.
This will ease playing with policies for either testing or exploration.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
