### PR TITLE
Migration based hotplug e2e tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -396,6 +396,8 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
     fi
     if [[ $KUBEVIRT_WITH_MULTUS_V3 == "true" ]]; then
       add_to_label_filter "(!in-place-hotplug-NICs)" "&&"
+    else
+      add_to_label_filter "(!migration-based-hotplug-NICs)" "&&"
     fi
   elif [[ $TARGET =~ sig-storage ]]; then
     label_filter='((sig-storage,storage-req) && !sig-compute-migrations)'

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -22,20 +22,21 @@ var (
 	Invtsc     = []interface{}{Label("Invtsc")}
 
 	// Features
-	Sysprep            = []interface{}{Label("Sysprep")}
-	Windows            = []interface{}{Label("Windows")}
-	Networking         = []interface{}{Label("Networking")}
-	VMIlifecycle       = []interface{}{Label("VMIlifecycle")}
-	Expose             = []interface{}{Label("Expose")}
-	NonRoot            = []interface{}{Label("verify-non-root")}
-	NativeSsh          = []interface{}{Label("native-ssh")}
-	ExcludeNativeSsh   = []interface{}{Label("exclude-native-ssh")}
-	Reenlightenment    = []interface{}{Label("Reenlightenment")}
-	TscFrequencies     = []interface{}{Label("TscFrequencies")}
-	PasstGate          = []interface{}{Label("PasstGate")}
-	VMX                = []interface{}{Label("VMX")}
-	Upgrade            = []interface{}{Label("Upgrade")}
-	CustomSELinux      = []interface{}{Label("CustomSELinux")}
-	Istio              = []interface{}{Label("Istio")}
-	InPlaceHotplugNICs = []interface{}{Label("in-place-hotplug-NICs")}
+	Sysprep                   = []interface{}{Label("Sysprep")}
+	Windows                   = []interface{}{Label("Windows")}
+	Networking                = []interface{}{Label("Networking")}
+	VMIlifecycle              = []interface{}{Label("VMIlifecycle")}
+	Expose                    = []interface{}{Label("Expose")}
+	NonRoot                   = []interface{}{Label("verify-non-root")}
+	NativeSsh                 = []interface{}{Label("native-ssh")}
+	ExcludeNativeSsh          = []interface{}{Label("exclude-native-ssh")}
+	Reenlightenment           = []interface{}{Label("Reenlightenment")}
+	TscFrequencies            = []interface{}{Label("TscFrequencies")}
+	PasstGate                 = []interface{}{Label("PasstGate")}
+	VMX                       = []interface{}{Label("VMX")}
+	Upgrade                   = []interface{}{Label("Upgrade")}
+	CustomSELinux             = []interface{}{Label("CustomSELinux")}
+	Istio                     = []interface{}{Label("Istio")}
+	InPlaceHotplugNICs        = []interface{}{Label("in-place-hotplug-NICs")}
+	MigrationBasedHotplugNICs = []interface{}{Label("migration-based-hotplug-NICs")}
 )

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -292,7 +292,8 @@ var _ = SIGDescribe("nic-hotplug", func() {
 			).To(Succeed())
 
 			Eventually(func() []v1.Network {
-				vm, err := kubevirt.Client().VirtualMachine(vm.GetNamespace()).Get(context.Background(), vm.GetName(), &metav1.GetOptions{})
+				var err error
+				vm, err = kubevirt.Client().VirtualMachine(vm.GetNamespace()).Get(context.Background(), vm.GetName(), &metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				return vm.Spec.Template.Spec.Networks
 			}, 30*time.Second).Should(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Those tests will run only on network lanes that have multus v3.
 
Since hotplug to a pod was introduced on multus v4, clusters with multus v3 cannot support VM in place hot plug.
When hotplugging an interface to a VM running on a cluster with multus v3, the new interface will be added to the VM/VMI immediately, but the virt-launcher pod will be updated only after a migration (when a new virt-launcher pod will be created).
Only then the hotplug will be completed and the interface will be hot-plugged to the guest.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
