### PR TITLE
[DO-NOT-MERGE][SIG-SCALE]: for testing performance impact 

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -177,6 +177,9 @@ type KubeInformerFactory interface {
 	// Watches for ControllerRevision objects
 	ControllerRevision() cache.SharedIndexInformer
 
+	// Watches for LimitRange objects
+	LimitRanges() cache.SharedIndexInformer
+
 	// Watches for CDI DataVolume objects
 	DataVolume() cache.SharedIndexInformer
 
@@ -864,6 +867,14 @@ func (f *kubeInformerFactory) PersistentVolumeClaim() cache.SharedIndexInformer 
 		restClient := f.clientSet.CoreV1().RESTClient()
 		lw := cache.NewListWatchFromClient(restClient, "persistentvolumeclaims", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &k8sv1.PersistentVolumeClaim{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	})
+}
+
+func (f *kubeInformerFactory) LimitRanges() cache.SharedIndexInformer {
+	return f.getInformer("limitrangeInformer", func() cache.SharedIndexInformer {
+		restClient := f.clientSet.CoreV1().RESTClient()
+		lw := cache.NewListWatchFromClient(restClient, "limitranges", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &k8sv1.LimitRange{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1009,6 +1009,7 @@ func (app *virtAPIApp) Run() {
 	kubeInformerFactory.KubeVirtCAConfigMap()
 	crdInformer := kubeInformerFactory.CRD()
 	vmiPresetInformer := kubeInformerFactory.VirtualMachinePreset()
+	namespaceLimitsInformer := kubeInformerFactory.LimitRanges()
 	vmRestoreInformer := kubeInformerFactory.VirtualMachineRestore()
 
 	stopChan := make(chan struct{}, 1)
@@ -1041,9 +1042,10 @@ func (app *virtAPIApp) Run() {
 	kubeInformerFactory.WaitForCacheSync(stopChan)
 
 	webhookInformers := &webhooks.Informers{
-		VMIPresetInformer:  vmiPresetInformer,
-		VMRestoreInformer:  vmRestoreInformer,
-		DataSourceInformer: dataSourceInformer,
+		VMIPresetInformer:       vmiPresetInformer,
+		NamespaceLimitsInformer: namespaceLimitsInformer,
+		VMRestoreInformer:       vmRestoreInformer,
+		DataSourceInformer:      dataSourceInformer,
 	}
 
 	// Build webhook subresources

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -81,7 +81,7 @@ func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtco
 }
 
 func ServeVMIs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, informers *webhooks.Informers) {
-	serve(resp, req, &mutators.VMIsMutator{ClusterConfig: clusterConfig, VMIPresetInformer: informers.VMIPresetInformer})
+	serve(resp, req, &mutators.VMIsMutator{ClusterConfig: clusterConfig, VMIPresetInformer: informers.VMIPresetInformer, NamespaceLimitsInformer: informers.NamespaceLimitsInformer})
 }
 
 func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "clone-create-mutator.go",
         "migration-create-mutator.go",
+        "namespace-limits.go",
         "preset.go",
         "vm-mutator.go",
         "vmi-mutator.go",
@@ -43,6 +44,7 @@ go_test(
         "clone-create-mutator_test.go",
         "migration-create-mutator_test.go",
         "mutators_suite_test.go",
+        "namespace-limits_test.go",
         "preset_test.go",
         "vm-mutator_test.go",
         "vmi-mutator_test.go",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package mutators
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	kubev1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
+)
+
+func memoryOrCpuIsMissing(resource k8sv1.ResourceList) bool {
+	for _, v := range []k8sv1.ResourceName{k8sv1.ResourceMemory, k8sv1.ResourceCPU} {
+		if _, ok := resource[v]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isResourceRequirementMissing(resourceRequirements kubev1.ResourceRequirements) bool {
+	if resourceRequirements.Limits == nil || resourceRequirements.Requests == nil {
+		return true
+	}
+
+	return memoryOrCpuIsMissing(resourceRequirements.Limits) || memoryOrCpuIsMissing(resourceRequirements.Requests)
+}
+
+func applyNamespaceLimitRangeValues(vmi *kubev1.VirtualMachineInstance, limitrangeInformer cache.SharedIndexInformer) {
+	// Copy namespace limits (if exist) to the VM spec
+	if isResourceRequirementMissing(vmi.Spec.Domain.Resources) {
+		limits, err := limitrangeInformer.GetIndexer().ByIndex(cache.NamespaceIndex, vmi.Namespace)
+		if err != nil {
+			return
+		}
+
+		log.Log.Object(vmi).V(4).Info("Apply namespace limits")
+		for _, limit := range limits {
+			defaultRequirements := defaultVMIResourceRequirements(limit.(*k8sv1.LimitRange))
+			mergeVMIResources(vmi, &defaultRequirements)
+		}
+	}
+}
+
+// See mergeContainerResources in https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/limitranger/admission.go
+func mergeVMIResources(vmi *kubev1.VirtualMachineInstance, defaultRequirements *k8sv1.ResourceRequirements) {
+	if vmi.Spec.Domain.Resources.Limits == nil {
+		vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{}
+	}
+	if vmi.Spec.Domain.Resources.Requests == nil {
+		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
+	}
+	// TODO: generate annotations like limitranger admission-plugin in kubernetes
+	for k, v := range defaultRequirements.Limits {
+		_, found := vmi.Spec.Domain.Resources.Limits[k]
+		if !found {
+			vmi.Spec.Domain.Resources.Limits[k] = v
+		}
+	}
+	for k, v := range defaultRequirements.Requests {
+		_, found := vmi.Spec.Domain.Resources.Requests[k]
+		if !found {
+			vmi.Spec.Domain.Resources.Requests[k] = v
+		}
+	}
+}
+
+// See defaultContainerResourceRequirements in https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/limitranger/admission.go
+func defaultVMIResourceRequirements(limitRange *k8sv1.LimitRange) k8sv1.ResourceRequirements {
+	requirements := k8sv1.ResourceRequirements{}
+	requirements.Requests = k8sv1.ResourceList{}
+	requirements.Limits = k8sv1.ResourceList{}
+
+	for i := range limitRange.Spec.Limits {
+		limit := limitRange.Spec.Limits[i]
+		if limit.Type == k8sv1.LimitTypeContainer {
+			for k, v := range limit.DefaultRequest {
+				requirements.Requests[k8sv1.ResourceName(k)] = v
+			}
+			for k, v := range limit.Default {
+				requirements.Limits[k8sv1.ResourceName(k)] = v
+			}
+		}
+	}
+	return requirements
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits.go
@@ -93,10 +93,10 @@ func defaultVMIResourceRequirements(limitRange *k8sv1.LimitRange) k8sv1.Resource
 		limit := limitRange.Spec.Limits[i]
 		if limit.Type == k8sv1.LimitTypeContainer {
 			for k, v := range limit.DefaultRequest {
-				requirements.Requests[k8sv1.ResourceName(k)] = v
+				requirements.Requests[k8sv1.ResourceName(k)] = v.DeepCopy()
 			}
 			for k, v := range limit.Default {
-				requirements.Limits[k8sv1.ResourceName(k)] = v
+				requirements.Limits[k8sv1.ResourceName(k)] = v.DeepCopy()
 			}
 		}
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/namespace-limits_test.go
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package mutators
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/testutils"
+)
+
+var _ = Describe("Mutating Webhook Namespace Limits", func() {
+	var vmi v1.VirtualMachineInstance
+	var namespaceLimit *k8sv1.LimitRange
+	var namespaceLimitInformer cache.SharedIndexInformer
+
+	BeforeEach(func() {
+		vmi = v1.VirtualMachineInstance{
+			Spec: v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		}
+		namespaceLimit = &k8sv1.LimitRange{
+			Spec: k8sv1.LimitRangeSpec{
+				Limits: []k8sv1.LimitRangeItem{
+					{
+						Type: k8sv1.LimitTypeContainer,
+						Default: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("256M"),
+							k8sv1.ResourceCPU:    resource.MustParse("4"),
+						},
+						DefaultRequest: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse("128M"),
+							k8sv1.ResourceCPU:    resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		}
+		namespaceLimitInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
+		namespaceLimitInformer.GetIndexer().Add(namespaceLimit)
+	})
+
+	When("VMI has all limits under spec", func() {
+		It("should not apply namespace limits", func() {
+			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64M"),
+				k8sv1.ResourceCPU:    resource.MustParse("2"),
+			}
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("32M"),
+				k8sv1.ResourceCPU:    resource.MustParse("500m"),
+			}
+
+			By("Applying namespace range values on the VMI")
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+
+			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("64M"))
+			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("32M"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal("500m"))
+		})
+	})
+
+	When("VMI does not have limits under spec", func() {
+		It("should apply all namespace limits", func() {
+			By("Applying namespace range values on the VMI")
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+
+			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("256M"))
+			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("4"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("128M"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal("1"))
+		})
+	})
+
+	When("VMI has some limits under spec", func() {
+		It("should apply only missing namespace default limits", func() {
+			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+				k8sv1.ResourceCPU: resource.MustParse("2"),
+			}
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("32M"),
+				k8sv1.ResourceCPU:    resource.MustParse("500m"),
+			}
+
+			By("Applying namespace range values on the VMI")
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+
+			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("256M"))
+			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("32M"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal("500m"))
+		})
+
+		It("should apply only missing namespace defaultRequest limits", func() {
+			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64M"),
+				k8sv1.ResourceCPU:    resource.MustParse("2"),
+			}
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("32M"),
+			}
+
+			By("Applying namespace range values on the VMI")
+			applyNamespaceLimitRangeValues(&vmi, namespaceLimitInformer)
+
+			Expect(vmi.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("64M"))
+			Expect(vmi.Spec.Domain.Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("32M"))
+			Expect(vmi.Spec.Domain.Resources.Requests.Cpu().String()).To(Equal("1"))
+		})
+	})
+})

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -42,8 +42,9 @@ import (
 )
 
 type VMIsMutator struct {
-	ClusterConfig     *virtconfig.ClusterConfig
-	VMIPresetInformer cache.SharedIndexInformer
+	ClusterConfig           *virtconfig.ClusterConfig
+	VMIPresetInformer       cache.SharedIndexInformer
+	NamespaceLimitsInformer cache.SharedIndexInformer
 }
 
 const presetDeprecationWarning = "kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2."
@@ -78,6 +79,10 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 			}
 		}
 
+		// Apply namespace limits
+		applyNamespaceLimitRangeValues(newVMI, mutator.NamespaceLimitsInformer)
+
+		// Set VMI defaults
 		// Set VirtualMachineInstance defaults
 		log.Log.Object(newVMI).V(4).Info("Apply defaults")
 		if err = webhooks.SetDefaultVirtualMachineInstance(mutator.ClusterConfig, newVMI); err != nil {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -55,9 +55,12 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	var vmi *v1.VirtualMachineInstance
 	var preset *v1.VirtualMachineInstancePreset
 	var presetInformer cache.SharedIndexInformer
+	var namespaceLimit *k8sv1.LimitRange
+	var namespaceLimitInformer cache.SharedIndexInformer
 	var kvInformer cache.SharedIndexInformer
 	var mutator *VMIsMutator
 
+	memoryLimit := "128M"
 	cpuModelFromConfig := "Haswell"
 	machineTypeFromConfig := "pc-q35-3.0"
 	cpuReq := resource.MustParse("800m")
@@ -166,9 +169,25 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		presetInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachineInstancePreset{})
 		presetInformer.GetIndexer().Add(preset)
 
+		namespaceLimit = &k8sv1.LimitRange{
+			Spec: k8sv1.LimitRangeSpec{
+				Limits: []k8sv1.LimitRangeItem{
+					{
+						Type: k8sv1.LimitTypeContainer,
+						Default: k8sv1.ResourceList{
+							k8sv1.ResourceMemory: resource.MustParse(memoryLimit),
+						},
+					},
+				},
+			},
+		}
+		namespaceLimitInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
+		namespaceLimitInformer.GetIndexer().Add(namespaceLimit)
+
 		mutator = &VMIsMutator{}
 		mutator.ClusterConfig, _, kvInformer = testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 		mutator.VMIPresetInformer = presetInformer
+		mutator.NamespaceLimitsInformer = namespaceLimitInformer
 	})
 
 	It("should apply presets on VMI create", func() {
@@ -184,12 +203,18 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(resp.Warnings[0]).To(ContainSubstring("VirtualMachineInstancePresets is now deprecated"))
 	})
 
+	It("should apply namespace limit ranges on VMI create", func() {
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
+		Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal(memoryLimit))
+	})
+
 	DescribeTable("should apply defaults on VMI create", func(arch string, cpuModel string) {
 		// no limits wanted on this test, to not copy the limit to requests
 		defer func() {
 			webhooks.Arch = rt.GOARCH
 		}()
 		webhooks.Arch = arch
+		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.CPU.Model).To(Equal(cpuModel))
 		Expect(vmiSpec.Domain.Resources.Requests.Cpu().IsZero()).To(BeTrue())
@@ -205,6 +230,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			webhooks.Arch = rt.GOARCH
 		}()
 		webhooks.Arch = arch
+		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
@@ -537,6 +563,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 	It("should apply memory-overcommit when guest-memory is set and memory-request is not set", func() {
 		// no limits wanted on this test, to not copy the limit to requests
+		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
@@ -556,6 +583,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 	It("should apply memory-overcommit when hugepages are set and memory-request is not set", func() {
 		// no limits wanted on this test, to not copy the limit to requests
+		mutator.NamespaceLimitsInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 		vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "3072M"}}
 		_, vmiSpec, _ := getMetaSpecStatusFromAdmit()
 		Expect(vmiSpec.Domain.Memory.Hugepages.PageSize).To(Equal("3072M"))

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -74,9 +74,10 @@ var MigrationGroupVersionResource = metav1.GroupVersionResource{
 }
 
 type Informers struct {
-	VMIPresetInformer  cache.SharedIndexInformer
-	VMRestoreInformer  cache.SharedIndexInformer
-	DataSourceInformer cache.SharedIndexInformer
+	VMIPresetInformer       cache.SharedIndexInformer
+	NamespaceLimitsInformer cache.SharedIndexInformer
+	VMRestoreInformer       cache.SharedIndexInformer
+	DataSourceInformer      cache.SharedIndexInformer
 }
 
 func IsKubeVirtServiceAccount(serviceAccount string) bool {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -934,6 +935,138 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BSnd{S: "grep -rs '^QEMU USB Tablet' /sys/devices | wc -l\n"},
 					&expect.BExp{R: console.RetValue("1")},
 				}, 60)).To(Succeed(), "should report input device")
+			})
+		})
+
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace memory limits lower than VMI required memory", func() {
+			var vmi *v1.VirtualMachineInstance
+			It("[test_id:1670]should failed to start the VMI", func() {
+				// create a namespace default limit
+				limitRangeObj := kubev1.LimitRange{
+
+					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
+					Spec: kubev1.LimitRangeSpec{
+						Limits: []kubev1.LimitRangeItem{
+							{
+								Type: kubev1.LimitTypeContainer,
+								Default: kubev1.ResourceList{
+									kubev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				}
+				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Starting a VirtualMachineInstance")
+				// Retrying up to 5 sec, then if you still succeeds in VMI creation, things must be going wrong.
+				Eventually(func() error {
+					vmi = libvmi.NewAlpine()
+					// TODO: Namespace must be specified for the webhook, https://github.com/kubevirt/kubevirt/issues/7681
+					vmi.Namespace = util.NamespaceTestDefault
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceMemory: resource.MustParse("64M"),
+						},
+					}
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
+					virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
+					return err
+				}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.memory '64M' is greater than spec.domain.resources.limits.memory '32Mi'"))
+			})
+		})
+
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace cpu limits lower than VMI required cpu", func() {
+			var vmi *v1.VirtualMachineInstance
+			It("[test_id:3119]should fail to start the VMI", func() {
+				// create a namespace default limit
+				limitRangeObj := kubev1.LimitRange{
+
+					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
+					Spec: kubev1.LimitRangeSpec{
+						Limits: []kubev1.LimitRangeItem{
+							{
+								Type: kubev1.LimitTypeContainer,
+								Default: kubev1.ResourceList{
+									kubev1.ResourceCPU: resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				}
+				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Starting a VirtualMachineInstance")
+				// Retrying up to 5 sec, then if you still succeeds in VMI creation, things must be going wrong.
+				Eventually(func() error {
+					vmi = libvmi.NewAlpine()
+					// TODO: Namespace must be specified for the webhook, https://github.com/kubevirt/kubevirt/issues/7681
+					vmi.Namespace = util.NamespaceTestDefault
+					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+						Requests: kubev1.ResourceList{
+							kubev1.ResourceCPU:    resource.MustParse("800m"),
+							kubev1.ResourceMemory: resource.MustParse("512M"),
+						},
+					}
+					vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
+					virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), vmi.Name, &metav1.DeleteOptions{})
+					return err
+				}, 5*time.Second, 1*time.Second).Should(MatchError("admission webhook \"virtualmachineinstances-create-validator.kubevirt.io\" denied the request: spec.domain.resources.requests.cpu '800m' is greater than spec.domain.resources.limits.cpu '500m'"))
+			})
+		})
+
+		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with namespace limits higher than VMI requests", func() {
+			var vmi *v1.VirtualMachineInstance
+			It("[test_id:3120]should start the VMI with the right default settings from namespace limits", func() {
+				// create a namespace default limit
+				limitRangeObj := kubev1.LimitRange{
+
+					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: util.NamespaceTestDefault},
+					Spec: kubev1.LimitRangeSpec{
+						Limits: []kubev1.LimitRangeItem{
+							{
+								Type: kubev1.LimitTypeContainer,
+								Default: kubev1.ResourceList{
+									kubev1.ResourceCPU:    resource.MustParse("2000m"),
+									kubev1.ResourceMemory: resource.MustParse("512M"),
+								},
+								DefaultRequest: kubev1.ResourceList{
+									kubev1.ResourceCPU: resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				}
+				_, err := virtClient.CoreV1().LimitRanges(util.NamespaceTestDefault).Create(context.Background(), &limitRangeObj, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi = libvmi.NewAlpine()
+				// TODO: Namespace must be specified for the webhook, https://github.com/kubevirt/kubevirt/issues/7681
+				vmi.Namespace = util.NamespaceTestDefault
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceMemory: resource.MustParse("64M"),
+					},
+					Limits: kubev1.ResourceList{
+						kubev1.ResourceCPU: resource.MustParse("1000m"),
+					},
+				}
+
+				By("Creating a VMI")
+				Eventually(func() bool {
+					createdVMI, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), vmi)
+					Expect(err).ToNot(HaveOccurred(), "should create vmi")
+
+					err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Delete(context.Background(), createdVMI.Name, &metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred(), "should delete vmi")
+
+					return reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega), int64(64)) &&
+						reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega), int64(512)) &&
+						reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Requests.Cpu().MilliValue(), int64(500)) &&
+						reflect.DeepEqual(createdVMI.Spec.Domain.Resources.Limits.Cpu().MilliValue(), int64(1000))
+				}, 30*time.Second, time.Second).Should(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
Revert "Do not inject LimitRange defaults into VMI"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
