### PR TITLE
Add alicefr as core approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,6 +15,7 @@ aliases:
       - xpivarc
       - vasiliy-ul
       - acardace
+      - alicefr
   emeritus_approvers:
       - danielBelenky
       - mazzystr


### PR DESCRIPTION
**What this PR does / why we need it**:

Proposing Alice as an approver for kubevirt/kubevirt.

Since her first contribution in Aug. 2020 (https://github.com/kubevirt/kubevirt/pull/4027), Alice has been a steady and reliable contributor to KubeVirt.

She has more than 30 PRs merged: https://github.com/kubevirt/kubevirt/pulls?q=is%3Aclosed+is%3Apr+author%3Aalicefr+

She helped reviewing on more than 100 PRs : https://github.com/kubevirt/kubevirt/pulls?page=4&q=is%3Apr+commenter%3Aalicefr+is%3Aclosed+-author%3Aalicefr

When you go through her contributions, you will see a broad set of contributions. From implementing and maintaining her biggest feature -- libguestfs (This break-glass support has been a life-saver in many customer debug sessions for me) -- over fixing flakes unrelated to her work, taking care of maintenance tasks and smoothing a lot of sorage aspects which requires deep storage knowledge.

She can also lead and bring complex discussion -- like for instance the scsi-pr-helper discussion -- to a successful conclusion. If you need help on complex topics, definitely reach out to her.

I know her as a skillful, curious, respectful and reliable engineer who has a big positive impact on all features which she touches as a code writer or reviewer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
