### PR TITLE
virt-launcher, converter: Refactor CreateDomainInterfaces()

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1765,7 +1765,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	domainInterfaces, err := CreateDomainInterfaces(vmi, domain, c)
+	domainInterfaces, err := CreateDomainInterfaces(vmi, domain, c, vmi.Spec.Domain.Devices.Interfaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -36,7 +36,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 )
 
-func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext, ifacesToPlug ...v1.Interface) ([]api.Interface, error) {
+func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, c *ConverterContext, ifacesToPlug []v1.Interface) ([]api.Interface, error) {
 	isVirtioNetProhibited, err := c.IsVirtIONetProhibited()
 	if err != nil {
 		return nil, err
@@ -46,9 +46,6 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 
 	networks := indexNetworksByName(vmi.Spec.Networks)
 
-	if len(ifacesToPlug) == 0 {
-		ifacesToPlug = vmi.Spec.Domain.Devices.Interfaces
-	}
 	for i, iface := range ifacesToPlug {
 		net, isExist := networks[iface.Name]
 		if !isExist {

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -46,7 +46,7 @@ func hotplugVirtioInterface(vmi *v1.VirtualMachineInstance, converterContext *co
 			return fmt.Errorf("could not find a matching interface for network: %s", network.Name)
 		}
 
-		domainInterfaces, err := converter.CreateDomainInterfaces(vmi, domain, converterContext, ifaceToHotplug)
+		domainInterfaces, err := converter.CreateDomainInterfaces(vmi, domain, converterContext, []v1.Interface{ifaceToHotplug})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a follow-up to PRs #6852 and #9406.

Currently, CreateDomainInterfaces() is called in two scenarios:
1. Regular VM setup.
2. NIC hot-plug.

The function currently receives a variadic parameter [1] that represents the VM's logical interfaces that should to be plugged.

The function also have an internal logic to determine whether it was called from a setup or hot-plug scenario.

Adjust the function signature to fit both scenarios. Remove the above internal logic, similarly to what was done in PR #9406.

[1] https://go.dev/ref/spec#Function_types

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
PR #9429 is supposed to add the relevant unit tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
