### PR TITLE
Remove --compat=1.17 from dep-update.sh

### DIFF
--- a/hack/dep-update.sh
+++ b/hack/dep-update.sh
@@ -23,31 +23,26 @@ done
     echo $_sync_only
     cd staging/src/kubevirt.io/api
     if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
-    # remove compat=1.17 when we move to go 1.18
-    go mod tidy -compat=1.17
+    go mod tidy
 )
 (
     echo $_sync_only
     cd staging/src/kubevirt.io/client-go
     if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
-    # remove compat=1.17 when we move to go 1.18
-    go mod tidy -compat=1.17
+    go mod tidy
 )
 
 (
     cd staging/src/github.com/golang/glog
     if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
-    # remove compat=1.17 when we move to go 1.18
-    go mod tidy -compat=1.17
+    go mod tidy
 )
 
 (
     cd staging/src/kubevirt.io/client-go/examples/listvms
     if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
-    # remove compat=1.17 when we move to go 1.18
-    go mod tidy -compat=1.17
+    go mod tidy
 )
 
-# remove compat=1.17 when we move to go 1.18
-go mod tidy -compat=1.17
+go mod tidy
 go mod vendor

--- a/staging/src/kubevirt.io/client-go/go.sum
+++ b/staging/src/kubevirt.io/client-go/go.sum
@@ -1282,6 +1282,7 @@ k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=


### PR DESCRIPTION
**What this PR does / why we need it**:
dep-update.sh has the following comment:
```
remove compat=1.17 when we move to go 1.18
```

Since we're running go 1.19+, this argument can be removed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
