### PR TITLE
[release-0.59] Backport sig-storage quarantines

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1047,7 +1047,7 @@ var _ = SIGDescribe("DataVolume Integration", func() {
 			dv.Annotations = map[string]string{"user.custom.annotation/storage.thick-provisioned": "false"}
 			return dv
 		}
-		DescribeTable("[rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
+		DescribeTable("[QUARANTINE][rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img", func(dvChange func(*cdiv1.DataVolume) *cdiv1.DataVolume, expectSmaller bool) {
 			sc, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
 				Skip("Skip test when Filesystem storage is not present")

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -196,7 +196,7 @@ var _ = SIGDescribe("Storage", func() {
 
 		})
 
-		Context("with faulty disk", func() {
+		Context("[QUARANTINE] with faulty disk", func() {
 
 			var (
 				nodeName   string


### PR DESCRIPTION
**What this PR does / why we need it**:
These tests have been deemed flaky enough on main, let's backport the quarantine to the release branches too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
