### PR TITLE
Start fixing the gomega.Eventually wrong pattern

### DIFF
--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -85,9 +85,9 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, de
 			return err
 		})
 
-		Eventually(func() bool {
+		Eventually(func(g Gomega) bool {
 			ds, err := virtCli.AppsV1().DaemonSets(originalKV.Namespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
 			return ds.Status.DesiredNumberScheduled == ds.Status.NumberReady && ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntValue() == 1
 		}, 60*time.Second, 1*time.Second).Should(BeTrue(), "waiting for virt-handler to be ready")
 	})

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -175,9 +175,9 @@ var _ = Describe("[Serial][sig-compute]VirtualMachineClone Tests", Serial, decor
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By(fmt.Sprintf("Waiting for the clone %s to finish", vmClone.Name))
-		Eventually(func() clonev1alpha1.VirtualMachineClonePhase {
+		Eventually(func(g Gomega) clonev1alpha1.VirtualMachineClonePhase {
 			vmClone, err = virtClient.VirtualMachineClone(vmClone.Namespace).Get(context.Background(), vmClone.Name, v1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(err).ShouldNot(HaveOccurred())
 
 			return vmClone.Status.Phase
 		}, 3*time.Minute, 3*time.Second).Should(Equal(clonev1alpha1.Succeeded), "clone should finish successfully")
@@ -305,9 +305,9 @@ var _ = Describe("[Serial][sig-compute]VirtualMachineClone Tests", Serial, decor
 			It("simple clone with snapshot source", func() {
 				By("Creating a VM")
 				sourceVM = createVM()
-				Eventually(func() virtv1.VirtualMachinePrintableStatus {
+				Eventually(func(g Gomega) virtv1.VirtualMachinePrintableStatus {
 					sourceVM, err = virtClient.VirtualMachine(sourceVM.Namespace).Get(context.Background(), sourceVM.Name, &v1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).ToNot(HaveOccurred())
 
 					return sourceVM.Status.PrintableStatus
 				}, 30*time.Second, 1*time.Second).Should(Equal(virtv1.VirtualMachineStatusStopped))

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -155,9 +155,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi)
 				Expect(err).ToNot(HaveOccurred())
 				By("Checking that the VMI failed")
-				Eventually(func() bool {
+				Eventually(func(g Gomega) bool {
 					vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).ToNot(HaveOccurred())
 					for _, condition := range vmi.Status.Conditions {
 						if condition.Type == v1.VirtualMachineInstanceSynchronized && condition.Status == k8sv1.ConditionFalse {
 							return strings.Contains(condition.Message, "failed to invoke qemu-img")

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -544,11 +544,9 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Waiting for a VirtualMachineInstancetypeSpec ControllerRevision to be referenced from the new VirtualMachine")
-			Eventually(func() string {
+			Eventually(func(g Gomega) string {
 				newVM, err = virtClient.VirtualMachine(newVM.Namespace).Get(context.Background(), newVM.Name, &metav1.GetOptions{})
-				if err != nil {
-					return ""
-				}
+				g.Expect(err).ToNot(HaveOccurred())
 				return newVM.Spec.Instancetype.RevisionName
 			}, 300*time.Second, 1*time.Second).ShouldNot(BeEmpty())
 
@@ -703,12 +701,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		}
 
 		waitPVCBound := func(pvc *k8sv1.PersistentVolumeClaim) *k8sv1.PersistentVolumeClaim {
-			Eventually(func() bool {
+			Eventually(func(g Gomega) k8sv1.PersistentVolumeClaimPhase {
 				var err error
 				pvc, err = virtClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.Background(), pvc.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return pvc.Status.Phase == k8sv1.ClaimBound
-			}, 180*time.Second, time.Second).Should(BeTrue())
+				g.Expect(err).ToNot(HaveOccurred())
+				return pvc.Status.Phase
+			}, 180*time.Second, time.Second).Should(Equal(k8sv1.ClaimBound))
 			return pvc
 		}
 

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -476,25 +476,17 @@ var _ = Describe("[Serial][sig-compute]MediatedDevices", Serial, decorators.VGPU
 
 			By("expecting the creation of a mediated device")
 			mdevUUIDPath := fmt.Sprintf(mdevUUIDPathFmt, pciId, uuidRegex)
-			Eventually(func() error {
+			Eventually(func(g Gomega) {
 				uuidPath, _, err := runBashCmd("ls -d " + mdevUUIDPath + " | head -1")
-				if err != nil {
-					return err
-				}
-				if uuidPath == "" {
-					return fmt.Errorf("no UUID found at %s", mdevUUIDPath)
-				}
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(uuidPath).ShouldNot(BeEmpty(), "no UUID found at %s", mdevUUIDPath)
 				uuid := strings.TrimSpace(filepath.Base(uuidPath))
 				mdevTypePath := fmt.Sprintf(mdevTypePathFmt, pciId, uuid)
 				effectiveTypePath, _, err := runBashCmd("readlink -e " + mdevTypePath)
-				if err != nil {
-					return err
-				}
-				if filepath.Base(effectiveTypePath) != mdevType {
-					return fmt.Errorf("%s != %s", filepath.Base(effectiveTypePath), mdevType)
-				}
-				return nil
-			}, 5*time.Minute, time.Second).ShouldNot(HaveOccurred())
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				g.Expect(effectiveTypePath).Should(Equal(mdevType))
+			}, 5*time.Minute, time.Second).Should(Succeed())
 		})
 	})
 })

--- a/tests/portforward_test.go
+++ b/tests/portforward_test.go
@@ -63,13 +63,10 @@ var _ = Describe("[sig-compute]PortForward", decorators.SigCompute, func() {
 			tunnel kubecli.StreamInterface
 			err    error
 		)
-		Eventually(func() error {
+		Eventually(func(g Gomega) {
 			tunnel, err = virtClient.VirtualMachineInstance(vmi.Namespace).PortForward(vmi.Name, 22, "tcp")
-			if err != nil {
-				return err
-			}
-			return nil
-		}, 12*60*time.Second, 2).ShouldNot(HaveOccurred())
+			g.Expect(err).ToNot(HaveOccurred())
+		}, 12*60*time.Second, 2).Should(Succeed())
 
 		inReader, in := io.Pipe()
 		var out bytes.Buffer

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -161,10 +161,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			vmi := libvmi.NewAlpine()
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
-			Eventually(func() kubev1.PodQOSClass {
+			Eventually(func(g Gomega) kubev1.PodQOSClass {
 				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.IsFinal()).To(BeFalse())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vmi.IsFinal()).To(BeFalse())
 				if vmi.Status.QOSClass == nil {
 					return ""
 				}
@@ -190,10 +190,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			vmi.ObjectMeta.Annotations = RenderSidecar(kubevirt_hooks_v1alpha2.Version)
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
-			Eventually(func() kubev1.PodQOSClass {
+			Eventually(func(g Gomega) kubev1.PodQOSClass {
 				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.IsFinal()).To(BeFalse())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vmi.IsFinal()).To(BeFalse())
 				if vmi.Status.QOSClass == nil {
 					return ""
 				}
@@ -216,10 +216,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			vmi.ObjectMeta.Annotations = RenderSidecar(kubevirt_hooks_v1alpha2.Version)
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
-			Eventually(func() kubev1.PodQOSClass {
+			Eventually(func(g Gomega) kubev1.PodQOSClass {
 				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.IsFinal()).To(BeFalse())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(vmi.IsFinal()).To(BeFalse())
 				if vmi.Status.QOSClass == nil {
 					return ""
 				}
@@ -1128,9 +1128,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					var vmiCondition v1.VirtualMachineInstanceCondition
-					Eventually(func() bool {
+					Eventually(func(g Gomega) bool {
 						vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(hugepagesVmi)).Get(context.Background(), hugepagesVmi.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred())
+						g.Expect(err).ToNot(HaveOccurred())
 
 						for _, cond := range vmi.Status.Conditions {
 							if cond.Type == v1.VirtualMachineInstanceConditionType(kubev1.PodScheduled) && cond.Status == kubev1.ConditionFalse {
@@ -1204,9 +1204,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				var freshVMI *v1.VirtualMachineInstance
 
 				By("VMI has the guest agent connected condition")
-				Eventually(func() []v1.VirtualMachineInstanceCondition {
+				Eventually(func(g Gomega) []v1.VirtualMachineInstanceCondition {
 					freshVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, &getOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+					g.Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
 					return freshVMI.Status.Conditions
 				}, 240*time.Second, 2).Should(
 					ContainElement(
@@ -1310,15 +1310,13 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				var err error
 
 				By("Expecting the Guest VM information")
-				Eventually(func() bool {
+				Eventually(func(g Gomega) bool {
 					updatedVmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).Get(context.Background(), agentVMI.Name, &getOptions)
-					if err != nil {
-						return false
-					}
+					g.Expect(err).ToNot(HaveOccurred())
+
 					return updatedVmi.Status.GuestOSInfo.Name != ""
 				}, 240*time.Second, 2).Should(BeTrue(), "Should have guest OS Info in vmi status")
 
-				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedVmi.Status.GuestOSInfo.Name).To(ContainSubstring("Fedora"))
 			})
 
@@ -1326,12 +1324,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
-				Eventually(func() bool {
+				Eventually(func(g Gomega) bool {
 					guestInfo, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).GuestOsInfo(context.Background(), agentVMI.Name)
-					if err != nil {
-						// invalid request, retry
-						return false
-					}
+					g.Expect(err).ToNot(HaveOccurred())
 
 					return guestInfo.Hostname != "" &&
 						guestInfo.Timezone != "" &&
@@ -1370,12 +1365,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(console.LoginToFedora(agentVMI)).To(Succeed())
 
 				By("Expecting the Guest VM information")
-				Eventually(func() bool {
+				Eventually(func(g Gomega) bool {
 					userList, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).UserList(context.Background(), agentVMI.Name)
-					if err != nil {
-						// invalid request, retry
-						return false
-					}
+					g.Expect(err).ToNot(HaveOccurred())
 
 					return len(userList.Items) > 0 && userList.Items[0].UserName == "fedora"
 
@@ -1386,12 +1378,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
-				Eventually(func() bool {
+				Eventually(func(g Gomega) bool {
 					fsList, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(agentVMI)).FilesystemList(context.Background(), agentVMI.Name)
-					if err != nil {
-						// invalid request, retry
-						return false
-					}
+					g.Expect(err).ToNot(HaveOccurred())
 
 					return len(fsList.Items) > 0 && fsList.Items[0].DiskName != "" && fsList.Items[0].MountPoint != ""
 
@@ -2234,9 +2223,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 
 			var vmiCondition v1.VirtualMachineInstanceCondition
 			// TODO
-			Eventually(func() bool {
+			Eventually(func(g Gomega) bool {
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 
 				for _, cond := range vmi.Status.Conditions {
 					if cond.Type == v1.VirtualMachineInstanceConditionType(v1.VirtualMachineInstanceSynchronized) && cond.Status == kubev1.ConditionFalse {
@@ -2296,9 +2285,9 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("setting the cpumanager label back to false")
-				Eventually(func() string {
+				Eventually(func(g Gomega) string {
 					n, err := virtClient.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					g.Expect(err).ToNot(HaveOccurred())
 					return n.Labels[v1.CPUManager]
 				}, 3*time.Minute, 2*time.Second).Should(Equal("false"))
 			})
@@ -3013,7 +3002,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 						"rss,command",
 					})
 				return err
-			}, time.Second, 50*time.Millisecond).Should(BeNil(), fmt.Sprintf(errorMassageFormat, stdout, stderr, err))
+			}, time.Second, 50*time.Millisecond).Should(Succeed(), fmt.Sprintf(errorMassageFormat, stdout, stderr, err))
 
 			By("Parsing the output of ps")
 			processRss := make(map[string]resource.Quantity)

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -85,22 +85,22 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", decorators.SigCom
 			By("Ensuring VMI is deleted")
 			err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, &v1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(func() (isVmiDeleted bool) {
+			Eventually(func(g Gomega) (isVmiDeleted bool) {
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, &v1.GetOptions{})
 				if errors.IsNotFound(err) {
 					return true
 				}
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				return false
 			}, 60*time.Second, 3*time.Second).Should(BeTrue(), "VMI Should be successfully deleted")
 
 			By("Ensuring virt-launcher is deleted")
-			Eventually(func() (isVmiDeleted bool) {
+			Eventually(func(g Gomega) (isVmiDeleted bool) {
 				_, err = virtClient.CoreV1().Pods(virtLauncherPod.Namespace).Get(context.Background(), virtLauncherPod.Name, v1.GetOptions{})
 				if errors.IsNotFound(err) {
 					return true
 				}
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				return false
 			}, 60*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("virt-launcher pod (%s) Should be successfully deleted", virtLauncherPod.Name))
 		})
@@ -168,22 +168,22 @@ var _ = Describe("[sig-compute]VMI with external kernel boot", decorators.SigCom
 			By("Ensuring VMI is deleted")
 			err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Delete(context.Background(), vmi.Name, &v1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(func() (isVmiDeleted bool) {
+			Eventually(func(g Gomega) (isVmiDeleted bool) {
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Get(context.Background(), vmi.Name, &v1.GetOptions{})
 				if errors.IsNotFound(err) {
 					return true
 				}
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				return false
 			}, 60*time.Second, 3*time.Second).Should(BeTrue(), "VMI Should be successfully deleted")
 
 			By("Ensuring virt-launcher is deleted")
-			Eventually(func() (isVmiDeleted bool) {
+			Eventually(func(g Gomega) (isVmiDeleted bool) {
 				_, err = virtClient.CoreV1().Pods(virtLauncherPod.Namespace).Get(context.Background(), virtLauncherPod.Name, v1.GetOptions{})
 				if errors.IsNotFound(err) {
 					return true
 				}
-				Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).ToNot(HaveOccurred())
 				return false
 			}, 60*time.Second, 3*time.Second).Should(BeTrue(), fmt.Sprintf("virt-launcher pod (%s) Should be successfully deleted", virtLauncherPod.Name))
 		})


### PR DESCRIPTION
When using `Eventually` or `Constantly`, if an inner assertion is failed, the whole function is fails and does not keep polling.

Example:
```go
Eventually(func() {
    ...
    Expect(something).To(...) // <<<<< if this fails, the whole Eventually fails
    ...
}).Should(...)
```
There is a built in solution for that, by passing a Gomega argument to the function:
```go
Eventually(func(g Gomega) { <<< add the Gomega argument here
    ...
    g.Expect(something).To(...) // <<<<< Now, only the current poll fails
    ...
}).Should(...)
```

This PR is starting to fix these cases in the `tests/` directory.

In some cases this issue was solved by returning an error, but the Gomega argument allow us to use nicer code. e.g. 
```go
Eventually(func() error {
	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
	if err != nil {
		return err
	}

	if vmi.Status.NodeName == vmiNodeOrig {
		return fmt.Errorf("VMI is still on the same node")
	}

	if vmi.Status.MigrationState == nil || vmi.Status.MigrationState.SourceNode != vmiNodeOrig {
		return fmt.Errorf("VMI did not migrate yet")
	}

	if vmi.Status.EvacuationNodeName != "" {
		return fmt.Errorf("VMI is still evacuating: %v", vmi.Status.EvacuationNodeName)
	}

	return nil
}, 360*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
```
We can do this instead:
```go
Eventually(func(g Gomega) {
	vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, &metav1.GetOptions{})
	g.Expect(err).ToNot(HaveOccurred())
	g.Expect(vmi.Status.NodeName).ShouldNot(Equal(vmiNodeOrig), "VMI is still on the same node")
	g.Expect(vmi.Status.MigrationState).ToNot(BeNil(), "VMI did not migrate yet")
	g.Expect(vmi.Status.MigrationState.SourceNode).Should(Equal(vmiNodeOrig), "VMI did not migrate yet")
	g.Expect(vmi.Status.EvacuationNodeName).Should(BeEmpty(), "VMI is still evacuating: %v", vmi.Status.EvacuationNodeName)
}, 360*time.Second, 1*time.Second).Should(Succeed())
```

```release-note
None
```
