### PR TITLE
e2e, SR-IOV: Ignore SyncVMI timeout warning

### DIFF
--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -711,7 +711,9 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 	// Running multi sriov jobs with Kind, DinD is resource extensive, causing DeadlineExceeded transient warning
 	// Kubevirt re-enqueue the request once it happens, so its safe to ignore this warning.
 	// see https://github.com/kubevirt/kubevirt/issues/5027
-	warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
+	warningsIgnoreList := []string{
+		"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+		"server error. command SyncVMI failed: \"timed out waiting for the condition\""}
 	libwait.WaitUntilVMIReadyIgnoreSelectedWarnings(vmi, console.LoginToFedora, warningsIgnoreList)
 
 	virtClient := kubevirt.Client()


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we run on the SR-IOV machine more non SR-IOV jobs in parallel, the machine might be busy
and have timeouts of SyncVMI.
Those are transient warnings which have a built-in retry mechanism, as was seen before.
Add another variant of the warning string that should be ignored.
It is safe because if there is a real error, even the retry would fail at the end causing an error,
not a warning, and we ignore only warnings with specific strings.

For more info see https://github.com/kubevirt/kubevirt/issues/5027
It proved itself and reduced this kind of flakes even without multi SR-IOV
(for the previous string which is pretty the same syndrome).

Failures for example
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9380/pull-kubevirt-e2e-kind-1.23-sriov-0.59/1633789071895564288
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9404/pull-kubevirt-e2e-kind-1.23-sriov/1634924801745227776
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9475/pull-kubevirt-e2e-k3d-1.25-sriov/1638475518925869056

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
