### PR TITLE
api, AddInterfaceOptions: Rename fields

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15462,7 +15462,7 @@
     "description": "AddInterfaceOptions is provided when dynamically hot plugging a network interface",
     "type": "object",
     "required": [
-     "networkName",
+     "networkAttachmentDefinitionName",
      "interfaceName"
     ],
     "properties": {
@@ -15470,8 +15470,8 @@
       "description": "InterfaceName indicates the logical name of the interface.",
       "type": "string"
      },
-     "networkName": {
-      "description": "NetworkName references a NetworkAttachmentDefinition CRD object. Format: \u003cnetworkName\u003e, \u003cnamespace\u003e/\u003cnetworkName\u003e. If namespace is not specified, VMI namespace is assumed.",
+     "networkAttachmentDefinitionName": {
+      "description": "NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition CRD object. Format: \u003cnetworkAttachmentDefinitionName\u003e, \u003cnamespace\u003e/\u003cnetworkAttachmentDefinitionName\u003e. If namespace is not specified, VMI namespace is assumed.",
       "type": "string"
      }
     }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15463,11 +15463,11 @@
     "type": "object",
     "required": [
      "networkAttachmentDefinitionName",
-     "interfaceName"
+     "name"
     ],
     "properties": {
-     "interfaceName": {
-      "description": "InterfaceName indicates the logical name of the interface.",
+     "name": {
+      "description": "Name indicates the logical name of the interface.",
       "type": "string"
      },
      "networkAttachmentDefinitionName": {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -392,7 +392,7 @@ func ApplyNetworkInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpe
 			Name: request.AddInterfaceOptions.InterfaceName,
 			NetworkSource: v1.NetworkSource{
 				Multus: &v1.MultusNetwork{
-					NetworkName: request.AddInterfaceOptions.NetworkName,
+					NetworkName: request.AddInterfaceOptions.NetworkAttachmentDefinitionName,
 				},
 			},
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -384,12 +384,12 @@ func AttachmentPods(ownerPod *k8sv1.Pod, podInformer cache.SharedIndexInformer) 
 
 func ApplyNetworkInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineInterfaceRequest) *v1.VirtualMachineInstanceSpec {
 	existingIface := vmispec.FilterInterfacesSpec(vmiSpec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
-		return iface.Name == request.AddInterfaceOptions.InterfaceName
+		return iface.Name == request.AddInterfaceOptions.Name
 	})
 
 	if len(existingIface) == 0 {
 		newNetwork := v1.Network{
-			Name: request.AddInterfaceOptions.InterfaceName,
+			Name: request.AddInterfaceOptions.Name,
 			NetworkSource: v1.NetworkSource{
 				Multus: &v1.MultusNetwork{
 					NetworkName: request.AddInterfaceOptions.NetworkAttachmentDefinitionName,
@@ -398,7 +398,7 @@ func ApplyNetworkInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpe
 		}
 
 		newIface := v1.Interface{
-			Name:                   request.AddInterfaceOptions.InterfaceName,
+			Name:                   request.AddInterfaceOptions.Name,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 		}
 

--- a/pkg/virt-api/rest/interfacehotplug.go
+++ b/pkg/virt-api/rest/interfacehotplug.go
@@ -142,7 +142,7 @@ func ApplyInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, requ
 			Name: canonicalIfaceName,
 			NetworkSource: v1.NetworkSource{
 				Multus: &v1.MultusNetwork{
-					NetworkName: request.AddInterfaceOptions.NetworkName,
+					NetworkName: request.AddInterfaceOptions.NetworkAttachmentDefinitionName,
 				},
 			},
 		}
@@ -213,8 +213,8 @@ func (app *SubresourceAPIApp) newInterfaceRequest(request *restful.Request) (v1.
 		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("`networkName` and `interfaceName` are expected")
 	}
 
-	if opts.NetworkName == "" {
-		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("AddInterfaceOptions requires `networkName` to be set")
+	if opts.NetworkAttachmentDefinitionName == "" {
+		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("AddInterfaceOptions requires `networkAttachmentDefinitionName` to be set")
 	}
 	if opts.InterfaceName == "" {
 		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("AddInterfaceOptions requires `interfaceName` to be set")

--- a/pkg/virt-api/rest/interfacehotplug.go
+++ b/pkg/virt-api/rest/interfacehotplug.go
@@ -124,7 +124,7 @@ func addAddInterfaceRequests(vm *v1.VirtualMachine, ifaceRequest *v1.VirtualMach
 }
 
 func dynamicIfaceName(plugRequest *v1.VirtualMachineInterfaceRequest) string {
-	return plugRequest.AddInterfaceOptions.InterfaceName
+	return plugRequest.AddInterfaceOptions.Name
 }
 
 func ApplyInterfaceRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineInterfaceRequest) *v1.VirtualMachineInstanceSpec {
@@ -216,8 +216,8 @@ func (app *SubresourceAPIApp) newInterfaceRequest(request *restful.Request) (v1.
 	if opts.NetworkAttachmentDefinitionName == "" {
 		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("AddInterfaceOptions requires `networkAttachmentDefinitionName` to be set")
 	}
-	if opts.InterfaceName == "" {
-		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("AddInterfaceOptions requires `interfaceName` to be set")
+	if opts.Name == "" {
+		return v1.VirtualMachineInterfaceRequest{}, fmt.Errorf("AddInterfaceOptions requires `name` to be set")
 	}
 
 	return v1.VirtualMachineInterfaceRequest{AddInterfaceOptions: opts}, nil

--- a/pkg/virt-api/rest/interfacehotplug_test.go
+++ b/pkg/virt-api/rest/interfacehotplug_test.go
@@ -222,11 +222,11 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 		},
 			Entry("VM with a valid add interface request", &v1.AddInterfaceOptions{
 				NetworkAttachmentDefinitionName: networkToHotplug,
-				InterfaceName:                   ifaceToHotplug,
+				Name:                            ifaceToHotplug,
 			}, successfulMockScenarioForVM),
 			Entry("VMI with a valid add interface request", &v1.AddInterfaceOptions{
 				NetworkAttachmentDefinitionName: networkToHotplug,
-				InterfaceName:                   ifaceToHotplug,
+				Name:                            ifaceToHotplug,
 			}, successfulMockScenarioForVMI),
 		)
 
@@ -239,14 +239,14 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 			Expect(response.StatusCode()).To(Equal(http.StatusBadRequest))
 		},
 			Entry("VM with an invalid add interface request missing a network name", &v1.AddInterfaceOptions{
-				InterfaceName: ifaceToHotplug,
+				Name: ifaceToHotplug,
 			}, failedMockScenarioForVM, virtconfig.HotplugNetworkIfacesGate),
 			Entry("VM with an invalid add interface request missing the interface name", &v1.AddInterfaceOptions{
 				NetworkAttachmentDefinitionName: networkToHotplug,
 			}, failedMockScenarioForVM, virtconfig.HotplugNetworkIfacesGate),
 			Entry("VM with a valid add interface request but no feature gate", &v1.AddInterfaceOptions{
 				NetworkAttachmentDefinitionName: networkToHotplug,
-				InterfaceName:                   ifaceToHotplug,
+				Name:                            ifaceToHotplug,
 			}, failedMockScenarioForVM),
 		)
 
@@ -267,7 +267,7 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 					&v1.VirtualMachineInterfaceRequest{
 						AddInterfaceOptions: &v1.AddInterfaceOptions{
 							NetworkAttachmentDefinitionName: networkToHotplug,
-							InterfaceName:                   ifaceToHotplug,
+							Name:                            ifaceToHotplug,
 						},
 					},
 				),
@@ -293,34 +293,34 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 				&v1.VirtualMachineInterfaceRequest{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
 						NetworkAttachmentDefinitionName: networkToHotplug,
-						InterfaceName:                   ifaceToHotplug,
+						Name:                            ifaceToHotplug,
 					},
 				},
 				nil,
-				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": null}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%q,"interfaceName":%q}}]}]`, networkToHotplug, ifaceToHotplug)),
+				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": null}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%q,"name":%q}}]}]`, networkToHotplug, ifaceToHotplug)),
 			Entry("add interface request when interface requests already exists",
 				&v1.VirtualMachineInterfaceRequest{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
 						NetworkAttachmentDefinitionName: networkToHotplug,
-						InterfaceName:                   ifaceToHotplug,
+						Name:                            ifaceToHotplug,
 					},
 				},
 				[]v1.VirtualMachineInterfaceRequest{
 					{
 						AddInterfaceOptions: &v1.AddInterfaceOptions{
 							NetworkAttachmentDefinitionName: existingNetworkName,
-							InterfaceName:                   existingIfaceName,
+							Name:                            existingIfaceName,
 						},
 					},
 				},
-				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[1]q,"interfaceName":%[2]q}}]}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[1]q,"interfaceName":%[2]q}},{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[3]q,"interfaceName":%[4]q}}]}]`, existingNetworkName, existingIfaceName, networkToHotplug, ifaceToHotplug)),
+				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[1]q,"name":%[2]q}}]}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[1]q,"name":%[2]q}},{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[3]q,"name":%[4]q}}]}]`, existingNetworkName, existingIfaceName, networkToHotplug, ifaceToHotplug)),
 			Entry("empty add interface request",
 				&v1.VirtualMachineInterfaceRequest{AddInterfaceOptions: nil},
 				[]v1.VirtualMachineInterfaceRequest{
 					{
 						AddInterfaceOptions: &v1.AddInterfaceOptions{
 							NetworkAttachmentDefinitionName: existingNetworkName,
-							InterfaceName:                   existingIfaceName,
+							Name:                            existingIfaceName,
 						},
 					},
 				}, ""))
@@ -333,7 +333,7 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 				{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
 						NetworkAttachmentDefinitionName: networkToHotplug,
-						InterfaceName:                   ifaceToHotplug,
+						Name:                            ifaceToHotplug,
 					},
 				},
 			}
@@ -342,7 +342,7 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 				generateVMInterfaceRequestPatch(vm, &v1.VirtualMachineInterfaceRequest{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
 						NetworkAttachmentDefinitionName: networkToHotplug,
-						InterfaceName:                   ifaceToHotplug,
+						Name:                            ifaceToHotplug,
 					},
 				}),
 			).To(BeEmpty())

--- a/pkg/virt-api/rest/interfacehotplug_test.go
+++ b/pkg/virt-api/rest/interfacehotplug_test.go
@@ -221,12 +221,12 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 			Expect(response.StatusCode()).To(Equal(http.StatusAccepted))
 		},
 			Entry("VM with a valid add interface request", &v1.AddInterfaceOptions{
-				NetworkName:   networkToHotplug,
-				InterfaceName: ifaceToHotplug,
+				NetworkAttachmentDefinitionName: networkToHotplug,
+				InterfaceName:                   ifaceToHotplug,
 			}, successfulMockScenarioForVM),
 			Entry("VMI with a valid add interface request", &v1.AddInterfaceOptions{
-				NetworkName:   networkToHotplug,
-				InterfaceName: ifaceToHotplug,
+				NetworkAttachmentDefinitionName: networkToHotplug,
+				InterfaceName:                   ifaceToHotplug,
 			}, successfulMockScenarioForVMI),
 		)
 
@@ -242,11 +242,11 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 				InterfaceName: ifaceToHotplug,
 			}, failedMockScenarioForVM, virtconfig.HotplugNetworkIfacesGate),
 			Entry("VM with an invalid add interface request missing the interface name", &v1.AddInterfaceOptions{
-				NetworkName: networkToHotplug,
+				NetworkAttachmentDefinitionName: networkToHotplug,
 			}, failedMockScenarioForVM, virtconfig.HotplugNetworkIfacesGate),
 			Entry("VM with a valid add interface request but no feature gate", &v1.AddInterfaceOptions{
-				NetworkName:   networkToHotplug,
-				InterfaceName: ifaceToHotplug,
+				NetworkAttachmentDefinitionName: networkToHotplug,
+				InterfaceName:                   ifaceToHotplug,
 			}, failedMockScenarioForVM),
 		)
 
@@ -266,8 +266,8 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 					vmi,
 					&v1.VirtualMachineInterfaceRequest{
 						AddInterfaceOptions: &v1.AddInterfaceOptions{
-							NetworkName:   networkToHotplug,
-							InterfaceName: ifaceToHotplug,
+							NetworkAttachmentDefinitionName: networkToHotplug,
+							InterfaceName:                   ifaceToHotplug,
 						},
 					},
 				),
@@ -292,35 +292,35 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 				"add interface request with no existing interfaces",
 				&v1.VirtualMachineInterfaceRequest{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
-						NetworkName:   networkToHotplug,
-						InterfaceName: ifaceToHotplug,
+						NetworkAttachmentDefinitionName: networkToHotplug,
+						InterfaceName:                   ifaceToHotplug,
 					},
 				},
 				nil,
-				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": null}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkName":%q,"interfaceName":%q}}]}]`, networkToHotplug, ifaceToHotplug)),
+				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": null}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%q,"interfaceName":%q}}]}]`, networkToHotplug, ifaceToHotplug)),
 			Entry("add interface request when interface requests already exists",
 				&v1.VirtualMachineInterfaceRequest{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
-						NetworkName:   networkToHotplug,
-						InterfaceName: ifaceToHotplug,
+						NetworkAttachmentDefinitionName: networkToHotplug,
+						InterfaceName:                   ifaceToHotplug,
 					},
 				},
 				[]v1.VirtualMachineInterfaceRequest{
 					{
 						AddInterfaceOptions: &v1.AddInterfaceOptions{
-							NetworkName:   existingNetworkName,
-							InterfaceName: existingIfaceName,
+							NetworkAttachmentDefinitionName: existingNetworkName,
+							InterfaceName:                   existingIfaceName,
 						},
 					},
 				},
-				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkName":%[1]q,"interfaceName":%[2]q}}]}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkName":%[1]q,"interfaceName":%[2]q}},{"addInterfaceOptions":{"networkName":%[3]q,"interfaceName":%[4]q}}]}]`, existingNetworkName, existingIfaceName, networkToHotplug, ifaceToHotplug)),
+				fmt.Sprintf(`[{ "op": "test", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[1]q,"interfaceName":%[2]q}}]}, { "op": "add", "path": "/status/interfaceRequests", "value": [{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[1]q,"interfaceName":%[2]q}},{"addInterfaceOptions":{"networkAttachmentDefinitionName":%[3]q,"interfaceName":%[4]q}}]}]`, existingNetworkName, existingIfaceName, networkToHotplug, ifaceToHotplug)),
 			Entry("empty add interface request",
 				&v1.VirtualMachineInterfaceRequest{AddInterfaceOptions: nil},
 				[]v1.VirtualMachineInterfaceRequest{
 					{
 						AddInterfaceOptions: &v1.AddInterfaceOptions{
-							NetworkName:   existingNetworkName,
-							InterfaceName: existingIfaceName,
+							NetworkAttachmentDefinitionName: existingNetworkName,
+							InterfaceName:                   existingIfaceName,
 						},
 					},
 				}, ""))
@@ -332,8 +332,8 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 			vm.Status.InterfaceRequests = []v1.VirtualMachineInterfaceRequest{
 				{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
-						NetworkName:   networkToHotplug,
-						InterfaceName: ifaceToHotplug,
+						NetworkAttachmentDefinitionName: networkToHotplug,
+						InterfaceName:                   ifaceToHotplug,
 					},
 				},
 			}
@@ -341,8 +341,8 @@ var _ = Describe("Interface Hotplug Subresource", func() {
 			Expect(
 				generateVMInterfaceRequestPatch(vm, &v1.VirtualMachineInterfaceRequest{
 					AddInterfaceOptions: &v1.AddInterfaceOptions{
-						NetworkName:   networkToHotplug,
-						InterfaceName: ifaceToHotplug,
+						NetworkAttachmentDefinitionName: networkToHotplug,
+						InterfaceName:                   ifaceToHotplug,
 					},
 				}),
 			).To(BeEmpty())

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -2637,7 +2637,7 @@ func (c *VMController) handleInterfaceRequests(vm *virtv1.VirtualMachine, vmi *v
 			continue
 		}
 
-		if _, exists := interfaceMap[ifaceRequest.AddInterfaceOptions.InterfaceName]; exists {
+		if _, exists := interfaceMap[ifaceRequest.AddInterfaceOptions.Name]; exists {
 			continue
 		}
 
@@ -2665,7 +2665,7 @@ func (c *VMController) trimDoneInterfaceRequests(vm *virtv1.VirtualMachine) {
 		removeRequest := false
 
 		if request.AddInterfaceOptions != nil {
-			ifaceName = request.AddInterfaceOptions.InterfaceName
+			ifaceName = request.AddInterfaceOptions.Name
 			added = true
 		}
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3151,7 +3151,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					virtv1.Network{
 						Name: req.InterfaceName,
 						NetworkSource: virtv1.NetworkSource{
-							Multus: &virtv1.MultusNetwork{NetworkName: req.NetworkName},
+							Multus: &virtv1.MultusNetwork{NetworkName: req.NetworkAttachmentDefinitionName},
 						},
 					})
 			}
@@ -3177,8 +3177,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			It("cannot handle dynamic network attachment when adding an interface", func() {
 				fakeHotPlugRequest(vmi, []virtv1.AddInterfaceOptions{{
-					NetworkName:   "net1",
-					InterfaceName: "iface1",
+					NetworkAttachmentDefinitionName: "net1",
+					InterfaceName:                   "iface1",
 				}})
 				Expect(controller.handleDynamicInterfaceRequests(vmi, pod)).To(HaveOccurred())
 			})
@@ -3201,19 +3201,19 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			},
 				Entry("hotplug a single interface",
 					[]virtv1.AddInterfaceOptions{{
-						NetworkName:   "net1",
-						InterfaceName: "iface1",
+						NetworkAttachmentDefinitionName: "net1",
+						InterfaceName:                   "iface1",
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
 						`[{"interface":"net1","name":"net1","namespace":"default"}]`)),
 				Entry("hotplug multiple interfaces",
 					[]virtv1.AddInterfaceOptions{{
-						NetworkName:   "net1",
-						InterfaceName: "iface1",
+						NetworkAttachmentDefinitionName: "net1",
+						InterfaceName:                   "iface1",
 					}, {
-						NetworkName:   "net1",
-						InterfaceName: "iface2",
+						NetworkAttachmentDefinitionName: "net1",
+						InterfaceName:                   "iface2",
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3149,7 +3149,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				vmi.Spec.Networks = append(
 					vmi.Spec.Networks,
 					virtv1.Network{
-						Name: req.InterfaceName,
+						Name: req.Name,
 						NetworkSource: virtv1.NetworkSource{
 							Multus: &virtv1.MultusNetwork{NetworkName: req.NetworkAttachmentDefinitionName},
 						},
@@ -3178,7 +3178,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			It("cannot handle dynamic network attachment when adding an interface", func() {
 				fakeHotPlugRequest(vmi, []virtv1.AddInterfaceOptions{{
 					NetworkAttachmentDefinitionName: "net1",
-					InterfaceName:                   "iface1",
+					Name:                            "iface1",
 				}})
 				Expect(controller.handleDynamicInterfaceRequests(vmi, pod)).To(HaveOccurred())
 			})
@@ -3202,7 +3202,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("hotplug a single interface",
 					[]virtv1.AddInterfaceOptions{{
 						NetworkAttachmentDefinitionName: "net1",
-						InterfaceName:                   "iface1",
+						Name:                            "iface1",
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,
@@ -3210,10 +3210,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("hotplug multiple interfaces",
 					[]virtv1.AddInterfaceOptions{{
 						NetworkAttachmentDefinitionName: "net1",
-						InterfaceName:                   "iface1",
+						Name:                            "iface1",
 					}, {
 						NetworkAttachmentDefinitionName: "net1",
-						InterfaceName:                   "iface2",
+						Name:                            "iface2",
 					}},
 					HaveKeyWithValue(
 						networkv1.NetworkAttachmentAnnot,

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6753,8 +6753,8 @@ var CRDsValidation map[string]string = map[string]string{
                   should be added. The details within this field specify how to add
                   the interface
                 properties:
-                  interfaceName:
-                    description: InterfaceName indicates the logical name of the interface.
+                  name:
+                    description: Name indicates the logical name of the interface.
                     type: string
                   networkAttachmentDefinitionName:
                     description: 'NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition
@@ -6762,7 +6762,7 @@ var CRDsValidation map[string]string = map[string]string{
                       If namespace is not specified, VMI namespace is assumed.'
                     type: string
                 required:
-                - interfaceName
+                - name
                 - networkAttachmentDefinitionName
                 type: object
             type: object
@@ -24450,9 +24450,9 @@ var CRDsValidation map[string]string = map[string]string{
                               network interface should be added. The details within
                               this field specify how to add the interface
                             properties:
-                              interfaceName:
-                                description: InterfaceName indicates the logical name
-                                  of the interface.
+                              name:
+                                description: Name indicates the logical name of the
+                                  interface.
                                 type: string
                               networkAttachmentDefinitionName:
                                 description: 'NetworkAttachmentDefinitionName references
@@ -24462,7 +24462,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   assumed.'
                                 type: string
                             required:
-                            - interfaceName
+                            - name
                             - networkAttachmentDefinitionName
                             type: object
                         type: object

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6756,14 +6756,14 @@ var CRDsValidation map[string]string = map[string]string{
                   interfaceName:
                     description: InterfaceName indicates the logical name of the interface.
                     type: string
-                  networkName:
-                    description: 'NetworkName references a NetworkAttachmentDefinition
-                      CRD object. Format: <networkName>, <namespace>/<networkName>.
+                  networkAttachmentDefinitionName:
+                    description: 'NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition
+                      CRD object. Format: <networkAttachmentDefinitionName>, <namespace>/<networkAttachmentDefinitionName>.
                       If namespace is not specified, VMI namespace is assumed.'
                     type: string
                 required:
                 - interfaceName
-                - networkName
+                - networkAttachmentDefinitionName
                 type: object
             type: object
           type: array
@@ -24454,15 +24454,16 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: InterfaceName indicates the logical name
                                   of the interface.
                                 type: string
-                              networkName:
-                                description: 'NetworkName references a NetworkAttachmentDefinition
-                                  CRD object. Format: <networkName>, <namespace>/<networkName>.
+                              networkAttachmentDefinitionName:
+                                description: 'NetworkAttachmentDefinitionName references
+                                  a NetworkAttachmentDefinition CRD object. Format:
+                                  <networkAttachmentDefinitionName>, <namespace>/<networkAttachmentDefinitionName>.
                                   If namespace is not specified, VMI namespace is
                                   assumed.'
                                 type: string
                             required:
                             - interfaceName
-                            - networkName
+                            - networkAttachmentDefinitionName
                             type: object
                         type: object
                       type: array

--- a/pkg/virtctl/network/dynamicifaces.go
+++ b/pkg/virtctl/network/dynamicifaces.go
@@ -36,8 +36,8 @@ import (
 const (
 	HotplugCmdName = "addinterface"
 
-	ifaceNameArg   = "iface-name"
-	networkNameArg = "network-name"
+	ifaceNameArg                       = "iface-name"
+	networkAttachmentDefinitionNameArg = "network-attachment-definition-name"
 )
 
 var (
@@ -67,8 +67,8 @@ func NewAddInterfaceCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 		},
 	}
 	cmd.SetUsageTemplate(templates.UsageTemplate())
-	cmd.Flags().StringVar(&networkAttachmentDefinitionName, networkNameArg, "", "The referenced network-attachment-definition name. Format:\n<netName>, <ns>/<netName>")
-	_ = cmd.MarkFlagRequired(networkNameArg)
+	cmd.Flags().StringVar(&networkAttachmentDefinitionName, networkAttachmentDefinitionNameArg, "", "The referenced network-attachment-definition name. Format:\n<networkAttachmentDefinitionName>, <ns>/<networkAttachmentDefinitionName>")
+	_ = cmd.MarkFlagRequired(networkAttachmentDefinitionNameArg)
 	cmd.Flags().StringVar(&ifaceName, ifaceNameArg, "", "Logical name of the interface to be plugged")
 	_ = cmd.MarkFlagRequired(ifaceNameArg)
 	cmd.Flags().BoolVar(&persist, "persist", false, "When set, the added interface will be persisted in the VM spec (if it exists)")
@@ -78,10 +78,10 @@ func NewAddInterfaceCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 
 func usageAddInterface() string {
 	usage := `  #Dynamically attach a network interface to a running VM.
-  {{ProgramName}} addinterface <vmi-name> --network-name <net name> --iface-name <iface name>
+  {{ProgramName}} addinterface <vmi-name> --network-attachment-definition-name <network-attachment-definition name> --iface-name <iface name>
 
   #Dynamically attach a network interface to a running VM and persisting it in the VM spec. At next VM restart the network interface will be attached like any other network interface.
-  {{ProgramName}} addinterface <vm-name> --network-name <net name> --iface-name <iface name> --persist
+  {{ProgramName}} addinterface <vm-name> --network-attachment-definition-name <network-attachment-definition name> --iface-name <iface name> --persist
   `
 	return usage
 }
@@ -98,13 +98,13 @@ func newDynamicIfaceCmd(clientCfg clientcmd.ClientConfig, persistState bool) (*d
 	return &dynamicIfacesCmd{kvClient: virtClient, isPersistent: persistState, namespace: namespace}, nil
 }
 
-func (dic *dynamicIfacesCmd) addInterface(vmName string, networkName string, ifaceName string) error {
+func (dic *dynamicIfacesCmd) addInterface(vmName string, networkAttachmentDefinitionName string, ifaceName string) error {
 	if dic.isPersistent {
 		return dic.kvClient.VirtualMachine(dic.namespace).AddInterface(
 			context.Background(),
 			vmName,
 			&v1.AddInterfaceOptions{
-				NetworkAttachmentDefinitionName: networkName,
+				NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
 				Name:                            ifaceName,
 			},
 		)
@@ -113,7 +113,7 @@ func (dic *dynamicIfacesCmd) addInterface(vmName string, networkName string, ifa
 		context.Background(),
 		vmName,
 		&v1.AddInterfaceOptions{
-			NetworkAttachmentDefinitionName: networkName,
+			NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
 			Name:                            ifaceName,
 		},
 	)

--- a/pkg/virtctl/network/dynamicifaces.go
+++ b/pkg/virtctl/network/dynamicifaces.go
@@ -104,8 +104,8 @@ func (dic *dynamicIfacesCmd) addInterface(vmName string, networkName string, ifa
 			context.Background(),
 			vmName,
 			&v1.AddInterfaceOptions{
-				NetworkName:   networkName,
-				InterfaceName: ifaceName,
+				NetworkAttachmentDefinitionName: networkName,
+				InterfaceName:                   ifaceName,
 			},
 		)
 	}
@@ -113,8 +113,8 @@ func (dic *dynamicIfacesCmd) addInterface(vmName string, networkName string, ifa
 		context.Background(),
 		vmName,
 		&v1.AddInterfaceOptions{
-			NetworkName:   networkName,
-			InterfaceName: ifaceName,
+			NetworkAttachmentDefinitionName: networkName,
+			InterfaceName:                   ifaceName,
 		},
 	)
 }

--- a/pkg/virtctl/network/dynamicifaces.go
+++ b/pkg/virtctl/network/dynamicifaces.go
@@ -105,7 +105,7 @@ func (dic *dynamicIfacesCmd) addInterface(vmName string, networkName string, ifa
 			vmName,
 			&v1.AddInterfaceOptions{
 				NetworkAttachmentDefinitionName: networkName,
-				InterfaceName:                   ifaceName,
+				Name:                            ifaceName,
 			},
 		)
 	}
@@ -114,7 +114,7 @@ func (dic *dynamicIfacesCmd) addInterface(vmName string, networkName string, ifa
 		vmName,
 		&v1.AddInterfaceOptions{
 			NetworkAttachmentDefinitionName: networkName,
-			InterfaceName:                   ifaceName,
+			Name:                            ifaceName,
 		},
 	)
 }

--- a/pkg/virtctl/network/dynamicifaces.go
+++ b/pkg/virtctl/network/dynamicifaces.go
@@ -36,7 +36,7 @@ import (
 const (
 	HotplugCmdName = "addinterface"
 
-	ifaceNameArg                       = "iface-name"
+	ifaceNameArg                       = "name"
 	networkAttachmentDefinitionNameArg = "network-attachment-definition-name"
 )
 
@@ -78,10 +78,10 @@ func NewAddInterfaceCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 
 func usageAddInterface() string {
 	usage := `  #Dynamically attach a network interface to a running VM.
-  {{ProgramName}} addinterface <vmi-name> --network-attachment-definition-name <network-attachment-definition name> --iface-name <iface name>
+  {{ProgramName}} addinterface <vmi-name> --network-attachment-definition-name <network-attachment-definition name> --name <iface name>
 
   #Dynamically attach a network interface to a running VM and persisting it in the VM spec. At next VM restart the network interface will be attached like any other network interface.
-  {{ProgramName}} addinterface <vm-name> --network-attachment-definition-name <network-attachment-definition name> --iface-name <iface name> --persist
+  {{ProgramName}} addinterface <vm-name> --network-attachment-definition-name <network-attachment-definition name> --name <iface name> --persist
   `
 	return usage
 }
@@ -98,14 +98,14 @@ func newDynamicIfaceCmd(clientCfg clientcmd.ClientConfig, persistState bool) (*d
 	return &dynamicIfacesCmd{kvClient: virtClient, isPersistent: persistState, namespace: namespace}, nil
 }
 
-func (dic *dynamicIfacesCmd) addInterface(vmName string, networkAttachmentDefinitionName string, ifaceName string) error {
+func (dic *dynamicIfacesCmd) addInterface(vmName string, networkAttachmentDefinitionName string, name string) error {
 	if dic.isPersistent {
 		return dic.kvClient.VirtualMachine(dic.namespace).AddInterface(
 			context.Background(),
 			vmName,
 			&v1.AddInterfaceOptions{
 				NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
-				Name:                            ifaceName,
+				Name:                            name,
 			},
 		)
 	}
@@ -114,7 +114,7 @@ func (dic *dynamicIfacesCmd) addInterface(vmName string, networkAttachmentDefini
 		vmName,
 		&v1.AddInterfaceOptions{
 			NetworkAttachmentDefinitionName: networkAttachmentDefinitionName,
-			Name:                            ifaceName,
+			Name:                            name,
 		},
 	)
 }

--- a/pkg/virtctl/network/dynamicifaces_test.go
+++ b/pkg/virtctl/network/dynamicifaces_test.go
@@ -128,7 +128,7 @@ func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterfa
 		Return(vmi).
 		Times(1)
 	vmi.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
-		Expect(arg2.(*v1.AddInterfaceOptions).NetworkName).To(Equal(networkName))
+		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkName))
 		Expect(arg2.(*v1.AddInterfaceOptions).InterfaceName).To(Equal(ifaceName))
 		return nil
 	})
@@ -141,7 +141,7 @@ func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName
 		Return(vm).
 		Times(1)
 	vm.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
-		Expect(arg2.(*v1.AddInterfaceOptions).NetworkName).To(Equal(networkName))
+		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkName))
 		Expect(arg2.(*v1.AddInterfaceOptions).InterfaceName).To(Equal(ifaceName))
 		return nil
 	})

--- a/pkg/virtctl/network/dynamicifaces_test.go
+++ b/pkg/virtctl/network/dynamicifaces_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Dynamic Interface Attachment", func() {
 	})
 
 	const (
-		ifaceName                           = "pluggediface1"
+		testIfaceName                       = "pluggediface1"
 		testNetworkAttachmentDefinitionName = "newnet"
 		vmName                              = "myvm1"
 	)
@@ -70,11 +70,11 @@ var _ = Describe("Dynamic Interface Attachment", func() {
 	},
 		Entry("missing the VM name as parameter for the `AddInterface` cmd", network.HotplugCmdName),
 		Entry("missing all required flags for the `AddInterface` cmd", network.HotplugCmdName, vmName),
-		Entry("missing the network attachment definition name flag for the `AddInterface` cmd", network.HotplugCmdName, vmName, "--iface-name", ifaceName),
+		Entry("missing the network attachment definition name flag for the `AddInterface` cmd", network.HotplugCmdName, vmName, "--name", testIfaceName),
 	)
 
 	It("fails when the VM name argument is missing but all flags are provided", func() {
-		cmd := clientcmd.NewVirtctlCommand(append([]string{network.HotplugCmdName}, requiredCmdFlags(testNetworkAttachmentDefinitionName, ifaceName)...)...)
+		cmd := clientcmd.NewVirtctlCommand(append([]string{network.HotplugCmdName}, requiredCmdFlags(testNetworkAttachmentDefinitionName, testIfaceName)...)...)
 		err := cmd.Execute()
 
 		const missingArgError = "argument validation failed"
@@ -91,18 +91,18 @@ var _ = Describe("Dynamic Interface Attachment", func() {
 
 		It("hot-plug an interface works", func() {
 			vmi = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
-			mockVMIAddInterfaceEndpoints(vmi, vmName, testNetworkAttachmentDefinitionName, ifaceName)
+			mockVMIAddInterfaceEndpoints(vmi, vmName, testNetworkAttachmentDefinitionName, testIfaceName)
 
-			cmdArgs := append(requiredCmdFlags(testNetworkAttachmentDefinitionName, ifaceName))
+			cmdArgs := append(requiredCmdFlags(testNetworkAttachmentDefinitionName, testIfaceName))
 			cmd := clientcmd.NewVirtctlCommand(buildDynamicIfaceCmd(network.HotplugCmdName, vmName, cmdArgs...)...)
 			Expect(cmd.Execute()).To(Succeed())
 		})
 
 		It("hot-plug an interface with the `--persist` option works", func() {
 			vm = kubecli.NewMockVirtualMachineInterface(ctrl)
-			mockVMAddInterfaceEndpoints(vm, vmName, testNetworkAttachmentDefinitionName, ifaceName)
+			mockVMAddInterfaceEndpoints(vm, vmName, testNetworkAttachmentDefinitionName, testIfaceName)
 
-			cmdArgs := append(requiredCmdFlags(testNetworkAttachmentDefinitionName, ifaceName), "--persist")
+			cmdArgs := append(requiredCmdFlags(testNetworkAttachmentDefinitionName, testIfaceName), "--persist")
 			cmd := clientcmd.NewVirtctlCommand(buildDynamicIfaceCmd(network.HotplugCmdName, vmName, cmdArgs...)...)
 			Expect(cmd.Execute()).To(Succeed())
 		})
@@ -120,7 +120,7 @@ func buildHotplugIfaceCmd(vmName string, requiredCmdArgs ...string) []string {
 	return append([]string{network.HotplugCmdName, vmName}, requiredCmdArgs...)
 }
 
-func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterface, vmName string, networkAttachmentDefinitionName string, ifaceName string) {
+func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterface, vmName string, networkAttachmentDefinitionName string, name string) {
 	kubecli.MockKubevirtClientInstance.
 		EXPECT().
 		VirtualMachineInstance(k8smetav1.NamespaceDefault).
@@ -128,12 +128,12 @@ func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterfa
 		Times(1)
 	vmi.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
 		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkAttachmentDefinitionName))
-		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(ifaceName))
+		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(name))
 		return nil
 	})
 }
 
-func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName string, networkAttachmentDefinitionName string, ifaceName string) {
+func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName string, networkAttachmentDefinitionName string, name string) {
 	kubecli.MockKubevirtClientInstance.
 		EXPECT().
 		VirtualMachine(k8smetav1.NamespaceDefault).
@@ -141,11 +141,11 @@ func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName
 		Times(1)
 	vm.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
 		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkAttachmentDefinitionName))
-		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(ifaceName))
+		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(name))
 		return nil
 	})
 }
 
-func requiredCmdFlags(networkAttachmentDefinitionName string, ifaceName string) []string {
-	return []string{"--network-attachment-definition-name", networkAttachmentDefinitionName, "--iface-name", ifaceName}
+func requiredCmdFlags(networkAttachmentDefinitionName string, name string) []string {
+	return []string{"--network-attachment-definition-name", networkAttachmentDefinitionName, "--name", name}
 }

--- a/pkg/virtctl/network/dynamicifaces_test.go
+++ b/pkg/virtctl/network/dynamicifaces_test.go
@@ -58,9 +58,9 @@ var _ = Describe("Dynamic Interface Attachment", func() {
 	})
 
 	const (
-		ifaceName   = "pluggediface1"
-		networkName = "newnet"
-		vmName      = "myvm1"
+		ifaceName                           = "pluggediface1"
+		testNetworkAttachmentDefinitionName = "newnet"
+		vmName                              = "myvm1"
 	)
 
 	DescribeTable("should fail when required input parameters are missing", func(cmdType string, args ...string) {
@@ -70,12 +70,11 @@ var _ = Describe("Dynamic Interface Attachment", func() {
 	},
 		Entry("missing the VM name as parameter for the `AddInterface` cmd", network.HotplugCmdName),
 		Entry("missing all required flags for the `AddInterface` cmd", network.HotplugCmdName, vmName),
-		Entry("missing the network name flag for the `AddInterface` cmd", network.HotplugCmdName, vmName, "--iface-name", ifaceName),
-		Entry("missing the interface name flag for the `AddInterface` cmd", network.HotplugCmdName, vmName, "--network-name", networkName),
+		Entry("missing the network attachment definition name flag for the `AddInterface` cmd", network.HotplugCmdName, vmName, "--iface-name", ifaceName),
 	)
 
 	It("fails when the VM name argument is missing but all flags are provided", func() {
-		cmd := clientcmd.NewVirtctlCommand(append([]string{network.HotplugCmdName}, requiredCmdFlags(networkName, ifaceName)...)...)
+		cmd := clientcmd.NewVirtctlCommand(append([]string{network.HotplugCmdName}, requiredCmdFlags(testNetworkAttachmentDefinitionName, ifaceName)...)...)
 		err := cmd.Execute()
 
 		const missingArgError = "argument validation failed"
@@ -92,18 +91,18 @@ var _ = Describe("Dynamic Interface Attachment", func() {
 
 		It("hot-plug an interface works", func() {
 			vmi = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
-			mockVMIAddInterfaceEndpoints(vmi, vmName, networkName, ifaceName)
+			mockVMIAddInterfaceEndpoints(vmi, vmName, testNetworkAttachmentDefinitionName, ifaceName)
 
-			cmdArgs := append(requiredCmdFlags(networkName, ifaceName))
+			cmdArgs := append(requiredCmdFlags(testNetworkAttachmentDefinitionName, ifaceName))
 			cmd := clientcmd.NewVirtctlCommand(buildDynamicIfaceCmd(network.HotplugCmdName, vmName, cmdArgs...)...)
 			Expect(cmd.Execute()).To(Succeed())
 		})
 
 		It("hot-plug an interface with the `--persist` option works", func() {
 			vm = kubecli.NewMockVirtualMachineInterface(ctrl)
-			mockVMAddInterfaceEndpoints(vm, vmName, networkName, ifaceName)
+			mockVMAddInterfaceEndpoints(vm, vmName, testNetworkAttachmentDefinitionName, ifaceName)
 
-			cmdArgs := append(requiredCmdFlags(networkName, ifaceName), "--persist")
+			cmdArgs := append(requiredCmdFlags(testNetworkAttachmentDefinitionName, ifaceName), "--persist")
 			cmd := clientcmd.NewVirtctlCommand(buildDynamicIfaceCmd(network.HotplugCmdName, vmName, cmdArgs...)...)
 			Expect(cmd.Execute()).To(Succeed())
 		})
@@ -121,32 +120,32 @@ func buildHotplugIfaceCmd(vmName string, requiredCmdArgs ...string) []string {
 	return append([]string{network.HotplugCmdName, vmName}, requiredCmdArgs...)
 }
 
-func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterface, vmName string, networkName string, ifaceName string) {
+func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterface, vmName string, networkAttachmentDefinitionName string, ifaceName string) {
 	kubecli.MockKubevirtClientInstance.
 		EXPECT().
 		VirtualMachineInstance(k8smetav1.NamespaceDefault).
 		Return(vmi).
 		Times(1)
 	vmi.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
-		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkName))
+		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkAttachmentDefinitionName))
 		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(ifaceName))
 		return nil
 	})
 }
 
-func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName string, networkName string, ifaceName string) {
+func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName string, networkAttachmentDefinitionName string, ifaceName string) {
 	kubecli.MockKubevirtClientInstance.
 		EXPECT().
 		VirtualMachine(k8smetav1.NamespaceDefault).
 		Return(vm).
 		Times(1)
 	vm.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
-		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkName))
+		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkAttachmentDefinitionName))
 		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(ifaceName))
 		return nil
 	})
 }
 
-func requiredCmdFlags(networkName string, ifaceName string) []string {
-	return []string{"--network-name", networkName, "--iface-name", ifaceName}
+func requiredCmdFlags(networkAttachmentDefinitionName string, ifaceName string) []string {
+	return []string{"--network-attachment-definition-name", networkAttachmentDefinitionName, "--iface-name", ifaceName}
 }

--- a/pkg/virtctl/network/dynamicifaces_test.go
+++ b/pkg/virtctl/network/dynamicifaces_test.go
@@ -129,7 +129,7 @@ func mockVMIAddInterfaceEndpoints(vmi *kubecli.MockVirtualMachineInstanceInterfa
 		Times(1)
 	vmi.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
 		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkName))
-		Expect(arg2.(*v1.AddInterfaceOptions).InterfaceName).To(Equal(ifaceName))
+		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(ifaceName))
 		return nil
 	})
 }
@@ -142,7 +142,7 @@ func mockVMAddInterfaceEndpoints(vm *kubecli.MockVirtualMachineInterface, vmName
 		Times(1)
 	vm.EXPECT().AddInterface(context.Background(), vmName, gomock.Any()).DoAndReturn(func(arg0, arg1, arg2 interface{}) interface{} {
 		Expect(arg2.(*v1.AddInterfaceOptions).NetworkAttachmentDefinitionName).To(Equal(networkName))
-		Expect(arg2.(*v1.AddInterfaceOptions).InterfaceName).To(Equal(ifaceName))
+		Expect(arg2.(*v1.AddInterfaceOptions).Name).To(Equal(ifaceName))
 		return nil
 	})
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2199,8 +2199,8 @@ type AddInterfaceOptions struct {
 	// specified, VMI namespace is assumed.
 	NetworkAttachmentDefinitionName string `json:"networkAttachmentDefinitionName"`
 
-	// InterfaceName indicates the logical name of the interface.
-	InterfaceName string `json:"interfaceName"`
+	// Name indicates the logical name of the interface.
+	Name string `json:"name"`
 }
 
 type TokenBucketRateLimiter struct {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2194,10 +2194,10 @@ type RemoveVolumeOptions struct {
 
 // AddInterfaceOptions is provided when dynamically hot plugging a network interface
 type AddInterfaceOptions struct {
-	// NetworkName references a NetworkAttachmentDefinition CRD object. Format:
-	// <networkName>, <namespace>/<networkName>. If namespace is not
+	// NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition CRD object. Format:
+	// <networkAttachmentDefinitionName>, <namespace>/<networkAttachmentDefinitionName>. If namespace is not
 	// specified, VMI namespace is assumed.
-	NetworkName string `json:"networkName"`
+	NetworkAttachmentDefinitionName string `json:"networkAttachmentDefinitionName"`
 
 	// InterfaceName indicates the logical name of the interface.
 	InterfaceName string `json:"interfaceName"`

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -669,7 +669,7 @@ func (AddInterfaceOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                                "AddInterfaceOptions is provided when dynamically hot plugging a network interface",
 		"networkAttachmentDefinitionName": "NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition CRD object. Format:\n<networkAttachmentDefinitionName>, <namespace>/<networkAttachmentDefinitionName>. If namespace is not\nspecified, VMI namespace is assumed.",
-		"interfaceName":                   "InterfaceName indicates the logical name of the interface.",
+		"name":                            "Name indicates the logical name of the interface.",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -667,9 +667,9 @@ func (RemoveVolumeOptions) SwaggerDoc() map[string]string {
 
 func (AddInterfaceOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":              "AddInterfaceOptions is provided when dynamically hot plugging a network interface",
-		"networkName":   "NetworkName references a NetworkAttachmentDefinition CRD object. Format:\n<networkName>, <namespace>/<networkName>. If namespace is not\nspecified, VMI namespace is assumed.",
-		"interfaceName": "InterfaceName indicates the logical name of the interface.",
+		"":                                "AddInterfaceOptions is provided when dynamically hot plugging a network interface",
+		"networkAttachmentDefinitionName": "NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition CRD object. Format:\n<networkAttachmentDefinitionName>, <namespace>/<networkAttachmentDefinitionName>. If namespace is not\nspecified, VMI namespace is assumed.",
+		"interfaceName":                   "InterfaceName indicates the logical name of the interface.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -14552,15 +14552,15 @@ func schema_kubevirtio_api_core_v1_AddInterfaceOptions(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
-					"interfaceName": {
+					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "InterfaceName indicates the logical name of the interface.",
+							Description: "Name indicates the logical name of the interface.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"networkAttachmentDefinitionName", "interfaceName"},
+				Required: []string{"networkAttachmentDefinitionName", "name"},
 			},
 		},
 	}

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -14545,9 +14545,9 @@ func schema_kubevirtio_api_core_v1_AddInterfaceOptions(ref common.ReferenceCallb
 				Description: "AddInterfaceOptions is provided when dynamically hot plugging a network interface",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"networkName": {
+					"networkAttachmentDefinitionName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NetworkName references a NetworkAttachmentDefinition CRD object. Format: <networkName>, <namespace>/<networkName>. If namespace is not specified, VMI namespace is assumed.",
+							Description: "NetworkAttachmentDefinitionName references a NetworkAttachmentDefinition CRD object. Format: <networkAttachmentDefinitionName>, <namespace>/<networkAttachmentDefinitionName>. If namespace is not specified, VMI namespace is assumed.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14560,7 +14560,7 @@ func schema_kubevirtio_api_core_v1_AddInterfaceOptions(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"networkName", "interfaceName"},
+				Required: []string{"networkAttachmentDefinitionName", "interfaceName"},
 			},
 		},
 	}

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -330,7 +330,7 @@ func vmiCurrentInterfaces(vmiNamespace, vmiName string) []v1.VirtualMachineInsta
 func addIfaceOptions(networkName, ifaceName string) *v1.AddInterfaceOptions {
 	return &v1.AddInterfaceOptions{
 		NetworkAttachmentDefinitionName: networkName,
-		InterfaceName:                   ifaceName,
+		Name:                            ifaceName,
 	}
 }
 

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -329,8 +329,8 @@ func vmiCurrentInterfaces(vmiNamespace, vmiName string) []v1.VirtualMachineInsta
 
 func addIfaceOptions(networkName, ifaceName string) *v1.AddInterfaceOptions {
 	return &v1.AddInterfaceOptions{
-		NetworkName:   networkName,
-		InterfaceName: ifaceName,
+		NetworkAttachmentDefinitionName: networkName,
+		InterfaceName:                   ifaceName,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
PR #6852 introduced the AddInterfaceOptions struct, which is used as part of a NIC hot-plug.
Currently, this struct contains a field named `NetworkName`. The field name is misleading, because it represents the name of a NetworkAttachmentDefinition[1] object, and not a Network[2] object.

Rename this field so its name will properly represent its value.
Rename the `InterfaceName` field to `Name`.

Also apply similar changes to `virtctl`.

[1] https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#create-network-attachment-definition
[2] http://kubevirt.io/api-reference/main/definitions.html#_v1_network

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR focuses on user-facing APIs.
Internal APIs will be fixed in a follow-up PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
API, AddInterfaceOptions: Rename NetworkName to NetworkAttachmentDefinitionName and InterfaceName to Name
```
