### PR TITLE
[e2e tests]: foreground delete testing manifests

### DIFF
--- a/tests/testsuite/manifest.go
+++ b/tests/testsuite/manifest.go
@@ -111,7 +111,7 @@ func DeleteRawManifest(object unstructured.Unstructured) error {
 	uri := composeResourceURI(object)
 	uri = path.Join(uri, object.GetName())
 
-	policy := metav1.DeletePropagationBackground
+	policy := metav1.DeletePropagationForeground
 	options := &metav1.DeleteOptions{PropagationPolicy: &policy}
 
 	log.DefaultLogger().Infof("Calling DELETE on testing manifest: %s", uri)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sometimes we pick up the wrong disks-images-provider pod due to the deletion happening asynchronously.
It may be nicer to just make sure the deletion of the pods is done here.
This appeared to be the motivation in https://github.com/kubevirt/kubevirt/pull/2182
(Not sure why background was chosen, as that is the default)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
