### PR TITLE
tests, console: Prevent NewExpecter negative timeout scenario

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -226,7 +226,11 @@ func NewExpecter(
 	if err != nil {
 		return nil, nil, err
 	}
-	timeout -= time.Since(startTime)
+	serialConsoleCreateDuration := time.Since(startTime)
+	if timeout-serialConsoleCreateDuration <= 0 {
+		return nil, nil, fmt.Errorf("creation of SerialConsole took %s - longer than given expecter timeout %s", serialConsoleCreateDuration.String(), timeout.String())
+	}
+	timeout -= serialConsoleCreateDuration
 
 	go func() {
 		resCh <- con.Stream(kubecli.StreamOptions{


### PR DESCRIPTION
The [NewExpecter](https://github.com/kubevirt/kubevirt/blob/13779f333957ec1937973262c91a21c06b0d30a3/tests/console/console.go#L214) constructor function is creating a serialConsole object and then spawns a generic process - both of which are included for the NewExpecter timeout.
Sometimes the first action takes longer than the whole timeout, causing the spawned process to start with no chance to finish within the overall timeout duration.

In order to fix this, Adding a check to prevent the spawned process from starting if the timeout has already passed.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
