### PR TITLE
[virt-operator]: fix issue with retrieval of virt-component version

### DIFF
--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -412,6 +412,11 @@ func (c *KubeVirtDeploymentConfig) GetOperatorVersion() string {
 	if c.UseShasums() {
 		return c.VirtOperatorSha
 	}
+
+	if digest := DigestFromImageName(c.VirtOperatorImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -419,6 +424,11 @@ func (c *KubeVirtDeploymentConfig) GetApiVersion() string {
 	if c.UseShasums() {
 		return c.VirtApiSha
 	}
+
+	if digest := DigestFromImageName(c.VirtApiImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -426,6 +436,11 @@ func (c *KubeVirtDeploymentConfig) GetControllerVersion() string {
 	if c.UseShasums() {
 		return c.VirtControllerSha
 	}
+
+	if digest := DigestFromImageName(c.VirtControllerImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -433,6 +448,11 @@ func (c *KubeVirtDeploymentConfig) GetHandlerVersion() string {
 	if c.UseShasums() {
 		return c.VirtHandlerSha
 	}
+
+	if digest := DigestFromImageName(c.VirtHandlerImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -440,6 +460,11 @@ func (c *KubeVirtDeploymentConfig) GetLauncherVersion() string {
 	if c.UseShasums() {
 		return c.VirtLauncherSha
 	}
+
+	if digest := DigestFromImageName(c.VirtLauncherImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -447,6 +472,11 @@ func (c *KubeVirtDeploymentConfig) GetExportProxyVersion() string {
 	if c.UseShasums() {
 		return c.VirtExportProxySha
 	}
+
+	if digest := DigestFromImageName(c.VirtExportProxyImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -454,6 +484,11 @@ func (c *KubeVirtDeploymentConfig) GetExportServerVersion() string {
 	if c.UseShasums() {
 		return c.VirtExportServerSha
 	}
+
+	if digest := DigestFromImageName(c.VirtExportServerImage); digest != "" {
+		return digest
+	}
+
 	return c.KubeVirtVersion
 }
 
@@ -666,4 +701,12 @@ func IsValidLabel(label string) bool {
 	// entire string must not exceed 63 chars
 	r := regexp.MustCompile(`^([a-z0-9A-Z]([a-z0-9A-Z\-\_\.]{0,61}[a-z0-9A-Z])?)?$`)
 	return r.Match([]byte(label))
+}
+
+func DigestFromImageName(name string) (digest string) {
+	if name != "" && strings.LastIndex(name, "@sha256:") != -1 {
+		digest = strings.Split(name, "@sha256:")[1]
+	}
+
+	return
 }

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -128,6 +128,37 @@ var _ = Describe("Operator Config", func() {
 			true),
 	)
 
+	It("should be able to extract shasum from image names", func() {
+		envVarManager.Setenv(VirtOperatorImageEnvName,
+			"acme.com/kubevirt/virt-operator@sha256:virt-operator-sha")
+		envVarManager.Setenv(VirtApiImageEnvName,
+			"acme.com/kubevirt/virt-api@sha256:virt-api-sha")
+		envVarManager.Setenv(VirtControllerImageEnvName,
+			"acme.com/kubevirt/virt-controller@sha256:virt-controller-sha")
+		envVarManager.Setenv(VirtHandlerImageEnvName,
+			"acme.com/kubevirt/virt-handler@sha256:virt-handler-sha")
+		envVarManager.Setenv(VirtLauncherImageEnvName,
+			"acme.com/kubevirt/virt-launcher@sha256:virt-launcher-sha")
+		envVarManager.Setenv(VirtExportProxyImageEnvName,
+			"acme.com/kubevirt/virt-exportproxy@sha256:virt-exportproxy-sha")
+		envVarManager.Setenv(VirtExportServerImageEnvName,
+			"acme.com/kubevirt/virt-exportserver@sha256:virt-exportserver-sha")
+
+		err := VerifyEnv()
+		Expect(err).ToNot(HaveOccurred())
+
+		parsedConfig, err := GetConfigFromEnv()
+		Expect(err).ToNot(HaveOccurred())
+		Expect("virt-operator-sha").To(Equal(parsedConfig.GetOperatorVersion()))
+		Expect("virt-api-sha").To(Equal(parsedConfig.GetApiVersion()))
+		Expect("virt-controller-sha").To(Equal(parsedConfig.GetControllerVersion()))
+		Expect("virt-handler-sha").To(Equal(parsedConfig.GetHandlerVersion()))
+		Expect("virt-launcher-sha").To(Equal(parsedConfig.GetLauncherVersion()))
+		Expect("virt-exportproxy-sha").To(Equal(parsedConfig.GetExportProxyVersion()))
+		Expect("virt-exportserver-sha").To(Equal(parsedConfig.GetExportServerVersion()))
+
+	})
+
 	Describe("GetPassthroughEnv()", func() {
 		It("should eturn environment variables matching the passthrough prefix (and only those vars)", func() {
 			realKey := rand.String(10)


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

**What this PR does / why we need it**:
now that its possible to pass the name of a virt-component image to the operator manifest using the VIRT_*_NAME env, its also possible to place a tag or digest of the container as part of the name, for example:
```
 acme-dot-com/kubevirt/my-virt-handler@sha256:afafaf
```
In case a digest is in use, we would like to keep the functionality as it was when the *_SHA_SUM vars were used per each virt-component (this method is deprecated), thus when asking for component version, the digest will be return, if used.


**Which issue(s) this PR fixes** 
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2180146

**Special notes for your reviewer**:
Regarding unit tests, since there is a lot of place for refactoring, I've found myself drifting 
from the scope while trying to reduce the boilerplate. Finally I just added the new spec w/o
consolidating, leaving the simplification for follow-up,

**Release note**:
```release-note
NONE
```
