### PR TITLE
e2e, VSOCK: only enable VSOCKGate in vmi_vsock_test

### DIFF
--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -105,7 +105,6 @@ func AdjustKubeVirtResource() {
 		virtconfig.ExpandDisksGate,
 		virtconfig.WorkloadEncryptionSEV,
 		virtconfig.VMExportGate,
-		virtconfig.VSOCKGate,
 		virtconfig.KubevirtSeccompProfile,
 		virtconfig.HotplugNetworkIfacesGate,
 	)

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -54,6 +54,7 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, func() {
 	var err error
 
 	BeforeEach(func() {
+		tests.EnableFeatureGate(virtconfig.VSOCKGate)
 		checks.SkipTestIfNoFeatureGate(virtconfig.VSOCKGate)
 		virtClient = kubevirt.Client()
 	})


### PR DESCRIPTION
As VSOCK is not isolated by network namespace, when enable this future gate in multiple node kind cluster, virt-handler would show error message when trying bind to same VSOCK port. So only enable VSOCKGate in vmi_vsock_test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9504


```release-note
NONE
```
