### PR TITLE
Support QEMU-level migration parallelism - with API for Kubevirt CR and migration policies.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20031,6 +20031,10 @@
       "type": "integer",
       "format": "int64"
      },
+     "parallelMigrationThreads": {
+      "type": "integer",
+      "format": "int32"
+     },
      "selectors": {
       "$ref": "#/definitions/v1alpha1.Selectors"
      }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17552,6 +17552,11 @@
       "description": "NodeDrainTaintKey defines the taint key that indicates a node should be drained. Note: this option relies on the deprecated node taint feature. Default: kubevirt.io/drain",
       "type": "string"
      },
+     "parallelMigrationThreads": {
+      "description": "ParallelMigrationThreads determines the number of threads that would be run in parallel in order to process the migration. Defaults to no parallelism.",
+      "type": "integer",
+      "format": "int32"
+     },
      "parallelMigrationsPerCluster": {
       "description": "ParallelMigrationsPerCluster is the total number of concurrent live migrations allowed cluster-wide. Defaults to 5",
       "type": "integer",

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -411,6 +411,11 @@ spec:
                           indicates a node should be drained. Note: this option relies
                           on the deprecated node taint feature. Default: kubevirt.io/drain'
                         type: string
+                      parallelMigrationThreads:
+                        description: ParallelMigrationThreads determines the number
+                          of threads that would be run in parallel in order to process
+                          the migration. Defaults to no parallelism.
+                        type: integer
                       parallelMigrationsPerCluster:
                         description: ParallelMigrationsPerCluster is the total number
                           of concurrent live migrations allowed cluster-wide. Defaults
@@ -3173,6 +3178,11 @@ spec:
                           indicates a node should be drained. Note: this option relies
                           on the deprecated node taint feature. Default: kubevirt.io/drain'
                         type: string
+                      parallelMigrationThreads:
+                        description: ParallelMigrationThreads determines the number
+                          of threads that would be run in parallel in order to process
+                          the migration. Defaults to no parallelism.
+                        type: integer
                       parallelMigrationsPerCluster:
                         description: ParallelMigrationsPerCluster is the total number
                           of concurrent live migrations allowed cluster-wide. Defaults

--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -91,3 +91,15 @@ func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {
 		return
 	}
 }
+
+func ValidateParallelMigrationThreads(parallelMigrationThreads *uint) error {
+	if parallelMigrationThreads == nil {
+		return nil
+	}
+
+	if *parallelMigrationThreads <= 1 {
+		return fmt.Errorf("parallel migration threads must be larger than 1, but it equals to %d", *parallelMigrationThreads)
+	}
+
+	return nil
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
     deps = [
         "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
+
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
@@ -93,6 +95,15 @@ func (admitter *MigrationPolicyAdmitter) Admit(ar *admissionv1.AdmissionReview) 
 				Field:   sourceField.Child("bandwidthPerMigration").String(),
 			})
 		}
+	}
+
+	err = validating_webhooks.ValidateParallelMigrationThreads(spec.ParallelMigrationThreads)
+	if err != nil {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: err.Error(),
+			Field:   sourceField.Child("parallelMigrationThreads").String(),
+		})
 	}
 
 	if len(causes) > 0 {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
@@ -42,6 +42,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"kubevirt.io/client-go/kubecli"
+
+	k6tpointer "kubevirt.io/kubevirt/pkg/pointer"
 )
 
 var _ = Describe("Validating MigrationPolicy Admitter", func() {
@@ -78,6 +80,14 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 		Entry("negative CompletionTimeoutPerGiB",
 			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: pointer.Int64Ptr(-1)},
 		),
+
+		Entry("ParallelMigrationThreads equals 0",
+			migrationsv1.MigrationPolicySpec{ParallelMigrationThreads: k6tpointer.P(uint(0))},
+		),
+
+		Entry("ParallelMigrationThreads equals 1",
+			migrationsv1.MigrationPolicySpec{ParallelMigrationThreads: k6tpointer.P(uint(1))},
+		),
 	)
 
 	DescribeTable("should accept migration policy with", func(policySpec migrationsv1.MigrationPolicySpec) {
@@ -102,6 +112,10 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 
 		Entry("zero BandwidthPerMigration",
 			migrationsv1.MigrationPolicySpec{BandwidthPerMigration: resource.NewScaledQuantity(0, 1)},
+		),
+
+		Entry("larger than 1 ParallelMigrationThreads",
+			migrationsv1.MigrationPolicySpec{ParallelMigrationThreads: k6tpointer.P(uint(123))},
 		),
 
 		Entry("empty spec",

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -69,12 +69,13 @@ const StandardInitLauncherSocketFileName = "launcher-init-sock"
 const StandardLauncherUnresponsiveFileName = "launcher-unresponsive"
 
 type MigrationOptions struct {
-	Bandwidth               resource.Quantity
-	ProgressTimeout         int64
-	CompletionTimeoutPerGiB int64
-	UnsafeMigration         bool
-	AllowAutoConverge       bool
-	AllowPostCopy           bool
+	Bandwidth                resource.Quantity
+	ProgressTimeout          int64
+	CompletionTimeoutPerGiB  int64
+	UnsafeMigration          bool
+	AllowAutoConverge        bool
+	AllowPostCopy            bool
+	ParallelMigrationThreads *uint
 }
 
 type LauncherClient interface {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2503,12 +2503,13 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationSource(origVMI *v1.Vir
 		}
 
 		options := &cmdclient.MigrationOptions{
-			Bandwidth:               *migrationConfiguration.BandwidthPerMigration,
-			ProgressTimeout:         *migrationConfiguration.ProgressTimeout,
-			CompletionTimeoutPerGiB: *migrationConfiguration.CompletionTimeoutPerGiB,
-			UnsafeMigration:         *migrationConfiguration.UnsafeMigrationOverride,
-			AllowAutoConverge:       *migrationConfiguration.AllowAutoConverge,
-			AllowPostCopy:           *migrationConfiguration.AllowPostCopy,
+			Bandwidth:                *migrationConfiguration.BandwidthPerMigration,
+			ProgressTimeout:          *migrationConfiguration.ProgressTimeout,
+			CompletionTimeoutPerGiB:  *migrationConfiguration.CompletionTimeoutPerGiB,
+			UnsafeMigration:          *migrationConfiguration.UnsafeMigrationOverride,
+			AllowAutoConverge:        *migrationConfiguration.AllowAutoConverge,
+			AllowPostCopy:            *migrationConfiguration.AllowPostCopy,
+			ParallelMigrationThreads: migrationConfiguration.ParallelMigrationThreads,
 		}
 
 		marshalledOptions, err := json.Marshal(options)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -90,7 +90,7 @@ type inflightMigrationAborted struct {
 	abortStatus v1.MigrationAbortStatus
 }
 
-func generateMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, allowPostyCopy, migratePaused bool) libvirt.DomainMigrateFlags {
+func generateMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, allowPostyCopy, parallelMigration, migratePaused bool) libvirt.DomainMigrateFlags {
 	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
 	if isBlockMigration {
@@ -107,6 +107,9 @@ func generateMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConver
 	}
 	if migratePaused {
 		migrateFlags |= libvirt.MIGRATE_PAUSED
+	}
+	if parallelMigration {
+		migrateFlags |= libvirt.MIGRATE_PARALLEL
 	}
 
 	return migrateFlags
@@ -813,17 +816,26 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 		return nil, err
 	}
 
+	parallelMigrationSet := false
+	parallelMigrationThreads := 1
+	if options.ParallelMigrationThreads != nil {
+		parallelMigrationSet = true
+		parallelMigrationThreads = int(*options.ParallelMigrationThreads)
+	}
+
 	key := migrationproxy.ConstructProxyKey(string(vmi.UID), migrationproxy.LibvirtDirectMigrationPort)
 	migrURI := fmt.Sprintf("unix://%s", migrationproxy.SourceUnixFile(virtShareDir, key))
 	params := &libvirt.DomainMigrateParameters{
-		URI:           migrURI,
-		URISet:        true,
-		Bandwidth:     bandwidth, // MiB/s
-		BandwidthSet:  bandwidth > 0,
-		DestXML:       xmlstr,
-		DestXMLSet:    true,
-		PersistXML:    xmlstr,
-		PersistXMLSet: true,
+		URI:                    migrURI,
+		URISet:                 true,
+		Bandwidth:              bandwidth, // MiB/s
+		BandwidthSet:           bandwidth > 0,
+		DestXML:                xmlstr,
+		DestXMLSet:             true,
+		PersistXML:             xmlstr,
+		PersistXMLSet:          true,
+		ParallelConnectionsSet: parallelMigrationSet,
+		ParallelConnections:    parallelMigrationThreads,
 	}
 
 	copyDisks := getDiskTargetsForMigration(dom, vmi)
@@ -857,7 +869,7 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 	if err != nil {
 		return fmt.Errorf("failed to retrive domain state")
 	}
-	migrateFlags := generateMigrationFlags(isBlockMigration(vmi), options.UnsafeMigration, options.AllowAutoConverge, options.AllowPostCopy, migratePaused)
+	migrateFlags := generateMigrationFlags(isBlockMigration(vmi), options.UnsafeMigration, options.AllowAutoConverge, options.AllowPostCopy, options.ParallelMigrationThreads != nil, migratePaused)
 
 	// anything that modifies the domain needs to be performed with the domainModifyLock held
 	// The domain params and unHotplug need to be performed in a critical section together.

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -90,25 +90,25 @@ type inflightMigrationAborted struct {
 	abortStatus v1.MigrationAbortStatus
 }
 
-func generateMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, allowPostyCopy, parallelMigration, migratePaused bool) libvirt.DomainMigrateFlags {
+func generateMigrationFlags(isBlockMigration, migratePaused bool, options *cmdclient.MigrationOptions) libvirt.DomainMigrateFlags {
 	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
 	if isBlockMigration {
 		migrateFlags |= libvirt.MIGRATE_NON_SHARED_INC
 	}
-	if isUnsafeMigration {
+	if options.UnsafeMigration {
 		migrateFlags |= libvirt.MIGRATE_UNSAFE
 	}
-	if allowAutoConverge {
+	if options.AllowAutoConverge {
 		migrateFlags |= libvirt.MIGRATE_AUTO_CONVERGE
 	}
-	if allowPostyCopy {
+	if options.AllowPostCopy {
 		migrateFlags |= libvirt.MIGRATE_POSTCOPY
 	}
 	if migratePaused {
 		migrateFlags |= libvirt.MIGRATE_PAUSED
 	}
-	if parallelMigration {
+	if options.ParallelMigrationThreads != nil {
 		migrateFlags |= libvirt.MIGRATE_PARALLEL
 	}
 
@@ -869,7 +869,7 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 	if err != nil {
 		return fmt.Errorf("failed to retrive domain state")
 	}
-	migrateFlags := generateMigrationFlags(isBlockMigration(vmi), options.UnsafeMigration, options.AllowAutoConverge, options.AllowPostCopy, options.ParallelMigrationThreads != nil, migratePaused)
+	migrateFlags := generateMigrationFlags(isBlockMigration(vmi), migratePaused, options)
 
 	// anything that modifies the domain needs to be performed with the domainModifyLock held
 	// The domain params and unHotplug need to be performed in a critical section together.

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1571,12 +1571,15 @@ var _ = Describe("Manager", func() {
 	DescribeTable("check migration flags",
 		func(migrationType string) {
 			isBlockMigration := migrationType == "block"
-			isUnsafeMigration := migrationType == "unsafe"
-			allowAutoConverge := migrationType == "autoConverge"
-			migrationMode := migrationType == "postCopy"
 			isVmiPaused := migrationType == "paused"
 
-			flags := generateMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, migrationMode, isVmiPaused)
+			options := &cmdclient.MigrationOptions{
+				UnsafeMigration:   migrationType == "unsafe",
+				AllowAutoConverge: migrationType == "autoConverge",
+				AllowPostCopy:     migrationType == "postCopy",
+			}
+
+			flags := generateMigrationFlags(isBlockMigration, isVmiPaused, options)
 			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
 			if isBlockMigration {
@@ -1584,7 +1587,7 @@ var _ = Describe("Manager", func() {
 			} else if migrationType == "unsafe" {
 				expectedMigrateFlags |= libvirt.MIGRATE_UNSAFE
 			}
-			if allowAutoConverge {
+			if options.AllowAutoConverge {
 				expectedMigrateFlags |= libvirt.MIGRATE_AUTO_CONVERGE
 			}
 			if migrationType == "postCopy" {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1573,10 +1573,17 @@ var _ = Describe("Manager", func() {
 			isBlockMigration := migrationType == "block"
 			isVmiPaused := migrationType == "paused"
 
+			var parallelMigrationThreads *uint = nil
+			if migrationType == "parallel" {
+				var fakeNumberOfThreads uint = 123
+				parallelMigrationThreads = &fakeNumberOfThreads
+			}
+
 			options := &cmdclient.MigrationOptions{
-				UnsafeMigration:   migrationType == "unsafe",
-				AllowAutoConverge: migrationType == "autoConverge",
-				AllowPostCopy:     migrationType == "postCopy",
+				UnsafeMigration:          migrationType == "unsafe",
+				AllowAutoConverge:        migrationType == "autoConverge",
+				AllowPostCopy:            migrationType == "postCopy",
+				ParallelMigrationThreads: parallelMigrationThreads,
 			}
 
 			flags := generateMigrationFlags(isBlockMigration, isVmiPaused, options)
@@ -1596,7 +1603,10 @@ var _ = Describe("Manager", func() {
 			if migrationType == "paused" {
 				expectedMigrateFlags |= libvirt.MIGRATE_PAUSED
 			}
-			Expect(flags).To(Equal(expectedMigrateFlags))
+			if migrationType == "parallel" {
+				expectedMigrateFlags |= libvirt.MIGRATE_PARALLEL
+			}
+			Expect(flags).To(Equal(expectedMigrateFlags), "libvirt migration flags are not set as expected")
 		},
 		Entry("with block migration", "block"),
 		Entry("without block migration", "live"),
@@ -1604,6 +1614,7 @@ var _ = Describe("Manager", func() {
 		Entry("migration auto converge", "autoConverge"),
 		Entry("migration using postcopy", "postCopy"),
 		Entry("migration of paused vmi", "paused"),
+		Entry("migration with parallel threads", "parallel"),
 	)
 
 	DescribeTable("on successful list all domains",

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -887,6 +887,11 @@ var CRDsValidation map[string]string = map[string]string{
                     a node should be drained. Note: this option relies on the deprecated
                     node taint feature. Default: kubevirt.io/drain'
                   type: string
+                parallelMigrationThreads:
+                  description: ParallelMigrationThreads determines the number of threads
+                    that would be run in parallel in order to process the migration.
+                    Defaults to no parallelism.
+                  type: integer
                 parallelMigrationsPerCluster:
                   description: ParallelMigrationsPerCluster is the total number of
                     concurrent live migrations allowed cluster-wide. Defaults to 5
@@ -11072,6 +11077,11 @@ var CRDsValidation map[string]string = map[string]string{
                     a node should be drained. Note: this option relies on the deprecated
                     node taint feature. Default: kubevirt.io/drain'
                   type: string
+                parallelMigrationThreads:
+                  description: ParallelMigrationThreads determines the number of threads
+                    that would be run in parallel in order to process the migration.
+                    Defaults to no parallelism.
+                  type: integer
                 parallelMigrationsPerCluster:
                   description: ParallelMigrationsPerCluster is the total number of
                     concurrent live migrations allowed cluster-wide. Defaults to 5
@@ -11446,6 +11456,11 @@ var CRDsValidation map[string]string = map[string]string{
                     a node should be drained. Note: this option relies on the deprecated
                     node taint feature. Default: kubevirt.io/drain'
                   type: string
+                parallelMigrationThreads:
+                  description: ParallelMigrationThreads determines the number of threads
+                    that would be run in parallel in order to process the migration.
+                    Defaults to no parallelism.
+                  type: integer
                 parallelMigrationsPerCluster:
                   description: ParallelMigrationsPerCluster is the total number of
                     concurrent live migrations allowed cluster-wide. Defaults to 5

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -3146,6 +3146,8 @@ var CRDsValidation map[string]string = map[string]string{
         completionTimeoutPerGiB:
           format: int64
           type: integer
+        parallelMigrationThreads:
+          type: integer
         selectors:
           properties:
             namespaceSelector:

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -2695,6 +2695,11 @@ func (in *MigrationConfiguration) DeepCopyInto(out *MigrationConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ParallelMigrationThreads != nil {
+		in, out := &in.ParallelMigrationThreads, &out.ParallelMigrationThreads
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2367,6 +2367,9 @@ type MigrationConfiguration struct {
 	// Network is the name of the CNI network to use for live migrations. By default, migrations go
 	// through the pod network.
 	Network *string `json:"network,omitempty"`
+	// ParallelMigrationThreads determines the number of threads that would be run in parallel in order
+	// to process the migration. Defaults to no parallelism.
+	ParallelMigrationThreads *uint `json:"parallelMigrationThreads,omitempty"`
 }
 
 // DiskVerification holds container disks verification limits

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -750,6 +750,7 @@ func (MigrationConfiguration) SwaggerDoc() map[string]string {
 		"allowPostCopy":                     "AllowPostCopy enables post-copy live migrations. Such migrations allow even the busiest VMIs\nto successfully live-migrate. However, events like a network failure can cause a VMI crash.\nIf set to true, migrations will still start in pre-copy, but switch to post-copy when\nCompletionTimeoutPerGiB triggers. Defaults to false",
 		"disableTLS":                        "When set to true, DisableTLS will disable the additional layer of live migration encryption\nprovided by KubeVirt. This is usually a bad idea. Defaults to false",
 		"network":                           "Network is the name of the CNI network to use for live migrations. By default, migrations go\nthrough the pod network.",
+		"parallelMigrationThreads":          "ParallelMigrationThreads determines the number of threads that would be run in parallel in order\nto process the migration. Defaults to no parallelism.",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/deepcopy_generated.go
@@ -136,6 +136,11 @@ func (in *MigrationPolicySpec) DeepCopyInto(out *MigrationPolicySpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ParallelMigrationThreads != nil {
+		in, out := &in.ParallelMigrationThreads, &out.ParallelMigrationThreads
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
@@ -43,6 +43,8 @@ type MigrationPolicy struct {
 type MigrationPolicySpec struct {
 	Selectors *Selectors `json:"selectors"`
 
+	// See MigrationConfiguration struct's documentation for more info
+
 	//+optional
 	AllowAutoConverge *bool `json:"allowAutoConverge,omitempty"`
 	//+optional
@@ -51,6 +53,8 @@ type MigrationPolicySpec struct {
 	CompletionTimeoutPerGiB *int64 `json:"completionTimeoutPerGiB,omitempty"`
 	//+optional
 	AllowPostCopy *bool `json:"allowPostCopy,omitempty"`
+	//+optional
+	ParallelMigrationThreads *uint `json:"parallelMigrationThreads,omitempty"`
 }
 
 type LabelSelector map[string]string

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types.go
@@ -103,6 +103,10 @@ func (m *MigrationPolicy) GetMigrationConfByPolicy(clusterMigrationConfiguration
 		changed = true
 		*clusterMigrationConfigurations.AllowPostCopy = *policySpec.AllowPostCopy
 	}
+	if policySpec.ParallelMigrationThreads != nil {
+		changed = true
+		clusterMigrationConfigurations.ParallelMigrationThreads = policySpec.ParallelMigrationThreads
+	}
 
 	return changed, nil
 }

--- a/staging/src/kubevirt.io/api/migrations/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/migrations/v1alpha1/types_swagger_generated.go
@@ -11,10 +11,11 @@ func (MigrationPolicy) SwaggerDoc() map[string]string {
 
 func (MigrationPolicySpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"allowAutoConverge":       "+optional",
-		"bandwidthPerMigration":   "+optional",
-		"completionTimeoutPerGiB": "+optional",
-		"allowPostCopy":           "+optional",
+		"allowAutoConverge":        "+optional",
+		"bandwidthPerMigration":    "+optional",
+		"completionTimeoutPerGiB":  "+optional",
+		"allowPostCopy":            "+optional",
+		"parallelMigrationThreads": "+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25631,6 +25631,12 @@ func schema_kubevirtio_api_migrations_v1alpha1_MigrationPolicySpec(ref common.Re
 							Format: "",
 						},
 					},
+					"parallelMigrationThreads": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 				Required: []string{"selectors"},
 			},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -18623,6 +18623,13 @@ func schema_kubevirtio_api_core_v1_MigrationConfiguration(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"parallelMigrationThreads": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ParallelMigrationThreads determines the number of threads that would be run in parallel in order to process the migration. Defaults to no parallelism.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -177,6 +177,7 @@ go_test(
         "//pkg/hooks/v1alpha1:go_default_library",
         "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/network/dns:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Backup of https://github.com/kubevirt/kubevirt/pull/8575 with full API.
Saving this as it could be used as a reference in the future.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
