### PR TITLE
Fix `make lint` lane failure

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -228,7 +228,12 @@ func NewExpecter(
 	}
 	serialConsoleCreateDuration := time.Since(startTime)
 	if timeout-serialConsoleCreateDuration <= 0 {
-		return nil, nil, fmt.Errorf("creation of SerialConsole took %s - longer than given expecter timeout %s", serialConsoleCreateDuration.String(), timeout.String())
+		return nil, nil,
+			fmt.Errorf(
+				"creation of SerialConsole took %s - longer than given expecter timeout %s",
+				serialConsoleCreateDuration.String(),
+				timeout.String(),
+			)
 	}
 	timeout -= serialConsoleCreateDuration
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Lane https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-code-lint is failing
since https://github.com/kubevirt/kubevirt/pull/9497 was merged.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
