### PR TITLE
[release-0.58] tests, console: Prevent NewExpecter negative timeout scenario

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -239,7 +239,16 @@ func NewExpecter(
 	if err != nil {
 		return nil, nil, err
 	}
-	timeout -= time.Since(startTime)
+	serialConsoleCreateDuration := time.Since(startTime)
+	if timeout-serialConsoleCreateDuration <= 0 {
+		return nil, nil,
+			fmt.Errorf(
+				"creation of SerialConsole took %s - longer than given expecter timeout %s",
+				serialConsoleCreateDuration.String(),
+				timeout.String(),
+			)
+	}
+	timeout -= serialConsoleCreateDuration
 
 	go func() {
 		resCh <- con.Stream(kubecli.StreamOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is a manual cherry-pick of #9497 and the proposed change in #9515.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
