### PR TITLE
Add Alpha label to the cpu metrics descriptions

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -70,13 +70,13 @@ Virtual Machine last transition timestamp to starting status. Type: Counter.
 Details the cpu pinning map via boolean labels in the form of vcpu_X_cpu_Y. Type: Counter.
 
 ### kubevirt_vmi_cpu_system_usage_seconds
-Total CPU time spent in system mode. Type: Gauge.
+Total CPU time spent in system mode [Alpha]. Type: Gauge.
 
 ### kubevirt_vmi_cpu_usage_seconds
-Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Gauge.
+Total CPU time spent in all modes (sum of both vcpu and hypervisor usage) [Alpha]. Type: Gauge.
 
 ### kubevirt_vmi_cpu_user_usage_seconds
-Total CPU time spent in user mode. Type: Gauge.
+Total CPU time spent in user mode [Alpha]. Type: Gauge.
 
 ### kubevirt_vmi_filesystem_capacity_bytes_total
 Total VM filesystem capacity in bytes. Type: Gauge.

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -242,7 +242,7 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 	if domainCPUStats.TimeSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_cpu_usage_seconds",
-			"Total CPU time spent in all modes (sum of both vcpu and hypervisor usage).",
+			"Total CPU time spent in all modes (sum of both vcpu and hypervisor usage) [Alpha].",
 			prometheus.GaugeValue,
 			float64(domainCPUStats.Time/1000000000),
 		)
@@ -251,7 +251,7 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 	if domainCPUStats.UserSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_cpu_user_usage_seconds",
-			"Total CPU time spent in user mode.",
+			"Total CPU time spent in user mode [Alpha].",
 			prometheus.GaugeValue,
 			float64(domainCPUStats.User/1000000000),
 		)
@@ -260,7 +260,7 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 	if domainCPUStats.SystemSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_cpu_system_usage_seconds",
-			"Total CPU time spent in system mode.",
+			"Total CPU time spent in system mode [Alpha].",
 			prometheus.GaugeValue,
 			float64(domainCPUStats.System/1000000000),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since it's much more complicated to add a stability level filed (https://github.com/kubevirt/kubevirt/issues/9139), in the current code we decided to refactor the monitoring code before adding the mew filed so it will be after 4.13.  In order to make sure customers are aware in 4.13 that the new cpu metrics are "Alpha" we added it to their description. 

**Special notes for your reviewer**:
This change will be removed from the metrics description in 4.13.1, once the stability level will be added or even before since QE will cover it in 4.13.1 it will no longer be needed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
The new CPU metrics introduced in 4.13 are in Alpha stability level:
kubevirt_vmi_cpu_system_seconds
kubevirt_vmi_cpu_user_seconds
kubevirt_vmi_cpu_usage_seconds


```
