### PR TITLE
[release-0.53] Fix Migration Metrics exposed to prometheus during VM migration

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -2112,41 +2112,54 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				cfg := getCurrentKv()
 				var timeout int64 = 5
 				cfg.MigrationConfiguration = &v1.MigrationConfiguration{
-					ProgressTimeout:         &timeout,
 					CompletionTimeoutPerGiB: &timeout,
 					BandwidthPerMigration:   resource.NewMilliQuantity(1, resource.BinarySI),
 				}
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
-			PIt("[test_id:2227] should abort a vmi migration without progress", func() {
-				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+			Context("without progress", func() {
 
-				By("Starting the VirtualMachineInstance")
-				vmi = runVMIAndExpectLaunch(vmi, 240)
+				BeforeEach(func() {
+					cfg := getCurrentKv()
+					var timeout int64 = 5
+					cfg.MigrationConfiguration = &v1.MigrationConfiguration{
+						ProgressTimeout:         &timeout,
+						CompletionTimeoutPerGiB: &timeout,
+						BandwidthPerMigration:   resource.NewMilliQuantity(1, resource.BinarySI),
+					}
+					tests.UpdateKubeVirtConfigValueAndWait(cfg)
+				})
 
-				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
+				It("[test_id:2227] should abort a vmi migration without progress", func() {
+					vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
-				// Need to wait for cloud init to finish and start the agent inside the vmi.
-				tests.WaitAgentConnected(virtClient, vmi)
+					By("Starting the VirtualMachineInstance")
+					vmi = runVMIAndExpectLaunch(vmi, 240)
 
-				runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
+					By("Checking that the VirtualMachineInstance console has expected output")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-				// execute a migration, wait for finalized state
-				By("Starting the Migration")
-				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
-				migrationUID := runMigrationAndExpectFailure(migration, 180)
+					// Need to wait for cloud init to finish and start the agent inside the vmi.
+					tests.WaitAgentConnected(virtClient, vmi)
 
-				// check VMI, confirm migration state
-				confirmVMIPostMigrationFailed(vmi, migrationUID)
+					runStressTest(vmi, stressLargeVMSize, stressDefaultTimeout)
 
-				// delete VMI
-				By("Deleting the VMI")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+					// execute a migration, wait for finalized state
+					By("Starting the Migration")
+					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+					migrationUID := runMigrationAndExpectFailure(migration, 180)
 
-				By("Waiting for VMI to disappear")
-				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+					// check VMI, confirm migration state
+					confirmVMIPostMigrationFailed(vmi, migrationUID)
+
+					// delete VMI
+					By("Deleting the VMI")
+					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+					By("Waiting for VMI to disappear")
+					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+				})
 			})
 
 			It("[test_id:8482] Migration Metrics exposed to prometheus during VM migration", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Moving the limitation of migration progress to a more specific context that needs it.

Syndrome `Live migration abort detected with reason: Live migration is not completed after 5 seconds and has been aborted`



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
