### PR TITLE
[release-0.59] Add 'Alpha' to the new CPU metrics description

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,13 +67,13 @@ Virtual Machine last transition timestamp to starting status. Type: Counter.
 Details the cpu pinning map via boolean labels in the form of vcpu_X_cpu_Y. Type: Counter.
 
 ### kubevirt_vmi_cpu_system_usage_seconds
-Total CPU time spent in system mode. Type: Gauge.
+Total CPU time spent in system mode [Alpha]. Type: Gauge.
 
 ### kubevirt_vmi_cpu_usage_seconds
-Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). Type: Gauge.
+Total CPU time spent in all modes (sum of both vcpu and hypervisor usage) [Alpha]. Type: Gauge.
 
 ### kubevirt_vmi_cpu_user_usage_seconds
-Total CPU time spent in user mode. Type: Gauge.
+Total CPU time spent in user mode [Alpha]. Type: Gauge.
 
 ### kubevirt_vmi_filesystem_capacity_bytes_total
 Total VM filesystem capacity in bytes. Type: Gauge.

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -242,7 +242,7 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 	if domainCPUStats.TimeSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_cpu_usage_seconds",
-			"Total CPU time spent in all modes (sum of both vcpu and hypervisor usage).",
+			"Total CPU time spent in all modes (sum of both vcpu and hypervisor usage) [Alpha].",
 			prometheus.GaugeValue,
 			float64(domainCPUStats.Time/1000000000),
 		)
@@ -251,7 +251,7 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 	if domainCPUStats.UserSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_cpu_user_usage_seconds",
-			"Total CPU time spent in user mode.",
+			"Total CPU time spent in user mode [Alpha].",
 			prometheus.GaugeValue,
 			float64(domainCPUStats.User/1000000000),
 		)
@@ -260,7 +260,7 @@ func (metrics *vmiMetrics) updateCPU(vmi *k6tv1.VirtualMachineInstance, domainCP
 	if domainCPUStats.SystemSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_cpu_system_usage_seconds",
-			"Total CPU time spent in system mode.",
+			"Total CPU time spent in system mode [Alpha].",
 			prometheus.GaugeValue,
 			float64(domainCPUStats.System/1000000000),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The new CPU metrics  are stilled considered as "Alpha" and a subjected to further testing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
The new CPU metrics in Alpha stability level are:
kubevirt_vmi_cpu_system_seconds
kubevirt_vmi_cpu_user_seconds
kubevirt_vmi_cpu_usage_seconds


```
