### PR TITLE
[release-0.59] instancetype: Handle DataVolumeSourceRef without namespace when inferring defaults

### DIFF
--- a/pkg/instancetype/instancetype.go
+++ b/pkg/instancetype/instancetype.go
@@ -758,7 +758,7 @@ func (m *methods) inferDefaultsFromDataVolume(vm *virtv1.VirtualMachine, dvName,
 			if dvt.Name != dvName {
 				continue
 			}
-			return m.inferDefaultsFromDataVolumeSpec(&dvt.Spec, defaultNameLabel, defaultKindLabel)
+			return m.inferDefaultsFromDataVolumeSpec(&dvt.Spec, defaultNameLabel, defaultKindLabel, vm.Namespace)
 		}
 	}
 	dv, err := m.clientset.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.Background(), dvName, metav1.GetOptions{})
@@ -774,15 +774,15 @@ func (m *methods) inferDefaultsFromDataVolume(vm *virtv1.VirtualMachine, dvName,
 	if err == nil {
 		return defaultName, defaultKind, nil
 	}
-	return m.inferDefaultsFromDataVolumeSpec(&dv.Spec, defaultNameLabel, defaultKindLabel)
+	return m.inferDefaultsFromDataVolumeSpec(&dv.Spec, defaultNameLabel, defaultKindLabel, vm.Namespace)
 }
 
-func (m *methods) inferDefaultsFromDataVolumeSpec(dataVolumeSpec *v1beta1.DataVolumeSpec, defaultNameLabel, defaultKindLabel string) (string, string, error) {
+func (m *methods) inferDefaultsFromDataVolumeSpec(dataVolumeSpec *v1beta1.DataVolumeSpec, defaultNameLabel, defaultKindLabel, vmNameSpace string) (string, string, error) {
 	if dataVolumeSpec != nil && dataVolumeSpec.Source != nil && dataVolumeSpec.Source.PVC != nil {
 		return m.inferDefaultsFromPVC(dataVolumeSpec.Source.PVC.Name, dataVolumeSpec.Source.PVC.Namespace, defaultNameLabel, defaultKindLabel)
 	}
 	if dataVolumeSpec != nil && dataVolumeSpec.SourceRef != nil {
-		return m.inferDefaultsFromDataVolumeSourceRef(dataVolumeSpec.SourceRef, defaultNameLabel, defaultKindLabel)
+		return m.inferDefaultsFromDataVolumeSourceRef(dataVolumeSpec.SourceRef, defaultNameLabel, defaultKindLabel, vmNameSpace)
 	}
 	return "", "", fmt.Errorf("unable to infer defaults from DataVolumeSpec as DataVolumeSource is not supported")
 }
@@ -803,10 +803,15 @@ func (m *methods) inferDefaultsFromDataSource(dataSourceName, dataSourceNamespac
 	return "", "", fmt.Errorf("unable to infer defaults from DataSource that doesn't provide DataVolumeSourcePVC")
 }
 
-func (m *methods) inferDefaultsFromDataVolumeSourceRef(sourceRef *v1beta1.DataVolumeSourceRef, defaultNameLabel, defaultKindLabel string) (string, string, error) {
+func (m *methods) inferDefaultsFromDataVolumeSourceRef(sourceRef *v1beta1.DataVolumeSourceRef, defaultNameLabel, defaultKindLabel, vmNameSpace string) (string, string, error) {
 	switch sourceRef.Kind {
 	case "DataSource":
-		return m.inferDefaultsFromDataSource(sourceRef.Name, *sourceRef.Namespace, defaultNameLabel, defaultKindLabel)
+		// The namespace can be left blank here with the assumption that the DataSource is in the same namespace as the VM
+		namespace := vmNameSpace
+		if sourceRef.Namespace != nil {
+			namespace = *sourceRef.Namespace
+		}
+		return m.inferDefaultsFromDataSource(sourceRef.Name, namespace, defaultNameLabel, defaultKindLabel)
 	}
 	return "", "", fmt.Errorf("unable to infer defaults from DataVolumeSourceRef as Kind %s is not supported", sourceRef.Kind)
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -654,6 +654,10 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		DescribeTable("should infer defaults from DataVolume, DataVolumeSourceRef", func(sourceRefName, sourceRefKind, sourceRefNamespace string, instancetypeMatcher, expectedInstancetypeMatcher *v1.InstancetypeMatcher, preferenceMatcher, expectedPreferenceMatcher *v1.PreferenceMatcher) {
 			vm.Spec.Instancetype = instancetypeMatcher
 			vm.Spec.Preference = preferenceMatcher
+			var sourceRefNamespacePointer *string
+			if sourceRefNamespace != "" {
+				sourceRefNamespacePointer = &sourceRefNamespace
+			}
 			dvWithSourceRef := &v1beta1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:      "dvWithSourceRef",
@@ -663,7 +667,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 					SourceRef: &v1beta1.DataVolumeSourceRef{
 						Name:      sourceRefName,
 						Kind:      sourceRefKind,
-						Namespace: &sourceRefNamespace,
+						Namespace: sourceRefNamespacePointer,
 					},
 				},
 			}
@@ -716,6 +720,48 @@ var _ = Describe("VirtualMachine Mutator", func() {
 			),
 			Entry("and DataSource with annotations for PreferenceMatcher",
 				dsWithAnnotationsName, "DataSource", k8sv1.NamespaceDefault,
+				nil, nil,
+				&v1.PreferenceMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.PreferenceMatcher{
+					Name: defaultInferedNameFromDS,
+					Kind: defaultInferedKindFromDS,
+				},
+			),
+			Entry(",DataSource without namespace and PersistentVolumeClaim for InstancetypeMatcher",
+				dsWithSourcePVCName, "DataSource", "",
+				&v1.InstancetypeMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.InstancetypeMatcher{
+					Name: defaultInferedNameFromPVC,
+					Kind: defaultInferedKindFromPVC,
+				}, nil, nil,
+			),
+			Entry(",DataSource without namespace and PersistentVolumeClaim for PreferenceMatcher",
+				dsWithSourcePVCName, "DataSource", "",
+				nil, nil,
+				&v1.PreferenceMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.PreferenceMatcher{
+					Name: defaultInferedNameFromPVC,
+					Kind: defaultInferedKindFromPVC,
+				},
+			),
+			Entry("and DataSource without namespace with annotations for InstancetypeMatcher",
+				dsWithAnnotationsName, "DataSource", "",
+				&v1.InstancetypeMatcher{
+					InferFromVolume: inferVolumeName,
+				},
+				&v1.InstancetypeMatcher{
+					Name: defaultInferedNameFromDS,
+					Kind: defaultInferedKindFromDS,
+				}, nil, nil,
+			),
+			Entry("and DataSource without namespace with annotations for PreferenceMatcher",
+				dsWithAnnotationsName, "DataSource", "",
 				nil, nil,
 				&v1.PreferenceMatcher{
 					InferFromVolume: inferVolumeName,

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -892,6 +892,44 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 					},
 				},
 			),
+			Entry(", DataVolumeSourceRef without namespace and DataSource",
+				&cdiv1beta1.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datavolume-",
+						Namespace:    util.NamespaceTestDefault,
+					},
+					Spec: cdiv1beta1.DataVolumeSpec{
+						SourceRef: &cdiv1beta1.DataVolumeSourceRef{
+							Name:      dataSourceName,
+							Kind:      "DataSource",
+							Namespace: nil,
+						},
+						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
+						Storage: &cdiv1beta1.StorageSpec{
+							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+							Resources: k8sv1.ResourceRequirements{
+								Requests: k8sv1.ResourceList{
+									"storage": resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+				&cdiv1beta1.DataSource{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datasource-",
+						Namespace:    util.NamespaceTestDefault,
+					},
+					Spec: cdiv1beta1.DataSourceSpec{
+						Source: cdiv1beta1.DataSourceSource{
+							PVC: &cdiv1beta1.DataVolumeSourcePVC{
+								Name:      pvcSourceName,
+								Namespace: util.NamespaceTestDefault,
+							},
+						},
+					},
+				},
+			),
 			Entry(", DataVolumeSourceRef and DataSource with annotations",
 				&cdiv1beta1.DataVolume{
 					ObjectMeta: metav1.ObjectMeta{
@@ -903,6 +941,50 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Name:      dataSourceName,
 							Kind:      "DataSource",
 							Namespace: &util.NamespaceTestDefault,
+						},
+						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
+						Storage: &cdiv1beta1.StorageSpec{
+							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+							Resources: k8sv1.ResourceRequirements{
+								Requests: k8sv1.ResourceList{
+									"storage": resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+				&cdiv1beta1.DataSource{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datasource-",
+						Namespace:    util.NamespaceTestDefault,
+						Annotations: map[string]string{
+							instancetypeapi.DefaultInstancetypeLabel:     instancetypeName,
+							instancetypeapi.DefaultInstancetypeKindLabel: instancetypeapi.SingularResourceName,
+							instancetypeapi.DefaultPreferenceLabel:       preferenceName,
+							instancetypeapi.DefaultPreferenceKindLabel:   instancetypeapi.SingularPreferenceResourceName,
+						},
+					},
+					Spec: cdiv1beta1.DataSourceSpec{
+						Source: cdiv1beta1.DataSourceSource{
+							PVC: &cdiv1beta1.DataVolumeSourcePVC{
+								Name:      pvcSourceName,
+								Namespace: util.NamespaceTestDefault,
+							},
+						},
+					},
+				},
+			),
+			Entry(", DataVolumeSourceRef without namespace and DataSource with annotations",
+				&cdiv1beta1.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "datavolume-",
+						Namespace:    util.NamespaceTestDefault,
+					},
+					Spec: cdiv1beta1.DataVolumeSpec{
+						SourceRef: &cdiv1beta1.DataVolumeSourceRef{
+							Name:      dataSourceName,
+							Kind:      "DataSource",
+							Namespace: nil,
 						},
 						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
 						Storage: &cdiv1beta1.StorageSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As set out in issue #9431 it is valid for a DataVolumeSourceRef to not provide a namespace, the assumption being that the resource it points to is in the same namespace as the VirtualMachine.

This change handles this by switching to the namespace of the VirtualMachine when no namespace is provided by the DataVolumeSourceRef, avoiding a previous panic.

NOTE(lyarwood): conflict caused by
c09acad4db9cddf75c5b059d62c1074c40bd85ab not being present the in release-0.59 branch.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>
(cherry picked from commit 50befd593b10b6a5c2a574f12ff9c6cbd6a9674d)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
