### PR TITLE
Close resp.Body from `/healthz` requests and fix deprecated ioutil call

### DIFF
--- a/hack/prom-rule-ci/rule-spec-dumper.go
+++ b/hack/prom-rule-ci/rule-spec-dumper.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
@@ -32,7 +31,7 @@ func main() {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(targetFile, b, 0644)
+	err = os.WriteFile(targetFile, b, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -3,7 +3,6 @@ package vm_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/utils/pointer"
@@ -652,7 +651,7 @@ status:
 			invalidYaml = `apiVersion: kubevirt.io/v1kind: VirtualMachine`
 		)
 		BeforeEach(func() {
-			file, err = ioutil.TempFile("", "file-*")
+			file, err = os.CreateTemp("", "file-*")
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -387,7 +387,7 @@ func enrichError(httpErr error, resp *http.Response) error {
 		return httpErr
 	}
 	// decode, but if the result is Status return that as an error instead.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/staging/src/kubevirt.io/client-go/util/util.go
+++ b/staging/src/kubevirt.io/client-go/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -12,7 +11,7 @@ const ServiceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccou
 const namespaceKubevirt = "kubevirt"
 
 func GetNamespace() (string, error) {
-	if data, err := ioutil.ReadFile(ServiceAccountNamespaceFile); err == nil {
+	if data, err := os.ReadFile(ServiceAccountNamespaceFile); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns, nil
 		}

--- a/tests/conformance/conformance.go
+++ b/tests/conformance/conformance.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -11,7 +10,7 @@ import (
 var containerTag = ""
 
 func done(files []string) {
-	err := ioutil.WriteFile("/tmp/sonobuoy/results/done", []byte(strings.Join(files, "\n")), 0666)
+	err := os.WriteFile("/tmp/sonobuoy/results/done", []byte(strings.Join(files, "\n")), 0666)
 	if err != nil {
 		fmt.Printf("Failed to notify sonobuoy that I am done: %v\n", err)
 	}

--- a/tests/libstorage/config.go
+++ b/tests/libstorage/config.go
@@ -21,7 +21,7 @@ package libstorage
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"kubevirt.io/kubevirt/tests/errorhandling"
@@ -60,7 +60,7 @@ func LoadConfig() (*KubeVirtTestsConfiguration, error) {
 	defer errorhandling.SafelyCloseFile(jsonFile)
 
 	// read the configuration file as a byte array
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 
 	// convert the byte array to a KubeVirtTestsConfiguration struct
 	config := &KubeVirtTestsConfiguration{}

--- a/tests/monitoring/prometheus_utils.go
+++ b/tests/monitoring/prometheus_utils.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os/exec"
@@ -129,7 +128,7 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 		url := getPrometheusURLForOpenShift()
 		resp := doHttpRequest(url, endpoint, token)
 		defer resp.Body.Close()
-		result, err = ioutil.ReadAll(resp.Body)
+		result, err = io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 	} else {
 		sourcePort := 4321 + rand.Intn(6000)
@@ -153,7 +152,7 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 			url := fmt.Sprintf("http://localhost:%d", sourcePort)
 			resp := doHttpRequest(url, endpoint, token)
 			defer resp.Body.Close()
-			result, err = ioutil.ReadAll(resp.Body)
+			result, err = io.ReadAll(resp.Body)
 			return err
 		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
 	}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -26,7 +26,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -922,11 +922,11 @@ spec:
 `, version, restoreName, vmYaml.vmName, snapshotName)
 
 					snapshotYamlFile := filepath.Join(workDir, fmt.Sprintf("%s.yaml", snapshotName))
-					err = ioutil.WriteFile(snapshotYamlFile, []byte(snapshotYaml), 0644)
+					err = os.WriteFile(snapshotYamlFile, []byte(snapshotYaml), 0644)
 					Expect(err).ToNot(HaveOccurred())
 
 					restoreYamlFile := filepath.Join(workDir, fmt.Sprintf("%s.yaml", restoreName))
-					err = ioutil.WriteFile(restoreYamlFile, []byte(restoreYaml), 0644)
+					err = os.WriteFile(restoreYamlFile, []byte(restoreYaml), 0644)
 					Expect(err).ToNot(HaveOccurred())
 
 					vmSnapshots = append(vmSnapshots, vmSnapshotDef{
@@ -1015,7 +1015,7 @@ spec:
 `, version, version, version, i, version, i, previousUtilityRegistry, cd.ContainerDiskCirros, previousUtilityTag)
 
 				yamlFile := filepath.Join(workDir, fmt.Sprintf("vm-%s.yaml", version))
-				err = ioutil.WriteFile(yamlFile, []byte(vmYaml), 0644)
+				err = os.WriteFile(yamlFile, []byte(vmYaml), 0644)
 				Expect(err).ToNot(HaveOccurred())
 
 				vmYamls[version] = &vmYamlDefinition{
@@ -2555,7 +2555,7 @@ spec:
 					gzreader, err := gzip.NewReader(bytes.NewReader(data))
 					Expect(err).ToNot(HaveOccurred())
 
-					decompressed, err := ioutil.ReadAll(gzreader)
+					decompressed, err := io.ReadAll(gzreader)
 					Expect(err).ToNot(HaveOccurred())
 
 					data = decompressed

--- a/tests/sysprep_test.go
+++ b/tests/sysprep_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -211,7 +210,7 @@ const (
 
 func insertProductKeyToAnswerFileTemplate(answerFileTemplate string) string {
 	productKeyFilePath := os.Getenv("KUBEVIRT_WINDOWS_PRODUCT_KEY_PATH")
-	keyFromFile, err := ioutil.ReadFile(productKeyFilePath)
+	keyFromFile, err := os.ReadFile(productKeyFilePath)
 	Expect(err).ToNot(HaveOccurred())
 	productKey := strings.TrimSpace(string(keyFromFile))
 	return fmt.Sprintf(answerFileTemplate, productKey)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -289,7 +288,7 @@ func generateTemplateJson(template *vmsgen.Template, generateDirectory string) (
 	}
 
 	jsonFile := filepath.Join(generateDirectory, template.Name+".json")
-	if err = ioutil.WriteFile(jsonFile, data, 0644); err != nil {
+	if err = os.WriteFile(jsonFile, data, 0644); err != nil {
 		return "", fmt.Errorf("failed to write json to file %q: %v", jsonFile, err)
 	}
 	return jsonFile, nil

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -32,7 +32,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -1336,7 +1335,7 @@ func GenerateVMJson(vm *v1.VirtualMachine, generateDirectory string) (string, er
 	}
 
 	jsonFile := filepath.Join(generateDirectory, fmt.Sprintf("%s.json", vm.Name))
-	err = ioutil.WriteFile(jsonFile, data, 0644)
+	err = os.WriteFile(jsonFile, data, 0644)
 	if err != nil {
 		return "", fmt.Errorf("failed to write json file %s", jsonFile)
 	}
@@ -1974,7 +1973,7 @@ func callUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // GetCertsForPods returns the used certificates for all pods matching  the label selector

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1973,6 +1973,7 @@ func callUrlOnPod(pod *k8sv1.Pod, port string, url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	return io.ReadAll(resp.Body)
 }
 

--- a/tests/virtctl/scp.go
+++ b/tests/virtctl/scp.go
@@ -3,7 +3,6 @@ package virtctl
 import (
 	"context"
 	"crypto/ecdsa"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -151,9 +150,9 @@ var _ = Describe("[sig-compute][virtctl]SCP", decorators.SigCompute, func() {
 })
 
 func compareFile(file1 string, file2 string) {
-	expected, err := ioutil.ReadFile(file1)
+	expected, err := os.ReadFile(file1)
 	Expect(err).ToNot(HaveOccurred())
-	actual, err := ioutil.ReadFile(file2)
+	actual, err := os.ReadFile(file2)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(string(actual)).To(Equal(string(expected)))
 }

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -1938,7 +1937,7 @@ status:
 				)
 
 				BeforeEach(func() {
-					file, err = ioutil.TempFile("", "file-*")
+					file, err = os.CreateTemp("", "file-*")
 					Expect(err).ToNot(HaveOccurred())
 				})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The response from `/healthz` request is not closed.
Also, switch using non deprecated function call. In the specific I replaced:
- `ioutil.ReadAll` with `io.ReadAll`
-  `ioutil.ReadFile` with `os.ReadFile`
- `ioutil.WriteFile` with `os.WriteFile`
- `ioutil.TempFile` with `os.CreateTemp`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
