### PR TITLE
[release-0.59] webhooks: Return early when VirtualMachine is being deleted

### DIFF
--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -1086,7 +1086,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should apply to VMI", func() {
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.IOThreadsPolicy).To(Equal(*instancetypeSpec.IOThreadsPolicy))
 			})
@@ -1112,7 +1112,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should apply to VMI", func() {
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.LaunchSecurity).To(Equal(*instancetypeSpec.LaunchSecurity))
 			})
@@ -1144,7 +1144,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply to VMI", func() {
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.GPUs).To(Equal(instancetypeSpec.GPUs))
 
@@ -1182,7 +1182,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply to VMI", func() {
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.HostDevices).To(Equal(instancetypeSpec.HostDevices))
 
@@ -1313,7 +1313,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 			It("should apply to VMI", func() {
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Devices.AutoattachGraphicsDevice).To(BeFalse())
 				Expect(*vmi.Spec.Domain.Devices.AutoattachMemBalloon).To(BeFalse())
@@ -1357,7 +1357,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk = nil
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(preferenceSpec.Devices.PreferredDiskBus))
 
@@ -1411,7 +1411,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 
 			It("should apply to VMI", func() {
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Features.ACPI).To(Equal(*preferenceSpec.Features.PreferredAcpi))
 				Expect(*vmi.Spec.Domain.Features.APIC).To(Equal(*preferenceSpec.Features.PreferredApic))
@@ -1432,7 +1432,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Features.Hyperv.EVMCS.Enabled).To(BeFalse())
 
@@ -1452,7 +1452,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.BIOS.UseSerial).To(Equal(*preferenceSpec.Firmware.PreferredUseBiosSerial))
 			})
@@ -1468,7 +1468,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot).To(Equal(*preferenceSpec.Firmware.PreferredUseSecureBoot))
 			})
@@ -1484,7 +1484,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(vmi.Spec.Domain.Machine.Type).To(Equal(preferenceSpec.Machine.PreferredMachineType))
 			})
@@ -1506,7 +1506,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				conflicts := instancetypeMethods.ApplyToVmi(field, instancetypeSpec, preferenceSpec, &vmi.Spec)
-				Expect(conflicts).To(HaveLen(0))
+				Expect(conflicts).To(BeEmpty())
 
 				Expect(*&vmi.Spec.Domain.Clock.ClockOffset).To(Equal(*preferenceSpec.Clock.PreferredClockOffset))
 				Expect(*vmi.Spec.Domain.Clock.Timer).To(Equal(*preferenceSpec.Clock.PreferredTimer))

--- a/pkg/storage/export/virt-exportserver/exportserver_test.go
+++ b/pkg/storage/export/virt-exportserver/exportserver_test.go
@@ -625,7 +625,7 @@ var _ = Describe("exportserver", func() {
 			err = yaml.Unmarshal([]byte(out[1]), resVm)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resVm.Name).To(Equal(testVm.Name))
-			Expect(resVm.Spec.DataVolumeTemplates).To(HaveLen(0))
+			Expect(resVm.Spec.DataVolumeTemplates).To(BeEmpty())
 			resDv := &cdiv1.DataVolume{}
 			err = yaml.Unmarshal([]byte(out[2]), resDv)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -63,6 +63,13 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
+	// If the VirtualMachine is being deleted return early and avoid racing any other in-flight resource deletions that might be happening
+	if vm.DeletionTimestamp != nil {
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
 	// Validate updates to the {Instancetype,Preference}Matchers
 	if ar.Request.Operation == admissionv1.Update {
 		newVM, oldVM, err := webhookutils.GetVMFromAdmissionReview(ar)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -153,6 +153,14 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		mutator.InstancetypeMethods = instancetype.NewMethods(nil, nil, nil, nil, nil, virtClient)
 	})
 
+	It("should allow VM being deleted without applying mutations", func() {
+		now := k8smetav1.Now()
+		vm.ObjectMeta.DeletionTimestamp = &now
+		resp := admitVM()
+		Expect(resp.Allowed).To(BeTrue())
+		Expect(resp.Patch).To(BeEmpty())
+	})
+
 	It("should apply defaults on VM create", func() {
 		vmSpec, _ := getVMSpecMetaFromResponse()
 		if webhooks.IsPPC64() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3785,12 +3785,12 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		Context("feature gate enabled", func() {
 			It("should accept vmi with no vsocks defined", func() {
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			})
 			It("should accept vmi with vsocks defined", func() {
 				vmi.Spec.Domain.Devices.AutoattachVSOCK = pointer.Bool(true)
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-				Expect(causes).To(HaveLen(0))
+				Expect(causes).To(BeEmpty())
 			})
 		})
 		Context("feature gate disabled", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -126,6 +126,24 @@ var _ = Describe("Validating VM Admitter", func() {
 		Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[0].name"))
 	})
 
+	It("should allow VM that is being deleted", func() {
+		vmi := api.NewMinimalVMI("testvmi")
+		now := metav1.Now()
+		vm := &v1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				DeletionTimestamp: &now,
+			},
+			Spec: v1.VirtualMachineSpec{
+				Running: &notRunning,
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+		}
+		resp := admitVm(vmsAdmitter, vm)
+		Expect(resp.Allowed).To(BeTrue())
+	})
+
 	It("should allow VM with missing volume disk or filesystem", func() {
 		vmi := api.NewMinimalVMI("testvmi")
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -2253,7 +2253,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Creating VirtualMachine")
 			vm = tests.NewRandomVirtualMachine(vmi, true)
-			Expect(vm.Finalizers).To(HaveLen(0))
+			Expect(vm.Finalizers).To(BeEmpty())
 
 		})
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -51,6 +51,7 @@ import (
 	"kubevirt.io/kubevirt/tests/util"
 
 	v1 "kubevirt.io/api/core/v1"
+	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
@@ -2250,34 +2251,29 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		BeforeEach(func() {
 			vmi = tests.NewRandomVMI()
-
-			By("Creating VirtualMachine")
 			vm = tests.NewRandomVirtualMachine(vmi, true)
 			Expect(vm.Finalizers).To(BeEmpty())
-
+			vm.Finalizers = append(vm.Finalizers, customFinalizer)
 		})
 
 		AfterEach(func() {
 			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			if controller.HasFinalizer(vm, customFinalizer) {
-				var ops []string
-				oldFinalizers, err := json.Marshal(vm.GetFinalizers())
-				Expect(err).ToNot(HaveOccurred())
-				newVm := vm.DeepCopy()
-				controller.RemoveFinalizer(newVm, customFinalizer)
-				newFinalizers, err := json.Marshal(newVm.GetFinalizers())
-				Expect(err).ToNot(HaveOccurred())
-				ops = append(ops, fmt.Sprintf(`{ "op": "test", "path": "/metadata/finalizers", "value": %s }`, string(oldFinalizers)))
-				ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/metadata/finalizers", "value": %s }`, string(newFinalizers)))
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), &metav1.PatchOptions{})
-				Expect(err).ToNot(HaveOccurred())
-			}
 
-			if vm.DeletionTimestamp == nil {
-				err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(vm.Name, &metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-			}
+			oldFinalizers, err := json.Marshal(vm.GetFinalizers())
+			Expect(err).ToNot(HaveOccurred())
+
+			newVm := vm.DeepCopy()
+			controller.RemoveFinalizer(newVm, customFinalizer)
+			newFinalizers, err := json.Marshal(newVm.GetFinalizers())
+			Expect(err).ToNot(HaveOccurred())
+
+			var ops []string
+			ops = append(ops, fmt.Sprintf(`{ "op": "test", "path": "/metadata/finalizers", "value": %s }`, string(oldFinalizers)))
+			ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/metadata/finalizers", "value": %s }`, string(newFinalizers)))
+
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Patch(vm.Name, types.JSONPatchType, controller.GeneratePatchBytes(ops), &metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Ensure the vm has disappeared")
 			Eventually(func() bool {
@@ -2286,18 +2282,8 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}, 2*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("vm %s is not deleted", vm.Name))
 		})
 
-		It("should be added when the vm is created", func() {
-			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(vm)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(func(g Gomega) {
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeTrue())
-			}, 2*time.Minute, 1*time.Second)
-		})
-
-		It("should be removed when the vm is being deleted", func() {
-			vm.Finalizers = append(vm.Finalizers, customFinalizer)
+		It("should be added when the vm is created and removed when the vm is being deleted", func() {
+			By("Creating VirtualMachine")
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(vm)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -2305,6 +2291,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeTrue())
+				g.Expect(controller.HasFinalizer(vm, customFinalizer)).To(BeTrue())
 			}, 2*time.Minute, 1*time.Second)
 
 			err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Delete(vm.Name, &metav1.DeleteOptions{})
@@ -2314,6 +2301,70 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeFalse())
+				g.Expect(controller.HasFinalizer(vm, customFinalizer)).To(BeTrue())
+			}, 2*time.Minute, 1*time.Second)
+		})
+
+		It("should be removed when the vm has child resources, such as instance type ControllerRevisions, that have been deleted before the vm - issue #9438", func() {
+			By("creating a VirtualMachineClusterInstancetype")
+			instancetype := &instancetypev1alpha2.VirtualMachineClusterInstancetype{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "instancetype-",
+				},
+				Spec: instancetypev1alpha2.VirtualMachineInstancetypeSpec{
+					CPU: instancetypev1alpha2.CPUInstancetype{
+						Guest: uint32(1),
+					},
+					Memory: instancetypev1alpha2.MemoryInstancetype{
+						Guest: resource.MustParse("64Mi"),
+					},
+				},
+			}
+			instancetype, err = virtClient.VirtualMachineClusterInstancetype().Create(context.Background(), instancetype, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("creating a VirtualMachine")
+			vm.Spec.Instancetype = &v1.InstancetypeMatcher{
+				Name: instancetype.Name,
+			}
+			vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{},
+				},
+			}
+			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting until the VirtualMachine has the VirtualMachineControllerFinalizer, customFinalizer and revisionName")
+			Eventually(func(g Gomega) {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeTrue())
+				g.Expect(controller.HasFinalizer(vm, customFinalizer)).To(BeTrue())
+				g.Expect(vm.Spec.Instancetype.RevisionName).ToNot(BeEmpty())
+			}, 2*time.Minute, 1*time.Second)
+
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("deleting the ControllerRevision associated with the VirtualMachine and VirtualMachineClusterInstancetype %s", vm.Spec.Instancetype.RevisionName))
+			err = virtClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(context.Background(), vm.Spec.Instancetype.RevisionName, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("deleting the VirtualMachineClusterInstancetype")
+			err = virtClient.VirtualMachineClusterInstancetype().Delete(context.Background(), vm.Spec.Instancetype.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("deleting the VirtualMachine")
+			err = virtClient.VirtualMachine(vm.Namespace).Delete(vm.Name, &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting until the VirtualMachineControllerFinalizer has been removed from the VirtualMachine")
+			Eventually(func(g Gomega) {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &k8smetav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(controller.HasFinalizer(vm, v1.VirtualMachineControllerFinalizer)).To(BeFalse())
+				g.Expect(controller.HasFinalizer(vm, customFinalizer)).To(BeTrue())
 			}, 2*time.Minute, 1*time.Second)
 		})
 	})


### PR DESCRIPTION
/hold
/area instancetype
/cc @fossedihelm
/cc @0xFelix
/cc @mhenriks

**What this PR does / why we need it**:

As set out in issue https://github.com/kubevirt/kubevirt/issues/9438 previously attempts to remove a namespace would be blocked if it contained VirtualMachines using VirtualMachineInstancetypes. This was due to the update call to remove the virtualMachineControllerFinalizer being rejected as the ControllerRevision associated with the VirtualMachineInstancetype had already been deleted, causing admission of the request to be rejected.

This change adds basic logic to both the mutation and admission webhooks that returns early if the VirtualMachine is being deleted. Ensuring the update to remove the virtualMachineControllerFinalizer is successful and allowing the overall namespace removal to also complete.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This PR is built on the following existing open backport PRs for the `release-0.59` branch and will remain on `/hold` until they land and this PR is rebased (oh how I miss gerrit):

* https://github.com/kubevirt/kubevirt/pull/9500
* https://github.com/kubevirt/kubevirt/pull/9501

Additionally https://github.com/kubevirt/kubevirt/pull/9221 is also cherry-picked as 0c08773ab708d84565c7857d2c62a34875787706 within this PR to avoid conflicts.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
