### PR TITLE
Remove "all" category from virtualmachineclusterinstancetypes/preferences

### DIFF
--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -650,7 +650,6 @@ func NewVirtualMachineClusterInstancetypeCrd() (*extv1.CustomResourceDefinition,
 			Singular:   instancetype.ClusterSingularResourceName,
 			ShortNames: []string{"vmclusterinstancetype", "vmclusterinstancetypes", "vmcf", "vmcfs"},
 			Kind:       "VirtualMachineClusterInstancetype",
-			Categories: []string{"all"},
 		},
 		Scope: extv1.ClusterScoped,
 		Conversion: &extv1.CustomResourceConversion{
@@ -718,7 +717,6 @@ func NewVirtualMachineClusterPreferenceCrd() (*extv1.CustomResourceDefinition, e
 			Singular:   instancetype.ClusterSingularPreferenceResourceName,
 			ShortNames: []string{"vmcp", "vmcps"},
 			Kind:       "VirtualMachineClusterPreference",
-			Categories: []string{"all"},
 		},
 		Scope: extv1.ClusterScoped,
 		Conversion: &extv1.CustomResourceConversion{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This results in `k get all -n <namespace>` returning those cluster-scoped resources.
```bash
$ oc get all -n openshift-config
Warning: kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
NAME                                                                                AGE
virtualmachineclusterinstancetype.instancetype.kubevirt.io/cx1.2xlarge              5d22h
virtualmachineclusterinstancetype.instancetype.kubevirt.io/cx1.4xlarge              5d22h
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2177763

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: virtualmachineclusterinstancetypes/preferences show up for get all -n <namespace>
```
