### PR TITLE
virt-launcher, manager: Simplify the logic around realizing which interface to hotplug

### DIFF
--- a/pkg/network/vmispec/network.go
+++ b/pkg/network/vmispec/network.go
@@ -61,3 +61,13 @@ func IndexNetworkSpecByName(networks []v1.Network) map[string]v1.Network {
 	}
 	return indexedNetworks
 }
+
+func LookupNetworkByName(networks []v1.Network, name string) *v1.Network {
+	for _, network := range networks {
+		if network.Name == name {
+			net := network
+			return &net
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Resolve #9399 review comments 
- https://github.com/kubevirt/kubevirt/pull/9399#issuecomment-1487576193
- https://github.com/kubevirt/kubevirt/pull/9399#discussion_r1150421006


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I did not change `hotplugVirtioInterfaces()` to receive the domain interfaces only (instead of both interfaces and domain object) because it requires more work (including changing `podNetworkSetupPhase2()` to get with the domain interfaces instead of the domain object).
I will post in a follow-up PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
