### PR TITLE
launcher: remove `converterContext` from virtIOInterfaceManager

### DIFF
--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -30,7 +30,6 @@ import (
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 )
 
 type vmConfigurator interface {
@@ -38,9 +37,8 @@ type vmConfigurator interface {
 }
 
 type virtIOInterfaceManager struct {
-	converterContext *converter.ConverterContext
-	dom              cli.VirDomain
-	configurator     vmConfigurator
+	dom          cli.VirDomain
+	configurator vmConfigurator
 }
 
 func newVirtIOInterfaceManager(


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This was a leftover from PR [0], and is not needed since the "updated" domain interfaces are calculated in [1]. Thus, the function `virtIOInterfaceManager.hotplugVirtioInterface` does not require the `converterContext` at all.

[0] - https://github.com/kubevirt/kubevirt/pull/9429
[1] - https://github.com/kubevirt/kubevirt/blob/615f9e5b6da1976854aa225e517fb41faa91cc53/pkg/virt-launcher/virtwrap/converter/converter.go#L1768


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
