### PR TITLE
[release-0.58] Remove hostname limitation for migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -588,9 +588,6 @@ func (c *MigrationController) createTargetPod(migration *virtv1.VirtualMachineIn
 	templatePod.ObjectMeta.Labels[virtv1.MigrationJobLabel] = string(migration.UID)
 	templatePod.ObjectMeta.Annotations[virtv1.MigrationJobNameAnnotation] = string(migration.Name)
 
-	// TODO libvirt requires unique host names for each target and source
-	templatePod.Spec.Hostname = ""
-
 	// If cpu model is "host model" allow migration only to nodes that supports this cpu model
 	if cpu := vmi.Spec.Domain.CPU; cpu != nil && cpu.Model == virtv1.CPUModeHostModel {
 		node, err := c.getNodeForVMI(vmi)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -222,6 +222,7 @@ go_test(
         "//tests/libdv:go_default_library",
         "//tests/libinstancetype:go_default_library",
         "//tests/libnet:go_default_library",
+        "//tests/libnet/service:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libreplicaset:go_default_library",
         "//tests/libstorage:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

For a long time, Libvirt was using the hostname
to perform a check if it performs migration
from&to the same node. This check was dropped
or rather it is implemented in another way
since 6799b72d927015db4ce4cab879f072abc91a41ae 2020.

Therefore we can drop this limitation and actually address a long-standing bug with services.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is manual backport of https://github.com/kubevirt/kubevirt/pull/9189
The conflict was in imports and the RunMigrationAndExpectCompletion has different signature

**Release note**:
```release-note
Bug fix: DNS integration continues to work after migration
```
