### PR TITLE
[release-0.53] Remove hostname limitation for migrations

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -562,9 +562,6 @@ func (c *MigrationController) createTargetPod(migration *virtv1.VirtualMachineIn
 	templatePod.ObjectMeta.Labels[virtv1.MigrationJobLabel] = string(migration.UID)
 	templatePod.ObjectMeta.Annotations[virtv1.MigrationJobNameAnnotation] = string(migration.Name)
 
-	// TODO libvirt requires unique host names for each target and source
-	templatePod.Spec.Hostname = ""
-
 	// If cpu model is "host model" allow migration only to nodes that supports this cpu model
 	if cpu := vmi.Spec.Domain.CPU; cpu != nil && cpu.Model == virtv1.CPUModeHostModel {
 		node, err := c.getNodeForVMI(vmi)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -222,6 +222,7 @@ go_test(
         "//tests/framework/matcher:go_default_library",
         "//tests/launchsecurity:go_default_library",
         "//tests/libnet:go_default_library",
+        "//tests/libnet/service:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libreplicaset:go_default_library",
         "//tests/libstorage:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -34,6 +34,7 @@ import (
 
 	"kubevirt.io/api/migrations/v1alpha1"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
+	"kubevirt.io/kubevirt/tests/libnet/service"
 
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 
@@ -59,6 +60,7 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -577,6 +579,67 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		tests.UpdateKubeVirtConfigValueAndWait(cfg)
 	}
 
+	Context("with Headless service", func() {
+		const subdomain = "mysub"
+
+		AfterEach(func() {
+			err := virtClient.CoreV1().Services(util.NamespaceTestDefault).Delete(context.Background(), subdomain, metav1.DeleteOptions{})
+			if !errors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should remain to able resolve the VM IP", func() {
+			withHostnameAndSubdomain := func(hostname, subdomain string) libvmi.Option {
+				return func(vmi *v1.VirtualMachineInstance) {
+					vmi.Spec.Hostname = hostname
+					vmi.Spec.Subdomain = subdomain
+
+				}
+			}
+			const hostname = "alpine"
+			const port int = 1500
+			const labelKey = "subdomain"
+			const labelValue = "mysub"
+
+			vmi := libvmi.NewCirros(
+				withHostnameAndSubdomain(hostname, subdomain),
+				libvmi.WithLabel(labelKey, labelValue),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Starting hello world in the VM")
+			tests.StartTCPServer(vmi, port, console.LoginToCirros)
+
+			By("Exposing headless service matching subdomain")
+			service := service.BuildHeadlessSpec(subdomain, port, port, labelKey, labelValue)
+			_, err = virtClient.CoreV1().Services(vmi.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			assertConnectivityToService := func(msg string) {
+				By(msg)
+				job := tests.NewHelloWorldJobTCP(fmt.Sprintf("%s.%s", hostname, subdomain), strconv.FormatInt(int64(port), 10))
+				job.Spec.BackoffLimit = pointer.Int32(3)
+				job, err := virtClient.BatchV1().Jobs(vmi.Namespace).Create(context.Background(), job, k8smetav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				err = tests.WaitForJobToSucceed(job, 90*time.Second)
+				Expect(err).ToNot(HaveOccurred(), msg)
+			}
+
+			assertConnectivityToService("Asserting connectivity through service before migration")
+
+			By("Executing a migration")
+			migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+			migrationuid := tests.RunMigrationAndExpectCompletion(virtClient, migration, tests.MigrationWaitTime)
+			tests.ConfirmVMIPostMigration(virtClient, vmi, migrationuid)
+
+			assertConnectivityToService("Asserting connectivity through service after migration")
+
+		})
+	})
 	Describe("Starting a VirtualMachineInstance ", func() {
 
 		var pvName string


### PR DESCRIPTION
**What this PR does / why we need it**:

For a long time, Libvirt was using the hostname
to perform a check if it performs migration
from&to the same node. This check was dropped
or rather it is implemented in another way
since 6799b72d927015db4ce4cab879f072abc91a41ae 2020.

Therefore we can drop this limitation and actually address a long-standing bug with services.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is manual backport of https://github.com/kubevirt/kubevirt/pull/9189
The conflict was in imports and the RunMigrationAndExpectCompletion has different signature

**Release note**:
```release-note
Bug fix: DNS integration continues to work after migration
```
