### PR TITLE
grpc: Fix authority header sent to unix sockets

### DIFF
--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -44,6 +44,7 @@ func DialSocket(socketPath string) (*grpc.ClientConn, error) {
 func DialSocketWithTimeout(socketPath string, timeout int) (*grpc.ClientConn, error) {
 
 	options := []grpc.DialOption{
+		grpc.WithAuthority("localhost"),
 		grpc.WithInsecure(),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)


### PR DESCRIPTION
**What this PR does / why we need it**:

Some non grpc-go servers fail with "protocol error" when contacted by KubeVirt's gRPC client. The suspected cause is that grpc-go sends invalid Authority headers when using unix domain sockets.

This issue prevents implementation of hook sidecars in other languages, such as Rust with its Tonic library.

A similar issue was encountered in Kubernetes [1], where it was solved by explicitly setting the Authority header. This patch uses the same approach.

[1] https://github.com/kubernetes/kubernetes/pull/112597

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The alternative approach, using `unix:` or `unix://` prefix proposed in the Kubernetes PR does not solve this problem. When adding the prefix to `socketPath`, the initial `Dial` fails.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
gRPC client now works correctly with non-Go gRPC servers
```
