### PR TITLE
call server stop method on error

### DIFF
--- a/pkg/virt-handler/vsock/server.go
+++ b/pkg/virt-handler/vsock/server.go
@@ -68,6 +68,7 @@ func (h *Hypervisor) serve() {
 	// Load the vhost_vsock module on demand.
 	if fd, err := os.Open("/dev/vhost-vsock"); err != nil {
 		log.DefaultLogger().Reason(err).Error("Failed to open /dev/vhost-vsock.")
+		h.Stop()
 		return
 	} else {
 		fd.Close()
@@ -75,6 +76,7 @@ func (h *Hypervisor) serve() {
 	conn, err := vsock.ListenContextID(vsock.Host, h.port, &vsock.Config{})
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Failed to bind to VSOCK port %v.", h.port)
+		h.Stop()
 		return
 	}
 	defer conn.Close()
@@ -82,6 +84,7 @@ func (h *Hypervisor) serve() {
 	err = h.server.Serve(conn)
 	if err != nil {
 		log.DefaultLogger().Reason(err).Error("Failed to listen for VSOCK connections.")
+		h.Stop()
 		return
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If there is a vsock enable flag on the server, it would throw an error when there is no vsock present. But, this makes the log messy because it would keep looping and printing out the same error. It is best we shut the server down when there is no vsock available


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9114 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
