### PR TITLE
[virt-operator]: fix kubevirt version parsing

### DIFF
--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -285,6 +285,7 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	imageString := GetOperatorImageWithEnvVarManager(envVarManager)
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
 	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)
+	kubeVirtVersion := envVarManager.Getenv(KubeVirtVersionEnvName)
 
 	tagFromOperator := ""
 	operatorSha := ""
@@ -309,6 +310,9 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 			// we have a shasum... chances are high that we get the shasums for the other images as well from env vars,
 			// but as a fallback use latest tag
 			tagFromOperator = "latest"
+			if kubeVirtVersion != "" {
+				tagFromOperator = kubeVirtVersion
+			}
 			operatorSha = strings.TrimPrefix(version, "@")
 		}
 
@@ -347,7 +351,6 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	exportServerSha := envVarManager.Getenv(VirtExportServerShasumEnvName)
 	gsSha := envVarManager.Getenv(GsEnvShasumName)
 	prHelperSha := envVarManager.Getenv(PrHelperShasumEnvName)
-	kubeVirtVersion := envVarManager.Getenv(KubeVirtVersionEnvName)
 	if operatorSha != "" && apiSha != "" && controllerSha != "" && handlerSha != "" && launcherSha != "" && kubeVirtVersion != "" {
 		config = newDeploymentConfigWithShasums(registry, imagePrefix, kubeVirtVersion, operatorSha, apiSha, controllerSha, handlerSha, launcherSha, exportProxySha, exportServerSha, gsSha, prHelperSha, namespace, additionalProperties, passthroughEnv)
 	}


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

When the virt-operator image has digest instead of a tag, parse kubevirt version from KUBEVIRT_VERSION environment variable.

**What this PR does / why we need it**:
there was an issue when virt-operator image had digest instead of a tag, the hardcoded "latest" tag was used and KUBEVIRT_VERSION was ignored.

This led to an issue with tracking the kubevirt upgrade process. Periodic comparison of the KUBEVIRT_VERSION with the `status.observedKubevirtVersion` failed because the latter field got the `latest` string, instead of having the version as defined in KUBEVIRT_VERSION. 

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=2180146

**Release note**:
```release-note
NONE
```
