### PR TITLE
Enable freePageReporting at vmi level

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -1049,10 +1049,11 @@ type Stats struct {
 }
 
 type MemBalloon struct {
-	Model   string            `xml:"model,attr"`
-	Stats   *Stats            `xml:"stats,omitempty"`
-	Address *Address          `xml:"address,omitempty"`
-	Driver  *MemBalloonDriver `xml:"driver,omitempty"`
+	Model             string            `xml:"model,attr"`
+	Stats             *Stats            `xml:"stats,omitempty"`
+	Address           *Address          `xml:"address,omitempty"`
+	Driver            *MemBalloonDriver `xml:"driver,omitempty"`
+	FreePageReporting string            `xml:"freePageReporting,attr,omitempty"`
 }
 
 type MemBalloonDriver struct {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -118,6 +118,7 @@ type ConverterContext struct {
 	Topology              *cmdv1.Topology
 	ExpandDisksEnabled    bool
 	UseLaunchSecurity     bool
+	FreePageReporting     bool
 }
 
 func contains(volumes []string, name string) bool {
@@ -1158,6 +1159,7 @@ func ConvertV1ToAPIBalloning(source *v1.Devices, ballooning *api.MemBalloon, c *
 				IOMMU: "on",
 			}
 		}
+		ballooning.FreePageReporting = boolToOnOff(&c.FreePageReporting, false)
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -736,15 +736,15 @@ var _ = Describe("Converter", func() {
   <iothreads>3</iothreads>
 </domain>`, domainType, "%s")
 		var convertedDomainWith5Period = fmt.Sprintf(convertedDomain,
-			`<memballoon model="virtio-non-transitional">
+			`<memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="5"></stats>
     </memballoon>`)
 		var convertedDomainWith0Period = fmt.Sprintf(convertedDomain,
-			`<memballoon model="virtio-non-transitional"></memballoon>`)
+			`<memballoon model="virtio-non-transitional" freePageReporting="on"></memballoon>`)
 		var convertedDomainWithFalseAutoattach = fmt.Sprintf(convertedDomain,
 			`<memballoon model="none"></memballoon>`)
 		convertedDomain = fmt.Sprintf(convertedDomain,
-			`<memballoon model="virtio-non-transitional">
+			`<memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="10"></stats>
     </memballoon>`)
 
@@ -936,16 +936,16 @@ var _ = Describe("Converter", func() {
 </domain>`, domainType, "%s")
 
 		var convertedDomainppc64leWith5Period = fmt.Sprintf(convertedDomainppc64le,
-			`<memballoon model="virtio-non-transitional">
+			`<memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="5"></stats>
     </memballoon>`)
 		var convertedDomainppc64leWith0Period = fmt.Sprintf(convertedDomainppc64le,
-			`<memballoon model="virtio-non-transitional"></memballoon>`)
+			`<memballoon model="virtio-non-transitional" freePageReporting="on"></memballoon>`)
 
 		var convertedDomainppc64leWithFalseAutoattach = fmt.Sprintf(convertedDomainppc64le,
 			`<memballoon model="none"></memballoon>`)
 		convertedDomainppc64le = fmt.Sprintf(convertedDomainppc64le,
-			`<memballoon model="virtio-non-transitional">
+			`<memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="10"></stats>
     </memballoon>`)
 
@@ -1140,15 +1140,15 @@ var _ = Describe("Converter", func() {
   <iothreads>3</iothreads>
 </domain>`, domainType, "%s")
 		var convertedDomainarm64With5Period = fmt.Sprintf(convertedDomainarm64,
-			`<memballoon model="virtio-non-transitional">
+			`<memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="5"></stats>
     </memballoon>`)
 		var convertedDomainarm64With0Period = fmt.Sprintf(convertedDomainarm64,
-			`<memballoon model="virtio-non-transitional"></memballoon>`)
+			`<memballoon model="virtio-non-transitional" freePageReporting="on"></memballoon>`)
 		var convertedDomainarm64WithFalseAutoattach = fmt.Sprintf(convertedDomainarm64,
 			`<memballoon model="none"></memballoon>`)
 		convertedDomainarm64 = fmt.Sprintf(convertedDomainarm64,
-			`<memballoon model="virtio-non-transitional">
+			`<memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="10"></stats>
     </memballoon>`)
 
@@ -1196,7 +1196,7 @@ var _ = Describe("Converter", func() {
     <graphics type="vnc">
       <listen type="socket" socket="/var/run/kubevirt-private/f4686d2c-6e8d-4335-b8fd-81bee22f4814/virt-vnc"></listen>
     </graphics>
-    <memballoon model="virtio-non-transitional">
+    <memballoon model="virtio-non-transitional" freePageReporting="on">
       <stats period="10"></stats>
       <address type="pci" domain="0x0000" bus="0x00" slot="0x0a" function="0x0"></address>
     </memballoon>
@@ -1375,6 +1375,7 @@ var _ = Describe("Converter", func() {
 				SMBios:                TestSmbios,
 				MemBalloonStatsPeriod: 10,
 				EphemeraldiskCreator:  EphemeralDiskImageCreator,
+				FreePageReporting:     true,
 			}
 		})
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -795,6 +795,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		PermanentVolumes:      permanentVolumes,
 		EphemeraldiskCreator:  l.ephemeralDiskCreator,
 		UseLaunchSecurity:     kutil.IsSEVVMI(vmi),
+		FreePageReporting:     isFreePageReportingEnabled(vmi),
 	}
 
 	if options != nil {
@@ -838,6 +839,16 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	}
 
 	return c, nil
+}
+
+func isFreePageReportingEnabled(vmi *v1.VirtualMachineInstance) bool {
+	if (vmi.Spec.Domain.Devices.AutoattachMemBalloon != nil && *vmi.Spec.Domain.Devices.AutoattachMemBalloon == false) ||
+		vmi.IsHighPerformanceVMI() ||
+		vmi.GetAnnotations()[v1.FreePageReportingDisabledAnnotation] == "true" {
+		return false
+	}
+
+	return true
 }
 
 func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmulation bool, options *cmdv1.VirtualMachineOptions) (*api.DomainSpec, error) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Manager", func() {
 	var testVirtShareDir string
 	var testEphemeralDiskDir string
 	var metadataCache *metadata.Cache
+	var topology *cmdv1.Topology
 	testVmName := "testvmi"
 	testNamespace := "testnamespace"
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
@@ -102,6 +103,282 @@ var _ = Describe("Manager", func() {
 		mockDirectIOChecker = converter.NewMockDirectIOChecker(ctrl)
 		mockDirectIOChecker.EXPECT().CheckBlockDevice(gomock.Any()).AnyTimes().Return(true, nil)
 		mockDirectIOChecker.EXPECT().CheckFile(gomock.Any()).AnyTimes().Return(true, nil)
+		topology = &cmdv1.Topology{
+			NumaCells: []*cmdv1.Cell{
+				{
+					Id: uint32(0),
+					Memory: &cmdv1.Memory{
+						Amount: 1289144,
+						Unit:   "KiB",
+					},
+					Pages: []*cmdv1.Pages{
+						{
+							Count: 314094,
+							Unit:  "KiB",
+							Size:  4,
+						},
+						{
+							Count: 16,
+							Unit:  "KiB",
+							Size:  2048,
+						},
+						{
+							Count: 0,
+							Unit:  "KiB",
+							Size:  1048576,
+						},
+					},
+					Distances: []*cmdv1.Sibling{
+						{
+							Id:    0,
+							Value: 10,
+						},
+						{
+							Id:    1,
+							Value: 10,
+						},
+						{
+							Id:    2,
+							Value: 10,
+						},
+						{
+							Id:    3,
+							Value: 10,
+						},
+					},
+					Cpus: []*cmdv1.CPU{
+						{
+							Id:       0,
+							Siblings: []uint32{0},
+						},
+						{
+							Id:       1,
+							Siblings: []uint32{1},
+						},
+						{
+							Id:       2,
+							Siblings: []uint32{2},
+						},
+						{
+							Id:       3,
+							Siblings: []uint32{3},
+						},
+						{
+							Id:       4,
+							Siblings: []uint32{4},
+						},
+						{
+							Id:       5,
+							Siblings: []uint32{5},
+						},
+					},
+				},
+				{
+					Id: uint32(2),
+					Memory: &cmdv1.Memory{
+						Amount: 1223960,
+						Unit:   "KiB",
+					},
+					Pages: []*cmdv1.Pages{
+						{
+							Count: 297798,
+							Unit:  "KiB",
+							Size:  4,
+						},
+						{
+							Count: 16,
+							Unit:  "KiB",
+							Size:  2048,
+						},
+						{
+							Count: 0,
+							Unit:  "KiB",
+							Size:  1048576,
+						},
+					},
+					Distances: []*cmdv1.Sibling{
+						{
+							Id:    0,
+							Value: 10,
+						},
+						{
+							Id:    1,
+							Value: 10,
+						},
+						{
+							Id:    2,
+							Value: 10,
+						},
+						{
+							Id:    3,
+							Value: 10,
+						},
+					},
+					Cpus: []*cmdv1.CPU{
+						{
+							Id:       0,
+							Siblings: []uint32{0},
+						},
+						{
+							Id:       1,
+							Siblings: []uint32{1},
+						},
+						{
+							Id:       2,
+							Siblings: []uint32{2},
+						},
+						{
+							Id:       3,
+							Siblings: []uint32{3},
+						},
+						{
+							Id:       4,
+							Siblings: []uint32{4},
+						},
+						{
+							Id:       5,
+							Siblings: []uint32{5},
+						},
+					},
+				},
+				{
+					Id: uint32(3),
+					Memory: &cmdv1.Memory{
+						Amount: 1251752,
+						Unit:   "KiB",
+					},
+					Pages: []*cmdv1.Pages{
+						{
+							Count: 304746,
+							Unit:  "KiB",
+							Size:  4,
+						},
+						{
+							Count: 16,
+							Unit:  "KiB",
+							Size:  2048,
+						},
+						{
+							Count: 0,
+							Unit:  "KiB",
+							Size:  1048576,
+						},
+					},
+					Distances: []*cmdv1.Sibling{
+						{
+							Id:    0,
+							Value: 10,
+						},
+						{
+							Id:    1,
+							Value: 10,
+						},
+						{
+							Id:    2,
+							Value: 10,
+						},
+						{
+							Id:    3,
+							Value: 10,
+						},
+					},
+					Cpus: []*cmdv1.CPU{
+						{
+							Id:       0,
+							Siblings: []uint32{0},
+						},
+						{
+							Id:       1,
+							Siblings: []uint32{1},
+						},
+						{
+							Id:       2,
+							Siblings: []uint32{2},
+						},
+						{
+							Id:       3,
+							Siblings: []uint32{3},
+						},
+						{
+							Id:       4,
+							Siblings: []uint32{4},
+						},
+						{
+							Id:       5,
+							Siblings: []uint32{5},
+						},
+					},
+				},
+				{
+					Id: uint32(4),
+					Memory: &cmdv1.Memory{
+						Amount: 1289404,
+						Unit:   "KiB",
+					},
+					Pages: []*cmdv1.Pages{
+						{
+							Count: 314159,
+							Unit:  "KiB",
+							Size:  4,
+						},
+						{
+							Count: 16,
+							Unit:  "KiB",
+							Size:  2048,
+						},
+						{
+							Count: 0,
+							Unit:  "KiB",
+							Size:  1048576,
+						},
+					},
+					Distances: []*cmdv1.Sibling{
+						{
+							Id:    0,
+							Value: 10,
+						},
+						{
+							Id:    1,
+							Value: 10,
+						},
+						{
+							Id:    2,
+							Value: 10,
+						},
+						{
+							Id:    3,
+							Value: 10,
+						},
+					},
+					Cpus: []*cmdv1.CPU{
+						{
+							Id:       0,
+							Siblings: []uint32{0},
+						},
+						{
+							Id:       1,
+							Siblings: []uint32{1},
+						},
+						{
+							Id:       2,
+							Siblings: []uint32{2},
+						},
+						{
+							Id:       3,
+							Siblings: []uint32{3},
+						},
+						{
+							Id:       4,
+							Siblings: []uint32{4},
+						},
+						{
+							Id:       5,
+							Siblings: []uint32{5},
+						},
+					},
+				},
+			},
+		}
 	})
 
 	expectedDomainFor := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {
@@ -117,12 +394,15 @@ var _ = Describe("Manager", func() {
 		}
 
 		c := &converter.ConverterContext{
-			Architecture:     runtime.GOARCH,
-			VirtualMachine:   vmi,
-			AllowEmulation:   true,
-			SMBios:           &cmdv1.SMBios{},
-			HotplugVolumes:   hotplugVolumes,
-			PermanentVolumes: permanentVolumes,
+			Architecture:      runtime.GOARCH,
+			VirtualMachine:    vmi,
+			AllowEmulation:    true,
+			SMBios:            &cmdv1.SMBios{},
+			HotplugVolumes:    hotplugVolumes,
+			PermanentVolumes:  permanentVolumes,
+			FreePageReporting: isFreePageReportingEnabled(vmi),
+			CPUSet:            []int{0, 1, 2, 3, 4, 5},
+			Topology:          topology,
 		}
 		Expect(converter.Convert_v1_VirtualMachineInstance_To_api_Domain(vmi, domain, c)).To(Succeed())
 		api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
@@ -941,6 +1221,38 @@ var _ = Describe("Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
 		})
+		DescribeTable("should set freePageReporting", func(memory *v1.Memory, cpu *v1.CPU, annotationValue, expectedFreePageReportingValue string) {
+			vmi := newVMI(testNamespace, testVmName)
+			if vmi.Annotations == nil {
+				vmi.Annotations = make(map[string]string)
+			}
+
+			vmi.Annotations[v1.FreePageReportingDisabledAnnotation] = annotationValue
+			vmi.Spec.Domain.Memory = memory
+			vmi.Spec.Domain.CPU = cpu
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(nil, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+
+			domainSpec := expectedDomainFor(vmi)
+
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
+			Expect(err).ToNot(HaveOccurred())
+			mockConn.EXPECT().DomainDefineXML(string(xml)).DoAndReturn(mockDomainWithFreeExpectation)
+			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
+			mockDomain.EXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
+			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache)
+			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}, Topology: topology})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newspec).ToNot(BeNil())
+			Expect(newspec.Devices.Ballooning.FreePageReporting).To(Equal(expectedFreePageReportingValue))
+		},
+			Entry("enabled if vmi is not requesting any high performance components", nil, nil, "false", "on"),
+			Entry("disabled if vmi is requesting Hugepages", &v1.Memory{Hugepages: &v1.Hugepages{PageSize: "1Gi"}}, nil, "false", "off"),
+			Entry("disabled if vmi is requesting Realtime", nil, &v1.CPU{Realtime: &v1.Realtime{}}, "false", "off"),
+			Entry("disabled if vmi is requesting DedicatedCPU", nil, &v1.CPU{
+				DedicatedCPUPlacement: true}, "false", "off"),
+			Entry("disabled if vmi has the disable free page reporting annotation", nil, nil, "true", "off"),
+		)
 	})
 	Context("test marking graceful shutdown", func() {
 		It("Should set metadata when calling MarkGracefulShutdown api", func() {

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -156,6 +156,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Serial, decorators.SigCompu
 					Slot:     "0x00",
 					Function: "0x0",
 				},
+				FreePageReporting: "on",
 			}
 			Expect(domain.Devices.Ballooning).ToNot(BeNil(), "There should be default memballoon device")
 			Expect(*domain.Devices.Ballooning).To(Equal(expected), "Default to virtio model and 10 seconds pooling")
@@ -193,6 +194,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Serial, decorators.SigCompu
 					Slot:     "0x00",
 					Function: "0x0",
 				},
+				FreePageReporting: "on",
 			}),
 			Entry("[test_id:4558]with period 0", uint32(0), api.MemBalloon{
 				Model: "virtio-non-transitional",
@@ -203,6 +205,7 @@ var _ = Describe("[Serial][sig-compute]VMIDefaults", Serial, decorators.SigCompu
 					Slot:     "0x00",
 					Function: "0x0",
 				},
+				FreePageReporting: "on",
 			}),
 		)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
With [freePageReporting](https://docs.kernel.org/mm/free_page_reporting.html) the [guest OS informs the hypervisor](https://lwn.net/Articles/808807/) about pages which are not in use by the guest anymore. The hypervisor can use this information for freeing these pages.
`freePageReporting` is an attribute that can be defined at [Memory balloon device in libvirt](https://libvirt.org/formatdomain.html#memory-balloon-device).

Currently, freePageReporting for the memballoon device is disabled by default, since in libvirt you need to explicitly enable it.

With this PR, freePageReporting will be enabled by default for all the new vmis which does not have `autoattachMemballoon` equal to false, *AND* which are not requesting any high performance components. A vmi is considered as high performance if one of the following is true:
- the vmi requests a dedicated cpu.
- the realtime flag is enabled.
- the vmi requests hugepages.

vmi creators can still opt-out from freePageReporting adding the annotation `kubevirt.io/free-page-reporting-disabled: "true"` to the vmi spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR is born from https://github.com/kubevirt/kubevirt/pull/9426 and offline discussions.
Instead of create one PR with cluster and vmi changes, we decided to go step by step, introducing first
the freePageReporting at vmi level, and then at cluster level.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable freePageReporting for new non high performance vmi
```

/cc @vladikr @xpivarc @fabiand @iholder101 @jean-edouard 