### PR TITLE
[release-0.59] virt-operator: fix kubevirt version parsing

### DIFF
--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -267,6 +267,7 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	imageString := GetOperatorImageWithEnvVarManager(envVarManager)
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
 	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)
+	kubeVirtVersion := envVarManager.Getenv(KubeVirtVersionEnvName)
 
 	tagFromOperator := ""
 	operatorSha := ""
@@ -291,6 +292,9 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 			// we have a shasum... chances are high that we get the shasums for the other images as well from env vars,
 			// but as a fallback use latest tag
 			tagFromOperator = "latest"
+			if kubeVirtVersion != "" {
+				tagFromOperator = kubeVirtVersion
+			}
 			operatorSha = strings.TrimPrefix(version, "@")
 		}
 
@@ -327,7 +331,6 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	exportProxySha := envVarManager.Getenv(VirtExportProxyShasumEnvName)
 	exportServerSha := envVarManager.Getenv(VirtExportServerShasumEnvName)
 	gsSha := envVarManager.Getenv(GsEnvShasumName)
-	kubeVirtVersion := envVarManager.Getenv(KubeVirtVersionEnvName)
 	if operatorSha != "" && apiSha != "" && controllerSha != "" && handlerSha != "" && launcherSha != "" && kubeVirtVersion != "" {
 		config = newDeploymentConfigWithShasums(registry, imagePrefix, kubeVirtVersion, operatorSha, apiSha, controllerSha, handlerSha, launcherSha, exportProxySha, exportServerSha, gsSha, namespace, additionalProperties, passthroughEnv)
 	}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/9564

Fixes [rhbz#2180146](https://bugzilla.redhat.com/show_bug.cgi?id=2180146)

```release-note
NONE
```
