### PR TITLE
fix issue #8519 make vm support localtime

### DIFF
--- a/api/api-rule-violations-known.list
+++ b/api/api-rule-violations-known.list
@@ -257,6 +257,7 @@ API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,
 API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,Type
 API rule violation: names_match,kubevirt.io/api/core/v1,CDRomTarget,ReadOnly
 API rule violation: names_match,kubevirt.io/api/core/v1,CPU,DedicatedCPUPlacement
+API rule violation: names_match,kubevirt.io/api/core/v1,ClockOffset,LocalTime
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitConfigDriveSource,UserDataSecretRef
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitNoCloudSource,UserDataSecretRef
 API rule violation: names_match,kubevirt.io/api/core/v1,DeveloperConfiguration,LessPVCSpaceToleration

--- a/api/api-rule-violations.list
+++ b/api/api-rule-violations.list
@@ -257,6 +257,7 @@ API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,
 API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,Type
 API rule violation: names_match,kubevirt.io/api/core/v1,CDRomTarget,ReadOnly
 API rule violation: names_match,kubevirt.io/api/core/v1,CPU,DedicatedCPUPlacement
+API rule violation: names_match,kubevirt.io/api/core/v1,ClockOffset,LocalTime
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitConfigDriveSource,UserDataSecretRef
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitNoCloudSource,UserDataSecretRef
 API rule violation: names_match,kubevirt.io/api/core/v1,DeveloperConfiguration,LessPVCSpaceToleration

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15645,6 +15645,10 @@
     "description": "Represents the clock and timers of a vmi.",
     "type": "object",
     "properties": {
+     "localtime": {
+      "description": "LocalTime sets the the guest clock to be synchronized to the host's configured timezone when booted, if any.",
+      "type": "boolean"
+     },
      "timer": {
       "description": "Timer specifies whih timers are attached to the vmi.",
       "$ref": "#/definitions/v1.Timer"
@@ -15663,6 +15667,10 @@
     "description": "Exactly one of its members must be set.",
     "type": "object",
     "properties": {
+     "localtime": {
+      "description": "LocalTime sets the the guest clock to be synchronized to the host's configured timezone when booted, if any.",
+      "type": "boolean"
+     },
      "timezone": {
       "description": "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
       "type": "string"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -105,6 +105,14 @@ func IsSEVVMI(vmi *v1.VirtualMachineInstance) bool {
 	return vmi.Spec.Domain.LaunchSecurity != nil && vmi.Spec.Domain.LaunchSecurity.SEV != nil
 }
 
+// Check if a VMI spec requests Localtime clock
+func IsLocalTimeClock(vmi *v1.VirtualMachineInstance) bool {
+	if vmi.Spec.Domain.Clock != nil && vmi.Spec.Domain.Clock.LocalTime != nil {
+		return *(vmi.Spec.Domain.Clock.LocalTime)
+	}
+	return false
+}
+
 func IsVmiUsingHyperVReenlightenment(vmi *v1.VirtualMachineInstance) bool {
 	if vmi == nil {
 		return false

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1468,6 +1468,9 @@ func (d *VirtualMachineController) calculateLiveMigrationCondition(vmi *v1.Virtu
 	if vmi.IsCPUDedicated() && vmi.Spec.Domain.CPU.IsolateEmulatorThread {
 		return newNonMigratableCondition("VMI uses dedicated CPUs and emulator thread isolation", v1.VirtualMachineInstanceReasonDedicatedCPU), isBlockMigration
 	}
+	if util.IsLocalTimeClock(vmi) {
+		return newNonMigratableCondition("VMI uses Localtime clock", v1.VirtualMachineInstanceReasonLocaltimeNotMigratable), isBlockMigration
+	}
 
 	return &v1.VirtualMachineInstanceCondition{
 		Type:   v1.VirtualMachineInstanceIsMigratable,

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2557,6 +2557,19 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
 			Expect(condition.Reason).To(Equal(v1.VirtualMachineInstanceReasonSEVNotMigratable))
 		})
+		It("should not be allowed to live-migrate if the VMI uses Localtime Clock", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Clock = &v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					LocalTime: pointer.Bool(true),
+				},
+			}
+			condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
+			Expect(isBlockMigration).To(BeFalse())
+			Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
+			Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(v1.VirtualMachineInstanceReasonLocaltimeNotMigratable))
+		})
 
 		It("should not be allowed to live-migrate if the VMI uses SCSI persistent reservation", func() {
 			vmi := api2.NewMinimalVMI("testvmi")

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1017,6 +1017,8 @@ func Convert_v1_Clock_To_api_Clock(source *v1.Clock, clock *api.Clock) error {
 	} else if source.Timezone != nil {
 		clock.Offset = "timezone"
 		clock.Timezone = string(*source.Timezone)
+	} else if source.LocalTime != nil && *source.LocalTime {
+		clock.Offset = "localtime"
 	}
 
 	if source.Timer != nil {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -105,6 +105,24 @@ var _ = Describe("Converter", func() {
 			Expect(string(data)).To(Equal(expectedClock))
 		})
 	})
+	Context("with localtime", func() {
+		It("Should set LocalTime attribute", func() {
+			clock := &v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					LocalTime: True(),
+				},
+				Timer: &v1.Timer{},
+			}
+
+			var convertClock api.Clock
+			Convert_v1_Clock_To_api_Clock(clock, &convertClock)
+			data, err := xml.MarshalIndent(convertClock, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedClock := `<Clock offset="localtime"></Clock>`
+			Expect(string(data)).To(Equal(expectedClock))
+		})
+	})
 
 	Context("with v1.Disk", func() {
 		DescribeTable("Should define disk capacity as the minimum of capacity and request", func(requests, capacity int64) {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -4894,6 +4894,10 @@ var CRDsValidation map[string]string = map[string]string{
                     clock:
                       description: Clock sets the clock and timers of the vmi.
                       properties:
+                        localtime:
+                          description: LocalTime sets the the guest clock to be synchronized
+                            to the host's configured timezone when booted, if any.
+                          type: boolean
                         timer:
                           description: Timer specifies whih timers are attached to
                             the vmi.
@@ -7534,6 +7538,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: ClockOffset allows specifying the UTC offset or the timezone
                 of the guest clock.
               properties:
+                localtime:
+                  description: LocalTime sets the the guest clock to be synchronized
+                    to the host's configured timezone when booted, if any.
+                  type: boolean
                 timezone:
                   description: Timezone sets the guest clock to the specified timezone.
                     Zone name follows the TZ environment variable format (e.g. 'America/New_York').
@@ -9219,6 +9227,10 @@ var CRDsValidation map[string]string = map[string]string{
             clock:
               description: Clock sets the clock and timers of the vmi.
               properties:
+                localtime:
+                  description: LocalTime sets the the guest clock to be synchronized
+                    to the host's configured timezone when booted, if any.
+                  type: boolean
                 timer:
                   description: Timer specifies whih timers are attached to the vmi.
                   properties:
@@ -11748,6 +11760,10 @@ var CRDsValidation map[string]string = map[string]string{
             clock:
               description: Clock sets the clock and timers of the vmi.
               properties:
+                localtime:
+                  description: LocalTime sets the the guest clock to be synchronized
+                    to the host's configured timezone when booted, if any.
+                  type: boolean
                 timer:
                   description: Timer specifies whih timers are attached to the vmi.
                   properties:
@@ -13831,6 +13847,10 @@ var CRDsValidation map[string]string = map[string]string{
                     clock:
                       description: Clock sets the clock and timers of the vmi.
                       properties:
+                        localtime:
+                          description: LocalTime sets the the guest clock to be synchronized
+                            to the host's configured timezone when booted, if any.
+                          type: boolean
                         timer:
                           description: Timer specifies whih timers are attached to
                             the vmi.
@@ -17786,6 +17806,11 @@ var CRDsValidation map[string]string = map[string]string{
                               description: Clock sets the clock and timers of the
                                 vmi.
                               properties:
+                                localtime:
+                                  description: LocalTime sets the the guest clock
+                                    to be synchronized to the host's configured timezone
+                                    when booted, if any.
+                                  type: boolean
                                 timer:
                                   description: Timer specifies whih timers are attached
                                     to the vmi.
@@ -19901,6 +19926,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: ClockOffset allows specifying the UTC offset or the timezone
                 of the guest clock.
               properties:
+                localtime:
+                  description: LocalTime sets the the guest clock to be synchronized
+                    to the host's configured timezone when booted, if any.
+                  type: boolean
                 timezone:
                   description: Timezone sets the guest clock to the specified timezone.
                     Zone name follows the TZ environment variable format (e.g. 'America/New_York').
@@ -22496,6 +22525,11 @@ var CRDsValidation map[string]string = map[string]string{
                                   description: Clock sets the clock and timers of
                                     the vmi.
                                   properties:
+                                    localtime:
+                                      description: LocalTime sets the the guest clock
+                                        to be synchronized to the host's configured
+                                        timezone when booted, if any.
+                                      type: boolean
                                     timer:
                                       description: Timer specifies whih timers are
                                         attached to the vmi.

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -420,6 +420,11 @@ func (in *ClockOffset) DeepCopyInto(out *ClockOffset) {
 		*out = new(ClockOffsetTimezone)
 		**out = **in
 	}
+	if in.LocalTime != nil {
+		in, out := &in.LocalTime, &out.LocalTime
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -846,6 +846,8 @@ type ClockOffset struct {
 	// Timezone sets the guest clock to the specified timezone.
 	// Zone name follows the TZ environment variable format (e.g. 'America/New_York').
 	Timezone *ClockOffsetTimezone `json:"timezone,omitempty"`
+	//LocalTime sets the the guest clock to be synchronized to the host's configured timezone when booted, if any.
+	LocalTime *bool `json:"localtime,omitempty"`
 }
 
 // UTC sets the guest clock to UTC on each boot.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -463,9 +463,10 @@ func (ContainerDiskSource) SwaggerDoc() map[string]string {
 
 func (ClockOffset) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":         "Exactly one of its members must be set.",
-		"utc":      "UTC sets the guest clock to UTC on each boot. If an offset is specified,\nguest changes to the clock will be kept during reboots and are not reset.",
-		"timezone": "Timezone sets the guest clock to the specified timezone.\nZone name follows the TZ environment variable format (e.g. 'America/New_York').",
+		"":          "Exactly one of its members must be set.",
+		"utc":       "UTC sets the guest clock to UTC on each boot. If an offset is specified,\nguest changes to the clock will be kept during reboots and are not reset.",
+		"timezone":  "Timezone sets the guest clock to the specified timezone.\nZone name follows the TZ environment variable format (e.g. 'America/New_York').",
+		"localtime": "LocalTime sets the the guest clock to be synchronized to the host's configured timezone when booted, if any.",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -512,8 +512,9 @@ const (
 	// Reason means that VMI is not live migratable because it requested SCSI persitent reservation
 	VirtualMachineInstanceReasonPRNotMigratable = "PersistentReservationNotLiveMigratable"
 	// Reason means that VMI is not live migratable because it uses dedicated CPU and emulator thread isolation
-
 	VirtualMachineInstanceReasonDedicatedCPU = "DedicatedCPUNotLiveMigratable"
+	// Reason means that VMI is not live migratable because it use Localtime clock
+	VirtualMachineInstanceReasonLocaltimeNotMigratable = "ClockLocaltimeNotLiveMigratable"
 )
 
 const (

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -15037,6 +15037,13 @@ func schema_kubevirtio_api_core_v1_Clock(ref common.ReferenceCallback) common.Op
 							Format:      "",
 						},
 					},
+					"localtime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LocalTime sets the the guest clock to be synchronized to the host's configured timezone when booted, if any.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"timer": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timer specifies whih timers are attached to the vmi.",
@@ -15068,6 +15075,13 @@ func schema_kubevirtio_api_core_v1_ClockOffset(ref common.ReferenceCallback) com
 						SchemaProps: spec.SchemaProps{
 							Description: "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
 							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"localtime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LocalTime sets the the guest clock to be synchronized to the host's configured timezone when booted, if any.",
+							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Make the guest virtual machine clock can use localtime paramete.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8507 

**Special notes for your reviewer**:

When I create a windows vm, I found the guest vm time is not consistent with the host date. 
Libvirt also suggest windows vm use 'localtime' : https://libvirt.org/formatdomain.html#time-keeping

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
