### PR TITLE
fix stamp for virt-operator

### DIFF
--- a/cmd/virt-operator/BUILD.bazel
+++ b/cmd/virt-operator/BUILD.bazel
@@ -13,11 +13,14 @@ go_library(
     ],
 )
 
+load("//vendor/kubevirt.io/client-go/version:def.bzl", "version_x_defs")
+
 go_binary(
     name = "virt-operator",
     embed = [":go_default_library"],
     static = "on",
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
 )
 
 load(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
virt-operator would write current version to `status.operatorVersion` of `KubeVirt` CR. but in current build rule, stamp is missing.

![image](https://user-images.githubusercontent.com/4017672/230593142-375199cc-4c68-4dc1-936d-8cbda5c0d95d.png)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix embed version info of virt-operator
```
