### PR TITLE
Improve mountinfo filtering for hotplugging NFS disks

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -131,7 +131,7 @@ var (
 		child isolation.IsolationResult,
 		findmntInfo FindmntInfo,
 	) (*safepath.Path, error) {
-		return isolation.ParentPathForMount(parent, child, findmntInfo.Target)
+		return isolation.ParentPathForMount(parent, child, findmntInfo.Source, findmntInfo.Target)
 	}
 )
 

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -192,12 +192,21 @@ func MountInfoRoot(r IsolationResult) (mountinfo *mount.Info, err error) {
 	return mountInfoFor(r, "/")
 }
 
+func mountsFilter(compare, m *mount.Info, source string) (bool, bool) {
+	nfsMatch := false
+	if m.FSType == "nfs4" && compare.FSType == m.FSType {
+		nfsMatch = m.Source != source
+	}
+
+	return m.Major != compare.Major || m.Minor != compare.Minor ||
+		!strings.HasPrefix(compare.Root, m.Root) || nfsMatch, false
+}
+
 // parentMountInfoFor takes the mountInfo record of a container (child) and
 // attempts to locate a mountpoint containing it on the parent.
-func parentMountInfoFor(parent IsolationResult, mountInfo *mount.Info) (*mount.Info, error) {
+func parentMountInfoFor(parent IsolationResult, mountInfo *mount.Info, source string) (*mount.Info, error) {
 	mounts, err := parent.Mounts(func(m *mount.Info) (bool, bool) {
-		return m.Major != mountInfo.Major || m.Minor != mountInfo.Minor ||
-			!strings.HasPrefix(mountInfo.Root, m.Root), false
+		return mountsFilter(mountInfo, m, source)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find mount for %v in the mount namespace of pid %d", mountInfo.Root, parent.Pid())
@@ -215,12 +224,12 @@ func parentMountInfoFor(parent IsolationResult, mountInfo *mount.Info) (*mount.I
 	return mounts[0], nil
 }
 
-func ParentPathForMount(parent IsolationResult, child IsolationResult, mountPoint string) (*safepath.Path, error) {
-	childMountInfo, err := mountInfoFor(child, mountPoint)
+func ParentPathForMount(parent IsolationResult, child IsolationResult, source, target string) (*safepath.Path, error) {
+	childMountInfo, err := mountInfoFor(child, target)
 	if err != nil {
 		return nil, err
 	}
-	parentMountInfo, err := parentMountInfoFor(parent, childMountInfo)
+	parentMountInfo, err := parentMountInfoFor(parent, childMountInfo, source)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +248,7 @@ func ParentPathForMount(parent IsolationResult, child IsolationResult, mountPoin
 // ParentPathForRootMount takes a container (child) and composes a path to
 // the root mount point in the context of the parent.
 func ParentPathForRootMount(parent IsolationResult, child IsolationResult) (*safepath.Path, error) {
-	return ParentPathForMount(parent, child, "/")
+	return ParentPathForMount(parent, child, "", "/")
 }
 
 func SafeJoin(res IsolationResult, elems ...string) (*safepath.Path, error) {

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -194,7 +194,7 @@ func MountInfoRoot(r IsolationResult) (mountinfo *mount.Info, err error) {
 
 func mountsFilter(compare, m *mount.Info, source string) (bool, bool) {
 	nfsMatch := false
-	if m.FSType == "nfs4" && compare.FSType == m.FSType {
+	if strings.Contains(m.FSType, "nfs") && compare.FSType == m.FSType {
 		nfsMatch = m.Source != source
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a VM was running multiple NFS disks (one boot disk) and one hotplugged disk. The mount filtering was returning multiple possible mounts on the host, and sorting on the length of the 'root' path of the mount. For NFS these are the same (/). This caused the wrong NFS mount to be picked when hotplugging and an attempt was made to hotplug the boot disk. This commit improves the situation by passing the 'source' field to the filter, and it filters out entries that don't have matching sources. This allows us to find the correct mount on the host.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: allow multiple NFS disks to be used/hotplugged
```
