### PR TITLE
Add "virtctl create clone" command

### DIFF
--- a/pkg/virtctl/create/BUILD.bazel
+++ b/pkg/virtctl/create/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/create",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virtctl/create/clone:go_default_library",
         "//pkg/virtctl/create/instancetype:go_default_library",
         "//pkg/virtctl/create/preference:go_default_library",
         "//pkg/virtctl/create/vm:go_default_library",

--- a/pkg/virtctl/create/clone/BUILD.bazel
+++ b/pkg/virtctl/create/clone/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,5 +13,22 @@ go_library(
         "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "clone_suite_test.go",
+        "clone_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//tests/clientcmd:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
     ],
 )

--- a/pkg/virtctl/create/clone/BUILD.bazel
+++ b/pkg/virtctl/create/clone/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["clone.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virtctl/create/clone",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//staging/src/kubevirt.io/api/clone/v1alpha1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+    ],
+)

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -1,0 +1,288 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package clone
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+)
+
+const (
+	Clone = "clone"
+
+	NameFlag             = "name"
+	SourceNameFlag       = "source-name"
+	TargetNameFlag       = "target-name"
+	SourceTypeFlag       = "source-type"
+	TargetTypeFlag       = "target-type"
+	LabelFilterFlag      = "label-filter"
+	AnnotationFilterFlag = "annotation-filter"
+	NewMacAddressesFlag  = "new-mac-address"
+	NewSMBiosSerialFlag  = "new-smbios-serial"
+
+	supportedSourceTypes = "vm, vmsnapshot"
+	supportedTargetTypes = "vm"
+)
+
+type createClone struct {
+	name              string
+	sourceName        string
+	targetName        string
+	sourceType        string
+	targetType        string
+	labelFilters      []string
+	annotationFilters []string
+	newMacAddresses   []string
+	newSmbiosSerial   string
+}
+
+type cloneSpec clonev1alpha1.VirtualMachineCloneSpec
+type optionFn func(*createClone, *cloneSpec) error
+
+var optFns = map[string]optionFn{
+	NewMacAddressesFlag: withNewMacAddresses,
+}
+
+func NewCommand() *cobra.Command {
+	c := createClone{}
+
+	cmd := &cobra.Command{
+		Use:     Clone,
+		Short:   "Create a clone object manifest",
+		Example: c.usage(),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.run(cmd)
+		},
+	}
+
+	const emptyValue = ""
+	const supportsMultipleFlags = "Can be provided multiple times."
+
+	cmd.Flags().StringVar(&c.name, NameFlag, emptyValue, "Specify the name of the clone. If not specified, name would be randomized.")
+	cmd.Flags().StringVar(&c.sourceName, SourceNameFlag, emptyValue, "Specify the clone's source name.")
+	cmd.Flags().StringVar(&c.targetName, TargetNameFlag, emptyValue, "Specify the clone's target name.")
+	cmd.Flags().StringVar(&c.sourceType, SourceTypeFlag, emptyValue, "Specify the clone's source type. Default type is VM. Supported types: "+supportedSourceTypes)
+	cmd.Flags().StringVar(&c.targetType, TargetTypeFlag, emptyValue, "Specify the clone's target type. Default type is VM. Supported types: "+supportedTargetTypes)
+	cmd.Flags().StringArrayVar(&c.labelFilters, LabelFilterFlag, nil, "Specify clone's label filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.annotationFilters, AnnotationFilterFlag, nil, "Specify clone's annotation filters. "+supportsMultipleFlags)
+	cmd.Flags().StringArrayVar(&c.newMacAddresses, NewMacAddressesFlag, nil, "Specify clone's new mac addresses. For example: 'interfaceName0:newAddress0'")
+	cmd.Flags().StringVar(&c.newSmbiosSerial, NewSMBiosSerialFlag, emptyValue, "Specify the clone's new smbios serial")
+
+	_ = cmd.MarkFlagRequired(SourceNameFlag)
+
+	return cmd
+}
+
+func withNewMacAddresses(c *createClone, cloneSpec *cloneSpec) error {
+	const flag = NewMacAddressesFlag
+
+	for _, param := range c.newMacAddresses {
+		splitParam := strings.Split(param, ":")
+		if len(splitParam) != 2 {
+			return fmt.Errorf("newMacAddress parameter %s is invalid: exactly one ':' is expected. For example: 'interface0:address0'", param)
+		}
+
+		interfaceName, newAddress := splitParam[0], splitParam[1]
+		if interfaceName == "" {
+			return fmt.Errorf("newMacAddress parameter %s has empty interface name", param)
+		}
+		if newAddress == "" {
+			return fmt.Errorf("newMacAddress parameter %s has empty address name", param)
+		}
+
+		if cloneSpec.NewMacAddresses == nil {
+			cloneSpec.NewMacAddresses = map[string]string{}
+		}
+
+		cloneSpec.NewMacAddresses[interfaceName] = newAddress
+	}
+
+	return nil
+}
+
+func (c *createClone) usage() string {
+	return `  # Create a manifest for a clone with a random name:
+  {{ProgramName}} create clone --source-name sourceVM --target-name targetVM
+  
+  # Create a manifest for a clone with a specified name:
+  {{ProgramName}} create clone --name my-clone --source-name sourceVM --target-name targetVM
+
+  # Create a manifest for a clone with a randomized target name (target name is omitted):
+  {{ProgramName}} create --source-name sourceVM
+
+  # Create a manifest for a clone with specified source / target types. The default type is VM.
+  {{ProgramName}} create clone --source-name sourceVM --source-type vm --target-name targetVM --target-type vm
+
+  # Create a manifest for a clone with a source type snapshot to a target type VM:
+  {{ProgramName}} create clone --source-name mySnapshot --source-type snapshot --target-name targetVM
+  
+  # Create a manifest for a clone with label filters:
+  {{ProgramName}} create clone --source-name sourceVM --label-filter "*" --label-filter "!some/key" 
+  
+  # Create a manifest for a clone with annotation filters:
+  {{ProgramName}} create clone --source-name sourceVM --annotation-filter "*" --annotation-filter "!some/key"
+
+  # Create a manifest for a clone with new MAC addresses:
+  {{ProgramName}} create clone --source-name sourceVM --new-mac-address interface1:00-11-22 --new-mac-address interface2:00-11-33
+
+  # Create a manifest for a clone with new SMBIOS serial:
+  {{ProgramName}} create clone --source-name sourceVM --new-smbios-serial "new-serial"
+
+  # Create a manifest for a clone and use it to create a resource with kubectl
+  {{ProgramName}} create clone --source-name sourceVM | kubectl create -f -`
+}
+
+func (c *createClone) newClone() (*clonev1alpha1.VirtualMachineClone, error) {
+	clone := kubecli.NewMinimalClone(c.name)
+
+	source, err := c.typeToTypedLocalObjectReference(c.sourceType, c.sourceName, true)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := c.typeToTypedLocalObjectReference(c.targetType, c.targetName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	clone.Spec = clonev1alpha1.VirtualMachineCloneSpec{
+		Source:            source,
+		Target:            target,
+		AnnotationFilters: c.annotationFilters,
+		LabelFilters:      c.labelFilters,
+		NewSMBiosSerial:   pointer.P(c.newSmbiosSerial),
+	}
+
+	return clone, nil
+}
+
+func (c *createClone) applyFlags(cmd *cobra.Command, spec *clonev1alpha1.VirtualMachineCloneSpec) error {
+	for flag := range optFns {
+		if cmd.Flags().Changed(flag) {
+			if err := optFns[flag](c, (*cloneSpec)(spec)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *createClone) run(cmd *cobra.Command) error {
+	c.setDefaults()
+	err := c.validateFlags()
+	if err != nil {
+		return err
+	}
+
+	clone, err := c.newClone()
+	if err != nil {
+		return err
+	}
+
+	err = c.applyFlags(cmd, &clone.Spec)
+	if err != nil {
+		return err
+	}
+
+	if clone.Name == "" {
+		clone.Name = "clone-" + rand.String(5)
+	}
+
+	cloneBytes, err := yaml.Marshal(clone)
+	if err != nil {
+		return err
+	}
+
+	cmd.Print(string(cloneBytes))
+	return nil
+}
+
+func (c *createClone) typeToTypedLocalObjectReference(sourceOrTargetType, sourceOrTargetName string, isSource bool) (*v1.TypedLocalObjectReference, error) {
+	var kind, apiGroup string
+
+	generateErr := func() error {
+		var sourceTargetStr string
+		var supportedTypes string
+
+		if isSource {
+			sourceTargetStr = "source"
+			supportedTypes = supportedSourceTypes
+		} else {
+			sourceTargetStr = "target"
+			supportedTypes = supportedTargetTypes
+		}
+
+		return fmt.Errorf("%s type %s is not supported. Supported types: %s", sourceTargetStr, sourceOrTargetType, supportedTypes)
+	}
+
+	switch sourceOrTargetType {
+	case "vm", "VM", "VirtualMachine", "virtualmachine":
+		kind = "VirtualMachine"
+		apiGroup = "kubevirt.io"
+	case "snapshot", "VirtualMachineSnapshot", "vmsnapshot", "VMSnapshot":
+		if !isSource {
+			return nil, generateErr()
+		}
+
+		kind = "VirtualMachineSnapshot"
+		apiGroup = "snapshot.kubevirt.io"
+	default:
+		return nil, generateErr()
+	}
+
+	return &v1.TypedLocalObjectReference{
+		Name:     sourceOrTargetName,
+		Kind:     kind,
+		APIGroup: &apiGroup,
+	}, nil
+}
+
+func (c *createClone) setDefaults() {
+	if c.name == "" {
+		c.name = "clone-" + rand.String(5)
+	}
+
+	const defaultType = "vm"
+
+	if c.sourceType == "" {
+		c.sourceType = defaultType
+	}
+	if c.targetType == "" {
+		c.targetType = defaultType
+	}
+}
+
+func (c *createClone) validateFlags() error {
+	if c.sourceName == "" {
+		return fmt.Errorf("source name must not be empty")
+	}
+
+	return nil
+}

--- a/pkg/virtctl/create/clone/clone_suite_test.go
+++ b/pkg/virtctl/create/clone/clone_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package clone_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCreate(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virtctl/create/clone/clone_test.go
+++ b/pkg/virtctl/create/clone/clone_test.go
@@ -1,0 +1,205 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package clone_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	clonev1alpha1 "kubevirt.io/api/clone/v1alpha1"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/create/clone"
+	"kubevirt.io/kubevirt/tests/clientcmd"
+)
+
+const (
+	create = "create"
+
+	vmKind, vmApiGroup             = "VirtualMachine", "kubevirt.io"
+	snapshotKind, snapshotApiGroup = "VirtualMachineSnapshot", "snapshot.kubevirt.io"
+)
+
+var _ = Describe("create clone", func() {
+	Context("required arguments", func() {
+
+		It("source name must be specified", func() {
+			_, err := newCommand()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("source name is the only required argument", func() {
+			flags := addFlag(nil, clone.SourceNameFlag, "fake-name")
+			_, err := newCommand(flags...)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("source and target", func() {
+
+		DescribeTable("supported types", func(sourceType, expectedSourceKind, expectedSourceApiGroup, targetType, expectedTargetKind, expectedTargetApiGroup string) {
+			const sourceName, targetName = "source-name", "target-name"
+
+			flags := addFlag(nil, clone.SourceNameFlag, sourceName)
+			flags = addFlag(flags, clone.TargetNameFlag, targetName)
+			flags = addFlag(flags, clone.SourceTypeFlag, sourceType)
+			flags = addFlag(flags, clone.TargetTypeFlag, targetType)
+
+			cloneObj, err := newCommand(flags...)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(cloneObj.Spec.Source.Name).To(Equal(sourceName))
+			Expect(cloneObj.Spec.Source.Kind).To(Equal(expectedSourceKind))
+			Expect(cloneObj.Spec.Source.APIGroup).ToNot(BeNil())
+			Expect(*cloneObj.Spec.Source.APIGroup).To(Equal(expectedSourceApiGroup))
+
+			Expect(cloneObj.Spec.Target.Name).To(Equal(targetName))
+			Expect(cloneObj.Spec.Target.Kind).To(Equal(expectedTargetKind))
+			Expect(cloneObj.Spec.Target.APIGroup).ToNot(BeNil())
+			Expect(*cloneObj.Spec.Target.APIGroup).To(Equal(expectedTargetApiGroup))
+		},
+			Entry("vm source, vm target", "vm", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("VM source, vm target", "VM", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("VirtualMachine source, vm target", "VirtualMachine", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("virtualmachine, vm target", "virtualmachine", vmKind, vmApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("vm source, VirtualMachine target", "vm", vmKind, vmApiGroup, "VirtualMachine", vmKind, vmApiGroup),
+
+			Entry("snapshot source, vm target", "snapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("VirtualMachineSnapshot source, vm target", "VirtualMachineSnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("vmsnapshot source, vm target", "vmsnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
+			Entry("VMSnapshot source, vm target", "VMSnapshot", snapshotKind, snapshotApiGroup, "vm", vmKind, vmApiGroup),
+		)
+
+		It("unknown source type", func() {
+			flags := getSourceNameFlags()
+			flags = addFlag(flags, clone.SourceTypeFlag, "unknown type")
+
+			_, err := newCommand(flags...)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("unknown target type", func() {
+			flags := getSourceNameFlags()
+			flags = addFlag(flags, clone.TargetTypeFlag, "unknown type")
+
+			_, err := newCommand(flags...)
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
+
+	Context("label and annotation filters", func() {
+		const (
+			withLabelFilters, withoutLabelFilters           = true, false
+			withAnnotationFilters, withoutAnnotationFilters = true, false
+		)
+
+		DescribeTable("with", func(addLabelFilter, addAnnotationFilter bool) {
+			flags := getSourceNameFlags()
+
+			if addLabelFilter {
+				flags = addFlag(flags, clone.LabelFilterFlag, "*")
+				flags = addFlag(flags, clone.LabelFilterFlag, `"!some/key"`)
+			}
+			if addAnnotationFilter {
+				flags = addFlag(flags, clone.AnnotationFilterFlag, "*")
+				flags = addFlag(flags, clone.AnnotationFilterFlag, `"!some/key"`)
+			}
+
+			cloneObj, err := newCommand(flags...)
+			Expect(err).ToNot(HaveOccurred())
+
+			const expectedLen = 2
+			if addLabelFilter {
+				Expect(cloneObj.Spec.LabelFilters).To(HaveLen(expectedLen))
+			}
+			if addAnnotationFilter {
+				Expect(cloneObj.Spec.AnnotationFilters).To(HaveLen(expectedLen))
+			}
+		},
+			Entry("label filters", withLabelFilters, withoutAnnotationFilters),
+			Entry("annotation filters", withoutLabelFilters, withAnnotationFilters),
+			Entry("label and annotation filters", withLabelFilters, withAnnotationFilters),
+		)
+	})
+
+	It("new mac addresses", func() {
+		const newMacAddressValueFmt = `%s:%s`
+
+		flags := getSourceNameFlags()
+
+		newMacAddresses := map[string]string{
+			"interface0": "custom-mac-address0",
+			"interface1": "custom-mac-address1",
+		}
+
+		for interfaceName, newMacAddress := range newMacAddresses {
+			flags = addFlag(flags, clone.NewMacAddressesFlag, fmt.Sprintf(newMacAddressValueFmt, interfaceName, newMacAddress))
+		}
+
+		cloneObj, err := newCommand(flags...)
+		Expect(err).ToNot(HaveOccurred())
+
+		for interfaceName, newMacAddress := range cloneObj.Spec.NewMacAddresses {
+			expectedAddress, exists := cloneObj.Spec.NewMacAddresses[interfaceName]
+			Expect(exists).To(BeTrue())
+			Expect(newMacAddress).To(Equal(expectedAddress))
+		}
+	})
+
+	It("new smbios serial", func() {
+		flags := getSourceNameFlags()
+
+		const newSerial = "newSerial"
+		flags = addFlag(flags, clone.NewSMBiosSerialFlag, newSerial)
+
+		cloneObj, err := newCommand(flags...)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(cloneObj.Spec.NewSMBiosSerial).ToNot(BeNil())
+		Expect(*cloneObj.Spec.NewSMBiosSerial).To(Equal(newSerial))
+	})
+
+})
+
+func addFlag(s []string, flag, value string) []string {
+	return append(s, fmt.Sprintf("--%s", flag), value)
+}
+
+func newCommand(createCloneFlags ...string) (*clonev1alpha1.VirtualMachineClone, error) {
+	baseArgs := []string{create, clone.Clone}
+	args := append(baseArgs, createCloneFlags...)
+
+	bytes, err := clientcmd.NewRepeatableVirtctlCommandWithOut(args...)()
+	if err != nil {
+		return nil, err
+	}
+
+	cloneObj := clonev1alpha1.VirtualMachineClone{}
+	err = yaml.Unmarshal(bytes, &cloneObj)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return &cloneObj, nil
+}
+
+func getSourceNameFlags() []string {
+	return addFlag(nil, clone.SourceNameFlag, "source-vm")
+}

--- a/pkg/virtctl/create/create.go
+++ b/pkg/virtctl/create/create.go
@@ -22,6 +22,8 @@ package create
 import (
 	"github.com/spf13/cobra"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/create/clone"
+
 	"kubevirt.io/kubevirt/pkg/virtctl/create/instancetype"
 	"kubevirt.io/kubevirt/pkg/virtctl/create/preference"
 	"kubevirt.io/kubevirt/pkg/virtctl/create/vm"
@@ -44,6 +46,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(vm.NewCommand())
 	cmd.AddCommand(preference.NewCommand())
 	cmd.AddCommand(instancetype.NewCommand())
+	cmd.AddCommand(clone.NewCommand())
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 
 	return cmd

--- a/pkg/virtctl/create/instancetype/instancetype.go
+++ b/pkg/virtctl/create/instancetype/instancetype.go
@@ -96,8 +96,8 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringArrayVar(&c.gpus, GPUFlag, c.gpus, "Specify the list of vGPUs to passthrough. Can be provided multiple times.")
 	cmd.Flags().StringArrayVar(&c.hostDevices, HostDeviceFlag, c.hostDevices, "Specify list of HostDevices to passthrough. Can be provided multiple times.")
 
-	cmd.MarkFlagRequired(CPUFlag)
-	cmd.MarkFlagRequired(MemoryFlag)
+	_ = cmd.MarkFlagRequired(CPUFlag)
+	_ = cmd.MarkFlagRequired(MemoryFlag)
 	return cmd
 }
 
@@ -190,7 +190,7 @@ func (c *createInstancetype) usage() string {
   {{ProgramName}} create instancetype --cpu 2 --memory 256Mi | kubectl create -f -`
 }
 
-func (c *createInstancetype) newInstancetype(cmd *cobra.Command) *instancetypev1alpha2.VirtualMachineInstancetype {
+func (c *createInstancetype) newInstancetype(_ *cobra.Command) *instancetypev1alpha2.VirtualMachineInstancetype {
 	return &instancetypev1alpha2.VirtualMachineInstancetype{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VirtualMachineInstancetype",
@@ -210,7 +210,7 @@ func (c *createInstancetype) newInstancetype(cmd *cobra.Command) *instancetypev1
 	}
 }
 
-func (c *createInstancetype) newClusterInstancetype(cmd *cobra.Command) *instancetypev1alpha2.VirtualMachineClusterInstancetype {
+func (c *createInstancetype) newClusterInstancetype(_ *cobra.Command) *instancetypev1alpha2.VirtualMachineClusterInstancetype {
 	return &instancetypev1alpha2.VirtualMachineClusterInstancetype{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VirtualMachineClusterInstancetype",

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -17,6 +17,21 @@ func FlagErr(flagName, format string, a ...any) error {
 	return fmt.Errorf("failed to parse \"--%s\" flag: %w", flagName, fmt.Errorf(format, a...))
 }
 
+/*
+The functions below can be used for complicated flags with multiple parameters.
+For example, let's think of the following flag: "--my-flag param1:value1,param2:value2".
+To automatically define such a flag, the following struct could be defined:
+
+type MyFlag struct {
+	Param1 string `param:"param1"`
+	Param2 string `param:"param2"`
+}
+
+The functions below use reflection to automatically handle such flags.
+*/
+
+// Supported returns the list of supported flags for a parameter struct. This is mainly used to show the user the
+// list of supported parameters
 func Supported(obj interface{}) string {
 	objVal := reflect.ValueOf(obj)
 	if objVal.Kind() != reflect.Struct {
@@ -49,13 +64,16 @@ func Supported(obj interface{}) string {
 	return strings.Join(params, ",")
 }
 
+// Map assigns the parameter value into the right struct field, which is represented by obj.
+// For example, if we use Map("param1", "value1", &myFlag) with MyFlag struct above, Param1 field would be
+// assigned with "value1".
 func Map(flagName, paramsStr string, obj interface{}) error {
-	params, err := Split(paramsStr)
+	params, err := split(paramsStr)
 	if err != nil {
 		return FlagErr(flagName, "%w", err)
 	}
 
-	err = Apply(params, obj)
+	err = apply(params, obj)
 	if err != nil {
 		return FlagErr(flagName, "%w", err)
 	}
@@ -71,7 +89,8 @@ func Map(flagName, paramsStr string, obj interface{}) error {
 	return nil
 }
 
-func Split(paramsStr string) (map[string]string, error) {
+// split parses a flag with multiple parameters into a map
+func split(paramsStr string) (map[string]string, error) {
 	if paramsStr == "" {
 		return nil, errors.New("params may not be empty")
 	}
@@ -89,7 +108,8 @@ func Split(paramsStr string) (map[string]string, error) {
 	return paramsMap, nil
 }
 
-func Apply(paramsMap map[string]string, obj interface{}) error {
+// apply assigns the different parameters into obj's corresponding fields
+func apply(paramsMap map[string]string, obj interface{}) error {
 	objVal := reflect.ValueOf(obj)
 	if objVal.Kind() != reflect.Ptr {
 		panic("passed in interface needs to be a pointer")
@@ -134,6 +154,7 @@ func Apply(paramsMap map[string]string, obj interface{}) error {
 	return nil
 }
 
+// SplitPrefixedName splits prefixedName with "/" as a separator
 func SplitPrefixedName(prefixedName string) (prefix string, name string, err error) {
 	s := strings.Split(prefixedName, "/")
 

--- a/pkg/virtctl/create/params/params.go
+++ b/pkg/virtctl/create/params/params.go
@@ -23,7 +23,7 @@ func Supported(obj interface{}) string {
 		panic("passed in interface needs to be a struct")
 	}
 
-	params := []string{}
+	var params []string
 	objValType := objVal.Type()
 	for i := 0; i < objValType.NumField(); i++ {
 		structField := objValType.Field(i)
@@ -61,7 +61,7 @@ func Map(flagName, paramsStr string, obj interface{}) error {
 	}
 
 	if len(params) > 0 {
-		unknown := []string{}
+		var unknown []string
 		for k, v := range params {
 			unknown = append(unknown, fmt.Sprintf("%s:%s", k, v))
 		}

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -314,7 +314,7 @@ func withInstancetype(c *createVM, vm *v1.VirtualMachine) error {
 	return nil
 }
 
-func withInferredInstancetype(c *createVM, vm *v1.VirtualMachine) error {
+func withInferredInstancetype(_ *createVM, vm *v1.VirtualMachine) error {
 	if len(vm.Spec.Template.Spec.Volumes) < 1 {
 		return params.FlagErr(InferInstancetypeFlag, "at least one volume is needed to infer instancetype")
 	}
@@ -348,7 +348,7 @@ func withPreference(c *createVM, vm *v1.VirtualMachine) error {
 	return nil
 }
 
-func withInferredPreference(c *createVM, vm *v1.VirtualMachine) error {
+func withInferredPreference(_ *createVM, vm *v1.VirtualMachine) error {
 	if len(vm.Spec.Template.Spec.Volumes) < 1 {
 		return params.FlagErr(InferPreferenceFlag, "at least one volume is needed to infer preference")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `virtctl create clone` command.

Here's the full usage details:
```bash
> ./cluster-up/virtctl.sh create clone --help
Create a clone object manifest

Usage:
  virtctl create clone [flags]

Examples:
  # Create a manifest for a clone with a random name:
  virtctl create clone --source-name sourceVM --target-name targetVM
  
  # Create a manifest for a clone with a specified name:
  virtctl create clone --name my-clone --source-name sourceVM --target-name targetVM

  # Create a manifest for a clone with a randomized target name (target name is omitted):
  virtctl create --source-name sourceVM

  # Create a manifest for a clone with specified source / target types. The default type is VM.
  virtctl create clone --source-name sourceVM --source-type vm --target-name targetVM --target-type vm

  # Create a manifest for a clone with a source type snapshot to a target type VM:
  virtctl create clone --source-name mySnapshot --source-type snapshot --target-name targetVM
  
  # Create a manifest for a clone with label filters:
  virtctl create clone --source-name sourceVM --label-filter "*" --label-filter "!some/key" 
  
  # Create a manifest for a clone with annotation filters:
  virtctl create clone --source-name sourceVM --annotation-filter "*" --annotation-filter "!some/key"

  # Create a manifest for a clone with new MAC addresses:
  virtctl create clone --source-name sourceVM --new-mac-address interface1:00-11-22 --new-mac-address interface2:00-11-33

  # Create a manifest for a clone with new SMBIOS serial:
  virtctl create clone --source-name sourceVM --new-smbios-serial "new-serial"

  # Create a manifest for a clone and use it to create a resource with kubectl virt
  virtctl create clone --source-name sourceVM | kubectl virt create -f -

Flags:
      --annotation-filter stringArray   Specify clone's annotation filters. Can be provided multiple times.
  -h, --help                            help for clone
      --label-filter stringArray        Specify clone's label filters. Can be provided multiple times.
      --name string                     Specify the name of the clone. If not specified, name would be randomized.
      --new-mac-address stringArray     Specify clone's new mac addresses. For example: 'interfaceName0:newAddress0'
      --new-smbios-serial string        Specify the clone's new smbios serial
      --source-name string              Specify the clone's source name.
      --source-type string              Specify the clone's source type. Default type is VM. Supported types: vm, vmsnapshot
      --target-name string              Specify the clone's target name.
      --target-type string              Specify the clone's target type. Default type is VM. Supported types: vm
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add "virtctl create clone" command
```
