### PR TITLE
[Refactor] Use ambient capabilities for the virt-launcher binary

### DIFF
--- a/cmd/virt-launcher-monitor/BUILD.bazel
+++ b/cmd/virt-launcher-monitor/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )
 

--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"golang.org/x/sys/unix"
 	"kubevirt.io/client-go/log"
 )
 
@@ -95,7 +96,11 @@ func RunAndMonitor(containerDiskDir string) (int, error) {
 	defer cleanupContainerDiskDirectory(containerDiskDir)
 	defer terminateIstioProxy()
 	args := removeArg(os.Args[1:], "--keep-after-failure")
+
 	cmd := exec.Command("/usr/bin/virt-launcher", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AmbientCaps: []uintptr{unix.CAP_NET_BIND_SERVICE},
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -68,9 +68,6 @@ pkg_tar(
 xattrs(
     name = "setcaps",
     capabilities = {
-        "/usr/bin/virt-launcher": [
-            "cap_net_bind_service",
-        ],
         "/usr/bin/virt-launcher-monitor": [
             "cap_net_bind_service",
         ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**What this PR does / why we need it**:

The `virt-launcher` binary needs the `cap_net_bind_service` capability to work. Currently, we are using [xattr](https://man7.org/linux/man-pages/man7/xattr.7.html) as a part of the bazel build toolchain to add this capability (https://github.com/rmohr/bazeldnf/blob/main/pkg/xattr/xattr.go) to the binary executable file as a file capability. Ambient capabilities are a better solution for this use case. #8967 suggests we use ambient capabilities rather than file capabilities (using xattr). [Here](https://github.com/kubevirt/kubevirt/blob/main/cmd/virt-launcher/BUILD.bazel#L72) we can see the `cap_net_bind_service` capability added to the virt-launcher binary using xattr. 

Ideal solution would be to ask Kubernetes to start `virt-launcher-monitor` with `cap_net_bind_service` as an ambient capability, that would then be inherited by `virt-launcher` without having to setcap any binary file. But Kubernetes doesn't support that just yet (see [KEP-2763](https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/2763-ambient-capabilities/README.md)).

This PR does the next best thing, which is to have `virt-launcher-monitor` start `virt-launcher` with the appropriate ambient capabilities so we don't have to setcap the virt-launcher binary file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8967 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
