### PR TITLE
builder: Add conversion-gen

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -79,6 +79,7 @@ RUN set -x && \
     source /etc/profile.d/gimme.sh && \
     go install -v golang.org/x/tools/cmd/goimports@d5fe738 && \
     go install -v mvdan.cc/sh/v3/cmd/shfmt@v3.1.1 && \
+    go install -v k8s.io/code-generator/cmd/conversion-gen@v0.20.2  && \
     go install -v k8s.io/code-generator/cmd/deepcopy-gen@v0.20.2 && \
     go install -v k8s.io/code-generator/cmd/defaulter-gen@v0.20.2  && \
     go install -v k8s.io/kube-openapi/cmd/openapi-gen@30be4d1 && \


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

We would like to generate code using conversion-gen to handle instance type version conversion. This first part of this process is adding the utility to the builder image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

https://github.com/kubevirt/kubevirt/pull/9575 will be making use of this generated conversion code once this PR lands and the builder image is updated.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
