### PR TITLE
node-labeller: Remove pipefail to fix non kvm envs

### DIFF
--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 
-set -e
-set -o pipefail
+set -xeo pipefail
 
 # nodelabeller currently only support x86.
 if ! uname -m | grep x86_64; then
   exit 0
 fi
 
+set +o pipefail
 KVM_MINOR=$(grep -w 'kvm' /proc/misc | cut -f 1 -d' ')
+set -o pipefail
+
 VIRTTYPE=qemu
+
 
 if [ ! -e /dev/kvm ] && [ -n "$KVM_MINOR" ]; then
   mknod /dev/kvm c 10 $KVM_MINOR


### PR DESCRIPTION
**What this PR does / why we need it**:
At some scenarios like running kubevirt on github actions there are not nested virtualization so kvm is not present at nodes and emulation have to be used, the node-labeller.sh script was failing if there is no kvm at pipefail. This change remove pipefail and also add "-x" to show the script and debug it in case of failure.

This prevent running stuff like https://kubevirt.io/quickstart_kind with emulation.

This issue was introduced at:
- https://github.com/kubevirt/kubevirt/pull/9320

/kind bug

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adapt node-labeller.sh script to work at non kvm envs with emulation.
```
