### PR TITLE
builder: Build and publish image using shared version

### DIFF
--- a/hack/builder/arch.sh
+++ b/hack/builder/arch.sh
@@ -1,0 +1,2 @@
+# TODO: reenable ppc64le when new builds are available
+ARCHITECTURES="amd64 arm64"

--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -16,9 +16,12 @@ cleanup() {
     rm manifests/ -rf || true
 }
 
-. ${SCRIPT_DIR}/version.sh
-
 cleanup
+
+# shellcheck source=hack/builder/arch.sh
+. "${SCRIPT_DIR}/arch.sh"
+# Use the value of VERSION returned from build.sh instead of version.sh to ensure the correct image is published
+VERSION=$($(dirname "$0")/build.sh)
 
 for ARCH in ${ARCHITECTURES}; do
     ${KUBEVIRT_CRI} push quay.io/kubevirt/builder:${VERSION}-${ARCH}

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,1 @@
 VERSION=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)
-# TODO: reenable ppc64le when new builds are available
-ARCHITECTURES="amd64 arm64"


### PR DESCRIPTION
/cc @brianmcarey 
/cc @rmohr 
/cc @xpivarc 

**What this PR does / why we need it**:

The builder-publish makefile target will now build and publish the
builder image in a single step. The version of the initial image now
being shared from the underlying build.sh script to ensure the correct
image is published.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
