### PR TITLE
cleanup(virtctl): Remove dryRun options

### DIFF
--- a/pkg/virtctl/create/preference/preference.go
+++ b/pkg/virtctl/create/preference/preference.go
@@ -124,13 +124,13 @@ func (c *createPreference) usage() string {
   {{ProgramName}} create preference
 	
   # Create a manifest for a ClusterPreference with a specified CPU topology:
-  {{ProgramName}} create preference --cpu preferSockets
+  {{ProgramName}} create preference --cpu-topology preferSockets
 
   # Create a manifest for a Preference with a specified CPU topology:
-  {{ProgramName}} create preference --cpu preferSockets --namespaced
+  {{ProgramName}} create preference --cpu-topology preferSockets --namespaced
 	
   # Create a manifest for a ClusterPreference and use it to create a resource with kubectl
-  {{ProgramName}} create preference --volume hostpath-provisioner | kubectl create -f -`
+  {{ProgramName}} create preference --volume-storage-class hostpath-provisioner | kubectl create -f -`
 }
 
 func (c *createPreference) newClusterPreference() *instancetypev1alpha2.VirtualMachineClusterPreference {

--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmi"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -1175,6 +1176,9 @@ func newVirtualMachineClusterInstancetype(vmi *v1.VirtualMachineInstance) *insta
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vm-cluster-instancetype-",
 			Namespace:    testsuite.GetTestNamespace(nil),
+			Labels: map[string]string{
+				cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(nil)): "",
+			},
 		},
 		Spec: newVirtualMachineInstancetypeSpec(vmi),
 	}
@@ -1212,6 +1216,9 @@ func newVirtualMachineClusterPreference() *instancetypev1alpha2.VirtualMachineCl
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vm-cluster-preference-",
 			Namespace:    testsuite.GetTestNamespace(nil),
+			Labels: map[string]string{
+				cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(nil)): "",
+			},
 		},
 	}
 }

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -106,6 +106,18 @@ func CleanNamespaces() {
 			util.PanicOnError(virtCli.VirtualMachineInstancetype(namespace).Delete(context.Background(), instancetype.Name, metav1.DeleteOptions{}))
 		}
 
+		clusterPreference, err := virtCli.VirtualMachineClusterPreference().List(context.Background(), listOptions)
+		util.PanicOnError(err)
+		for _, clusterpreference := range clusterPreference.Items {
+			util.PanicOnError(virtCli.VirtualMachineClusterPreference().Delete(context.Background(), clusterpreference.Name, metav1.DeleteOptions{}))
+		}
+
+		vmPreference, err := virtCli.VirtualMachinePreference(namespace).List(context.Background(), metav1.ListOptions{})
+		util.PanicOnError(err)
+		for _, preference := range vmPreference.Items {
+			util.PanicOnError(virtCli.VirtualMachinePreference(namespace).Delete(context.Background(), preference.Name, metav1.DeleteOptions{}))
+		}
+
 		//Remove all Jobs
 		jobDeleteStrategy := metav1.DeletePropagationOrphan
 		jobDeleteOptions := metav1.DeleteOptions{PropagationPolicy: &jobDeleteStrategy}

--- a/tests/virtctl/create_preference.go
+++ b/tests/virtctl/create_preference.go
@@ -16,6 +16,8 @@ import (
 	. "kubevirt.io/kubevirt/pkg/virtctl/create/preference"
 	"kubevirt.io/kubevirt/tests/clientcmd"
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/cleanup"
+	"kubevirt.io/kubevirt/tests/testsuite"
 	"kubevirt.io/kubevirt/tests/util"
 )
 
@@ -36,13 +38,16 @@ var _ = Describe("[sig-compute] create preference", decorators.SigCompute, func(
 		case *instancetypev1alpha2.VirtualMachinePreference:
 			ExpectWithOffset(1, namespaced).To(BeTrue(), "expected VirtualMachinePreference to be created")
 			ExpectWithOffset(1, obj.Kind).To(Equal("VirtualMachinePreference"))
-			preference, err := virtClient.VirtualMachinePreference(util.NamespaceTestDefault).Create(context.Background(), (*instancetypev1alpha2.VirtualMachinePreference)(obj), metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			preference, err := virtClient.VirtualMachinePreference(util.NamespaceTestDefault).Create(context.Background(), (*instancetypev1alpha2.VirtualMachinePreference)(obj), metav1.CreateOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			return &preference.Spec, nil
 		case *instancetypev1alpha2.VirtualMachineClusterPreference:
 			ExpectWithOffset(1, namespaced).To(BeFalse(), "expected VirtualMachineClusterPreference to be created")
 			ExpectWithOffset(1, obj.Kind).To(Equal("VirtualMachineClusterPreference"))
-			clusterPreference, err := virtClient.VirtualMachineClusterPreference().Create(context.Background(), (*instancetypev1alpha2.VirtualMachineClusterPreference)(obj), metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			obj.Labels = map[string]string{
+				cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(obj)): "",
+			}
+			clusterPreference, err := virtClient.VirtualMachineClusterPreference().Create(context.Background(), (*instancetypev1alpha2.VirtualMachineClusterPreference)(obj), metav1.CreateOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			return &clusterPreference.Spec, nil
 		default:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes dryRun options and adds functionality to CleanNamespaces to remove VirtualMachinePreference and VirtualMachineClusterPreference instead. It also updates help message for this command.

**Release note**:
```
None
```
