### PR TITLE
Run the virtiofsd container as non-root for config volumes

### DIFF
--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -103,7 +103,7 @@ func isConfig(volume *v1.Volume) bool {
 		volume.ServiceAccount != nil || volume.DownwardAPI != nil
 }
 
-func isAutomount(volume *v1.Volume) bool {
+func isAutoMount(volume *v1.Volume) bool {
 	// The template service sets pod.Spec.AutomountServiceAccountToken as true
 	return volume.ServiceAccount != nil
 }
@@ -143,7 +143,7 @@ func generateContainerFromVolume(volume *v1.Volume, image string, config *virtco
 		},
 	}
 
-	if !isAutomount(volume) {
+	if !isAutoMount(volume) {
 		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      volume.Name,
 			MountPath: virtioFSMountPoint(volume),

--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -70,7 +70,7 @@ func resourcesForVirtioFSContainer(dedicatedCPUs bool, guaranteedQOS bool, confi
 
 }
 
-var userAndGroup = int64(util.RootUser)
+var privilegedId = int64(util.RootUser)
 
 func getVirtiofsCapabilities() []k8sv1.Capability {
 	return []k8sv1.Capability{
@@ -89,8 +89,8 @@ func getVirtiofsCapabilities() []k8sv1.Capability {
 func securityContextVirtioFS() *k8sv1.SecurityContext {
 
 	return &k8sv1.SecurityContext{
-		RunAsUser:    &userAndGroup,
-		RunAsGroup:   &userAndGroup,
+		RunAsUser:    &privilegedId,
+		RunAsGroup:   &privilegedId,
 		RunAsNonRoot: pointer.Bool(false),
 		Capabilities: &k8sv1.Capabilities{
 			Add: getVirtiofsCapabilities(),

--- a/tests/virtiofs/config.go
+++ b/tests/virtiofs/config.go
@@ -68,7 +68,7 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 				"option2": "value2",
 				"option3": "value3",
 			}
-			tests.CreateConfigMap(configMapName, testsuite.NamespacePrivileged, data)
+			tests.CreateConfigMap(configMapName, testsuite.GetTestNamespace(nil), data)
 		})
 
 		It("Should be the mounted virtiofs layout the same for a pod and vmi", func() {
@@ -77,7 +77,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Running VMI")
 			vmi := libvmi.NewFedora(
 				libvmi.WithConfigMapFs(configMapName, configMapName),
-				libvmi.WithNamespace(testsuite.NamespacePrivileged),
 			)
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 
@@ -126,7 +125,7 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 				"user":     "admin",
 				"password": "redhat",
 			}
-			tests.CreateSecret(secretName, testsuite.NamespacePrivileged, data)
+			tests.CreateSecret(secretName, testsuite.GetTestNamespace(nil), data)
 		})
 
 		It("Should be the mounted virtiofs layout the same for a pod and vmi", func() {
@@ -135,7 +134,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Running VMI")
 			vmi := libvmi.NewFedora(
 				libvmi.WithSecretFs(secretName, secretName),
-				libvmi.WithNamespace(testsuite.NamespacePrivileged),
 			)
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 
@@ -178,7 +176,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			By("Running VMI")
 			vmi := libvmi.NewFedora(
 				libvmi.WithServiceAccountFs("default", serviceAccountVolumeName),
-				libvmi.WithNamespace(testsuite.NamespacePrivileged),
 			)
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 
@@ -238,7 +235,6 @@ var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, 
 			vmi := libvmi.NewFedora(
 				libvmi.WithLabel(testLabelKey, testLabelVal),
 				libvmi.WithDownwardAPIFs(downwardAPIName),
-				libvmi.WithNamespace(testsuite.NamespacePrivileged),
 			)
 			vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, we can share configuration volumes, such as ConfigMaps, Secrets, DownwardAPI and ServiceAccount using virtiofs, but the virtiofs container requires to be run as root. 

Virtiofsd supports being run without privileges, so this PR to modify the container to run as the unprivileged user when sharing configuration volumes.

Reported-by: Javier Cano Cano <jcanocan@redhat.com>

Tested-by: Javier Cano Cano <jcanocan@redhat.com>

Related #7735

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for running virtiofsd in an unprivileged container when sharing configuration volumes.
```
