### PR TITLE
[LimitRange tests]: Fix cleanup of LimitRange

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1330,7 +1330,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 		AfterEach(func() {
 			if lr != nil {
-				err = virtClient.CoreV1().LimitRanges(namespace).Delete(context.Background(), lr.Name, metav1.DeleteOptions{})
+				err = virtClient.CoreV1().LimitRanges(lr.Namespace).Delete(context.Background(), lr.Name, metav1.DeleteOptions{})
 				if !errors.IsNotFound(err) {
 					Expect(err).ToNot(HaveOccurred())
 				}

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -44,10 +44,10 @@ const (
 	imagePath            = "/tmp/alpine.iso"
 	getDataVolume        = "Get DataVolume"
 	getPVC               = "Get PVC"
-	imageUpload          = "image-upload"
-	namespace            = "--namespace"
-	size                 = "--size"
-	insecure             = "--insecure"
+	imageUploadCmd       = "image-upload"
+	namespaceArg         = "--namespace"
+	sizeArg              = "--size"
+	insecureArg          = "--insecure"
 )
 
 var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
@@ -165,14 +165,14 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 			defer deleteFunc(targetName)
 
 			By("Upload image")
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				resource, targetName,
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--image-path", imagePath,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--storage-class", sc,
 				"--block-volume",
-				insecure)
+				insecureArg)
 			err := virtctlCmd()
 			if err != nil {
 				fmt.Printf("UploadImage Error: %+v\n", err)
@@ -233,15 +233,15 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 			defer deleteFunc(targetName)
 
 			By("Upload image")
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				resource, targetName,
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--image-path", imagePath,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--storage-class", storageClass,
 				"--access-mode", "ReadWriteOnce",
 				"--force-bind",
-				insecure)
+				insecureArg)
 
 			Expect(virtctlCmd()).To(Succeed())
 			validateFunc(targetName)
@@ -289,13 +289,13 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 			defer deleteFunc(targetName)
 
 			By("Upload archive content")
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				resource, targetName,
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--archive-path", archivePath,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--force-bind",
-				insecure)
+				insecureArg)
 
 			Expect(virtctlCmd()).To(Succeed())
 			validateArchiveUpload(targetName, uploadDV)
@@ -319,14 +319,14 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 		})
 
 		It("Upload fails creating a DV when using a non-existent storageClass", func() {
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				"dv", "alpine-archive-dv-"+rand.String(12),
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--archive-path", archivePath,
 				"--storage-class", invalidStorageClass,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--force-bind",
-				insecure)
+				insecureArg)
 
 			err := virtctlCmd()
 			Expect(err).To(HaveOccurred())
@@ -334,14 +334,14 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 		})
 
 		It("Upload fails creating a PVC when using a non-existent storageClass", func() {
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				"pvc", "alpine-archive-"+rand.String(12),
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--archive-path", archivePath,
 				"--storage-class", invalidStorageClass,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--force-bind",
-				insecure)
+				insecureArg)
 
 			err := virtctlCmd()
 			Expect(err).To(HaveOccurred())
@@ -350,14 +350,14 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 
 		It("Upload doesn't succeed when DV provisioning fails", func() {
 			libstorage.CreateStorageClass(invalidStorageClass, nil)
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				"dv", "alpine-archive-dv-"+rand.String(12),
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--archive-path", archivePath,
 				"--storage-class", invalidStorageClass,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--force-bind",
-				insecure)
+				insecureArg)
 
 			err := virtctlCmd()
 			Expect(err).To(HaveOccurred())
@@ -367,14 +367,14 @@ var _ = SIGDescribe("[Serial]ImageUpload", Serial, func() {
 
 		It("Upload doesn't succeed when PVC provisioning fails", func() {
 			libstorage.CreateStorageClass(invalidStorageClass, nil)
-			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUpload,
+			virtctlCmd := clientcmd.NewRepeatableVirtctlCommand(imageUploadCmd,
 				"pvc", "alpine-archive-pvc-"+rand.String(12),
-				namespace, testsuite.GetTestNamespace(nil),
+				namespaceArg, testsuite.GetTestNamespace(nil),
 				"--archive-path", archivePath,
 				"--storage-class", invalidStorageClass,
-				size, pvcSize,
+				sizeArg, pvcSize,
 				"--force-bind",
-				insecure)
+				insecureArg)
 
 			err := virtctlCmd()
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`namespace` in this context is the `--namespace` string
I guess this is not a problem in main because the tests are parallel so each one gets it's own fresh ns,
but, for older lanes such as 0.53 where these tests are serial we get
```
"reason": "FailedCreate",
"message": "failed to create virtual machine pod: pods \"virt-launcher-testvmi-lvm87-sm5n8\" is forbidden: [cpu max limit to request ratio per Container is 5750m, but provided ratio is 10.000000, memory max limit to request ratio per Container is 2250m, but provided ratio is 2.780720]"
```
on a totally different test.
Also changed variable names to avoid this confusion later on.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
