### PR TITLE
api: Move the core API storage version to `v1` and deprecate `v1alpha3`

### DIFF
--- a/cmd/container-disk-v2alpha/README.md
+++ b/cmd/container-disk-v2alpha/README.md
@@ -34,7 +34,7 @@ Example: Create a KubeVirt VMI definition with container backed ephemeral disk.
 
 ```
 cat << END > vm.yaml
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   creationTimestamp: null

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -41,7 +41,7 @@ by patching the imageTag value with a new release tag.
 The cluster has the following KubeVirt CR deployed.
 
 ```
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: KubeVirt
 metadata:
   name: kubevirt
@@ -69,7 +69,7 @@ updating KubeVirt as well.
 The cluster has the following KubeVirt CR deployed.
 
 ```
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: KubeVirt
 metadata:
   name: kubevirt

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -2884,6 +2884,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    deprecated: true
+    deprecationWarning: kubevirt.io/v1alpha3 is now deprecated and will be removed
+      in a future release.
     name: v1alpha3
     schema:
       openAPIV3Schema:

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -2874,7 +2874,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -5733,6 +5733,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/manifests/release/demo-content.yaml.in
+++ b/manifests/release/demo-content.yaml.in
@@ -1,5 +1,5 @@
 # Virtual Machine Presets
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstancePreset
 metadata:
   name: windows-server-2012r2

--- a/staging/src/kubevirt.io/api/core/v1/BUILD.bazel
+++ b/staging/src/kubevirt.io/api/core/v1/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/staging/src/kubevirt.io/api/core/v1/doc.go
+++ b/staging/src/kubevirt.io/api/core/v1/doc.go
@@ -1,8 +1,9 @@
 // +k8s:deepcopy-gen=package
+// +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=kubevirt.io
-// +versionName=v1alpha3
-// +k8s:openapi-gen=true
+// +versionName=v1
+
 // Package v1 is the v1 version of the API.
 package v1

--- a/staging/src/kubevirt.io/api/core/v1/register.go
+++ b/staging/src/kubevirt.io/api/core/v1/register.go
@@ -33,17 +33,17 @@ const KubeVirtClientGoSchemeRegistrationVersionEnvVar = "KUBEVIRT_CLIENT_GO_SCHE
 var (
 	ApiLatestVersion            = "v1"
 	ApiSupportedWebhookVersions = []string{"v1alpha3", "v1"}
-	ApiStorageVersion           = "v1alpha3"
+	ApiStorageVersion           = "v1"
 	ApiSupportedVersions        = []extv1.CustomResourceDefinitionVersion{
 		{
 			Name:    "v1",
 			Served:  true,
-			Storage: false,
+			Storage: true,
 		},
 		{
 			Name:    "v1alpha3",
 			Served:  true,
-			Storage: true,
+			Storage: false,
 		},
 	}
 )
@@ -62,7 +62,7 @@ var (
 
 	// SubresourceGroupVersions is group version list used to register these objects
 	// The preferred group version is the first item in the list.
-	SubresourceGroupVersions = []schema.GroupVersion{{Group: SubresourceGroupName, Version: ApiLatestVersion}, {Group: SubresourceGroupName, Version: ApiStorageVersion}}
+	SubresourceGroupVersions = []schema.GroupVersion{{Group: SubresourceGroupName, Version: ApiLatestVersion}, {Group: SubresourceGroupName, Version: "v1alpha3"}}
 
 	// SubresourceStorageGroupVersion is the group version our api is persistented internally as
 	SubresourceStorageGroupVersion = schema.GroupVersion{Group: SubresourceGroupName, Version: ApiStorageVersion}

--- a/staging/src/kubevirt.io/api/core/v1/register.go
+++ b/staging/src/kubevirt.io/api/core/v1/register.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	"kubevirt.io/api/core"
 )
@@ -41,9 +42,11 @@ var (
 			Storage: true,
 		},
 		{
-			Name:    "v1alpha3",
-			Served:  true,
-			Storage: false,
+			Name:               "v1alpha3",
+			Served:             true,
+			Storage:            false,
+			Deprecated:         true,
+			DeprecationWarning: pointer.String("kubevirt.io/v1alpha3 is now deprecated and will be removed in a future release."),
 		},
 	}
 )

--- a/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kv_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("Kubevirt Client", func() {
 	var server *ghttp.Server
-	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/kubevirts"
+	basePath := "/apis/kubevirt.io/v1/namespaces/default/kubevirts"
 	kubevirtPath := path.Join(basePath, "testkubevirt")
 	proxyPath := "/proxy/path"
 

--- a/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/migration_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("Kubevirt Migration Client", func() {
 	var server *ghttp.Server
-	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstancemigrations"
+	basePath := "/apis/kubevirt.io/v1/namespaces/default/virtualmachineinstancemigrations"
 	migrationPath := path.Join(basePath, "testmigration")
 	proxyPath := "/proxy/path"
 

--- a/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/replicaset_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("Kubevirt VirtualMachineInstanceReplicaSet Client", func() {
 	var server *ghttp.Server
-	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstancereplicasets"
+	basePath := "/apis/kubevirt.io/v1/namespaces/default/virtualmachineinstancereplicasets"
 	rsPath := path.Join(basePath, "testrs")
 	proxyPath := "/proxy/path"
 

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -41,7 +41,7 @@ import (
 var _ = Describe("Kubevirt VirtualMachine Client", func() {
 
 	var server *ghttp.Server
-	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"
+	basePath := "/apis/kubevirt.io/v1/namespaces/default/virtualmachines"
 	vmPath := path.Join(basePath, "testvm")
 	subBasePath := fmt.Sprintf("/apis/subresources.kubevirt.io/%s/namespaces/default/virtualmachines", v1.SubresourceStorageGroupVersion.Version)
 	subVMPath := path.Join(subBasePath, "testvm")

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi_test.go
@@ -44,9 +44,9 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 
 	var upgrader websocket.Upgrader
 	var server *ghttp.Server
-	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances"
+	basePath := "/apis/kubevirt.io/v1/namespaces/default/virtualmachineinstances"
 	vmiPath := path.Join(basePath, "testvm")
-	subVMIPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"
+	subVMIPath := "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/testvm"
 	proxyPath := "/proxy/path"
 
 	BeforeEach(func() {
@@ -169,7 +169,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
 		Expect(err).ToNot(HaveOccurred())
 
-		vncPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm/vnc"
+		vncPath := "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/testvm/vnc"
 
 		server.AppendHandlers(ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, vncPath)),
@@ -191,7 +191,7 @@ var _ = Describe("Kubevirt VirtualMachineInstance Client", func() {
 		client, err := GetKubevirtClientFromFlags(server.URL()+proxyPath, "")
 		Expect(err).ToNot(HaveOccurred())
 
-		vncPath := "/apis/subresources.kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm/vnc"
+		vncPath := "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/testvm/vnc"
 
 		server.AppendHandlers(ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", path.Join(proxyPath, vncPath)),

--- a/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmipreset_test.go
@@ -34,7 +34,7 @@ import (
 
 var _ = Describe("Kubevirt VirtualMachineInstancePreset Client", func() {
 	var server *ghttp.Server
-	basePath := "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstancepresets"
+	basePath := "/apis/kubevirt.io/v1/namespaces/default/virtualmachineinstancepresets"
 	presetPath := path.Join(basePath, "testpreset")
 	proxyPath := "/proxy/path"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This change moves the storage version for all core API CRDs to v1. This does not impact existing objects that will continue to be stored using their original v1alpha3 version while being served as v1alpha3 or v1, as was the case previously.

Work will be required in the future to ensure all stored v1alpha3 objects are read and updated to v1 but for the time being this isn't required as part of this PR.

For more context please review the following k8s documentation:

https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning

Additionally the following KubeVirt dev ML thread covers this topic:

https://groups.google.com/g/kubevirt-dev/c/bSayedthHmY

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Interested in this PR? Then you will love https://github.com/kubevirt/kubevirt/pull/9575 !

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* The `kubevirt.io/v1` `apiVersion` is now the default storage version for newly created objects
* The `kubevirt.io/v1alpha3` `apiVersion` is now deprecated and will be removed in a future release
```
