### PR TITLE
feat(virtctl): Add boot order support to create vm

### DIFF
--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -180,7 +180,6 @@ func NewCommand() *cobra.Command {
 
 func defaultCreateVM() createVM {
 	return createVM{
-		name:                   "vm-" + rand.String(5),
 		terminationGracePeriod: 180,
 		runStrategy:            string(v1.RunStrategyAlways),
 	}
@@ -197,6 +196,8 @@ func checkVolumeExists(flag string, vols []v1.Volume, name string) error {
 }
 
 func (c *createVM) run(cmd *cobra.Command) error {
+	c.setDefaults()
+
 	vm := newVM(c)
 	for _, flag := range flags {
 		if cmd.Flags().Changed(flag) {
@@ -213,6 +214,12 @@ func (c *createVM) run(cmd *cobra.Command) error {
 
 	cmd.Print(string(out))
 	return nil
+}
+
+func (c *createVM) setDefaults() {
+	if c.name == "" {
+		c.name = "vm-" + rand.String(5)
+	}
 }
 
 func (c *createVM) usage() string {

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -198,7 +198,7 @@ func checkVolumeExists(flag string, vols []v1.Volume, name string) error {
 func (c *createVM) run(cmd *cobra.Command) error {
 	c.setDefaults()
 
-	vm := newVM(c)
+	vm := c.newVM()
 	for _, flag := range flags {
 		if cmd.Flags().Changed(flag) {
 			if err := optFns[flag](c, vm); err != nil {
@@ -269,7 +269,7 @@ func (c *createVM) usage() string {
   {{ProgramName}} create vm --instancetype=my-instancetype --preference=my-preference --volume-pvc=my-pvc`
 }
 
-func newVM(c *createVM) *v1.VirtualMachine {
+func (c *createVM) newVM() *v1.VirtualMachine {
 	runStrategy := v1.VirtualMachineRunStrategy(c.runStrategy)
 	return &v1.VirtualMachine{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -113,6 +113,18 @@ var _ = Describe("create vm", func() {
 			Expect(vm.Spec.Instancetype.InferFromVolume).To(Equal(fmt.Sprintf("%s-ds-%s", vm.Name, "my-ds")))
 		})
 
+		It("VM with boot order and inferred instancetype", func() {
+			out, err := runCmd(
+				setFlag(DataSourceVolumeFlag, "src:my-ds-2,bootorder:2"),
+				// This DS with bootorder 1 should be used to infer the instancetype, although it is defined second
+				setFlag(DataSourceVolumeFlag, "src:my-ds-1,bootorder:1"),
+				setFlag(InferInstancetypeFlag, "true"))
+			Expect(err).ToNot(HaveOccurred())
+			vm := unmarshalVM(out)
+
+			Expect(vm.Spec.Instancetype.InferFromVolume).To(Equal(fmt.Sprintf("%s-ds-%s", vm.Name, "my-ds-1")))
+		})
+
 		DescribeTable("VM with specified preference", func(flag, name, kind string) {
 			out, err := runCmd(setFlag(PreferenceFlag, flag))
 			Expect(err).ToNot(HaveOccurred())
@@ -134,6 +146,18 @@ var _ = Describe("create vm", func() {
 			vm := unmarshalVM(out)
 
 			Expect(vm.Spec.Preference.InferFromVolume).To(Equal(fmt.Sprintf("%s-ds-%s", vm.Name, "my-ds")))
+		})
+
+		It("VM with boot order and inferred preference", func() {
+			out, err := runCmd(
+				setFlag(DataSourceVolumeFlag, "src:my-ds-2,bootorder:2"),
+				// This DS with bootorder 1 should be used to infer the preference, although it is defined second
+				setFlag(DataSourceVolumeFlag, "src:my-ds-1,bootorder:1"),
+				setFlag(InferPreferenceFlag, "true"))
+			Expect(err).ToNot(HaveOccurred())
+			vm := unmarshalVM(out)
+
+			Expect(vm.Spec.Preference.InferFromVolume).To(Equal(fmt.Sprintf("%s-ds-%s", vm.Name, "my-ds-1")))
 		})
 
 		DescribeTable("VM with specified containerdisk", func(containerdisk, volName string, bootOrder int, params string) {
@@ -460,7 +484,7 @@ var _ = Describe("create vm", func() {
 		It("InferInstancetypeFlag needs at least one volume", func() {
 			out, err := runCmd(setFlag(InferInstancetypeFlag, "true"))
 
-			Expect(err).To(MatchError("failed to parse \"--infer-instancetype\" flag: at least one volume is needed to infer instancetype"))
+			Expect(err).To(MatchError("failed to parse \"--infer-instancetype\" flag: at least one volume is needed to infer instancetype or preference"))
 			Expect(out).To(BeEmpty())
 		})
 
@@ -488,7 +512,7 @@ var _ = Describe("create vm", func() {
 		It("InferPreferenceFlag needs at least one volume", func() {
 			out, err := runCmd(setFlag(InferPreferenceFlag, "true"))
 
-			Expect(err).To(MatchError("failed to parse \"--infer-preference\" flag: at least one volume is needed to infer preference"))
+			Expect(err).To(MatchError("failed to parse \"--infer-preference\" flag: at least one volume is needed to infer instancetype or preference"))
 			Expect(out).To(BeEmpty())
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds a new param `bootorder` to flags of `virtctl create vm`,
which allows to specify the boot order of added volumes.

Support for fields of type `*uint` is added to `params.go` for this. 
Also some refactorings are applied to `virtctl create vm`.

The param is added to the following flags:
  - volume-containerdisk
  - volume-datasource
  - volume-clone-pvc
  - volume-pvc

The method getInferFromVolume is added to vm.go to allow inferring
instancetypes or preferences from the disk with the lowest boot order or
if no boot order was specified the first volume.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: Allow to specify the boot order of volumes when creating VMs
```
