### PR TITLE
feat(virtctl): Allow to infer from specified volume in create vm

### DIFF
--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -154,6 +154,7 @@ func NewCommand() *cobra.Command {
 		Use:     VM,
 		Short:   "Create a VirtualMachine manifest.",
 		Long:    "Create a VirtualMachine manifest.\n\nIf no boot order was specified volumes have the following fixed boot order:\nContainerdisk > DataSource > Clone PVC > PVC",
+		Args:    cobra.NoArgs,
 		Example: c.usage(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return c.run(cmd)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This changes the --infer-instancetype and --infer-preference flags to
take optional strings which allow to specify the volume of the VM from
which the instancetype or preference should be inferred from. If no
string is passed the previous behaviour is kept (infer from first boot
disk or first volume).

**Special notes for your reviewer**:

This is based on #9629, merge after.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl: Allow to infer instancetype or preference from specified volume when creating VMs
```
