### PR TITLE
virtctl create clone: minor improvements

### DIFF
--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -134,19 +134,22 @@ func (c *createClone) usage() string {
   {{ProgramName}} create clone --name my-clone --source-name sourceVM --target-name targetVM
 
   # Create a manifest for a clone with a randomized target name (target name is omitted):
-  {{ProgramName}} create --source-name sourceVM
+  {{ProgramName}} create clone --source-name sourceVM
 
   # Create a manifest for a clone with specified source / target types. The default type is VM.
   {{ProgramName}} create clone --source-name sourceVM --source-type vm --target-name targetVM --target-type vm
+
+  # Supported source types are vm (aliases: VM, VirtualMachine, virtualmachine) and snapshot (aliases: vmsnapshot
+  # VirtualMachineSnapshot, VMSnapshot). The only supported target type is vm.
 
   # Create a manifest for a clone with a source type snapshot to a target type VM:
   {{ProgramName}} create clone --source-name mySnapshot --source-type snapshot --target-name targetVM
   
   # Create a manifest for a clone with label filters:
-  {{ProgramName}} create clone --source-name sourceVM --label-filter "*" --label-filter "!some/key" 
+  {{ProgramName}} create clone --source-name sourceVM --label-filter '*' --label-filter '!some/key' 
   
   # Create a manifest for a clone with annotation filters:
-  {{ProgramName}} create clone --source-name sourceVM --annotation-filter "*" --annotation-filter "!some/key"
+  {{ProgramName}} create clone --source-name sourceVM --annotation-filter '*' --annotation-filter '!some/key'
 
   # Create a manifest for a clone with new MAC addresses:
   {{ProgramName}} create clone --source-name sourceVM --new-mac-address interface1:00-11-22 --new-mac-address interface2:00-11-33

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -94,7 +94,9 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringArrayVar(&c.newMacAddresses, NewMacAddressesFlag, nil, "Specify clone's new mac addresses. For example: 'interfaceName0:newAddress0'")
 	cmd.Flags().StringVar(&c.newSmbiosSerial, NewSMBiosSerialFlag, emptyValue, "Specify the clone's new smbios serial")
 
-	_ = cmd.MarkFlagRequired(SourceNameFlag)
+	if err := cmd.MarkFlagRequired(SourceNameFlag); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/pkg/virtctl/create/clone/clone.go
+++ b/pkg/virtctl/create/clone/clone.go
@@ -102,8 +102,6 @@ func NewCommand() *cobra.Command {
 }
 
 func withNewMacAddresses(c *createClone, cloneSpec *cloneSpec) error {
-	const flag = NewMacAddressesFlag
-
 	for _, param := range c.newMacAddresses {
 		splitParam := strings.Split(param, ":")
 		if len(splitParam) != 2 {

--- a/pkg/virtctl/create/instancetype/instancetype.go
+++ b/pkg/virtctl/create/instancetype/instancetype.go
@@ -96,8 +96,14 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringArrayVar(&c.gpus, GPUFlag, c.gpus, "Specify the list of vGPUs to passthrough. Can be provided multiple times.")
 	cmd.Flags().StringArrayVar(&c.hostDevices, HostDeviceFlag, c.hostDevices, "Specify list of HostDevices to passthrough. Can be provided multiple times.")
 
-	_ = cmd.MarkFlagRequired(CPUFlag)
-	_ = cmd.MarkFlagRequired(MemoryFlag)
+	if err := cmd.MarkFlagRequired(CPUFlag); err != nil {
+		panic(err)
+	}
+
+	if err := cmd.MarkFlagRequired(MemoryFlag); err != nil {
+		panic(err)
+	}
+
 	return cmd
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
virtctl create clone command was introduced not long ago in this PR: https://github.com/kubevirt/kubevirt/pull/9596.

After the PR had merged, I received some further feedback. This follow-up addresses this feedback.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
