### PR TITLE
[virt-operator]: Fix kubevirt version parsing when custom operator image name provided 

### DIFF
--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -286,6 +286,9 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 	imageRegEx := regexp.MustCompile(operatorImageRegex)
 	matches := imageRegEx.FindAllStringSubmatch(imageString, 1)
 	kubeVirtVersion := envVarManager.Getenv(KubeVirtVersionEnvName)
+	if kubeVirtVersion == "" {
+		kubeVirtVersion = "latest"
+	}
 
 	tagFromOperator := ""
 	operatorSha := ""
@@ -309,10 +312,7 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 		} else {
 			// we have a shasum... chances are high that we get the shasums for the other images as well from env vars,
 			// but as a fallback use latest tag
-			tagFromOperator = "latest"
-			if kubeVirtVersion != "" {
-				tagFromOperator = kubeVirtVersion
-			}
+			tagFromOperator = kubeVirtVersion
 			operatorSha = strings.TrimPrefix(version, "@")
 		}
 
@@ -320,6 +320,13 @@ func getConfig(registry, tag, namespace string, additionalProperties map[string]
 		// and if it was given, don't look for shasums
 		if tag == "" {
 			tag = tagFromOperator
+		} else {
+			skipShasums = true
+		}
+	} else {
+		// operator image name has unexpected syntax.
+		if tag == "" {
+			tag = kubeVirtVersion
 		} else {
 			skipShasums = true
 		}

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -404,9 +404,8 @@ var _ = Describe("Operator Config", func() {
 
 	Context("kubevirt version", func() {
 		type testInput struct {
+			imageName         string
 			kubevirtVerEnvVar string
-			tag               string
-			digest            string
 			version           string
 		}
 
@@ -416,13 +415,7 @@ var _ = Describe("Operator Config", func() {
 		})
 
 		DescribeTable("is read from", func(input *testInput) {
-			operatorImage := fmt.Sprintf("acme.com/kubevirt/my-virt-operator%s", input.tag)
-
-			if input.digest != "" {
-				operatorImage = fmt.Sprintf("acme.com/kubevirt/my-virt-operator%s", input.digest)
-			}
-
-			Expect(envVarManager.Setenv(VirtOperatorImageEnvName, operatorImage)).To(Succeed())
+			Expect(envVarManager.Setenv(VirtOperatorImageEnvName, input.imageName)).To(Succeed())
 
 			if input.kubevirtVerEnvVar != "" {
 				Expect(envVarManager.Setenv(KubeVirtVersionEnvName, input.kubevirtVerEnvVar)).To(Succeed())
@@ -441,24 +434,36 @@ var _ = Describe("Operator Config", func() {
 			Entry("virt-operator image tag when both KUBEVIRT_VERSION is set and virt-operator provided with tag",
 				&testInput{
 					kubevirtVerEnvVar: "v3.0.0-env.var",
-					tag:               ":v3.0.0",
+					imageName:         "acme.com/kubevirt/my-virt-operator:v3.0.0",
 					version:           "v3.0.0",
 				}),
 
 			Entry("KUBEVIRT_VERSION variable when virt-operator provided with digest",
 				&testInput{
 					kubevirtVerEnvVar: "v3.0.0",
-					digest:            "@sha256:trivebuk",
+					imageName:         "acme.com/kubevirt/my-virt-operator@sha256:trivebuk",
 					version:           "v3.0.0",
 				}),
 			Entry("operator tag when no KUBEVIRT_VERSION provided and operator image is with a tag",
 				&testInput{
-					tag:     ":v3.0.0",
-					version: "v3.0.0",
+					imageName: "acme.com/kubevirt/my-virt-operator:v3.0.0",
+					version:   "v3.0.0",
 				}),
 			Entry("hardcoded \"latest\" string when no KUBEVIRT_VERSION provided and operator image is with a digest",
 				&testInput{
-					version: "latest",
+					version:   "latest",
+					imageName: "acme.com/kubevirt/my-virt-operator@sha256:trivebuk",
+				}),
+			Entry("KUBEVIRT_VERSION variable when virt-operator image name is corrupted",
+				&testInput{
+					kubevirtVerEnvVar: "v3.0.0",
+					imageName:         "blablabla",
+					version:           "v3.0.0",
+				}),
+			Entry("hardcoded \"latest\" string when no KUBEVIRT_VERSION provided and operator image is corrupted",
+				&testInput{
+					imageName: "blablabla",
+					version:   "latest",
 				}))
 	})
 })


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>


**Background**

***Kubevirt upgrade process***

The upgrade process consists of the following steps:
* Patching of the virt-operator deployment and the core resources (RBAC, service-account, etc).
* (Optional) Re-create the Kubevirt CR.
* New virt-operator re-creates the install strategy.
* New virt-operator patches the control plane deployments (virt-api, virt-controller, virt-handler, etc.)

In order to trigger the upgrade you can choose one of these methods to patch your virt-operator deployment:
**1**. Operator image pull URL, KUBEVIRT_VERSION 
**2**. Operator image pull URL, SHASUM of each operand (this way is deprecated).
**3**. Operator image pull URL, VIRT_*_NAME of each operand.
**Note**: There is another semi-upgrade process where you can specify `spec.imagePrefix` and `spec.imageTag` in the Kubevirt CR, in that case only the operands would be updated (together with operand core resources and CRs) but the virt-operator version will remain the same.


The virt-operator calculates the pull image URL of each one of the operands using the abovementioned environment variables, depending on which one of them you decided to use.

**(To prevent inconsistency, you need to choose a method similar to what exists in the current virt-operator deployment).

Now in order to track the upgrade process, watching the status conditions of the Kubevirt CR is not enough, since the upgrade starts from virt-operator deployment rollout. During the rollout, the status in the Kubevirt CR is not correct. Therefore one can write a script that watches the operator rollout and then the Kubevrit CR status. Another, more consolidated way is to watch for Kubevirt CR status field `status.observedKiubevirtVersion`. Upon successful upgrade KUBEVIRT_VERSION is propagated to `status.observedKiubevirtVersion`, so the desired state should be equal to the KUBEVIRT_VERSION value. Please note that using KUBEVIRT_VERSION in methods 2 or 3 mentioned above is fine, it will not override the usage of the variables mentioned.



**What this PR does / why we need it**:
Now we’ve found an issue when upgrading according to method 3 and using KUBEVIRT_VERSION to track the process, then for some reason the `status.observedKiubevirtVersion` disappears from the Kubevirt CR. Digging deep into the code I’ve found that if the operator image name doesn’t end with `virt-operator`, the parsing fails and as a result the kubevirt version becomes empty, which causes the status field to disappear (for example when using `virt-operator-123` as the image name).

Because of the code complexity, failure in the regex matching leads to a situation where KUBEVIRT_VERSION is not propogated to the `status.observedKiubevirtVersion`. Long-term this require major refactoring, because such dependency doesn't make sense at all. Given the current time-frame I've decided to provide a quick fix, that will recover 
the `status.observedKiubevirtVersion` even when regex matching is failed.

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=2180146

**Special notes for your reviewer**:
We have an upgrade blocker bug. This fix doesn't include refactoring, and e2e coverage ATM. Main reason is that by fixing the regex itself new corner cases revealed, and since the code needs some refactoring, small change in the regex results in side effects as well.

Regex refactoring and e2e addition would be added as a supplementary PR.

**Release note**:
```release-note
NONE
```
