### PR TITLE
TSC frequencies: add 250PPM tolerance

### DIFF
--- a/pkg/virt-controller/watch/topology/filter.go
+++ b/pkg/virt-controller/watch/topology/filter.go
@@ -1,6 +1,8 @@
 package topology
 
 import (
+	"math"
+
 	v1 "k8s.io/api/core/v1"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -10,6 +12,7 @@ import (
 const TSCFrequencyLabel = virtv1.CPUTimerLabel + "tsc-frequency"
 const TSCFrequencySchedulingLabel = "scheduling.node.kubevirt.io/tsc-frequency"
 const TSCScalableLabel = virtv1.CPUTimerLabel + "tsc-scalable"
+const TSCTolerancePPM float64 = 250
 
 type FilterPredicateFunc func(node *v1.Node) bool
 
@@ -88,4 +91,9 @@ func FilterNodesFromCache(objs []interface{}, predicates ...FilterPredicateFunc)
 		}
 	}
 	return match
+}
+
+// ToleranceForFrequency returns TSCTolerancePPM parts per million of freq, rounded down to the nearest Hz
+func ToleranceForFrequency(freq int64) int64 {
+	return int64(math.Floor(float64(freq) * (TSCTolerancePPM / 1000000)))
 }

--- a/pkg/virt-controller/watch/topology/tsc_test.go
+++ b/pkg/virt-controller/watch/topology/tsc_test.go
@@ -42,8 +42,8 @@ var _ = Describe("TSC", func() {
 
 	DescribeTable("should calculate the node label diff", func(frequenciesInUse []int64, frequenciesOnNode []int64, nodeFrequency int64, scalable bool, expectedToAdd []int64, expectedToRemove []int64) {
 		toAdd, toRemove := topology.CalculateTSCLabelDiff(frequenciesInUse, frequenciesOnNode, nodeFrequency, scalable)
-		Expect(toAdd).To(Equal(expectedToAdd))
-		Expect(toRemove).To(Equal(expectedToRemove))
+		Expect(toAdd).To(ConsistOf(expectedToAdd))
+		Expect(toRemove).To(ConsistOf(expectedToRemove))
 	},
 		Entry(
 			"on a scalable node",
@@ -56,20 +56,29 @@ var _ = Describe("TSC", func() {
 		),
 		Entry(
 			"on a scalable node where not all required frequencies are compatible",
-			[]int64{1, 2, 3, 200},
+			[]int64{1, 2, 3, 123130, 200000}, // 123130 is above but within 250 PPM
 			[]int64{2, 4},
-			int64(123),
+			int64(123123),
 			true,
-			[]int64{1, 2, 3, 123},
+			[]int64{1, 2, 3, 123123, 123130},
 			[]int64{4},
 		),
 		Entry(
-			"on a not scalable node where only the node frequency can be set",
+			"on a non-scalable node where only the node frequency can be set",
 			[]int64{1, 2, 3},
 			[]int64{2, 4},
 			int64(123),
 			false,
 			[]int64{123},
+			[]int64{2, 4},
+		),
+		Entry(
+			"on a non-scalable node where other node frequencies are close-enough",
+			[]int64{1, 2, 123120, 123130}, // 250 PPM of 123123 is 30
+			[]int64{2, 4},
+			int64(123123),
+			false,
+			[]int64{123123, 123120, 123130},
 			[]int64{2, 4},
 		),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
It is possible to migrate VMs to nodes that have a TSC frequency within 250PPM of theirs.
This adds support for it by tagging nodes with VMI frequencies within the tolerance range.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes RHBZ#2184860

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TSC-enabled VMs can now migrate to a node with a non-identical (but close-enough) frequency
```
