### PR TITLE
enable monitor  without prometheus

### DIFF
--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -102,3 +102,37 @@ func UpdateFakeKubeVirtClusterConfig(kubeVirtInformer cache.SharedIndexInformer,
 
 	kubeVirtInformer.GetStore().Update(clone)
 }
+
+func AddServiceMonitorAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Add(&extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "service-monitors.monitoring.coreos.com",
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Names: extv1.CustomResourceDefinitionNames{
+				Kind: "ServiceMonitor",
+			},
+		},
+	})
+}
+
+func RemoveServiceMonitorAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Replace(nil, "")
+}
+
+func AddPrometheusRuleAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Add(&extv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheusrules.monitoring.coreos.com",
+		},
+		Spec: extv1.CustomResourceDefinitionSpec{
+			Names: extv1.CustomResourceDefinitionNames{
+				Kind: "PrometheusRule",
+			},
+		},
+	})
+}
+
+func RemovePrometheusRuleAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Replace(nil, "")
+}

--- a/pkg/virt-config/configuration.go
+++ b/pkg/virt-config/configuration.go
@@ -119,10 +119,19 @@ func isDataSourceCrd(crd *extv1.CustomResourceDefinition) bool {
 	return crd.Spec.Names.Kind == "DataSource"
 }
 
+func isServiceMonitor(crd *extv1.CustomResourceDefinition) bool {
+	return crd.Spec.Names.Kind == "ServiceMonitor"
+}
+
+func isPrometheusRules(crd *extv1.CustomResourceDefinition) bool {
+	return crd.Spec.Names.Kind == "PrometheusRule"
+}
+
 func (c *ClusterConfig) crdAddedDeleted(obj interface{}) {
 	go c.GetConfig()
 	crd := obj.(*extv1.CustomResourceDefinition)
-	if !isDataVolumeCrd(crd) && !isDataSourceCrd(crd) {
+	if !isDataVolumeCrd(crd) && !isDataSourceCrd(crd) &&
+		!isServiceMonitor(crd) && !isPrometheusRules(crd) {
 		return
 	}
 
@@ -372,6 +381,36 @@ func (c *ClusterConfig) HasDataVolumeAPI() bool {
 	for _, obj := range objects {
 		if crd, ok := obj.(*extv1.CustomResourceDefinition); ok && crd.DeletionTimestamp == nil {
 			if isDataVolumeCrd(crd) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *ClusterConfig) HasServiceMonitorAPI() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	objects := c.crdInformer.GetStore().List()
+	for _, obj := range objects {
+		if crd, ok := obj.(*extv1.CustomResourceDefinition); ok && crd.DeletionTimestamp == nil {
+			if isServiceMonitor(crd) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *ClusterConfig) HasPrometheusRuleAPI() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	objects := c.crdInformer.GetStore().List()
+	for _, obj := range objects {
+		if crd, ok := obj.(*extv1.CustomResourceDefinition); ok && crd.DeletionTimestamp == nil {
+			if isPrometheusRules(crd) {
 				return true
 			}
 		}

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
     name = "go_default_test",
     timeout = "long",
     srcs = [
+        "application_test.go",
         "kubevirt_test.go",
         "virt_operator_suite_test.go",
     ],

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -94,6 +94,8 @@ type VirtOperatorApp struct {
 	kubeVirtInformer cache.SharedIndexInformer
 	kubeVirtCache    cache.Store
 
+	crdInformer cache.SharedIndexInformer
+
 	stores    util.Stores
 	informers util.Informers
 
@@ -103,6 +105,10 @@ type VirtOperatorApp struct {
 
 	clusterConfig *virtconfig.ClusterConfig
 	host          string
+
+	ctx context.Context
+
+	reInitChan chan string
 }
 
 var (
@@ -233,6 +239,8 @@ func Execute() {
 		ConfigMapCache:                app.informerFactory.OperatorConfigMap().GetStore(),
 	}
 
+	app.crdInformer = app.informerFactory.CRD()
+
 	onOpenShift, err := clusterutil.IsOnOpenShift(app.clientSet)
 	if err != nil {
 		golog.Fatalf("Error determining cluster type: %v", err)
@@ -300,10 +308,16 @@ func Execute() {
 		app.operatorNamespace,
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	app.ctx = ctx
+
+	app.reInitChan = make(chan string, 0)
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeLogVerbosity)
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldUpdateConfigurationMetrics)
 
-	app.Run()
+	go app.Run()
+	<-app.reInitChan
 }
 
 func (app *VirtOperatorApp) Run() {
@@ -336,9 +350,6 @@ func (app *VirtOperatorApp) Run() {
 		}
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	endpointName := VirtOperator
 
 	recorder := app.getNewRecorder(k8sv1.NamespaceAll, endpointName)
@@ -363,8 +374,13 @@ func (app *VirtOperatorApp) Run() {
 
 	apiAuthConfig := app.informerFactory.ApiAuthConfigMap()
 
-	stop := ctx.Done()
+	stop := app.ctx.Done()
 	app.informerFactory.Start(stop)
+
+	stopChan := app.ctx.Done()
+	cache.WaitForCacheSync(stopChan, app.crdInformer.HasSynced, app.kubeVirtInformer.HasSynced)
+	app.clusterConfig.SetConfigModifiedCallback(app.configModificationCallback)
+
 	cache.WaitForCacheSync(stop, apiAuthConfig.HasSynced)
 
 	go app.operatorCertManager.Start()
@@ -423,9 +439,37 @@ func (app *VirtOperatorApp) Run() {
 
 	readyGauge.Set(1)
 	log.Log.Infof("Attempting to acquire leader status")
-	leaderElector.Run(ctx)
+	leaderElector.Run(app.ctx)
+
 	panic("unreachable")
 
+}
+
+// Detects if ServiceMonitor or PrometheusRule crd has been applied or deleted that
+// re-initializing virt-operator.
+func (app *VirtOperatorApp) configModificationCallback() {
+	msgf := "Reinitialize virt-operator, %s has been %s"
+
+	smEnabled := app.clusterConfig.HasServiceMonitorAPI()
+	if app.stores.ServiceMonitorEnabled != smEnabled {
+		if !app.stores.ServiceMonitorEnabled && smEnabled {
+			log.Log.Infof(msgf, "ServiceMonitor", "introduced")
+		} else {
+			log.Log.Infof(msgf, "ServiceMonitor", "removed")
+		}
+		app.reInitChan <- "reinit"
+		return
+	}
+
+	prEnabled := app.clusterConfig.HasPrometheusRuleAPI()
+	if app.stores.PrometheusRulesEnabled != prEnabled {
+		if !app.stores.PrometheusRulesEnabled && prEnabled {
+			log.Log.Infof(msgf, "PrometheusRule", "introduced")
+		} else {
+			log.Log.Infof(msgf, "PrometheusRule", "removed")
+		}
+		app.reInitChan <- "reinit"
+	}
 }
 
 func (app *VirtOperatorApp) getNewRecorder(namespace string, componentName string) record.EventRecorder {

--- a/pkg/virt-operator/application_test.go
+++ b/pkg/virt-operator/application_test.go
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package virt_operator
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/testutils"
+)
+
+var _ = Describe("Reinitialization conditions", func() {
+	DescribeTable("Re-trigger initialization", func(
+		hasServiceMonitor bool, hasPrometheusRules bool,
+		addServiceMonitorCrd bool, removeServiceMonitorCrd bool,
+		addPrometheusRuleCrd bool, removePrometheusRuleCrd bool,
+		expectReInit bool) {
+		var reInitTriggered bool
+
+		app := VirtOperatorApp{}
+
+		clusterConfig, crdInformer, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
+		app.clusterConfig = clusterConfig
+		app.reInitChan = make(chan string, 10)
+		app.stores.ServiceMonitorEnabled = hasServiceMonitor
+		app.stores.PrometheusRulesEnabled = hasPrometheusRules
+
+		if addServiceMonitorCrd {
+			testutils.AddServiceMonitorAPI(crdInformer)
+		} else if removeServiceMonitorCrd {
+			testutils.RemoveServiceMonitorAPI(crdInformer)
+		}
+
+		if addPrometheusRuleCrd {
+			testutils.AddPrometheusRuleAPI(crdInformer)
+		} else if removePrometheusRuleCrd {
+			testutils.RemovePrometheusRuleAPI(crdInformer)
+		}
+
+		app.clusterConfig.SetConfigModifiedCallback(app.configModificationCallback)
+
+		select {
+		case <-app.reInitChan:
+			reInitTriggered = true
+		case <-time.After(1 * time.Second):
+			reInitTriggered = false
+		}
+
+		Expect(reInitTriggered).To(Equal(expectReInit))
+	},
+		Entry("when ServiceMonitor is introduced", false, false, true, false, false, false, true),
+		Entry("when ServiceMonitor is removed", true, false, false, true, false, false, true),
+		Entry("when PrometheusRule is introduced", false, false, false, false, true, false, true),
+		Entry("when PrometheusRule is removed", false, true, false, false, false, true, true),
+
+		Entry("when ServiceMonitor and PrometheusRule are introduced", false, false, true, false, true, false, true),
+		Entry("when ServiceMonitor and PrometheusRule are removed", true, true, false, true, false, true, true),
+
+		Entry("not when nothing changed and ServiceMonitor and PrometheusRule exists", true, true, true, false, true, false, false),
+		Entry("not when nothing changed and ServiceMonitor and PrometheusRule does not exists", false, false, false, true, false, true, false),
+
+		Entry("when ServiceMonitor is introduced and PrometheusRule is removed", false, true, true, false, false, true, true),
+		Entry("when ServiceMonitor is removed and PrometheusRule is introduced", true, false, false, true, true, false, true),
+	)
+})

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -278,13 +278,7 @@ func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, 
 func getMonitorNamespace(clientset k8coresv1.CoreV1Interface, config *operatorutil.KubeVirtDeploymentConfig) (namespace string, err error) {
 	for _, ns := range config.GetPotentialMonitorNamespaces() {
 		if nsExists, err := isNamespaceExist(clientset, ns); nsExists {
-			// the monitoring service account must be in the monitoring namespace otherwise
-			// we won't be able to create roleBinding for prometheus operator pods
-			if saExists, err := isServiceAccountExist(clientset, ns, config.GetMonitorServiceAccountName()); saExists {
-				return ns, nil
-			} else if err != nil {
-				return "", err
-			}
+			return ns, nil
 		} else if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

If I install kubevirt with setting vm monitor options firstly (ref : https://kubevirt.io/user-guide/operations/component_monitoring/#integrating-with-the-prometheus-operator) , and then install proemtheus-operator , the servicemonitor prometheus-kubevirt-rules and prometheusrule prometheus-kubevirt-rules will not be created anymore.

This pr  based on  pr #8914 , and  makes an enhancement.  With this pr, if setting vm monitor options in KubeVirt custom resource firstly , virt-operator will generate the servicemonitor and promethusrule resources in installstrategy configmap  without depending on whether prometheus stack is installed, and then install these resources automatically after the prometheus stack is installed.  

The benifit is that we don't need to update yaml KubeVirt custom resource again. Actually, cdi-operator has aready implement it.

**Which issue(s) this PR fixes** 
Fixes #9356

