### PR TITLE
tests: Support the output from recent kubectl

### DIFF
--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -46,7 +46,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		Expect(err).NotTo(HaveOccurred(), stderr)
 		Expect(output).To(ContainSubstring("apiVersion	<string>"))
 		Expect(output).To(ContainSubstring("kind	<string>"))
-		Expect(output).To(ContainSubstring("metadata	<Object>"))
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("metadata	<Object>"),
+			ContainSubstring("metadata	<ObjectMeta>"),
+		))
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 		Expect(output).To(ContainSubstring("status	<Object>"))
 	},
@@ -66,7 +69,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("apiVersion	<string>"))
 		Expect(output).To(ContainSubstring("kind	<string>"))
-		Expect(output).To(ContainSubstring("metadata	<Object>"))
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("metadata	<Object>"),
+			ContainSubstring("metadata	<ObjectMeta>"),
+		))
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 
@@ -78,7 +84,10 @@ var _ = Describe("[sig-compute]oc/kubectl integration", decorators.SigCompute, f
 		Expect(err).NotTo(HaveOccurred())
 		Expect(output).To(ContainSubstring("apiVersion	<string>"))
 		Expect(output).To(ContainSubstring("kind	<string>"))
-		Expect(output).To(ContainSubstring("metadata	<Object>"))
+		Expect(output).To(SatisfyAny(
+			ContainSubstring("metadata	<Object>"),
+			ContainSubstring("metadata	<ObjectMeta>"),
+		))
 		Expect(output).To(ContainSubstring("spec	<Object>"))
 	})
 


### PR DESCRIPTION
Starting from version 1.27, `kubectl explain` returns

    metadata	<ObjectMeta>

instead of

    metadata	<Object>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
