### PR TITLE
Fix version detection for builder build script

### DIFF
--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -15,8 +15,8 @@ SCRIPT_DIR="$(
 # packages on Fedora or by having already run this script earlier,
 # then we shouldn't alter the existing configuration to avoid the
 # risk of possibly breaking it
-if ! grep -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
-    ${KUBEVIRT_CRI} run --rm --privileged multiarch/qemu-user-static --reset -p yes
+if ! grep -q -E '^enabled$' /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null; then
+    ${KUBEVIRT_CRI} >&2 run --rm --privileged multiarch/qemu-user-static --reset -p yes
 fi
 
 # shellcheck source=hack/builder/arch.sh
@@ -35,8 +35,8 @@ for ARCH in ${ARCHITECTURES}; do
         bazel_arch=${ARCH}
         ;;
     esac
-    ${KUBEVIRT_CRI} pull --platform="linux/${ARCH}" quay.io/centos/centos:stream9
-    ${KUBEVIRT_CRI} build --platform="linux/${ARCH}" -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+    ${KUBEVIRT_CRI} >&2 pull --platform="linux/${ARCH}" quay.io/centos/centos:stream9
+    ${KUBEVIRT_CRI} >&2 build --platform="linux/${ARCH}" -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg SONOBUOY_ARCH=${sonobuoy_arch} --build-arg BAZEL_ARCH=${bazel_arch} -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
 done
 
 # Print the version for use by other callers such as publish.sh


### PR DESCRIPTION

**What this PR does / why we need it**:

In order to only echo the build VERSION, some commands need their output redirected to stderr.

Fixes a regression introduced in #9604


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
