### PR TITLE
[release-0.59] SELinux policy: ensure it never gets installed if the feature gate is set

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -311,7 +311,6 @@ func (app *virtHandlerApp) Run() {
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeLogVerbosity)
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeRateLimiter)
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldInstallKubevirtSeccompProfile)
-	app.clusterConfig.SetConfigModifiedCallback(app.shouldInstallSELinuxPolicy)
 
 	if err := app.setupTLS(factory); err != nil {
 		glog.Fatalf("Error constructing migration tls config: %v", err)
@@ -423,6 +422,10 @@ func (app *virtHandlerApp) Run() {
 	}
 
 	cache.WaitForCacheSync(stop, vmiSourceInformer.HasSynced, factory.CRD().HasSynced, factory.KubeVirt().HasSynced)
+
+	// This callback can only be called only after the KubeVirt CR has synced,
+	// to avoid installing the SELinux policy when the feature gate is set
+	app.clusterConfig.SetConfigModifiedCallback(app.shouldInstallSELinuxPolicy)
 
 	go vmController.Run(10, stop)
 

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -50,7 +50,7 @@ func Has2MiHugepages(node *v1.Node) bool {
 func HasFeature(feature string) bool {
 	virtClient := kubevirt.Client()
 
-	featureGates := []string{}
+	var featureGates []string
 	kv := util.GetCurrentKv(virtClient)
 	if kv.Spec.Configuration.DeveloperConfiguration != nil {
 		featureGates = kv.Spec.Configuration.DeveloperConfiguration.FeatureGates


### PR DESCRIPTION
This is a manual backport of https://github.com/kubevirt/kubevirt/pull/9639

```release-note
NONE
```
