### PR TITLE
Make createHostDevices logs more compact

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -21,6 +21,7 @@ package hostdevice
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -59,7 +60,10 @@ func CreateMDEVHostDevices(hostDevicesData []HostDeviceMetaData, mdevAddrPool Ad
 }
 
 func createHostDevices(hostDevicesData []HostDeviceMetaData, addrPool AddressPooler, createHostDev createHostDevice) ([]api.HostDevice, error) {
-	var hostDevices []api.HostDevice
+	var (
+		hostDevices          []api.HostDevice
+		hostDevicesAddresses []string
+	)
 
 	for _, hostDeviceData := range hostDevicesData {
 		address, err := addrPool.Pop(hostDeviceData.ResourceName)
@@ -83,8 +87,13 @@ func createHostDevices(hostDevicesData []HostDeviceMetaData, addrPool AddressPoo
 			}
 		}
 		hostDevices = append(hostDevices, *hostDevice)
-		log.Log.Infof("host-device created: %s", address)
+		hostDevicesAddresses = append(hostDevicesAddresses, address)
 	}
+
+	if len(hostDevices) > 0 {
+		log.Log.Infof("host-devices created: [%s]", strings.Join(hostDevicesAddresses, ", "))
+	}
+
 	return hostDevices, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR reduces the number of log entries produced by virt-launchers in `createHostDevice` function, by compacting multiple log records into a single one. Logs cluttering is especially significant when multiple devices are created often. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
