### PR TITLE
allow kubevirt VM work under container

### DIFF
--- a/pkg/virt-handler/virt-chroot/virt-chroot.go
+++ b/pkg/virt-handler/virt-chroot/virt-chroot.go
@@ -20,6 +20,8 @@
 package virt_chroot
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -32,16 +34,42 @@ const (
 	mountNamespace = "/proc/1/ns/mnt"
 )
 
+// GetHostNamespacePath - returns the path of the parent process's mount namespace.
+// This is needed to handle Kubernetes and KubeVirt running inside a container,
+// e.g., in a containerd-based runtime, where the mount namespace is different
+// from the host/node.
+func GetHostNamespacePath() string {
+	return fmt.Sprintf("/proc/%d/ns/mnt", os.Getppid())
+}
+
 func getBaseArgs() []string {
-	return []string{"--mount", mountNamespace}
+	return []string{"--mount", GetChrootMountNamespace()}
+}
+
+func GetChrootNSMountPath() string {
+	return mountNamespace
 }
 
 func GetChrootBinaryPath() string {
 	return binaryPath
 }
 
+// If the ENV "VIRT_IN_CONTAINER" with a value of "true" is passed into 'virt-handler',
+// the function GetChrootMountNamespace() will call GetHostNamespacePath() to
+// search for the PPID and its mount namespace; by default, it just uses the
+// mount namespace for the PID of 1.
+//
+// To use the PPID namespace mount search scheme, the user needs to specify
+// 'KV_IO_EXTRA_ENV_VIRT_IN_CONTAINER' with a value of "true" in kubevirt-operator.yaml.
 func GetChrootMountNamespace() string {
+	if getEnvVirtInContainer() {
+		return GetHostNamespacePath()
+	}
 	return mountNamespace
+}
+
+func getEnvVirtInContainer() bool {
+	return os.Getenv("VIRT_IN_CONTAINER") == "true"
 }
 
 func MountChroot(sourcePath, targetPath *safepath.Path, ro bool) *exec.Cmd {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -320,7 +320,7 @@ func (r *KubernetesReporter) logDMESG(virtCli kubecli.KubevirtClient, logsdir st
 			commands := []string{
 				virt_chroot.GetChrootBinaryPath(),
 				"--mount",
-				virt_chroot.GetChrootMountNamespace(),
+				virt_chroot.GetChrootNSMountPath(),
 				"exec",
 				"--",
 				"/proc/1/root/bin/dmesg",
@@ -606,7 +606,7 @@ func (r *KubernetesReporter) logJournal(virtCli kubecli.KubevirtClient, logsdir 
 		commands := []string{
 			virt_chroot.GetChrootBinaryPath(),
 			"--mount",
-			virt_chroot.GetChrootMountNamespace(),
+			virt_chroot.GetChrootNSMountPath(),
 			"exec",
 			"--",
 			"/usr/bin/journalctl",


### PR DESCRIPTION
What this PR does / why we need it:

 We have EVE open-source project, https://github.com/lf-edge/eve, needs
 to run kubernetes(k3s for example) inside a container. Kubevirt is part
 of that setup. Although this patch should be needed for running k8s/kubevirt
 inside a container in general.

 This patch addresses this issue:
 -- launch a VM in kubevirt, can not mount the disk
 mount target invalid: failed opening kubelet for path root: /, relative: /var/lib/kubelet/pods/91a750fc-c0e5-4ea4-923a-7e86e831f599/volumes/kubernetes.io~empty-dir/container-disks/disk_0.img: no such file or directory

( another issue  'error: failed to get emulator capabilities, and
    error: internal error: Failed to start QEMU binary /usr/libexec/qemu-kvm for probing:'
  was resolved by the system to add read/write capabilities to /dev/null, which does not
  involve the kubevirt code)

 it seems rather than the normal bare-metal or VM cases,
 just statically using '/proc/1/ns/mnt' for MountChroot won't work in
 the case running kubernetes and kubevirt inside a container.
 This patch is to get the pod's current process, and finds its parent processes.
 If the parent process's name is 'containerd-shim', we then found the
 mountNamespace and this '/proc/<process-id>/ns/mnt' instead to be used,
 which is the namespace of the container running the kubernetes and kubevirt.
 BTW, the similar issue also is addressed in the longhorn project, see the
 PR: https://github.com/longhorn/go-iscsi-helper/pull/63

Special notes for your reviewer:

Release note:

None

