### PR TITLE
virt-handler, net: Use ConfigState before entring virt-launcher's network namespace

### DIFF
--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "configstate.go",
+        "configstatecache.go",
         "netconf.go",
         "netstat.go",
         "network.go",
@@ -34,6 +35,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "configstate_test.go",
+        "configstatecache_test.go",
         "netconf_test.go",
         "netstat_test.go",
         "network_suite_test.go",

--- a/pkg/network/setup/configstate.go
+++ b/pkg/network/setup/configstate.go
@@ -20,9 +20,7 @@
 package network
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"kubevirt.io/client-go/log"
 
@@ -30,13 +28,17 @@ import (
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 )
 
-type ConfigState struct {
-	cacheCreator cacheCreator
-	vmiUID       string
+type configStateCacheReaderWriter interface {
+	Read(podInterfaceName string) (cache.PodIfaceState, error)
+	Write(podInterfaceName string, state cache.PodIfaceState) error
 }
 
-func NewConfigState(cc cacheCreator, vmiUID string) ConfigState {
-	return ConfigState{cc, vmiUID}
+type ConfigState struct {
+	cache configStateCacheReaderWriter
+}
+
+func NewConfigState(configStateCache configStateCacheReaderWriter) ConfigState {
+	return ConfigState{configStateCache}
 }
 
 // Run passes through the state machine flow, executing the following steps:
@@ -49,7 +51,7 @@ func (c ConfigState) Run(nics []podNIC, discoverFunc func(*podNIC) error, config
 	var pendingNICs []podNIC
 	for _, nic := range nics {
 		ifaceName := nic.podInterfaceName
-		state, err := c.read(ifaceName)
+		state, err := c.cache.Read(ifaceName)
 		if err != nil {
 			return err
 		}
@@ -73,8 +75,8 @@ func (c ConfigState) Run(nics []podNIC, discoverFunc func(*podNIC) error, config
 
 	for _, nic := range nics {
 		ifaceName := nic.podInterfaceName
-		if werr := c.write(ifaceName, cache.PodIfaceNetworkPreparationStarted); werr != nil {
-			return fmt.Errorf("failed to mark configuration as started for %s: %v", ifaceName, werr)
+		if werr := c.cache.Write(ifaceName, cache.PodIfaceNetworkPreparationStarted); werr != nil {
+			return fmt.Errorf("failed to mark configuration as started for %s: %w", ifaceName, werr)
 		}
 	}
 
@@ -90,43 +92,11 @@ func (c ConfigState) Run(nics []podNIC, discoverFunc func(*podNIC) error, config
 
 	for _, nic := range nics {
 		ifaceName := nic.podInterfaceName
-		if werr := c.write(ifaceName, cache.PodIfaceNetworkPreparationFinished); werr != nil {
+		if werr := c.cache.Write(ifaceName, cache.PodIfaceNetworkPreparationFinished); werr != nil {
 			return neterrors.CreateCriticalNetworkError(
-				fmt.Errorf("failed to mark configuration as finished for %s: %v", ifaceName, werr),
+				fmt.Errorf("failed to mark configuration as finished for %s: %w", ifaceName, werr),
 			)
 		}
-	}
-	return nil
-}
-
-func (c ConfigState) read(networkName string) (cache.PodIfaceState, error) {
-	var podIfaceCacheData *cache.PodIfaceCacheData
-	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, networkName)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return defaultState, nil
-		}
-		return defaultState, fmt.Errorf("failed to read pod interface network state from cache: %v", err)
-	}
-	return podIfaceCacheData.State, nil
-}
-
-func (c ConfigState) write(networkName string, state cache.PodIfaceState) error {
-	var podIfaceCacheData *cache.PodIfaceCacheData
-	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, networkName)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			log.Log.Reason(err).Errorf("failed to read pod interface network (%s) state from cache", networkName)
-			return err
-		}
-		podIfaceCacheData = &cache.PodIfaceCacheData{}
-	}
-
-	podIfaceCacheData.State = state
-	err = cache.WritePodInterfaceCache(c.cacheCreator, c.vmiUID, networkName, podIfaceCacheData)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to write pod interface network (%s) state to cache", networkName)
-		return err
 	}
 	return nil
 }

--- a/pkg/network/setup/configstatecache.go
+++ b/pkg/network/setup/configstatecache.go
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/network/cache"
+)
+
+type ConfigStateCache struct {
+	vmiUID                string
+	cacheCreator          cacheCreator
+	volatilePodIfaceState map[string]cache.PodIfaceState
+}
+
+func NewConfigStateCache(vmiUID string, cacheCreator cacheCreator) ConfigStateCache {
+	return NewConfigStateCacheWithPodIfaceStateData(vmiUID, cacheCreator, map[string]cache.PodIfaceState{})
+}
+
+func NewConfigStateCacheWithPodIfaceStateData(vmiUID string, cacheCreator cacheCreator, volatilePodIfaceState map[string]cache.PodIfaceState) ConfigStateCache {
+	return ConfigStateCache{vmiUID, cacheCreator, volatilePodIfaceState}
+}
+
+func (c *ConfigStateCache) Read(podInterfaceName string) (cache.PodIfaceState, error) {
+	if volatilePodIfaceState, ok := c.volatilePodIfaceState[podInterfaceName]; ok {
+		return volatilePodIfaceState, nil
+	}
+	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, podInterfaceName)
+	var state cache.PodIfaceState
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return defaultState, fmt.Errorf("failed to read pod interface network state from cache: %v", err)
+		}
+		state = defaultState
+	} else {
+		state = podIfaceCacheData.State
+	}
+	c.volatilePodIfaceState[podInterfaceName] = state
+	return state, nil
+}
+
+func (c *ConfigStateCache) Write(podInterfaceName string, state cache.PodIfaceState) error {
+	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, podInterfaceName)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Log.Reason(err).Errorf("failed to read pod interface network (%s) state from cache", podInterfaceName)
+			return err
+		}
+		podIfaceCacheData = &cache.PodIfaceCacheData{}
+	}
+
+	podIfaceCacheData.State = state
+	err = cache.WritePodInterfaceCache(c.cacheCreator, c.vmiUID, podInterfaceName, podIfaceCacheData)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to write pod interface network (%s) state to cache", podInterfaceName)
+		return err
+	}
+	c.volatilePodIfaceState[podInterfaceName] = state
+	return nil
+}

--- a/pkg/network/setup/configstatecache_test.go
+++ b/pkg/network/setup/configstatecache_test.go
@@ -1,0 +1,117 @@
+/*
+* This file is part of the KubeVirt project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Copyright 2023 Red Hat, Inc.
+*
+ */
+
+package network_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	network "kubevirt.io/kubevirt/pkg/network/setup"
+
+	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
+	"kubevirt.io/kubevirt/pkg/network/cache"
+)
+
+var _ = Describe("config state cache", func() {
+	const (
+		uid     = "123"
+		testNet = "testnet"
+	)
+	var (
+		configStateCache      network.ConfigStateCache
+		baseCacheCreator      tempCacheCreator
+		volatilePodIfaceState map[string]cache.PodIfaceState
+	)
+
+	BeforeEach(func() {
+		dutils.MockDefaultOwnershipManager()
+		volatilePodIfaceState = map[string]cache.PodIfaceState{}
+		configStateCache = network.NewConfigStateCacheWithPodIfaceStateData(uid, &baseCacheCreator, volatilePodIfaceState)
+	})
+	AfterEach(func() {
+		Expect(baseCacheCreator.New("").Delete()).To(Succeed())
+	})
+
+	Context("read", func() {
+		It("from an empty cache", func() {
+			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationPending))
+			Expect(volatilePodIfaceState).To(HaveKeyWithValue(testNet, cache.PodIfaceNetworkPreparationPending))
+		})
+		It("state stored only in the file cache", func() {
+			podIfaceCacheData := &cache.PodIfaceCacheData{State: cache.PodIfaceNetworkPreparationStarted}
+			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, uid, testNet, podIfaceCacheData)).To(Succeed())
+
+			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+		})
+		It("state stored only in file cache while the memory cache is not empty", func() {
+			podIfaceCacheData := &cache.PodIfaceCacheData{State: cache.PodIfaceNetworkPreparationStarted}
+			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, uid, testNet, podIfaceCacheData)).To(Succeed())
+
+			volatilePodIfaceState["not"+testNet] = cache.PodIfaceNetworkPreparationStarted
+
+			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+		})
+		It("state stored only in the memory", func() {
+			volatilePodIfaceState[testNet] = cache.PodIfaceNetworkPreparationStarted
+
+			state, err := configStateCache.Read(testNet)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+		})
+		It("state stored in both the file cache and the memory, prefer memory", func() {
+			podIfaceCacheData := &cache.PodIfaceCacheData{State: cache.PodIfaceNetworkPreparationStarted}
+			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, uid, testNet, podIfaceCacheData)).To(Succeed())
+			volatilePodIfaceState[testNet] = cache.PodIfaceNetworkPreparationFinished
+
+			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+		})
+	})
+
+	Context("write", func() {
+		It("to an empty cache", func() {
+			err := configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationStarted)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+			podIfaceCacheData, err := cache.ReadPodInterfaceCache(&baseCacheCreator, uid, testNet)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podIfaceCacheData.State).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+
+		})
+		It("to a non empty cache", func() {
+			err := configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationStarted)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+			podIfaceCacheData, err := cache.ReadPodInterfaceCache(&baseCacheCreator, uid, testNet)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podIfaceCacheData.State).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+
+			err = configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationFinished)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+			podIfaceCacheData, err = cache.ReadPodInterfaceCache(&baseCacheCreator, uid, testNet)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podIfaceCacheData.State).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+
+		})
+	})
+})

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -65,6 +65,10 @@ var _ = Describe("netconf", func() {
 
 	It("fails the setup run", func() {
 		netConf := netsetup.NewNetConfWithCustomFactory(nsFailureFactory, &tempCacheCreator{})
+		vmi.Spec.Networks = []v1.Network{{
+			Name:          "default",
+			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+		}}
 		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)).NotTo(Succeed())
 	})
 

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -50,13 +50,6 @@ var _ = Describe("netconf", func() {
 
 	It("runs setup successfully", func() {
 		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)).To(Succeed())
-		Expect(netConf.SetupCompleted(vmi)).To(BeFalse())
-	})
-
-	It("does not skip secondary setup run", func() {
-		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)).To(Succeed())
-		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupFail)).NotTo(Succeed())
-		Expect(netConf.SetupCompleted(vmi)).To(BeFalse())
 	})
 
 	It("fails the pre-setup run", func() {
@@ -75,61 +68,6 @@ var _ = Describe("netconf", func() {
 	It("fails the teardown run", func() {
 		netConf := netsetup.NewNetConfWithCustomFactory(nil, failingCacheCreator{})
 		Expect(netConf.Teardown(vmi)).NotTo(Succeed())
-	})
-
-	Context("with completion cache", func() {
-		It("runs setup successfully", func() {
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)
-			})).To(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeTrue())
-		})
-
-		It("runs teardown successfully", func() {
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)
-			})).To(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeTrue())
-			Expect(netConf.Teardown(vmi)).To(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeFalse())
-		})
-
-		It("fails first setup and succeeds second setup", func() {
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupFail)
-			})).NotTo(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeFalse())
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)
-			})).To(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeTrue())
-		})
-
-		It("skips secondary setup runs", func() {
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupDummyNoop)
-			})).To(Succeed())
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return netConf.Setup(vmi, vmi.Spec.Networks, launcherPid, netPreSetupFail)
-			})).To(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeTrue())
-		})
-
-		It("fails the teardown run", func() {
-			netConf := netsetup.NewNetConfWithCustomFactory(nil, failingCacheCreator{})
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return nil
-			})).To(Succeed())
-			Expect(netConf.Teardown(vmi)).NotTo(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeFalse())
-		})
-
-		It("fails completion cache body", func() {
-			Expect(netConf.WithCompletionCache(vmi.UID, func() error {
-				return fmt.Errorf("fail")
-			})).NotTo(Succeed())
-			Expect(netConf.SetupCompleted(vmi)).To(BeFalse())
-		})
 	})
 })
 

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -80,13 +80,12 @@ func (v VMNetworkConfigurator) getPhase2NICs(domain *api.Domain, networks []v1.N
 	return nics, nil
 }
 
-func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networks []v1.Network) error {
+func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networks []v1.Network, configState ConfigState) error {
 	nics, err := n.getPhase1NICs(&launcherPID, networks)
 	if err != nil {
 		return err
 	}
 
-	configState := NewConfigState(n.cacheCreator, string(n.vmi.UID))
 	err = configState.Run(
 		nics,
 		func(nic *podNIC) error {

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -96,8 +96,7 @@ func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(launcherPID int, networks 
 				return nil
 			}
 			return nic.infraConfigurator.PreparePodNetworkInterface()
-		},
-	)
+		})
 	if err != nil {
 		return fmt.Errorf("failed setup pod network phase1: %w", err)
 	}

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
+
 	"kubevirt.io/kubevirt/pkg/network/infraconfigurators"
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -67,7 +68,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				}}
 				vmNetworkConfigurator = NewVMNetworkConfigurator(vmi, &baseCacheCreator)
 				stateCache := NewConfigStateCache(string(vmi.UID), vmNetworkConfigurator.cacheCreator)
-				configState = NewConfigState(&stateCache)
+				configState = NewConfigState(&stateCache, nsExecutorStub{})
 			})
 			It("should propagate errors when phase1 is called", func() {
 				launcherPID := 0
@@ -324,7 +325,7 @@ var _ = Describe("VMNetworkConfigurator", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmNetworkConfigurator = newVMNetworkConfiguratorWithHandlerAndCache(vmi, mockNetworkH, &baseCacheCreator)
 			stateCache := NewConfigStateCache(string(vmi.UID), vmNetworkConfigurator.cacheCreator)
-			configState = NewConfigState(&stateCache)
+			configState = NewConfigState(&stateCache, nsExecutorStub{})
 		})
 
 		It("fails setup during network discovery", func() {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -101,8 +101,6 @@ import (
 type netconf interface {
 	Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, launcherPid int, preSetup func() error) error
 	Teardown(vmi *v1.VirtualMachineInstance) error
-	WithCompletionCache(id any, f func() error) error
-	SetupCompleted(vmi *v1.VirtualMachineInstance) bool
 }
 
 type netstat interface {
@@ -2647,7 +2645,7 @@ func (d *VirtualMachineController) vmUpdateHelperMigrationTarget(origVMI *v1.Vir
 	}
 
 	// configure network inside virt-launcher compute container
-	if err := d.netConf.WithCompletionCache(vmi.UID, func() error { return d.setupNetwork(vmi, vmi.Spec.Networks) }); err != nil {
+	if err := d.setupNetwork(vmi, vmi.Spec.Networks); err != nil {
 		return fmt.Errorf("failed to configure vmi network for migration target: %w", err)
 	}
 
@@ -2811,7 +2809,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			return err
 		}
 
-		if err := d.netConf.WithCompletionCache(vmi.UID, func() error { return d.setupNetwork(vmi, vmi.Spec.Networks) }); err != nil {
+		if err := d.setupNetwork(vmi, vmi.Spec.Networks); err != nil {
 			return fmt.Errorf("failed to configure vmi network: %w", err)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR extends ConfigState to contain in-memory cache alongside with
a file cache.
This is needed to avoid reading from the file each time the cache is
accessed.

Previously this cache was used by SetupPodNetworkPhase1 in virt-launcher's
network namespace.
This PR is changing the code to use this cache to check whether virt-handler should
try to plug an interface or not before entring the virt-launcher's network namespace.
Only if there is actually an interface to plug, virt-launcher's network namespace is entered.

The PR also removes NetConf.WithCompletionCache since now ConfigState cache is cehcked before entring the virt-launcher's network namespace it is redundant.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
