### PR TITLE
macvtap: fix ownership change of the tap interface

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/hotplug-disk:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/errors:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/setup:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/pointer:go_default_library",

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -107,10 +107,10 @@ func (d *VirtualMachineController) prepareStorage(vmi *v1.VirtualMachineInstance
 }
 
 func getTapDevices(vmi *v1.VirtualMachineInstance) []string {
-	macvtap := map[string]bool{}
+	macvtap := map[string]struct{}{}
 	for _, inf := range vmi.Spec.Domain.Devices.Interfaces {
 		if inf.Macvtap != nil {
-			macvtap[inf.Name] = true
+			macvtap[inf.Name] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Virt-handler needs to perform an extra step for non-root VMIs with
macvtap interfaces: it needs to set the owner of the device files as the
pod user. Thus, to identify the ifindex of a pod interface, it was
needed to update the algorithm to find the corresponding pod interface.

Before this patch we were attempting to change the ownership of the file
pointed to by the name of the multus network - i.e. the network
attachment definition name. This was wrong: we need to use the name of
the pod interface (macvlan side). This only worked in CI since the name
of the net-attach-def used is `net1` - which [matches the name of the pod
interface](https://github.com/kubevirt/kubevirt/blob/c2a498a00f4f9ecc974f547db7db24f5a5f728bd/tests/network/macvtap.go#L66), since the algorithm requests for multus interfaces named
`net<X>` where X is the ordinal of the interface in the
`vmi.Spec.Domain.Devices.Interfaces` slice.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9633 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix ownership of macvtap's char devices on non-root pods
```

