### PR TITLE
controller, VMI: Wait for PVC informer cache sync

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -265,7 +265,15 @@ func (c *VMIController) Run(threadiness int, stopCh <-chan struct{}) {
 	log.Log.Info("Starting vmi controller.")
 
 	// Wait for cache sync before we start the pod controller
-	cache.WaitForCacheSync(stopCh, c.vmInformer.HasSynced, c.vmiInformer.HasSynced, c.podInformer.HasSynced, c.dataVolumeInformer.HasSynced, c.cdiConfigInformer.HasSynced, c.cdiInformer.HasSynced)
+	cache.WaitForCacheSync(stopCh,
+		c.vmInformer.HasSynced,
+		c.vmiInformer.HasSynced,
+		c.podInformer.HasSynced,
+		c.dataVolumeInformer.HasSynced,
+		c.cdiConfigInformer.HasSynced,
+		c.cdiInformer.HasSynced,
+		c.pvcInformer.HasSynced,
+	)
 	// Sync the CIDs from exist VMIs
 	var vmis []*virtv1.VirtualMachineInstance
 	for _, obj := range c.vmiInformer.GetStore().List() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `VMIController` struct has seven informers.
In `VMIController.Run()` there is a call to `WaitForCacheSync()` with a list of all informers except for `pvcInformer`.

Add `pvcInformer` to the list of informers, in order to wait for its cache to sync as well.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
