### PR TITLE
[node-labeller] Labeling of nodes with ksm enabled

### DIFF
--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/node-labeller/api:go_default_library",

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -95,3 +95,8 @@ type SEVConfiguration struct {
 	Cbitpos         string `xml:"cbitpos"`
 	ReducedPhysBits string `xml:"reducedPhysBits"`
 }
+
+type KSMConfiguration struct {
+	SysfsFilePath string
+	Enabled       bool
+}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -908,6 +908,9 @@ const (
 	// SEVLabel marks the node as capable of running workloads with SEV
 	SEVLabel string = "kubevirt.io/sev"
 
+	// KSMEnabledLabel marks the node as KSM enabled
+	KSMEnabledLabel string = "kubevirt.io/ksm-enabled"
+
 	// InstancetypeAnnotation is the name of a VirtualMachineInstancetype
 	InstancetypeAnnotation string = "kubevirt.io/instancetype-name"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If KSM is enabled (not only available) on a node,
then handler will add `kubevirt.io/ksm-enabled` label to the node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ksm enabled nodes will have `kubevirt.io/ksm-enabled` label
```
