### PR TITLE
Fix flaky VM snapshot test

### DIFF
--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -37,11 +37,10 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
-	"kubevirt.io/kubevirt/pkg/instancetype"
-	"kubevirt.io/kubevirt/pkg/util"
-
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/instancetype"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/status"
 )
 
@@ -436,6 +435,11 @@ var _ = Describe("Snapshot controlleer", func() {
 				controller.dynamicInformerMap[volumeSnapshotClassCRD].informer = volumeSnapshotClassInformer
 				go volumeSnapshotInformer.Run(stopCh)
 				go volumeSnapshotClassInformer.Run(stopCh)
+				Expect(cache.WaitForCacheSync(
+					stopCh,
+					volumeSnapshotInformer.HasSynced,
+					volumeSnapshotClassInformer.HasSynced,
+				)).To(BeTrue())
 			})
 
 			It("should initialize VirtualMachineSnapshot status", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Example flake:  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9268/pull-kubevirt-unit-test/1651563524318564352

Pleoblem is that the test infra was not waiting for informers to start

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/CNV-28423

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
