### PR TITLE
virt-launcher: Use libvirt function to set SSH keys in the guest

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/access-credentials/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
+        "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -564,6 +564,27 @@ func (_mr *_MockVirDomainRecorder) SetTime(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTime", arg0, arg1, arg2)
 }
 
+func (_m *MockVirDomain) AuthorizedSSHKeysGet(user string, flags libvirt.DomainAuthorizedSSHKeysFlags) ([]string, error) {
+	ret := _m.ctrl.Call(_m, "AuthorizedSSHKeysGet", user, flags)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirDomainRecorder) AuthorizedSSHKeysGet(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizedSSHKeysGet", arg0, arg1)
+}
+
+func (_m *MockVirDomain) AuthorizedSSHKeysSet(user string, keys []string, flags libvirt.DomainAuthorizedSSHKeysFlags) error {
+	ret := _m.ctrl.Call(_m, "AuthorizedSSHKeysSet", user, keys, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) AuthorizedSSHKeysSet(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizedSSHKeysSet", arg0, arg1, arg2)
+}
+
 func (_m *MockVirDomain) AbortJob() error {
 	ret := _m.ctrl.Call(_m, "AbortJob")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -505,6 +505,8 @@ type VirDomain interface {
 	GetJobInfo() (*libvirt.DomainJobInfo, error)
 	GetDiskErrors(flags uint32) ([]libvirt.DomainDiskError, error)
 	SetTime(secs int64, nsecs uint, flags libvirt.DomainSetTimeFlags) error
+	AuthorizedSSHKeysGet(user string, flags libvirt.DomainAuthorizedSSHKeysFlags) ([]string, error)
+	AuthorizedSSHKeysSet(user string, keys []string, flags libvirt.DomainAuthorizedSSHKeysFlags) error
 	AbortJob() error
 	Free() error
 	CoreDumpWithFormat(to string, format libvirt.DomainCoreDumpFormat, flags libvirt.DomainCoreDumpFlags) error


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simplifies how SSH keys are set in the guest. It uses functions provided by libvirt, instead of writing to the `authorized_keys` file directly.

**Release note**:
```release-note
None
```
