### PR TITLE
multi-arch: set ARCHITECTURE equal to BUILD_ARCH

### DIFF
--- a/hack/multi-arch.sh
+++ b/hack/multi-arch.sh
@@ -28,5 +28,5 @@ if [ "$build_count" -gt 1 ]; then
         DOCKER_TAG=$DOCKER_TAG-$arch ARCHITECTURE=$arch hack/bazel-${COMMAND}.sh
     done
 else
-    hack/bazel-${COMMAND}.sh
+    ARCHITECTURE=${BUILD_ARCH} hack/bazel-${COMMAND}.sh
 fi

--- a/hack/multi-arch.sh
+++ b/hack/multi-arch.sh
@@ -20,19 +20,24 @@
 COMMAND=$1
 # We are formatting the architecture name here to ensure that
 # it is consistent with the platform name specified in ../.bazelrc
+# if the second argument is set, the function would formating arch name for
+# image tag.
 function format_archname() {
     local local_platform=$(uname -m)
     local platform=$1
+    local tag=$2
 
     if [ $# -lt 1 ]; then
         echo ${local_platform}
     else
         case ${platform} in
         x86_64 | amd64)
+            [[ $tag ]] && echo "amd64" && return
             arch="x86_64"
             echo ${arch}
             ;;
         crossbuild-aarch64 | aarch64 | arm64)
+            [[ $tag ]] && echo "arm64" && return
             if [ ${local_platform} != "aarch64" ]; then
                 arch="crossbuild-aarch64"
             else
@@ -55,7 +60,8 @@ if [ "$build_count" -gt 1 ]; then
     for arch in ${BUILD_ARCH//,/ }; do
         echo "[INFO] -- working on $arch --"
         arch=$(format_archname $arch)
-        DOCKER_TAG=$DOCKER_TAG-$arch ARCHITECTURE=$arch hack/bazel-${COMMAND}.sh
+        tag=$(format_archname $arch tag)
+        DOCKER_TAG=$DOCKER_TAG-$tag ARCHITECTURE=$arch hack/bazel-${COMMAND}.sh
     done
 else
     arch=$(format_archname ${BUILD_ARCH})


### PR DESCRIPTION
Make bazel build for correct Architecture, when there is only one parameter in BUILD_ARCH

As we set `BUILD_ARCH=crossbuild-aarch64` in the build process, and the parameter does not pass to `bazel build` which lead to cross build not works at the moment.
https://github.com/kubevirt/project-infra/blob/39e4c9854a682d00f762868f58ec0b9a4bf6e013/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml#L322-L323

**Special notes for your reviewer**:
This is a fix to https://github.com/kubevirt/kubevirt/issues/3558#issuecomment-1533261386

```release-note
NONE
```
