### PR TITLE
prom-rule-ci: Relabel bind mounted test files

### DIFF
--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -33,7 +33,7 @@ function lint() {
     local target_file="${1:?}"
 
     ${KUBEVIRT_CRI} run --rm --entrypoint=/bin/promtool \
-        -v "$target_file":/tmp/rules.verify:ro "$PROM_IMAGE" \
+        -v "$target_file":/tmp/rules.verify:ro,Z "$PROM_IMAGE" \
         check rules /tmp/rules.verify
 }
 
@@ -42,8 +42,8 @@ function unit_test() {
     local tests_file="${2:?}"
 
     ${KUBEVIRT_CRI} run --rm --entrypoint=/bin/promtool \
-        -v "$tests_file":/tmp/rules.test:Z \
-        -v "$target_file":/tmp/rules.verify:ro \
+        -v "$tests_file":/tmp/rules.test:ro,Z \
+        -v "$target_file":/tmp/rules.verify:ro,Z \
         "$PROM_IMAGE" \
         test rules /tmp/rules.test
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

By relabeling bind mounted test files the Makefile target prom-rules-verify is able to be used with Podman.

Additionally all files are mounted read-only.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
