### PR TITLE
[release-0.59] instancetype: Handle VirtualMachineInstancetypeSpecRevision without APIVersion

### DIFF
--- a/pkg/instancetype/BUILD.bazel
+++ b/pkg/instancetype/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",

--- a/pkg/instancetype/compatibility.go
+++ b/pkg/instancetype/compatibility.go
@@ -41,10 +41,6 @@ func decodeOldInstancetypeRevisionObject(data []byte) (*instancetypev1alpha1.Vir
 		return nil, nil
 	}
 
-	if revision.APIVersion != instancetypev1alpha1.SchemeGroupVersion.String() {
-		return nil, nil
-	}
-
 	instancetypeSpec := &instancetypev1alpha1.VirtualMachineInstancetypeSpec{}
 	err = json.Unmarshal(revision.Spec, instancetypeSpec)
 	if err != nil {
@@ -68,10 +64,6 @@ func decodeOldPreferenceRevisionObject(data []byte) (*instancetypev1alpha1.Virtu
 	err := json.Unmarshal(data, revision)
 	if err != nil {
 		// Failed to unmarshall, so the object is not the expected type
-		return nil, nil
-	}
-
-	if revision.APIVersion != instancetypev1alpha1.SchemeGroupVersion.String() {
 		return nil, nil
 	}
 

--- a/pkg/instancetype/compatibility_test.go
+++ b/pkg/instancetype/compatibility_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("instancetype compatibility", func() {
 	Context("reading old ControllerRevision", func() {
-		It("should decode v1alpha1 instancetype from ControllerRevision", func() {
+		DescribeTable("should decode v1alpha1 instancetype from ControllerRevision", func(apiVersion string) {
 			instancetypeSpec := v1alpha1.VirtualMachineInstancetypeSpec{
 				CPU: v1alpha1.CPUInstancetype{
 					Guest: 4,
@@ -27,7 +27,7 @@ var _ = Describe("instancetype compatibility", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			revision := v1alpha1.VirtualMachineInstancetypeSpecRevision{
-				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				APIVersion: apiVersion,
 				Spec:       specBytes,
 			}
 
@@ -38,9 +38,12 @@ var _ = Describe("instancetype compatibility", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(decoded).ToNot(BeNil())
 			Expect(decoded.Spec.CPU).To(Equal(instancetypeSpec.CPU))
-		})
+		},
+			Entry("with APIVersion", v1alpha1.SchemeGroupVersion.String()),
+			Entry("without APIVersion", ""),
+		)
 
-		It("should decode v1alpha1 preference from ControllerRevision", func() {
+		DescribeTable("should decode v1alpha1 preference from ControllerRevision", func(apiVersion string) {
 			preferredTopology := v1alpha1.PreferCores
 			preferenceSpec := v1alpha1.VirtualMachinePreferenceSpec{
 				CPU: &v1alpha1.CPUPreferences{
@@ -52,7 +55,7 @@ var _ = Describe("instancetype compatibility", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			revision := v1alpha1.VirtualMachinePreferenceSpecRevision{
-				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				APIVersion: apiVersion,
 				Spec:       specBytes,
 			}
 
@@ -63,7 +66,11 @@ var _ = Describe("instancetype compatibility", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(decoded).ToNot(BeNil())
 			Expect(decoded.Spec).To(Equal(preferenceSpec))
-		})
+
+		},
+			Entry("with APIVersion", v1alpha1.SchemeGroupVersion.String()),
+			Entry("without APIVersion", ""),
+		)
 	})
 
 	Context("instancetype conversion", func() {

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -29,6 +30,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 	apiinstancetype "kubevirt.io/api/instancetype"
+	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
 	instancetypev1alpha2 "kubevirt.io/api/instancetype/v1alpha2"
 	fakeclientset "kubevirt.io/client-go/generated/kubevirt/clientset/versioned/fake"
 	"kubevirt.io/client-go/generated/kubevirt/clientset/versioned/typed/instancetype/v1alpha2"
@@ -292,6 +294,41 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("VM field conflicts with selected Instancetype")))
 			})
 
+			It("find fails to decode v1alpha1 VirtualMachineInstancetypeSpecRevision ControllerRevision without APIVersion set - bug #9261", func() {
+				specData, err := json.Marshal(clusterInstancetype.Spec)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Do not set APIVersion as part of VirtualMachineInstancetypeSpecRevision in order to trigger bug #9261
+				specRevision := instancetypev1alpha1.VirtualMachineInstancetypeSpecRevision{
+					Spec: specData,
+				}
+				specRevisionData, err := json.Marshal(specRevision)
+				Expect(err).ToNot(HaveOccurred())
+
+				controllerRevision := &appsv1.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "crName",
+						Namespace:       vm.Namespace,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vm, v1.VirtualMachineGroupVersionKind)},
+					},
+					Data: runtime.RawExtension{
+						Raw: specRevisionData,
+					},
+				}
+
+				_, err = virtClient.AppsV1().ControllerRevisions(vm.Namespace).Create(context.Background(), controllerRevision, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vm.Spec.Instancetype = &v1.InstancetypeMatcher{
+					Name:         clusterInstancetype.Name,
+					RevisionName: controllerRevision.Name,
+					Kind:         apiinstancetype.ClusterSingularResourceName,
+				}
+
+				_, err = instancetypeMethods.FindInstancetypeSpec(vm)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Object 'Kind' is missing in"))
+			})
 		})
 
 		Context("Using namespaced Instancetype", func() {
@@ -441,6 +478,42 @@ var _ = Describe("Instancetype and Preferences", func() {
 				}
 
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("VM field conflicts with selected Instancetype")))
+			})
+
+			It("find fails to decode v1alpha1 VirtualMachineInstancetypeSpecRevision ControllerRevision without APIVersion set - bug #9261", func() {
+				specData, err := json.Marshal(f.Spec)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Do not set APIVersion as part of VirtualMachineInstancetypeSpecRevision in order to trigger bug #9261
+				specRevision := instancetypev1alpha1.VirtualMachineInstancetypeSpecRevision{
+					Spec: specData,
+				}
+				specRevisionData, err := json.Marshal(specRevision)
+				Expect(err).ToNot(HaveOccurred())
+
+				controllerRevision := &appsv1.ControllerRevision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "crName",
+						Namespace:       vm.Namespace,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vm, v1.VirtualMachineGroupVersionKind)},
+					},
+					Data: runtime.RawExtension{
+						Raw: specRevisionData,
+					},
+				}
+
+				_, err = virtClient.AppsV1().ControllerRevisions(vm.Namespace).Create(context.Background(), controllerRevision, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vm.Spec.Instancetype = &v1.InstancetypeMatcher{
+					Name:         f.Name,
+					RevisionName: controllerRevision.Name,
+					Kind:         apiinstancetype.SingularResourceName,
+				}
+
+				_, err = instancetypeMethods.FindInstancetypeSpec(vm)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Object 'Kind' is missing in"))
 			})
 		})
 	})

--- a/pkg/instancetype/instancetype_test.go
+++ b/pkg/instancetype/instancetype_test.go
@@ -167,6 +167,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 						CPU: instancetypev1alpha2.CPUInstancetype{
 							Guest: uint32(2),
 						},
+						Memory: instancetypev1alpha2.MemoryInstancetype{
+							Guest: resource.MustParse("128Mi"),
+						},
 					},
 				}
 
@@ -294,7 +297,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("VM field conflicts with selected Instancetype")))
 			})
 
-			It("find fails to decode v1alpha1 VirtualMachineInstancetypeSpecRevision ControllerRevision without APIVersion set - bug #9261", func() {
+			It("find successfully decodes v1alpha1 VirtualMachineInstancetypeSpecRevision ControllerRevision without APIVersion set - bug #9261", func() {
 				specData, err := json.Marshal(clusterInstancetype.Spec)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -325,9 +328,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Kind:         apiinstancetype.ClusterSingularResourceName,
 				}
 
-				_, err = instancetypeMethods.FindInstancetypeSpec(vm)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Object 'Kind' is missing in"))
+				foundInstancetypeSpec, err := instancetypeMethods.FindInstancetypeSpec(vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*foundInstancetypeSpec).To(Equal(clusterInstancetype.Spec))
 			})
 		})
 
@@ -354,6 +357,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Spec: instancetypev1alpha2.VirtualMachineInstancetypeSpec{
 						CPU: instancetypev1alpha2.CPUInstancetype{
 							Guest: uint32(2),
+						},
+						Memory: instancetypev1alpha2.MemoryInstancetype{
+							Guest: resource.MustParse("128Mi"),
 						},
 					},
 				}
@@ -480,7 +486,7 @@ var _ = Describe("Instancetype and Preferences", func() {
 				Expect(instancetypeMethods.StoreControllerRevisions(vm)).To(MatchError(ContainSubstring("VM field conflicts with selected Instancetype")))
 			})
 
-			It("find fails to decode v1alpha1 VirtualMachineInstancetypeSpecRevision ControllerRevision without APIVersion set - bug #9261", func() {
+			It("find successfully decodes v1alpha1 VirtualMachineInstancetypeSpecRevision ControllerRevision without APIVersion set - bug #9261", func() {
 				specData, err := json.Marshal(f.Spec)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -511,9 +517,9 @@ var _ = Describe("Instancetype and Preferences", func() {
 					Kind:         apiinstancetype.SingularResourceName,
 				}
 
-				_, err = instancetypeMethods.FindInstancetypeSpec(vm)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Object 'Kind' is missing in"))
+				foundInstancetypeSpec, err := instancetypeMethods.FindInstancetypeSpec(vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*foundInstancetypeSpec).To(Equal(f.Spec))
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/kubevirt/pull/9584

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
