### PR TITLE
Add metrics name linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,9 @@ lint:
 	  tests/libvmi/... \
 	"
 
+lint-metrics:
+	hack/dockerized "./hack/metric_name_linter.sh"
+
 .PHONY: \
 	build-verify \
 	conformance \
@@ -246,4 +249,5 @@ lint:
 	format \
 	fmt \
 	lint \
+	lint-metrics \
 	$(NULL)

--- a/hack/metric_name_linter.sh
+++ b/hack/metric_name_linter.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+#
+
+set -e
+
+PROJECT_ROOT="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")"/../)"
+metrics_doc_path="${PROJECT_ROOT}/docs/metrics.md"
+
+# Run the metric name linter and store the output in errors
+errors=$(go run "${PROJECT_ROOT}"/tools/prom-metric-linter/*.go "$metrics_doc_path" 2>&1)
+
+# Check if there were any errors, if yes print and fail
+if [[ $errors != "" ]]; then
+    echo "$errors"
+    exit 1
+fi

--- a/tools/prom-metric-linter/BUILD.bazel
+++ b/tools/prom-metric-linter/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "custom_linter_rules.go",
+        "metric_name_linter.go",
+        "metrics_collector.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tools/prom-metric-linter",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/github.com/prometheus/client_model/go:go_default_library"],
+)
+
+go_binary(
+    name = "prom-metric-linter",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/prom-metric-linter/custom_linter_rules.go
+++ b/tools/prom-metric-linter/custom_linter_rules.go
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func CustomLinterRules(problems []promlint.Problem, mf *dto.MetricFamily, operatorName string, subOperatorName string) []promlint.Problem {
+	// Check metric prefix
+	nameParts := strings.Split(*mf.Name, "_")
+
+	if nameParts[0] != operatorName {
+		problems = append(problems, promlint.Problem{
+			Metric: *mf.Name,
+			Text:   fmt.Sprintf("name need to start with '%s_'", operatorName),
+		})
+	} else if operatorName != subOperatorName && nameParts[1] != subOperatorName {
+		problems = append(problems, promlint.Problem{
+			Metric: *mf.Name,
+			Text:   fmt.Sprintf("name need to start with \"%s_%s_\"", operatorName, subOperatorName),
+		})
+	}
+
+	// Check "_timestamp_seconds" suffix for non-counter metrics
+	if *mf.Type != dto.MetricType_COUNTER && strings.HasSuffix(*mf.Name, "_timestamp_seconds") {
+		problems = append(problems, promlint.Problem{
+			Metric: *mf.Name,
+			Text:   "non-counter metric should not have \"_timestamp_seconds\" suffix",
+		})
+	}
+
+	// If promlint fails on a "total" suffix, check also for "_timestamp_seconds" suffix. If it exists, do not fail
+	var newProblems []promlint.Problem
+	for _, problem := range problems {
+		if strings.Contains(problem.Text, "counter metrics should have \"_total\" suffix") {
+			if !strings.HasSuffix(problem.Metric, "_timestamp_seconds") {
+				problem.Text = "counter metrics should have \"_total\" or \"_timestamp_seconds\" suffix"
+				newProblems = append(newProblems, problem)
+			}
+		} else {
+			newProblems = append(newProblems, problem)
+		}
+	}
+
+	// Sort the problems by metric name
+	sort.Slice(newProblems, func(i, j int) bool {
+		return newProblems[i].Metric < newProblems[j].Metric
+	})
+
+	return newProblems
+}

--- a/tools/prom-metric-linter/metric_name_linter.go
+++ b/tools/prom-metric-linter/metric_name_linter.go
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("please provide path to the metrics file")
+		os.Exit(1)
+	}
+
+	path := os.Args[1]
+	if _, err := os.Stat(path); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	metricFamilies, err := ReadMetrics(path)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Call customRules function to apply the custom rules to the linter
+	linter := promlint.NewWithMetricFamilies(metricFamilies)
+
+	problems, err := linter.Lint()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Set the operator and sub-operator names
+	operatorName := flag.String("operator-name", "kubevirt", "")
+	subOperatorName := flag.String("sub-operator-name", "kubevirt", "")
+	flag.Parse()
+
+	for _, family := range metricFamilies {
+		problems = CustomLinterRules(problems, family, *operatorName, *subOperatorName)
+	}
+
+	for _, problem := range problems {
+		fmt.Printf("%s: %s\n", problem.Metric, problem.Text)
+	}
+}

--- a/tools/prom-metric-linter/metrics_collector.go
+++ b/tools/prom-metric-linter/metrics_collector.go
@@ -1,0 +1,126 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Metric represents a Prometheus metric
+type Metric struct {
+	Name string
+	Help string
+	Type string
+}
+
+// excludedMetrics defines the metrics to ignore, open issue:https://github.com/kubevirt/kubevirt/issues/9714
+// Do not add metrics to this list!
+var excludedMetrics = map[string]string{
+	"kubevirt_migrate_vmi_pending_count":                   "",
+	"kubevirt_migrate_vmi_running_count":                   "",
+	"kubevirt_migrate_vmi_scheduling_count":                "",
+	"kubevirt_vmi_cpu_affinity":                            "",
+	"kubevirt_vmi_filesystem_capacity_bytes_total":         "",
+	"kubevirt_vmi_memory_domain_bytes_total":               "",
+	"kubevirt_vmi_memory_pgmajfault":                       "",
+	"kubevirt_vmi_memory_pgminfault":                       "",
+	"kubevirt_vmi_memory_swap_in_traffic_bytes_total":      "",
+	"kubevirt_vmi_memory_swap_out_traffic_bytes_total":     "",
+	"kubevirt_vmi_outdated_count":                          "",
+	"kubevirt_vmi_storage_flush_times_ms_total":            "",
+	"kubevirt_vmi_storage_read_times_ms_total":             "",
+	"kubevirt_vmi_storage_write_times_ms_total":            "",
+	"kubevirt_vmi_vcpu_seconds":                            "",
+	"kubevirt_vmi_vcpu_wait_seconds":                       "",
+	"kubevirt_vmsnapshot_disks_restored_from_source_total": "",
+}
+
+// Extract the name, help, and type from the metrics doc file
+func ExtractMetrics(metricsContent string) ([]Metric, error) {
+	var metrics []Metric
+	re := regexp.MustCompile(`### (.*)\n(.*Type: (Counter|Gauge|Histogram|Summary)\.\n)?`)
+	matches := re.FindAllStringSubmatch(metricsContent, -1)
+	for _, match := range matches {
+		name := match[1]
+		help := ""
+		if len(match) > 2 {
+			help = match[2]
+		}
+		help = strings.TrimSpace(help)
+		typ := ""
+		if len(match) > 3 {
+			typ = match[3]
+		}
+		metrics = append(metrics, Metric{Name: name, Help: help, Type: typ})
+	}
+	if len(metrics) == 0 {
+		return nil, fmt.Errorf("no metrics found")
+	}
+	return metrics, nil
+}
+
+// Set the correct metric type for creating MetricFamily
+func CreateMetricFamily(m Metric) *dto.MetricFamily {
+	metricType := dto.MetricType_UNTYPED
+
+	switch m.Type {
+	case "Counter":
+		metricType = dto.MetricType_COUNTER
+	case "Gauge":
+		metricType = dto.MetricType_GAUGE
+	case "Histogram":
+		metricType = dto.MetricType_HISTOGRAM
+	case "Summary":
+		metricType = dto.MetricType_SUMMARY
+	}
+
+	return &dto.MetricFamily{
+		Name: &m.Name,
+		Help: &m.Help,
+		Type: &metricType,
+	}
+}
+
+// Read the metrics and parse them to a MetricFamily
+func ReadMetrics(metricsPath string) ([]*dto.MetricFamily, error) {
+	metricsContent, err := os.ReadFile(metricsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading metrics file: %s", err)
+	}
+
+	metrics, err := ExtractMetrics(string(metricsContent))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing metrics file: %s", err)
+	}
+
+	var metricFamily []*dto.MetricFamily
+	for _, metric := range metrics {
+		// Remove ignored metrics from all rules
+		if _, ok := excludedMetrics[metric.Name]; !ok {
+			mf := CreateMetricFamily(metric)
+			metricFamily = append(metricFamily, mf)
+		}
+	}
+	return metricFamily, nil
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,387 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.FmtText)
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func lint(mf *dto.MetricFamily) []Problem {
+	fns := []func(mf *dto.MetricFamily) []Problem{
+		lintHelp,
+		lintMetricUnits,
+		lintCounter,
+		lintHistogramSummaryReserved,
+		lintMetricTypeInName,
+		lintReservedChars,
+		lintCamelCase,
+		lintUnitAbbreviations,
+	}
+
+	var problems []Problem
+	for _, fn := range fns {
+		problems = append(problems, fn(mf)...)
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}
+
+// lintHelp detects issues related to the help text for a metric.
+func lintHelp(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, newProblem(mf, "no help text"))
+	}
+
+	return problems
+}
+
+// lintMetricUnits detects issues with metric unit names.
+func lintMetricUnits(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, newProblem(mf, fmt.Sprintf("use base unit %q instead of %q", base, unit)))
+
+	return problems
+}
+
+// lintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func lintCounter(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}
+
+// lintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func lintHistogramSummaryReserved(mf *dto.MetricFamily) []Problem {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []Problem
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, newProblem(mf, `non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, newProblem(mf, `non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, newProblem(mf, `non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}
+
+// lintMetricTypeInName detects when metric types are included in the metric name.
+func lintMetricTypeInName(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems = append(problems, newProblem(mf, fmt.Sprintf(`metric name should not include type '%s'`, typename)))
+		}
+	}
+	return problems
+}
+
+// lintReservedChars detects colons in metric names.
+func lintReservedChars(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, newProblem(mf, "metric names should not contain ':'"))
+	}
+	return problems
+}
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// lintCamelCase detects metric names and label names written in camelCase.
+func lintCamelCase(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, newProblem(mf, "metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, newProblem(mf, "label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// lintUnitAbbreviations detects abbreviated units in the metric name.
+func lintUnitAbbreviations(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, newProblem(mf, "metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for unit, base := range units {
+		// Also check for "no prefix".
+		for _, p := range append(unitPrefixes, "") {
+			for _, s := range ss {
+				// Attempt to explicitly match a known unit with a known prefix,
+				// as some words may look like "units" when matching suffix.
+				//
+				// As an example, "thermometers" should not match "meters", but
+				// "kilometers" should.
+				if s == p+unit {
+					return p + unit, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a metrics name linter. in order to monitor metrics naming and make sure they aligned with the Prometheus metrics naming best practices. 
The linter will lint the metrics in kubevirt/docs/metrics.md file.

**Which issue(s) this PR fixes:**
Fixes #

**Special notes for your reviewer**:
jira-ticket: https://issues.redhat.com/browse/CNV-28163

Linter output:
```
$ make lint-metrics
hack/dockerized "./hack/prom-metric-linter/metric_name_linter.sh"
go version go1.19.2 linux/amd64

go version go1.19.2 linux/amd64
kubevirt_migrate_vmi_pending_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_migrate_vmi_running_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_migrate_vmi_scheduling_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_vmi_cpu_affinity: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_filesystem_capacity_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_memory_domain_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_memory_pgmajfault: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_memory_pgminfault: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_memory_swap_in_traffic_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_memory_swap_out_traffic_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_outdated_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_vmi_storage_flush_times_ms_total: metric names should not contain abbreviated units
kubevirt_vmi_storage_read_times_ms_total: metric names should not contain abbreviated units
kubevirt_vmi_storage_write_times_ms_total: metric names should not contain abbreviated units
kubevirt_vmi_vcpu_seconds: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_vcpu_wait_seconds: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmsnapshot_disks_restored_from_source_total: non-counter metrics should not have "_total" suffix
make: *** [Makefile:213: lint-metrics] Error 1
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a metrics name linter. In order to monitor metrics naming and make sure they aligned with the Prometheus metrics naming best practices. 
```
