### PR TITLE
[e2e tests]: Wait for testing manifests to be gone on suite cleanup

### DIFF
--- a/tests/testsuite/manifest.go
+++ b/tests/testsuite/manifest.go
@@ -28,8 +28,11 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+
+	. "github.com/onsi/gomega"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,7 +101,7 @@ func ApplyRawManifest(object unstructured.Unstructured) error {
 	util.PanicOnError(err)
 	b, err := virtCli.CoreV1().RESTClient().Post().RequestURI(uri).Body(jsonbody).DoRaw(context.Background())
 	if err != nil {
-		fmt.Printf(fmt.Sprintf("ERROR: Can not apply %s\n", object))
+		fmt.Printf(fmt.Sprintf("ERROR: Can not apply %s\n, err: %#v", object, err))
 		panic(err)
 	}
 	status := unstructured.Unstructured{}
@@ -115,11 +118,14 @@ func DeleteRawManifest(object unstructured.Unstructured) error {
 	options := &metav1.DeleteOptions{PropagationPolicy: &policy}
 
 	log.DefaultLogger().Infof("Calling DELETE on testing manifest: %s", uri)
-	result := virtCli.CoreV1().RESTClient().Delete().RequestURI(uri).Body(options).Do(context.Background())
-	if err := result.Error(); err != nil && !k8serrors.IsNotFound(err) {
-		panic(fmt.Errorf("ERROR: Can not delete %s err: %#v %s\n", object.GetName(), err, object))
 
-	}
+	EventuallyWithOffset(2, func() error {
+		result := virtCli.CoreV1().RESTClient().Delete().RequestURI(uri).Body(options).Do(context.Background())
+		return result.Error()
+	}, 30*time.Second, 1*time.Second).Should(
+		SatisfyAll(HaveOccurred(), WithTransform(k8serrors.IsNotFound, BeTrue())),
+		fmt.Sprintf("%s failed to be cleaned up", uri),
+	)
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In external testing, we see that `AlreadyExists` occurs from time to time
when a new test suite attempts to recreate the DaemonSet.
This happens because we now use foreground deletion which waits for the underlying pods to be gone (https://github.com/kubevirt/kubevirt/pull/9496),
which may take a while.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
