### PR TITLE
[snapshot-restore tests]: Bump VM start timeout

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -150,7 +150,7 @@ var _ = SIGDescribe("VirtualMachineRestore Tests", func() {
 			}
 			Expect(err).ToNot(HaveOccurred())
 			return vmi.Status.Phase == v1.Running
-		}, 180*time.Second, time.Second).Should(BeTrue())
+		}, 360*time.Second, time.Second).Should(BeTrue())
 
 		return vm, vmi
 	}

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -327,7 +327,7 @@ var _ = SIGDescribe("VirtualMachineSnapshot Tests", func() {
 					}
 					Expect(err).ToNot(HaveOccurred())
 					return vmi.Status.Phase == v1.Running
-				}, 180*time.Second, time.Second).Should(BeTrue())
+				}, 360*time.Second, time.Second).Should(BeTrue())
 
 				return vm, vmi
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
180 seconds may be too short of a timeout for an external import to complete and a VM to start.
This presented itself in external testing where we don't use a local registry for the images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
