### PR TITLE
Take tests out of quarantine

### DIFF
--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -174,7 +174,7 @@ var _ = Describe("[Serial][sig-operator]virt-handler canary upgrade", Serial, de
 		return eventsQueue
 	}
 
-	It("[QUARANTINE]should successfully upgrade virt-handler", func() {
+	It("should successfully upgrade virt-handler", func() {
 		var expectedEventsLock sync.Mutex
 		expectedEvents := []string{
 			"maxUnavailable=1",

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -163,7 +163,7 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", Serial, decorators.SigCo
 			Expect(slowDuration.Seconds()).To(BeNumerically(">", 2*fastDuration.Seconds()))
 		})
 
-		It("[QUARANTINE]on the virt handler rate limiter should lead to delayed VMI running states", func() {
+		It("on the virt handler rate limiter should lead to delayed VMI running states", func() {
 			By("first getting the basetime for a replicaset")
 			targetNode := libnode.GetAllSchedulableNodes(virtClient).Items[0]
 			vmi := libvmi.New(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Takes tests:
* [sig-compute: Infrastructure changes to the kubernetes client on the virt handler rate limiter should lead to delayed VMI running states](https://github.com/kubevirt/kubevirt/tree/e7016777cc6e8207d8dbc0cc9dcb47d83a79e83c/tests/infra_test.go#L166)
* [sig-operator: virt-handler canary upgrade should successfully upgrade virt-handler](https://github.com/kubevirt/kubevirt/tree/e7016777cc6e8207d8dbc0cc9dcb47d83a79e83c/tests/canary_upgrade_test.go#L177)

See https://storage.googleapis.com/kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/index.html

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @enp0s3 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
