### PR TITLE
monitoring: Add KubeVirtDeprecatedAPIsRequested alert

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,6 +15,9 @@ Version information.
 ### kubevirt_allocatable_nodes_count
 The number of nodes in the cluster that have the devices.kubevirt.io/kvm resource available. Type: Gauge.
 
+### kubevirt_api_request_deprecated_total
+The total number of requests to deprecated KubeVirt APIs. Type: Counter.
+
 ### kubevirt_configuration_emulation_enabled
 Indicates whether the Software Emulation is enabled in the configuration. Type: Gauge.
 

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -848,3 +848,49 @@ tests:
               kubernetes_operator_component: "kubevirt"
               kubernetes_operator_part_of: "kubevirt"
               operator_health_impact: "critical"
+
+  # Deprecated APIs being requested.
+  - interval: 1m
+    input_series:
+      - series: 'apiserver_requested_deprecated_apis{resource="virtualmachines", group="kubevirt.io", version="v1alpha3"}'
+        values: '0 0 1'
+      - series: 'apiserver_request_total{resource="virtualmachines", group="kubevirt.io", version="v1alpha3"}'
+        values: '0 0 1 2'
+
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: KubeVirtDeprecatedAPIsRequested
+        exp_alerts: []
+      - eval_time: 2m
+        alertname: KubeVirtDeprecatedAPIsRequested
+        exp_alerts:
+          - exp_annotations:
+              description: "Detected requests to the deprecated virtualmachines.kubevirt.io/v1alpha3 API."
+              summary: "Detected 1 requests in the last 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtDeprecatedAPIsRequested"
+            exp_labels:
+              severity: "info"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              resource: "virtualmachines"
+              group: "kubevirt.io"
+              version: "v1alpha3"
+      - eval_time: 3m
+        alertname: KubeVirtDeprecatedAPIsRequested
+        exp_alerts:
+          - exp_annotations:
+              description: "Detected requests to the deprecated virtualmachines.kubevirt.io/v1alpha3 API."
+              summary: "Detected 2 requests in the last 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/KubeVirtDeprecatedAPIsRequested"
+            exp_labels:
+              severity: "info"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              resource: "virtualmachines"
+              group: "kubevirt.io"
+              version: "v1alpha3"
+      - eval_time: 13m
+        alertname: KubeVirtDeprecatedAPIsRequested
+        exp_alerts: []

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -19,7 +19,7 @@
 source $(dirname "$0")/../common.sh
 
 fail_if_cri_bin_missing
-readonly PROM_IMAGE="quay.io/prometheus/prometheus:v2.15.2"
+readonly PROM_IMAGE="quay.io/prometheus/prometheus:v2.44.0"
 
 function cleanup() {
     local cleanup_files=("${@:?}")

--- a/tests/monitoring/prometheus_utils.go
+++ b/tests/monitoring/prometheus_utils.go
@@ -311,7 +311,7 @@ func verifyAlertExist(virtClient kubecli.KubevirtClient, alertName string) {
 	verifyAlertExistWithCustomTime(virtClient, alertName, 120*time.Second)
 }
 
-func waitUntilAlertDoesNotExist(virtClient kubecli.KubevirtClient, alertNames ...string) {
+func waitUntilAlertDoesNotExistWithCustomTime(virtClient kubecli.KubevirtClient, timeout time.Duration, alertNames ...string) {
 	presentAlert := EventuallyWithOffset(1, func() string {
 		for _, name := range alertNames {
 			if checkAlertExists(virtClient, name) {
@@ -319,9 +319,13 @@ func waitUntilAlertDoesNotExist(virtClient kubecli.KubevirtClient, alertNames ..
 			}
 		}
 		return ""
-	}, 5*time.Minute, 1*time.Second)
+	}, timeout, 1*time.Second)
 
 	presentAlert.Should(BeEmpty(), "Alert %v should not exist", presentAlert)
+}
+
+func waitUntilAlertDoesNotExist(virtClient kubecli.KubevirtClient, alertNames ...string) {
+	waitUntilAlertDoesNotExistWithCustomTime(virtClient, 5*time.Minute, alertNames...)
 }
 
 func reduceAlertPendingTime(virtClient kubecli.KubevirtClient) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds an alert which triggers when KubeVirt APIs marked as deprecated
are used. It makes use of the Kubernetes apiserver_requested_deprecated_apis
and apiserver_request_total metrics.

The PromQL query is based on the Kubernetes API deprecation docs [1].

[1] https://kubernetes.io/docs/reference/using-api/deprecation-policy/#rest-resources-aka-api-objects

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
An alert which triggers when KubeVirt APIs marked as deprecated are used was added.
```
