### PR TITLE
virt-handler: LabellerSkipNodeAnnotation should work in runtime

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -206,6 +206,39 @@ var _ = Describe("Node-labeller config", func() {
 		}
 		Expect(badKey).To(BeEmpty())
 	})
+
+	It("The new labels is added if there is no LabellerSkipNodeAnnotation.", func() {
+		node := &k8sv1.Node{}
+
+		obsoleteCPUsx86 := nlController.clusterConfig.GetObsoleteCPUModels()
+		cpuModels := nlController.getSupportedCpuModels()
+		cpuFeatures := nlController.getSupportedCpuFeatures()
+		hostCpuModel = nlController.GetHostCpuModel()
+
+		newLabels := nlController.prepareLabels(node, cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
+
+		Expect(newLabels).ToNot(BeEmpty(), "has labels")
+	})
+
+	It("The new labels is not added if there is LabellerSkipNodeAnnotation.", func() {
+		node := &k8sv1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: nodeLabels,
+				Annotations: map[string]string{
+					kubevirtv1.LabellerSkipNodeAnnotation: "true",
+				},
+			},
+		}
+
+		obsoleteCPUsx86 := nlController.clusterConfig.GetObsoleteCPUModels()
+		cpuModels := nlController.getSupportedCpuModels()
+		cpuFeatures := nlController.getSupportedCpuFeatures()
+		hostCpuModel = nlController.GetHostCpuModel()
+
+		newLabels := nlController.prepareLabels(node, cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
+
+		Expect(newLabels).To(BeEmpty(), "skip labels")
+	})
 })
 
 var nodeLabels = map[string]string{

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -201,10 +201,6 @@ func (n *NodeLabeller) run() error {
 
 	node := originalNode.DeepCopy()
 
-	if skipNode(node) {
-		return nil
-	}
-
 	//prepare new labels
 	newLabels := n.prepareLabels(node, cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
 	//remove old labeller labels
@@ -272,6 +268,10 @@ func (n *NodeLabeller) loadHypervFeatures() {
 // e.g. "cpu-feature.node.kubevirt.io/Penryn": "true"
 func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatures cpuFeatures, hostCpuModel hostCPUModel, obsoleteCPUsx86 map[string]bool) map[string]string {
 	newLabels := make(map[string]string)
+
+	if skipNode(node) {
+		return newLabels
+	}
 	for key := range cpuFeatures {
 		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In some scenarios, users may be very clear about the model of their cluster and do not want to have too many labels.
But the current SkipNode can only work when the handler is started for the first time.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
