### PR TITLE
Add /apis as unAuth enpoint

### DIFF
--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -45,6 +45,7 @@ const (
 
 var noAuthEndpoints = map[string]struct{}{
 	"/":           {},
+	"/apis":       {},
 	"/healthz":    {},
 	"/openapi/v2": {},
 	// The endpoints with just the version are needed for api aggregation discovery

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -223,6 +223,7 @@ var _ = Describe("Authorizer", func() {
 			},
 				// Root resources
 				Entry("root", "/"),
+				Entry("apis", "/apis"),
 				Entry("healthz", "/healthz"),
 				Entry("openapi", "/openapi/v2"),
 				Entry("start profiler", "/start-profiler"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Add /apis as unAuth enpoint
This path is being queried by Kubernetes
\>= 1.27 and therefore needs to be exposed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9725


**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
