### PR TITLE
Add vmi cached memory  metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -90,6 +90,9 @@ Current balloon size in bytes. Type: Gauge.
 ### kubevirt_vmi_memory_available_bytes
 Amount of usable memory as seen by the domain. This value may not be accurate if a balloon driver is in use or if the guest OS does not initialize all assigned pages Type: Gauge.
 
+### kubevirt_vmi_memory_cached_bytes
+The amount of memory that is being used to cache I/O and is available to be reclaimed, corresponds to the sum of `Buffers` + `Cached` + `SwapCached` in `/proc/meminfo`. Type: Gauge.
+
 ### kubevirt_vmi_memory_domain_bytes_total
 The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file. Type: Gauge.
 

--- a/pkg/monitoring/domainstats/prometheus/prometheus.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus.go
@@ -150,6 +150,15 @@ func (metrics *vmiMetrics) updateMemory(mem *stats.DomainStatsMemory) {
 		)
 	}
 
+	if mem.CachedSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_cached_bytes",
+			"The amount of memory that is being used to cache I/O and is available to be reclaimed, corresponds to the sum of `Buffers` + `Cached` + `SwapCached` in `/proc/meminfo`.",
+			prometheus.GaugeValue,
+			float64(mem.Cached)*1024,
+		)
+	}
+
 	if mem.SwapInSet {
 		metrics.pushCommonMetric(
 			"kubevirt_vmi_memory_swap_in_traffic_bytes_total",

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -152,6 +152,8 @@ type DomainStatsBlock struct {
 type DomainStatsMemory struct {
 	UnusedSet        bool
 	Unused           uint64
+	CachedSet        bool
+	Cached           uint64
 	AvailableSet     bool
 	Available        uint64
 	ActualBalloonSet bool

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -84,6 +84,9 @@ func Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem []libvirt.Domai
 		case libvirt.DOMAIN_MEMORY_STAT_UNUSED:
 			ret.UnusedSet = true
 			ret.Unused = stat.Val
+		case libvirt.DOMAIN_MEMORY_STAT_DISK_CACHES:
+			ret.CachedSet = true
+			ret.Cached = stat.Val
 		case libvirt.DOMAIN_MEMORY_STAT_AVAILABLE:
 			ret.AvailableSet = true
 			ret.Available = stat.Val

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -172,6 +172,8 @@ var Testdataexpected = `{
      "SwapOutSet": false,
      "Unused": 0, 
      "UnusedSet": false,
+     "Cached": 0, 
+     "CachedSet": false,
      "MajorFault": 0,
      "MajorFaultSet": false,
      "MinorFault": 0,

--- a/tools/doc-generator/fakeDomainCollector.go
+++ b/tools/doc-generator/fakeDomainCollector.go
@@ -43,6 +43,7 @@ func (fc fakeDomainCollector) Collect(ch chan<- prometheus.Metric) {
 
 	out.Memory.ActualBalloonSet = true
 	out.Memory.UnusedSet = true
+	out.Memory.CachedSet = true
 	out.Memory.AvailableSet = true
 	out.Memory.RSSSet = true
 	out.Memory.SwapInSet = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does**: 
This PR adds a vmi metric -`kubevirt_vmi_memory_cached_bytes`, which relies on [VIR_DOMAIN_MEMORY_STAT_DISK_CACHES](https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainMemoryStatTags) stat, by using https://github.com/libvirt/libvirt-go/blob/master/domain.go#L383.

**why we need it**:
Some applications use cached memory and never release it. Users need to take this memory into account when planning the memory requirements. 

**Which issue(s) this PR fixes**:
[CNV-15415](https://issues.redhat.com/browse/CNV-15415) (same metric that was added in https://bugzilla.redhat.com/show_bug.cgi?id=1024010 is needed in KV).


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `kubevirt_vmi_memory_cached_bytes` metric
```
