### PR TITLE
Update OWNERS to the new alias

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
-  - scale-reviewers
+  - sig-scale-reviewers
 approvers:
-  - scale-approvers
+  - sig-scale-approvers
 labels:
   - sig/scale

--- a/pkg/monitoring/perfscale/OWNERS
+++ b/pkg/monitoring/perfscale/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
-  - scale-reviewers
+  - sig-scale-reviewers
 approvers:
-  - scale-approvers
+  - sig-scale-approvers
 labels:
   - sig/scale

--- a/pkg/network/OWNERS
+++ b/pkg/network/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
-  - network-reviewers
+  - sig-network-reviewers
 approvers:
-  - network-approvers
+  - sig-network-approvers
 labels:
   - sig/network

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 reviewers:
-  - test-reviewers
+  - sig-test-reviewers
 approvers:
-  - test-approvers
+  - sig-test-approvers

--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
-  - network-reviewers
+  - sig-network-reviewers
 approvers:
-  - network-approvers
+  - sig-network-approvers
 labels:
   - sig/network

--- a/tests/performance/OWNERS
+++ b/tests/performance/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
-  - scale-reviewers
+  - sig-scale-reviewers
 approvers:
-  - scale-approvers
+  - sig-scale-approvers
 labels:
   - sig/scale

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
-  - scale-reviewers
+  - sig-scale-reviewers
 approvers:
-  - scale-approvers
+  - sig-scale-approvers
 labels:
   - sig/scale


### PR DESCRIPTION
Approvers and Reviewers aliases were updated as part of https://github.com/kubevirt/kubevirt/pull/9453.  Update the affected OWNERS files.

```release-note
None
```
