### PR TITLE
sig-scale: use right directory for ARTIFACTS in density tests

### DIFF
--- a/hack/perfscale-tests.sh
+++ b/hack/perfscale-tests.sh
@@ -29,7 +29,7 @@ export PROMETHEUS_URL=${PROMETHEUS_URL:-http://127.0.0.1}
 export PERFSCALE_WORKLOAD=${PERFSCALE_WORKLOAD:-${_perfscale_workload}}
 
 echo 'Preparing directory for artifacts'
-export ARTIFACTS=_out/artifacts/perfscale
+export ARTIFACTS=${ARTIFACTS}/performance-density
 export AUDIT_CONFIG=${ARTIFACTS}/perfscale-audit-cfg.json
 export AUDIT_RESULTS=${ARTIFACTS}/perfscale-audit-results.json
 rm -rf $ARTIFACTS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This fixes the artifacts exported to s3 bucket. Currently the artifacts directory is missing the audit results

See this for reference: https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/logs/periodic-kubevirt-performance-cluster-100-density-test/1638400214094057472/




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This removes overriding the ARTIFACTS variable set by prow 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
