### PR TITLE
hotunplug - reverse phase1

### DIFF
--- a/pkg/network/cache/dhcpconfig.go
+++ b/pkg/network/cache/dhcpconfig.go
@@ -49,6 +49,14 @@ func WriteDHCPInterfaceCache(c cacheCreator, pid, ifaceName string, dhcpConfig *
 	return dhcpCache.Write(dhcpConfig)
 }
 
+func DeleteDHCPInterfaceCache(c cacheCreator, pid, ifaceName string) error {
+	dhcpCache, err := NewDHCPInterfaceCache(c, pid).IfaceEntry(ifaceName)
+	if err != nil {
+		return err
+	}
+	return dhcpCache.Delete()
+}
+
 func NewDHCPInterfaceCache(creator cacheCreator, pid string) DHCPInterfaceCache {
 	podRootFilesystemPath := fmt.Sprintf("/proc/%s/root", pid)
 	return DHCPInterfaceCache{creator.New(filepath.Join(podRootFilesystemPath, util.VirtPrivateDir))}
@@ -73,6 +81,10 @@ func (d DHCPInterfaceCache) Read() (*DHCPConfig, error) {
 
 func (d DHCPInterfaceCache) Write(dhcpConfig *DHCPConfig) error {
 	return d.cache.Write(dhcpConfig)
+}
+
+func (d DHCPInterfaceCache) Delete() error {
+	return d.cache.Delete()
 }
 
 type DHCPConfig struct {

--- a/pkg/network/cache/domaininterface.go
+++ b/pkg/network/cache/domaininterface.go
@@ -52,6 +52,14 @@ func NewDomainInterfaceCache(creator cacheCreator, pid string) DomainInterfaceCa
 	return DomainInterfaceCache{creator.New(filepath.Join(podRootFilesystemPath, util.VirtPrivateDir))}
 }
 
+func DeleteDomainInterfaceCache(c cacheCreator, pid, ifaceName string) error {
+	domainCache, err := NewDomainInterfaceCache(c, pid).IfaceEntry(ifaceName)
+	if err != nil {
+		return err
+	}
+	return domainCache.Delete()
+}
+
 func (d DomainInterfaceCache) IfaceEntry(ifaceName string) (DomainInterfaceCache, error) {
 	const domainIfaceCacheFileFormat = "interface-cache-%s.json"
 	cacheFileName := fmt.Sprintf(domainIfaceCacheFileFormat, ifaceName)
@@ -71,4 +79,8 @@ func (d DomainInterfaceCache) Read() (*api.Interface, error) {
 
 func (d DomainInterfaceCache) Write(domainInterface *api.Interface) error {
 	return d.cache.Write(domainInterface)
+}
+
+func (d DomainInterfaceCache) Delete() error {
+	return d.cache.Delete()
 }

--- a/pkg/network/cache/domaininterface_test.go
+++ b/pkg/network/cache/domaininterface_test.go
@@ -39,4 +39,17 @@ var _ = Describe("DomainInterfaceCache", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(newObj).To(Equal(obj))
 	})
+
+	It("should delete pod interface from the cache", func() {
+		domainIfaceCache, err := cache.NewDomainInterfaceCache(&cacheCreator, "123").IfaceEntry("abc")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domainIfaceCache.Write(obj)).To(Succeed())
+		newObj, err := domainIfaceCache.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(newObj).To(Equal(obj))
+
+		Expect(domainIfaceCache.Delete()).To(Succeed())
+		_, err = domainIfaceCache.Read()
+		Expect(err).To(MatchError(os.ErrNotExist))
+	})
 })

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -71,6 +71,7 @@ type NetworkHandler interface {
 	LinkSetUp(link netlink.Link) error
 	LinkSetName(link netlink.Link, name string) error
 	LinkAdd(link netlink.Link) error
+	LinkDel(link netlink.Link) error
 	LinkSetLearningOff(link netlink.Link) error
 	ParseAddr(s string) (*netlink.Addr, error)
 	LinkSetHardwareAddr(link netlink.Link, hwaddr net.HardwareAddr) error
@@ -126,6 +127,9 @@ func (h *NetworkUtilsHandler) LinkSetName(link netlink.Link, name string) error 
 }
 func (h *NetworkUtilsHandler) LinkAdd(link netlink.Link) error {
 	return netlink.LinkAdd(link)
+}
+func (h *NetworkUtilsHandler) LinkDel(link netlink.Link) error {
+	return netlink.LinkDel(link)
 }
 func (h *NetworkUtilsHandler) LinkSetLearningOff(link netlink.Link) error {
 	return netlink.LinkSetLearning(link, false)

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -149,6 +149,16 @@ func (_mr *_MockNetworkHandlerRecorder) LinkAdd(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkAdd", arg0)
 }
 
+func (_m *MockNetworkHandler) LinkDel(link netlink.Link) error {
+	ret := _m.ctrl.Call(_m, "LinkDel", link)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) LinkDel(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkDel", arg0)
+}
+
 func (_m *MockNetworkHandler) LinkSetLearningOff(link netlink.Link) error {
 	ret := _m.ctrl.Call(_m, "LinkSetLearningOff", link)
 	ret0, _ := ret[0].(error)

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -70,6 +70,5 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -60,7 +60,6 @@ go_test(
         "//pkg/network/sriov:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/os/fs:go_default_library",
-        "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
     ],
 )
 
@@ -66,5 +67,6 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "netstat.go",
         "network.go",
         "podnic.go",
+        "unpluggedpodnic.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/network/setup",
     visibility = ["//visibility:public"],
@@ -29,6 +30,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
     ],
@@ -44,6 +46,7 @@ go_test(
         "network_suite_test.go",
         "network_test.go",
         "podnic_test.go",
+        "unpluggedpodnic_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/network/setup/configstate_test.go
+++ b/pkg/network/setup/configstate_test.go
@@ -48,198 +48,264 @@ var _ = Describe("config state", func() {
 		ns               nsExecutorStub
 	)
 
-	BeforeEach(func() {
-		configStateCache = newConfigStateCacheStub()
-		ns = nsExecutorStub{}
-		configState = NewConfigState(&configStateCache, ns)
-		nics = []podNIC{{
-			vmiSpecNetwork: &v1.Network{Name: testNet0},
-		}}
-	})
-
-	It("runs with no current state (cache is empty)", func() {
-		discover, config := &funcStub{}, &funcStub{}
-
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
-
-		Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
-		Expect(config.executedNetworks).To(Equal([]string{testNet0}), "the config step should execute")
-
-		state, err := configStateCache.Read(testNet0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
-	})
-
-	It("runs with current pending state", func() {
-		Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationPending)).To(Succeed())
-		discover, config := &funcStub{}, &funcStub{}
-
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
-
-		Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
-		Expect(config.executedNetworks).To(Equal([]string{testNet0}), "the config step should execute")
-
-		state, err := configStateCache.Read(testNet0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
-	})
-
-	It("runs with current started state", func() {
-		Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationStarted)).To(Succeed())
-		discover, config := &funcStub{}, &funcStub{}
-
-		ns.shouldNotBeExecuted = true
-		err := configState.Run(nics, noopCSPreRun, discover.f, config.f)
-		Expect(err).To(HaveOccurred())
-		var criticalNetErr *neterrors.CriticalNetworkError
-		Expect(errors.As(err, &criticalNetErr)).To(BeTrue())
-
-		Expect(discover.executedNetworks).To(BeEmpty(), "the discover step should not be execute")
-		Expect(config.executedNetworks).To(BeEmpty(), "the config step should not be execute")
-
-		state, err := configStateCache.Read(testNet0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
-	})
-
-	It("runs with current finished state", func() {
-		Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
-		discover, config := &funcStub{}, &funcStub{}
-
-		ns.shouldNotBeExecuted = true
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
-
-		Expect(discover.executedNetworks).To(BeEmpty(), "the discover step should not be execute")
-		Expect(config.executedNetworks).To(BeEmpty(), "the config step should not be execute")
-
-		state, err := configStateCache.Read(testNet0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
-	})
-
-	It("runs and fails at the discover step", func() {
-		injectedErr := fmt.Errorf("fail discovery")
-		discover, config := &funcStub{errRun: injectedErr}, &funcStub{}
-
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
-
-		Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
-		Expect(config.executedNetworks).To(BeEmpty(), "the config step should not execute")
-
-		state, err := configStateCache.Read(testNet0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(state).To(Equal(cache.PodIfaceNetworkPreparationPending))
-	})
-
-	It("runs and fails at the config step", func() {
-		injectedErr := fmt.Errorf("fail config")
-		discover, config := &funcStub{}, &funcStub{errRun: injectedErr}
-
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
-
-		Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
-		Expect(config.executedNetworks).To(Equal([]string{testNet0}), "the config step should execute")
-
-		state, err := configStateCache.Read(testNet0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
-	})
-
-	It("runs and fails reading the cache", func() {
-		injectedErr := fmt.Errorf("fail read cache")
-		configStateCache.readErr = injectedErr
-		configState = NewConfigState(&configStateCache, ns)
-
-		discover, config := &funcStub{}, &funcStub{}
-
-		ns.shouldNotBeExecuted = true
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
-
-		Expect(discover.executedNetworks).To(BeEmpty(), "the discover step shouldn't execute")
-		Expect(config.executedNetworks).To(BeEmpty(), "the config step shouldn't execute")
-	})
-
-	It("runs and fails writing the cache", func() {
-		injectedErr := fmt.Errorf("fail write cache")
-		configStateCache.writeErr = injectedErr
-		configState = NewConfigState(&configStateCache, ns)
-
-		discover, config := &funcStub{}, &funcStub{}
-
-		Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
-
-		Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
-		Expect(config.executedNetworks).To(BeEmpty(), "the config step shouldn't execute")
-	})
-
-	When("with multiple interfaces", func() {
+	Context("Run", func() {
 		BeforeEach(func() {
-			nics = append(nics,
-				podNIC{vmiSpecNetwork: &v1.Network{Name: testNet1}},
-				podNIC{vmiSpecNetwork: &v1.Network{Name: testNet2}},
-			)
+			configStateCache = newConfigStateCacheStub()
+			ns = nsExecutorStub{}
+			configState = NewConfigState(&configStateCache, ns)
+			nics = []podNIC{{
+				vmiSpecNetwork: &v1.Network{Name: testNet0},
+			}}
 		})
 
 		It("runs with no current state (cache is empty)", func() {
-			discover, config := &funcStub{}, &funcStub{}
+			discover, config := &plugFuncStub{}, &plugFuncStub{}
 
 			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
 
-			Expect(discover.executedNetworks).To(Equal([]string{testNet0, testNet1, testNet2}))
-			Expect(config.executedNetworks).To(Equal([]string{testNet0, testNet1, testNet2}))
+			Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
+			Expect(config.executedNetworks).To(Equal([]string{testNet0}), "the config step should execute")
 
-			for _, testNet := range []string{testNet0, testNet1, testNet2} {
-				state, err := configStateCache.Read(testNet)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
-			}
+			state, err := configStateCache.Read(testNet0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
 		})
 
-		It("runs and fails at the config step, 2nd network", func() {
-			injectedErr := fmt.Errorf("fail config")
-			discover, config := &funcStub{}, &funcStub{errRun: injectedErr, errRunForPodIfaceName: testNet1}
+		It("runs with current pending state", func() {
+			Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationPending)).To(Succeed())
+			discover, config := &plugFuncStub{}, &plugFuncStub{}
+
+			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
+
+			Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
+			Expect(config.executedNetworks).To(Equal([]string{testNet0}), "the config step should execute")
+
+			state, err := configStateCache.Read(testNet0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+		})
+
+		It("runs with current started state", func() {
+			Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationStarted)).To(Succeed())
+			discover, config := &plugFuncStub{}, &plugFuncStub{}
+
+			ns.shouldNotBeExecuted = true
+			err := configState.Run(nics, noopCSPreRun, discover.f, config.f)
+			Expect(err).To(HaveOccurred())
+			var criticalNetErr *neterrors.CriticalNetworkError
+			Expect(errors.As(err, &criticalNetErr)).To(BeTrue())
+
+			Expect(discover.executedNetworks).To(BeEmpty(), "the discover step should not be execute")
+			Expect(config.executedNetworks).To(BeEmpty(), "the config step should not be execute")
+
+			state, err := configStateCache.Read(testNet0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+		})
+
+		It("runs with current finished state", func() {
+			Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
+			discover, config := &plugFuncStub{}, &plugFuncStub{}
+
+			ns.shouldNotBeExecuted = true
+			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
+
+			Expect(discover.executedNetworks).To(BeEmpty(), "the discover step should not be execute")
+			Expect(config.executedNetworks).To(BeEmpty(), "the config step should not be execute")
+
+			state, err := configStateCache.Read(testNet0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+		})
+
+		It("runs and fails at the discover step", func() {
+			injectedErr := fmt.Errorf("fail discovery")
+			discover, config := &plugFuncStub{errRun: injectedErr}, &plugFuncStub{}
 
 			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
 
-			Expect(discover.executedNetworks).To(Equal([]string{testNet0, testNet1, testNet2}))
-			Expect(config.executedNetworks).To(Equal([]string{testNet0, testNet1}))
+			Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
+			Expect(config.executedNetworks).To(BeEmpty(), "the config step should not execute")
 
-			for _, testNet := range []string{testNet0, testNet1, testNet2} {
-				state, err := configStateCache.Read(testNet)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
-			}
+			state, err := configStateCache.Read(testNet0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationPending))
 		})
 
-		It("runs with filter that removes all networks", func() {
-			discover, config := &funcStub{}, &funcStub{}
-			preRunFilterOutAll := func(_ []podNIC) ([]podNIC, error) {
-				return nil, nil
-			}
-			Expect(configState.Run(nics, preRunFilterOutAll, discover.f, config.f)).To(Succeed())
+		It("runs and fails at the config step", func() {
+			injectedErr := fmt.Errorf("fail config")
+			discover, config := &plugFuncStub{}, &plugFuncStub{errRun: injectedErr}
 
-			Expect(discover.executedNetworks).To(BeEmpty())
-			Expect(config.executedNetworks).To(BeEmpty())
+			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
+
+			Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
+			Expect(config.executedNetworks).To(Equal([]string{testNet0}), "the config step should execute")
+
+			state, err := configStateCache.Read(testNet0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+		})
+
+		It("runs and fails reading the cache", func() {
+			injectedErr := fmt.Errorf("fail read cache")
+			configStateCache.readErr = injectedErr
+			configState = NewConfigState(&configStateCache, ns)
+
+			discover, config := &plugFuncStub{}, &plugFuncStub{}
+
+			ns.shouldNotBeExecuted = true
+			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
+
+			Expect(discover.executedNetworks).To(BeEmpty(), "the discover step shouldn't execute")
+			Expect(config.executedNetworks).To(BeEmpty(), "the config step shouldn't execute")
+		})
+
+		It("runs and fails writing the cache", func() {
+			injectedErr := fmt.Errorf("fail write cache")
+			configStateCache.writeErr = injectedErr
+			configState = NewConfigState(&configStateCache, ns)
+
+			discover, config := &plugFuncStub{}, &plugFuncStub{}
+
+			Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
+
+			Expect(discover.executedNetworks).To(Equal([]string{testNet0}), "the discover step should execute")
+			Expect(config.executedNetworks).To(BeEmpty(), "the config step shouldn't execute")
+		})
+
+		When("with multiple interfaces", func() {
+			BeforeEach(func() {
+				nics = append(nics,
+					podNIC{vmiSpecNetwork: &v1.Network{Name: testNet1}},
+					podNIC{vmiSpecNetwork: &v1.Network{Name: testNet2}},
+				)
+			})
+
+			It("runs with no current state (cache is empty)", func() {
+				discover, config := &plugFuncStub{}, &plugFuncStub{}
+
+				Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(Succeed())
+
+				Expect(discover.executedNetworks).To(Equal([]string{testNet0, testNet1, testNet2}))
+				Expect(config.executedNetworks).To(Equal([]string{testNet0, testNet1, testNet2}))
+
+				for _, testNet := range []string{testNet0, testNet1, testNet2} {
+					state, err := configStateCache.Read(testNet)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(state).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+				}
+			})
+
+			It("runs and fails at the config step, 2nd network", func() {
+				injectedErr := fmt.Errorf("fail config")
+				discover, config := &plugFuncStub{}, &plugFuncStub{errRun: injectedErr, errRunForPodIfaceName: testNet1}
+
+				Expect(configState.Run(nics, noopCSPreRun, discover.f, config.f)).To(MatchError(injectedErr))
+
+				Expect(discover.executedNetworks).To(Equal([]string{testNet0, testNet1, testNet2}))
+				Expect(config.executedNetworks).To(Equal([]string{testNet0, testNet1}))
+
+				for _, testNet := range []string{testNet0, testNet1, testNet2} {
+					state, err := configStateCache.Read(testNet)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(state).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+				}
+			})
+
+			It("runs with filter that removes all networks", func() {
+				discover, config := &plugFuncStub{}, &plugFuncStub{}
+				preRunFilterOutAll := func(_ []podNIC) ([]podNIC, error) {
+					return nil, nil
+				}
+				Expect(configState.Run(nics, preRunFilterOutAll, discover.f, config.f)).To(Succeed())
+
+				Expect(discover.executedNetworks).To(BeEmpty())
+				Expect(config.executedNetworks).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("UnplugNetworks", func() {
+		var specInterfaces []v1.Interface
+
+		BeforeEach(func() {
+			configStateCache = newConfigStateCacheStub()
+			ns = nsExecutorStub{}
+			configState = NewConfigState(&configStateCache, ns)
+			specInterfaces = []v1.Interface{{Name: testNet0}, {Name: testNet1}, {Name: testNet2}}
+			Expect(configStateCache.Write(testNet0, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
+			Expect(configStateCache.Write(testNet1, cache.PodIfaceNetworkPreparationStarted)).To(Succeed())
+			Expect(configStateCache.Write(testNet2, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
+		})
+		It("There are no networks to unplug", func() {
+			ns.shouldNotBeExecuted = true
+			unplugFunc := &unplugFuncStub{}
+			err := configState.UnplugNetworks(specInterfaces, unplugFunc.f)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unplugFunc.executedNetworks).To(BeEmpty(), "the unplug step shouldn't execute")
+		})
+		It("There is one network to unplug", func() {
+			specInterfaces[0].State = v1.InterfaceStateAbsent
+
+			ns.shouldNotBeExecuted = false
+			unplugFunc := &unplugFuncStub{}
+			err := configState.UnplugNetworks(specInterfaces, unplugFunc.f)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unplugFunc.executedNetworks).To(ConsistOf([]string{testNet0}))
+		})
+		It("There are multiple networks to unplug", func() {
+			specInterfaces[0].State = v1.InterfaceStateAbsent
+			specInterfaces[1].State = v1.InterfaceStateAbsent
+
+			ns.shouldNotBeExecuted = false
+			unplugFunc := &unplugFuncStub{}
+			err := configState.UnplugNetworks(specInterfaces, unplugFunc.f)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unplugFunc.executedNetworks).To(ConsistOf([]string{testNet0, testNet1}))
+		})
+		It("There are multiple networks to unplug and some have errors on cleanup", func() {
+			specInterfaces[0].State = v1.InterfaceStateAbsent
+			specInterfaces[1].State = v1.InterfaceStateAbsent
+			specInterfaces[2].State = v1.InterfaceStateAbsent
+
+			ns.shouldNotBeExecuted = false
+			injectedErr := fmt.Errorf("fails unplug")
+			injectedErr3 := fmt.Errorf("fails unplug3")
+			unplugFunc := &unplugFuncStub{errRunForPodIfaces: map[string]error{testNet0: injectedErr, testNet2: injectedErr3}}
+			err := configState.UnplugNetworks(specInterfaces, unplugFunc.f)
+			Expect(err.Error()).To(ContainSubstring(injectedErr.Error()))
+			Expect(err.Error()).To(ContainSubstring(injectedErr3.Error()))
+			Expect(unplugFunc.executedNetworks).To(ConsistOf([]string{testNet0, testNet1, testNet2}))
 		})
 	})
 })
 
-type funcStub struct {
+type plugFuncStub struct {
 	executedNetworks      []string
 	errRun                error
 	errRunForPodIfaceName string
 }
 
-func (f *funcStub) f(nic *podNIC) error {
+func (f *plugFuncStub) f(nic *podNIC) error {
 	f.executedNetworks = append(f.executedNetworks, nic.vmiSpecNetwork.Name)
 
 	// If an error is specified, return it if there is no filter at all, or if the filter is specified and matches.
-	// The filter is the pod interface name.
+	// The filter is the network name.
 	var err error
 	if f.errRunForPodIfaceName == "" || f.errRunForPodIfaceName == nic.vmiSpecNetwork.Name {
 		err = f.errRun
 	}
 	return err
+}
+
+type unplugFuncStub struct {
+	executedNetworks   []string
+	errRunForPodIfaces map[string]error
+}
+
+func (f *unplugFuncStub) f(name string) error {
+	f.executedNetworks = append(f.executedNetworks, name)
+	return f.errRunForPodIfaces[name]
 }
 
 func noopCSPreRun(nics []podNIC) ([]podNIC, error) {

--- a/pkg/network/setup/configstatecache.go
+++ b/pkg/network/setup/configstatecache.go
@@ -97,5 +97,17 @@ func (c *ConfigStateCache) Exists(key string) (bool, error) {
 
 func (c *ConfigStateCache) Delete(key string) error {
 	delete(c.volatilePodIfaceState, key)
-	return cache.DeletePodInterfaceCache(c.cacheCreator, c.vmiUID, key)
+	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, key)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	podIfaceCacheData.State = cache.PodIfaceNetworkPreparationPending
+	err = cache.WritePodInterfaceCache(c.cacheCreator, c.vmiUID, key, podIfaceCacheData)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/network/setup/configstatecache_test.go
+++ b/pkg/network/setup/configstatecache_test.go
@@ -114,4 +114,16 @@ var _ = Describe("config state cache", func() {
 
 		})
 	})
+
+	Context("delete", func() {
+		It("from an empty cache", func() {
+			Expect(configStateCache.Delete(testNet)).To(Succeed())
+		})
+		It("successfully", func() {
+			Expect(configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationStarted)).To(Succeed())
+			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+			Expect(configStateCache.Delete(testNet)).To(Succeed())
+			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationPending))
+		})
+	})
 })

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -130,3 +130,15 @@ func (c *NetConf) Teardown(vmi *v1.VirtualMachineInstance) error {
 
 	return nil
 }
+
+func (c *NetConf) HotUnplugInterfaces(vmi *v1.VirtualMachineInstance) error {
+	c.configStateMutex.RLock()
+	configState, ok := c.configState[string(vmi.UID)]
+	c.configStateMutex.RUnlock()
+
+	if !ok {
+		return nil
+	}
+	netConfigurator := NewVMNetworkConfigurator(vmi, c.cacheCreator)
+	return netConfigurator.UnplugPodNetworksPhase1(vmi, &configState)
+}

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -84,7 +84,7 @@ func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, l
 			return err
 		}
 		ns := c.nsFactory(launcherPid)
-		configState = NewConfigState(configStateCache, ns)
+		configState = NewConfigState(configStateCache, ns, launcherPid)
 		c.configStateMutex.Lock()
 		c.configState[string(vmi.UID)] = configState
 		c.configStateMutex.Unlock()

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -38,7 +38,7 @@ type VMNetworkConfigurator struct {
 }
 
 type configStateUnplugger interface {
-	UnplugNetworks(specInterfaces []v1.Interface, cleanupFunc func(string) error) error
+	UnplugNetworks(specInterfaces []v1.Interface, cleanupFunc func(network string, launcherPid int) error) error
 }
 
 func newVMNetworkConfiguratorWithHandlerAndCache(vmi *v1.VirtualMachineInstance, handler netdriver.NetworkHandler, cacheCreator cacheCreator) *VMNetworkConfigurator {
@@ -167,8 +167,8 @@ func (n *VMNetworkConfigurator) UnplugPodNetworksPhase1(vmi *v1.VirtualMachineIn
 	networkByName := vmispec.IndexNetworkSpecByName(vmi.Spec.Networks)
 	err := configState.UnplugNetworks(
 		vmi.Spec.Domain.Devices.Interfaces,
-		func(network string) error {
-			unpluggedPodNic := NewUnpluggedpodnic(networkByName[network], n.handler)
+		func(network string, launcherPid int) error {
+			unpluggedPodNic := NewUnpluggedpodnic(string(vmi.UID), networkByName[network], n.handler, launcherPid, n.cacheCreator)
 			return unpluggedPodNic.UnplugPhase1()
 		})
 	if err != nil {

--- a/pkg/network/setup/network.go
+++ b/pkg/network/setup/network.go
@@ -164,12 +164,12 @@ func filterOutAbsentIfaces(nics []podNIC) []podNIC {
 }
 
 func (n *VMNetworkConfigurator) UnplugPodNetworksPhase1(vmi *v1.VirtualMachineInstance, configState configStateUnplugger) error {
+	networkByName := vmispec.IndexNetworkSpecByName(vmi.Spec.Networks)
 	err := configState.UnplugNetworks(
 		vmi.Spec.Domain.Devices.Interfaces,
 		func(network string) error {
-			// TODO clean cache
-			// TODO remove bridge and tap device
-			return nil
+			unpluggedPodNic := NewUnpluggedpodnic(networkByName[network], n.handler)
+			return unpluggedPodNic.UnplugPhase1()
 		})
 	if err != nil {
 		return fmt.Errorf("failed unplug pod networks phase1: %w", err)

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -82,13 +82,18 @@ func newConfigStateCacheStub() configStateCacheStub {
 	return configStateCacheStub{map[string]cache.PodIfaceState{}, nil, nil}
 }
 
-func (c configStateCacheStub) Read(podInterfaceName string) (cache.PodIfaceState, error) {
-	return c.stateCache[podInterfaceName], c.readErr
+func (c configStateCacheStub) Read(key string) (cache.PodIfaceState, error) {
+	return c.stateCache[key], c.readErr
 }
 
-func (c configStateCacheStub) Write(podInterfaceName string, state cache.PodIfaceState) error {
-	c.stateCache[podInterfaceName] = state
+func (c configStateCacheStub) Write(key string, state cache.PodIfaceState) error {
+	c.stateCache[key] = state
 	return c.writeErr
+}
+
+func (c configStateCacheStub) Delete(key string) error {
+	delete(c.stateCache, key)
+	return nil
 }
 
 type nsExecutorStub struct {

--- a/pkg/network/setup/network_suite_test.go
+++ b/pkg/network/setup/network_suite_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -103,4 +104,23 @@ type nsExecutorStub struct {
 func (n nsExecutorStub) Do(f func() error) error {
 	Expect(n.shouldNotBeExecuted).To(BeFalse(), "The namespace executor shouldn't be invoked")
 	return f()
+}
+
+type ConfigStateStub struct {
+	UnplugShouldFail  bool
+	UnplugWasExecuted bool
+	RunWasExecuted    bool
+}
+
+func (c *ConfigStateStub) Unplug(_ []v1.Network, _ func([]v1.Network) ([]string, error), _ func(string) error) error {
+	c.UnplugWasExecuted = true
+	if c.UnplugShouldFail {
+		return fmt.Errorf("Unplug failure")
+	}
+	return nil
+}
+
+func (c *ConfigStateStub) Run(_ []podNIC, _ func([]podNIC) ([]podNIC, error), _ func(*podNIC) error, _ func(*podNIC) error) error {
+	c.RunWasExecuted = true
+	return nil
 }

--- a/pkg/network/setup/network_test.go
+++ b/pkg/network/setup/network_test.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	dutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 
 	"github.com/golang/mock/gomock"
@@ -373,7 +375,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 		var configState configStateUnplugger
 
 		BeforeEach(func() {
-			vmi = api2.NewMinimalVMIWithNS("testnamespace", "testVmName")
+			vmi = &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{UID: "123"}}
+			vmi.Spec.Networks = []v1.Network{}
 			vmNetworkConfigurator = NewVMNetworkConfigurator(vmi, nil)
 		})
 		It("should succeed on successful UnplugNetworks", func() {

--- a/pkg/network/setup/podnic.go
+++ b/pkg/network/setup/podnic.go
@@ -96,7 +96,11 @@ func newPhase2PodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, handle
 	if err != nil {
 		return nil, err
 	}
-	podnic.podInterfaceName = ifaceLink.Attrs().Name
+	if ifaceLink == nil {
+		podnic.podInterfaceName = ""
+	} else {
+		podnic.podInterfaceName = ifaceLink.Attrs().Name
+	}
 
 	podnic.dhcpConfigurator = podnic.newDHCPConfigurator()
 	podnic.domainGenerator = podnic.newLibvirtSpecGenerator(domain)

--- a/pkg/network/setup/unpluggedpodnic.go
+++ b/pkg/network/setup/unpluggedpodnic.go
@@ -1,0 +1,85 @@
+/*
+* This file is part of the KubeVirt project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Copyright 2023 Red Hat, Inc.
+*
+ */
+
+package network
+
+import (
+	"errors"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
+
+	"github.com/vishvananda/netlink"
+	k8serrors "k8s.io/apimachinery/pkg/util/errors"
+
+	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
+	virtnetlink "kubevirt.io/kubevirt/pkg/network/link"
+)
+
+type Unpluggedpodnic struct {
+	network v1.Network
+	handler netdriver.NetworkHandler
+}
+
+func NewUnpluggedpodnic(network v1.Network, handler netdriver.NetworkHandler) Unpluggedpodnic {
+	return Unpluggedpodnic{network: network, handler: handler}
+}
+
+func (c Unpluggedpodnic) UnplugPhase1() error {
+	var unplugErrors []error
+
+	podInterfaceName := namescheme.HashedPodInterfaceName(c.network)
+	bridgeName := virtnetlink.GenerateBridgeName(podInterfaceName)
+	err := c.delLinkIfExists(bridgeName)
+	if err != nil {
+		unplugErrors = append(unplugErrors, err)
+	}
+
+	// remove extra nic
+	dummyIfaceName := virtnetlink.GenerateNewBridgedVmiInterfaceName(podInterfaceName)
+	err = c.delLinkIfExists(dummyIfaceName)
+	if err != nil {
+		unplugErrors = append(unplugErrors, err)
+	}
+
+	// remove tap if exists
+	tapDeviceName := virtnetlink.GenerateTapDeviceName(podInterfaceName)
+	err = c.delLinkIfExists(tapDeviceName)
+	if err != nil {
+		unplugErrors = append(unplugErrors, err)
+	}
+
+	// clean caches
+	// TODO remove all three cache files
+
+	return k8serrors.NewAggregate(unplugErrors)
+}
+
+func (c Unpluggedpodnic) delLinkIfExists(linkName string) error {
+	link, err := c.handler.LinkByName(linkName)
+	if err != nil {
+		var linkNotFoundErr netlink.LinkNotFoundError
+		if errors.As(err, &linkNotFoundErr) {
+			return nil
+		}
+		return err
+	}
+	return c.handler.LinkDel(link)
+}

--- a/pkg/network/setup/unpluggedpodnic_test.go
+++ b/pkg/network/setup/unpluggedpodnic_test.go
@@ -1,0 +1,101 @@
+/*
+* This file is part of the KubeVirt project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Copyright 2023 Red Hat, Inc.
+*
+ */
+
+package network_test
+
+import (
+	"fmt"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/vishvananda/netlink"
+
+	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
+	network "kubevirt.io/kubevirt/pkg/network/setup"
+)
+
+var _ = Describe("Unpluggedpodnic", func() {
+	var (
+		mockHandler     *netdriver.MockNetworkHandler
+		ctrl            *gomock.Controller
+		unpluggedpodnic network.Unpluggedpodnic
+		tapLink         *netlink.GenericLink
+		dummyIfaceLink  *netlink.GenericLink
+		bridgeLink      *netlink.GenericLink
+	)
+	const (
+		tapName        = "tap16477688c0e"
+		dummyIfaceName = "16477688c0e-nic"
+		bridgeName     = "k6t-16477688c0e"
+		networkName    = "blue"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockHandler = netdriver.NewMockNetworkHandler(ctrl)
+
+		unpluggedpodnic = network.NewUnpluggedpodnic(v1.Network{Name: networkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}}}, mockHandler)
+
+		tapLink = &netlink.GenericLink{}
+		dummyIfaceLink = &netlink.GenericLink{}
+		bridgeLink = &netlink.GenericLink{}
+	})
+
+	Context("UnplugPhase1", func() {
+		It("successfully when bridge, tap and dummy nic exist", func() {
+			mockHandler.EXPECT().LinkByName(tapName).Return(tapLink, nil)
+			mockHandler.EXPECT().LinkByName(dummyIfaceName).Return(dummyIfaceLink, nil)
+			mockHandler.EXPECT().LinkByName(bridgeName).Return(bridgeLink, nil)
+			mockHandler.EXPECT().LinkDel(tapLink).Return(nil)
+			mockHandler.EXPECT().LinkDel(dummyIfaceLink).Return(nil)
+			mockHandler.EXPECT().LinkDel(bridgeLink).Return(nil)
+
+			Expect(unpluggedpodnic.UnplugPhase1()).To(Succeed())
+		})
+		It("successfully when dummy nic doesn't exist", func() {
+			mockHandler.EXPECT().LinkByName(tapName).Return(tapLink, nil)
+			mockHandler.EXPECT().LinkByName(dummyIfaceName).Return(nil, netlink.LinkNotFoundError{})
+			mockHandler.EXPECT().LinkByName(bridgeName).Return(bridgeLink, nil)
+			mockHandler.EXPECT().LinkDel(tapLink).Return(nil)
+			mockHandler.EXPECT().LinkDel(bridgeLink).Return(nil)
+
+			Expect(unpluggedpodnic.UnplugPhase1()).To(Succeed())
+		})
+		It("partially fails when some of the devices fail to be removed", func() {
+			const (
+				linkByNameErr1 = "link by name error1"
+				linkByNameErr2 = "link by name error2"
+			)
+
+			mockHandler.EXPECT().LinkByName(tapName).Return(tapLink, nil)
+			mockHandler.EXPECT().LinkByName(dummyIfaceName).Return(nil, fmt.Errorf(linkByNameErr1))
+			mockHandler.EXPECT().LinkByName(bridgeName).Return(bridgeLink, fmt.Errorf(linkByNameErr2))
+			mockHandler.EXPECT().LinkDel(tapLink).Return(nil)
+
+			err := unpluggedpodnic.UnplugPhase1()
+			Expect(err.Error()).To(ContainSubstring(linkByNameErr1))
+			Expect(err.Error()).To(ContainSubstring(linkByNameErr1))
+		})
+	})
+})

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -101,7 +101,6 @@ import (
 
 type netconf interface {
 	Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, launcherPid int, preSetup func() error) error
-	HotUnplugInterfaces(vmi *v1.VirtualMachineInstance) error
 	Teardown(vmi *v1.VirtualMachineInstance) error
 }
 
@@ -2979,21 +2978,21 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 		}
 
 		if d.clusterConfig.HotplugNetworkInterfacesEnabled() {
-			nets := netvmispec.NetworksToHotplugWhosePodIfacesAreReady(vmi)
+			netsToHotplug := netvmispec.NetworksToHotplugWhosePodIfacesAreReady(vmi)
 			nonAbsentIfaces := netvmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
 				return iface.State != v1.InterfaceStateAbsent
 			})
-			nonAbsentNets := netvmispec.FilterNetworksByInterfaces(nets, nonAbsentIfaces)
+			netsToHotplug = netvmispec.FilterNetworksByInterfaces(netsToHotplug, nonAbsentIfaces)
 
-			if err := d.setupNetwork(vmi, nonAbsentNets); err != nil {
+			ifacesToHotunplug := netvmispec.FilterInterfacesSpec(vmi.Spec.Domain.Devices.Interfaces, func(iface v1.Interface) bool {
+				return iface.State == v1.InterfaceStateAbsent
+			})
+			netsToHotunplug := netvmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, ifacesToHotunplug)
+
+			setupNets := append(netsToHotplug, netsToHotunplug...)
+			if err := d.setupNetwork(vmi, setupNets); err != nil {
 				log.Log.Object(vmi).Error(err.Error())
 				d.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotplug", err.Error())
-				errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)
-			}
-
-			if err := d.netConf.HotUnplugInterfaces(vmi); err != nil {
-				log.Log.Object(vmi).Error(err.Error())
-				d.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotunplug", err.Error())
 				errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)
 			}
 		}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2991,7 +2991,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 				errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)
 			}
 
-			if err := d.netConf.HotUnplugInterfaces(vmi); err != nil { // TODO don't try to unplug from VMs with old name scheme
+			if err := d.netConf.HotUnplugInterfaces(vmi); err != nil {
 				log.Log.Object(vmi).Error(err.Error())
 				d.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotunplug", err.Error())
 				errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -101,6 +101,7 @@ import (
 
 type netconf interface {
 	Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, launcherPid int, preSetup func() error) error
+	HotUnplugInterfaces(vmi *v1.VirtualMachineInstance) error
 	Teardown(vmi *v1.VirtualMachineInstance) error
 }
 
@@ -2987,6 +2988,12 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 			if err := d.setupNetwork(vmi, nonAbsentNets); err != nil {
 				log.Log.Object(vmi).Error(err.Error())
 				d.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotplug", err.Error())
+				errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)
+			}
+
+			if err := d.netConf.HotUnplugInterfaces(vmi); err != nil { // TODO don't try to unplug from VMs with old name scheme
+				log.Log.Object(vmi).Error(err.Error())
+				d.recorder.Event(vmi, k8sv1.EventTypeWarning, "NicHotunplug", err.Error())
 				errorTolerantFeaturesError = append(errorTolerantFeaturesError, err)
 			}
 		}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3491,6 +3491,10 @@ func (nc *netConfStub) Teardown(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
+func (nc *netConfStub) HotUnplugInterfaces(vmi *v1.VirtualMachineInstance) error {
+	return nil
+}
+
 type netStatStub struct{}
 
 func (ns *netStatStub) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -673,7 +673,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		return iface.State != v1.InterfaceStateAbsent
 	})
 	nonAbsentNets := netvmispec.FilterNetworksByInterfaces(vmi.Spec.Networks, nonAbsentIfaces)
-	err = netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}).SetupPodNetworkPhase2(domain, nonAbsentNets)
+	err = netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}, nil).SetupPodNetworkPhase2(domain, nonAbsentNets)
 	if err != nil {
 		return domain, fmt.Errorf("preparing the pod network failed: %v", err)
 	}
@@ -1118,7 +1118,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 
 	if vmi.IsRunning() {
 		networkInterfaceManager := newVirtIOInterfaceManager(
-			dom, netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}))
+			dom, netsetup.NewVMNetworkConfigurator(vmi, cache.CacheCreator{}, nil))
 		if err := networkInterfaceManager.hotplugVirtioInterface(vmi, &api.Domain{Spec: oldSpec}, domain); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The purpose of the PR is on hotunplug - to remove the interfaces created by phase1 (bridge, tap, dummy nic) and the caches (file and volatile).
Hotunplug is detected when the spec interfaces/networks doesn't contain a network that is stored in the configState cache.
In such case unplug phase1 will try to clean the bridge, tap, dummy nic and the caches in case they exist.

The PR doesn't include -
In case a network has caches but the preparation for some reason didn't start, hotunplug won't remove the cached since the indicator to the cleanup is that the configState is `PodIfaceNetworkPreparationStarted` or `PodIfaceNetworkPreparationFinished`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
On hotunplug - remove bridge, tap and dummy interface from virt-launcher and the caches (file and volatile) from the node.
```
