### PR TITLE
[Migration-Controller]Indicate resource quota rejection

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -748,6 +748,13 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - ""
+          resources:
+          - resourcequotas
+          verbs:
+          - list
+          - watch
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -676,6 +676,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -297,6 +297,8 @@ type KubeInformerFactory interface {
 	// Pod returns an informer for ALL Pods in the system
 	Pod() cache.SharedIndexInformer
 
+	ResourceQuota() cache.SharedIndexInformer
+
 	K8SInformerFactory() informers.SharedInformerFactory
 }
 
@@ -1268,6 +1270,13 @@ func (f *kubeInformerFactory) Pod() cache.SharedIndexInformer {
 	return f.getInformer("podInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "pods", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &k8sv1.Pod{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	})
+}
+
+func (f *kubeInformerFactory) ResourceQuota() cache.SharedIndexInformer {
+	return f.getInformer("resourceQuotaInformer", func() cache.SharedIndexInformer {
+		lw := cache.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "resourcequotas", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &k8sv1.ResourceQuota{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -199,6 +199,7 @@ type VirtControllerApp struct {
 	vmRestoreInformer            cache.SharedIndexInformer
 	storageClassInformer         cache.SharedIndexInformer
 	allPodInformer               cache.SharedIndexInformer
+	resourceQuotaInformer        cache.SharedIndexInformer
 
 	crdInformer cache.SharedIndexInformer
 
@@ -385,6 +386,7 @@ func Execute() {
 	app.unmanagedSecretInformer = app.informerFactory.UnmanagedSecrets()
 	app.allPodInformer = app.informerFactory.Pod()
 	app.exportServiceInformer = app.informerFactory.ExportService()
+	app.resourceQuotaInformer = app.informerFactory.ResourceQuota()
 
 	if app.hasCDI {
 		app.dataVolumeInformer = app.informerFactory.DataVolume()
@@ -633,6 +635,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.persistentVolumeClaimInformer,
 		vca.pdbInformer,
 		vca.migrationPolicyInformer,
+		vca.resourceQuotaInformer,
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.clusterConfig,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Application", func() {
 		pdbInformer, _ := testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
 		migrationPolicyInformer, _ := testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		podInformer, _ := testutils.NewFakeInformerFor(&kubev1.Pod{})
+		resourceQuotaInformer, _ := testutils.NewFakeInformerFor(&kubev1.ResourceQuota{})
 		pvcInformer, _ := testutils.NewFakeInformerFor(&kubev1.PersistentVolumeClaim{})
 		crInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 		dataVolumeInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
@@ -154,6 +155,7 @@ var _ = Describe("Application", func() {
 			pvcInformer,
 			pdbInformer,
 			migrationPolicyInformer,
+			resourceQuotaInformer,
 			recorder,
 			virtClient,
 			config,

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Migration watcher", func() {
 	var nodeInformer cache.SharedIndexInformer
 	var pdbInformer cache.SharedIndexInformer
 	var migrationPolicyInformer cache.SharedIndexInformer
+	var resourceQuotaInformer cache.SharedIndexInformer
 	var stop chan struct{}
 	var controller *MigrationController
 	var recorder *record.FakeRecorder
@@ -275,6 +276,7 @@ var _ = Describe("Migration watcher", func() {
 		go nodeInformer.Run(stop)
 		go pdbInformer.Run(stop)
 		go migrationPolicyInformer.Run(stop)
+		go resourceQuotaInformer.Run(stop)
 
 		Expect(cache.WaitForCacheSync(stop,
 			vmiInformer.HasSynced,
@@ -282,7 +284,9 @@ var _ = Describe("Migration watcher", func() {
 			migrationInformer.HasSynced,
 			nodeInformer.HasSynced,
 			pdbInformer.HasSynced,
+			resourceQuotaInformer.HasSynced,
 			migrationPolicyInformer.HasSynced)).To(BeTrue())
+
 	}
 
 	initController := func(kvConfig *virtv1.KubeVirtConfiguration) {
@@ -297,6 +301,7 @@ var _ = Describe("Migration watcher", func() {
 			pvcInformer,
 			pdbInformer,
 			migrationPolicyInformer,
+			resourceQuotaInformer,
 			recorder,
 			virtClient,
 			config,
@@ -318,6 +323,7 @@ var _ = Describe("Migration watcher", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstanceMigration{})
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		pdbInformer, _ = testutils.NewFakeInformerFor(&policyv1.PodDisruptionBudget{})
+		resourceQuotaInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ResourceQuota{})
 		migrationPolicyInformer, _ = testutils.NewFakeInformerFor(&migrationsv1.MigrationPolicy{})
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -516,6 +516,18 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"get",
 				},
 			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"resourcequotas",
+				},
+				Verbs: []string{
+					"list",
+					"watch",
+				},
+			},
 		},
 	}
 }

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -535,7 +535,7 @@ type VirtualMachineInstanceMigrationConditionType string
 // These are valid conditions of VMIs.
 const (
 	// VirtualMachineInstanceMigrationAbortRequested indicates that live migration abort has been requested
-	VirtualMachineInstanceMigrationAbortRequested VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
+	VirtualMachineInstanceMigrationAbortRequested          VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
 	VirtualMachineInstanceMigrationRejectedByResourceQuota VirtualMachineInstanceMigrationConditionType = "migrationRejectedByResourceQuota"
 )
 

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -536,6 +536,7 @@ type VirtualMachineInstanceMigrationConditionType string
 const (
 	// VirtualMachineInstanceMigrationAbortRequested indicates that live migration abort has been requested
 	VirtualMachineInstanceMigrationAbortRequested VirtualMachineInstanceMigrationConditionType = "migrationAbortRequested"
+	VirtualMachineInstanceMigrationRejectedByResourceQuota VirtualMachineInstanceMigrationConditionType = "migrationRejectedByResourceQuota"
 )
 
 type VirtualMachineInstanceCondition struct {

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -170,6 +170,17 @@ func CleanNamespaces() {
 			Expect(err).ToNot(HaveOccurred())
 		}
 
+		// Remove all ResourceQuota
+		rqList, err := virtCli.CoreV1().ResourceQuotas(namespace).List(context.Background(), metav1.ListOptions{})
+		util.PanicOnError(err)
+		for _, rq := range rqList.Items {
+			err := virtCli.CoreV1().ResourceQuotas(namespace).Delete(context.Background(), rq.Name, metav1.DeleteOptions{})
+			if errors.IsNotFound(err) {
+				continue
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
+
 		// Remove PVCs
 		util.PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("persistentvolumeclaims").Do(context.Background()).Error())
 		if libstorage.HasCDI() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

- Add condition that indicates that migration was rejected by ResourceQuota
- Add resourceQuota informer within the migration controller to get fast response 
whenever resourceQuota blocked the migration and than was deleted/modified
the migration controller should respond quickly.

**What this PR does / why we need it**:
In a multi-tenant environment, a cluster administrator creates a namespace for each tenant and controls the amount of resources that they can use by creating a ResourceQuota object within the namespace.

During the migration process, there is a hidden cost involved in creating a new virt-launcher pod before terminating the old one. This differs from how standard pods are moved and can result in unexpected resource utilization from the user's perspective. This poses a challenge where the hidden cost of live migration can prevent live migrating a VM for reasons not reflected to the VM creator / namespace owner.

Migrating a virtual machine in the presence of a resource quota can cause the migration to fail and subsequently cause the upgrade to fail.

As mentioned in :
https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-and-cluster-capacity

Kubernetes recommendation for "complex policies" such as Live Migration is writing a "controller" that watches the quota usage and adjusts the quota hard limits of each namespace according to other signals.

In order to build such controller we need the migration controller to provide the following benefits:

- Ability to detect when a resourceQuota blocks a migration
- Quick response once the resourceQuota is no longer blocking a migration

Example for such controller:
https://github.com/Barakmor1/Managed-Tenant-Quota

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add condition to migrations that indicates that migration was rejected by ResourceQuota
```
