### PR TITLE
api, virt-launcher: Reserve domain resources for network interfaces

### DIFF
--- a/pkg/apimachinery/resource/BUILD.bazel
+++ b/pkg/apimachinery/resource/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["extend.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/apimachinery/resource",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+    ],
+)

--- a/pkg/apimachinery/resource/extend.go
+++ b/pkg/apimachinery/resource/extend.go
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package resource
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type ExtendedResourceList struct {
+	k8sv1.ResourceList `json:"omitempty"`
+}
+
+const (
+	ResourceInterface k8sv1.ResourceName = "kubevirt.io/interface"
+)
+
+// Interface returns the number of network interfaces if specified.
+func (e *ExtendedResourceList) Interface() *resource.Quantity {
+	return e.Name(ResourceInterface, resource.DecimalSI)
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "migration-create-admitter.go",
         "migration-update-admitter.go",
         "migrationpolicy-admitter.go",
+        "network.go",
         "pod-eviction-admitter.go",
         "preference-admitter.go",
         "status-admitter.go",
@@ -25,6 +26,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
@@ -82,6 +84,7 @@ go_test(
         "migration-create-admitter_test.go",
         "migration-update-admitter_test.go",
         "migrationpolicy-admitter_test.go",
+        "network_test.go",
         "pod-eviction-admitter_test.go",
         "vmclone-admitter_test.go",
         "vmexport-admitter_test.go",
@@ -96,6 +99,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/instancetype:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/network.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/network.go
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package admitters
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/resource"
+)
+
+const (
+	ifaceRequestMinValue = 0
+	ifaceRequestMaxValue = 32
+)
+
+func validateInterfaceRequestIsInRange(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	requests := resource.ExtendedResourceList{ResourceList: spec.Domain.Resources.Requests}
+	value := requests.Interface().Value()
+
+	if !isIntegerValue(value, requests) || value < ifaceRequestMinValue || value > ifaceRequestMaxValue {
+		causes = []metav1.StatusCause{{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf(
+				"provided resources interface requests must be an integer between %d to %d",
+				ifaceRequestMinValue,
+				ifaceRequestMaxValue,
+			),
+			Field: field.Child("domain", "resources", "requests", string(resource.ResourceInterface)).String(),
+		}}
+	}
+	return causes
+}
+
+func isIntegerValue(value int64, requests resource.ExtendedResourceList) bool {
+	return value*1000 == requests.Interface().MilliValue()
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/network_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/network_test.go
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package admitters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+
+	"kubevirt.io/client-go/api"
+
+	"kubevirt.io/kubevirt/pkg/apimachinery/resource"
+)
+
+var _ = Describe("Validating VMI network spec", func() {
+
+	DescribeTable("network interface resources requests valid value", func(value string) {
+		vm := api.NewMinimalVMI("testvm")
+		vm.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+			resource.ResourceInterface: k8sresource.MustParse(value),
+		}
+		Expect(validateInterfaceRequestIsInRange(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
+	},
+		Entry("is an integer between 0 to 32", "5"),
+		Entry("is the minimum", "0"),
+		Entry("is the maximum", "32"),
+	)
+
+	DescribeTable("network interface resources requests invalid value", func(value string) {
+		vm := api.NewMinimalVMI("testvm")
+		vm.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+			resource.ResourceInterface: k8sresource.MustParse(value),
+		}
+		Expect(validateInterfaceRequestIsInRange(k8sfield.NewPath("fake"), &vm.Spec)).To(
+			ConsistOf(metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "provided resources interface requests must be an integer between 0 to 32",
+				Field:   "fake.domain.resources.requests.kubevirt.io/interface",
+			}))
+	},
+		Entry("is not an integer", "1.2"),
+		Entry("is negative", "-2"),
+		Entry("is beyond the maximum", "33"),
+	)
+})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -194,6 +194,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	}
 
 	causes = append(causes, validateNetworksAssignedToInterfaces(field, spec, networkInterfaceMap)...)
+	causes = append(causes, validateInterfaceRequestIsInRange(field, spec)...)
 
 	causes = append(causes, validateInputDevices(field, spec)...)
 	causes = append(causes, validateIOThreadsPolicy(field, spec)...)

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/services",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/container-disk:go_default_library",
         "//pkg/downwardmetrics:go_default_library",
@@ -62,6 +63,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/network/istio:go_default_library",

--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -467,6 +467,12 @@ func WithVirtualizationResources(virtResources k8sv1.ResourceList) ResourceRende
 	}
 }
 
+func WithFilterOutResourceRequest(reservedResourceName k8sv1.ResourceName) ResourceRendererOption {
+	return func(renderer *ResourceRenderer) {
+		delete(renderer.vmRequests, reservedResourceName)
+	}
+}
+
 func getNetworkToResourceMap(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (networkToResourceMap map[string]string, err error) {
 	networkToResourceMap = make(map[string]string)
 	for _, network := range vmi.Spec.Networks {

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	k6tresource "kubevirt.io/kubevirt/pkg/apimachinery/resource"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 
@@ -370,6 +371,18 @@ var _ = Describe("Resource pod spec renderer", func() {
 			kubev1.ResourceMemory: resource.MustParse("80M"),
 		}),
 	)
+
+	It("removes reserved resources from requests", func() {
+		resourceValue := resource.MustParse("5")
+		resources := kubev1.ResourceList{k6tresource.ResourceInterface: resourceValue}
+		rr = NewResourceRenderer(
+			nil,
+			resources,
+			WithFilterOutResourceRequest(k6tresource.ResourceInterface),
+		)
+		Expect(rr.Requests()).NotTo(HaveKeyWithValue(k6tresource.ResourceInterface, resourceValue))
+		Expect(rr.Limits()).To(BeEmpty())
+	})
 })
 
 func addResources(firstQuantity resource.Quantity, resources ...resource.Quantity) resource.Quantity {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
 
+	k6tresource "kubevirt.io/kubevirt/pkg/apimachinery/resource"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/network/istio"
@@ -718,6 +719,7 @@ func (t *templateService) newResourceRenderer(vmi *v1.VirtualMachineInstance, ne
 	baseOptions := []ResourceRendererOption{
 		WithEphemeralStorageRequest(),
 		WithVirtualizationResources(getRequiredResources(vmi, t.clusterConfig.AllowEmulation())),
+		WithFilterOutResourceRequest(k6tresource.ResourceInterface),
 	}
 
 	if err := validatePermittedHostDevices(&vmi.Spec, t.clusterConfig); err != nil {

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/cloud-init:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/container-disk:go_default_library",
@@ -71,6 +72,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/cloud-init:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/ephemeral-disk/fake:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -882,10 +882,17 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, allowEmul
 				logger.Reason(err).Error("pre start setup for VirtualMachineInstance failed.")
 				return nil, err
 			}
-			dom, err = l.setDomainSpecWithHooks(vmi, &domain.Spec)
+
+			dom, err = withNetworkIfacesResources(
+				vmi, &domain.Spec,
+				func(v *v1.VirtualMachineInstance, s *api.DomainSpec) (cli.VirDomain, error) {
+					return l.setDomainSpecWithHooks(v, s)
+				},
+			)
 			if err != nil {
 				return nil, err
 			}
+
 			l.metadataCache.UID.Set(vmi.UID)
 			l.metadataCache.GracePeriod.Set(
 				api.GracePeriodMetadata{DeletionGracePeriodSeconds: converter.GracePeriodSeconds(vmi)},

--- a/pkg/virt-launcher/virtwrap/nichotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug_test.go
@@ -20,14 +20,22 @@
 package virtwrap
 
 import (
+	"encoding/xml"
 	"fmt"
+	"strconv"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"libvirt.org/go/libvirt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/resource"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
@@ -138,6 +146,81 @@ var _ = Describe("nic hotplug on virt-launcher", func() {
 			&fakeVMConfigurator{},
 			libvirtClientResult{expectedError: fmt.Errorf("boom")},
 		),
+	)
+})
+
+var _ = Describe("domain network interfaces resources", func() {
+
+	DescribeTable("are ignored when",
+		func(interfaceResourceRequest string, vmiSpecIfaces []v1.Interface) {
+			vmi := &v1.VirtualMachineInstance{}
+			vmi.Spec.Domain.Devices.Interfaces = vmiSpecIfaces
+			if interfaceResourceRequest != "" {
+				vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+					resource.ResourceInterface: k8sresource.MustParse(interfaceResourceRequest),
+				}
+			}
+			domainSpec := &api.DomainSpec{}
+			countCalls := 0
+			_, _ = withNetworkIfacesResources(vmi, domainSpec, func(v *v1.VirtualMachineInstance, s *api.DomainSpec) (cli.VirDomain, error) {
+				countCalls++
+				return nil, nil
+			})
+			// The counter tracks the tested function behavior.
+			// It is expected that the callback function is called only once when there is no need
+			// to add placeholders interfaces.
+			Expect(countCalls).To(Equal(1))
+		},
+		Entry("no interface resource-request is present", "", []v1.Interface{{}}),
+		Entry("the interface resource-request is zero", "0", []v1.Interface{{}}),
+		Entry("the interface resource-request is less than defined interfaces", "1", []v1.Interface{{}, {}}),
+		Entry("the interface resource-request is equal to the defined interfaces", "2", []v1.Interface{{}, {}}),
+	)
+
+	DescribeTable("are reserved when",
+		func(interfaceResourceRequest string, vmiSpecIfaces []v1.Interface) {
+			vmi := &v1.VirtualMachineInstance{}
+			vmi.Spec.Domain.Devices.Interfaces = vmiSpecIfaces
+			if interfaceResourceRequest != "" {
+				vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+					resource.ResourceInterface: k8sresource.MustParse(interfaceResourceRequest),
+				}
+			}
+			domainSpec := &api.DomainSpec{}
+			for range vmiSpecIfaces {
+				domainSpec.Devices.Interfaces = append(domainSpec.Devices.Interfaces, api.Interface{})
+			}
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockDomain := cli.NewMockVirDomain(ctrl)
+			domxml, err := xml.MarshalIndent(domainSpec, "", "\t")
+			Expect(err).ToNot(HaveOccurred())
+			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).Return(string(domxml), nil)
+
+			originalDomainSpec := domainSpec.DeepCopy()
+			countCalls := 0
+			_, err = withNetworkIfacesResources(vmi, domainSpec, func(v *v1.VirtualMachineInstance, s *api.DomainSpec) (cli.VirDomain, error) {
+				// Tracking the behavior of the tested function.
+				// It is expected that the callback function is called twice when placeholders are needed.
+				// The first time it is called with the placeholders in place.
+				// The second time it is called without the placeholders.
+				countCalls++
+				if countCalls == 1 {
+					ifaceRequest, err := strconv.Atoi(interfaceResourceRequest)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(s.Devices.Interfaces).To(HaveLen(ifaceRequest))
+				} else {
+					Expect(s.Devices.Interfaces).To(Equal(originalDomainSpec.Devices.Interfaces))
+				}
+
+				return mockDomain, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countCalls).To(Equal(2))
+			Expect(domainSpec.Devices.Interfaces).To(Equal(originalDomainSpec.Devices.Interfaces))
+		},
+		Entry("no defined interfaces exist", "1", nil),
+		Entry("the interface resource-request is larger than the defined interfaces", "2", []v1.Interface{{}}),
 	)
 })
 

--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libvmi",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/resource:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -20,7 +20,12 @@
 package libvmi
 
 import (
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	kvirtv1 "kubevirt.io/api/core/v1"
+
+	k6sresource "kubevirt.io/kubevirt/pkg/apimachinery/resource"
 
 	"kubevirt.io/kubevirt/tests/libnet"
 )
@@ -120,5 +125,15 @@ func MultusNetwork(name, nadName string) *kvirtv1.Network {
 				NetworkName: nadName,
 			},
 		},
+	}
+}
+
+// WithResourceRequestInterface specifies the vmi network interface resource.
+func WithResourceRequestInterface(value string) Option {
+	return func(vmi *kvirtv1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.Resources.Requests == nil {
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
+		}
+		vmi.Spec.Domain.Resources.Requests[k6sresource.ResourceInterface] = resource.MustParse(value)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce the `kubevirt.io/interface` resource name to reserve domain resources for network interfaces

Users may express the requested number of network interfaces that
the domain should reserve for future additions (hotplug).
    
The value is expressed through the VMI spec, as a resource-name
(`kubevirt.io/interface`) in the `resources.requests` list.
    
The value may be any integer between 0 and 32 (including).

The domain configuration is now generated as follows:
- Add to the domain configuration input, interfaces as placeholders.
- Create a (libvirt) object which contains auto-generated domain
   configuration values (beyond the user input one).
- Remove the placeholder interfaces from the (full) domain configuration
- Create a new (libvirt) object which do not contain the placeholder
   interfaces but does contain the auto-generated dependencies from it
   (e.g. the PCIe controllers).
    
Resources are reserved in this method only if the requested interfaces
count is beyond the existing explicitly defined interfaces in the VMI spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This implements the design proposal: https://github.com/kubevirt/community/pull/220

**Release note**:
```release-note
Introduce the `kubevirt.io/interface` resource name to reserve domain resources for network interfaces.
Network interfaces may be hotplug to at least the specified integer value.
```
