### PR TITLE
docs: Add upgrade note regarding v1 storage version migration

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -117,9 +117,15 @@ New APIs are not available until after the entire update process has completed.
 This ensures that a new API object can't be posted to the cluster until every
 component within the cluster is updated to learn of the object.
 
-### API version field changes
+## Notes
 
-Changes to the CRD's version field are not currently supported. We do not intend
-to change the version field of any of our APIs until we have the ability to
-support multiple versions in parallel. 
+### `v1.0.0` Migration To New Storage Versions
 
+With the `v1.0.0` release of KubeVirt the storage version of all core
+`kubevirt.io` APIs will be moving to version `v1`. To
+accommodate the eventual removal of the `v1alpha3` version with KubeVirt >=
+`v1.2.0` it is recommended that operators deploy the
+[`kube-storage-version-migrator`](https://github.com/kubernetes-sigs/kube-storage-version-migrator)
+tool within their environment. This will ensure any existing `v1alpha3`
+stored objects are migrated to `v1` well in advance of the removal of the
+underlying `v1alpha3` version.


### PR DESCRIPTION
**What this PR does / why we need it**:

The following PR recently merged moving the storage version of all core objects to `v1`:

https://github.com/kubevirt/kubevirt/pull/9628

To accommodate the eventual removal of the original `v1alpha3` version this change adds a note to the updates document recommending the use of the kube-storage-version-migrator tool to automate the upgrade of all stored core objects to `v1` ahead of the removal of `v1alpha3`.

An older note suggesting new CRD versions are not allowed is also removed as this is no longer the case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required - With the `v1.0.0` release of KubeVirt the storage version of all core `kubevirt.io` APIs will be moving to version `v1`. To accommodate the eventual removal of the `v1alpha3` version with KubeVirt >=`v1.2.0` it is recommended that operators deploy the [`kube-storage-version-migrator`](https://github.com/kubernetes-sigs/kube-storage-version-migrator) tool within their environment. This will ensure any existing `v1alpha3` stored objects are migrated to `v1` well in advance of the removal of the underlying `v1alpha3` version.
```
