### PR TITLE
virt-config: Deprecate CPUNodeDiscoveryGate

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -71,6 +71,7 @@ var deprecatedFeatureGates = [...]string{
 	NonRoot,
 	NonRootDeprecated,
 	PSA,
+	CPUNodeDiscoveryGate,
 }
 
 func (config *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {


### PR DESCRIPTION
CPUNodeDiscoveryGate is not used, depercate the feature.

I am not sure if we should put it in `deprecatedFeatureGates` or just remove it.
-->
```release-note
NONE
```
