### PR TITLE
virtctl: Add default instance type support on image-upload

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/storage/types:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virtctl/templates:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
@@ -37,6 +38,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//pkg/virtctl/utils:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",


### PR DESCRIPTION
/area instancetype

**What this PR does / why we need it**:

This change introduces support for labelling images being uploaded to newly created PVCs or DVs with a default instance type or preference.

Users can then use the existing inferFromVolume feature [1] to automatically select an instance type and/or preference when creating a VirtualMachine from the given image.

[1] https://kubevirt.io/user-guide/virtual_machines/instancetypes/#inferfromvolume

See below for an example of how this currently works:

```
$ env | grep KUBEVIRT
KUBEVIRT_PROVIDER=k8s-1.24
KUBEVIRT_MEMORY=32768
KUBEVIRT_DEPLOY_CDI_LATEST=true
KUBEVIRT_STORAGE=rook-ceph-default 
$ ./cluster-up/kubectl.sh kustomize https://github.com/kubevirt/common-instancetypes.git | ./cluster-up/kubectl.sh apply -f -
[..]
$ ./cluster-up/virtctl.sh image-upload dv cirros --size=1Gi --default-instancetype n1.medium --default-preference cirros --force-bind --image-path=/home/lyarwood/Downloads/cirros-0.6.1-x86_64-disk.img
$ ./cluster-up/kubectl.sh get pvc/cirros -o json | jq .metadata.labels
selecting podman as container runtime
{
  "app": "containerized-data-importer",
  "app.kubernetes.io/component": "storage",
  "app.kubernetes.io/managed-by": "cdi-controller",
  "instancetype.kubevirt.io/default-instancetype": "n1.medium",
  "instancetype.kubevirt.io/default-preference": "cirros"
}
$ ./cluster-up/kubectl.sh get dv/cirros -o json | jq .metadata.labels
selecting podman as container runtime
{
  "instancetype.kubevirt.io/default-instancetype": "n1.medium",
  "instancetype.kubevirt.io/default-preference": "cirros"
}
$ ./cluster-up/virtctl.sh create vm --volume-pvc=name:cirros,src:cirros --infer-instancetype --infer-preference --name cirros | yq .
selecting podman as container runtime
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  creationTimestamp: null
  name: cirros
spec:
  instancetype:
    inferFromVolume: cirros
  preference:
    inferFromVolume: cirros
  runStrategy: Always
  template:
    metadata:
      creationTimestamp: null
    spec:
      domain:
        devices: {}
        resources: {}
      terminationGracePeriodSeconds: 180
      volumes:
        - name: cirros
          persistentVolumeClaim:
            claimName: cirros
status: {}
$ ./cluster-up/virtctl.sh create vm --volume-pvc=name:cirros,src:cirros --infer-instancetype --infer-preference --name cirros | ./cluster-up/kubectl.sh apply -f -
selecting podman as container runtime
selecting podman as container runtime
virtualmachine.kubevirt.io/cirros created
$ ./cluster-up/kubectl.sh get vms/cirros -o json | jq '.spec.instancetype,.spec.preference'
selecting podman as container runtime
{
  "kind": "virtualmachineclusterinstancetype",
  "name": "n1.medium",
  "revisionName": "cirros-n1.medium-1cbceb96-2771-497b-a4b7-7cad6742b385-1"
}
{
  "kind": "virtualmachineclusterpreference",
  "name": "cirros",
  "revisionName": "cirros-cirros-efc9aeac-05df-4034-aa82-45817ca0b6dc-1"
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The following flags have been added to the `virtctl image-upload` command allowing users to associate a default instance type and/or preference with an image during upload. `--default-instancetype`,  `--default-instancetype-kind`, `--default-preference` and `--default-preference-kind`. [See the user-guide documentation](https://kubevirt.io/user-guide/virtual_machines/instancetypes/#inferfromvolume) for more details on using the uploaded image with the `inferFromVolume` feature during `VirtualMachine` creation.
```
