### PR TITLE
network, e2e: Convert anonymous functions to regular ones

### DIFF
--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -90,13 +90,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		virtClient = kubevirt.Client()
 	})
 
-	appendIpFamilyToExposeArgs := func(ipFamily ipFamily, vmiExposeArgs []string) []string {
-		if inlcudesIpv6(ipFamily) {
-			vmiExposeArgs = append(vmiExposeArgs, "--ip-family", string(ipFamily))
-		}
-		return vmiExposeArgs
-	}
-
 	createAndWaitForJobToSucceed := func(jobFactory func(host, port string) *batchv1.Job, namespace, ip, port, viaMessage string) error {
 		By(fmt.Sprintf("Starting a job which tries to reach the VMI via the %s", viaMessage))
 		job := jobFactory(ip, port)
@@ -775,6 +768,13 @@ func skipIfNotSupportedCluster(ipFamily ipFamily) {
 	if isDualStack(ipFamily) {
 		checks.SkipIfVersionBelow("Dual stack service requires v1.20 and above", "1.20")
 	}
+}
+
+func appendIpFamilyToExposeArgs(ipFamily ipFamily, vmiExposeArgs []string) []string {
+	if inlcudesIpv6(ipFamily) {
+		vmiExposeArgs = append(vmiExposeArgs, "--ip-family", string(ipFamily))
+	}
+	return vmiExposeArgs
 }
 
 func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -100,11 +100,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		return tests.WaitForJobToSucceed(job, time.Duration(120)*time.Second)
 	}
 
-	executeVirtctlExposeCommand := func(ExposeArgs []string) error {
-		virtctl := clientcmd.NewRepeatableVirtctlCommand(ExposeArgs...)
-		return virtctl()
-	}
-
 	getService := func(namespace, serviceName string) (*k8sv1.Service, error) {
 		svc, err := virtClient.CoreV1().Services(namespace).Get(context.Background(), serviceName, k8smetav1.GetOptions{})
 		if err != nil {
@@ -775,6 +770,11 @@ func appendIpFamilyToExposeArgs(ipFamily ipFamily, vmiExposeArgs []string) []str
 		vmiExposeArgs = append(vmiExposeArgs, "--ip-family", string(ipFamily))
 	}
 	return vmiExposeArgs
+}
+
+func executeVirtctlExposeCommand(ExposeArgs []string) error {
+	virtctl := clientcmd.NewRepeatableVirtctlCommand(ExposeArgs...)
+	return virtctl()
 }
 
 func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -90,10 +90,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		virtClient = kubevirt.Client()
 	})
 
-	randomizeName := func(currentName string) string {
-		return currentName + rand.String(5)
-	}
-
 	validateClusterIp := func(clusterIp string, ipFamily ipFamily) error {
 		var correctPrimaryFamily bool
 		switch ipFamily {
@@ -776,6 +772,10 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		})
 	})
 })
+
+func randomizeName(currentName string) string {
+	return currentName + rand.String(5)
+}
 
 func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {
 	for _, address := range nodeAddresses {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -90,18 +90,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		virtClient = kubevirt.Client()
 	})
 
-	skipIfNotSupportedCluster := func(ipFamily ipFamily) {
-		if includesIpv4(ipFamily) {
-			libnet.SkipWhenClusterNotSupportIpv4()
-		}
-		if inlcudesIpv6(ipFamily) {
-			libnet.SkipWhenClusterNotSupportIpv6()
-		}
-		if isDualStack(ipFamily) {
-			checks.SkipIfVersionBelow("Dual stack service requires v1.20 and above", "1.20")
-		}
-	}
-
 	appendIpFamilyToExposeArgs := func(ipFamily ipFamily, vmiExposeArgs []string) []string {
 		if inlcudesIpv6(ipFamily) {
 			vmiExposeArgs = append(vmiExposeArgs, "--ip-family", string(ipFamily))
@@ -775,6 +763,18 @@ func validateClusterIp(clusterIp string, ipFamily ipFamily) error {
 		return fmt.Errorf("the ClusterIP %s belongs to the wrong ip family", clusterIp)
 	}
 	return nil
+}
+
+func skipIfNotSupportedCluster(ipFamily ipFamily) {
+	if includesIpv4(ipFamily) {
+		libnet.SkipWhenClusterNotSupportIpv4()
+	}
+	if inlcudesIpv6(ipFamily) {
+		libnet.SkipWhenClusterNotSupportIpv6()
+	}
+	if isDualStack(ipFamily) {
+		checks.SkipIfVersionBelow("Dual stack service requires v1.20 and above", "1.20")
+	}
 }
 
 func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -90,20 +90,6 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		virtClient = kubevirt.Client()
 	})
 
-	validateClusterIp := func(clusterIp string, ipFamily ipFamily) error {
-		var correctPrimaryFamily bool
-		switch ipFamily {
-		case ipv4, dualIPv4Primary:
-			correctPrimaryFamily = netutils.IsIPv4String(clusterIp)
-		case ipv6, dualIPv6Primary:
-			correctPrimaryFamily = netutils.IsIPv6String(clusterIp)
-		}
-		if !correctPrimaryFamily {
-			return fmt.Errorf("the ClusterIP %s belongs to the wrong ip family", clusterIp)
-		}
-		return nil
-	}
-
 	skipIfNotSupportedCluster := func(ipFamily ipFamily) {
 		if includesIpv4(ipFamily) {
 			libnet.SkipWhenClusterNotSupportIpv4()
@@ -775,6 +761,20 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 func randomizeName(currentName string) string {
 	return currentName + rand.String(5)
+}
+
+func validateClusterIp(clusterIp string, ipFamily ipFamily) error {
+	var correctPrimaryFamily bool
+	switch ipFamily {
+	case ipv4, dualIPv4Primary:
+		correctPrimaryFamily = netutils.IsIPv4String(clusterIp)
+	case ipv6, dualIPv6Primary:
+		correctPrimaryFamily = netutils.IsIPv6String(clusterIp)
+	}
+	if !correctPrimaryFamily {
+		return fmt.Errorf("the ClusterIP %s belongs to the wrong ip family", clusterIp)
+	}
+	return nil
 }
 
 func getNodeHostname(nodeAddresses []k8sv1.NodeAddress) *string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, the expose e2e test contains several anonymous functions that are not closures [1].
Convert them to regular functions in order to reduce noise from the test body.

[1] https://go.dev/tour/moretypes/25

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
