### PR TITLE
Use KUBECONFIG for functests against external cluster

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -40,6 +40,10 @@ if [[ ${KUBEVIRT_STORAGE} == rook-ceph* ]]; then
     kubevirt_test_config="${KUBEVIRT_DIR}/tests/default-ceph-config.json"
 fi
 
+if [ -z "$kubeconfig" ]; then
+    kubeconfig="$KUBECONFIG"
+fi
+
 echo "Using $kubevirt_test_config as test configuration"
 
 if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`kubeconfig` comes from kubevirtci cluster-up, so when syncing kubevirt to an external cluster,
we simply do not have it populated, and this manifests itself as an issue in running functional tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
