### PR TITLE
Extend VMI status interfaces to reflect virt-laucnher pod interfaces names

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19070,6 +19070,10 @@
       "description": "Name of the interface, corresponds to name of the network assigned to the interface",
       "type": "string"
      },
+     "podInterfaceName": {
+      "description": "the interface name inside the Virtual Machine launcher pod",
+      "type": "string"
+     },
      "queueCount": {
       "description": "Specifies how many queues are allocated by MultiQueue",
       "type": "integer",

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -132,9 +132,10 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 	}
 
 	for ifaceIndex, ifaceStatus := range interfacesStatus {
-		if _, exists := multusStatusNetworksByName[ifaceStatus.Name]; exists {
+		if vmiIfaceStatus, exists := multusStatusNetworksByName[ifaceStatus.Name]; exists {
 			interfacesStatus[ifaceIndex].InfoSource = netvmispec.AddInfoSource(
 				ifaceStatus.InfoSource, netvmispec.InfoSourceMultusStatus)
+			interfacesStatus[ifaceIndex].PodInterfaceName = vmiIfaceStatus.PodInterfaceName
 		}
 	}
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -2288,14 +2288,16 @@ func (c *VMIController) updateInterfaceStatus(vmi *virtv1.VirtualMachineInstance
 			return fmt.Errorf("could not find the pod interface name for network [%s]", network.Name)
 		}
 
-		if _, exists := indexedMultusStatusIfaces[podIfaceName]; exists {
+		if podIfaceStatus, exists := indexedMultusStatusIfaces[podIfaceName]; exists {
 			if vmiIfaceStatus == nil {
 				vmi.Status.Interfaces = append(vmi.Status.Interfaces, virtv1.VirtualMachineInstanceNetworkInterface{
-					Name:       network.Name,
-					InfoSource: vmispec.InfoSourceMultusStatus,
+					Name:             network.Name,
+					InfoSource:       vmispec.InfoSourceMultusStatus,
+					PodInterfaceName: podIfaceStatus.Interface,
 				})
 			} else {
 				vmiIfaceStatus.InfoSource = vmispec.AddInfoSource(vmiIfaceStatus.InfoSource, vmispec.InfoSourceMultusStatus)
+				vmiIfaceStatus.PodInterfaceName = podIfaceStatus.Interface
 			}
 		}
 	}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -3309,7 +3309,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("VMI with an interface on spec (matched on status) with the pod interface ready",
 					newVMIWithOneIface(api.NewMinimalVMI(vmName), networkName, ifaceName),
 					PodVmIfaceStatus{
-						vmIfaceStatus: readyHotpluggedIfaceStatus(ifaceName),
+						vmIfaceStatus: readyHotpluggedIfaceStatus(ifaceName, "pod7e0055a6880"),
 						podIfaceStatus: &networkv1.NetworkStatus{
 							Name:      networkName,
 							Interface: "pod7e0055a6880",
@@ -3318,7 +3318,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Entry("VMI with an interface on spec, (matched on status), with the pod interface ready and ordinal name",
 					newVMIWithOneIface(api.NewMinimalVMI(vmName), networkName, ifaceName),
 					PodVmIfaceStatus{
-						vmIfaceStatus: readyHotpluggedIfaceStatus(ifaceName),
+						vmIfaceStatus: readyHotpluggedIfaceStatus(ifaceName, "net1"),
 						podIfaceStatus: &networkv1.NetworkStatus{
 							Name:      networkName,
 							Interface: "net1",
@@ -3638,10 +3638,11 @@ func simpleIfaceStatus(ifaceName string) *virtv1.VirtualMachineInstanceNetworkIn
 	}
 }
 
-func readyHotpluggedIfaceStatus(ifaceName string) *virtv1.VirtualMachineInstanceNetworkInterface {
+func readyHotpluggedIfaceStatus(ifaceName string, podIfaceName string) *virtv1.VirtualMachineInstanceNetworkInterface {
 	return &virtv1.VirtualMachineInstanceNetworkInterface{
-		Name:       ifaceName,
-		InfoSource: vmispec.InfoSourceMultusStatus,
+		Name:             ifaceName,
+		InfoSource:       vmispec.InfoSourceMultusStatus,
+		PodInterfaceName: podIfaceName,
 	}
 }
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -11125,6 +11125,10 @@ var CRDsValidation map[string]string = map[string]string{
                 description: Name of the interface, corresponds to name of the network
                   assigned to the interface
                 type: string
+              podInterfaceName:
+                description: the interface name inside the Virtual Machine launcher
+                  pod
+                type: string
               queueCount:
                 description: Specifies how many queues are allocated by MultiQueue
                 format: int32

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -599,6 +599,8 @@ type VirtualMachineInstanceNetworkInterface struct {
 	IPs []string `json:"ipAddresses,omitempty"`
 	// The interface name inside the Virtual Machine
 	InterfaceName string `json:"interfaceName,omitempty"`
+	// the interface name inside the Virtual Machine launcher pod
+	PodInterfaceName string `json:"podInterfaceName,omitempty"`
 	// Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.
 	InfoSource string `json:"infoSource,omitempty"`
 	// Specifies how many queues are allocated by MultiQueue

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -143,13 +143,14 @@ func (VirtualMachineInstanceMigrationCondition) SwaggerDoc() map[string]string {
 
 func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"ipAddress":     "IP address of a Virtual Machine interface. It is always the first item of\nIPs",
-		"mac":           "Hardware address of a Virtual Machine interface",
-		"name":          "Name of the interface, corresponds to name of the network assigned to the interface",
-		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface",
-		"interfaceName": "The interface name inside the Virtual Machine",
-		"infoSource":    "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
-		"queueCount":    "Specifies how many queues are allocated by MultiQueue",
+		"ipAddress":        "IP address of a Virtual Machine interface. It is always the first item of\nIPs",
+		"mac":              "Hardware address of a Virtual Machine interface",
+		"name":             "Name of the interface, corresponds to name of the network assigned to the interface",
+		"ipAddresses":      "List of all IP addresses of a Virtual Machine interface",
+		"interfaceName":    "The interface name inside the Virtual Machine",
+		"podInterfaceName": "the interface name inside the Virtual Machine launcher pod",
+		"infoSource":       "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",
+		"queueCount":       "Specifies how many queues are allocated by MultiQueue",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -21664,6 +21664,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceNetworkInterface(ref co
 							Format:      "",
 						},
 					},
+					"podInterfaceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "the interface name inside the Virtual Machine launcher pod",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"infoSource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies the origin of the interface data collected. values: domain, guest-agent, multus-status.",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "vmi_multus.go",
         "vmi_networking.go",
         "vmi_passt.go",
+        "vmi_pod_iface_name.go",
         "vmi_slirp_interface.go",
         "vmi_subdomain.go",
     ],

--- a/tests/network/hotplug.go
+++ b/tests/network/hotplug.go
@@ -77,7 +77,7 @@ var _ = SIGDescribe("nic-hotplug", func() {
 		}
 		Expect(secondaryNetworksNames).NotTo(BeEmpty())
 		EventuallyWithOffset(1, func() []v1.VirtualMachineInstanceNetworkInterface {
-			return cleanMACAddressesFromStatus(vmiCurrentInterfaces(vmi.GetNamespace(), vmi.GetName()))
+			return sanitizeIfaceStatusForAssertion(vmiCurrentInterfaces(vmi.GetNamespace(), vmi.GetName()))
 		}, 30*time.Second).Should(
 			ConsistOf(interfaceStatusFromInterfaceNames(secondaryNetworksNames...)))
 
@@ -445,9 +445,12 @@ func indexVMsSecondaryNetworks(vmi *v1.VirtualMachineInstance) map[string]v1.Net
 	return indexedSecondaryNetworks
 }
 
-func cleanMACAddressesFromStatus(status []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
+// sanitizeIfaceStatusForAssertion remove the VMI interface status MAC and PodInterfaceName attributes
+// because they are not easy to predict in tests and may require using the production code.
+func sanitizeIfaceStatusForAssertion(status []v1.VirtualMachineInstanceNetworkInterface) []v1.VirtualMachineInstanceNetworkInterface {
 	for i := range status {
 		status[i].MAC = ""
+		status[i].PodInterfaceName = ""
 	}
 	return status
 }

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -155,6 +155,7 @@ var _ = SIGDescribe("Infosource", func() {
 			for i := range vmi.Status.Interfaces {
 				vmi.Status.Interfaces[i].IP = ""
 				vmi.Status.Interfaces[i].IPs = nil
+				vmi.Status.Interfaces[i].PodInterfaceName = ""
 			}
 
 			Expect(expectedInterfaces).To(ConsistOf(vmi.Status.Interfaces))

--- a/tests/network/vmi_pod_iface_name.go
+++ b/tests/network/vmi_pod_iface_name.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kvv1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = SIGDescribe("pod interface name", func() {
+
+	Context("VMI with default pod network and two secondary networks", func() {
+		var testVMI *kvv1.VirtualMachineInstance
+
+		const (
+			testNetAttachDefName = "blue-net"
+			blueNetworkName      = "blue-network"
+			redNetworkName       = "red-network"
+		)
+
+		BeforeEach(func() {
+			By("Create NetworkAttachmentDefinition")
+			Expect(libnet.CreateNAD(util.NamespaceTestDefault, testNetAttachDefName)).To(Succeed())
+
+			testVMI = libvmi.NewAlpineWithTestTooling(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(kvv1.DefaultPodNetwork()),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(blueNetworkName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(blueNetworkName, testNetAttachDefName)),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(redNetworkName)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(redNetworkName, testNetAttachDefName)),
+			)
+
+			By("Starting VMI")
+			var err error
+			testVMI, err = kubevirt.Client().VirtualMachineInstance(util.NamespaceTestDefault).Create(context.Background(), testVMI)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for VMI status pod iface name update")
+			Eventually(func() bool {
+				var err error
+				testVMI, err = kubevirt.Client().VirtualMachineInstance(testVMI.Namespace).Get(context.Background(), testVMI.Name, &metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				return podIfaceNameExistInStatus(testVMI)
+			}, 10*time.Minute, 5*time.Second).Should(BeTrue())
+		})
+
+		It("should have secondary networks pod interface name in status", func() {
+			vmiPodIfaceNames := map[string]string{}
+			for _, iface := range testVMI.Status.Interfaces {
+				vmiPodIfaceNames[iface.Name] = iface.PodInterfaceName
+			}
+
+			Expect(vmiPodIfaceNames).To(HaveKeyWithValue(blueNetworkName, "podd05c0e2a83b"))
+			Expect(vmiPodIfaceNames).To(HaveKeyWithValue(redNetworkName, "pod3c12b9d89fa"))
+		})
+	})
+})
+
+func podIfaceNameExistInStatus(vmi *kvv1.VirtualMachineInstance) bool {
+	for i := range vmi.Status.Interfaces {
+		if vmi.Status.Interfaces[i].PodInterfaceName != "" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Extend the VMI status interfaces to also reflect the pod interface name.
- virt-controller update the new field according to the pod Multus network-status annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The VMI status interface now reflects pod interface names.
```
