### PR TITLE
Follow up on PR#9746 comments

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/network.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/network.go
@@ -36,12 +36,11 @@ const (
 )
 
 func validateInterfaceRequestIsInRange(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
-	var causes []metav1.StatusCause
 	requests := resource.ExtendedResourceList{ResourceList: spec.Domain.Resources.Requests}
 	value := requests.Interface().Value()
 
 	if !isIntegerValue(value, requests) || value < ifaceRequestMinValue || value > ifaceRequestMaxValue {
-		causes = []metav1.StatusCause{{
+		return []metav1.StatusCause{{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf(
 				"provided resources interface requests must be an integer between %d to %d",
@@ -51,7 +50,7 @@ func validateInterfaceRequestIsInRange(field *k8sfield.Path, spec *v1.VirtualMac
 			Field: field.Child("domain", "resources", "requests", string(resource.ResourceInterface)).String(),
 		}}
 	}
-	return causes
+	return nil
 }
 
 func isIntegerValue(value int64, requests resource.ExtendedResourceList) bool {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/network_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/network_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		Expect(validateInterfaceRequestIsInRange(k8sfield.NewPath("fake"), &vm.Spec)).To(BeEmpty())
 	},
 		Entry("is an integer between 0 to 32", "5"),
+		Entry("is an integer between 0 to 32 with symbol", "10000m"),
 		Entry("is the minimum", "0"),
 		Entry("is the maximum", "32"),
 	)
@@ -62,5 +63,6 @@ var _ = Describe("Validating VMI network spec", func() {
 		Entry("is not an integer", "1.2"),
 		Entry("is negative", "-2"),
 		Entry("is beyond the maximum", "33"),
+		Entry("is beyond the maximum with size symbol", "1M"),
 	)
 })

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1384,6 +1384,7 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 			vmi.Spec.Domain.Devices.DisableHotplug = false
 			c.UseVirtioTransitional = true
+			vmi.Spec.Domain.Devices.UseVirtioTransitional = &c.UseVirtioTransitional
 			dom := vmiToDomain(vmi, c)
 			testutils.ExpectVirtioTransitionalOnly(&dom.Spec)
 		})

--- a/pkg/virt-launcher/virtwrap/converter/network.go
+++ b/pkg/virt-launcher/virtwrap/converter/network.go
@@ -59,7 +59,7 @@ func CreateDomainInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain, 
 		ifaceType := GetInterfaceType(&vmi.Spec.Domain.Devices.Interfaces[i])
 		domainIface := api.Interface{
 			Model: &api.Model{
-				Type: translateModel(c, ifaceType),
+				Type: translateModel(vmi.Spec.Domain.Devices.UseVirtioTransitional, ifaceType),
 			},
 			Alias: api.NewUserDefinedAlias(iface.Name),
 		}
@@ -288,4 +288,11 @@ func GetResolvConfDetailsFromPod() ([][]byte, []string, error) {
 	log.Log.Reason(err).Infof("Found search domains in %s: %s", resolvConf, strings.Join(searchDomains, " "))
 
 	return nameservers, searchDomains, err
+}
+
+func translateModel(useVirtioTransitional *bool, bus string) string {
+	if bus == v1.VirtIO {
+		return InterpretTransitionalModelType(useVirtioTransitional)
+	}
+	return bus
 }

--- a/pkg/virt-launcher/virtwrap/nichotplug.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug.go
@@ -33,6 +33,7 @@ import (
 	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
 )
 
@@ -159,17 +160,10 @@ func appendPlaceholderInterfacesToTheDomain(vmi *v1.VirtualMachineInstance, doma
 	for i := 0; i < interfacePlaceholderCount; i++ {
 		domainSpecWithIfacesResource.Devices.Interfaces = append(
 			domainSpecWithIfacesResource.Devices.Interfaces,
-			newInterfacePlaceholder(i, interpretModelType(vmi.Spec.Domain.Devices.UseVirtioTransitional)),
+			newInterfacePlaceholder(i, converter.InterpretTransitionalModelType(vmi.Spec.Domain.Devices.UseVirtioTransitional)),
 		)
 	}
 	return domainSpecWithIfacesResource
-}
-
-func interpretModelType(useVirtioTransitional *bool) string {
-	if useVirtioTransitional != nil && *useVirtioTransitional {
-		return "virtio-transitional"
-	}
-	return "virtio-non-transitional"
 }
 
 func newInterfacePlaceholder(index int, modelType string) api.Interface {

--- a/pkg/virt-launcher/virtwrap/nichotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/nichotplug_test.go
@@ -195,7 +195,7 @@ var _ = Describe("domain network interfaces resources", func() {
 			mockDomain := cli.NewMockVirDomain(ctrl)
 			domxml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).ToNot(HaveOccurred())
-			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(2)).Return(string(domxml), nil)
+			mockDomain.EXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).Return(string(domxml), nil)
 
 			originalDomainSpec := domainSpec.DeepCopy()
 			countCalls := 0

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -25,7 +25,7 @@ import (
 
 	kvirtv1 "kubevirt.io/api/core/v1"
 
-	k6sresource "kubevirt.io/kubevirt/pkg/apimachinery/resource"
+	k6tresource "kubevirt.io/kubevirt/pkg/apimachinery/resource"
 
 	"kubevirt.io/kubevirt/tests/libnet"
 )
@@ -134,6 +134,6 @@ func WithResourceRequestInterface(value string) Option {
 		if vmi.Spec.Domain.Resources.Requests == nil {
 			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 		}
-		vmi.Spec.Domain.Resources.Requests[k6sresource.ResourceInterface] = resource.MustParse(value)
+		vmi.Spec.Domain.Resources.Requests[k6tresource.ResourceInterface] = resource.MustParse(value)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up on several comments in https://github.com/kubevirt/kubevirt/pull/9746 .

It includes the interpretation processing of the `UseVirtioTransitional` flag to better share its logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
