### PR TITLE
builder: Workaround podman bug during manifest push

### DIFF
--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -30,4 +30,10 @@ done
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
 ${KUBEVIRT_CRI} manifest create --amend quay.io/kubevirt/builder:${VERSION} ${TMP_IMAGES}
-${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION}
+
+if [ "${KUBEVIRT_CRI}" = "podman" ]; then
+    # Workaround https://github.com/containers/podman/issues/18360 and remove once https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f is released
+    ${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION} quay.io/kubevirt/builder:${VERSION}
+else
+    ${KUBEVIRT_CRI} manifest push quay.io/kubevirt/builder:${VERSION}
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirt-builder/1660974893405048832

```
723dd28d880e090e13b29aadf1792d4153dbad74a0a0dbd0b22979218e18137e
+ podman manifest push quay.io/kubevirt/builder:2305231145-64a7cd17b
Error: accepts 2 arg(s), received 1
```

publish-kubevirt-builder uses podman to build and publish the builder image. This change works around a known podman manifest push bug [1] by providing the destination until a now merged fix is released [2].

[1] https://github.com/containers/podman/issues/18360
[2] https://github.com/containers/podman/commit/bab4217cd16be609ac35ccf3061d1e34f787856f

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
