### PR TITLE
[release-0.53]node-labeller: Take CPU features into account when labeling nodes && fixing MinCPUModel's field logic

### DIFF
--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -97,11 +97,14 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 		if mode.Name == v1.CPUModeHostModel {
 			n.cpuModelVendor = mode.Vendor.Name
 
-			hostCpuModel := mode.Model[0]
-			if len(mode.Model) > 0 {
+			if len(mode.Model) < 1 {
+				return fmt.Errorf("host model mode is expected to contain a model")
+			}
+			if len(mode.Model) > 1 {
 				log.Log.Warning("host model mode is expected to contain only one model")
 			}
 
+			hostCpuModel := mode.Model[0]
 			n.hostCPUModel.name = hostCpuModel.Name
 			n.hostCPUModel.fallback = hostCpuModel.Fallback
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -46,7 +46,7 @@ func (n *NodeLabeller) getMinCpuFeature() cpuFeatures {
 	if minCPUModel == "" {
 		minCPUModel = util.DefaultMinCPUModel
 	}
-	return n.cpuInfo.models[minCPUModel]
+	return n.cpuInfo.usableModels[minCPUModel]
 }
 
 func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []string {
@@ -180,7 +180,7 @@ func (n *NodeLabeller) loadCPUInfo() error {
 		}
 	}
 
-	n.cpuInfo.models = models
+	n.cpuInfo.usableModels = models
 	return nil
 }
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -68,12 +68,9 @@ func (n *NodeLabeller) getSupportedCpuModels(obsoleteCPUsx86 map[string]bool) []
 
 func (n *NodeLabeller) getSupportedCpuFeatures() cpuFeatures {
 	supportedCpuFeatures := make(cpuFeatures)
-	minCpuFeatures := n.getMinCpuFeature()
 
 	for _, feature := range n.supportedFeatures {
-		if _, exist := minCpuFeatures[feature]; !exist {
-			supportedCpuFeatures[feature] = true
-		}
+		supportedCpuFeatures[feature] = true
 	}
 
 	return supportedCpuFeatures
@@ -91,8 +88,6 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 	}
 
 	usableModels := make([]string, 0)
-	minCpuFeatures := n.getMinCpuFeature()
-	log.Log.Infof("CPU features of a minimum baseline CPU model: %+v", minCpuFeatures)
 	for _, mode := range hostDomCapabilities.CPU.Mode {
 		if mode.Name == v1.CPUModeHostModel {
 			n.cpuModelVendor = mode.Vendor.Name
@@ -109,7 +104,7 @@ func (n *NodeLabeller) loadDomCapabilities() error {
 			n.hostCPUModel.fallback = hostCpuModel.Fallback
 
 			for _, feature := range mode.Feature {
-				if _, isMinCpuFeature := minCpuFeatures[feature.Name]; !isMinCpuFeature && feature.Policy == isRequired {
+				if feature.Policy == isRequired {
 					n.hostCPUModel.requiredFeatures[feature.Name] = true
 				}
 			}

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Node-labeller config", func() {
 		cpuModels := nlController.getSupportedCpuModels(nlController.clusterConfig.GetObsoleteCPUModels())
 		cpuFeatures := nlController.getSupportedCpuFeatures()
 
-		Expect(cpuModels).To(HaveLen(3), "number of models must match")
+		Expect(cpuModels).To(HaveLen(5), "number of models must match")
 
 		Expect(cpuFeatures).To(HaveLen(2), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()

--- a/pkg/virt-handler/node-labeller/cpu_plugin_test.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Node-labeller config", func() {
 
 		Expect(cpuModels).To(HaveLen(5), "number of models must match")
 
-		Expect(cpuFeatures).To(HaveLen(2), "number of features must match")
+		Expect(cpuFeatures).To(HaveLen(4), "number of features must match")
 		counter, err := nlController.capabilities.GetTSCCounter()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(counter).ToNot(BeNil())
@@ -133,7 +133,7 @@ var _ = Describe("Node-labeller config", func() {
 
 		Expect(cpuModels).To(BeEmpty(), "number of models doesn't match")
 
-		Expect(cpuFeatures).To(HaveLen(2), "number of features doesn't match")
+		Expect(cpuFeatures).To(HaveLen(4), "number of features doesn't match")
 	})
 
 	Context("should return correct host cpu", func() {

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -33,7 +33,7 @@ type hostCPUModel struct {
 //hostCapabilities holds informations which provides libvirt,
 //so we don't have to call libvirt at every request
 type cpuInfo struct {
-	models map[string]cpuFeatures
+	usableModels map[string]cpuFeatures
 }
 
 //HostDomCapabilities represents structure for parsing output of virsh capabilities

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -246,18 +246,11 @@ func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures
 	for key := range cpuFeatures {
 		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
 	}
-	_, svmIsSupported := newLabels[kubevirtv1.CPUFeatureLabel+"svm"]
 
 	for _, value := range cpuModels {
-
-		//This workaround is necessary because currently Opteron_G2 require svm by libvirt (see /usr/share/libvirt/cpu_map/x86_Opteron_G2.xml )
-		//But libvirt still marks it as Usable:yes even without `svm` because it is usable by qemu (/var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml)
-		//For more information : https://wiki.qemu.org/Features/CPUModels in "Getting information about CPU models" section
-		//TODO: Delete this workaround once libvirt resolve the disagreement with qemu
-		if value == "Opteron_G2" && svmIsSupported == false {
+		if !n.shouldAddCPUModelLabel(value, &hostCpuModel, newLabels) {
 			continue
 		}
-
 		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
 		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
 	}
@@ -351,4 +344,36 @@ func isNodeRealtimeCapable() (bool, error) {
 	}
 	st := strings.Trim(string(ret), "\n")
 	return fmt.Sprintf("%s = -1", kernelSchedRealtimeRuntimeInMicrosecods) == st, nil
+}
+
+func (n *NodeLabeller) shouldAddCPUModelLabel(
+	cpuModelName string,
+	hostCpuModel *hostCPUModel,
+	featureLabels map[string]string,
+) bool {
+	if cpuModelName == hostCpuModel.name {
+		return true
+	}
+	// The logic below is necessary to handle the scenarios when libvirt's definition of a
+	// particular CPU model differs from hypervisor's definition.
+	// E.g. currently Opteron_G2 requires svm by libvirt:
+	//     /usr/share/libvirt/cpu_map/x86_Opteron_G2.xml
+	// But libvirt marks it as Usable:yes even without svm because it is usable by qemu:
+	//     /var/lib/kubevirt-node-labeller/virsh_domcapabilities.xml
+	// For more information refer to https://wiki.qemu.org/Features/CPUModels, "Getting
+	// information about CPU models" section.
+	// Another similar issue:
+	//     https://gitlab.com/libvirt/libvirt/-/issues/304
+	requiredFeatures, ok := n.cpuInfo.usableModels[cpuModelName]
+	if !ok {
+		n.logger.Warningf("The list of required features for CPU model %s is not defined", cpuModelName)
+		return false
+	}
+	missingFeatures := make([]string, 0)
+	for f, _ := range requiredFeatures {
+		if _, isFeatureSupported := featureLabels[kubevirtv1.CPUFeatureLabel+f]; !isFeatureSupported {
+			missingFeatures = append(missingFeatures, f)
+		}
+	}
+	return len(missingFeatures) == 0
 }

--- a/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Opteron_G2.xml
+++ b/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Opteron_G2.xml
@@ -1,0 +1,8 @@
+<cpus>
+  <model name='Opteron_G2'>
+    <decode host='on' guest='on'/>
+    <signature family='15' model='6'/> <!-- 100e60 -->
+    <vendor name='AMD'/>
+    <feature name='svm'/>
+  </model>
+</cpus>

--- a/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Skylake-Client-IBRS.xml
+++ b/pkg/virt-handler/node-labeller/testdata/cpu_map/x86_Skylake-Client-IBRS.xml
@@ -1,0 +1,76 @@
+<cpus>
+  <model name='Skylake-Client-IBRS'>
+    <decode host='on' guest='on'/>
+    <signature family='6' model='94'/> <!-- 0506e0 -->
+    <signature family='6' model='78'/> <!-- 0406e0 -->
+    <!-- These are Kaby Lake and Coffee Lake successors to Skylake,
+         but we don't have specific models for them. -->
+    <signature family='6' model='142'/> <!-- 0806e0 -->
+    <signature family='6' model='158'/> <!-- 0906e0 -->
+    <vendor name='Intel'/>
+    <feature name='3dnowprefetch'/>
+    <feature name='abm'/>
+    <feature name='adx'/>
+    <feature name='aes'/>
+    <feature name='apic'/>
+    <feature name='arat'/>
+    <feature name='avx'/>
+    <feature name='avx2'/>
+    <feature name='bmi1'/>
+    <feature name='bmi2'/>
+    <feature name='clflush'/>
+    <feature name='cmov'/>
+    <feature name='cx16'/>
+    <feature name='cx8'/>
+    <feature name='de'/>
+    <feature name='erms'/>
+    <feature name='f16c'/>
+    <feature name='fma'/>
+    <feature name='fpu'/>
+    <feature name='fsgsbase'/>
+    <feature name='fxsr'/>
+    <feature name='hle'/>
+    <feature name='invpcid'/>
+    <feature name='lahf_lm'/>
+    <feature name='lm'/>
+    <feature name='mca'/>
+    <feature name='mce'/>
+    <feature name='mmx'/>
+    <feature name='movbe'/>
+    <feature name='mpx'/>
+    <feature name='msr'/>
+    <feature name='mtrr'/>
+    <feature name='nx'/>
+    <feature name='pae'/>
+    <feature name='pat'/>
+    <feature name='pcid'/>
+    <feature name='pclmuldq'/>
+    <feature name='pge'/>
+    <feature name='pni'/>
+    <feature name='popcnt'/>
+    <feature name='pse'/>
+    <feature name='pse36'/>
+    <feature name='rdrand'/>
+    <feature name='rdseed'/>
+    <feature name='rdtscp'/>
+    <feature name='rtm'/>
+    <feature name='sep'/>
+    <feature name='smap'/>
+    <feature name='smep'/>
+    <feature name='spec-ctrl'/>
+    <feature name='sse'/>
+    <feature name='sse2'/>
+    <feature name='sse4.1'/>
+    <feature name='sse4.2'/>
+    <feature name='ssse3'/>
+    <feature name='syscall'/>
+    <feature name='tsc'/>
+    <feature name='tsc-deadline'/>
+    <feature name='vme'/>
+    <feature name='x2apic'/>
+    <feature name='xgetbv1'/>
+    <feature name='xsave'/>
+    <feature name='xsavec'/>
+    <feature name='xsaveopt'/>
+  </model>
+</cpus>

--- a/pkg/virt-handler/node-labeller/testdata/virsh_domcapabilities.xml
+++ b/pkg/virt-handler/node-labeller/testdata/virsh_domcapabilities.xml
@@ -16,6 +16,8 @@
             <model usable='yes'>Penryn</model>
             <model usable='yes'>IvyBridge</model>
             <model usable='yes'>Haswell</model>
+            <model usable='yes'>Skylake-Client-IBRS</model>
+            <model usable='yes'>Opteron_G2</model>
         </mode>
     </cpu>
     <features>

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1282,14 +1282,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 			})
 
-			It("[test_id:6248] should set default min cpu model filter when min-cpu is not set in kubevirt config", func() {
-				node := nodesWithKVM[0]
-
-				for key := range node.Labels {
-					Expect(key).ToNot(Equal(v1.CPUFeatureLabel+"apic"), "Node can't contain label with apic feature (it is feature of default min cpu)")
-				}
-			})
-
 			It("[test_id:6995]should expose tsc frequency and tsc scalability", func() {
 				node := nodesWithKVM[0]
 				Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
@@ -1354,22 +1346,6 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 				}
 
 				Fail("No node contains label " + v1.CPUModelVendorLabel)
-			})
-
-			It("[test_id:6251] should update node with new cpu feature label set", func() {
-				node := nodesWithKVM[0]
-
-				numberOfLabelsBeforeUpdate := len(node.Labels)
-				minCPU := "Haswell"
-
-				kvConfig := originalKubeVirt.Spec.Configuration.DeepCopy()
-				kvConfig.MinCPUModel = minCPU
-				tests.UpdateKubeVirtConfigValueAndWait(*kvConfig)
-
-				node, err = virtClient.CoreV1().Nodes().Get(context.Background(), nodesWithKVM[0].Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(numberOfLabelsBeforeUpdate).ToNot(Equal(len(node.Labels)), "Node should have different number of labels")
 			})
 
 			It("[test_id:6252] should remove all cpu model labels (all cpu model are in obsolete list)", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
manual back-port of:
https://github.com/kubevirt/kubevirt/pull/9325
and of:
https://github.com/kubevirt/kubevirt/pull/7765

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
