### PR TITLE
Add help text to the phase transition time metrics

### DIFF
--- a/pkg/monitoring/perfscale/vmi-phase-transitions.go
+++ b/pkg/monitoring/perfscale/vmi-phase-transitions.go
@@ -122,6 +122,7 @@ func newVMIPhaseTransitionTimeHistogramVec(informer cache.SharedIndexInformer) *
 	histogramVec := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kubevirt_vmi_phase_transition_time_seconds",
+			Help:    "Histogram of VM phase transitions duration between different phases in seconds",
 			Buckets: phaseTransitionTimeBuckets(),
 		},
 		[]string{
@@ -190,6 +191,7 @@ func newVMIPhaseTransitionTimeFromCreationHistogramVec(informer cache.SharedInde
 	histogramVec := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kubevirt_vmi_phase_transition_time_from_creation_seconds",
+			Help:    "Histogram of VM phase transitions duration from creation time in seconds",
 			Buckets: phaseTransitionTimeBuckets(),
 		},
 		[]string{
@@ -210,6 +212,7 @@ func newVMIPhaseTransitionTimeFromDeletionHistogramVec(informer cache.SharedInde
 	histogramVec := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kubevirt_vmi_phase_transition_time_from_deletion_seconds",
+			Help:    "Histogram of VM phase transitions duration from deletion time in seconds",
 			Buckets: phaseTransitionTimeBuckets(),
 		},
 		[]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It adds a help text to the VMI phase transition time metrics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2196257

**Special notes for your reviewer**:
The metrics are histograms.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
