### PR TITLE
e2e: Remove events in the namespace after each test

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -270,6 +270,13 @@ func CleanNamespaces() {
 		}
 
 		util.PanicOnError(virtCli.VirtualMachineRestore(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{}))
+
+		// Remove events
+		eventList, err := virtCli.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{})
+		util.PanicOnError(err)
+		for _, event := range eventList.Items {
+			util.PanicOnError(virtCli.CoreV1().Events(namespace).Delete(context.Background(), event.Name, metav1.DeleteOptions{}))
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Events are never deleted; they will be only at the end of the entire suite execution, during namespace deletion.
Events cardinality can be very high, delaying the namespace deletion. Since events scope ends at the end of each test we can remove them during namespace cleanup.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
