### PR TITLE
builder: Create KubeVirt source directory and mark it as safe for git

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -133,4 +133,7 @@ COPY create_bazel_cache_rcs.sh /create_bazel_cache_rcs.sh
 RUN curl -L -o /usr/bin/bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${BAZEL_ARCH} && \
     chmod u+x /usr/bin/bazel
 
+# Add /root/go/src/kubevirt.io/kubevirt and mark it as a safe directory for git
+RUN mkdir -p /root/go/src/kubevirt.io/kubevirt && git config --global --add safe.directory /root/go/src/kubevirt.io/kubevirt
+
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves the following error when using builder >= 2304121609-faf545b82 that now provides git-2.39.1-1.el9.x86_64 (previously git-2.31.1-2.el9.2.x86_64 with 2212180911-8818abcfa):

```
$ make generate
[..]
+ /root/go/src/kubevirt.io/kubevirt/hack/build-go.sh generate
fatal: detected dubious ownership in repository at '/root/go/src/kubevirt.io/kubevirt'
To add an exception for this directory, call:

        git config --global --add safe.directory /root/go/src/kubevirt.io/kubevirt
[..]
+ go build
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
make: *** [Makefile:48: generate] Error 1
```

This could be handled in the individual build and generate scripts but would result in the same directory being appended to the global git config with each run. Adding it once during the build of the builder image is cleaner.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9806

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
