### PR TITLE
instancetype: Remove CDI bug #2502 workaround from func tests

### DIFF
--- a/tests/instancetype_test.go
+++ b/tests/instancetype_test.go
@@ -867,15 +867,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Kind:      "DataSource",
 							Namespace: &util.NamespaceTestDefault,
 						},
-						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
-						Storage: &cdiv1beta1.StorageSpec{
-							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-							Resources: k8sv1.ResourceRequirements{
-								Requests: k8sv1.ResourceList{
-									"storage": resource.MustParse("1Gi"),
-								},
-							},
-						},
+						Storage: &cdiv1beta1.StorageSpec{},
 					},
 				},
 				&cdiv1beta1.DataSource{
@@ -905,15 +897,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Kind:      "DataSource",
 							Namespace: nil,
 						},
-						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
-						Storage: &cdiv1beta1.StorageSpec{
-							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-							Resources: k8sv1.ResourceRequirements{
-								Requests: k8sv1.ResourceList{
-									"storage": resource.MustParse("1Gi"),
-								},
-							},
-						},
+						Storage: &cdiv1beta1.StorageSpec{},
 					},
 				},
 				&cdiv1beta1.DataSource{
@@ -943,15 +927,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Kind:      "DataSource",
 							Namespace: &util.NamespaceTestDefault,
 						},
-						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
-						Storage: &cdiv1beta1.StorageSpec{
-							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-							Resources: k8sv1.ResourceRequirements{
-								Requests: k8sv1.ResourceList{
-									"storage": resource.MustParse("1Gi"),
-								},
-							},
-						},
+						Storage: &cdiv1beta1.StorageSpec{},
 					},
 				},
 				&cdiv1beta1.DataSource{
@@ -987,15 +963,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 							Kind:      "DataSource",
 							Namespace: nil,
 						},
-						// CDI bug #2502, revert to &cdiv1beta1.StorageSpec{} once that is fixed.
-						Storage: &cdiv1beta1.StorageSpec{
-							AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-							Resources: k8sv1.ResourceRequirements{
-								Requests: k8sv1.ResourceList{
-									"storage": resource.MustParse("1Gi"),
-								},
-							},
-						},
+						Storage: &cdiv1beta1.StorageSpec{},
 					},
 				},
 				&cdiv1beta1.DataSource{


### PR DESCRIPTION
/area instancetype
/hold

**What this PR does / why we need it**:

We can remove a workaround from the functional inferFromVolume tests now that CDI bug #2502 [1] has been fixed [2] and released in v1.56.0[3].

[1] https://github.com/kubevirt/containerized-data-importer/issues/2502
[2] https://github.com/kubevirt/containerized-data-importer/pull/2503
[3] https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.56.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Waiting for https://github.com/kubevirt/kubevirtci/pull/911 to land and be pulled into `kubevirt/kubevirt`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
