### PR TITLE
vTPM: switch model from tpm-tis to tpm-crb when persistence is enabled

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1827,6 +1827,10 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 		if vmi.Spec.Domain.Devices.TPM.Persistent != nil && *vmi.Spec.Domain.Devices.TPM.Persistent {
 			domain.Spec.Devices.TPMs[0].Backend.PersistentState = "yes"
+			// tpm-crb is not techincally required for persistence, but since there was a desire for both,
+			//   we decided to introduce them together. Ultimately, we should use tpm-crb for all cases,
+			//   as it is now the generally preferred model
+			domain.Spec.Devices.TPMs[0].Model = "tpm-crb"
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`tpm-crb` is now the preferred vTPM model:
https://bugzilla.redhat.com/show_bug.cgi?id=1519013#c20
https://bugzilla.redhat.com/show_bug.cgi?id=1867917#c8

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This change should not cause issues with existing VM(I)s, since KubeVirt has yet to release with persistent vTPM support.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
