### PR TITLE
Add LiveMigrateIfPossible eviction strategy

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -72,5 +72,14 @@ func VMIEvictionStrategy(clusterConfig *virtconfig.ClusterConfig, vmi *v1.Virtua
 
 func VMIMigratableOnEviction(clusterConfig *virtconfig.ClusterConfig, vmi *v1.VirtualMachineInstance) bool {
 	strategy := VMIEvictionStrategy(clusterConfig, vmi)
-	return strategy != nil && *strategy == v1.EvictionStrategyLiveMigrate
+	if strategy == nil {
+		return false
+	}
+	switch *strategy {
+	case v1.EvictionStrategyLiveMigrate:
+		return true
+	case v1.EvictionStrategyLiveMigrateIfPossible:
+		return vmi.IsMigratable()
+	}
+	return false
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -57,6 +57,10 @@ func (admitter *PodEvictionAdmitter) Admit(ar *admissionv1.AdmissionReview) *adm
 			return denied(fmt.Sprintf("VMI %s is configured with an eviction strategy but is not live-migratable", vmi.Name))
 		}
 		markForEviction = true
+	case virtv1.EvictionStrategyLiveMigrateIfPossible:
+		if vmi.IsMigratable() {
+			markForEviction = true
+		}
 	case virtv1.EvictionStrategyExternal:
 		markForEviction = true
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -776,9 +776,9 @@ func podNetworkRequiredStatusCause(field *k8sfield.Path) metav1.StatusCause {
 func isValidEvictionStrategy(evictionStrategy *v1.EvictionStrategy) bool {
 	return evictionStrategy == nil ||
 		*evictionStrategy == v1.EvictionStrategyLiveMigrate ||
+		*evictionStrategy == v1.EvictionStrategyLiveMigrateIfPossible ||
 		*evictionStrategy == v1.EvictionStrategyNone ||
 		*evictionStrategy == v1.EvictionStrategyExternal
-
 }
 
 func validateLiveMigration(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) (causes []metav1.StatusCause) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -180,6 +180,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	Context("tolerations with eviction policies given", func() {
 		var vmi *v1.VirtualMachineInstance
 		var policyMigrate = v1.EvictionStrategyLiveMigrate
+		var policyMigrateIfPossible = v1.EvictionStrategyLiveMigrateIfPossible
 		var policyNone = v1.EvictionStrategyNone
 		var policyExternal = v1.EvictionStrategyExternal
 
@@ -197,6 +198,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Entry("migration policy to be set to LiveMigrate", &policyMigrate),
 			Entry("migration policy to be set None", &policyNone),
 			Entry("migration policy to be set External", &policyExternal),
+			Entry("migration policy to be set to LiveMigrateIfPossible", &policyMigrateIfPossible),
 			Entry("migration policy to be set nil", nil),
 		)
 

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -569,6 +569,8 @@ func (c *DisruptionBudgetController) vmiNeedsEvictionPDB(vmiExists bool, vmi *vi
 	switch *evictionStrategy {
 	case virtv1.EvictionStrategyLiveMigrate, virtv1.EvictionStrategyExternal:
 		return true
+	case virtv1.EvictionStrategyLiveMigrateIfPossible:
+		return vmi.IsMigratable()
 	default:
 		return false
 	}

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1974,9 +1974,10 @@ const (
 )
 
 const (
-	EvictionStrategyNone        EvictionStrategy = "None"
-	EvictionStrategyLiveMigrate EvictionStrategy = "LiveMigrate"
-	EvictionStrategyExternal    EvictionStrategy = "External"
+	EvictionStrategyNone                  EvictionStrategy = "None"
+	EvictionStrategyLiveMigrate           EvictionStrategy = "LiveMigrate"
+	EvictionStrategyLiveMigrateIfPossible EvictionStrategy = "LiveMigrateIfPossible"
+	EvictionStrategyExternal              EvictionStrategy = "External"
 )
 
 // RestartOptions may be provided when deleting an API object.

--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/policy/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/tests/framework/matcher/getter.go
+++ b/tests/framework/matcher/getter.go
@@ -3,6 +3,8 @@ package matcher
 import (
 	"context"
 
+	policyv1 "k8s.io/api/policy/v1"
+
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
 	k8sv1 "k8s.io/api/apps/v1"
@@ -72,6 +74,14 @@ func AllVMIs(namespace string) func() ([]virtv1.VirtualMachineInstance, error) {
 	return func() (p []virtv1.VirtualMachineInstance, err error) {
 		virtClient := kubevirt.Client()
 		list, err := virtClient.VirtualMachineInstance(namespace).List(context.Background(), &k8smetav1.ListOptions{})
+		return list.Items, err
+	}
+}
+
+func AllPDBs(namespace string) func() ([]policyv1.PodDisruptionBudget, error) {
+	return func() (p []policyv1.PodDisruptionBudget, err error) {
+		virtClient := kubevirt.Client()
+		list, err := virtClient.PolicyV1().PodDisruptionBudgets(namespace).List(context.Background(), k8smetav1.ListOptions{})
 		return list.Items, err
 	}
 }

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -239,7 +239,6 @@ var _ = Describe("[rfe_id:273][crit:high][arm64][vendor:cnv-qe@redhat.com][level
 				Expect(vmi.Status.EvacuationNodeName).ToNot(Equal(""))
 				return nil
 			}, 20*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
 		})
 
 		It("[test_id:1622]should log libvirtd logs", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a `LiveMigrateIfPossible` eviction strategy to the KubeVirt CR and VMIs. This strategy makes it easier to express an admin intent on the KubeVirt CR, that in general live-migrations are preferred, but if users do not explicitly request on VMs that they require a live-migration, non-migratable VMs would still just be stopped during evictions.

This solves the issue, that right now we would create for non-migratable VMIs a PodDisruptionBudget if the cluster-wide  eviction strategy is `LiveMigrate`, leading to to the following two situations:
1. Evictions may be blocked by such VMs indefinitely, where the user did not itself explicitly request migrations.
1. We emit warning events, despite no explicit opt-in from the user that live migrations are a must. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8555 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Add LiveMigrateIfPossible eviction strategy to allow admins to express a live migration preference instead of a live migration requirement for evictions.
```
