### PR TITLE
Quarantine test [Serial][sig-operator]Operator Obsolete ConfigMap sho…

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2939,7 +2939,7 @@ spec:
 			Eventually(ThisDeploymentWith(flags.KubeVirtInstallNamespace, components.VirtOperatorName), 180*time.Second, 1*time.Second).Should(HaveReadyReplicasNumerically(">", 0))
 		})
 
-		It("should emit event if the obsolete kubevirt-config configMap still exists", func() {
+		It("[QUARANTINE] should emit event if the obsolete kubevirt-config configMap still exists", func() {
 			cm := &k8sv1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kubevirt-config",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Quarantines test `[Serial][sig-operator]Operator Obsolete ConfigMap should emit event if the obsolete kubevirt-config configMap still exists`

Test failures have a 25% impact: https://search.ci.kubevirt.io/?search=Operator+Obsolete+ConfigMap+should+emit+event+if+the+obsolete+kubevirt-config+configMap+still+exists&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

See https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2023-05-23-168h.html#row0

See [quarantine rules](https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md#putting-tests-in-quarantine)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @acardace @stu-gott 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
