### PR TITLE
Quarantine test_id:4023 VirtualMachineInstance with CPU pinning with cpu pinning enabled should start a vmi with dedicated cpus and isolated emulator thread with explicit resources set

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2540,7 +2540,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				Expect(kvmpitmask).To(Equal(vcpuzeromask))
 
 			},
-				Entry("with explicit resources set", &virtv1.ResourceRequirements{
+				Entry("[QUARANTINE] with explicit resources set", &virtv1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
 						kubev1.ResourceCPU:    resource.MustParse("2"),
 						kubev1.ResourceMemory: resource.MustParse("256Mi"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Quarantine test `[sig-compute]Configurations [rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning [Serial]with cpu pinning enabled [test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread with explicit resources set`

Flakefinder report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2023-05-23-168h.html#row3

CI search: https://search.ci.kubevirt.io/?search=should+start+a+vmi+with+dedicated+cpus+and+isolated+emulator+thread+with+explicit+resources+set&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

[Quarantine rules](https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md#putting-tests-in-quarantine)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @vladikr @xpivarc @iholder101 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
