### PR TITLE
host-disk: Limit disk size to that requested by PVC

### DIFF
--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -110,6 +110,11 @@ func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVol
 	isShared := types.HasSharedAccessMode(volumeStatus.PersistentVolumeClaimInfo.AccessModes)
 	file := getPVCDiskImgPath(volumeName, "disk.img")
 	capacity := volumeStatus.PersistentVolumeClaimInfo.Capacity[k8sv1.ResourceStorage]
+	requested := volumeStatus.PersistentVolumeClaimInfo.Requests[k8sv1.ResourceStorage]
+	// Use the requested size if it is smaller than the overall capacity of the PVC to ensure the created disks are the size requested by the user
+	if capacity.Value() > requested.Value() {
+		capacity = requested
+	}
 	// The host-disk must be 1MiB-aligned. If the volume specifies a misaligned size, shrink it down to the nearest multiple of 1MiB
 	size := util.AlignImageSizeTo1MiB(capacity.Value(), log.Log)
 	if size == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This change limits the Capacity of any host-disks created when using a
filesystem PVC. This ensures the overall Capacity of the underlying PV
is not used as this can cause issues with providers as set out in
bug https://github.com/kubevirt/kubevirt/issues/9809.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9809

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
