### PR TITLE
Avoid test failure that occurs when lost+found exists

### DIFF
--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -439,6 +439,7 @@ var _ = SIGDescribe("Export", func() {
 	}
 
 	verifyArchiveGzContent := func(fileName, expectedMD5 string, downloadPod *k8sv1.Pod, volumeMode k8sv1.PersistentVolumeMode) {
+		extractedFileName := strings.ReplaceAll(fileName, ".tar.gz", ".img")
 		command := []string{
 			"/usr/bin/tar",
 			"--strip-components",
@@ -446,13 +447,13 @@ var _ = SIGDescribe("Export", func() {
 			"-xzvf",
 			filepath.Join(dataPath, fileName),
 			"-C",
-			dataPath,
+			filepath.Join(dataPath),
+			"./" + extractedFileName,
 		}
 		out, stderr, err := exec.ExecuteCommandOnPodWithResults(virtClient, downloadPod, downloadPod.Spec.Containers[0].Name, command)
 		Expect(err).ToNot(HaveOccurred(), out, stderr)
 
-		fileName = strings.ReplaceAll(fileName, ".tar.gz", ".img")
-		fileAndPathName := filepath.Join(dataPath, fileName)
+		fileAndPathName := filepath.Join(dataPath, extractedFileName)
 		if volumeMode == k8sv1.PersistentVolumeBlock {
 			fileAndPathName = blockVolumeMountPath
 		}


### PR DESCRIPTION
lost+found is a special directory in the root directory of a mounted file system  to help recover files lost to file system corruption and is restricted to root.

When it exists, our exported tarballs will contain it, and when we try to unpack it in the download pod where lost+found exists too, we will have a permissions error for trying to modify the permissions and contents of this directory with the unprivileged download pod.

Avoid this problem by only extracting the file that is going to be checksummed for comparison, the other files are not checked.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
