### PR TITLE
[release-0.58] [virt-controller] fix out-of-bound slice index in evacuation controller

### DIFF
--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -375,6 +375,10 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	}
 
 	migrationCandidates, nonMigrateable := c.filterRunningNonMigratingVMIs(vmisToMigrate, activeMigrations)
+	if len(migrationCandidates) == 0 && len(nonMigrateable) == 0 {
+		return nil
+	}
+
 	activeMigrationsFromThisSourceNode := c.numOfVMIMForThisSourceNode(vmisOnNode, activeMigrations)
 	maxParallelMigrationsPerOutboundNode :=
 		int(*c.clusterConfig.GetMigrationConfiguration().ParallelOutboundMigrationsPerNode)
@@ -383,10 +387,8 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	freeSpotsPerThisSourceNode := maxParallelMigrationsPerOutboundNode - activeMigrationsFromThisSourceNode
 	freeSpots := int(math.Min(float64(freeSpotsPerCluster), float64(freeSpotsPerThisSourceNode)))
 	if freeSpots <= 0 {
-		if len(migrationCandidates) > 0 || len(nonMigrateable) > 0 {
-			c.Queue.AddAfter(node.Name, 5*time.Second)
-			return nil
-		}
+		c.Queue.AddAfter(node.Name, 5*time.Second)
+		return nil
 	}
 
 	diff := int(math.Min(float64(freeSpots), float64(len(migrationCandidates))))


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/9338, since the automatic one failed: https://github.com/kubevirt/kubevirt/pull/9788.
A test has been refactored to avoid the dep of `kubevirt.io/kubevirt/pkg/pointer`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-controller: fix out-of-bound slice index bug in evacuation controller.
```
