### PR TITLE
Add metrics name linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,10 @@ lint:
 	  tests/libvmi/... \
 	"
 
+lint-metrics:
+	hack/dockerized "./hack/prom-metric-linter/metrics_collector.sh > metrics.json"
+	./hack/prom-metric-linter/metric_name_linter.sh --operator-name="kubevirt" --sub-operator-name="kubevirt" --metrics-file=metrics.json
+
 .PHONY: \
 	build-verify \
 	conformance \
@@ -246,4 +250,5 @@ lint:
 	format \
 	fmt \
 	lint \
+	lint-metrics\
 	$(NULL)

--- a/hack/prom-metric-linter/metric_name_linter.sh
+++ b/hack/prom-metric-linter/metric_name_linter.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+#
+
+set -e
+
+linter_image_tag="v0.0.1"
+
+source $(dirname "$0")/../common.sh
+
+fail_if_cri_bin_missing
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --operator-name=*)
+        operator_name="${1#*=}"
+        shift
+        ;;
+    --sub-operator-name=*)
+        sub_operator_name="${1#*=}"
+        shift
+        ;;
+    --metrics-file=*)
+        metrics_file="${1#*=}"
+        shift
+        ;;
+    *)
+        echo "Invalid argument: $1"
+        exit 1
+        ;;
+    esac
+done
+
+# Run the linter by using the prom-metrics-linter Docker container
+errors=$(${KUBEVIRT_CRI} run -i "quay.io/kubevirt/prom-metrics-linter:$linter_image_tag" \
+    --metric-families="$(cat "$metrics_file")" \
+    --operator-name="$operator_name" \
+    --sub-operator-name="$sub_operator_name" 2>&1)
+
+# Check if the linter found any errors with the metrics names, if yes print and fail
+if [[ $errors != "" ]]; then
+    echo "$errors"
+    exit 1
+fi

--- a/hack/prom-metric-linter/metrics_collector.sh
+++ b/hack/prom-metric-linter/metrics_collector.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+#
+
+set -e
+
+PROJECT_ROOT="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")"/../../)"
+export METRICS_DOC_PATH="${METRICS_DOC_PATH:-${PROJECT_ROOT}/docs/metrics.md}"
+export METRICS_COLLECTOR_PATH="${METRICS_COLLECTOR_PATH:-${PROJECT_ROOT}/tools/prom-metrics-collector}"
+
+if [[ ! -f "$METRICS_DOC_PATH" ]]; then
+    echo "Invalid METRICS_DOC_PATH: $METRICS_DOC_PATH is not a valid file path"
+    exit 1
+fi
+
+if [[ ! -d "$METRICS_COLLECTOR_PATH" ]]; then
+    echo "Invalid METRICS_COLLECTOR_PATH: $METRICS_COLLECTOR_PATH is not a valid directory path"
+    exit 1
+fi
+
+# Get the metrics list
+go build -o _out/prom-metrics-collector "$METRICS_COLLECTOR_PATH/..."
+json_output=$(_out/prom-metrics-collector "$METRICS_DOC_PATH" 2>/dev/null)
+
+echo "$json_output"

--- a/tools/prom-metrics-collector/BUILD.bazel
+++ b/tools/prom-metrics-collector/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "metrics_collector.go",
+        "metrics_json_generator.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tools/prom-metrics-collector",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/github.com/prometheus/client_model/go:go_default_library"],
+)
+
+go_binary(
+    name = "prom-metrics-collector",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/prom-metrics-collector/metrics_collector.go
+++ b/tools/prom-metrics-collector/metrics_collector.go
@@ -1,0 +1,135 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Metric represents a Prometheus metric
+type Metric struct {
+	Name string `json:"name,omitempty"`
+	Help string `json:"help,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+// excludedMetrics defines the metrics to ignore, open issue:https://github.com/kubevirt/kubevirt/issues/9714
+// Do not add metrics to this list!
+var excludedMetrics = map[string]struct{}{
+	"kubevirt_allocatable_nodes_count":                     struct{}{},
+	"kubevirt_kvm_available_nodes_count":                   struct{}{},
+	"kubevirt_migrate_vmi_pending_count":                   struct{}{},
+	"kubevirt_migrate_vmi_running_count":                   struct{}{},
+	"kubevirt_migrate_vmi_scheduling_count":                struct{}{},
+	"kubevirt_virt_api_up_total":                           struct{}{},
+	"kubevirt_virt_controller_ready_total":                 struct{}{},
+	"kubevirt_virt_controller_up_total":                    struct{}{},
+	"kubevirt_virt_handler_up_total":                       struct{}{},
+	"kubevirt_virt_operator_leading_total":                 struct{}{},
+	"kubevirt_virt_operator_ready_total":                   struct{}{},
+	"kubevirt_virt_operator_up_total":                      struct{}{},
+	"kubevirt_vmi_cpu_affinity":                            struct{}{},
+	"kubevirt_vmi_filesystem_capacity_bytes_total":         struct{}{},
+	"kubevirt_vmi_memory_domain_bytes_total":               struct{}{},
+	"kubevirt_vmi_memory_pgmajfault":                       struct{}{},
+	"kubevirt_vmi_memory_pgminfault":                       struct{}{},
+	"kubevirt_vmi_memory_swap_in_traffic_bytes_total":      struct{}{},
+	"kubevirt_vmi_memory_swap_out_traffic_bytes_total":     struct{}{},
+	"kubevirt_vmi_outdated_count":                          struct{}{},
+	"kubevirt_vmi_phase_count":                             struct{}{},
+	"kubevirt_vmi_storage_flush_times_ms_total":            struct{}{},
+	"kubevirt_vmi_storage_read_times_ms_total":             struct{}{},
+	"kubevirt_vmi_storage_write_times_ms_total":            struct{}{},
+	"kubevirt_vmi_vcpu_seconds":                            struct{}{},
+	"kubevirt_vmi_vcpu_wait_seconds":                       struct{}{},
+	"kubevirt_vmsnapshot_disks_restored_from_source_total": struct{}{},
+}
+
+// Extract the name, help, and type from the metrics doc file
+func ExtractMetrics(metricsContent string) ([]Metric, error) {
+	var metrics []Metric
+	re := regexp.MustCompile(`### (.*)\n(.*Type: (Counter|Gauge|Histogram|Summary)\.\n)?`)
+	matches := re.FindAllStringSubmatch(metricsContent, -1)
+	for _, match := range matches {
+		name := match[1]
+		help := ""
+		if len(match) > 2 {
+			help = strings.TrimSpace(match[2])
+		}
+		typ := ""
+		if len(match) > 3 {
+			typ = match[3]
+		}
+		metrics = append(metrics, Metric{Name: name, Help: help, Type: typ})
+	}
+	if len(metrics) == 0 {
+		return nil, fmt.Errorf("no metrics found")
+	}
+	return metrics, nil
+}
+
+// Set the correct metric type for creating MetricFamily
+func CreateMetricFamily(m Metric) *dto.MetricFamily {
+	metricType := dto.MetricType_UNTYPED
+
+	switch m.Type {
+	case "Counter":
+		metricType = dto.MetricType_COUNTER
+	case "Gauge":
+		metricType = dto.MetricType_GAUGE
+	case "Histogram":
+		metricType = dto.MetricType_HISTOGRAM
+	case "Summary":
+		metricType = dto.MetricType_SUMMARY
+	}
+
+	return &dto.MetricFamily{
+		Name: &m.Name,
+		Help: &m.Help,
+		Type: &metricType,
+	}
+}
+
+// Read the metrics and parse them to a MetricFamily
+func ReadMetrics(metricsPath string) ([]*dto.MetricFamily, error) {
+	metricsContent, err := os.ReadFile(metricsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading metrics file: %s", err)
+	}
+
+	metrics, err := ExtractMetrics(string(metricsContent))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing metrics file: %s", err)
+	}
+
+	var metricFamily []*dto.MetricFamily
+	for _, metric := range metrics {
+		// Remove ignored metrics from all rules
+		if _, isExcludedMetric := excludedMetrics[metric.Name]; !isExcludedMetric {
+			mf := CreateMetricFamily(metric)
+			metricFamily = append(metricFamily, mf)
+		}
+	}
+	return metricFamily, nil
+}

--- a/tools/prom-metrics-collector/metrics_json_generator.go
+++ b/tools/prom-metrics-collector/metrics_json_generator.go
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("please provide path to the metrics file")
+		os.Exit(1)
+	}
+
+	path := os.Args[1]
+	if _, err := os.Stat(path); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	metricFamilies, err := ReadMetrics(path)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	jsonBytes, err := json.Marshal(metricFamilies)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(jsonBytes)) // Write the JSON string to standard output
+}


### PR DESCRIPTION
This linter will lint the metrics in kubevirt/docs/metrics.md file. In order to run the linter:
1.make lint-metrics

**What this PR does / why we need it**:
jira-ticket: https://issues.redhat.com/browse/CNV-29217

**Reviewer notes**:
Linter output:
```
kubevirt_allocatable_nodes_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_kvm_available_nodes_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_migrate_vmi_pending_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_migrate_vmi_running_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_migrate_vmi_scheduling_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_virt_api_up_total: non-counter metrics should not have "_total" suffix
kubevirt_virt_controller_ready_total: non-counter metrics should not have "_total" suffix
kubevirt_virt_controller_up_total: non-counter metrics should not have "_total" suffix
kubevirt_virt_handler_up_total: non-counter metrics should not have "_total" suffix
kubevirt_virt_operator_leading_total: non-counter metrics should not have "_total" suffix
kubevirt_virt_operator_ready_total: non-counter metrics should not have "_total" suffix
kubevirt_virt_operator_up_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_cpu_affinity: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_filesystem_capacity_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_memory_domain_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_memory_pgmajfault: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_memory_pgminfault: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_memory_swap_in_traffic_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_memory_swap_out_traffic_bytes_total: non-counter metrics should not have "_total" suffix
kubevirt_vmi_outdated_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_vmi_phase_count: non-histogram and non-summary metrics should not have "_count" suffix
kubevirt_vmi_storage_flush_times_ms_total: metric names should not contain abbreviated units
kubevirt_vmi_storage_read_times_ms_total: metric names should not contain abbreviated units
kubevirt_vmi_storage_write_times_ms_total: metric names should not contain abbreviated units
kubevirt_vmi_vcpu_seconds: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmi_vcpu_wait_seconds: counter metrics should have "_total" or "_timestamp_seconds" suffix
kubevirt_vmsnapshot_disks_restored_from_source_total: non-counter metrics should not have "_total" suffix
make: *** [Makefile:213: lint-metrics] Error 1
```

note that we ignore all current errors until the metrics names will be fixed in:https://github.com/kubevirt/kubevirt/pull/9821

**Release note**:

```
Add a metrics name linter. In order to monitor metrics naming and make sure they aligned with the Prometheus metrics naming best practices. 

```